### PR TITLE
refactor(qa): remove aggregate test facades

### DIFF
--- a/extensions/qa-lab/api.ts
+++ b/extensions/qa-lab/api.ts
@@ -107,7 +107,6 @@ export {
 } from "./src/gateway-child.js";
 export {
   buildQaSuiteSummaryJson,
-  qaSuiteProgressTesting,
   type QaSuiteResult,
   type QaSuiteRunParams,
   type QaSuiteScenarioResult,

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -5,9 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
+import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type { QaSuiteScenarioResult } from "./suite.js";
-import { qaSuiteProgressTesting, throwQaSuiteCleanupErrors } from "./suite.js";
+import { throwQaSuiteCleanupErrors } from "./suite.js";
 import type {
   QaTestFileScenario,
   QaTestFileScenarioRunResult,
@@ -1307,7 +1308,7 @@ describe("qa suite runtime launcher", () => {
         failedFileName: fileName,
         outputDir,
         publish: async () =>
-          await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+          await writeQaSuiteArtifacts({
             outputDir,
             startedAt: new Date("2026-08-12T00:00:00.000Z"),
             finishedAt: new Date("2026-08-12T00:01:00.000Z"),

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab tests cover suite runtime flow plugin behavior.
 import { parseModelRef, resolveModelRefFromString } from "openclaw/plugin-sdk/agent-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createQaScenarioRuntimeApi = vi.hoisted(() => vi.fn());
 const runScenarioFlow = vi.hoisted(() => vi.fn(async (params: { api: unknown }) => params.api));
@@ -43,9 +43,74 @@ import { runQaSuiteScenarioDefinition, runQaSuiteScenarioSteps } from "./suite-r
 import * as suiteRuntimeGateway from "./suite-runtime-gateway.js";
 import * as suiteRuntimeTransport from "./suite-runtime-transport.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import * as webRuntime from "./web-runtime.js";
 
+const qaSuiteRuntimeFlowTestConstants = {
+  imageUnderstandingPngBase64: "small",
+  imageUnderstandingLargePngBase64: "large",
+  imageUnderstandingValidPngBase64: "valid",
+};
+
+function createQaSuiteRuntimeFlowTestEnv(
+  transportOverrides: Partial<QaSuiteRuntimeEnv["transport"]> = {},
+) {
+  return {
+    lab: { baseUrl: "http://127.0.0.1:4444" },
+    webSessionIds: new Set<string>(),
+    gateway: {} as QaSuiteRuntimeEnv["gateway"],
+    transport: {
+      id: "qa-channel",
+      label: "QA Channel",
+      accountId: "qa-channel",
+      waitReady: vi.fn(),
+      createGatewayConfig: vi.fn(),
+      buildAgentDelivery: vi.fn(),
+      requiredPluginIds: [],
+      supportedActions: [],
+      handleAction: vi.fn(),
+      createReportNotes: vi.fn(),
+      reset: vi.fn(),
+      sendInbound: vi.fn(),
+      sendNativeCommand: vi.fn(),
+      waitForNoOutbound: vi.fn(),
+      waitForOutbound: vi.fn(),
+      waitForOutboundSequence: vi.fn(),
+      state: {
+        reset: vi.fn(),
+        getSnapshot: vi.fn(),
+        addInboundMessage: vi.fn(),
+        addOutboundMessage: vi.fn(),
+        readMessage: vi.fn(),
+        searchMessages: vi.fn(),
+        waitFor: vi.fn(),
+      },
+      waitForCondition: vi.fn(),
+      ...transportOverrides,
+    },
+    outputDir: "/artifacts",
+    repoRoot: "/repo",
+    providerMode: "mock-openai",
+    primaryModel: "openai/gpt-5.6-luna",
+    alternateModel: "openai/gpt-5.6-luna-mini",
+    mock: null,
+    cfg: {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-5": { alias: "opus" },
+          },
+        },
+      },
+    },
+  } satisfies Parameters<typeof runQaSuiteScenarioDefinition>[0]["env"];
+}
+
 describe("qa suite runtime flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("records intentional scenario skips without running later steps", async () => {
     const laterStep = vi.fn();
     const result = await runQaSuiteScenarioSteps("requires group credentials", [
@@ -73,54 +138,7 @@ describe("qa suite runtime flow", () => {
   });
 
   it("wires the split suite runtime deps into the scenario runtime api", async () => {
-    const env = {
-      lab: { baseUrl: "http://127.0.0.1:4444" },
-      webSessionIds: new Set<string>(),
-      gateway: {} as QaSuiteRuntimeEnv["gateway"],
-      transport: {
-        id: "qa-channel",
-        label: "QA Channel",
-        accountId: "qa-channel",
-        waitReady: vi.fn(),
-        createGatewayConfig: vi.fn(),
-        buildAgentDelivery: vi.fn(),
-        requiredPluginIds: [],
-        supportedActions: [],
-        handleAction: vi.fn(),
-        createReportNotes: vi.fn(),
-        reset: vi.fn(),
-        sendInbound: vi.fn(),
-        sendNativeCommand: vi.fn(),
-        waitForNoOutbound: vi.fn(),
-        waitForOutbound: vi.fn(),
-        waitForOutboundSequence: vi.fn(),
-        state: {
-          reset: vi.fn(),
-          getSnapshot: vi.fn(),
-          addInboundMessage: vi.fn(),
-          addOutboundMessage: vi.fn(),
-          readMessage: vi.fn(),
-          searchMessages: vi.fn(),
-          waitFor: vi.fn(),
-        },
-        waitForCondition: vi.fn(),
-      },
-      outputDir: "/artifacts",
-      repoRoot: "/repo",
-      providerMode: "mock-openai",
-      primaryModel: "openai/gpt-5.6-luna",
-      alternateModel: "openai/gpt-5.6-luna-mini",
-      mock: null,
-      cfg: {
-        agents: {
-          defaults: {
-            models: {
-              "anthropic/claude-opus-5": { alias: "opus" },
-            },
-          },
-        },
-      },
-    } satisfies Parameters<typeof runQaSuiteScenarioDefinition>[0]["env"];
+    const env = createQaSuiteRuntimeFlowTestEnv();
     const scenario = {
       id: "session-memory-ranking",
       title: "Session memory ranking",
@@ -149,11 +167,7 @@ describe("qa suite runtime flow", () => {
       formatErrorMessage,
       liveTurnTimeoutMs,
       resolveQaLiveTurnTimeoutMs,
-      constants: {
-        imageUnderstandingPngBase64: "small",
-        imageUnderstandingLargePngBase64: "large",
-        imageUnderstandingValidPngBase64: "valid",
-      },
+      constants: qaSuiteRuntimeFlowTestConstants,
     });
 
     expect(result).toEqual({ api: "ok" });
@@ -259,5 +273,74 @@ describe("qa suite runtime flow", () => {
     await call.deps.webOpenPage({ url: "https://openclaw.ai" });
     expect(webOpenPage).toHaveBeenCalledWith({ url: "https://openclaw.ai", repoRoot: "/repo" });
     expect(env.webSessionIds.has("page-1")).toBe(true);
+  });
+
+  it("records live transport preparation as the first shared flow step", async () => {
+    const prepareFlow = vi.fn(async () => {
+      throw new Error("setup failed");
+    });
+    const env = createQaSuiteRuntimeFlowTestEnv({
+      label: "Matrix live",
+      prepareFlow,
+    });
+    const scenario = makeQaSuiteTestScenario("matrix-preparation-failure", {
+      channel: "matrix",
+      config: { expected: "value" },
+    });
+    if (scenario.execution.kind !== "flow") {
+      throw new Error("expected flow scenario");
+    }
+    scenario.execution.timeoutMs = 45_000;
+    const runScenario = vi.fn(runQaSuiteScenarioSteps);
+
+    createQaScenarioRuntimeApi.mockReturnValueOnce({ api: "ok" });
+    await runQaSuiteScenarioDefinition({
+      env,
+      scenario,
+      runScenario,
+      splitModelRef: (raw) => parseModelRef(raw, "openai"),
+      formatErrorMessage: (error) => String(error),
+      liveTurnTimeoutMs: () => 60_000,
+      resolveQaLiveTurnTimeoutMs: () => 60_000,
+      constants: qaSuiteRuntimeFlowTestConstants,
+    });
+
+    expect(createQaScenarioRuntimeApi).toHaveBeenCalledTimes(1);
+    const capturedCall = createQaScenarioRuntimeApi.mock.calls[0]?.[0];
+    if (!capturedCall) {
+      throw new Error("expected QA scenario runtime API call");
+    }
+    const capturedDeps = (
+      capturedCall as {
+        deps: {
+          runScenario: Parameters<typeof runQaSuiteScenarioDefinition>[0]["runScenario"];
+        };
+      }
+    ).deps;
+    const scenarioStep = vi.fn(async () => "not reached");
+    await expect(
+      capturedDeps.runScenario("Matrix preparation", [{ name: "Scenario", run: scenarioStep }]),
+    ).resolves.toEqual({
+      name: "Matrix preparation",
+      status: "fail",
+      steps: [{ name: "Prepare Matrix live", status: "fail", details: "setup failed" }],
+      details: "setup failed",
+    });
+
+    expect(runScenario).toHaveBeenCalledWith("Matrix preparation", [
+      { name: "Prepare Matrix live", run: expect.any(Function) },
+      { name: "Scenario", run: scenarioStep },
+    ]);
+    expect(prepareFlow).toHaveBeenCalledWith({
+      config: { expected: "value" },
+      gateway: env.gateway,
+      outputDir: "/artifacts",
+      primaryModel: "openai/gpt-5.6-luna",
+      scenarioId: "matrix-preparation-failure",
+      scenarioTitle: "matrix-preparation-failure",
+      timeoutMs: 45_000,
+      waitForConfigRestartSettle: expect.any(Function),
+    });
+    expect(scenarioStep).not.toHaveBeenCalled();
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -250,7 +250,7 @@ function createQaSuiteScenarioFlowApi(params: QaSuiteScenarioFlowApiParams) {
   });
 }
 
-export function createQaSuiteScenarioStepRunner(
+function createQaSuiteScenarioStepRunner(
   env: QaSuiteScenarioFlowEnv,
   scenario: QaSeedScenarioWithSource,
   vars: Record<string, unknown>,

--- a/extensions/qa-lab/src/suite-support.ts
+++ b/extensions/qa-lab/src/suite-support.ts
@@ -121,7 +121,7 @@ export function remapModelRefForForcedRuntime(params: {
   return `openai/${split.model}`;
 }
 
-export function appendNodeOption(raw: string | undefined, option: string) {
+function appendNodeOption(raw: string | undefined, option: string) {
   const parts = (raw ?? "").split(/\s+/u).filter(Boolean);
   return parts.includes(option) ? parts.join(" ") : [...parts, option].join(" ");
 }

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -5,10 +5,29 @@ import { CRABLINE_SERVER_CHANNELS } from "@openclaw/crabline";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { QA_EVIDENCE_FILENAME, QA_EVIDENCE_SUMMARY_KIND } from "./evidence-summary.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
+import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
+import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
+import {
+  buildQaGatewayHeapCheckpointRuntimeEnvPatch,
+  buildQaIsolatedScenarioWorkerParams,
+  mergeQaRuntimeEnvPatches,
+  remapModelRefForForcedRuntime,
+} from "./suite-support.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type { QaSuiteResult } from "./suite-types.js";
-import { qaSuiteProgressTesting, runQaFlowSuite } from "./suite.js";
+import {
+  buildQaSuiteRuntimeMetrics,
+  createQaSuiteTransportAdapter,
+  formatQaSuiteRunStartProgress,
+  resolveQaSuiteTransportReadyTimeoutMs,
+  runQaFlowSuite,
+  runQaFlowSuiteCleanupPlan,
+  shouldLogQaSuiteProgress,
+  shouldRunQaSuiteWithIsolatedScenarioWorkers,
+  throwQaSuiteCleanupErrors,
+  waitForQaLabReadyOrStopOwned,
+} from "./suite.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -49,7 +68,7 @@ describe("qa suite", () => {
       }
     };
 
-    const failures = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+    const failures = await runQaFlowSuiteCleanupPlan({
       closeWebSessions: step("web sessions"),
       cleanupTransportBeforeGatewayStop: step("transport before gateway", transportFailure),
       cleanupTransportAfterGatewayStop: step("transport after gateway"),
@@ -80,7 +99,7 @@ describe("qa suite", () => {
 
     let thrown: unknown;
     try {
-      qaSuiteProgressTesting.throwQaSuiteCleanupErrors({
+      throwQaSuiteCleanupErrors({
         cleanupFailures: [{ phase: "transport before gateway stop", error: cleanupError }],
         runFailed: true,
         runError,
@@ -103,7 +122,7 @@ describe("qa suite", () => {
     const cleanupError = new Error("stop failed");
     let thrown: unknown;
     try {
-      qaSuiteProgressTesting.throwQaSuiteCleanupErrors({
+      throwQaSuiteCleanupErrors({
         cleanupFailures: [{ phase: "lab stop", error: cleanupError }],
         runFailed: false,
         runError: undefined,
@@ -136,7 +155,7 @@ describe("qa suite", () => {
 
     let thrown: unknown;
     try {
-      qaSuiteProgressTesting.throwQaSuiteCleanupErrors({
+      throwQaSuiteCleanupErrors({
         cleanupFailures: [
           { phase: "agent\nharnesses", error: new Error("dispose failed") },
           { phase: "lab stop", error: new Error("stop failed") },
@@ -172,7 +191,7 @@ describe("qa suite", () => {
       }
     };
 
-    const failures = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+    const failures = await runQaFlowSuiteCleanupPlan({
       cleanupTransportBeforeGatewayStop: step("transport before gateway"),
       cleanupTransportAfterGatewayStop: step("transport after gateway"),
       stopGateway: step("gateway", gatewayFailure),
@@ -201,7 +220,7 @@ describe("qa suite", () => {
     const create = vi.fn();
 
     await expect(
-      qaSuiteProgressTesting.createQaSuiteTransportAdapter({
+      createQaSuiteTransportAdapter({
         adapterFactories: [{ id: "telegram", matches: () => true, create }],
         channelDriver: "live",
         outputDir: "/tmp/qa-output",
@@ -213,53 +232,12 @@ describe("qa suite", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it("records live transport preparation as the first shared flow step", async () => {
-    const prepareFlow = vi.fn(async () => {
-      throw new Error("setup failed");
-    });
-    const scenario = makeQaSuiteTestScenario("matrix-preparation-failure", {
-      channel: "matrix",
-      config: { expected: "value" },
-    });
-    if (scenario.execution.kind !== "flow") {
-      throw new Error("expected flow scenario");
-    }
-    scenario.execution.timeoutMs = 45_000;
-    const env = {
-      gateway: { baseUrl: "http://127.0.0.1:18789" },
-      outputDir: "/tmp/qa-output",
-      transport: { label: "Matrix live", prepareFlow },
-    } as unknown as Parameters<typeof qaSuiteProgressTesting.createScenarioStepRunner>[0];
-    const run = qaSuiteProgressTesting.createScenarioStepRunner(env, scenario, {});
-    const scenarioStep = vi.fn(async () => "not reached");
-
-    await expect(
-      run("Matrix preparation", [{ name: "Scenario", run: scenarioStep }]),
-    ).resolves.toEqual({
-      name: "Matrix preparation",
-      status: "fail",
-      steps: [{ name: "Prepare Matrix live", status: "fail", details: "setup failed" }],
-      details: "setup failed",
-    });
-
-    expect(prepareFlow).toHaveBeenCalledWith({
-      config: { expected: "value" },
-      gateway: env.gateway,
-      outputDir: "/tmp/qa-output",
-      scenarioId: "matrix-preparation-failure",
-      scenarioTitle: "matrix-preparation-failure",
-      timeoutMs: 45_000,
-      waitForConfigRestartSettle: expect.any(Function),
-    });
-    expect(scenarioStep).not.toHaveBeenCalled();
-  });
-
   it("uses a contributed live adapter when its channel is selected", async () => {
     const adapter = { id: "telegram" } as QaTransportAdapter;
     const create = vi.fn(async () => adapter);
 
     await expect(
-      qaSuiteProgressTesting.createQaSuiteTransportAdapter({
+      createQaSuiteTransportAdapter({
         adapterFactories: [{ id: "telegram", matches: () => true, create }],
         channelDriver: "live",
         channelId: "telegram",
@@ -284,7 +262,7 @@ describe("qa suite", () => {
     const adapter = { id: "telegram" } as QaTransportAdapter;
     const create = vi.fn(async () => adapter);
 
-    await qaSuiteProgressTesting.createQaSuiteTransportAdapter({
+    await createQaSuiteTransportAdapter({
       adapterFactories: [{ id: "telegram", matches: () => true, create }],
       adapterOptions: { transportPolicy: { topLevelReplies: true } },
       channelDriver: "live",
@@ -309,7 +287,7 @@ describe("qa suite", () => {
     });
 
     await expect(
-      qaSuiteProgressTesting.waitForQaLabReadyOrStopOwned({
+      waitForQaLabReadyOrStopOwned({
         lab: {
           listenUrl: "http://127.0.0.1:43123",
           stop,
@@ -339,7 +317,7 @@ describe("qa suite", () => {
     });
 
     await expect(
-      qaSuiteProgressTesting.waitForQaLabReadyOrStopOwned({
+      waitForQaLabReadyOrStopOwned({
         lab: {
           listenUrl: "http://127.0.0.1:43123",
           stop,
@@ -362,7 +340,7 @@ describe("qa suite", () => {
         }),
     );
 
-    const readiness = qaSuiteProgressTesting.waitForQaLabReadyOrStopOwned({
+    const readiness = waitForQaLabReadyOrStopOwned({
       lab: {
         listenUrl: "http://127.0.0.1:43123",
         stop,
@@ -390,7 +368,7 @@ describe("qa suite", () => {
     });
 
     await expect(
-      qaSuiteProgressTesting.waitForQaLabReadyOrStopOwned({
+      waitForQaLabReadyOrStopOwned({
         lab: {
           listenUrl: "http://127.0.0.1:43123",
           stop,
@@ -403,61 +381,59 @@ describe("qa suite", () => {
   });
 
   it("defaults progress logging from CI when no override is set", () => {
-    expect(qaSuiteProgressTesting.shouldLogQaSuiteProgress({ CI: "true" })).toBe(true);
-    expect(qaSuiteProgressTesting.shouldLogQaSuiteProgress({ CI: "false" })).toBe(false);
+    expect(shouldLogQaSuiteProgress({ CI: "true" })).toBe(true);
+    expect(shouldLogQaSuiteProgress({ CI: "false" })).toBe(false);
   });
 
   it("resolves transport-ready timeout from params and env", () => {
-    expect(qaSuiteProgressTesting.resolveQaSuiteTransportReadyTimeoutMs(undefined, {})).toBe(
-      120_000,
-    );
+    expect(resolveQaSuiteTransportReadyTimeoutMs(undefined, {})).toBe(120_000);
     expect(
-      qaSuiteProgressTesting.resolveQaSuiteTransportReadyTimeoutMs(undefined, {
+      resolveQaSuiteTransportReadyTimeoutMs(undefined, {
         OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "180000",
       }),
     ).toBe(180_000);
     expect(
-      qaSuiteProgressTesting.resolveQaSuiteTransportReadyTimeoutMs(undefined, {
+      resolveQaSuiteTransportReadyTimeoutMs(undefined, {
         OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "bad",
       }),
     ).toBe(120_000);
     for (const value of ["0x10", "1e3", "10.5"]) {
       expect(
-        qaSuiteProgressTesting.resolveQaSuiteTransportReadyTimeoutMs(undefined, {
+        resolveQaSuiteTransportReadyTimeoutMs(undefined, {
           OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: value,
         }),
       ).toBe(120_000);
     }
-    expect(qaSuiteProgressTesting.resolveQaSuiteTransportReadyTimeoutMs(90_000, {})).toBe(90_000);
+    expect(resolveQaSuiteTransportReadyTimeoutMs(90_000, {})).toBe(90_000);
   });
 
   it("applies OPENCLAW_QA_SUITE_PROGRESS override and falls back on invalid values", () => {
     expect(
-      qaSuiteProgressTesting.shouldLogQaSuiteProgress({
+      shouldLogQaSuiteProgress({
         CI: "false",
         OPENCLAW_QA_SUITE_PROGRESS: "true",
       }),
     ).toBe(true);
     expect(
-      qaSuiteProgressTesting.shouldLogQaSuiteProgress({
+      shouldLogQaSuiteProgress({
         CI: "true",
         OPENCLAW_QA_SUITE_PROGRESS: "false",
       }),
     ).toBe(false);
     expect(
-      qaSuiteProgressTesting.shouldLogQaSuiteProgress({
+      shouldLogQaSuiteProgress({
         CI: "false",
         OPENCLAW_QA_SUITE_PROGRESS: "on",
       }),
     ).toBe(true);
     expect(
-      qaSuiteProgressTesting.shouldLogQaSuiteProgress({
+      shouldLogQaSuiteProgress({
         CI: "true",
         OPENCLAW_QA_SUITE_PROGRESS: "off",
       }),
     ).toBe(false);
     expect(
-      qaSuiteProgressTesting.shouldLogQaSuiteProgress({
+      shouldLogQaSuiteProgress({
         CI: "true",
         OPENCLAW_QA_SUITE_PROGRESS: "definitely",
       }),
@@ -465,16 +441,14 @@ describe("qa suite", () => {
   });
 
   it("sanitizes scenario ids for progress logs", () => {
-    expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("scenario-id")).toBe("scenario-id");
-    expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("scenario\nid\tvalue")).toBe(
-      "scenario id value",
-    );
-    expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("\u0000\u0001")).toBe("<empty>");
+    expect(sanitizeQaSuiteProgressValue("scenario-id")).toBe("scenario-id");
+    expect(sanitizeQaSuiteProgressValue("scenario\nid\tvalue")).toBe("scenario id value");
+    expect(sanitizeQaSuiteProgressValue("\u0000\u0001")).toBe("<empty>");
   });
 
   it("includes effective channel driver in run start progress logs", () => {
     expect(
-      qaSuiteProgressTesting.formatQaSuiteRunStartProgress({
+      formatQaSuiteRunStartProgress({
         selectedScenarioCount: 80,
         concurrency: 8,
         transportId: "qa-channel",
@@ -482,7 +456,7 @@ describe("qa suite", () => {
     ).toBe("run start: scenarios=80 concurrency=8 transport=qa-channel");
 
     expect(
-      qaSuiteProgressTesting.formatQaSuiteRunStartProgress({
+      formatQaSuiteRunStartProgress({
         selectedScenarioCount: 80,
         concurrency: 1,
         transportId: "qa-channel",
@@ -500,7 +474,7 @@ describe("qa suite", () => {
 
   it("records gateway RSS peak and trace samples", () => {
     expect(
-      qaSuiteProgressTesting.buildQaSuiteRuntimeMetrics({
+      buildQaSuiteRuntimeMetrics({
         startedAt: new Date("2026-04-22T12:00:00.000Z"),
         finishedAt: new Date("2026-04-22T12:00:12.000Z"),
         gatewayProcessCpuStartMs: 1_000,
@@ -563,7 +537,7 @@ describe("qa suite", () => {
   it("writes standalone evidence while keeping suite summary evidence-free", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-artifacts-");
     try {
-      const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+      const artifacts = await writeQaSuiteArtifacts({
         outputDir,
         startedAt: new Date("2026-04-11T00:00:00.000Z"),
         finishedAt: new Date("2026-04-11T00:01:00.000Z"),
@@ -617,7 +591,7 @@ describe("qa suite", () => {
   it("can return evidence without writing duplicate child evidence files", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-artifacts-memory-evidence-");
     try {
-      const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+      const artifacts = await writeQaSuiteArtifacts({
         outputDir,
         startedAt: new Date("2026-04-11T00:00:00.000Z"),
         finishedAt: new Date("2026-04-11T00:01:00.000Z"),
@@ -661,7 +635,7 @@ describe("qa suite", () => {
         release: vi.fn(async () => {}),
       });
 
-      const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+      const artifacts = await writeQaSuiteArtifacts({
         outputDir,
         startedAt: new Date("2026-04-11T00:00:00.000Z"),
         finishedAt: new Date("2026-04-11T00:01:00.000Z"),
@@ -774,7 +748,7 @@ describe("qa suite", () => {
     await fs.writeFile(smokeArtifactPath, "authoritative smoke\n", "utf8");
     await fs.writeFile(providerReadinessArtifactPath, "authoritative provider readiness\n", "utf8");
 
-    const artifacts = await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+    const artifacts = await writeQaSuiteArtifacts({
       outputDir,
       startedAt: new Date("2026-07-12T00:00:00.000Z"),
       finishedAt: new Date("2026-07-12T00:01:00.000Z"),
@@ -866,12 +840,12 @@ describe("qa suite", () => {
 
   it("arms gateway heap checkpoint env only when requested", () => {
     expect(
-      qaSuiteProgressTesting.buildQaGatewayHeapCheckpointRuntimeEnvPatch({
+      buildQaGatewayHeapCheckpointRuntimeEnvPatch({
         OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS: "0",
       }),
     ).toBeUndefined();
     expect(
-      qaSuiteProgressTesting.buildQaGatewayHeapCheckpointRuntimeEnvPatch({
+      buildQaGatewayHeapCheckpointRuntimeEnvPatch({
         OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS: "1",
         NODE_OPTIONS: "--max-old-space-size=4096",
       }),
@@ -879,7 +853,7 @@ describe("qa suite", () => {
       NODE_OPTIONS: "--max-old-space-size=4096 --heapsnapshot-signal=SIGUSR2",
     });
     expect(
-      qaSuiteProgressTesting.mergeQaRuntimeEnvPatches(
+      mergeQaRuntimeEnvPatches(
         { OPENAI_API_KEY: "mock" },
         { NODE_OPTIONS: "--heapsnapshot-signal=SIGUSR2" },
       ),
@@ -912,7 +886,7 @@ describe("qa suite", () => {
     };
 
     expect(
-      qaSuiteProgressTesting.buildQaIsolatedScenarioWorkerParams({
+      buildQaIsolatedScenarioWorkerParams({
         repoRoot: "/repo",
         outputDir: "/repo/.artifacts/qa-e2e/scenarios/patched-control-ui",
         providerMode: "mock-openai",
@@ -964,7 +938,7 @@ describe("qa suite", () => {
       const scenario = makeQaSuiteTestScenario("isolated-control-ui-ownership", { surface });
 
       expect(
-        qaSuiteProgressTesting.buildQaIsolatedScenarioWorkerParams({
+        buildQaIsolatedScenarioWorkerParams({
           repoRoot: "/repo",
           outputDir: "/repo/.artifacts/qa-e2e/scenarios/isolated-control-ui-ownership",
           providerMode: "mock-openai",
@@ -979,36 +953,6 @@ describe("qa suite", () => {
       ).toBe(expected);
     },
   );
-
-  it("enables Control UI only for Control UI scenarios unless explicitly overridden", () => {
-    const channelScenario = makeQaSuiteTestScenario("channel-baseline", { surface: "channel" });
-    const controlUiScenario = makeQaSuiteTestScenario("control-ui-roundtrip", {
-      surface: "control-ui",
-    });
-
-    expect(
-      qaSuiteProgressTesting.resolveQaSuiteControlUiEnabled({
-        scenarios: [channelScenario],
-      }),
-    ).toBe(false);
-    expect(
-      qaSuiteProgressTesting.resolveQaSuiteControlUiEnabled({
-        scenarios: [channelScenario, controlUiScenario],
-      }),
-    ).toBe(true);
-    expect(
-      qaSuiteProgressTesting.resolveQaSuiteControlUiEnabled({
-        explicit: true,
-        scenarios: [channelScenario],
-      }),
-    ).toBe(true);
-    expect(
-      qaSuiteProgressTesting.resolveQaSuiteControlUiEnabled({
-        explicit: false,
-        scenarios: [controlUiScenario],
-      }),
-    ).toBe(false);
-  });
 
   it("keeps caller-owned serial labs on shared workers without a launcher", () => {
     const scenarios = [
@@ -1027,14 +971,14 @@ describe("qa suite", () => {
     const startLab = vi.fn();
 
     expect(
-      qaSuiteProgressTesting.shouldRunQaSuiteWithIsolatedScenarioWorkers({
+      shouldRunQaSuiteWithIsolatedScenarioWorkers({
         scenarios,
         concurrency: 1,
         lab,
       }),
     ).toBe(false);
     expect(
-      qaSuiteProgressTesting.shouldRunQaSuiteWithIsolatedScenarioWorkers({
+      shouldRunQaSuiteWithIsolatedScenarioWorkers({
         scenarios,
         concurrency: 1,
         lab,
@@ -1045,14 +989,14 @@ describe("qa suite", () => {
 
   it("remaps mock-openai model refs onto the app-server OpenAI provider for codex cells only", () => {
     expect(
-      qaSuiteProgressTesting.remapModelRefForForcedRuntime({
+      remapModelRefForForcedRuntime({
         modelRef: "mock-openai/gpt-5.6-luna",
         providerMode: "mock-openai",
         forcedRuntime: "codex",
       }),
     ).toBe("openai/gpt-5.6-luna");
     expect(
-      qaSuiteProgressTesting.remapModelRefForForcedRuntime({
+      remapModelRefForForcedRuntime({
         modelRef: "mock-openai/gpt-5.6-luna",
         providerMode: "mock-openai",
         forcedRuntime: "openclaw",

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -28,40 +28,12 @@ import type { QaReportCheck } from "./report.js";
 import type { RuntimeId, RuntimeParityCell, RuntimeParityResult } from "./runtime-parity.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
-import {
-  type QaSuiteGatewayHeapSnapshot,
-  type QaSuiteGatewayRssSample,
-  writeQaSuiteArtifacts,
-} from "./suite-artifacts.js";
-import {
-  scenarioRequiresControlUi,
-  shouldUseIsolatedQaSuiteScenarioWorkers,
-  splitModelRef,
-} from "./suite-planning.js";
+import type { QaSuiteGatewayHeapSnapshot, QaSuiteGatewayRssSample } from "./suite-artifacts.js";
+import { shouldUseIsolatedQaSuiteScenarioWorkers, splitModelRef } from "./suite-planning.js";
 import type { QaSuiteRoundTripProbe } from "./suite-round-trip.js";
-import {
-  createQaSuiteScenarioStepRunner,
-  runQaSuiteScenarioDefinition,
-  runQaSuiteScenarioSteps,
-} from "./suite-runtime-flow.js";
+import { runQaSuiteScenarioDefinition, runQaSuiteScenarioSteps } from "./suite-runtime-flow.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 import type { QaSuiteSummaryJson } from "./suite-summary.js";
-import {
-  appendNodeOption,
-  buildQaGatewayHeapCheckpointRuntimeEnvPatch,
-  buildQaIsolatedScenarioWorkerParams,
-  mergeQaRuntimeEnvPatches,
-  remapModelRefForForcedRuntime,
-} from "./suite-support.js";
-
-function resolveQaSuiteControlUiEnabled(params: {
-  explicit?: boolean;
-  scenarios: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"];
-}) {
-  return (
-    params.explicit ?? params.scenarios.some((scenario) => scenarioRequiresControlUi(scenario))
-  );
-}
 
 export type QaSuiteScenarioResult = {
   name: string;
@@ -594,26 +566,3 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
   const { runQaFlowSuiteFromRuntime } = await import("./suite-run.runtime.js");
   return await runQaFlowSuiteFromRuntime(params);
 }
-
-export const qaSuiteProgressTesting = {
-  appendNodeOption,
-  buildQaGatewayHeapCheckpointRuntimeEnvPatch,
-  buildQaIsolatedScenarioWorkerParams,
-  buildQaSuiteRuntimeMetrics,
-  createQaSuiteTransportAdapter,
-  createScenarioStepRunner: createQaSuiteScenarioStepRunner,
-  formatQaSuiteRunStartProgress,
-  mergeQaRuntimeEnvPatches,
-  remapModelRefForForcedRuntime,
-  runQaFlowSuiteCleanupPlan,
-  runQaSuiteCleanupSteps,
-  throwQaSuiteCleanupErrors,
-  resolveQaSuiteControlUiEnabled,
-  scenarioRequiresControlUi,
-  resolveQaSuiteTransportReadyTimeoutMs,
-  sanitizeQaSuiteProgressValue,
-  shouldRunQaSuiteWithIsolatedScenarioWorkers,
-  shouldLogQaSuiteProgress,
-  waitForQaLabReadyOrStopOwned,
-  writeQaSuiteArtifacts,
-};

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -6,13 +6,16 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { validateQaEvidenceSummaryJson } from "./evidence-summary.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
-import { runQaScenarioCommandLifecycle } from "./test-file-scenario-command-lifecycle.js";
+import {
+  resetQaScenarioCommandCleanupTimings,
+  runQaScenarioCommandLifecycle,
+  setQaScenarioCommandCleanupTimings,
+} from "./test-file-scenario-command-lifecycle.js";
 import {
   dockerE2eLaneName,
   prepareDockerE2eEnvironment,
 } from "./test-file-scenario-docker-batch.js";
 import {
-  qaTestFileScenarioRunnerTesting,
   runQaTestFileScenarios,
   type QaScenarioCommandExecution,
 } from "./test-file-scenario-runner.js";
@@ -352,7 +355,7 @@ async function writeScriptProducerEvidence(params: {
 describe("qa test file scenario runner", () => {
   afterEach(async () => {
     vi.unstubAllEnvs();
-    qaTestFileScenarioRunnerTesting.resetTimeoutCleanupTimings();
+    resetQaScenarioCommandCleanupTimings();
     await Promise.all([
       cleanupTempDirs(),
       ...tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
@@ -1349,7 +1352,7 @@ describe("qa test file scenario runner", () => {
         "utf8",
       );
 
-      qaTestFileScenarioRunnerTesting.setTimeoutCleanupTimings({
+      setQaScenarioCommandCleanupTimings({
         forceSettleMs: 25,
         killGraceMs: 50,
       });
@@ -1396,47 +1399,6 @@ describe("qa test file scenario runner", () => {
       }
       expect(isProcessRunning(descendantPid)).toBe(false);
     });
-  });
-
-  it("force-kills Windows scenario command trees when graceful taskkill fails", () => {
-    const originalSystemRoot = process.env.SystemRoot;
-    const originalWindir = process.env.WINDIR;
-    process.env.SystemRoot = "C:\\Windows";
-    delete process.env.WINDIR;
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ status: 1 })
-      .mockReturnValueOnce({ status: 0 });
-
-    try {
-      expect(
-        qaTestFileScenarioRunnerTesting.killQaScenarioWindowsProcessTree(
-          12345,
-          "SIGTERM",
-          runTaskkill,
-        ),
-      ).toBe(true);
-      const taskkillPath = path.win32.join("C:\\Windows", "System32", "taskkill.exe");
-      expect(runTaskkill).toHaveBeenNthCalledWith(1, taskkillPath, ["/pid", "12345", "/T"], {
-        stdio: "ignore",
-        windowsHide: true,
-      });
-      expect(runTaskkill).toHaveBeenNthCalledWith(2, taskkillPath, ["/pid", "12345", "/T", "/F"], {
-        stdio: "ignore",
-        windowsHide: true,
-      });
-    } finally {
-      if (originalSystemRoot === undefined) {
-        delete process.env.SystemRoot;
-      } else {
-        process.env.SystemRoot = originalSystemRoot;
-      }
-      if (originalWindir === undefined) {
-        delete process.env.WINDIR;
-      } else {
-        process.env.WINDIR = originalWindir;
-      }
-    }
   });
 
   it("fails script scenarios that exit cleanly after timeout termination", async () => {

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -21,10 +21,7 @@ import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { shellQuote } from "./shell-quote.js";
 import {
-  killQaScenarioWindowsProcessTree,
-  resetQaScenarioCommandCleanupTimings,
   runQaScenarioCommandLifecycle,
-  setQaScenarioCommandCleanupTimings,
   type QaScenarioCommandExecution,
   type QaScenarioCommandResult,
 } from "./test-file-scenario-command-lifecycle.js";
@@ -651,13 +648,3 @@ export async function runQaTestFileScenarios(
     results,
   };
 }
-
-export const qaTestFileScenarioRunnerTesting = {
-  killQaScenarioWindowsProcessTree,
-  resetTimeoutCleanupTimings() {
-    resetQaScenarioCommandCleanupTimings();
-  },
-  setTimeoutCleanupTimings(params: { forceSettleMs: number; killGraceMs: number }) {
-    setQaScenarioCommandCleanupTimings(params);
-  },
-};


### PR DESCRIPTION
## What Problem This Solves

Removes two QA Lab aggregate testing facades that mixed unrelated runtime owners, a dead Control UI predicate, and a duplicated Windows process-tree test left behind after lifecycle extraction.

The facades made private implementation helpers look like one supported API and kept otherwise-unused exports alive. The duplicate `taskkill` test replayed the same graceful-then-forced sequence already exercised through the command-lifecycle owner.

## Why This Change Was Made

Tests now import from the modules that own each behavior. `appendNodeOption` and `createQaSuiteScenarioStepRunner` are private again. The unique live transport-preparation regression moved from a direct helper call to the exported `runQaSuiteScenarioDefinition` boundary, where it still proves preparation is first and failure prevents scenario execution.

The canonical Windows timeout lifecycle, trusted System32 resolution, and POSIX descendant cleanup tests remain.

## User Impact

No user-visible behavior changes. QA Lab has fewer test-only exports and clearer runtime ownership while preserving suite execution, transport preparation, artifact writing, cleanup, and process-tree behavior.

## Evidence

- QA suite, runtime-flow, launcher, scenario runner, command lifecycle, and Windows system-tool owners: 6 files, 156 tests passed.
- `extensions` and `extensionTests` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready; extension typechecks, formatting, lint, doctor-contract guards, dead-export scan, and import-cycle checks passed.
- `git diff --check` passed.
- Fresh complete-branch structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/31879252677

Production delta: +5/-70, net -65. Tests: +210/-220, net -10. Total: +215/-290, net -75. No docs, config, schema, protocol, dependency, or changelog change.