### PR TITLE
fix(macos): canceled node worker invokes no longer hang

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -182,6 +182,9 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                     ])
                     for control in self.takePendingInvokeControlsLocked(invokeId: request.id) {
                         try self.enqueueInvokeControlLocked(control, invokeId: request.id)
+                        if case .cancel = control {
+                            self.finishCancelledInvokeLocked(invokeId: request.id)
+                        }
                     }
                 } catch {
                     self.invokeContinuations.removeValue(forKey: request.id)?.resume(returning:
@@ -211,6 +214,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 let control = PendingInvokeControl.cancel
                 if self.invokeContinuations[invokeId] != nil {
                     try? self.enqueueInvokeControlLocked(control, invokeId: invokeId)
+                    self.finishCancelledInvokeLocked(invokeId: invokeId)
                 } else if self.process?.isRunning == true, self.manifest != nil {
                     self.bufferInvokeControlLocked(control, invokeId: invokeId)
                 }
@@ -266,6 +270,11 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 "invokeId": invokeId,
             ])
         }
+    }
+
+    private func finishCancelledInvokeLocked(invokeId: String) {
+        self.invokeContinuations.removeValue(forKey: invokeId)?.resume(returning:
+            Self.unavailableResponse(invokeId, "UNAVAILABLE: node-host worker invocation cancelled"))
     }
 
     func setRoute(_ route: GatewayNodeSessionRoute?, authorityGeneration: UInt64) async -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -398,33 +398,65 @@ struct MacNodeHostWorkerTests {
         }
     }
 
-    @Test func `worker forwards terminal input and cancellation frames`() async throws {
+    @Test func `worker cancellation settles when the child suppresses its result`() async throws {
         let worker = MacNodeHostWorker(session: GatewayNodeSession())
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-worker-cancel-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: marker) }
         let script = """
         printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":["terminal"],"commands":["codex.terminal.resume.v1"],"pathEnv":"/usr/bin:/bin"},"inventory":{"skills":null,"pluginTools":[]}}'
-        IFS= read -r invoke
+        IFS= read -r buffered_invoke
         IFS= read -r input
-        IFS= read -r cancel
-        printf '%s' "$invoke" | grep -q '"id":"terminal-1"' || exit 40
+        IFS= read -r buffered_cancel
+        printf '%s' "$buffered_invoke" | grep -q '"id":"terminal-1"' || exit 40
         printf '%s' "$input" | grep -q '"type":"invoke-input"' || exit 41
         printf '%s' "$input" | grep -q '"invokeId":"terminal-1"' || exit 42
         printf '%s' "$input" | grep -q '"seq":7' || exit 43
-        printf '%s' "$cancel" | grep -q '"type":"invoke-cancel"' || exit 44
-        printf '%s' "$cancel" | grep -q '"invokeId":"terminal-1"' || exit 45
-        printf '%s\\n' '{"type":"invoke-result","result":{"id":"terminal-1","ok":true}}'
+        printf '%s' "$buffered_cancel" | grep -q '"type":"invoke-cancel"' || exit 44
+        printf '%s' "$buffered_cancel" | grep -q '"invokeId":"terminal-1"' || exit 45
+        IFS= read -r active_invoke
+        printf '%s' "$active_invoke" | grep -q '"id":"terminal-2"' || exit 46
+        printf '%s\\n' "$$" > "$1"
+        IFS= read -r active_cancel
+        printf '%s' "$active_cancel" | grep -q '"type":"invoke-cancel"' || exit 47
+        printf '%s' "$active_cancel" | grep -q '"invokeId":"terminal-2"' || exit 48
         while IFS= read -r line; do :; done
         """
 
         _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
