### PR TITLE
fix(shared): read Windows creation time for file-lock identities (#124125)

### DIFF
--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -2,6 +2,7 @@
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readWindowsProcessStartTimeSync } from "../infra/windows-port-pids.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import {
   getFileLockProcessStartTime,
@@ -10,8 +11,17 @@ import {
   isPidDefinitelyDead,
 } from "./pid-alive.js";
 
+vi.mock("../infra/windows-port-pids.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/windows-port-pids.js")>();
+  return {
+    ...mod,
+    readWindowsProcessStartTimeSync: vi.fn(mod.readWindowsProcessStartTimeSync),
+  };
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.mocked(readWindowsProcessStartTimeSync).mockReset();
 });
 
 function mockProcReads(entries: Record<string, string>) {
@@ -226,7 +236,15 @@ describe("process start times", () => {
   it("returns null on unsupported platforms", () => {
     return withMockedPlatform("win32", async () => {
       expect(getProcessStartTime(process.pid)).toBeNull();
-      expect(getFileLockProcessStartTime(process.pid)).toBeNull();
+    });
+  });
+
+  it("reads Windows creation time for file-lock identities on win32", () => {
+    vi.mocked(readWindowsProcessStartTimeSync).mockReturnValue(1_752_000_000_000);
+
+    return withMockedPlatform("win32", async () => {
+      expect(getFileLockProcessStartTime(process.pid)).toBe(1_752_000_000_000);
+      expect(readWindowsProcessStartTimeSync).toHaveBeenCalledWith(process.pid);
     });
   });
 

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -1,6 +1,7 @@
 // PID liveness helpers check whether process ids still refer to active processes.
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
+import { readWindowsProcessStartTimeSync } from "../infra/windows-port-pids.js";
 
 const DARWIN_PS_TIMEOUT_MS = 1000;
 
@@ -108,6 +109,12 @@ export function getProcessStartTime(pid: number): number | null {
 export function getFileLockProcessStartTime(pid: number): number | null {
   if (!isValidPid(pid)) {
     return null;
+  }
+  if (process.platform === "win32") {
+    // Windows has no procfs; read the process creation time via PowerShell
+    // (wmic fallback) so the cron durable fence can establish a PID-reuse-safe
+    // identity instead of failing every tick.
+    return readWindowsProcessStartTimeSync(pid);
   }
   return process.platform === "darwin" ? getDarwinProcessStartTime(pid) : getProcessStartTime(pid);
 }


### PR DESCRIPTION
## What Problem

On Windows, every cron timer tick fails with `cron run cannot acquire a durable fence without process start identity`, leaving all cron jobs (heartbeats, reminders, scheduled jobs) idle. `getFileLockProcessStartTime` in `src/shared/pid-alive.ts` only dispatched darwin → `getDarwinProcessStartTime` and everything else → `getProcessStartTime`, which reads `/proc/<pid>/stat` and returns `null` on non-Linux platforms. The cron durable fence (`prepareCronRunReceiptClaim` in `src/cron/store/run-receipt-store.ts`) throws when that identity is `null`, so every tick on Windows fails.

## Why

The repo already owns a proven Windows process-creation-time reader: `readWindowsProcessStartTimeSync` in `src/infra/windows-port-pids.ts` (PowerShell `Get-CimInstance Win32_Process` with a `wmic` fallback), used by `src/node-host/node-worker-process-identity.ts` for the same PID-reuse-safe identity purpose. `getFileLockProcessStartTime` just missed the win32 dispatch, so the cron fence had no Windows identity path at all.

## User Impact

Windows installs on 2026.8.1-beta.2 get all timer-based functionality back: cron jobs run on schedule, `openclaw status` shows jobs as scheduled instead of `idle`, and heartbeats stop reporting `skipped · unknown`. Non-Windows platforms are untouched (linux/darwin paths unchanged).

## Evidence

Unit test run (`src/shared/pid-alive.test.ts`, 20/20 pass, including the new win32 dispatch test):

```text
 RUN  v4.1.10 /home/0668001400/AI/code/openclaw

 ✓  shared-core  ../../src/shared/pid-alive.test.ts (20 tests) 18ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  20:20:52
   Duration  1.02s (transform 686ms, setup 104ms, import 335ms, tests 18ms, environment 0ms)
```

The new test asserts `getFileLockProcessStartTime(pid)` returns the mocked Windows creation time and forwards the pid to `readWindowsProcessStartTimeSync` under `process.platform === "win32"`.

Note: `src/cron/store/run-receipt-store.null-start-time.test.ts` cannot run in this sandbox because the local Node 24.13.1 embeds SQLite 3.51.2, which the repo's WAL-safety guard rejects (pre-existing environment limitation, unrelated to this change); the changed file's own suite is green.

[AI-assisted]
