### PR TITLE
refactor(scripts): remove duplicate parser test facades

### DIFF
--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -402,7 +402,7 @@ export const BUILD_ALL_PROFILE_STEP_ENV: Record<string, Record<string, NodeJS.Pr
   },
 };
 
-export function buildAllUsage() {
+function buildAllUsage() {
   return [
     "Usage: node --import tsx scripts/build-all.mts [profile]",
     "",

--- a/scripts/check-gateway-watch-regression.mts
+++ b/scripts/check-gateway-watch-regression.mts
@@ -18,8 +18,6 @@ import { parseStrictNonNegativeDecimal as readNonNegativeInteger } from "./lib/n
 import { sleep } from "./lib/sleep.mjs";
 import { resolveBuildRequirement } from "./run-node.mts";
 
-export { readNonNegativeInteger };
-
 const DEFAULTS = {
   outputDir: path.join(process.cwd(), ".local", "gateway-watch-regression"),
   windowMs: 10_000,

--- a/scripts/check-memory-fd-repro.mts
+++ b/scripts/check-memory-fd-repro.mts
@@ -16,8 +16,6 @@ import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 import { parseStrictNonNegativeDecimal as parseNonNegativeInteger } from "./lib/numeric-options.mjs";
 
-export { parseNonNegativeInteger };
-
 const ISSUE_FILE_COUNTS = [
   ["memory/transcripts", 9394],
   ["memory/transcripts.archived", 1695],
@@ -64,7 +62,7 @@ export const GATEWAY_READY_OUTPUT_MAX_CHARS = 128 * 1024;
 /**
  * Maximum bytes read from the memory_search HTTP response.
  */
-export const MEMORY_SEARCH_RESPONSE_MAX_BYTES = 256 * 1024;
+const MEMORY_SEARCH_RESPONSE_MAX_BYTES = 256 * 1024;
 /**
  * Probe query expected to hit the synthetic top-level memory file.
  */
@@ -130,7 +128,7 @@ function stripPackageManagerSeparatorForKnownFlags(argv: string[]) {
 /**
  * Parses a safe positive integer option.
  */
-export function readPositiveNumber(value: unknown, label: string) {
+function readPositiveNumber(value: unknown, label: string) {
   const parsed = parseNonNegativeInteger(value, label);
   if (parsed <= 0) {
     throw new Error(`${label} must be greater than 0`);
@@ -583,8 +581,6 @@ export async function stopGatewayWithRuntime({
 /**
  * Reads an HTTP response body up to a configured byte limit.
  */
-export { readBoundedResponseText };
-
 function signalChild(child: StoppableGatewayChild, signal: GatewaySignal) {
   try {
     child.kill(signal);

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -9,7 +9,6 @@ import {
   BUILD_ALL_PROFILES,
   BUILD_ALL_PROFILE_STEP_ENV,
   BUILD_ALL_STEPS,
-  buildAllUsage,
   finalizeBuildAllStepCache,
   formatBuildAllDuration,
   formatBuildAllTimingSummary,
@@ -351,7 +350,8 @@ describe("resolveBuildAllSteps", () => {
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("unknown argument: --bogus");
-    expect(result.stderr).toContain(buildAllUsage());
+    expect(result.stderr).toContain("Usage: node --import tsx scripts/build-all.mts [profile]");
+    expect(result.stderr).toContain("Profiles:");
     expect(result.stderr).not.toContain("[build-all]");
     expect(result.stderr).not.toContain("at ");
   });

--- a/test/scripts/check-gateway-watch-regression.test.ts
+++ b/test/scripts/check-gateway-watch-regression.test.ts
@@ -12,7 +12,6 @@ import {
   parseArgs,
   resolveTimedWatchShell,
   runTimedWatch,
-  readNonNegativeInteger,
   shouldReportDuplicateDistRuntimeRegression,
   shouldRefreshBuildStampForRestoredArtifacts,
   stopTimedWatchChild,
@@ -34,8 +33,6 @@ describe("check-gateway-watch-regression", () => {
   });
 
   it("parses timing and growth limits as strict non-negative integers", () => {
-    expect(readNonNegativeInteger("0", "limit")).toBe(0);
-    expect(readNonNegativeInteger(" 42 ", "limit")).toBe(42);
     expect(
       parseArgs([
         "--window-ms",
@@ -69,21 +66,15 @@ describe("check-gateway-watch-regression", () => {
       windowMs: 0,
     });
 
-    expect(() => readNonNegativeInteger("1.5", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => readNonNegativeInteger("1e3", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => readNonNegativeInteger("-1", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => readNonNegativeInteger("9007199254740992", "limit")).toThrow(
-      "limit must be a safe integer",
-    );
-    expect(() => parseArgs(["--window-ms", "soon"])).toThrow(
-      "--window-ms must be a non-negative integer",
-    );
+    for (const [value, message] of [
+      ["1.5", "--window-ms must be a non-negative integer"],
+      ["1e3", "--window-ms must be a non-negative integer"],
+      ["-1", "--window-ms must be a non-negative integer"],
+      ["9007199254740992", "--window-ms must be a safe integer"],
+      ["soon", "--window-ms must be a non-negative integer"],
+    ] as const) {
+      expect(() => parseArgs(["--window-ms", value])).toThrow(message);
+    }
   });
 
   it("recognizes current and legacy gateway ready logs", () => {

--- a/test/scripts/check-memory-fd-repro.test.ts
+++ b/test/scripts/check-memory-fd-repro.test.ts
@@ -9,14 +9,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   GATEWAY_READY_OUTPUT_MAX_CHARS,
   MEMORY_SEARCH_PROBE_QUERY,
-  MEMORY_SEARCH_RESPONSE_MAX_BYTES,
   classifyMemorySearchInvokeResponse,
   hasChildExited,
   invokeMemorySearch,
   parseArgs,
-  parseNonNegativeInteger,
-  readBoundedResponseText,
-  readPositiveNumber,
   stopGatewayWithRuntime,
   updateGatewayReadyOutputState,
   waitForGatewayReady,
@@ -41,23 +37,6 @@ async function listen(server: Server): Promise<number> {
 }
 
 describe("check-memory-fd-repro", () => {
-  it("parses file, fd, and timing limits as strict integers", () => {
-    expect(parseNonNegativeInteger("0", "limit")).toBe(0);
-    expect(parseNonNegativeInteger(" 42 ", "limit")).toBe(42);
-    expect(readPositiveNumber("1", "limit")).toBe(1);
-
-    expect(() => parseNonNegativeInteger("1.5", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => parseNonNegativeInteger("1e3", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => parseNonNegativeInteger("10files", "limit")).toThrow(
-      "limit must be a non-negative integer",
-    );
-    expect(() => readPositiveNumber("0", "limit")).toThrow("limit must be greater than 0");
-  });
-
   it("rejects loose numeric environment limits before generating files", () => {
     expect(
       withEnv(
@@ -383,45 +362,5 @@ describe("check-memory-fd-repro", () => {
 
     expect(state.readySeen).toBe(true);
     expect(state.tail).toBe("w output");
-  });
-
-  it("reads memory_search response bodies under the byte cap", async () => {
-    await expect(
-      readBoundedResponseText(
-        new Response("ok"),
-        "memory_search",
-        MEMORY_SEARCH_RESPONSE_MAX_BYTES,
-      ),
-    ).resolves.toBe("ok");
-  });
-
-  it("rejects oversized memory_search response bodies from content-length", async () => {
-    const response = new Response("ignored", {
-      headers: { "content-length": String(MEMORY_SEARCH_RESPONSE_MAX_BYTES + 1) },
-    });
-
-    await expect(
-      readBoundedResponseText(response, "memory_search", MEMORY_SEARCH_RESPONSE_MAX_BYTES),
-    ).rejects.toThrow(
-      `memory_search response body exceeded ${MEMORY_SEARCH_RESPONSE_MAX_BYTES} bytes`,
-    );
-  });
-
-  it("stops reading memory_search response streams after the byte cap", async () => {
-    const chunk = new Uint8Array(MEMORY_SEARCH_RESPONSE_MAX_BYTES + 1);
-    const response = new Response(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(chunk);
-          controller.close();
-        },
-      }),
-    );
-
-    await expect(
-      readBoundedResponseText(response, "memory_search", MEMORY_SEARCH_RESPONSE_MAX_BYTES),
-    ).rejects.toThrow(
-      `memory_search response body exceeded ${MEMORY_SEARCH_RESPONSE_MAX_BYTES} bytes`,
-    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Removes script-private helper exports and tests that duplicated their shared owners or compared an executable's output to the same helper that generated it.

The affected scripts retained direct testing surfaces for build usage text, strict non-negative parsing, and bounded response reading even though production calls the shared numeric/bounded-response implementations and stronger owner tests already cover those algorithms.

## Why This Change Was Made

Script helpers are private again. The build and gateway-watch suites continue to test exact executable argument behavior, and the memory FD repro still exercises its real `memory_search` invocation path. Numeric and response-size algorithms remain covered once at their shared owners.

## User Impact

No behavior changes. Script tests are less coupled to helper exports and focus on executable outcomes.

## Evidence

- Build-all, memory FD repro, gateway-watch regression, numeric-option, and bounded-response owners: 5 files, 120 tests passed.
- The `scripts`, `testRoot`, and `tooling` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready. Script/root typechecks, formatting, lint, Docker boundaries, and raw HTTP/2 guards passed.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings on the final branch.

Production tooling delta: +3/-9, net -6. Tests: +11/-81, net -70. Total: +14/-90, net -76. No behavior, docs, config, schema, protocol, dependency, or changelog change.

AI-assisted: yes.
