### PR TITLE
docs: add Browser Use as a direct CDP provider

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -643,6 +643,39 @@ Notes:
 - See the [Browserbase docs](https://docs.browserbase.com) for full API
   reference, SDK guides, and integration examples.
 
+### Browser Use
+
+[Browser Use](https://browser-use.com) provides managed cloud browsers with
+stealth, CAPTCHA handling, proxies, and persistent profiles through a direct
+CDP WebSocket endpoint.
+
+```json5
+{
+  browser: {
+    enabled: true,
+    defaultProfile: "browser-use",
+    profiles: {
+      "browser-use": {
+        cdpUrl: "wss://connect.browser-use.com?apiKey=<BROWSER_USE_API_KEY>&proxyCountryCode=us",
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- [Sign up](https://cloud.browser-use.com) and copy your API key from
+  [Settings -> API Keys](https://cloud.browser-use.com/settings?tab=api-keys).
+- Replace `<BROWSER_USE_API_KEY>` with your real Browser Use API key.
+- Browser Use creates a browser session when OpenClaw connects and stops it
+  when the WebSocket disconnects.
+- Optional query parameters include `profileId` for a persistent browser
+  profile, `proxyCountryCode` for country-specific routing, and `timeout` for
+  the session duration in seconds.
+- See the [Browser Use OpenClaw guide](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw)
+  for CLI-skill setup and additional examples.
+
 ### Notte
 
 [Notte](https://www.notte.cc) is a cloud platform for running headless


### PR DESCRIPTION
## What Problem This Solves

OpenClaw already accepts Browser Use as a direct WebSocket CDP provider, but the provider is absent from the existing examples. Users otherwise have to translate Browser Use documentation into OpenClaw config themselves.

## Why This Change Was Made

The provider fits OpenClaw’s current `browser.profiles.*.cdpUrl` contract. Browser Use already exposes a single `wss://connect.browser-use.com` URL that creates a browser during the WebSocket handshake, so no Cloud endpoint or OpenClaw runtime code is needed.

## User Impact

Users can paste one Browser Use CDP URL into OpenClaw and use its built-in browser tool without a prior create-browser API call.

## Evidence

- Browser Use’s current OpenClaw guide documents this exact `cdpUrl` and config shape
- A live unauthenticated WebSocket handshake reached the endpoint and returned its expected `apiKey` validation errors; no browser session was created
- `pnpm check:docs` passed on current OpenClaw main: formatting, markdown lint, MDX, glossary, 7,283 internal links, and 1,216 config examples
- `git diff --check` passed

AI-assisted: yes. I reviewed the final diff and validation output.