### PR TITLE
fix(codex): keep plugin loaded for explicit multi-agent gateways

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -1,5 +1,6 @@
 // Codex tests cover index plugin behavior.
 import fs from "node:fs";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { describe, expect, it, vi } from "vitest";
 import openAIPlugin from "../openai/index.js";
@@ -17,6 +18,12 @@ import { CODEX_SUPERVISION_COMPAT_TOOL_NAMES } from "./src/supervision-tools.js"
 
 const runCodexAppServerAttemptMock = vi.hoisted(() => vi.fn());
 const runCodexAppServerSideQuestionMock = vi.hoisted(() => vi.fn());
+const explicitAgentConfig = {
+  agents: {
+    ownership: "explicit",
+    entries: { main: {}, clawblocker: {}, blockdigest: {} },
+  },
+} as OpenClawConfig;
 
 function createCodexTestRuntime(
   current?: () => unknown,
@@ -55,7 +62,7 @@ describe("codex plugin", () => {
     expect(manifest.providers).toBeUndefined();
   });
 
-  it("does not open plugin state while registering with the base runtime", () => {
+  it("does not select an agent or open plugin state while registering", () => {
     const openSyncKeyedStore = vi.fn(() => {
       throw new Error("openSyncKeyedStore is only available through the plugin runtime proxy");
     });
@@ -66,13 +73,45 @@ describe("codex plugin", () => {
           id: "codex",
           name: "Codex",
           source: "test",
-          config: {},
+          config: explicitAgentConfig,
           pluginConfig: {},
           runtime: { state: { openSyncKeyedStore } } as never,
         }),
       ),
     ).not.toThrow();
     expect(openSyncKeyedStore).not.toHaveBeenCalled();
+  });
+
+  it("registers request-scoped surfaces with explicit multi-agent ownership", () => {
+    const registerAgentHarness = vi.fn();
+    const registerNodeHostCommand = vi.fn();
+    const registerSessionCatalog = vi.fn();
+
+    expect(() =>
+      plugin.register(
+        createTestPluginApi({
+          id: "codex",
+          name: "Codex",
+          source: "test",
+          config: explicitAgentConfig,
+          pluginConfig: {},
+          runtime: createCodexTestRuntime(() => explicitAgentConfig),
+          registerAgentHarness,
+          registerNodeHostCommand,
+          registerSessionCatalog,
+        }),
+      ),
+    ).not.toThrow();
+
+    expect(registerAgentHarness).toHaveBeenCalledOnce();
+    expect(registerSessionCatalog).toHaveBeenCalledOnce();
+    expect(registerNodeHostCommand.mock.calls.map(([command]) => command.command)).toEqual(
+      expect.arrayContaining([
+        "codex.appServer.threads.list.v1",
+        "codex.appServer.thread.turns.list.v1",
+        "codex.terminal.resume.v1",
+      ]),
+    );
   });
 
   it("proactively monitors an explicitly configured remote websocket app-server", () => {
@@ -222,7 +261,7 @@ describe("codex plugin", () => {
         id: "codex",
         name: "Codex",
         source: "test",
-        config: {},
+        config: explicitAgentConfig,
         pluginConfig: { sessionCatalog: { enabled: false } },
         runtime: createCodexTestRuntime(),
         registerAgentHarness,

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -1,4 +1,3 @@
-import { resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 /**
  * Bundled Codex plugin entry: app-server harness, media understanding,
  * migration provider, CLI-session commands, and binding hooks.
@@ -133,11 +132,6 @@ export default definePluginEntry({
       getPluginConfig: resolveCurrentPluginConfig,
       getRuntimeConfig: resolveCurrentConfig,
     });
-    const nodeSessionCatalogControl = sessionCatalogControlFactory.forRequest(
-      resolveSessionAgentIds({
-        config: resolveCurrentConfig() ?? (api.config as OpenClawConfig),
-      }).sessionAgentId,
-    );
     const sessionCatalogEnabled =
       readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
     if (sessionCatalogEnabled) {
@@ -148,10 +142,13 @@ export default definePluginEntry({
         getPluginConfig: resolveCurrentPluginConfig,
         getRuntimeConfig: resolveCurrentConfig,
       });
-      for (const command of createCodexSessionCatalogNodeHostCommands(nodeSessionCatalogControl, {
-        getPluginConfig: resolveCurrentPluginConfig,
-        getRuntimeConfig: resolveCurrentConfig,
-      })) {
+      for (const command of createCodexSessionCatalogNodeHostCommands(
+        sessionCatalogControlFactory,
+        {
+          getPluginConfig: resolveCurrentPluginConfig,
+          getRuntimeConfig: () => resolveCurrentConfig() ?? (api.config as OpenClawConfig),
+        },
+      )) {
         api.registerNodeHostCommand(command);
       }
     }

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -81,6 +81,7 @@ function canContinueCodexOnNode(node: CatalogNode): boolean {
 }
 
 export async function listPairedNode(params: {
+  agentId: string;
   runtime: PluginRuntime;
   node: CatalogNode;
   query: CodexSessionCatalogParams;
@@ -111,6 +112,7 @@ export async function listPairedNode(params: {
         nodeId: params.node.nodeId,
         command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
         params: {
+          agentId: params.agentId,
           cursor: params.query.cursors?.[hostId],
           limit: params.query.limitPerHost,
           searchTerm: params.query.search,
@@ -177,6 +179,7 @@ async function requireNodeForCodexContinue(params: {
 }
 
 async function resolveNodeCodexRecord(params: {
+  agentId: string;
   runtime: PluginRuntime;
   nodeId: string;
   threadId: string;
@@ -188,6 +191,7 @@ async function resolveNodeCodexRecord(params: {
       nodeId: params.nodeId,
       command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
       params: {
+        agentId: params.agentId,
         limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
         ...(cursor ? { cursor } : {}),
       },
@@ -233,6 +237,7 @@ function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void 
 }
 
 async function readNodeCodexHistory(params: {
+  agentId: string;
   runtime: PluginRuntime;
   nodeId: string;
   record: CodexSessionCatalogSession;
@@ -241,6 +246,7 @@ async function readNodeCodexHistory(params: {
     nodeId: params.nodeId,
     command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
     params: {
+      agentId: params.agentId,
       threadId: params.record.threadId,
       limit: MAX_TRANSCRIPT_PAGE_LIMIT,
     },
@@ -279,6 +285,7 @@ async function continueNodeCodexSessionInner(params: {
     hostId: params.hostId,
   });
   const record = await resolveNodeCodexRecord({
+    agentId: params.agentId,
     runtime: params.api.runtime,
     nodeId,
     threadId: params.threadId,
@@ -301,6 +308,7 @@ async function continueNodeCodexSessionInner(params: {
     disposition = "existing";
   } else {
     const history = await readNodeCodexHistory({
+      agentId: params.agentId,
       runtime: params.api.runtime,
       nodeId,
       record,

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -135,7 +135,11 @@ async function findCatalogEligibleThread(
 }
 
 export function createCodexTerminalNodeHostCommand(
-  control: CodexSessionCatalogControl,
+  bindRequest: (paramsJSON?: string | null) => {
+    agentId: string;
+    control: CodexSessionCatalogControl;
+    paramsJSON: string;
+  },
   configSources: CodexTerminalConfigSources,
 ): OpenClawPluginNodeHostCommand {
   return {
@@ -155,7 +159,8 @@ export function createCodexTerminalNodeHostCommand(
       if (!io) {
         throw new Error("Codex terminal command requires duplex transport");
       }
-      const resume = decodeNodePtyResumeParams(paramsJSON, (value) => {
+      const request = bindRequest(paramsJSON);
+      const resume = decodeNodePtyResumeParams(request.paramsJSON, (value) => {
         if (
           typeof value !== "string" ||
           !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(value)
@@ -164,7 +169,7 @@ export function createCodexTerminalNodeHostCommand(
         }
         return value;
       });
-      const record = await requireCatalogEligibleThread(control, resume.threadId);
+      const record = await requireCatalogEligibleThread(request.control, resume.threadId);
       const resolution = resolveNodeHostExecutable("codex", {
         env: process.env,
         pathEnv: process.env.PATH ?? process.env.Path ?? "",
@@ -179,7 +184,12 @@ export function createCodexTerminalNodeHostCommand(
             file: resolution.executable,
             args: ["resume", resume.threadId],
             cwd: record.cwd,
-            env: { CODEX_HOME: resolveCodexCatalogTerminalHome(configSources) },
+            env: {
+              CODEX_HOME: resolveCodexCatalogTerminalHome({
+                ...configSources,
+                agentId: request.agentId,
+              }),
+            },
             cols: resume.cols,
             rows: resume.rows,
           },
@@ -191,6 +201,7 @@ export function createCodexTerminalNodeHostCommand(
 }
 
 async function resolveNodeCatalogEligibleThread(params: {
+  agentId: string;
   runtime: PluginRuntime;
   nodeId: string;
   threadId: string;
@@ -203,6 +214,7 @@ async function resolveNodeCatalogEligibleThread(params: {
       nodeId: params.nodeId,
       command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
       params: {
+        agentId: params.agentId,
         limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
         ...(cursor ? { cursor } : {}),
       },
@@ -276,6 +288,7 @@ export async function openCodexCatalogTerminal(
     throw new CatalogParamsError("paired-node Codex terminal is unavailable");
   }
   const record = await resolveNodeCatalogEligibleThread({
+    agentId: params.agentId,
     runtime: params.api.runtime,
     nodeId,
     threadId: params.threadId,
@@ -285,7 +298,7 @@ export async function openCodexCatalogTerminal(
     kind: "node",
     nodeId,
     command: CODEX_TERMINAL_RESUME_COMMAND,
-    paramsJSON: JSON.stringify({ threadId: params.threadId }),
+    paramsJSON: JSON.stringify({ agentId: params.agentId, threadId: params.threadId }),
     ...(record.cwd ? { cwd: record.cwd } : {}),
     title,
   };

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -165,13 +165,16 @@ function registerCodexSessionCatalog(
 }
 
 function createCodexSessionCatalogNodeHostCommands(
-  control: CodexSessionCatalogControl,
+  control:
+    | CodexSessionCatalogControl
+    | CodexSessionCatalogControlFactory
+    | CodexSessionCatalogControlFactoryStub,
   configSources: CodexTerminalConfigSources = {
     getPluginConfig: () => undefined,
     getRuntimeConfig: () => config,
   },
 ) {
-  return createCodexSessionCatalogNodeHostCommandsRuntime(control, configSources);
+  return createCodexSessionCatalogNodeHostCommandsRuntime(asControlFactory(control), configSources);
 }
 
 const commandRpcMocks = vi.hoisted(() => ({
@@ -1668,11 +1671,12 @@ describe("Codex supervision catalog", () => {
       expect.objectContaining({
         nodeId: "devbox",
         command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-        params: expect.not.objectContaining({ archived: expect.anything() }),
+        params: expect.objectContaining({ agentId: "main" }),
         timeoutMs: 65_000,
         scopes: ["operator.write"],
       }),
     );
+    expect(invoke.mock.calls[0]?.[0].params).not.toHaveProperty("archived");
     expect(JSON.stringify(result)).not.toContain("private");
 
     const [nodeCommand] = createCodexSessionCatalogNodeHostCommands(control);
@@ -1864,14 +1868,14 @@ describe("Codex supervision catalog", () => {
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         nodeId: "healthy",
-        params: { cursor: "healthy-page-2", limit: 7, searchTerm: "match" },
+        params: { agentId: "main", cursor: "healthy-page-2", limit: 7, searchTerm: "match" },
         scopes: ["operator.write"],
       }),
     );
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         nodeId: "broken",
-        params: { cursor: "broken-page-2", limit: 7, searchTerm: "match" },
+        params: { agentId: "main", cursor: "broken-page-2", limit: 7, searchTerm: "match" },
         scopes: ["operator.write"],
       }),
     );
@@ -1911,6 +1915,7 @@ describe("Codex supervision catalog", () => {
         async () => await new Promise<never>(() => {}),
       );
       const pending = listPairedNode({
+        agentId: "main",
         runtime: { nodes: { invoke } } as unknown as PluginRuntime,
         node: {
           nodeId: "slow-node",
@@ -1946,6 +1951,7 @@ describe("Codex supervision catalog", () => {
       const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => await invokeResult);
       const onHost = vi.fn();
       const pending = listPairedNode({
+        agentId: "main",
         runtime: { nodes: { invoke } } as unknown as PluginRuntime,
         node: {
           nodeId: "slow-node",
@@ -2020,6 +2026,60 @@ describe("Codex supervision catalog", () => {
     });
   });
 
+  it("binds paired-node catalog commands to the invocation agent after config reload", async () => {
+    let runtimeConfig = { agents: { list: [{ id: "main" }] } } as OpenClawConfig;
+    const alphaListPage = vi.fn(async () => {
+      throw new Error("alpha control must not serve beta");
+    });
+    const betaListPage = vi.fn(async () => ({
+      sessions: [{ threadId: "thread-beta", status: "idle", source: "cli", archived: false }],
+    }));
+    const betaListTurnPage = vi.fn(async () => ({ data: [] }));
+    const alphaControl = createControl({ listPage: alphaListPage });
+    const betaControl = createControl({
+      listPage: betaListPage,
+      listTurnPage: betaListTurnPage,
+    });
+    const forRequest = vi.fn((agentId: string) =>
+      agentId === "beta" ? betaControl : alphaControl,
+    );
+    const commands = createCodexSessionCatalogNodeHostCommands(
+      { forRequest },
+      {
+        getPluginConfig: () => undefined,
+        getRuntimeConfig: () => runtimeConfig,
+      },
+    );
+    runtimeConfig = {
+      agents: { ownership: "explicit", list: [{ id: "alpha" }, { id: "beta" }] },
+    } as OpenClawConfig;
+    const listCommand = commands.find(
+      (candidate) => candidate.command === CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+    );
+    const transcriptCommand = commands.find(
+      (candidate) => candidate.command === CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+    );
+    if (!listCommand || !transcriptCommand) {
+      throw new Error("Codex node catalog commands were not registered");
+    }
+
+    expect(
+      JSON.parse(await listCommand.handle(JSON.stringify({ agentId: "beta", limit: 25 }))),
+    ).toEqual({
+      sessions: [{ threadId: "thread-beta", status: "idle", source: "cli", archived: false }],
+    });
+    await expect(
+      transcriptCommand.handle(
+        JSON.stringify({ agentId: "beta", threadId: "thread-beta", limit: 25 }),
+      ),
+    ).resolves.toBe(JSON.stringify({ data: [] }));
+    await expect(listCommand.handle(JSON.stringify({ limit: 25 }))).rejects.toThrow(
+      "session agent resolution has no explicit owner",
+    );
+
+    expect(alphaListPage).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed terminal resume thread ids before spawning", async () => {
     const command = createCodexSessionCatalogNodeHostCommands(createEligibleControl()).find(
       (candidate) => candidate.command === CODEX_TERMINAL_RESUME_COMMAND,
@@ -2049,6 +2109,9 @@ describe("Codex supervision catalog", () => {
       await fs.chmod(executable, 0o755);
     }
     process.env.PATH = binDir;
+    const explicitConfig = {
+      agents: { ownership: "explicit", list: [{ id: "alpha" }, { id: "beta" }] },
+    } as OpenClawConfig;
     const command = createCodexSessionCatalogNodeHostCommands(
       createEligibleControl({
         listPage: vi.fn(async () => ({
@@ -2065,18 +2128,21 @@ describe("Codex supervision catalog", () => {
       }),
       {
         getPluginConfig: () => ({ appServer: { homeScope: "agent" } }),
-        getRuntimeConfig: () => config,
+        getRuntimeConfig: () => explicitConfig,
       },
     ).find((candidate) => candidate.command === CODEX_TERMINAL_RESUME_COMMAND);
     if (!command || command.duplex !== true) {
       throw new Error("Codex terminal command was not registered as duplex");
     }
 
-    await command.handle(JSON.stringify({ threadId, cwd: "/caller/cwd", cols: 80, rows: 24 }), {
-      signal: new AbortController().signal,
-      emitChunk: async () => {},
-      onInput: () => {},
-    });
+    await command.handle(
+      JSON.stringify({ agentId: "beta", threadId, cwd: "/caller/cwd", cols: 80, rows: 24 }),
+      {
+        signal: new AbortController().signal,
+        emitChunk: async () => {},
+        onInput: () => {},
+      },
+    );
 
     expect(command.dangerous).toBe(false);
     expect(nodeHostMocks.runNodePtyCommand).toHaveBeenCalledWith(
@@ -2084,7 +2150,7 @@ describe("Codex supervision catalog", () => {
         file: executable,
         cwd: "/node/catalog/cwd",
         env: {
-          CODEX_HOME: resolveCodexAppServerHomeDir(resolveDefaultAgentDir(config)),
+          CODEX_HOME: resolveCodexAppServerHomeDir(resolveAgentDir(explicitConfig, "beta")),
         },
       }),
       expect.any(Object),
@@ -4276,6 +4342,13 @@ describe("Codex supervision actions", () => {
     expect(alpha).toMatchObject({ conversationBinding: { data: { agentId: "alpha" } } });
     expect(beta).toMatchObject({ conversationBinding: { data: { agentId: "beta" } } });
     expect(createSessionEntry).toHaveBeenCalledTimes(2);
+    expect(
+      new Set(
+        invoke.mock.calls.map(
+          ([request]) => (request.params as { agentId?: string } | undefined)?.agentId,
+        ),
+      ),
+    ).toEqual(new Set(["alpha", "beta"]));
   });
 
   it("rejects paired-node continue without the permitted run command", async () => {
@@ -4731,7 +4804,12 @@ describe("Codex supervision actions", () => {
     expect(invoke).toHaveBeenLastCalledWith({
       nodeId: "devbox",
       command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
-      params: { threadId: "thread-remote", cursor: "remote-turns-1", limit: 25 },
+      params: {
+        agentId: "main",
+        threadId: "thread-remote",
+        cursor: "remote-turns-1",
+        limit: 25,
+      },
       timeoutMs: 65_000,
       scopes: ["operator.write"],
     });

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -662,6 +662,7 @@ async function listCodexSessionCatalog(params: {
   });
   const nodeHosts = nodes.toSorted(compareNodeLabels).map(async (node) => {
     const host = await listPairedNode({
+      agentId,
       runtime: params.runtime,
       node,
       query,
@@ -675,19 +676,42 @@ async function listCodexSessionCatalog(params: {
 
 /** Builds the node-local read-only Codex app-server catalog command. */
 export function createCodexSessionCatalogNodeHostCommands(
-  control: CodexSessionCatalogControl,
+  controlFactory: CodexSessionCatalogControlFactory,
   configSources: CodexTerminalConfigSources,
 ): OpenClawPluginNodeHostCommand[] {
+  // Node commands register before an agent request exists. Bind from the invoke payload so
+  // explicit multi-agent Codex homes never collapse to an ambient default.
+  const bindRequest = (paramsJSON?: string | null) => {
+    const parsed = parseJsonParams(paramsJSON);
+    if (!isRecord(parsed)) {
+      throw new CatalogParamsError("Codex session catalog parameters must be an object");
+    }
+    const requestedAgentId = readBoundedOptionalString(parsed, "agentId", MAX_SESSION_ID_LENGTH);
+    const config = configSources.getRuntimeConfig() ?? {};
+    const agentId = resolveSessionAgentIds({ config, agentId: requestedAgentId }).sessionAgentId;
+    if (!listAgentIds(config).includes(agentId)) {
+      throw new CatalogParamsError(`unknown Codex session catalog agent: ${agentId}`);
+    }
+    const request = { ...parsed };
+    delete request.agentId;
+    return {
+      agentId,
+      control: controlFactory.forRequest(agentId),
+      params: request,
+      paramsJSON: JSON.stringify(request),
+    };
+  };
   return [
     {
       command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
       cap: CODEX_APP_SERVER_THREADS_CAPABILITY,
       dangerous: false,
       handle: async (paramsJSON) => {
-        const pageParams = readPageParams(parseJsonParams(paramsJSON));
+        const request = bindRequest(paramsJSON);
+        const pageParams = readPageParams(request.params);
         try {
           const page = filterCatalogPageByTitle(
-            parseCatalogPage(await control.listPage(pageParams)),
+            parseCatalogPage(await request.control.listPage(pageParams)),
             pageParams.searchTerm,
           );
           return JSON.stringify(page);
@@ -702,11 +726,12 @@ export function createCodexSessionCatalogNodeHostCommands(
       cap: CODEX_APP_SERVER_THREADS_CAPABILITY,
       dangerous: false,
       handle: async (paramsJSON) => {
-        const action = readNodeTranscriptParams(parseJsonParams(paramsJSON));
+        const request = bindRequest(paramsJSON);
+        const action = readNodeTranscriptParams(request.params);
         try {
-          await requireCatalogEligibleThread(control, action.threadId);
+          await requireCatalogEligibleThread(request.control, action.threadId);
           const page = parseTranscriptPage(
-            await control.listTurnPage({
+            await request.control.listTurnPage({
               threadId: action.threadId,
               limit: action.limit,
               sortDirection: "desc",
@@ -723,7 +748,7 @@ export function createCodexSessionCatalogNodeHostCommands(
         }
       },
     },
-    createCodexTerminalNodeHostCommand(control, configSources),
+    createCodexTerminalNodeHostCommand(bindRequest, configSources),
   ];
 }
 
@@ -812,6 +837,7 @@ async function readCodexSessionTranscript(params: {
     nodeId,
     command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
     params: {
+      agentId: params.agentId,
       threadId: params.threadId,
       limit: params.limit,
       ...(params.cursor ? { cursor: params.cursor } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateways with multiple explicitly owned agents lost the bundled Codex plugin during startup. The Gateway remained generally healthy, but Codex session catalogs, harness turns, tools, hosted search, and media support were all absent because plugin registration threw `AgentSelectionRequiredError` before any request owner existed.

Regression provenance: #123899 added the eager bind in squash merge `632581477f042de83bfdc095b9fdb042330deb72`. Line blame attributes it to WhatsSkiLL (PR author @IWhatsskill); the PR was merged by @steipete on 2026-08-15.

## Why This Change Was Made

Codex registration is now owner-neutral. The already-authorized catalog request carries its agent ID through every paired-node list, transcript, continuation, eligibility, history, and terminal-resume hop; the node binds `CodexSessionCatalogControlFactory.forRequest(agentId)` only when handling that request. Missing owners still fail closed for explicit multi-agent configurations, and config reloads cannot retain a startup-selected owner.

This is the owning boundary because Codex App Server has no OpenClaw-agent field: it resolves one `CODEX_HOME` at process startup and keeps one process-scoped thread store. Upstream source: [`find_codex_home`](https://github.com/openai/codex/blob/a7edf37cb46b5fc4d50bd03df8e5999a86f602eb/codex-rs/utils/home-dir/src/lib.rs#L5-L17), [process-scoped thread store](https://github.com/openai/codex/blob/a7edf37cb46b5fc4d50bd03df8e5999a86f602eb/codex-rs/app-server/src/message_processor.rs#L252-L256), and [`thread/list` store dispatch](https://github.com/openai/codex/blob/a7edf37cb46b5fc4d50bd03df8e5999a86f602eb/codex-rs/app-server/src/request_processors/thread_processor.rs#L2293-L2363).

Production LOC: +66/-22 (net +44) | Tests: +133/-16. The production growth is the explicit ownership handoff across the five paired-node operation families; it replaces the invalid single registration-time owner with one canonical request-bound flow.

## User Impact

Operators can run Codex on explicit multi-agent Gateways without losing the plugin at startup. Paired-node catalogs and terminals now use the selected agent's Codex home instead of an ambient default. Release-note context: fix Codex plugin startup and paired-node ownership for explicit multi-agent configurations.

## Evidence

- Immutable built-output A/B reproduction with the same explicit three-agent config:

  ```text
  94a06613227b5d1bedea7115af39b4219b81c104 register ok
  3109bc3b5d1504ee635bd25aee0f7ac14379df99 AgentSelectionRequiredError: session agent resolution has no explicit owner
  ```

- Focused regression proof: `pnpm test extensions/codex/index.test.ts extensions/codex/src/session-catalog.test.ts` — 138/138 passed. It covers explicit registration with the catalog enabled and disabled, sole-to-explicit config reload, beta-only control selection, missing-owner rejection, beta `CODEX_HOME`, and alpha/beta paired-node continuation isolation.
- Changed gate: `pnpm check:changed` — all selected formatting, guards, plugin boundaries, typechecks, lints, dead-export, database-first, and import-cycle checks passed on [Blacksmith Testbox run 31884284652](https://github.com/openclaw/openclaw/actions/runs/31884284652).
- Structured autoreview: clean, with no accepted/actionable findings.
- `git diff --check`: clean.
