### PR TITLE
fix(memory-wiki): render ingested Markdown sources as Markdown (#124154)

### DIFF
--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -75,6 +75,71 @@ hello from source
     );
   });
 
+  it("renders ingested Markdown as Markdown and lifts non-owned frontmatter", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-md-");
+    const inputPath = path.join(rootDir, "upstream-repro.md");
+    await fs.writeFile(
+      inputPath,
+      [
+        "---",
+        "tags: [demo]",
+        "url: https://example.invalid/demo",
+        "---",
+        "",
+        "# Demo heading",
+        "",
+        "Body text with `code`.",
+        "",
+        "```bash",
+        "echo hi",
+        "```",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const { config } = await createVault({
+      rootDir: path.join(rootDir, "vault"),
+    });
+
+    const result = await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    expect(result.pageId).toBe("source.upstream-repro");
+    const page = await fs.readFile(
+      path.join(config.vault.path, "sources", "upstream-repro.md"),
+      "utf8",
+    );
+    expect(page).toContain("tags:\n  - demo");
+    expect(page).toContain("url: https://example.invalid/demo");
+    // The source body must render as Markdown, not sit inside a ```text fence.
+    expect(page).not.toContain("```text");
+    expect(page).toContain("## Content\n# Demo heading");
+    expect(page).toContain("Body text with `code`.");
+    expect(page).toContain("```bash\necho hi\n```");
+  });
+
+  it("keeps malformed frontmatter fenced instead of corrupting the page", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-badfm-");
+    const inputPath = path.join(rootDir, "broken.md");
+    await fs.writeFile(inputPath, "---\n- not\n- a\n- mapping\n---\n\n# Body\n", "utf8");
+    const { config } = await createVault({
+      rootDir: path.join(rootDir, "vault"),
+    });
+
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const page = await fs.readFile(path.join(config.vault.path, "sources", "broken.md"), "utf8");
+    expect(page).toContain("```text");
+    expect(page).not.toContain("## Content\n# Body");
+  });
+
   it("queues behind a held vault mutation instead of writing mid-transaction", async () => {
     const rootDir = await createTempDir("memory-wiki-ingest-lock-");
     const inputPath = path.join(rootDir, "meeting-notes.txt");

--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -6,6 +6,7 @@ import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
 import {
+  parseWikiMarkdown,
   preserveHumanNotesBlock,
   renderMarkdownFence,
   renderWikiMarkdown,
@@ -50,6 +51,50 @@ function isEmptyExistingSourcePage(error: unknown): boolean {
   );
 }
 
+/** Page-owned frontmatter keys that a source file must never override. */
+const PAGE_OWNED_FRONTMATTER_KEYS = new Set([
+  "pageType",
+  "id",
+  "title",
+  "sourceType",
+  "sourcePath",
+  "ingestedAt",
+  "updatedAt",
+  "status",
+]);
+
+function isMarkdownSourcePath(sourcePath: string): boolean {
+  const extension = path.extname(sourcePath).toLowerCase();
+  return extension === ".md" || extension === ".markdown";
+}
+
+/**
+ * Render an ingested file's body. Markdown sources keep their body as real
+ * Markdown (so headings/tables/links render as such) and may contribute valid
+ * non-owned frontmatter keys (tags, url, date, ...). Non-Markdown inputs and
+ * malformed/non-mapping frontmatter stay fenced as plain text.
+ */
+function renderIngestContent(params: { content: string; sourcePath: string }): {
+  body: string;
+  frontmatter: Record<string, unknown>;
+} {
+  if (!isMarkdownSourcePath(params.sourcePath)) {
+    return { body: renderMarkdownFence(params.content, "text"), frontmatter: {} };
+  }
+  let parsed: ReturnType<typeof parseWikiMarkdown>;
+  try {
+    parsed = parseWikiMarkdown(params.content);
+  } catch {
+    // Malformed or non-mapping frontmatter: keep the whole input fenced so a
+    // broken source cannot corrupt page structure or leak bogus metadata.
+    return { body: renderMarkdownFence(params.content, "text"), frontmatter: {} };
+  }
+  const promoted = Object.fromEntries(
+    Object.entries(parsed.frontmatter).filter(([key]) => !PAGE_OWNED_FRONTMATTER_KEYS.has(key)),
+  );
+  return { body: parsed.body.trim(), frontmatter: promoted };
+}
+
 async function readExistingSourcePage(pagePath: string): Promise<string> {
   let readError: unknown;
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -83,6 +128,7 @@ async function ingestMemoryWikiSourceUnlocked(params: {
   const pagePath = path.join(params.config.vault.path, pageRelativePath);
   const created = !(await pathExists(pagePath));
   const timestamp = resolveMemoryWikiTimestamp(params.nowMs);
+  const rendered = renderIngestContent({ content, sourcePath });
 
   const markdown = renderWikiMarkdown({
     frontmatter: {
@@ -94,6 +140,9 @@ async function ingestMemoryWikiSourceUnlocked(params: {
       ingestedAt: timestamp,
       updatedAt: timestamp,
       status: "active",
+      // Non-owned keys lifted from a Markdown source's own frontmatter
+      // (tags, url, date, ...). Page-owned keys above always win.
+      ...rendered.frontmatter,
     },
     body: [
       `# ${title}`,
@@ -105,7 +154,7 @@ async function ingestMemoryWikiSourceUnlocked(params: {
       `- Updated: ${timestamp}`,
       "",
       "## Content",
-      renderMarkdownFence(content, "text"),
+      rendered.body,
       "",
       "## Notes",
       "<!-- openclaw:human:start -->",


### PR DESCRIPTION
## What Problem

`openclaw wiki ingest` wrapped every input in a ```` ```text ```` fence, so ingesting a Markdown file produced a source page whose entire body rendered as one code block — headings, tables and links never rendered as Markdown, and the file's own frontmatter (`tags`, `url`, `date`, …) stayed buried inside the block instead of landing in the page frontmatter where `wiki lint` / `wiki compile` can see it.

## Why

`ingestMemoryWikiSourceUnlocked` in `extensions/memory-wiki/src/ingest.ts` called `renderMarkdownFence(content, "text")` unconditionally. The sibling import path (`unsafe-local`) already renders per-file-type via `detectFenceLanguage`, which returns `"markdown"` for `.md` — the `wiki ingest` call site was the outlier hardcoding `"text"`.

## User Impact

Ingesting `.md` files into a memory wiki now produces readable source pages: Markdown structure renders as Markdown, and valid non-owned frontmatter keys (`tags`, `url`, `date`, …) are lifted into the page frontmatter. Non-Markdown inputs (`.txt`, binary, etc.) and malformed/non-mapping frontmatter keep the previous fenced-as-text behavior, so nothing regresses for opaque inputs.

## Evidence

New regression tests in `extensions/memory-wiki/src/ingest.test.ts` — full memory-wiki suite 444/444 pass:

```text
 RUN  v4.1.10 /home/0668001400/AI/code/openclaw

 ✓  extension-memory  ../../extensions/memory-wiki/src/ingest.test.ts (4 tests) 1221ms
     ✓ copies a local text file into sources markdown  379ms
     ✓ renders ingested Markdown as Markdown and lifts non-owned frontmatter
     ✓ keeps malformed frontmatter fenced instead of corrupting the page
     ✓ queues behind a held vault mutation instead of writing mid-transaction

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full suite:

```text
 Test Files  39 passed (39)
      Tests  444 passed (444)
   Start at  20:26:05
   Duration  142.72s (transform 10.14s, setup 13.04s, import 70.04s, tests 53.22s)
```

The Markdown test ingests the issue's exact repro shape (`tags: [demo]`, `url`, a `# heading`, inline code and a ```` ```bash ```` block) and asserts: frontmatter contains `tags`/`url`, no ```` ```text ```` fence appears, and `## Content` is followed by the rendered Markdown body. The malformed-frontmatter test ingests a non-mapping YAML root and asserts the whole input stays fenced.

[AI-assisted]
