### PR TITLE
fix(build): prevent CLI metadata timeout under disk contention

### DIFF
--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -9,7 +9,7 @@ import fs, {
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { availableParallelism, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
@@ -42,10 +42,9 @@ const ROOT_HELP_RENDER_TIMEOUT_MS = 120_000;
 const COMMAND_HELP_RENDER_TIMEOUT_MS = 120_000;
 const COMMAND_HELP_RENDER_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const COMMAND_HELP_RENDER_KILL_GRACE_MS = 5_000;
-// Each help render is an isolated CLI boot; concurrency only bounds process
-// fan-out, not output content, so scale with the host instead of serializing
-// eight boots two at a time.
-const COMMAND_HELP_RENDER_CONCURRENCY = Math.min(8, Math.max(2, availableParallelism()));
+// Cold CLI boots compete for the same module graph, so CPU count is not a safe
+// proxy for module-loading throughput on a disk-contended host.
+const COMMAND_HELP_RENDER_CONCURRENCY = 2;
 const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = [
   "doctor",
   "gateway",
@@ -1085,6 +1084,11 @@ async function writeCliStartupMetadata(options?: {
               taskContext,
             ),
       );
+  // Root help traverses the plugin metadata graph too; finish it before command
+  // fan-out so sibling cold boots cannot starve its bounded render.
+  const afterRootHelp = <T>(render: () => Awaitable<T>) => rootHelpTextPromise.then(render);
+  const runSourceRenderer = <T>(render: SourceHelpRenderer<T>) =>
+    afterRootHelp(() => supervisor.run((taskContext) => render(renderContext, taskContext)));
   const hasCustomCommandRenderer =
     options?.renderSourceBrowserHelpText ||
     options?.renderSourceSecretsHelpText ||
@@ -1106,37 +1110,24 @@ async function writeCliStartupMetadata(options?: {
   const commandHelpTextPromise =
     hasCustomCommandRenderer || sourceCommandsToRender.length === 0
       ? null
-      : renderSourceCommandHelpTextRecord(sourceCommandsToRender, renderContext, supervisor);
+      : afterRootHelp(() =>
+          renderSourceCommandHelpTextRecord(sourceCommandsToRender, renderContext, supervisor),
+        );
   const browserHelpTextPromise = reusableBrowserHelpText
     ? Promise.resolve(reusableBrowserHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.browser)
-      : supervisor.run((taskContext) =>
-          (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(
-            renderContext,
-            taskContext,
-          ),
-        );
+      : runSourceRenderer(options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText);
   const secretsHelpTextPromise = reusableSecretsHelpText
     ? Promise.resolve(reusableSecretsHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.secrets)
-      : supervisor.run((taskContext) =>
-          (options?.renderSourceSecretsHelpText ?? renderSourceSecretsHelpText)(
-            renderContext,
-            taskContext,
-          ),
-        );
+      : runSourceRenderer(options?.renderSourceSecretsHelpText ?? renderSourceSecretsHelpText);
   const nodesHelpTextPromise = reusableNodesHelpText
     ? Promise.resolve(reusableNodesHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.nodes)
-      : supervisor.run((taskContext) =>
-          (options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText)(
-            renderContext,
-            taskContext,
-          ),
-        );
+      : runSourceRenderer(options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText);
   const subcommandHelpTextPromise = reusableSubcommandHelpText
     ? Promise.resolve(reusableSubcommandHelpText)
     : commandHelpTextPromise
@@ -1150,10 +1141,8 @@ async function writeCliStartupMetadata(options?: {
             ) as PrecomputedSubcommandHelpText,
         )
       : options?.renderSourceSubcommandHelpTextRecord
-        ? supervisor.run((taskContext) =>
-            options.renderSourceSubcommandHelpTextRecord!(renderContext, taskContext),
-          )
-        : renderSourceSubcommandHelpTextRecord(renderContext, supervisor);
+        ? runSourceRenderer(options.renderSourceSubcommandHelpTextRecord)
+        : afterRootHelp(() => renderSourceSubcommandHelpTextRecord(renderContext, supervisor));
   const [rootHelpText, browserHelpText, secretsHelpText, nodesHelpText, subcommandHelpText] =
     await settleRootHelpRenderPromises(
       [

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -2,7 +2,6 @@
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs, { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { availableParallelism } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -19,7 +18,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 // These subprocess tests use explicit ready/close signals; timeout only catches broken fixtures.
 const LOAD_SENSITIVE_PROCESS_TIMEOUT_MS = process.env.CI ? 30_000 : 15_000;
-const COMMAND_HELP_RENDER_CONCURRENCY = Math.min(8, Math.max(2, availableParallelism()));
+const COMMAND_HELP_RENDER_CONCURRENCY = 2;
 const DEFAULT_COMMAND_HELP_NAMES = [
   "browser",
   "secrets",
@@ -166,6 +165,74 @@ describe("write-cli-startup-metadata", () => {
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
+  });
+
+  it("finishes root help before rendering at most two command snapshots", async () => {
+    const actualSpawn = (
+      await vi.importActual<typeof import("node:child_process")>("node:child_process")
+    ).spawn;
+    const spawnMock = vi.mocked(spawn);
+    const tempRoot = createTempDir("openclaw-startup-metadata-scheduling-");
+    const distDir = path.join(tempRoot, "dist");
+    const extensionsDir = path.join(tempRoot, "extensions");
+    const outputPath = path.join(distDir, "cli-startup-metadata.json");
+    const startedCommands: string[] = [];
+    let activeCommands = 0;
+    let maxActiveCommands = 0;
+    let writePromise: Promise<void> | undefined;
+    let releaseRootHelp = () => {};
+    let reportRootHelpStarted = () => {};
+    const rootHelpStarted = new Promise<void>((resolve) => {
+      reportRootHelpStarted = resolve;
+    });
+    const rootHelpBlocked = new Promise<void>((resolve) => {
+      releaseRootHelp = resolve;
+    });
+
+    writeStartupMetadataSourceSignatureFixture(tempRoot);
+    writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+    spawnMock.mockImplementation((_command, args) => {
+      const commandName = String(args[1]);
+      const child = createSpawnTextChild();
+      startedCommands.push(commandName);
+      activeCommands += 1;
+      maxActiveCommands = Math.max(maxActiveCommands, activeCommands);
+      setImmediate(() => {
+        child.stdout.write(`Usage: openclaw ${commandName}\n`);
+        activeCommands -= 1;
+        child.emit("close", 0, null);
+      });
+      return child as unknown as ReturnType<typeof spawn>;
+    });
+
+    try {
+      writePromise = testing.writeCliStartupMetadata({
+        distDir,
+        outputPath,
+        extensionsDir,
+        sourceRootDir: tempRoot,
+        renderBundledRootHelpText: async () => {
+          reportRootHelpStarted();
+          await rootHelpBlocked;
+          return "Usage: openclaw\n";
+        },
+      });
+
+      await rootHelpStarted;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(startedCommands).toEqual([]);
+
+      releaseRootHelp();
+      await writePromise;
+
+      expect(startedCommands).toEqual(DEFAULT_COMMAND_HELP_NAMES);
+      expect(maxActiveCommands).toBe(COMMAND_HELP_RENDER_CONCURRENCY);
+    } finally {
+      releaseRootHelp();
+      await writePromise?.catch(() => {});
+      spawnMock.mockImplementation(actualSpawn);
+    }
   });
 
   it("fails command help rendering when captured output exceeds the byte limit", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a source package build could finish its main compilation work and then fail while generating CLI startup metadata on a disk-contended host. The generator started root help alongside a wide batch of cold CLI boots, allowing the root renderer to be starved until its existing 120-second safety bound fired.

## Why This Change Was Made

Root help now completes before command-help generation begins, and command renderers use a fixed concurrency of two instead of deriving I/O-heavy fan-out from CPU count. The existing per-child timeout, cancellation supervisor, and descendant process-group drain remain unchanged.

This restores the conservative scheduler that preceded #109628 while retaining its built-launcher rendering and cache improvements.

## User Impact

Source builds remain deterministic and bounded, but are resilient to temporary disk contention during CLI metadata generation. There is no runtime behavior or public API change.

## Evidence

- Pre-fix regression: four command renders started while root help was deliberately blocked; the new ordering assertion failed for the intended reason.
- Focused Testbox proof: all 23 startup-metadata tests pass, including existing timeout and descendant-drain cases.
- Cache-disabled `cliStartup` build: 18.8 seconds total; `write-cli-startup-metadata` completed in 12 seconds.
- Built proof: generated root help (7,635 bytes) matched the direct root-help bundle and launcher fast path; generated gateway help (4,675 bytes) matched a fast-path-disabled launcher render.
- Changed gate: formatting, scripts/test-root typechecks, focused lint, dependency guards, and tooling guards passed.
- Autoreview: clean, confidence 0.99.

Production/tooling LOC: +17/-28 (net -11) | Tests: +69/-2
