### PR TITLE
fix: ask_user stops accepting answers when prompt delivery fails

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -28,8 +28,8 @@ import {
 } from "./dispatch-from-config.payloads.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
+import { requireQueuedReplyDelivery } from "./dispatch-from-config.turn-ledger.js";
 import { bindPreparedReplyDispatchRuntime } from "./prepared-reply-dispatch-context.js";
-import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import { REPLY_OPERATION_RUN_STATE } from "./reply-operation-run-state.js";
 
 export async function executeDispatch(state: PrepareDispatchExecutionReadyState) {
@@ -209,10 +209,8 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     markInboundDedupeReplayUnsafe();
                     // Buffered commentary preceded this tool; land it before the summary.
                     await flushPendingCommentaryProgress();
-                    // When the operator opts into messages.suppressToolErrors, never
-                    // surface tool-error tool-result payloads as channel progress,
-                    // regardless of source delivery mode. payloads.ts already drops
-                    // the warning text; this drops the visible progress delivery too.
+                    // Tool-error suppression covers visible progress as well as warning text,
+                    // regardless of source delivery mode.
                     if (
                       payload.isError === true &&
                       replyConfig.messages?.suppressToolErrors === true
@@ -332,15 +330,13 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     if (shouldRouteToOriginating) {
                       await sendPayloadAsync(deliveryPayload, undefined, false);
                     } else {
-                      markInboundDedupeReplayUnsafe();
-                      const delivered = state.turnLedger.sendQueued("tool", deliveryPayload).queued;
-                      if (delivered && hasAskUserPayload(deliveryPayload)) {
-                        // ask_user blocks until this callback resolves; drain its prompt now
-                        // or the answerable UI can remain queued behind the blocked agent run.
-                        await waitForReplyDispatcherIdle(
+                      const delivery = state.turnLedger.sendQueued("tool", deliveryPayload);
+                      if (hasAskUserPayload(deliveryPayload)) {
+                        await requireQueuedReplyDelivery({
+                          delivery,
                           dispatcher,
-                          getDispatchAbortOperation()?.abortSignal,
-                        );
+                          abortSignal: getDispatchAbortOperation()?.abortSignal,
+                        });
                       }
                     }
                   };

--- a/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
@@ -11,6 +11,7 @@ import {
 } from "../reply-payload.js";
 import { resolveRoutedPolicyConversationType } from "./dispatch-from-config.context.js";
 import type { GatherDispatchRequestReadyState } from "./dispatch-from-config.gather.js";
+import { hasAskUserPayload } from "./dispatch-from-config.payloads.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import {
   loadReplyMediaPathsRuntime,
@@ -211,6 +212,9 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     });
     if (result && !result.ok) {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
+    }
+    if (hasAskUserPayload(payload) && !effectiveAbortSignal?.aborted && !result?.delivered) {
+      throw new Error("ask_user prompt delivery failed");
     }
     return result;
   };

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -26,6 +26,7 @@ import {
   globalBeforeAll0,
   describe0BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { buildTestCtx } from "./test-ctx.js";
 
@@ -425,6 +426,110 @@ describe("dispatchReplyFromConfig", () => {
         .mocked(dispatcher.waitForIdle)
         .mock.invocationCallOrder.some((order) => order > toolDeliveryOrder),
     ).toBe(true);
+  });
+
+  it.each([
+    ["cancelled", "cancelled", true],
+    ["failed before transport", "failed-before-deliver", true],
+    ["delivered", "delivered", false],
+    ["failed during transport", "failed-deliver", false],
+  ] as const)(
+    "settles ask_user delivery when the prompt is %s",
+    async (_name, outcome, rejects) => {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      const deliver = vi.fn(async (_payload: ReplyPayload, info: { kind: string }) => {
+        if (outcome === "failed-deliver" && info.kind === "tool") {
+          throw new Error("transport failure");
+        }
+      });
+      const dispatcher = createReplyDispatcher({
+        deliver,
+        beforeDeliver: async (candidate, info) => {
+          if (info.kind !== "tool") {
+            return candidate;
+          }
+          if (outcome === "cancelled") {
+            return null;
+          }
+          if (outcome === "failed-before-deliver") {
+            throw new Error("before-delivery failure");
+          }
+          return candidate;
+        },
+      });
+      const payload = {
+        text: "Question for you: Where should this deploy?",
+        channelData: { askUser: { questionId: "question-not-delivered" } },
+      } satisfies ReplyPayload;
+
+      const dispatch = dispatchReplyFromConfig({
+        ctx: buildTestCtx({ Provider: "telegram", ChatType: "direct" }),
+        cfg: emptyConfig,
+        dispatcher,
+        replyResolver: async (_ctx, opts) => {
+          await requireToolResultHandler(opts?.onToolResult)(payload);
+          return { text: "done" };
+        },
+      });
+
+      if (rejects) {
+        await expect(dispatch).rejects.toThrow();
+      } else {
+        await expect(dispatch).resolves.toMatchObject({ queuedFinal: true });
+      }
+    },
+  );
+
+  it("rejects ask_user prompts not delivered to the originating channel", async () => {
+    setNoAbort();
+    installThreadingTestPlugin({ id: "telegram" });
+    mocks.routeReply.mockResolvedValue({ ok: false, delivered: false, error: "not delivered" });
+    const payload = {
+      text: "Question for you: Where should this deploy?",
+      channelData: { askUser: { questionId: "question-not-routed" } },
+    } satisfies ReplyPayload;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+    });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await requireToolResultHandler(opts?.onToolResult)(payload);
+      return undefined;
+    };
+
+    await expect(
+      dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects ask_user prompts declined by the dispatcher", async () => {
+    setNoAbort();
+    const payload = {
+      text: "Question for you: Where should this deploy?",
+      channelData: { askUser: { questionId: "question-not-admitted" } },
+    } satisfies ReplyPayload;
+    const dispatcher = createDispatcher();
+    vi.mocked(dispatcher.sendToolResult).mockReturnValue(false);
+    const ctx = buildTestCtx({ Provider: "telegram", ChatType: "direct" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await requireToolResultHandler(opts?.onToolResult)(payload);
+      return undefined;
+    };
+
+    await expect(
+      dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver }),
+    ).rejects.toThrow();
   });
 
   it("delivers approval-unavailable notices when verbose tool progress is disabled", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -5,9 +5,12 @@
 // no-visible-reply fallback gate with a fresh inference flag.
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "../reply-payload.js";
+import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
 import {
   captureReplyDispatchDeliveryOutcome,
+  isReplyDispatchProvenInvisible,
   type ReplyDispatchDeliveryOutcome,
+  waitForReplyDispatcherIdle,
 } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 
@@ -39,6 +42,27 @@ type ReplyTurnLedger = {
    * treats them conservatively as visible: silence over a double-send. */
   hasForeignQueuedAdmissions: () => boolean;
 };
+
+export async function requireQueuedReplyDelivery(params: {
+  delivery: LedgerQueuedSend;
+  dispatcher: Pick<ReplyDispatcher, "waitForIdle">;
+  abortSignal: AbortSignal | undefined;
+}): Promise<void> {
+  if (!params.delivery.queued) {
+    throw new Error("queued reply delivery failed");
+  }
+  const outcome = params.delivery.outcome;
+  // Core dispatchers expose the payload's exact settlement. Custom dispatchers
+  // expose only an idle barrier, which preserves their existing admission contract.
+  if (!outcome) {
+    await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+    return;
+  }
+  const settledOutcome = await runWithDispatchAbortSignal(params.abortSignal, () => outcome);
+  if (isReplyDispatchProvenInvisible(settledOutcome)) {
+    throw new Error("queued reply delivery failed");
+  }
+}
 
 export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLedger {
   let visibleDeliveries = 0;
@@ -80,7 +104,7 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
           // chunked sends may already have shown partial content, so only
           // outcomes that never reached the transport ("cancelled",
           // "failed-before-deliver") count as proven-invisible.
-          if (contentful && outcome !== "cancelled" && outcome !== "failed-before-deliver") {
+          if (contentful && !isReplyDispatchProvenInvisible(outcome)) {
             visibleDeliveries += 1;
           }
         }),

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -58,6 +58,10 @@ export type ReplyDispatchDeliveryOutcome =
   | "failed-before-deliver"
   | "failed-deliver";
 
+export function isReplyDispatchProvenInvisible(outcome: ReplyDispatchDeliveryOutcome): boolean {
+  return outcome === "cancelled" || outcome === "failed-before-deliver";
+}
+
 function isRetryableNoSendFailure(error: unknown): boolean {
   return (
     isProvenDeliveryNotSentError(error) &&
@@ -624,10 +628,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         }
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
         deliveryOutcome = await deliverOnce(normalized, dispatchInfo);
-        if (
-          deliveryFallback &&
-          (deliveryOutcome === "cancelled" || deliveryOutcome === "failed-before-deliver")
-        ) {
+        if (deliveryFallback && isReplyDispatchProvenInvisible(deliveryOutcome)) {
           deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo);
         }
         if (deliveryOutcome === "cancelled") {


### PR DESCRIPTION
Closes #123915

## What Problem This Solves

Fixes an issue where an `ask_user` prompt could be marked answerable even though its channel delivery was cancelled or failed before transport. The next unrelated inbound message could then be consumed as the missing answer.

## Why This Change Was Made

The tool callback treated dispatcher idleness as delivery success and discarded the existing per-payload settlement outcome. The queued-delivery owner now requires the exact outcome for tracked dispatchers and rejects only outcomes proven invisible; routed delivery applies the same invariant at its result owner. Ambiguous failures after transport begins remain accepted because the prompt may already be visible.

No provider-specific path, retry, compatibility shim, or fallback was added. Production delta: +25 lines; regression/test delta: +105 lines. The production growth is the generic exact-settlement and abort contract shared by the owner boundary; the call site is net negative.

## User Impact

Invisible questions no longer remain armed to capture a later message. Visible and possibly partially delivered questions keep their existing answer flow.

## Evidence

- Pre-fix owner-boundary reproduction: the real reply dispatcher resolved both `cancelled` and `failed-before-deliver` cases; 2 table cases failed because rejection was expected.
- Regression table covers `cancelled`, `failed-before-deliver`, `delivered`, and ambiguous `failed-deliver`; routed non-delivery and queue-admission rejection have sibling coverage.
- `git diff --check`
- Oxfmt check on all 5 touched files
- Oxlint with `config/tsconfig/oxlint.core.json` on all 5 touched files
- `pnpm tsgo:core`
- `pnpm check:test-types`
- Focused grouped Vitest run: 9 files, 453 tests passed
- `$distill`: zero findings
- `$greybeard`: zero findings
- Exact-head CI gate: passed
- Exact-head Telegram real-user DM (`ba7edcdbdcc16c12b037f61bdc55f189a80e0956`):
  - Normal delivery showed the release-channel question; the delayed user reply `Stable` resolved as `status: answered`, then Telegram received `ASK_USER_E2E_FINISHED`.
  - A live `reply_payload_sending` hook cancelled only the `ask_user` payload. Telegram recorded no question event; the bridge received `ask_user prompt delivery failed | queued reply delivery failed`; the model resumed and Telegram received the single visible final message `ASK_USER_E2E_FINISHED`.
  - Side effects: normal run recorded typing plus final-message/progress edits; cancelled run recorded one SUT message, no edit, deletion, reaction, or stray question.
- Exact-head ClawSweeper rerun after live evidence: passed with a correct patch, 0 findings, 0 security concerns, no maintainer decision, and 0 Rank-up moves.
