### PR TITLE
refactor(plugins): trim test-only barrel exports

### DIFF
--- a/extensions/matrix/api.ts
+++ b/extensions/matrix/api.ts
@@ -26,7 +26,6 @@ export {
 export {
   createMatrixThreadBindingManager,
   getMatrixThreadBindingManager,
-  resetMatrixThreadBindingsForTests,
 } from "./src/matrix/thread-bindings.js";
 export {
   setMatrixThreadBindingIdleTimeoutBySessionKey,

--- a/extensions/signal/api.ts
+++ b/extensions/signal/api.ts
@@ -26,15 +26,7 @@ export {
   resolveSignalSender,
   type SignalSender,
 } from "./src/identity.js";
-export {
-  extractSignalCliArchive,
-  installSignalCli,
-  looksLikeArchive,
-  type NamedAsset,
-  pickAsset,
-  type ReleaseAsset,
-  type SignalInstallResult,
-} from "./src/install-signal-cli.js";
+export { installSignalCli, type SignalInstallResult } from "./src/install-signal-cli.js";
 export { signalMessageActions } from "./src/message-actions.js";
 export { type MonitorSignalOpts, monitorSignalProvider } from "./src/monitor.js";
 export { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./src/normalize.js";

--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -80,7 +80,6 @@ export {
 export {
   createTelegramThreadBindingManager,
   getTelegramThreadBindingManager,
-  resetTelegramThreadBindingsForTests,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
   setTelegramThreadBindingMaxAgeBySessionKey,
 } from "./src/thread-bindings.js";

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -223,7 +223,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
       'export { resolveTelegramFetch, resolveTelegramTransport, shouldRetryTelegramTransportFallback } from "./src/fetch.js";',
       'export { makeProxyFetch } from "./src/proxy.js";',
       'export { createForumTopicTelegram, deleteMessageTelegram, editForumTopicTelegram, editMessageReplyMarkupTelegram, editMessageTelegram, pinMessageTelegram, reactMessageTelegram, renameForumTopicTelegram, sendMessageTelegram, sendPollTelegram, sendStickerTelegram, sendTypingTelegram, unpinMessageTelegram } from "./src/send.js";',
-      'export { createTelegramThreadBindingManager, getTelegramThreadBindingManager, resetTelegramThreadBindingsForTests, setTelegramThreadBindingIdleTimeoutBySessionKey, setTelegramThreadBindingMaxAgeBySessionKey } from "./src/thread-bindings.js";',
+      'export { createTelegramThreadBindingManager, getTelegramThreadBindingManager, setTelegramThreadBindingIdleTimeoutBySessionKey, setTelegramThreadBindingMaxAgeBySessionKey } from "./src/thread-bindings.js";',
       'export { resolveTelegramToken } from "./src/token.js";',
       'export { setTelegramRuntime } from "./src/runtime.js";',
       'export type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";',


### PR DESCRIPTION
## What Problem This Solves

Removes test-only helpers from broad plugin API barrels when their real owners already provide a narrower path.

- Signal installer archive/asset helpers and fixture types remain local to `install-signal-cli.ts`, where production and owner tests use them directly.
- Matrix and Telegram thread-binding reset hooks remain available through their dedicated session-binding contract APIs and owner modules, but no longer appear in the general plugin barrels.

The broader cache-reset candidates were deliberately left unchanged because removing those underlying exports requires a separate cache-state owner refactor.

## Why This Change Was Made

Broad `api.ts` and `runtime-api.ts` barrels are production/plugin surfaces. Re-exporting test-only helpers makes them look supported and increases compatibility and dead-code pressure without adding runtime capability.

The retained owner tests still exercise Signal install selection/extraction and Matrix/Telegram binding reset behavior. Core session-binding tests continue to load the narrow contract sidecars rather than the broad barrels.

## User Impact

No runtime behavior change. Plugin public surfaces are smaller and more accurately describe supported capabilities.

## Evidence

- Signal installer, Telegram thread bindings, Matrix thread bindings, channel session-binding contracts, and Plugin SDK runtime guardrails: 81 tests passed across 5 Vitest shards.
- `pnpm build` passed, including bundled plugin assets, package builds, runtime postbuild, and import guards.
- The `core`, `coreTests`, `extensions`, and `extensionTests` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready. Typechecks, formatting, lint, dead-export scans, plugin boundaries, import cycles, database/sidecar/security guards, and architecture checks passed.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.

Production delta: +1/-11, net -10. Tests: +1/-1, net 0. Total: +2/-12, net -10. No docs, config, schema, protocol, dependency, or changelog change.

AI-assisted: yes.
