### PR TITLE
fix(gateway): Apple node commands recover after reconnect

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -1197,8 +1197,8 @@ extension GatewayNodeSession {
                     id: request.id,
                     ok: false,
                     error: OpenClawNodeError(
-                        code: .unavailable,
-                        message: "UNAVAILABLE: node lifecycle transition in progress")),
+                        code: .notReady,
+                        message: "Node lifecycle transition in progress")),
                 channel: channel,
                 socketGeneration: socketGeneration)
             return

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
@@ -6,6 +6,8 @@ public enum OpenClawNodeErrorCode: String, Codable, Sendable {
     case backgroundUnavailable = "NODE_BACKGROUND_UNAVAILABLE"
     case invalidRequest = "INVALID_REQUEST"
     case unavailable = "UNAVAILABLE"
+    /// Rejected before a command handler or progress frame; safe for bounded admission recovery.
+    case notReady = "NODE_NOT_READY"
     case systemRunDenied = "SYSTEM_RUN_DENIED"
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1831,8 +1831,8 @@ struct GatewayNodeSessionTests {
         let error = try #require(params["error"] as? [String: Any])
         #expect(params["id"] as? String == "during-lifecycle")
         #expect(params["ok"] as? Bool == false)
-        #expect(error["code"] as? String == OpenClawNodeErrorCode.unavailable.rawValue)
-        #expect(error["message"] as? String == "UNAVAILABLE: node lifecycle transition in progress")
+        #expect(error["code"] as? String == OpenClawNodeErrorCode.notReady.rawValue)
+        #expect(error["message"] as? String == "Node lifecycle transition in progress")
         #expect(await invocations.values() == [])
 
         await invalidationGate.release()

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -714,6 +714,12 @@ methods. Treat this as feature discovery, not a full enumeration of
     - `node.rename` updates a paired node label.
     - `node.invoke` forwards a command to a connected node.
     - `node.invoke.result` returns the result for an invoke request.
+      A node may return `NODE_NOT_READY` only when lifecycle cleanup prevented
+      execution, before calling a command handler or emitting progress. The
+      Gateway retries this rejection up to four times within the original invoke
+      deadline, rechecking the connection, pairing, and command authorization at
+      each dispatch. General `UNAVAILABLE` errors, disconnects, timeouts, and
+      failures after progress are not retried.
     - `mcp.tools.call.v1` is the headless node-host command for calling a configured node-local MCP tool. It is carried through `node.invoke`, requires the node to declare the command, and remains subject to pairing approval and `gateway.nodes.commands.deny`.
     - `node.event` carries node-originated events back into the gateway.
     - `node.pluginTools.update` is the only publication path for replacing the connected node's agent-visible plugin/MCP tool descriptors; `connect` params do not carry them.

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -97,13 +97,41 @@ describe("applyPluginNodeInvokePolicy", () => {
       idempotencyKey: undefined,
       isDispatchAuthorized: expect.any(Function),
       onDispatchReady: expect.any(Function),
+      onProgress: expect.any(Function),
     });
     expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(true);
     context.getRuntimeConfig = () => nodeCommandsConfig({ deny: [DEMO_COMMAND] });
     expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(false);
   });
 
