### PR TITLE
fix(telegram): edit rich callback messages through the rich raw API (#123886)

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-actions.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.runtime.test.ts
@@ -1,0 +1,149 @@
+// Callback-edit action tests cover rich-vs-legacy message edit routing.
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramCallbackMessageActions } from "./bot-handlers.callback-actions.runtime.js";
+
+function buildTestBot(apiOverrides: Record<string, unknown> = {}) {
+  const editMessageText = vi.fn(async () => true);
+  const richEditMessageText = vi.fn(async () => true);
+  const bot = {
+    api: {
+      editMessageText,
+      editMessageReplyMarkup: vi.fn(async () => true),
+      deleteMessage: vi.fn(async () => true),
+      sendMessage: vi.fn(async () => true),
+      ...apiOverrides,
+      raw: {
+        editMessageText: richEditMessageText,
+        ...(apiOverrides.raw ?? {}),
+      },
+    },
+  } as never;
+  return { bot, editMessageText, richEditMessageText };
+}
+
+const callbackMessage = {
+  chat: { id: 123 },
+  message_id: 456,
+  message_thread_id: undefined,
+  direct_messages_topic: undefined,
+} as never;
+
+describe("createTelegramCallbackMessageActions", () => {
+  it("edits through the rich raw API when rich messages are enabled", async () => {
+    const { bot, editMessageText, richEditMessageText } = buildTestBot();
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("Select a model:", {
+      reply_markup: { inline_keyboard: [] },
+    });
+
+    expect(richEditMessageText).toHaveBeenCalledTimes(1);
+    expect(editMessageText).not.toHaveBeenCalled();
+    const params = richEditMessageText.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params.chat_id).toBe(123);
+    expect(params.message_id).toBe(456);
+    expect(params.rich_message).toBeDefined();
+    expect(params.reply_markup).toEqual({ inline_keyboard: [] });
+  });
+
+  it("keeps legacy text edits when rich messages are disabled", async () => {
+    const { bot, editMessageText, richEditMessageText } = buildTestBot();
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: false,
+    });
+
+    await actions.editCallbackMessage("Select a model:");
+
+    expect(editMessageText).toHaveBeenCalledTimes(1);
+    expect(richEditMessageText).not.toHaveBeenCalled();
+    expect(editMessageText).toHaveBeenCalledWith(123, 456, "Select a model:", undefined);
+  });
+
+  it("keeps caller-authored HTML edits on the legacy parse_mode HTML path", async () => {
+    const { bot, editMessageText, richEditMessageText } = buildTestBot();
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("✅ Model changed to <b>zai/model</b>", {
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: [] },
+    });
+
+    expect(editMessageText).toHaveBeenCalledTimes(1);
+    expect(richEditMessageText).not.toHaveBeenCalled();
+    expect(editMessageText).toHaveBeenCalledWith(123, 456, "✅ Model changed to <b>zai/model</b>", {
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
+  it("falls back to the legacy text edit when the rich edit fails", async () => {
+    const { bot, editMessageText, richEditMessageText } = buildTestBot();
+    richEditMessageText.mockRejectedValueOnce(new Error("Bad Request: rich payload rejected"));
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("Select a model:");
+
+    expect(richEditMessageText).toHaveBeenCalledTimes(1);
+    expect(editMessageText).toHaveBeenCalledTimes(1);
+    expect(editMessageText).toHaveBeenCalledWith(123, 456, "Select a model:", undefined);
+  });
+
+  it("re-raises message-is-not-modified from the rich edit without a legacy retry", async () => {
+    const { bot, editMessageText, richEditMessageText } = buildTestBot();
+    richEditMessageText.mockRejectedValueOnce(
+      Object.assign(new Error("400: Bad Request: message is not modified"), {
+        error_code: 400,
+      }),
+    );
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await expect(actions.editCallbackMessage("Select a model:")).rejects.toThrow(
+      "message is not modified",
+    );
+    expect(editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to legacy edits when the raw rich API is unavailable", async () => {
+    const { bot, editMessageText } = buildTestBot();
+    (bot.api as { raw?: unknown }).raw = undefined;
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: false,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("Select a model:");
+
+    expect(editMessageText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
@@ -1,6 +1,8 @@
 import type { Message } from "grammy/types";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { buildTelegramThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
+import { isTelegramMessageNotModifiedError } from "./network-errors.js";
+import { buildTelegramRichMarkdown, getTelegramRichRawApi } from "./rich-message.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export type TelegramCallbackButton = {
@@ -34,8 +36,9 @@ export function createTelegramCallbackMessageActions(params: {
   callbackMessage: Message;
   isGroup: boolean;
   isForum: boolean;
+  richMessages?: boolean;
 }): TelegramCallbackMessageActions {
-  const { bot, callbackMessage, isGroup, isForum } = params;
+  const { bot, callbackMessage, isGroup, isForum, richMessages = false } = params;
   const callbackBusinessParams =
     callbackMessage.business_connection_id !== undefined
       ? { business_connection_id: callbackMessage.business_connection_id }
@@ -47,6 +50,44 @@ export function createTelegramCallbackMessageActions(params: {
     text: string,
     editParams?: Parameters<typeof bot.api.editMessageText>[3],
   ) => {
+    // Rich-enabled accounts send picker messages through the rich raw API.
+    // Editing that same message through the legacy text path makes Telegram
+    // for iOS render the new body over the stale rich body. Mirror the rich
+    // send path for callback edits, keeping caller-authored HTML edits on
+    // the legacy parse_mode HTML funnel (rich wire path is blocks-only).
+    if (
+      richMessages &&
+      editParams?.parse_mode !== "HTML" &&
+      (bot.api as { raw?: unknown }).raw !== undefined
+    ) {
+      const richRawApi = getTelegramRichRawApi(bot.api);
+      const richMessage = buildTelegramRichMarkdown(text);
+      try {
+        const richEditParams = {
+          chat_id: callbackMessage.chat.id,
+          message_id: callbackMessage.message_id,
+          rich_message: richMessage,
+          ...(editParams?.reply_markup !== undefined
+            ? { reply_markup: editParams.reply_markup }
+            : {}),
+        };
+        return (await richRawApi.editMessageText(
+          callbackBusinessParams ? withCallbackBusinessParams(richEditParams) : richEditParams,
+        )) as unknown as Awaited<ReturnType<typeof bot.api.editMessageText>>;
+      } catch (richErr) {
+        // "message is not modified" is expected for idempotent picker edits.
+        if (isTelegramMessageNotModifiedError(richErr)) {
+          throw richErr;
+        }
+        // Fall back to the legacy text edit, mirroring the rich-send funnel.
+        return await bot.api.editMessageText(
+          callbackMessage.chat.id,
+          callbackMessage.message_id,
+          text,
+          editParams ? withCallbackBusinessParams(editParams) : callbackBusinessParams,
+        );
+      }
+    }
     return await bot.api.editMessageText(
       callbackMessage.chat.id,
       callbackMessage.message_id,

--- a/extensions/telegram/src/bot-handlers.callback.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback.runtime.ts
@@ -1,6 +1,7 @@
 // Telegram callback-query routing across approvals, plugin actions, selects, commands, and models.
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { mergeTelegramAccountConfig } from "./account-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   hasTelegramApprovalCallbackPrefix,
@@ -183,6 +184,7 @@ export function registerTelegramCallbackQueryHandler(
         callbackMessage,
         isGroup,
         isForum,
+        richMessages: mergeTelegramAccountConfig(runtimeCfg, accountId).richMessages === true,
       });
       const approvalRuntime = createTelegramCallbackApprovalRuntime({
         accountId,


### PR DESCRIPTION
## What Problem

With `channels.telegram.richMessages: true`, the `/models` picker is sent through the rich raw API (`sendRichMessage`), but every callback edit — provider/model selection steps and the final "Model changed" confirmation — went through the legacy `bot.api.editMessageText(chatId, messageId, text)` text path. Telegram for iOS then rendered the new body over the stale rich picker body, producing overlapping, unreadable text (issue #123886).

## Why

`createTelegramCallbackMessageActions` in `extensions/telegram/src/bot-handlers.callback-actions.runtime.ts` only ever called the legacy text `editMessageText` signature. The rich send funnel (`send.ts`, `draft-stream.ts`) already routes through `getTelegramRichRawApi(api).editMessageText({ chat_id, message_id, rich_message, ... })` — the callback-edit owner was the one path that missed the rich branch, so it edited a rich message as if it were plain text.

## User Impact

Telegram users with `richMessages: true` get a clean model picker: each step replaces the previous rich body in place, and the final confirmation no longer overlaps the stale "Select a provider:" text. Caller-authored HTML edits (e.g. the `✅ Model changed to <b>…</b>` confirmation) stay on the legacy `parse_mode: HTML` path per the rich-wire blocks-only contract, and any rich-edit failure falls back to the previous legacy text edit — so nothing regresses when the rich raw API is unavailable.

## Evidence

New unit tests in `extensions/telegram/src/bot-handlers.callback-actions.runtime.test.ts` (6/6 pass) covering rich routing, legacy fallback, HTML-mode preservation, not-modified re-raise, and missing-raw-API fallback:

```text
 ✓  extension-telegram  ../../extensions/telegram/src/bot-handlers.callback-actions.runtime.test.ts (6 tests) 29ms

 Test Files  3 passed (3)
      Tests  14 passed (14)
   Start at  20:49:34
   Duration  13.18s (transform 6.14s, setup 544ms, import 12.34s, tests 69ms, environment 0ms)
```

Also verified with the full callback-related suites (`bot-handlers.callback-questions.runtime.test.ts`, `approval-handler.runtime.test.ts`) — all 14 tests pass, and `tsc -p extensions/telegram/tsconfig.json` reports no new errors from these files (the 6 remaining errors in that project pre-exist on `origin/main` and touch unrelated files: `inbound-debounce`, `bot-message-context`, `bot-native-commands`, `state-migrations`).

Note: this sandbox cannot run a live Telegram bot; per ClawSweeper's own review this is a source-reproducible representation mismatch with a clear focused test boundary (`clawsweeper:source-repro`, no `needs-live-repro` label).

[AI-assisted]
