### PR TITLE
fix(gateway): restart after prepared maintenance suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway suspended restarts:** allow an exact predecessor-targeted non-safe restart request to cross a prepared suspension while keeping stale targets, failed delivery, safe restarts, and untargeted restarts fail-closed.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway suspended restarts:** allow an exact predecessor-targeted non-safe restart request to cross a prepared suspension while keeping stale targets, failed delivery, safe restarts, and untargeted restarts fail-closed.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -69,10 +69,13 @@ host-neutral suspension handshake:
    `openclaw gateway resume <suspensionId>`.
 
 A prepared Gateway accepts authenticated WebSocket connects, but fences every
-method except `gateway.suspend.*`. Controllers may reconnect after thaw and
-call resume. The [Admin HTTP RPC plugin](/plugins/admin-http-rpc) remains
-available for hosts that cannot speak WebSocket at all. If every control path
-is lost, the two-minute lease expiry reopens admission automatically.
+method except `gateway.suspend.*` and one exact predecessor-bound restart. That
+exception requires a non-safe `gateway.restart.request` whose `target` matches
+the live Gateway lock; safe and untargeted restart requests remain fenced.
+Controllers may reconnect after thaw and call resume. The
+[Admin HTTP RPC plugin](/plugins/admin-http-rpc) remains available for hosts
+that cannot speak WebSocket at all. If every control path is lost, the
+two-minute lease expiry reopens admission automatically.
 
 The RPC contract is:
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -529,7 +529,7 @@ methods. Treat this as feature discovery, not a full enumeration of
     - `last-heartbeat` returns the latest persisted heartbeat event.
     - `set-heartbeats` toggles heartbeat processing on the gateway.
     - `gateway.restart.preflight` is a deprecated, read-only compatibility preview of restart-specific active work. It does not close admission, create a suspension lease, or provide the atomic full-work fence of `gateway.suspend.prepare`; new restart flows should call `gateway.restart.request`.
-    - `gateway.suspend.prepare` creates a short cooperative-suspension lease only when tracked Gateway work is idle. While prepared, authenticated WebSocket connects remain available, but every method except `gateway.suspend.*` is fenced. `gateway.suspend.status` checks the lease, and `gateway.suspend.resume` releases it after thaw or an aborted host operation.
+    - `gateway.suspend.prepare` creates a short cooperative-suspension lease only when tracked Gateway work is idle. While prepared, authenticated WebSocket connects remain available, but only `gateway.suspend.*` and an exact targeted non-safe `gateway.restart.request` may run; safe and untargeted restarts remain fenced. `gateway.suspend.status` checks the lease, and `gateway.suspend.resume` releases it after thaw or an aborted host operation.
 
   </Accordion>
 

--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -102,7 +102,7 @@ Treat this plugin as a full Gateway operator surface.
 - Trusted identity-bearing HTTP auth (`trusted-proxy` mode) honors `x-openclaw-scopes` when present.
 - `gateway.auth.mode="none"` means this route is unauthenticated if the plugin is enabled. Use that only behind a private ingress you fully trust.
 - Requests dispatch through the same Gateway method handlers and scope checks as WebSocket RPC, after the plugin route auth passes.
-- The route remains reachable during a prepared suspension lease. Bounded request validation and the local `commands.list` discovery response remain available. Of the methods dispatched into the Gateway, only `gateway.suspend.prepare`, `gateway.suspend.status`, and `gateway.suspend.resume` may run while admission is closed; other allowlisted methods return the normal retryable Gateway `UNAVAILABLE` response.
+- The route remains reachable during a prepared suspension lease. Bounded request validation and the local `commands.list` discovery response remain available. Of the methods dispatched into the Gateway, `gateway.suspend.prepare`, `gateway.suspend.status`, `gateway.suspend.resume`, and an exact targeted non-safe `gateway.restart.request` may run while admission is closed; safe, untargeted, and other allowlisted methods return the normal retryable Gateway `UNAVAILABLE` response.
 - Keep this route on loopback, tailnet, or a private trusted ingress. Do not expose it directly to the public internet. Use separate gateways when callers cross trust boundaries.
 
 ## Request

