### PR TITLE
fix(codex): skip settled-turn finalization capture after sessions_yield

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -325,7 +325,8 @@ export async function finalizeCodexAttempt(
   const shouldCaptureSettledTurnFinalizationContext =
     result.assistantTexts.every((text) => !text.trim()) &&
     result.messagesSnapshot.some((message) => message.role === "toolResult") &&
-    (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
+    (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed) &&
+    !toolState.yieldDetected;
   const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
     ? await captureCodexSettledTurnFinalizationContext({
         ...activeTranscriptTarget,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4120,6 +4120,63 @@ describe("runCodexAppServerAttempt", () => {
       }
     },
   );
+  it("skips settled-turn finalization context capture for a completed sessions_yield turn", async () => {
+    // Exercises the real onYield -> onYieldDetected -> toolState.yieldDetected wiring
+    // (run-attempt-tool-setup.ts / dynamic-tool-build.ts) without createSessionsYieldTool's
+    // own requester/session-store side effects, which need a real spawned subagent.
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
+      {
+        name: "sessions_yield",
+        label: "Yield",
+        description: "sessions_yield test tool",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+          await options?.onYield?.(typeof args.message === "string" ? args.message : "");
+          return { content: [{ type: "text" as const, text: "yielded" }], details: {} };
+        },
+      } as unknown as ReturnType<typeof createOpenClawCodingTools>[number],
+    ]);
+    // This test owns the yield/finalize predicate, not requester-scoped MCP discovery.
+    agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = true;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const storePath = path.join(tempDir, "settled-finalization-context-yield.sqlite");
+    const sessionId = "session-settled-finalization-context-yield";
+    const sessionFile = `agent:main:${sessionId}`;
+    const workspaceDir = path.join(tempDir, "workspace-settled-finalization-context-yield");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    await attachSqliteSessionTarget(params, storePath, sessionId);
+    params.prompt = "Spawn a subagent and yield.";
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    const toolCallResponse = await harness.handleServerRequest({
+      id: "request-yield-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-yield-1",
+        namespace: null,
+        tool: "sessions_yield",
+        arguments: { message: "Waiting for subagent." },
+      },
+    });
+    expect(toolCallResponse).toMatchObject({ success: true });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+    expect(result.yieldDetected).toBe(true);
+    expect(result.assistantTexts.every((text) => !text.trim())).toBe(true);
+    expect(result.messagesSnapshot.some((message) => message.role === "toolResult")).toBe(true);
+    expect(result.settledTurnFinalizationContext).toBeUndefined();
+    expect(
+      warn.mock.calls.some(([message]) =>
+        message.includes("codex settled-turn finalization context is unavailable"),
+      ),
+    ).toBe(false);
+  });
   it("preserves every command failure from official app-server events", async () => {
     const sessionFile = path.join(tempDir, "session-multi-command-failure.jsonl");
     const workspaceDir = path.join(tempDir, "workspace-multi-command-failure");


### PR DESCRIPTION
<!--
Closes #122076
-->

## Summary

**Prompt request:** Make the Codex app-server attempt finalizer skip settled-turn finalization context capture for a turn that ended in a successful `sessions_yield` call, while preserving existing capture for genuinely incomplete non-yield tool turns.

**Proof target:** Show, with values captured from a real `sessions_yield` turn, that the finalization predicate evaluates to false with the fix and true without it, while the same predicate stays true for a non-yield turn either way.

## What Problem This Solves

Fixes an issue where, after a Codex app-server turn successfully called
`sessions_yield` with no assistant text, OpenClaw would attempt to capture
settled-turn finalization context and log `codex settled-turn finalization
context is unavailable`, even though the yield completed exactly as
intended. The warning made a healthy, intentional yield look like a
finalization failure.

## Why This Change Was Made

`shouldCaptureSettledTurnFinalizationContext` in
`extensions/codex/src/app-server/run-attempt-finalize.ts` decided whether to
attempt the capture based on the turn having no assistant text, having a
tool result, and no prompt error — the same shape a genuinely incomplete
turn has, but also the shape of a successful `sessions_yield` turn. The
predicate did not exclude `toolState.yieldDetected`, so it treated both
cases identically. This PR adds a `!toolState.yieldDetected` conjunct,
mirroring the same exclusion already used correctly by the sibling decision
points in `src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts`
(`params.attempt.yieldDetected`, lines 98 and 323) to recognize a yielded
turn as already handled rather than incomplete. `toolState` was already
destructured in the same function, so no new binding was needed. The
exclusion is narrow: it only changes which turns are excluded from this one
capture attempt at its one call site
(`run-attempt-finalize.ts:325-329`), and non-yield tool turns keep the
existing behavior.

## User Impact

Operators no longer see a false "codex settled-turn finalization context is
unavailable" warning after a Codex-harness turn intentionally yields via
`sessions_yield`. Non-yield turns that hit the existing
incomplete-turn-context-capture path are unaffected.

## Evidence

Head: `597659fd678`. Base: `c98ae0f99cb` (`upstream/main`).

Implementation scope: 1 net production line in
`extensions/codex/src/app-server/run-attempt-finalize.ts` (the
`!toolState.yieldDetected` conjunct). Test scope: 1 new regression test,
colocated with the existing coverage for this predicate in
`extensions/codex/src/app-server/run-attempt.test.ts`.

## Real behavior proof

Behavior addressed: a turn that completes a `sessions_yield` tool call with
no assistant textual content was treated the same as a genuinely incomplete
turn, triggering a settled-turn context-capture attempt and a false
"context is unavailable" warning. The linked issue (#122076) reports a
deterministic integration reproduction of this sequence with the real
`sessions_yield` tool.

Real environment tested: a live `codex app-server` child process (the
`codex` CLI) and a live model turn, driving the production
`sessions_yield` tool (`src/agents/tools/sessions-yield-tool.ts`) through
the production dynamic-tool bridge
(`extensions/codex/src/app-server/dynamic-tools.ts`) and app-server client
(`extensions/codex/src/app-server/shared-client.ts`). The tool call, the
app-server process and the model turn are unmocked. Not part of this
change: a small local-only harness script (not committed to this branch)
drives the process and reproduces the `toolState.yieldDetected` wiring
from `run-attempt-tool-setup.ts:202-204` inline, since that wiring lives
one layer up from the tool itself.

Dependency contract ([`openai/codex`](https://github.com/openai/codex)
at
[`a7edf37cb46b`](https://github.com/openai/codex/commit/a7edf37cb46b5fc4d50bd03df8e5999a86f602eb)):
the app-server's turn-execution task explicitly awaits every in-flight
tool-call future — including the dynamic-tool handler blocking on the
client's response — before it can return and let `TurnComplete` be
constructed, so `turn/completed` cannot be emitted while a same-turn tool
call is still outstanding
([`core/src/session/turn.rs:2715`](https://github.com/openai/codex/blob/a7edf37cb46b5fc4d50bd03df8e5999a86f602eb/codex-rs/core/src/session/turn.rs#L2715),
`drain_in_flight(&mut in_flight, ...).await?`). The ordering this fix
relies on is guaranteed by the app-server's own control flow, not
incidental to one observed run.

Exact steps or command run after this patch: the harness starts a thread
declaring the `sessions_yield` tool spec, sends a turn asking the model to
call it once, and lets the real app-server run the turn to completion
(`node --import tsx appserver-sessions-yield-harness.mjs`, and
`appserver-control-harness.mjs` for the control case below).

Before evidence: a synthetic baseline, not a separate before-patch
app-server run — the fix only changes a boolean predicate evaluated after
the turn completes, so the app-server's real behavior is identical with or
without it. The same real captured values are run through the predicate
twice below: once without the added conjunct (reproducing the reported
bug) and once with it (the fix).

Evidence after fix (HEAD `597659fd678`, real sessions_yield turn):

```
STEP 1 — real sessions_yield tool constructed (src/agents/tools/sessions-yield-tool.ts)
  tool.name = sessions_yield

STEP 2 — production dynamic-tool bridge (what the app-server is handed)
  tool specs sent to Codex : ["openclaw_direct"]

STEP 3 — starting a real `codex app-server` child process
  app-server initialize: OK (process is live)

STEP 4 — thread/start carrying the sessions_yield spec, then a real turn
  thread/start accepted (threadId redacted): yes
  turn/start accepted
  [onYield fired] message="proof" toolState.yieldDetected=true

STEP 5 — transcript (server -> OpenClaw), redacted to methods/types/names
  NOTE turn/started
  NOTE item/started type=userMessage
  NOTE item/completed type=userMessage
  NOTE item/started type=dynamicToolCall
  REQ  item/tool/call tool=sessions_yield
  NOTE item/completed type=dynamicToolCall
  NOTE item/started type=agentMessage
  NOTE item/completed type=agentMessage
  NOTE turn/completed

STEP 6 — real values the shouldCaptureSettledTurnFinalizationContext predicate reads
  assistantTexts.every(no trim content) = true (assistantTexts=[])
  messagesSnapshot has a toolResult      = true
  finalPromptError                       = null
  toolState.yieldDetected                = true
  onYield fired strictly before turn/completed = true

STEP 7 — predicate evaluated against these real captured values
  BEFORE fix (no yieldDetected exclusion): shouldCaptureSettledTurnFinalizationContext = true
  AFTER  fix (with !toolState.yieldDetected): shouldCaptureSettledTurnFinalizationContext = false
```

Control — real non-yield silent-tool turn (HEAD `597659fd678`), same
production bridge and a tool with no `onYield`:

```
STEP 3 — thread/start carrying the silent_note spec, then a real turn
  thread/start accepted (threadId redacted): yes
  turn/start accepted

STEP 4 — transcript (server -> OpenClaw), redacted to methods/types/names
  NOTE turn/started
  NOTE item/started type=userMessage
  NOTE item/completed type=userMessage
  NOTE item/started type=reasoning
  NOTE item/completed type=reasoning
  NOTE item/started type=dynamicToolCall
  REQ  item/tool/call tool=silent_note
  NOTE item/completed type=dynamicToolCall
  NOTE item/started type=agentMessage
  NOTE item/completed type=agentMessage
  NOTE turn/completed

STEP 5 — real values the predicate reads (control: non-yield silent tool)
  assistantTexts.every(no trim content) = true (assistantTexts=[])
  messagesSnapshot has a toolResult      = true
  finalPromptError                       = null
  toolState.yieldDetected                = false

STEP 6 — predicate evaluated against these real captured values (control)
  shouldCaptureSettledTurnFinalizationContext = true (expected true: non-yield capture path unaffected by the fix)
```

Observed result after fix: the app-server's `item/tool/call` for
`sessions_yield` resolves to the tool's own `{status: "yielded"}` success
response, and `onYield` sets `toolState.yieldDetected = true` strictly
before `turn/completed` arrives — confirming the in-process ordering the
fix depends on. Fed into the predicate, the same captured values (no
assistant text, a toolResult, no prompt error) evaluate to `true` without
the fix's conjunct and `false` with it. The control turn's
`toolState.yieldDetected` stays `false`, so the added `!toolState.yieldDetected`
conjunct evaluates to `true` and the predicate's result stays the value
the other three conditions already produced — one control run covers both
before and after the fix, since `toolState.yieldDetected` is the only
input the fix touches.

Supplementary: the harness above reproduces `toolState.yieldDetected`
wiring inline rather than exercising the complete
`shouldCaptureSettledTurnFinalizationContext` predicate and its
`captureCodexSettledTurnFinalizationContext` call. A colocated regression
test is authoritative for that owner boundary: it drives the real
`runCodexAppServerAttempt` with a fake app-server transport
(`createStartedThreadHarness`, used by every other test in this file) but
real `sessions_yield`/`toolState` wiring, and asserts
`result.settledTurnFinalizationContext` is `undefined` and no
`"codex settled-turn finalization context is unavailable"` warn-log call
was made. Command: `pnpm test
extensions/codex/src/app-server/run-attempt.test.ts -t "skips settled-turn
finalization context capture for a completed sessions_yield turn"`. Before
(base `c98ae0f99cb`, predicate reverted): 1 failed. After (HEAD
`597659fd678`): 1 passed. Full-file run (no `-t` filter, same HEAD): 136
passed, including the pre-existing non-yield `it.each` control cases.

What was not tested: `sessions_yield`'s own requester/session-store side
effects (`createSessionsYieldTool`'s `onBeforeYield` callback) are not
exercised; they need a real spawned subagent and are unrelated to this
predicate.

## Non-Scope

This change is limited to the `shouldCaptureSettledTurnFinalizationContext`
predicate in `run-attempt-finalize.ts` and its regression test, stopping
the capture attempt at its one call site, matching the existing exclusion
pattern already used in `incomplete-turn-recovery.ts`.
