### PR TITLE
refactor(test): remove unused testing bag members

### DIFF
--- a/scripts/bench-gateway-restart.ts
+++ b/scripts/bench-gateway-restart.ts
@@ -1295,11 +1295,9 @@ async function main() {
 }
 
 export const testing = {
-  classifyGatewayReadyLog,
   collectOutputLines,
   collectTraceLine,
   countLsofFileDescriptors,
-  computeResourceSlope,
   createRestartIteration,
   ensureSupportedRestartPlatform,
   finalizeRestartIteration,
@@ -1320,7 +1318,6 @@ export const testing = {
   shouldFailBenchmark,
   stopChild,
   summarizeCase,
-  validateCliArgs,
   waitForRestartProbe,
   writeConfig,
   writeRestartIntent,

--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -830,7 +830,6 @@ export const testing = {
   sanitizedEnv,
   stopChild,
   summarizeCase,
-  validateCliArgs,
   waitForProbe,
   waitForStartupTracePhase,
   writeConfig,

--- a/scripts/bench-model.ts
+++ b/scripts/bench-model.ts
@@ -231,10 +231,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 }
 
 export const testing = {
-  median,
   parseArgs,
-  parseRuns,
-  validateCliArgs,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -405,13 +405,11 @@ function runStartupMemoryCheck(argv = process.argv.slice(2), params = {}) {
  */
 export const testing = {
   cases,
-  nodeImportSpecifierForPath,
   parseArgs,
   readPositiveIntEnv,
   readPositiveNumberEnv,
   repoRoot,
   resolveDefaultLimitsMb,
-  runCase,
   runStartupMemoryCheck,
   sampleCount: STARTUP_MEMORY_SAMPLE_COUNT,
 };

--- a/scripts/check-gateway-cpu-scenarios.mts
+++ b/scripts/check-gateway-cpu-scenarios.mts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
 // Runs gateway startup and QA scenarios while checking hot CPU observations.
-import { spawnSync as defaultSpawnSync } from "node:child_process";
-import type { SpawnSyncOptions } from "node:child_process";
+import {
+  spawnSync as defaultSpawnSync,
+  type SpawnSyncOptions,
+  type SpawnSyncReturns,
+} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -46,11 +49,7 @@ const PRIVATE_QA_REQUIRED_DIST_ENTRIES = [
   "dist/plugin-sdk/qa-runtime.js",
 ];
 
-type SpawnSyncResultLike = {
-  error?: Error;
-  signal?: NodeJS.Signals | null;
-  status?: number | null;
-};
+type SpawnSyncResultLike = Pick<SpawnSyncReturns<Buffer>, "error" | "signal" | "status">;
 type SpawnSyncFn = (
   command: string,
   args: string[],
@@ -633,11 +632,8 @@ async function main(params: GatewayCpuRunParams = {}) {
  * Test-only access to the gateway CPU scenario parser and runner helpers.
  */
 export const testing = {
-  hasPrivateQaDist,
   parseArgs,
-  readStartupReport,
   runGatewayCpuScenarios,
-  validateStartupReport,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/check-gateway-cpu-scenarios.mts
+++ b/scripts/check-gateway-cpu-scenarios.mts
@@ -49,7 +49,7 @@ const PRIVATE_QA_REQUIRED_DIST_ENTRIES = [
   "dist/plugin-sdk/qa-runtime.js",
 ];
 
-type SpawnSyncResultLike = Pick<SpawnSyncReturns<Buffer>, "error" | "signal" | "status">;
+type SpawnSyncResultLike = Partial<Pick<SpawnSyncReturns<Buffer>, "error" | "signal" | "status">>;
 type SpawnSyncFn = (
   command: string,
   args: string[],

--- a/scripts/dev/discord-acp-plain-language-smoke.ts
+++ b/scripts/dev/discord-acp-plain-language-smoke.ts
@@ -1114,14 +1114,9 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 export const testing = {
   parseDriverMode,
   parseArgs,
-  parseNumber,
-  DISCORD_RESPONSE_BODY_MAX_BYTES,
   redactDiscordApiPath,
-  readDiscordResponseText,
   remainingTimeoutMs,
   requestDiscordJson,
-  resolveStateDir,
-  safeErrorMessage,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/scripts/dev/tui-pty-test-watch.ts
+++ b/scripts/dev/tui-pty-test-watch.ts
@@ -524,5 +524,4 @@ export const testing = {
   parseOptions,
   readNewMirrorData,
   signalChildProcessTree,
-  usage,
 };

--- a/scripts/test-perf-budget.mts
+++ b/scripts/test-perf-budget.mts
@@ -171,7 +171,6 @@ function main() {
 export const testing = {
   collectPerfReportStats,
   parseArgs,
-  parseBudgetNumber,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/src/agents/subagents/announce/subagent-announce-delivery-retry.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery-retry.ts
@@ -117,7 +117,7 @@ function hasAnnounceErrorMatch(
   return ANNOUNCE_ERROR_CHAIN_KEYS.some((key) => hasAnnounceErrorMatch(error[key], matches, seen));
 }
 
-export function hasWriterClaimReboundAnnounceError(error: unknown): boolean {
+function hasWriterClaimReboundAnnounceError(error: unknown): boolean {
   return hasAnnounceErrorMatch(error, isWriterClaimReboundAnnounceError);
 }
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test-support.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test-support.ts
@@ -27,7 +27,6 @@ type DeliveryDeps = Omit<
 type Testing = {
   setDepsForTest(overrides?: Partial<DeliveryDeps>): void;
   hasAnnounceSendEvidence(error: unknown): boolean;
-  hasWriterClaimReboundAnnounceError(error: unknown): boolean;
   isWriterClaimReboundAnnounceError(error: unknown): boolean;
 };
 
@@ -40,8 +39,6 @@ function getTesting(): Testing {
 export const testing: Testing = {
   setDepsForTest: (overrides) => getTesting().setDepsForTest(overrides),
   hasAnnounceSendEvidence: (error) => getTesting().hasAnnounceSendEvidence(error),
-  hasWriterClaimReboundAnnounceError: (error) =>
-    getTesting().hasWriterClaimReboundAnnounceError(error),
   isWriterClaimReboundAnnounceError: (error) =>
     getTesting().isWriterClaimReboundAnnounceError(error),
 };

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -25,7 +25,6 @@ import { getSubagentDepthFromSessionStore } from "../spawn/subagent-depth.js";
 import { maybeSteerSubagentAnnounce } from "./subagent-announce-active-wake.js";
 import {
   hasAnnounceSendEvidence,
-  hasWriterClaimReboundAnnounceError,
   isWriterClaimReboundAnnounceError,
   resolveSubagentAnnounceTimeoutMs,
   runAnnounceDeliveryWithRetry,
@@ -269,7 +268,6 @@ const testing = {
     setSubagentAnnounceDeliveryDepsForTest(overrides);
   },
   hasAnnounceSendEvidence,
-  hasWriterClaimReboundAnnounceError,
   isWriterClaimReboundAnnounceError,
 };
 if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## What Problem This Solves

Removes 20 properties exposed through internal testing bags that have no callers anywhere in the repository. These members made private benchmark, diagnostic, smoke, and subagent helpers look like supported test APIs without protecting behavior.

Removing the subagent forwarding property also revealed that its underlying helper only needed module-local visibility, so that export is private again.

## Why This Change Was Made

Only zero-caller testing-bag members are removed. Every property used by owner tests remains, including benchmark parsers/classifiers, prompt-probe signal handling, Discord request boundaries, TUI process control, and startup-memory runners.

A touched CPU scenario result type now derives its `error`, `signal`, and `status` fields directly from Node's `SpawnSyncReturns<Buffer>` contract instead of a broken ambient signal alias.

## User Impact

No behavior changes. Internal test surfaces are narrower and accurately reflect what tests consume.

## Evidence

- Subagent announcement, model/restart/startup benchmark, dev-tooling safety, gateway CPU, performance-budget, and startup-memory owners: 8 files, 335 tests passed.
- The `core`, `coreTests`, `scripts`, and `tooling` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready. Typechecks, formatting, lint, dead-export scans, plugin boundaries, import cycles, and architecture guards passed.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings on the final branch.

Production/tooling delta: +7/-29, net -22. Test support: -3. Total: +7/-32, net -25. No behavior, docs, config, schema, protocol, dependency, or changelog change.

AI-assisted: yes.