-  it("preserves session identity through approved dangerous streaming transport", async () => {
+  it("recovers a preexecution node-not-ready rejection without rerunning plugin policy", async () => {
+    const policy = vi.fn((ctx: OpenClawPluginNodeInvokePolicyContext) => ctx.invokeNode());
+    setDangerousDemoCommandRegistry([createDemoPolicy(policy)]);
+    const { context, invoke } = createContext();
+    const execute = vi.fn(() => ({ completed: true }));
+    invoke
+      .mockImplementationOnce(async (params) => {
+        params?.onDispatchReady?.("not-ready-attempt");
+        return {
+          ok: false,
+          error: { code: "NODE_NOT_READY", message: "Node lifecycle transition in progress" },
+        };
+      })
+      .mockImplementationOnce(async (params) => {
+        params?.onDispatchReady?.("ready-attempt");
+        return { ok: true, payload: execute() };
+      });
+
+    await expect(invokeDemoPolicy(context)).resolves.toMatchObject({
+      ok: true,
+      payload: { completed: true },
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(policy).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves one approval and session identity through streaming readiness recovery", async () => {
     const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
     const nodeSession = createNodeSession();
     nodeSession.pairingGeneration = "paired-generation-1";
@@ -134,6 +162,13 @@ describe("applyPluginNodeInvokePolicy", () => {
       isRuntimeCurrent: () => runtimeCurrent,
     };
     invoke.mockImplementationOnce(async (params) => {
+      params?.onDispatchReady?.("rejected-duplex-invoke");
+      return {
+        ok: false,
+        error: { code: "NODE_NOT_READY", message: "Node lifecycle transition in progress" },
+      };
+    });
+    invoke.mockImplementationOnce(async (params) => {
       params?.onDispatchReady?.("approved-duplex-invoke");
       params?.onProgress?.("approved-duplex-progress");
       return { ok: true, payload: { approved: true }, payloadJSON: null, error: null };
@@ -160,8 +195,14 @@ describe("applyPluginNodeInvokePolicy", () => {
     expect(manager.resolve(approval.id, "allow-once")).toBe(true);
 
     await expect(resultPromise).resolves.toMatchObject({ ok: true });
-    expect(stream.onDispatchReady).toHaveBeenCalledWith("approved-duplex-invoke");
-    expect(stream.onProgress).toHaveBeenCalledWith("approved-duplex-progress");
+    expect(stream.onDispatchReady.mock.calls).toEqual([
+      ["rejected-duplex-invoke"],
+      ["approved-duplex-invoke"],
+    ]);
+    expect(stream.onProgress.mock.calls).toEqual([["approved-duplex-progress"]]);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(manager.listPendingRecords()).toHaveLength(0);
+    expect(manager.getSnapshot(approval.id)?.consumedDecision).toBe("allow-once");
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         expectedConnId: "conn-1",

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -97,7 +97,6 @@ describe("applyPluginNodeInvokePolicy", () => {
       idempotencyKey: undefined,
       isDispatchAuthorized: expect.any(Function),
       onDispatchReady: expect.any(Function),
-      onProgress: expect.any(Function),
     });
     expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(true);
     context.getRuntimeConfig = () => nodeCommandsConfig({ deny: [DEMO_COMMAND] });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -21,6 +21,7 @@ import type {
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";
+import { invokeNodeWithReadinessRetry } from "./node-invoke-readiness.js";
 import type { NodeSession } from "./node-registry.js";
 import { runApprovalRequestDeliveries } from "./server-methods/approval-request-delivery.js";
 import {
@@ -499,7 +500,7 @@ export async function applyPluginNodeInvokePolicy(params: {
         "Gateway node pairing, capability, and plugin policy gates allowed transport dispatch.",
     });
     nodeGateDecisionRecorded = true;
-    const res = await params.context.nodeRegistry.invoke({
+    const res = await invokeNodeWithReadinessRetry(params.context.nodeRegistry, {
       nodeId: params.nodeSession.nodeId,
       expectedConnId: params.nodeSession.connId,
       ...(params.nodeSession.pairingGeneration

--- a/src/gateway/node-invoke-readiness.ts
+++ b/src/gateway/node-invoke-readiness.ts
@@ -1,0 +1,72 @@
+import { sleep } from "../utils/sleep.js";
+import { NODE_INVOKE_NOT_READY } from "./node-registry.invoke-stream.js";
+import type { NodeInvokeResult, NodeRegistry } from "./node-registry.js";
+
+const READINESS_RETRY_DELAYS_MS = [100, 250, 500, 1_000] as const;
+
+/** Recover only an explicit rejection before native execution, inside the RPC's authority. */
+export async function invokeNodeWithReadinessRetry(
+  registry: Pick<NodeRegistry, "invoke">,
+  request: Parameters<NodeRegistry["invoke"]>[0],
+): Promise<NodeInvokeResult> {
+  let deadlineAtMs =
+    request.timeoutMs !== undefined && Number.isFinite(request.timeoutMs) && request.timeoutMs > 0
+      ? Date.now() + request.timeoutMs
+      : undefined;
+  let receivedProgress = false;
+  const timedOut = (): NodeInvokeResult => ({
+    ok: false,
+    error: { code: "TIMEOUT", message: "node invoke timed out" },
+  });
+  for (let attempt = 0; ; attempt += 1) {
+    const timeoutMs =
+      deadlineAtMs === undefined ? request.timeoutMs : Math.max(0, deadlineAtMs - Date.now());
+    if (deadlineAtMs !== undefined && timeoutMs === 0) {
+      return timedOut();
+    }
+    const result = await registry.invoke({
+      ...request,
+      timeoutMs,
+      onProgress: (chunk) => {
+        receivedProgress = true;
+        request.onProgress?.(chunk);
+      },
+      onDispatchReady: (invokeId, dispatchDeadlineAtMs) => {
+        // The omitted timeout starts at registry dispatch, not at RPC admission.
+        // Capture that first armed deadline so retries cannot replenish its budget.
+        if (
+          dispatchDeadlineAtMs !== undefined &&
+          (deadlineAtMs === undefined || dispatchDeadlineAtMs < deadlineAtMs)
+        ) {
+          deadlineAtMs = dispatchDeadlineAtMs;
+        }
+        request.onDispatchReady?.(invokeId, dispatchDeadlineAtMs);
+      },
+    });
+    const delayMs = READINESS_RETRY_DELAYS_MS[attempt];
+    if (
+      result.ok ||
+      receivedProgress ||
+      result.error?.code !== NODE_INVOKE_NOT_READY ||
+      delayMs === undefined
+    ) {
+      return result;
+    }
+    try {
+      await sleep(
+        deadlineAtMs === undefined
+          ? delayMs
+          : Math.min(delayMs, Math.max(0, deadlineAtMs - Date.now())),
+        request.signal,
+      );
+    } catch (error) {
+      if (deadlineAtMs !== undefined && Date.now() >= deadlineAtMs) {
+        return timedOut();
+      }
+      if (request.signal?.aborted) {
+        return { ok: false, error: { code: "ABORTED", message: "node invoke cancelled" } };
+      }
+      throw error;
+    }
+  }
+}

--- a/src/gateway/node-invoke-readiness.ts
+++ b/src/gateway/node-invoke-readiness.ts
@@ -13,7 +13,6 @@ export async function invokeNodeWithReadinessRetry(
     request.timeoutMs !== undefined && Number.isFinite(request.timeoutMs) && request.timeoutMs > 0
       ? Date.now() + request.timeoutMs
       : undefined;
-  let receivedProgress = false;
   const timedOut = (): NodeInvokeResult => ({
     ok: false,
     error: { code: "TIMEOUT", message: "node invoke timed out" },
@@ -27,10 +26,6 @@ export async function invokeNodeWithReadinessRetry(
     const result = await registry.invoke({
       ...request,
       timeoutMs,
-      onProgress: (chunk) => {
-        receivedProgress = true;
-        request.onProgress?.(chunk);
-      },
       onDispatchReady: (invokeId, dispatchDeadlineAtMs) => {
         // The omitted timeout starts at registry dispatch, not at RPC admission.
         // Capture that first armed deadline so retries cannot replenish its budget.
@@ -44,12 +39,7 @@ export async function invokeNodeWithReadinessRetry(
       },
     });
     const delayMs = READINESS_RETRY_DELAYS_MS[attempt];
-    if (
-      result.ok ||
-      receivedProgress ||
-      result.error?.code !== NODE_INVOKE_NOT_READY ||
-      delayMs === undefined
-    ) {
+    if (result.ok || result.error?.code !== NODE_INVOKE_NOT_READY || delayMs === undefined) {
       return result;
     }
     try {

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -71,7 +71,7 @@ type NodeInvokeParams = {
   signal?: AbortSignal;
   idempotencyKey?: string;
   sessionKey?: string;
-  onDispatchReady?: (invokeId: string) => void;
+  onDispatchReady?: (invokeId: string, deadlineAtMs?: number) => void;
   isDispatchAuthorized?: () => boolean;
 };
 
@@ -398,9 +398,11 @@ async function invokeNodeRegistryCore(
       ...(signal ? { signal } : {}),
     });
   });
-  if (!state.context.pendingInvokes.has(requestId)) {
+  const pendingAtDispatch = state.context.pendingInvokes.get(requestId);
+  if (!pendingAtDispatch) {
     return await result;
   }
+  const dispatchDeadlineAtMs = pendingAtDispatch.deadlineAtMs;
   const ok = state.context.sendEventToSession(node, "node.invoke.request", payload);
   if (!ok) {
     const pending = state.context.pendingInvokes.get(requestId);
@@ -421,7 +423,7 @@ async function invokeNodeRegistryCore(
       ...systemRunEvent,
     });
   }
-  params.onDispatchReady?.(requestId);
+  params.onDispatchReady?.(requestId, dispatchDeadlineAtMs);
   return await result;
 }
 

--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -30,6 +30,7 @@ export type PendingInvoke = {
   idleTimer?: ReturnType<typeof setTimeout>;
   idleTimeoutMs?: number;
   onProgress?: (chunk: string) => void;
+  receivedProgress?: boolean;
   nextProgressSeq: number;
   progressChunks: Map<number, string>;
   nextInputSeq: number;
@@ -139,8 +140,7 @@ export class NodeInvokeStreamController {
     // Even an out-of-order frame proves execution. A contradictory readiness
     // rejection must not authorize another attempt of a non-idempotent command.
     const error =
-      params.error?.code === NODE_INVOKE_NOT_READY &&
-      (pending.nextProgressSeq > 0 || pending.progressChunks.size > 0)
+      params.error?.code === NODE_INVOKE_NOT_READY && pending.receivedProgress
         ? { code: "UNAVAILABLE", message: "node reported not-ready after invocation progress" }
         : (params.error ?? null);
     pending.resolve({
@@ -209,12 +209,17 @@ export class NodeInvokeStreamController {
       pending.nodeId !== params.nodeId ||
       pending.connId !== params.connId ||
       !this.options.isConnectionActive(pending) ||
-      !pending.onProgress ||
       params.seq < pending.nextProgressSeq
     ) {
       return false;
     }
     if (this.settleIfExpired(params.invokeId, pending)) {
+      return false;
+    }
+    // Receipt proves execution even without a stream consumer. Keep ignored
+    // acknowledgments and cancellation capability independent of this fact.
+    pending.receivedProgress = true;
+    if (!pending.onProgress) {
       return false;
     }
     if (params.seq > pending.nextProgressSeq) {

--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -4,6 +4,9 @@ import {
 } from "../process/gateway-work-admission.js";
 import { NODE_INVOKE_PAIRING_CHANGED_ABORT } from "./node-registry-private-token.js";
 
+/** A node may emit this only before invoking a handler or sending any progress. */
+export const NODE_INVOKE_NOT_READY = "NODE_NOT_READY";
+
 export type PendingSystemRunEvent = {
   runId: string;
   sessionKey?: string;
@@ -133,11 +136,18 @@ export class NodeInvokeStreamController {
     if (!params.ok) {
       this.options.onFailedResult(pending);
     }
+    // Even an out-of-order frame proves execution. A contradictory readiness
+    // rejection must not authorize another attempt of a non-idempotent command.
+    const error =
+      params.error?.code === NODE_INVOKE_NOT_READY &&
+      (pending.nextProgressSeq > 0 || pending.progressChunks.size > 0)
+        ? { code: "UNAVAILABLE", message: "node reported not-ready after invocation progress" }
+        : (params.error ?? null);
     pending.resolve({
       ok: params.ok,
       payload: params.payload,
       payloadJSON: params.payloadJSON ?? null,
-      error: params.error ?? null,
+      error,
     });
     return true;
   }

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -2079,7 +2079,7 @@ describe("gateway/node-registry", () => {
       const request = JSON.parse(frames[0] ?? "{}");
       expect(request.payload.timeoutMs).toBe(30);
       expect(JSON.parse(request.payload.paramsJSON).timeoutMs).toBe(5_000);
-      expect(onDispatchReady).toHaveBeenCalledExactlyOnceWith(request.payload.id);
+      expect(onDispatchReady).toHaveBeenCalledExactlyOnceWith(request.payload.id, 1_100);
       await vi.advanceTimersByTimeAsync(30);
       await expect(invoke).resolves.toMatchObject({ ok: false, error: { code: "TIMEOUT" } });
       expect(

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1114,8 +1114,8 @@ export class NodeRegistry {
     signal?: AbortSignal;
     idempotencyKey?: string;
     sessionKey?: string;
-    /** Receives the id after pairing validation and a successful dispatch. */
-    onDispatchReady?: (invokeId: string) => void;
+    /** Receives the id and armed hard deadline after a successful dispatch. */
+    onDispatchReady?: (invokeId: string, deadlineAtMs?: number) => void;
     /** Revalidates caller authority at the registry-owned transport handoff. */
     isDispatchAuthorized?: () => boolean;
   }): Promise<NodeInvokeResult> {

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1008,41 +1008,79 @@ describe("node.invoke APNs wake path", () => {
       },
     );
 
-    it.each([0, 1])("does not retry node-not-ready after progress sequence %i", async (seq) => {
-      const onProgress = vi.fn();
-      const invocation = start(
-        {},
-        {
-          ...createOperatorClient({ pluginRuntimeOwnerId: "readiness-fixture" }),
-          internal: {
-            syntheticClient: true,
-            pluginRuntimeOwnerId: "readiness-fixture",
-            nodeInvokeStream: {
-              onProgress,
-              onDispatchReady: vi.fn(),
-              isRuntimeCurrent: () => true,
-            },
-          },
-        },
-      );
-      await vi.advanceTimersByTimeAsync(0);
-      const request = expectDefined(requests[0], "expected streamed node request");
-      expect(
-        registry.handleInvokeProgress({
-          invokeId: request.id,
-          nodeId,
-          connId,
-          seq,
-          chunk: "execution started",
-        }),
-      ).toBe(true);
-      rejectNotReady();
-      await vi.advanceTimersByTimeAsync(2_000);
+    it.each([
+      { seq: 0, streaming: true },
+      { seq: 1, streaming: true },
+      { seq: 0, streaming: false },
+      { seq: 1, streaming: false },
+    ])(
+      "does not retry node-not-ready after progress $seq (streaming=$streaming)",
+      async ({ seq, streaming }) => {
+        const onProgress = vi.fn();
+        const invocation = start(
+          {},
+          streaming
+            ? {
+                ...createOperatorClient({ pluginRuntimeOwnerId: "readiness-fixture" }),
+                internal: {
+                  syntheticClient: true,
+                  pluginRuntimeOwnerId: "readiness-fixture",
+                  nodeInvokeStream: {
+                    onProgress,
+                    onDispatchReady: vi.fn(),
+                    isRuntimeCurrent: () => true,
+                  },
+                },
+              }
+            : undefined,
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        const request = expectDefined(requests[0], "expected streamed node request");
+        expect(
+          registry.handleInvokeProgress({
+            invokeId: request.id,
+            nodeId,
+            connId,
+            seq,
+            chunk: seq === 0 ? "" : "execution started",
+          }),
+        ).toBe(streaming);
+        rejectNotReady();
+        await vi.advanceTimersByTimeAsync(2_000);
 
-      expect(requests).toHaveLength(1);
-      expect(firstRespondCall(await invocation)[0]).toBe(false);
-      expect(onProgress).toHaveBeenCalledTimes(seq === 0 ? 1 : 0);
-    });
+        expect(requests).toHaveLength(1);
+        expect(firstRespondCall(await invocation)).toMatchObject([
+          false,
+          undefined,
+          { details: { nodeError: { code: "UNAVAILABLE" } } },
+        ]);
+        expect(onProgress).toHaveBeenCalledTimes(streaming && seq === 0 ? 1 : 0);
+      },
+    );
+
+    it.each(["nodeId", "connId"] as const)(
+      "ignores foreign progress with mismatched %s during recovery",
+      async (field) => {
+        const invocation = start();
+        await vi.advanceTimersByTimeAsync(0);
+        const request = expectDefined(requests[0], "expected node request");
+        expect(
+          registry.handleInvokeProgress({
+            invokeId: request.id,
+            nodeId,
+            connId,
+            seq: 0,
+            chunk: "foreign progress",
+            [field]: "different-owner",
+          }),
+        ).toBe(false);
+        rejectNotReady();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(requests).toHaveLength(2);
+        reply(1, { ok: true, payloadJSON: "{}" });
+        expect(firstRespondCall(await invocation)[0]).toBe(true);
+      },
+    );
   });
 
   it.each(["browser.proxy", "browser.proxy.upload.v1"])(

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -4,9 +4,11 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
 import * as nodeInvokePluginPolicy from "../node-invoke-plugin-policy.js";
+import { NodeRegistry, type NodeInvokeResult } from "../node-registry.js";
 import {
   captureNodeWakeLifecycle,
   clearNodeWakeState,
@@ -378,6 +380,7 @@ async function invokeNode(params: {
     }>;
   };
   client?: unknown;
+  signal?: AbortSignal;
   requestParams?: Partial<Record<string, unknown>>;
   validateAgentRuntimeApprovalAuthority?: () => boolean;
   execApprovalManager?: {
@@ -416,6 +419,7 @@ async function invokeNode(params: {
       validateAgentRuntimeApprovalAuthority: params.validateAgentRuntimeApprovalAuthority,
     } as never,
     client: (params.client ?? null) as never,
+    signal: params.signal,
     req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
     isWebchatConnect: () => false,
   });
@@ -771,6 +775,274 @@ describe("node.invoke APNs wake path", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("node readiness recovery", () => {
+    const nodeId = "ios-node-readiness";
+    const command = "system.which";
+    const initialGeneration = `generation:${nodeId}:1`;
+    let registry: NodeRegistry;
+    let controller: AbortController;
+    let pairing: { identity: string; generation: string };
+    let pairingDelayMs: number;
+    let connId: string;
+    let requests: Array<{ id: string; connId: string; timeoutMs: number }>;
+    let pending: Array<Promise<unknown>>;
+
+    function register(connection: string) {
+      connId = connection;
+      registry.register(
+        {
+          ...createNodeClient(nodeId, [command]),
+          connId,
+          usesSharedGatewayAuth: false,
+          socket: {
+            readyState: WebSocket.OPEN,
+            bufferedAmount: 0,
+            close: vi.fn(),
+            send(raw: string) {
+              const frame = JSON.parse(raw) as {
+                event: string;
+                payload: { id: string; timeoutMs: number };
+              };
+              if (frame.event === "node.invoke.request") {
+                requests.push({ ...frame.payload, connId: connection });
+              }
+            },
+          },
+        } as never,
+        { pairingIdentity: pairing.identity, pairingGeneration: pairing.generation },
+      );
+    }
+
+    function start(requestParams: Partial<Record<string, unknown>> = {}, client?: unknown) {
+      const invocation = invokeNode({
+        nodeRegistry: {
+          get: registry.get.bind(registry),
+          getForPairingGeneration: registry.getForPairingGeneration.bind(registry),
+          invoke: registry.invoke.bind(registry),
+        },
+        requestParams: { nodeId, command, params: { bins: ["git"] }, ...requestParams },
+        signal: controller.signal,
+        client,
+      });
+      pending.push(invocation);
+      return invocation;
+    }
+
+    function reply(index: number, result: NodeInvokeResult) {
+      const request = expectDefined(requests[index], "expected node transport request");
+      expect(
+        registry.handleInvokeResult({
+          id: request.id,
+          nodeId,
+          connId: request.connId,
+          ...result,
+        }),
+      ).toBe(true);
+    }
+
+    function rejectNotReady(index = 0) {
+      reply(index, {
+        ok: false,
+        error: { code: "NODE_NOT_READY", message: "Node lifecycle transition in progress" },
+      });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      controller = new AbortController();
+      pairing = { identity: "readiness-identity", generation: initialGeneration };
+      pairingDelayMs = 0;
+      requests = [];
+      pending = [];
+      mocks.getRuntimeConfig.mockReturnValue({
+        gateway: { nodes: { commands: { allow: [command] } } },
+      });
+      mocks.resolveNodeCommandAllowlist.mockImplementation((cfg) => {
+        const allowed = new Set(cfg.gateway?.nodes?.commands?.allow ?? []);
+        for (const denied of cfg.gateway?.nodes?.commands?.deny ?? []) {
+          allowed.delete(denied);
+        }
+        return allowed;
+      });
+      mocks.isNodeCommandAllowed.mockImplementation(({ command: candidate, allowlist }) =>
+        allowlist.has(candidate) ? { ok: true } : { ok: false, reason: "command not allowlisted" },
+      );
+      registry = new NodeRegistry({
+        resolveCurrentPairingState: async () => {
+          if (pairingDelayMs > 0) {
+            await new Promise((resolve) => {
+              setTimeout(resolve, pairingDelayMs);
+            });
+          }
+          return pairing;
+        },
+      });
+      register("readiness-connection");
+    });
+
+    afterEach(async () => {
+      controller.abort();
+      for (const session of registry.listConnected()) {
+        registry.unregister(session.connId);
+      }
+      await vi.runAllTimersAsync();
+      await Promise.allSettled(pending);
+    });
+
+    it("recovers a preexecution node-not-ready rejection through the real registry", async () => {
+      const invocation = start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(requests).toHaveLength(1);
+      rejectNotReady();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(requests).toHaveLength(2);
+      reply(1, { ok: true, payload: { paths: { git: "/usr/bin/git" } } });
+
+      expect(firstRespondCall(await invocation)).toMatchObject([
+        true,
+        { payload: { paths: { git: "/usr/bin/git" } } },
+        undefined,
+      ]);
+      expect(requests).toHaveLength(2);
+    });
+
+    it.each(["command denial", "cancellation", "connection replacement", "pairing replacement"])(
+      "does not redispatch after %s during readiness backoff",
+      async (change) => {
+        const invocation = start();
+        await vi.advanceTimersByTimeAsync(0);
+        rejectNotReady();
+        await vi.advanceTimersByTimeAsync(50);
+        switch (change) {
+          case "command denial":
+            mocks.getRuntimeConfig.mockReturnValue({
+              gateway: { nodes: { commands: { deny: [command] } } },
+            });
+            break;
+          case "cancellation":
+            controller.abort();
+            break;
+          case "connection replacement":
+            register("replacement-connection");
+            break;
+          case "pairing replacement":
+            pairing = { ...pairing, generation: "replacement-generation" };
+            break;
+        }
+        await vi.advanceTimersByTimeAsync(2_000);
+
+        expect(requests).toHaveLength(1);
+        expect(firstRespondCall(await invocation)[0]).toBe(false);
+      },
+    );
+
+    it.each([undefined, 500])(
+      "preserves the first dispatch deadline for timeout %s",
+      async (timeoutMs) => {
+        pairingDelayMs = 250;
+        const invocation = start({ timeoutMs });
+        await vi.advanceTimersByTimeAsync(250);
+        pairingDelayMs = 0;
+        const budget = timeoutMs === undefined ? 30_000 : timeoutMs - 250;
+        expect(requests[0]?.timeoutMs).toBe(budget);
+        await vi.advanceTimersByTimeAsync(budget - 150);
+        rejectNotReady();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(requests).toHaveLength(2);
+        expect(requests[1]?.timeoutMs).toBe(50);
+        await vi.advanceTimersByTimeAsync(50);
+
+        expect(firstRespondCall(await invocation)).toMatchObject([
+          false,
+          undefined,
+          { details: { nodeError: { code: "TIMEOUT" } } },
+        ]);
+        expect(requests).toHaveLength(2);
+      },
+    );
+
+    it("expires during readiness backoff without dispatching another attempt", async () => {
+      const invocation = start({ timeoutMs: 50 });
+      await vi.advanceTimersByTimeAsync(0);
+      rejectNotReady();
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(requests).toHaveLength(1);
+      expect(firstRespondCall(await invocation)).toMatchObject([
+        false,
+        undefined,
+        { details: { nodeError: { code: "TIMEOUT" } } },
+      ]);
+    });
+
+    it("returns the final readiness rejection after exhausting bounded retries", async () => {
+      const invocation = start({ timeoutMs: 0 });
+      await vi.advanceTimersByTimeAsync(0);
+      for (const [index, delay] of [100, 250, 500, 1_000].entries()) {
+        rejectNotReady(index);
+        await vi.advanceTimersByTimeAsync(delay);
+        expect(requests).toHaveLength(index + 2);
+      }
+      rejectNotReady(4);
+      expect(firstRespondCall(await invocation)).toMatchObject([
+        false,
+        undefined,
+        { details: { nodeError: { code: "NODE_NOT_READY" } } },
+      ]);
+      expect(requests).toHaveLength(5);
+    });
+
+    it.each(["UNAVAILABLE", "NODE_BACKGROUND_UNAVAILABLE"])(
+      "does not retry a generic or execution-dependent %s rejection",
+      async (code) => {
+        const invocation = start();
+        await vi.advanceTimersByTimeAsync(0);
+        reply(0, { ok: false, error: { code, message: "Node lifecycle transition in progress" } });
+        await vi.advanceTimersByTimeAsync(2_000);
+
+        expect(firstRespondCall(await invocation)[0]).toBe(false);
+        expect(requests).toHaveLength(1);
+      },
+    );
+
+    it.each([0, 1])("does not retry node-not-ready after progress sequence %i", async (seq) => {
+      const onProgress = vi.fn();
+      const invocation = start(
+        {},
+        {
+          ...createOperatorClient({ pluginRuntimeOwnerId: "readiness-fixture" }),
+          internal: {
+            syntheticClient: true,
+            pluginRuntimeOwnerId: "readiness-fixture",
+            nodeInvokeStream: {
+              onProgress,
+              onDispatchReady: vi.fn(),
+              isRuntimeCurrent: () => true,
+            },
+          },
+        },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      const request = expectDefined(requests[0], "expected streamed node request");
+      expect(
+        registry.handleInvokeProgress({
+          invokeId: request.id,
+          nodeId,
+          connId,
+          seq,
+          chunk: "execution started",
+        }),
+      ).toBe(true);
+      rejectNotReady();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(requests).toHaveLength(1);
+      expect(firstRespondCall(await invocation)[0]).toBe(false);
+      expect(onProgress).toHaveBeenCalledTimes(seq === 0 ? 1 : 0);
+    });
   });
 
   it.each(["browser.proxy", "browser.proxy.upload.v1"])(

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -14,6 +14,7 @@ import {
 import { isForbiddenBrowserProxyMutation } from "../node-browser-proxy-policy.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import { applyPluginNodeInvokePolicy } from "../node-invoke-plugin-policy.js";
+import { invokeNodeWithReadinessRetry } from "../node-invoke-readiness.js";
 import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.js";
 import { enqueuePendingNodeAction, removePendingNodeAction } from "../node-runtime-state.js";
 import {
@@ -559,7 +560,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        const res = await context.nodeRegistry.invoke({
+        const res = await invokeNodeWithReadinessRetry(context.nodeRegistry, {
           nodeId,
           expectedConnId: nodeSession.connId,
           expectedPairingGeneration: generation.key,


### PR DESCRIPTION
Related: #30138

Maintainer rewrite: `2de47ac3263adf7dd480fc276afb6bdf145707cd`, based on `4c6ed51733d37975450914dd268d34530ee85737`.

## What Problem This Solves

Apple-node commands immediately after reconnect can fail even though the Gateway already shows the node as connected. The node correctly refuses execution while the previous route's cleanup is pending; the original request had no safe recovery path.

## Why This Change Was Made

The Apple lifecycle owner now emits the explicit preexecution-only `NODE_NOT_READY` result. One shared Gateway recovery path handles it for both raw node RPCs and plugin-policy transport without re-running policy or acquiring approval again. This replaces the incoming branch's message-string matching and raw-RPC-only retry path.

Each attempt retains the admitted connection, pairing generation, cancellation, current command/runtime/approval authority, session and idempotency key. Four bounded delays (100/250/500/1000 ms) share the original hard deadline, including the registry's default post-dispatch deadline. Generic unavailability, disconnects and timeouts do not authorize retry.

The registry records authenticated progress at receipt, independently of whether the caller consumes it. Ordered, buffered and intentionally ignored progress all prohibit replay. Non-streaming requests still report `ignored: true` for progress and retain their existing cancellation capability; the retry helper does not invent a stream consumer.

Native barrier/reconnect ordering is unchanged. Direct terminal relay stays single-dispatch because its endpoint retains the first invoke ID. Plugin duplex can recover only before its ready progress frame exposes the endpoint.

Provenance: #105282 (`7303f429177b`, authored and merged by @steipete on July 12) deliberately introduced the native fail-fast safety boundary. Waiting for cleanup before reconnecting would undo #105091's transport-liveness repair. This adds recovery around that intentional boundary, not removal of it.

## User Impact

Short reconnect cleanup windows can recover within the original request instead of requiring a manual retry. Both the shared Apple client and Gateway need this update; old clients still emit terminal `UNAVAILABLE`. Arbitrarily long cleanup can exhaust the bounded attempts and return a visible failure. No new config, persistence/schema change or protocol-version bump.

Thanks @TheAngryPit for identifying the failure and the bounded recovery approach. Contributor co-author credit is preserved.

## Evidence

### Real Gateway and shared Apple transport

The final corrected Gateway was tested against both the old native client and updated native client, using a real isolated Gateway, Swift `GatewayNodeSession`/`URLSession` peer and transparent loopback WebSocket relay. The relay physically dropped the first socket; automatic reconnect occurred while the public route-invalidation callback was held. No transport result was mocked or rewritten. The handler used synthetic `camera.list` data and did not access a camera.

```text
Old native client, corrected candidate Gateway:
  old route cleanup held -> automatic replacement socket connected
  original RPC -> native UNAVAILABLE -> failure, zero executions
  cleanup returned -> separate later RPC -> one execution

Updated native client, corrected candidate Gateway:
  old route cleanup held -> automatic replacement socket connected
  original RPC attempt 1 -> NODE_NOT_READY, zero executions
  cleanup returned -> same RPC attempt 2 -> success, exactly one execution
  distinct invoke IDs; unchanged idempotency key
  timeout decreases from 11997 ms to 11873 ms
  normal peer exit 0; Gateway, relay and task state cleaned
```

Redacted final-run events (synthetic invocation IDs only):

```jsonl
{"event":"invoke-dispatched","generation":2,"id":"31ac7855-a59e-4518-8e71-9007f6dc3d18","command":"camera.list","timeoutMs":11997}
{"event":"native-result","generation":2,"id":"31ac7855-a59e-4518-8e71-9007f6dc3d18","ok":false,"code":"NODE_NOT_READY"}
{"event":"barrier-returned"}
{"event":"invoke-dispatched","generation":2,"id":"72463945-5592-4a51-bf00-c5ad6f24b5a7","command":"camera.list","timeoutMs":11873}
{"event":"handler-executed","command":"camera.list","count":1,"id":"72463945-5592-4a51-bf00-c5ad6f24b5a7"}
{"event":"native-result","generation":2,"id":"72463945-5592-4a51-bf00-c5ad6f24b5a7","ok":true,"code":null}
{"event":"peer-exit","code":0,"signal":null}
```

Both traces bind all eight final production files plus harness sources and native binary by SHA-256. The comparison holds the corrected candidate Gateway fixed and varies the native client; it is not a full baseline-Gateway comparison. Final candidate transcript SHA-256: `1004e2c127d83fff51c738efeac4de10431d3d32b9df58616c74a884d215405d`; old-native control: `073ba18820973e000ac28075f415144a77122cb7f3ac2c70ad16f20df8c89cc0`.

This proves shared native transport/lifecycle recovery on macOS, not a physical iPhone, APNs, Watch or foreground-app transition. The peer uses a launch-local volatile instance-ID override and verifies selection without writing the saved preference; Foundation-internal read absence is not claimed. Earlier harness traces were superseded after correcting that preference isolation. The final repeat reused verified unchanged native binaries; no new Swift build is claimed for the Gateway-only follow-up.

### CI-driven owner correction

The first published rewrite, `182c033f1e17`, had a real regression: [CI job 98993046241](https://github.com/openclaw/openclaw/actions/runs/33213801895/job/98993046241) failed the existing `server.roles-allowlist-update.test.ts` assertion because the helper's synthetic progress callback changed a non-streaming acknowledgment from `ignored: true` to `ignored: false`. It also changed the callback-presence gate for legacy unary cancellation. The unchanged test reproduced the same failure locally.

The correction removes that artificial consumer and records progress at the registry owner. The latest ClawSweeper request to record raw progress and prove single dispatch is addressed. Its proposed duplicate-dispatch scenario was not observed on `182c033f1e17`, where the synthetic callback prevented replay but caused the acknowledgment regression; the corrected implementation preserves both contracts without relying on that callback.

Before the correction, the extended consumer-present/absent × sequence-0/1 table had exactly two nonconsumer failures and two streaming passes. Afterward, all 267 tests in the four-file owner/server group pass, including the unchanged CI assertion, empty heartbeat, out-of-order progress, no second dispatch after progress, foreign-node/connection rejection, legacy cancellation, deadlines and plugin approval-once behavior. One intermediate run passed 266/267: its only failure was the old mock expectation demanding the callback that was deliberately removed; the expectation was corrected and the whole group rerun green.

### Other verification and retained limits

- The original plugin-policy recovery regression failed on unchanged base before production edits. Initial six-suite Gateway coverage passed 275 tests; terminal relay passed 6, and selected plugin-duplex siblings passed 11.
- The initial full runtime build and real-Gateway node-plugin deadline test passed: an unanswered dispatched command times out once with dispatch provenance, not a retry.
- Fresh default-traits Swift package build (`--jobs 2`, no `--skip-build`) and all 77 `GatewayNodeSessionTests` passed. Swift sources remain byte-identical through the Gateway correction. Two preexisting unused-result warnings outside this patch remain.
- Initial complete 31-check gate passed, including 523 macOS CI tests across 14 files. The final four-file Gateway correction passed its complete 29-check changed gate, including both type graphs, core lint, dead exports, import cycles and pairing guards. No assertion or check was disabled.
- Managed Codex review passed for the original rewrite and the final correction with no actionable P0 findings, the helper's default priority scope. Normal commit hooks preserved all 13 final file hashes.
- Earlier failures retained: one test-only response-tuple expectation, one Promise-executor timer lint error on Linux, and a local SwiftLint 0.65.1 versus required 0.65.0 mismatch. Expectations/lint were corrected; checksum-verified pinned tools were installed task-locally and the full gate rerun green. The Linux Testbox was stopped and verified completed.

Production LOC: +94/-11 (net +83). Tests: +356/-6 (net +350). Docs: +6/-0. The shared admission-recovery capability and typed no-execution contract justify the growth; no duplicate retry helper remains. The registry receipt repair reduces production growth compared with the initial rewrite. Issue #30138 remains related rather than automatically closed because it describes broader device behavior.

Exact-head hosted CI is required before landing. AI-assisted maintainer repair and verification.
