### PR TITLE
fix(ci): rebuild session catalog sdk declarations

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -164,6 +164,8 @@ const PLUGIN_SDK_TYPE_INPUTS = [
   // provider-auth re-exports these signatures into generated SDK declarations.
   "src/agents/cli-credentials.ts",
   "src/plugins/provider-runtime-model.types.ts",
+  // session-catalog re-exports provider params into generated SDK declarations.
+  "src/plugins/session-catalog.ts",
   "src/plugins/types.ts",
   "src/auto-reply",
   // doctor-repair-runtime re-exports the state migration contract into the SDK.


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI failure where session-catalog provider type changes could leave cache-restored Plugin SDK declarations stale, causing bundled plugins to compile against the previous public contract.

## Why This Change Was Made

The boundary declaration cache now fingerprints `src/plugins/session-catalog.ts`, the owner of the provider parameter types re-exported by `openclaw/plugin-sdk/session-catalog`. This keeps the existing content-hash cache fast path while invalidating it whenever that public type source changes.

## User Impact

No user-visible behavior changes. Plugin package-boundary CI now rebuilds the correct declarations after session-catalog contract changes.

## Evidence

- Before: [main CI run 31882948045](https://github.com/openclaw/openclaw/actions/runs/31882948045) failed the extension package-boundary compile because ACPX saw stale `SessionCatalog*ProviderParams` declarations.
- After: [Blacksmith Testbox run 31883435761](https://github.com/openclaw/openclaw/actions/runs/31883435761) passed `pnpm test:extensions:package-boundary:compile` across all 123 plugins.
- `node scripts/run-vitest.mjs test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 19 tests passed.
- `node scripts/check-changed.mjs` — passed all changed-file checks (local fallback after remote workload routing had no ready provider).
- AutoReview: clean, no actionable findings.
- Tooling LOC: +2/-0; tests: +0/-0.
