### PR TITLE
fix(plugins): accept reviewed llama runtime probe after build

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -49,6 +49,7 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<strin
   ["@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js", 2],
   ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
+  ["@openclaw/llama-cpp-provider:dangerous-exec:dist/index.js", 1],
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the publishable-plugin security release scan failed after the llama.cpp provider's canonical package runtime build emitted its reviewed `llama-server --version` probe in package-local `dist/index.js`.

## Why This Change Was Made

Adds the generated llama.cpp runtime probe to the optional publishable-dist census with an exact count of one. The expectation activates only when that packed path exists, so source-only checkouts still pass while unknown findings and count drift remain release failures.

## User Impact

No production runtime behavior changes. Maintainers can run the full publish security scan against both clean source trees and built llama.cpp package artifacts without a false release failure.

## Evidence

- Red on `571009dd8b885826c354c0bc82c506efef064502`: canonical llama package runtime build followed by `src/plugins/npm-install-security-scan.release.test.ts` produced 93/94 passing tests and one unexpected `@openclaw/llama-cpp-provider:dangerous-exec:dist/index.js:146` finding.
- Green on signed head `6130a91106eea5e6ed98f1d44c72e6dacfe0edcb`: the same full release test passes 94/94 with package-local dist absent.
- Green on the same head after `node scripts/lib/plugin-npm-runtime-build.mjs extensions/llama-cpp`: the generated probe remains at `dist/index.js:146`, and the same full release test passes 94/94.
- `git diff --check` passes; autoreview reports no actionable findings.