--- a/src/gateway/server-methods.suspension-admission.test.ts
+++ b/src/gateway/server-methods.suspension-admission.test.ts
@@ -28,7 +28,7 @@ function dispatch(params: {
   method: string;
   scope: "operator.read" | "operator.write" | "operator.admin";
   handler: GatewayRequestHandler;
-  requestParams?: Record<string, unknown>;
+  requestParams?: unknown;
   context?: Parameters<typeof handleGatewayRequest>[0]["context"];
 }) {
   const respond = vi.fn();
@@ -350,6 +350,82 @@ describe("gateway request suspension admission", () => {
       expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
     );
     suspension?.release();
+  });
+
+  it.each([undefined, false])(
+    "admits an exact targeted restart with safe=%s on an owned root",
+    async (safe) => {
+      const suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension?.commit()).toBe(true);
+      const handler = vi.fn<GatewayRequestHandler>(({ respond }) => {
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        respond(true, { ok: true });
+      });
+
+      const restarted = dispatch({
+        method: "gateway.restart.request",
+        scope: "operator.admin",
+        handler,
+        requestParams: {
+          ...(safe === undefined ? {} : { safe }),
+          target: { pid: process.pid, ownerId: "gateway-owner", port: 18_789 },
+          restartIntent: { waitMs: 5_000 },
+        },
+      });
+      await restarted.request;
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(restarted.respond).toHaveBeenCalledWith(true, { ok: true });
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+      expect(suspension?.release()).toBe(true);
+    },
+  );
+
+  it.each([
+    ["untargeted", { reason: "operator" }],
+    [
+      "safe targeted",
+      {
+        safe: true,
+        target: { pid: process.pid, ownerId: "gateway-owner", port: 18_789 },
+      },
+    ],
+    ["malformed target", { target: { pid: process.pid, ownerId: "", port: 18_789 } }],
+    [
+      "malformed intent",
+      {
+        target: { pid: process.pid, ownerId: "gateway-owner", port: 18_789 },
+        restartIntent: { force: true, waitMs: 1 },
+      },
+    ],
+  ])("rejects %s restart requests while suspension is prepared", async (_name, requestParams) => {
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    const handler = vi.fn<GatewayRequestHandler>();
+
+    const blocked = dispatch({
+      method: "gateway.restart.request",
+      scope: "operator.admin",
+      handler,
+      requestParams,
+    });
+    await blocked.request;
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(blocked.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        details: expect.objectContaining({
+          method: "gateway.restart.request",
+          reason: "gateway-suspending",
+          phase: "prepared",
+        }),
+      }),
+    );
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(suspension?.release()).toBe(true);
   });
 
   it("keeps suspension status reachable while prepared", async () => {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -16,6 +16,7 @@ import {
 import {
   getGatewaySuspendAdmissionPhase,
   isGatewayRestartDraining,
+  tryBeginGatewayPreparedRestartRootWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
@@ -45,6 +46,7 @@ import {
 import { isOperatorScope } from "./operator-scopes.js";
 import { isRoleAuthorizedForMethod, parseGatewayRole } from "./role-policy.js";
 import { createLazyCoreHandlers, lazyHandlerModule } from "./server-methods/lazy-core-handlers.js";
+import { isTargetedNonSafeGatewayRestartRequest } from "./server-methods/restart-request.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandler,
@@ -409,6 +411,7 @@ type GatewayRequestEnvelopeOptions<T> = Pick<
   "context" | "isWebchatConnect"
 > & {
   methodRegistry: GatewayMethodRegistry;
+  requestParams?: unknown;
   reject: (error: ReturnType<typeof errorShape>) => T | Promise<T>;
 };
 
@@ -452,7 +455,12 @@ export async function runWithGatewayRequestEnvelope<T>(
     // Preparation must stay protected even before it owns the root admission that it closes.
     return await options.reject(preAdmissionRateLimitError);
   }
-  const rootWorkAdmission = tryBeginGatewayRootWorkAdmission();
+  const rootWorkAdmission =
+    tryBeginGatewayRootWorkAdmission() ??
+    (method === "gateway.restart.request" &&
+    isTargetedNonSafeGatewayRestartRequest(options.requestParams)
+      ? tryBeginGatewayPreparedRestartRootWorkAdmission()
+      : null);
   if (isSuspendPrepare && rootWorkAdmission && !rootWorkAdmission.ownsRoot) {
     return await options.reject(
       errorShape(ErrorCodes.UNAVAILABLE, "gateway suspension cannot begin from a nested request", {
@@ -581,6 +589,7 @@ export async function handleGatewayRequest(
     context,
     isWebchatConnect,
     methodRegistry,
+    requestParams: req.params,
     reject: (error) => respond(false, undefined, error),
   });
 }

--- a/src/gateway/server-methods/restart-request.ts
+++ b/src/gateway/server-methods/restart-request.ts
@@ -1,6 +1,9 @@
 // Restart request parsing keeps restart sentinel payloads limited to resumable
 // session, delivery, thread, and delay fields.
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 
 type RestartDeliveryContext = {
@@ -59,4 +62,87 @@ export function parseRestartRequestParams(params: unknown): {
       ? Math.max(0, Math.floor(restartDelayMsRaw))
       : undefined;
   return { sessionKey, deliveryContext, threadId, note, continuationMessage, restartDelayMs };
+}
+
+type TargetedGatewayRestart = {
+  pid: number;
+  ownerId: string;
+  port: number;
+};
+
+export function parseTargetedGatewayRestart(
+  value: unknown,
+): TargetedGatewayRestart | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const target = value as { pid?: unknown; ownerId?: unknown; port?: unknown };
+  if (
+    typeof target.pid !== "number" ||
+    !Number.isSafeInteger(target.pid) ||
+    target.pid <= 0 ||
+    typeof target.ownerId !== "string" ||
+    !target.ownerId.trim() ||
+    typeof target.port !== "number" ||
+    !Number.isInteger(target.port) ||
+    target.port <= 0 ||
+    target.port > 65_535
+  ) {
+    return null;
+  }
+  return {
+    pid: target.pid,
+    ownerId: target.ownerId.trim(),
+    port: target.port,
+  };
+}
+
+export function parseTargetedGatewayRestartIntent(
+  value: unknown,
+  reason: string | undefined,
+): GatewayRestartIntent | null {
+  if (value !== undefined && (!value || typeof value !== "object" || Array.isArray(value))) {
+    return null;
+  }
+  const raw = (value ?? {}) as { force?: unknown; waitMs?: unknown };
+  const force = raw.force === true;
+  const waitMs =
+    typeof raw.waitMs === "number" &&
+    Number.isSafeInteger(raw.waitMs) &&
+    raw.waitMs >= 0 &&
+    raw.waitMs <= MAX_TIMER_TIMEOUT_MS
+      ? raw.waitMs
+      : undefined;
+  if (
+    (raw.force !== undefined && typeof raw.force !== "boolean") ||
+    (raw.waitMs !== undefined && waitMs === undefined) ||
+    (force && waitMs !== undefined)
+  ) {
+    return null;
+  }
+  return {
+    ...(reason ? { reason } : {}),
+    ...(force ? { force: true } : {}),
+    ...(waitMs !== undefined ? { waitMs } : {}),
+  };
+}
+
+/**
+ * Only the predecessor-bound restart may cross a prepared suspension lease.
+ * The live lock target is sufficient: restart drain becomes the stronger owner
+ * and explicitly retires the reversible suspension token after delivery.
+ */
+export function isTargetedNonSafeGatewayRestartRequest(params: unknown): boolean {
+  if (!isRecord(params) || (params.safe !== undefined && params.safe !== false)) {
+    return false;
+  }
+  const target = parseTargetedGatewayRestart(params.target);
+  return (
+    target !== undefined &&
+    target !== null &&
+    parseTargetedGatewayRestartIntent(params.restartIntent, undefined) !== null
+  );
 }

--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -3,7 +3,13 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getGatewaySuspendAdmissionPhase,
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+} from "../../process/gateway-work-admission.js";
+import { handleGatewayRequest } from "../server-methods.js";
 import { restartHandlers } from "./restart.js";
 
 const scheduleSafeGatewayRestart = vi.hoisted(() => vi.fn());
@@ -54,6 +60,40 @@ function invokeRestartPreflight() {
   ).then(() => respond);
 }
 
+async function invokeRestartRequestThroughGateway(params: unknown) {
+  const respond = vi.fn();
+  const handler = expectDefined(
+    restartHandlers["gateway.restart.request"],
+    'restartHandlers["gateway.restart.request"] test invariant',
+  );
+  await handleGatewayRequest({
+    req: {
+      type: "req",
+      id: `request-${crypto.randomUUID()}`,
+      method: "gateway.restart.request",
+      params,
+    },
+    respond,
+    client: {
+      connId: `conn-${crypto.randomUUID()}`,
+      clientIp: "127.0.0.1",
+      connect: {
+        role: "operator",
+        scopes: ["operator.admin"],
+        client: { id: "cli", version: "test", platform: "linux", mode: "cli" },
+        minProtocol: 1,
+        maxProtocol: 1,
+      },
+    },
+    isWebchatConnect: () => false,
+    context: { logGateway: { warn: vi.fn() } } as unknown as Parameters<
+      typeof handleGatewayRequest
+    >[0]["context"],
+    extraHandlers: { "gateway.restart.request": handler },
+  });
+  return respond;
+}
+
 function mockScheduledRestart(preflight: { safe: boolean; summary: string }) {
   scheduleSafeGatewayRestart.mockReturnValueOnce({
     ok: true,
@@ -81,6 +121,7 @@ function expectRestartRequest(skipDeferral: boolean) {
 
 describe("gateway restart handlers", () => {
   beforeEach(() => {
+    resetGatewayWorkAdmission();
     scheduleSafeGatewayRestart.mockClear();
     createSafeGatewayRestartPreflight.mockReset();
     requestGatewayRestartWithSignalAdmission.mockReset();
@@ -92,6 +133,10 @@ describe("gateway restart handlers", () => {
       createdAt: "2026-07-16T12:00:00.000Z",
       port: 18_789,
     });
+  });
+
+  afterEach(() => {
+    resetGatewayWorkAdmission();
   });
 
   it("keeps the deprecated read-only preflight response shape", async () => {
@@ -235,6 +280,95 @@ describe("gateway restart handlers", () => {
     expect(respond).toHaveBeenCalledWith(false, undefined, {
       code: "INVALID_REQUEST",
       message: "target gateway no longer owns the active lock",
+    });
+  });
+
+  it("retains prepared suspension when the exact restart target is stale", async () => {
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    readActiveGatewayLockIdentity.mockResolvedValue({
+      pid: process.pid,
+      ownerId: "replacement-owner",
+      createdAt: "2026-07-16T12:00:01.000Z",
+      port: 18_789,
+    });
+
+    const respond = await invokeRestartRequestThroughGateway({
+      reason: "operator",
+      target: {
+        pid: process.pid,
+        ownerId: "gateway-owner",
+        port: 18_789,
+      },
+    });
+
+    expect(readActiveGatewayLockIdentity).toHaveBeenCalledOnce();
+    expect(requestGatewayRestartWithSignalAdmission).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "INVALID_REQUEST",
+      message: "target gateway no longer owns the active lock",
+    });
+    expect(getGatewaySuspendAdmissionPhase()).toBe("prepared");
+    expect(suspension?.release()).toBe(true);
+  });
+
+  it("retains prepared suspension when exact restart delivery fails", async () => {
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    requestGatewayRestartWithSignalAdmission.mockReturnValueOnce({ status: "failed" });
+
+    const respond = await invokeRestartRequestThroughGateway({
+      reason: "operator",
+      target: {
+        pid: process.pid,
+        ownerId: "gateway-owner",
+        port: 18_789,
+      },
+    });
+
+    expect(readActiveGatewayLockIdentity).toHaveBeenCalledOnce();
+    expect(requestGatewayRestartWithSignalAdmission).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "UNAVAILABLE",
+      message: "target gateway restart delivery failed",
+    });
+    expect(getGatewaySuspendAdmissionPhase()).toBe("prepared");
+    expect(suspension?.release()).toBe(true);
+  });
+
+  it("finishes an admitted exact restart after suspension resumes", async () => {
+    let resolveLock: (value: unknown) => void = () => {};
+    readActiveGatewayLockIdentity.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLock = resolve;
+      }),
+    );
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+
+    const request = invokeRestartRequestThroughGateway({
+      reason: "operator",
+      target: {
+        pid: process.pid,
+        ownerId: "gateway-owner",
+        port: 18_789,
+      },
+    });
+    await vi.waitFor(() => expect(readActiveGatewayLockIdentity).toHaveBeenCalledOnce());
+    expect(suspension?.release()).toBe(true);
+    resolveLock({
+      pid: process.pid,
+      ownerId: "gateway-owner",
+      createdAt: "2026-07-16T12:00:00.000Z",
+      port: 18_789,
+    });
+
+    const respond = await request;
+    expect(requestGatewayRestartWithSignalAdmission).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, {
+      ok: true,
+      status: "emitted",
+      pid: process.pid,
     });
   });
 

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -1,5 +1,4 @@
 // Gateway RPC handlers for safe gateway restart requests and preflight state.
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
@@ -8,8 +7,11 @@ import {
   createSafeGatewayRestartPreflight,
   scheduleSafeGatewayRestart,
 } from "../../infra/restart-coordinator.js";
-import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
 import { requestGatewayRestartWithSignalAdmission } from "../../infra/restart.js";
+import {
+  parseTargetedGatewayRestart,
+  parseTargetedGatewayRestartIntent,
+} from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 function isRestartRequestParams(value: unknown): value is Record<string, unknown> {
@@ -28,70 +30,6 @@ function normalizeSkipDeferral(value: unknown): boolean {
   // Only an explicit boolean may bypass deferral; truthy strings from loose
   // clients must not skip the safe-restart preflight queue.
   return value === true;
-}
-
-type TargetedGatewayRestart = {
-  pid: number;
-  ownerId: string;
-  port: number;
-};
-
-function parseTargetedGatewayRestart(value: unknown): TargetedGatewayRestart | null | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const target = value as { pid?: unknown; ownerId?: unknown; port?: unknown };
-  if (
-    typeof target.pid !== "number" ||
-    !Number.isSafeInteger(target.pid) ||
-    target.pid <= 0 ||
-    typeof target.ownerId !== "string" ||
-    !target.ownerId.trim() ||
-    typeof target.port !== "number" ||
-    !Number.isInteger(target.port) ||
-    target.port <= 0 ||
-    target.port > 65_535
-  ) {
-    return null;
-  }
-  return {
-    pid: target.pid,
-    ownerId: target.ownerId.trim(),
-    port: target.port,
-  };
-}
-
-function parseTargetedRestartIntent(
-  value: unknown,
-  reason: string | undefined,
-): GatewayRestartIntent | null {
-  if (value !== undefined && (!value || typeof value !== "object" || Array.isArray(value))) {
-    return null;
-  }
-  const raw = (value ?? {}) as { force?: unknown; waitMs?: unknown };
-  const force = raw.force === true;
-  const waitMs =
-    typeof raw.waitMs === "number" &&
-    Number.isSafeInteger(raw.waitMs) &&
-    raw.waitMs >= 0 &&
-    raw.waitMs <= MAX_TIMER_TIMEOUT_MS
-      ? raw.waitMs
-      : undefined;
-  if (
-    (raw.force !== undefined && typeof raw.force !== "boolean") ||
-    (raw.waitMs !== undefined && waitMs === undefined) ||
-    (force && waitMs !== undefined)
-  ) {
-    return null;
-  }
-  return {
-    ...(reason ? { reason } : {}),
-    ...(force ? { force: true } : {}),
-    ...(waitMs !== undefined ? { waitMs } : {}),
-  };
 }
 
 /** Gateway request handlers for safe restart coordination. */
@@ -141,7 +79,7 @@ export const restartHandlers: GatewayRequestHandlers = {
         respond(true, result);
         return;
       }
-      const intent = parseTargetedRestartIntent(params.restartIntent, reason);
+      const intent = parseTargetedGatewayRestartIntent(params.restartIntent, reason);
       if (!intent) {
         respond(
           false,

--- a/src/infra/restart-suspension.test.ts
+++ b/src/infra/restart-suspension.test.ts
@@ -5,6 +5,7 @@ import {
   isGatewayWorkAdmissionClosed,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
+  tryBeginGatewayPreparedRestartRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import type { GatewayActiveWorkInspectors } from "./gateway-active-work.js";
 import {
@@ -15,6 +16,7 @@ import {
 } from "./gateway-suspend-coordinator.js";
 import {
   isGatewaySigusr1RestartExternallyAllowed,
+  requestGatewayRestartWithSignalAdmission,
   resetGatewayRestartStateForInProcessRestart,
   scheduleGatewaySigusr1Restart,
   setGatewaySigusr1RestartPolicy,
@@ -97,6 +99,76 @@ describe("scheduled restart during gateway suspension", () => {
     });
     await vi.advanceTimersByTimeAsync(0);
     expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(1);
+  });
+
+  it("lets delivered targeted restart drain supersede prepared suspension", async () => {
+    const restartHandler = () => markGatewayRestartDraining();
+    const resumeScheduling = vi.fn();
+    process.on("SIGUSR1", restartHandler);
+    try {
+      const prepared = prepareGatewaySuspend({
+        requestId: "request-targeted-restart",
+        pauseScheduling: vi.fn(),
+        resumeScheduling,
+        inspect: inspectors(),
+        createSuspensionId: () => "suspension-targeted-restart",
+      });
+      expect(prepared).toMatchObject({ status: "ready" });
+      const admission = tryBeginGatewayPreparedRestartRootWorkAdmission();
+      expect(admission?.ownsRoot).toBe(true);
+
+      const result = await admission?.run(async () =>
+        requestGatewayRestartWithSignalAdmission("gateway.restart", { waitMs: 5_000 }),
+      );
+      admission?.release();
+
+      expect(result).toEqual({ status: "emitted" });
+      expect(getGatewaySuspendStatus("suspension-targeted-restart")).toEqual({
+        status: "running",
+      });
+      expect(resumeScheduling).not.toHaveBeenCalled();
+      expect(isGatewayWorkAdmissionClosed()).toBe(true);
+    } finally {
+      process.removeListener("SIGUSR1", restartHandler);
+    }
+  });
+
+  it("preserves prepared suspension when targeted restart delivery fails", async () => {
+    const resumeScheduling = vi.fn();
+    const prepared = prepareGatewaySuspend({
+      requestId: "request-failed-targeted-restart",
+      pauseScheduling: vi.fn(),
+      resumeScheduling,
+      inspect: inspectors(),
+      createSuspensionId: () => "suspension-failed-targeted-restart",
+    });
+    expect(prepared).toMatchObject({ status: "ready" });
+    const admission = tryBeginGatewayPreparedRestartRootWorkAdmission();
+    expect(admission?.ownsRoot).toBe(true);
+    const emitSpy = vi.spyOn(process, "emit").mockImplementationOnce(() => {
+      throw new Error("synthetic signal failure");
+    });
+
+    const result = await admission?.run(async () =>
+      requestGatewayRestartWithSignalAdmission("gateway.restart", { waitMs: 5_000 }),
+    );
+    admission?.release();
+
+    expect(result).toEqual({ status: "failed" });
+    expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+    expect(getGatewaySuspendStatus("suspension-failed-targeted-restart")).toEqual({
+      status: "ready",
+      expiresAtMs: expect.any(Number),
+    });
+    expect(isGatewayWorkAdmissionClosed()).toBe(true);
+    expect(resumeScheduling).not.toHaveBeenCalled();
+    expect(resumeGatewaySuspend("suspension-failed-targeted-restart")).toEqual({
+      ok: true,
+      status: "running",
+      resumed: true,
+    });
+    expect(resumeScheduling).toHaveBeenCalledOnce();
+    expect(isGatewayWorkAdmissionClosed()).toBe(false);
   });
 
   it("reports active work while a due restart is preparing to emit", async () => {

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -13,6 +13,7 @@ import {
   rollbackGatewayRestartSignalFence,
   runWithGatewayIndependentRootWorkContinuation,
   runOutsideGatewayRootWorkAdmission,
+  tryBeginGatewayPreparedRestartRootWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
   waitForActiveGatewayRootWork,
@@ -65,6 +66,34 @@ it("rolls back or releases a generation-bound suspension without resetting roots
   expect(prepared?.release()).toBe(false);
   expect(invalidated).not.toHaveBeenCalled();
   expect(isGatewayWorkAdmissionClosed()).toBe(false);
+});
+
+it("admits a targeted restart root only from prepared suspension", () => {
+  expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
+
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(suspension).not.toBeNull();
+  expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
+  expect(suspension?.commit()).toBe(true);
+
+  const restartRoot = tryBeginGatewayPreparedRestartRootWorkAdmission();
+  expect(restartRoot?.ownsRoot).toBe(true);
+  expect(getActiveGatewayRootWorkCount()).toBe(1);
+  expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
+  restartRoot?.release();
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+  expect(suspension?.release()).toBe(true);
+
+  const prepared = tryBeginGatewaySuspendAdmission(() => {});
+  expect(prepared?.commit()).toBe(true);
+  const pendingSignal = beginGatewayRestartSignalAdmission();
+  expect(pendingSignal).not.toBeNull();
+  expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
+  expect(pendingSignal?.rollback()).toBe(true);
+  expect(prepared?.release()).toBe(true);
+
+  markGatewayRestartDraining();
+  expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
 });
 
 it("lets an admitted root cross only the reversible suspension fence", async () => {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -142,7 +142,11 @@ function clearRestartSignalFence(): boolean {
   GATEWAY_WORK_ADMISSION_STATE.restartSignalPending = false;
   GATEWAY_WORK_ADMISSION_STATE.restartSignalGeneration += 1;
   resolveSuspendOpenWaiters();
-  logAdmissionReopened("restart-signal fence");
+  if (GATEWAY_WORK_ADMISSION_STATE.suspendPhase === "accepting") {
+    logAdmissionReopened("restart-signal fence");
+  } else {
+    admissionLog.info("restart-signal fence cleared; suspension remains closed");
+  }
   return true;
 }
 
@@ -264,6 +268,22 @@ export function tryBeginGatewayRootWorkAdmission(): GatewayRootWorkAdmissionLeas
     GATEWAY_WORK_ADMISSION_STATE.restartDraining ||
     GATEWAY_WORK_ADMISSION_STATE.restartSignalPending ||
     GATEWAY_WORK_ADMISSION_STATE.suspendPhase !== "accepting"
+  ) {
+    return null;
+  }
+  return createGatewayRootWorkAdmission();
+}
+
+/**
+ * Admits only the exact predecessor-bound restart selected by the RPC router.
+ * The held root preserves signal-to-drain ordering without reopening suspension.
+ */
+export function tryBeginGatewayPreparedRestartRootWorkAdmission(): GatewayRootWorkAdmissionLease | null {
+  if (
+    GATEWAY_WORK_ADMISSION_STATE.restartDraining ||
+    GATEWAY_WORK_ADMISSION_STATE.restartSignalPending ||
+    GATEWAY_WORK_ADMISSION_STATE.suspendPhase !== "prepared" ||
+    GATEWAY_WORK_ADMISSION_STATE.activeRootWork.size > 0
   ) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an external lifecycle controller could atomically prepare a Gateway for maintenance, then have its exact predecessor-targeted restart rejected because the prepared suspension fenced the restart RPC itself.

## Why This Change Was Made

The request router now grants one tracked root only to a structurally valid, non-safe `gateway.restart.request` carrying an exact process target while suspension is prepared. The existing restart handler still validates that target against the live Gateway lock before signal admission; stale targets and failed delivery leave the reversible suspension intact, while successful restart drain becomes the stronger lifecycle owner and retires the suspension without reopening work admission.

Safe, untargeted, malformed, and arbitrary RPCs remain fenced. The special root is single-flight and exists only in the prepared phase. Production growth is +122/-69 (net +53), justified by the explicit lifecycle-ownership seam and shared target/intent parser required to avoid policy drift between routing and execution.

## User Impact

Managed immutable deployments can keep their atomic maintenance fence through exact predecessor restart delivery instead of failing with `gateway.restart.request unavailable during gateway suspension`. Other callers retain the existing fail-closed suspension behavior.

## Evidence

- Pre-fix regression: [Testbox run 31881526766](https://github.com/openclaw/openclaw/actions/runs/31881526766) — 18 passed, 1 expected failure because the stale exact target never reached live-lock validation.
- Focused post-fix owner matrix: [Testbox run 31881667404](https://github.com/openclaw/openclaw/actions/runs/31881667404) — 61 assertions passed across restart handler, suspension router, real signal lifecycle, and work admission.
- Final focused refinement: [Testbox run 31881743426](https://github.com/openclaw/openclaw/actions/runs/31881743426) — 32 assertions passed for safe-absent/false routing and admission ownership.
- Changed gate: [Testbox run 31881882247](https://github.com/openclaw/openclaw/actions/runs/31881882247) — core/test typechecks, lint, formatting, dead-code, dependency, boundary, docs-scoped, database-first, and import-cycle checks passed.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings, confidence 0.98.

Regression coverage proves exact-target success, stale-target/no-signal lease retention, safe/untargeted/malformed rejection, real delivery-failure rollback with exact resume, single-flight prepared-only admission, and the resume-during-lock-validation race.
