### PR TITLE
fix(ui): prevent queued double-clicks from removing the next message

### DIFF
--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -1,5 +1,12 @@
 import { expect, it } from "vitest";
-import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import {
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+  requireRecord,
+  requireString,
+  waitForRequests,
+} from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -112,6 +119,227 @@ suite.define(() => {
         })
         .toEqual([...QUEUED]);
       expect(await composer.inputValue()).toBe("");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps edit, remove, and reorder outcomes exact through reconnect", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.history": {
+          messages: [],
+          sessionId: "control-ui-e2e-session",
+          sessionInfo: { hasActiveRun: false, status: "done" },
+          thinkingLevel: null,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await page.locator("[data-settings-follow-up-mode]").selectOption("queue");
+      await page.goto(`${suite.server.baseUrl}chat?session=main`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 15_000 });
+      await composer.fill("keep the first run active");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const active = requireRecord((await gateway.waitForRequest("chat.send")).params);
+      const activeRunId = requireString(active.idempotencyKey, "active run idempotency key");
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+
+      for (const message of ["send first", "edit before send", "remove me", "send last"]) {
+        await composer.fill(message);
+        await page.getByRole("button", { name: "Queue message" }).click();
+        await page.locator(".chat-queue__item", { hasText: message }).waitFor({ timeout: 10_000 });
+      }
+      await gateway.setOnline(false);
+      await gateway.closeLatest();
+      await page.locator(".agent-chat__offline-hint").waitFor({ timeout: 10_000 });
+
+      await page.locator(".chat-queue__item", { hasText: "edit before send" }).dblclick();
+      await expect.poll(() => composer.inputValue()).toBe("edit before send");
+      await composer.fill("edited before send");
+      await composer.press("Enter");
+      await page.locator(".chat-queue__item", { hasText: "edited before send" }).waitFor();
+
+      const lastGrip = page
+        .locator(".chat-queue__item", { hasText: "send last" })
+        .locator(".chat-queue__grip");
+      await lastGrip.focus();
+      for (const expected of [
+        ["send first", "edited before send", "send last", "remove me"],
+        ["send first", "send last", "edited before send", "remove me"],
+        ["send last", "send first", "edited before send", "remove me"],
+      ]) {
+        await page.keyboard.press("ArrowUp");
+        await expect
+          .poll(() => page.locator(".chat-queue__item .chat-queue__text").allTextContents())
+          .toEqual(expected);
+      }
+
+      const row = page.locator(".chat-queue__item", {
+        hasText: "remove me",
+      });
+
+      await page.evaluate(() => {
+        const descriptor = Object.getOwnPropertyDescriptor(Storage.prototype, "setItem");
+        if (!descriptor || typeof descriptor.value !== "function") {
+          throw new Error("Storage.setItem is unavailable");
+        }
+        const original = descriptor.value as (this: Storage, key: string, value: string) => void;
+        Object.defineProperty(window, "restoreQueueStorage", {
+          configurable: true,
+          value: () => {
+            Object.defineProperty(Storage.prototype, "setItem", descriptor);
+            delete (window as Window & { restoreQueueStorage?: () => void }).restoreQueueStorage;
+          },
+        });
+        Object.defineProperty(Storage.prototype, "setItem", {
+          ...descriptor,
+          value(this: Storage, ...args: [string, string]) {
+            if (this === window.sessionStorage) {
+              throw new DOMException("exceeded the quota", "QuotaExceededError");
+            }
+            return Reflect.apply(original, this, args);
+          },
+        });
+      });
+      await row.locator(".chat-queue__remove").click();
+
+      await page
+        .getByRole("alert")
+        .getByText("Could not store this message for reconnect.", { exact: false })
+        .waitFor({ timeout: 10_000 });
+      await row.waitFor();
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.waitForTimeout(100);
+        await page.screenshot({ path: `${artifactDir}/01-remove-rejected.png`, fullPage: true });
+      }
+
+      await page.evaluate(() => {
+        (window as Window & { restoreQueueStorage?: () => void }).restoreQueueStorage?.();
+      });
+      await page.evaluate(() => {
+        const trace: Array<{ detail: number; rowText?: string }> = [];
+        Object.defineProperty(window, "queueRemovalEventTrace", {
+          configurable: true,
+          value: trace,
+        });
+        document.addEventListener(
+          "click",
+          (event) => {
+            const target = event.target instanceof Element ? event.target : null;
+            trace.push({
+              detail: (event as MouseEvent).detail,
+              rowText: target?.closest(".chat-queue__item")?.querySelector(".chat-queue__text")
+                ?.textContent,
+            });
+          },
+          { capture: true },
+        );
+      });
+      await row.locator(".chat-queue__remove").dblclick();
+      expect(
+        await page.evaluate(
+          () =>
+            (
+              window as Window & {
+                queueRemovalEventTrace?: Array<{ detail: number; rowText?: string }>;
+              }
+            ).queueRemovalEventTrace,
+        ),
+      ).toEqual([
+        { detail: 1, rowText: "remove me" },
+        { detail: 2, rowText: "edited before send" },
+      ]);
+      await row.waitFor({ state: "detached", timeout: 10_000 });
+      await page.getByRole("alert").waitFor({ state: "detached", timeout: 10_000 });
+      await expect
+        .poll(() => page.locator(".chat-queue__item .chat-queue__text").allTextContents())
+        .toEqual(["send last", "send first", "edited before send"]);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+
+      const queueDisposable = async (text: string) => {
+        await composer.fill(text);
+        await composer.press("Enter");
+        const disposable = page.locator(".chat-queue__item", { hasText: text });
+        await disposable.waitFor({ timeout: 10_000 });
+        return disposable;
+      };
+      const singleClickRow = await queueDisposable("single-click removal");
+      await singleClickRow.locator(".chat-queue__remove").click();
+      await singleClickRow.waitFor({ state: "detached", timeout: 10_000 });
+      const keyboardRow = await queueDisposable("keyboard removal");
+      await keyboardRow.locator(".chat-queue__remove").focus();
+      await page.keyboard.press("Enter");
+      await keyboardRow.waitFor({ state: "detached", timeout: 10_000 });
+      const programmaticRow = await queueDisposable("programmatic removal");
+      await programmaticRow
+        .locator(".chat-queue__remove")
+        .evaluate((button: HTMLElement) => button.click());
+      await programmaticRow.waitFor({ state: "detached", timeout: 10_000 });
+      await page.getByRole("alert").waitFor({ state: "detached", timeout: 10_000 });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/02-duplicate-noop.png`, fullPage: true });
+      }
+
+      await gateway.deferNext("chat.send");
+      await gateway.setOnline(true);
+      await page
+        .locator(".agent-chat__offline-hint")
+        .waitFor({ state: "detached", timeout: 10_000 });
+      await gateway.emitChatFinal({ runId: activeRunId, text: "Initial run completed." });
+      await gateway.emitGatewayEvent("sessions.changed", {
+        activeRunIds: [],
+        agentId: "main",
+        hasActiveRun: false,
+        key: "global",
+        status: "done",
+      });
+
+      const first = requireRecord((await waitForRequests(gateway, "chat.send", 2))[1]?.params);
+      expect(first.message).toBe("send last");
+      const firstRunId = requireString(first.idempotencyKey, "first queued send idempotency key");
+      await gateway.resolveDeferred("chat.send", { runId: firstRunId, status: "started" });
+      await gateway.emitChatFinal({ runId: firstRunId, text: "First queued turn completed." });
+
+      const second = requireRecord((await waitForRequests(gateway, "chat.send", 3))[2]?.params);
+      const secondRunId = requireString(
+        second.idempotencyKey,
+        "second queued send idempotency key",
+      );
+      await gateway.emitChatFinal({ runId: secondRunId, text: "Second queued turn completed." });
+
+      const sends = await waitForRequests(gateway, "chat.send", 4);
+      const third = requireRecord(sends[3]?.params);
+      const thirdRunId = requireString(third.idempotencyKey, "third queued send idempotency key");
+      await gateway.emitChatFinal({ runId: thirdRunId, text: "Third queued turn completed." });
+      const params = sends.map((request) => requireRecord(request.params));
+      expect(params.map((entry) => entry.message)).toEqual([
+        "keep the first run active",
+        "send last",
+        "send first",
+        "edited before send",
+      ]);
+      expect(new Set(params.map((entry) => entry.idempotencyKey)).size).toBe(4);
+      await expectRequestCountStable(gateway, "chat.send", 4);
+      await page.locator(".chat-queue").waitFor({ state: "detached", timeout: 10_000 });
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/03-exact-drain.png`, fullPage: true });
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -361,10 +361,12 @@ export function excludeComposerAttachments(
 }
 
 export function removeQueuedMessage(host: ChatQueueScopedSessionHost, id: string) {
-  const removed = removeQueuedMessageWithoutReleasing(host, id);
+  const item = readQueuedMessageById(host, id);
+  const removed = item ? removeQueuedMessageWithoutReleasing(host, id) : null;
   if (removed) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
   }
