### PR TITLE
test(diffs): remove private icon source mirrors

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -72,25 +72,6 @@ function renderCard(payloadOverride?: string): void {
 }
 
 describe("createToolbarButton icon safety", () => {
-  it("toolbarIconSvg map exists and has exactly 8 icon names", () => {
-    const requiredNames = [
-      "split",
-      "unified",
-      "wrap-on",
-      "wrap-off",
-      "background-on",
-      "background-off",
-      "theme-dark",
-      "theme-light",
-    ] as const;
-    for (const name of requiredNames) {
-      expect(
-        VIEWER_CLIENT_SRC.includes(name + ":") || VIEWER_CLIENT_SRC.includes(`"${name}"`),
-        `icon "${name}" should exist in toolbarIconSvg`,
-      ).toBe(true);
-    }
-  });
-
   it("no iconMarkup: string parameter exists", () => {
     expect(VIEWER_CLIENT_SRC.includes("iconMarkup: string")).toBe(false);
   });
@@ -104,19 +85,6 @@ describe("createToolbarButton icon safety", () => {
       expect(VIEWER_CLIENT_SRC.includes(pattern), `source must not contain "${pattern}"`).toBe(
         false,
       );
-    }
-  });
-
-  it("old icon functions are removed", () => {
-    const removedFunctions = [
-      "function splitIcon(",
-      "function unifiedIcon(",
-      "function wrapIcon(",
-      "function backgroundIcon(",
-      "function themeIcon(",
-    ];
-    for (const fn of removedFunctions) {
-      expect(VIEWER_CLIENT_SRC.includes(fn), `"${fn}" should be removed`).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Removes two Diffs viewer tests that copy private implementation details from `viewer-client.ts`:

- an eight-name toolbar icon key inventory;
- a blacklist of five obsolete private icon helper function names.

Both tests fail under harmless internal refactors without detecting a user-visible or security regression.

## Why This Change Was Made

The meaningful security and behavior coverage remains:

- `iconMarkup: string` is still forbidden;
- `innerHTML` must still read from the sealed `toolbarIconSvg` lookup;
- SVG source is still checked for unsafe markup patterns;
- DOM/controller tests still exercise all four toolbar toggles, state initialization, toolbar rendering, and image-mode omission.

The deleted cases preserve only the current names and refactor shape.

## User Impact

No behavior change. The Diffs viewer retains its security guards and functional toolbar coverage with less source coupling.

## Evidence

- Diffs viewer client suite: 16 tests passed.
- The `extensionTests` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready. Typecheck, formatting, lint, dead-export scans, plugin boundaries, and architecture guards passed.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.

Production delta: 0. Tests: -32. No docs, config, schema, protocol, dependency, or changelog change.

AI-assisted: yes.