-            command: ["/bin/sh", "-c", script]))
+            command: ["/bin/sh", "-c", script, "worker", marker.path]))
         await worker.handleInput(invokeId: "terminal-1", seq: 7, payloadJSON: #"{"data":"x"}"#)
         await worker.cancel(invokeId: "terminal-1")
-        let response = await worker.invoke(BridgeInvokeRequest(
-            id: "terminal-1",
-            command: "codex.terminal.resume.v1"))
+        do {
+            let buffered = try await AsyncTimeout.withTimeout(
+                seconds: 1,
+                onTimeout: { WorkerBackpressureTimeout() },
+                operation: {
+                    await worker.invoke(BridgeInvokeRequest(
+                        id: "terminal-1",
+                        command: "codex.terminal.resume.v1"))
+                })
+            #expect(!buffered.ok)
+            #expect(buffered.error?.message == "UNAVAILABLE: node-host worker invocation cancelled")
 
-        #expect(response.ok)
-        await worker.stop()
+            let invoking = Task {
+                await worker.invoke(BridgeInvokeRequest(
+                    id: "terminal-2",
+                    command: "codex.terminal.resume.v1"))
+            }
+            _ = try await TestProcessSupport.waitForPID(in: marker)
+            await worker.cancel(invokeId: "terminal-2")
+            let active = try await AsyncTimeout.withTimeout(
+                seconds: 1,
+                onTimeout: { WorkerBackpressureTimeout() },
+                operation: { await invoking.value })
+            await worker.stop()
+            #expect(!active.ok)
+            #expect(active.error?.message == "UNAVAILABLE: node-host worker invocation cancelled")
+        } catch {
+            await worker.stop()
+            throw error
+        }
     }
 
     @Test func `ready worker exit notifies its route owner`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canceling an app-owned macOS node-host invocation could leave the Gateway request suspended indefinitely. The TypeScript worker intentionally suppresses invocation results after cancellation, but the native worker previously kept waiting for that suppressed result.

## Why This Change Was Made

Buffered and active cancellation now consume and settle the invocation's existing Swift continuation with a bounded unavailable response after preserving the existing invoke/input/cancel frame order. The serial worker queue and single continuation map remain the exact-once owner, so a late child result finds no continuation and cannot resume it again.

Gateway route, placement, session, device, and build authority are unchanged. The app-worker JSONL wire protocol, config, persistence, replay, and security boundaries are also unchanged. This is compatible with the node-tunnel readiness repair already landed in #124109.

## User Impact

Canceled macOS node-host terminal and other worker invocations now finish promptly instead of hanging, and the same worker remains usable for subsequent invocations.

## Evidence

- Pre-fix negative control: the 23-test worker suite produced exactly one failure, with `worker cancellation settles when the child suppresses its result` timing out as `WorkerBackpressureTimeout`; the other 22 tests passed.
- Exact-tree native suites: 23 `MacNodeHostWorkerTests`, 37 `MacNodeModeCoordinatorTests`, and 75 `GatewayNodeSessionTests` passed.
- TypeScript sibling proof: 26 tests passed across `src/node-host/invoke.test.ts` and `src/node-host/runtime.worker-supervisor.test.ts`, covering canceled-result suppression, replacement ownership, reconnect, and terminal cleanup.
- Supplemental same-process probe passed after sending a late result for the canceled invocation and then completing a healthy third invocation; the committed test was restored byte-for-byte afterward.
- Isolated Gateway/node-worker E2E passed pairing, route reconnect/replacement, launch/status/terminal flow, workspace transfer/reconciliation, active placement continuity, one visible assistant result, and cleanup on Testbox run https://github.com/openclaw/openclaw/actions/runs/31879240862.
- Changed gate passed formatting, static guards, production/test types, lint, macOS CI tests, schema/storage boundaries, and runtime import-cycle checks on Testbox run https://github.com/openclaw/openclaw/actions/runs/31879633565.
- Exact release build passed: `swift build --package-path apps/macos --product OpenClaw --configuration release`.
- SwiftFormat, strict SwiftLint, native schema-version guard, `git diff --check`, runtime cycle check, and Madge cycle check passed.
- Fresh autoreview passed with no accepted/actionable findings.

Root cause provenance: #107361 added buffered input/cancel forwarding but left Swift settlement dependent on a child result. #115033 later correctly suppressed canceled result/progress/event publication, exposing that cross-boundary mismatch.

Production LOC: +9/-0. Tests: +46/-14 (net +32). The production growth is the missing exact-once settlement at the existing native continuation owner; no parallel map, tombstone, retry, fallback, or downstream guard was added.

No changelog entry: `CHANGELOG.md` is release-owned. No docs update: the wire and user-facing configuration contracts are unchanged. AI-assisted; I reviewed the lifecycle, authority, and exact-once boundaries.