+  return removed ? ("removed" as const) : item ? ("rejected" as const) : ("absent" as const);
 }
 
 export function removeDeliveredQueuedChatSendForRun(

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -9380,7 +9380,7 @@ describe("handleSendChat", () => {
     ]);
   });
 
-  it("releases queued attachment payloads when the queued item is removed", () => {
+  it("releases queued attachment payloads once across duplicate removal", () => {
     const revokeObjectURL = vi.fn();
     vi.stubGlobal(
       "URL",
@@ -9401,12 +9401,16 @@ describe("handleSendChat", () => {
       file,
     });
     const host = makeChatHost({
-      chatQueue: [{ id: "queued", text: "later", createdAt: 1, attachments: [attachment] }],
+      chatQueue: [
+        { id: "queued", text: "later", createdAt: 1, attachments: [attachment] },
+        { id: "sibling", text: "keep me", createdAt: 2 },
+      ],
     });
 
-    removeQueuedMessage(host, "queued");
+    expect(removeQueuedMessage(host, "queued")).toBe("removed");
+    expect(removeQueuedMessage(host, "queued")).toBe("absent");
 
-    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatQueue).toEqual([expect.objectContaining({ id: "sibling" })]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
   });

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -52,6 +52,7 @@ import {
   normalizeSidebarLayout,
   openSlot,
 } from "./sidebar-layout.ts";
+import { OFFLINE_QUEUE_STORAGE_ERROR } from "./steer-lifecycle.ts";
 import { resetToolStream } from "./tool-stream.ts";
 
 type ChatPageElement = {
@@ -309,8 +310,13 @@ export function createPageState(
     renderLifecycle.invalidate();
   };
   state.removeQueuedMessage = (id) => {
-    removeQueuedMessage(state, id);
-    void resumeStoredChatOutboxes(state);
+    const outcome = removeQueuedMessage(state, id);
+    if (outcome === "removed") {
+      setChatError(state, null);
+      void resumeStoredChatOutboxes(state);
+    } else if (outcome === "rejected") {
+      setChatError(state, OFFLINE_QUEUE_STORAGE_ERROR);
+    }
     renderLifecycle.invalidate();
   };
   state.retryQueuedChatMessage = async (id) => {

--- a/ui/src/pages/chat/components/chat-composer-queue.ts
+++ b/ui/src/pages/chat/components/chat-composer-queue.ts
@@ -267,7 +267,13 @@ function renderChatQueueItem(
                   type="button"
                   ?disabled=${editing}
                   aria-label=${t("chat.queue.removeQueuedMessage")}
-                  @click=${() => props.onQueueRemove(item.id)}
+                  @click=${(event: MouseEvent) => {
+                    // Chromium retargets click 2 after row removal; detail still owns the gesture.
+                    if (event.detail <= 1) {
+                      props.onQueueRemove(item.id);
+                    }
+                  }}
+                  @dblclick=${(event: MouseEvent) => event.stopPropagation()}
                 >
                   ${icons.x}
                 </button>


### PR DESCRIPTION
Related: #121667 (context only; this PR does not close the broader queue UX work)

## What Problem This Solves

Fixes an issue where removing a queued Control UI message could wake delivery after the removal had actually failed, while a native Chromium double-click could retarget its second click onto the row that shifted underneath and remove that sibling too.

## Why This Change Was Made

The queue removal owner now returns one closed result: `removed`, `absent`, or `rejected`. Only `removed` releases attachment payloads and resumes the outbox; `absent` is a harmless stale no-op; `rejected` retains the durable row and shows the existing browser-storage recovery guidance. The remove button accepts native single clicks plus keyboard/programmatic activation, but ignores Chromium's retargeted click 2 without adding a timer or broad inert state.

The architectural owner remains the existing Control UI queue/session-storage boundary. This does not change delivery, replay, retry, idempotency, protocol, configuration, security, or persistence formats.

Production LOC: +18/-4 (net +14) | Tests: +237/-5 (net +232). The positive production delta is the explicit owner result and gesture-boundary guard; it replaces an ambiguous void outcome without adding a parallel path.

No changelog or docs change: this restores the existing remove/recovery contract and introduces no new user-facing control or configuration surface.

## User Impact

Operators can remove queued messages without risking the adjacent row. A storage failure leaves the message recoverable and explains what to do; duplicate stale activation remains silent. Immediate single-click, keyboard, and programmatic removal still work.

## Evidence

- 323 focused Control UI owner/sibling tests passed across four files.
- 3 real Chromium mocked-Gateway E2Es passed.
- Rejected durable removal retained the row, showed recovery guidance, and did not drain.
- Native double-click emitted detail 1 for the intended row and retargeted detail 2 to the shifted sibling; only the intended row was removed.
- Immediate next-row single click, keyboard activation, and programmatic activation each remained functional.
- Edit/reorder/remove/reconnect dispatched exactly `send last`, `send first`, and `edited before send` once each, with unique idempotency keys and no removed or duplicate send.
- Source-blind behavior contract: 4/4 clauses passed; 3/3 anti-cheat probes passed.
- Changed gate passed via the documented local fallback after no remote `ci-fast` provider was ready: format, Control UI i18n, changed-file oxlint/stylelint, core-test types, UI types, and repository guards were clean.
- Both import-cycle checks reported zero cycles; `git diff --check` passed.
- Fresh autoreview: no accepted/actionable findings; patch correct, confidence 0.99.
- Exact-head CI is green, including all Control UI, real-Gateway UI E2E, build, lint, and type lanes: https://github.com/openclaw/openclaw/actions/runs/31879889614

### Rejected removal retains the row and shows recovery

![Rejected queued-message removal](https://github.com/user-attachments/assets/12485493-5756-45f8-a9b9-b2c1d3f477b0)

### Duplicate/retargeted click is a no-op for the shifted sibling

![Duplicate queued-message removal is harmless](https://github.com/user-attachments/assets/61523370-fa2d-495c-a522-8967002f32cc)

### Surviving queue drains exactly once

![Exact queued-message drain](https://github.com/user-attachments/assets/4840433c-f1f2-4e24-a715-77b580e83ae5)

### Chromium flow recording

https://github.com/user-attachments/assets/7c4e3877-9458-48d6-b809-275a35f0b0fa
