### PR TITLE
fix(cli): migrate apply refusal suggests a valid preview command

### DIFF
--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -330,7 +330,7 @@ describe("migrateApplyCommand", () => {
 
   it("requires --yes in non-interactive apply mode", async () => {
     await expect(migrateApplyCommand(runtime, { provider: "hermes" })).rejects.toThrow(
-      "requires --yes in non-interactive mode. Preview first with openclaw migrate plan hermes.",
+      "requires --yes in non-interactive mode. Preview first with openclaw migrate plan 'hermes'.",
     );
     expect(mocks.provider.plan).not.toHaveBeenCalled();
   });

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -330,7 +330,7 @@ describe("migrateApplyCommand", () => {
 
   it("requires --yes in non-interactive apply mode", async () => {
     await expect(migrateApplyCommand(runtime, { provider: "hermes" })).rejects.toThrow(
-      "requires --yes",
+      "requires --yes in non-interactive mode. Preview first with openclaw migrate plan hermes.",
     );
     expect(mocks.provider.plan).not.toHaveBeenCalled();
   });

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -415,7 +415,7 @@ export async function migrateApplyCommand(
   }
   if (!opts.yes && !process.stdin.isTTY) {
     throw new Error(
-      `openclaw migrate apply requires --yes in non-interactive mode. Preview first with ${formatCliCommand("openclaw migrate plan --provider <provider>")}.`,
+      `openclaw migrate apply requires --yes in non-interactive mode. Preview first with ${formatCliCommand(`openclaw migrate plan ${providerId}`)}.`,
     );
   }
   const provider = resolveMigrationProvider(providerId, opts.configOverride);

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -415,7 +415,7 @@ export async function migrateApplyCommand(
   }
   if (!opts.yes && !process.stdin.isTTY) {
     throw new Error(
-      `openclaw migrate apply requires --yes in non-interactive mode. Preview first with ${formatCliCommand(`openclaw migrate plan ${providerId}`)}.`,
+      `openclaw migrate apply requires --yes in non-interactive mode. Preview first with ${formatCliCommand(`openclaw migrate plan '${providerId.replaceAll("'", "'\\''")}'`)}.`,
     );
   }
   const provider = resolveMigrationProvider(providerId, opts.configOverride);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw migrate apply <provider>` without `--yes` in a non-interactive shell were told to preview with `openclaw migrate plan --provider <provider>`. The CLI does not accept that flag, so the recovery command failed instead of showing the selected provider's plan.

## Why This Change Was Made

The refusal now preserves the selected provider as one shell-safe positional argument in the documented `openclaw migrate plan <provider>` form, then applies the existing command formatter. The regression assertion covers the complete executable guidance. No migration, config, backup, storage, or schema behavior changes; the CLI and migration docs already document the positional contract.

## User Impact

Operators who omit `--yes` in automation now receive a preview command they can copy and run successfully, including when a plugin-owned provider ID contains shell-sensitive characters.

## Evidence

- Built CLI before the fix: `migrate apply hermes --json` exited 1 with zero stdout and recommended `migrate plan --provider <provider>`; substituting `hermes` exited 1 with `OpenClaw does not recognize option "--provider"`.
- Built CLI after the fix: the refusal exited 1 with zero stdout and recommended exactly `openclaw migrate plan 'hermes'`; that exact quoted command exited 0. The JSON form exited 0 with one parseable JSON document, and the isolated state/config paths remained absent.
- Hostile-provider copy/paste probe: a provider ID containing a quote, semicolon, `touch` command, and comment marker remained one quoted argument. Executing the extracted guidance failed only as an unknown provider; the sentinel and state/config paths remained absent.
- Source-blind independent behavior validation: 5/5 clauses passed on Blacksmith Testbox `tbx_01m02dz5apfaews54en0yk6kxn` (`coral-prawn-91ca`).
- Focused migration suite: 92 tests passed (44 unit-fast, 1 CLI, 47 command tests).
- `pnpm build` passed on the corrected built CLI.
- `pnpm check:changed` passed, covering changed-file format/lint, core production and test types, database-first guard, native schema guard, and import cycles.
- `pnpm db:kysely:check`, `pnpm lint:kysely`, `pnpm sqlite:sessions-schema:check`, and `pnpm config:schema:check` passed.
- Fresh Codex autoreview after the quoting refinement: clean, no accepted/actionable findings.
- Initial exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31879593404; the final head reruns the same required matrix.
- Testbox hydration/run: https://github.com/openclaw/openclaw/actions/runs/31878526650
