### PR TITLE
test(plugins): refresh reviewed publish scan baseline

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -32,8 +32,8 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
-  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
+  ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],
   ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],
   ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],
   ["@openclaw/raft:dangerous-exec:src/gateway.ts", 1],
@@ -49,7 +49,6 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<strin
   ["@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js", 2],
   ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
-  ["@openclaw/google-meet:dangerous-exec:dist/index.js", 1],
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);


### PR DESCRIPTION
## Summary

- remove obsolete Google Meet source and generated-bundle dangerous-exec review entries
- review the llama.cpp provider's single managed-binary `--version` probe at its exact source path and count
- preserve the release scan's exact-count and unexpected-finding failures

## Root cause

The scanner is behaving correctly, but its manually reviewed publishable-plugin census did not follow two producer changes. Google Meet no longer executes a child process from its plugin node host, while the managed llama-server installer now performs one fixed-argument version probe against its verified executable.

## Validation

- `PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts` (124 passed)
- source-blind behavior validation: 94 security-scan cases and 30 runtime-authority cases passed
- autoreview: clean, no actionable findings
- `git diff --check`

No production code or configuration changes.
