### PR TITLE
test(plugins): drop stale Google Meet scan baselines

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -32,7 +32,6 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
-  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],
   ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],
@@ -49,7 +48,6 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<strin
   ["@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js", 2],
   ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
-  ["@openclaw/google-meet:dangerous-exec:dist/index.js", 1],
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);


### PR DESCRIPTION
Related: #123229

## What Problem This Solves

Resolves a release-validation failure where plugin publishing remains blocked by stale Google Meet security-scan expectations after the reviewed process-execution findings were removed.

## Why This Change Was Made

Removes both obsolete Google Meet baseline entries: the source finding and the generated `dist/index.js` finding. This supersedes the narrower #123229 change, which removes only the source expectation and still fails after a clean Google Meet runtime rebuild.

## User Impact

Release operators can validate the Google Meet plugin against its current clean package contents without a stale expected-finding mismatch. There is no runtime behavior change.

## Evidence

- `node scripts/lib/plugin-npm-runtime-build.mjs extensions/google-meet` — clean runtime build succeeded.
- Package-local `npm pack --dry-run --json --ignore-scripts` — succeeded and included the rebuilt runtime artifacts.
- Direct package scan with `excludeTestFiles: true` — scanned 64 Google Meet source/runtime files and reported `criticalCount: 0`.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
