### PR TITLE
fix(canvas): load on fresh production installs

### DIFF
--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -5,13 +5,13 @@
   "description": "OpenClaw Canvas plugin",
   "type": "module",
   "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*"
-  },
-  "dependencies": {
     "@a2ui/lit": "0.10.2",
     "@lit/context": "1.1.6",
+    "@openclaw/plugin-sdk": "workspace:*",
+    "lit": "3.3.3"
+  },
+  "dependencies": {
     "chokidar": "5.0.0",
-    "lit": "3.3.3",
     "typebox": "1.3.6",
     "ws": "8.21.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,18 +570,9 @@ importers:
 
   extensions/canvas:
     dependencies:
-      '@a2ui/lit':
-        specifier: 0.10.2
-        version: 0.10.2(signal-polyfill@0.2.2)
-      '@lit/context':
-        specifier: 1.1.6
-        version: 1.1.6
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
-      lit:
-        specifier: 3.3.3
-        version: 3.3.3
       typebox:
         specifier: 1.3.6
         version: 1.3.6
@@ -589,9 +580,18 @@ importers:
         specifier: 8.21.1
         version: 8.21.1
     devDependencies:
+      '@a2ui/lit':
+        specifier: 0.10.2
+        version: 0.10.2(signal-polyfill@0.2.2)
+      '@lit/context':
+        specifier: 1.1.6
+        version: 1.1.6
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      lit:
+        specifier: 3.3.3
+        version: 3.3.3
 
   extensions/cerebras:
     devDependencies:

--- a/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
+++ b/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
@@ -13,6 +13,14 @@ import {
 const EXTENSION_ROOT = "extensions";
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const EXTENSION_RUNTIME_FILE_EXTENSIONS = new Set([".cjs", ".js", ".jsx", ".mjs", ".ts", ".tsx"]);
+// These sources produce static browser assets and do not execute in the packaged plugin runtime.
+const BUNDLED_BUILD_SOURCE_ROOTS = new Set([
+  "extensions/canvas/scripts",
+  "extensions/canvas/src/host/a2ui-app",
+]);
+const BUNDLED_BUILD_ONLY_DEPENDENCIES = new Map<string, Set<string>>([
+  ["extensions/canvas", new Set(["@a2ui/lit", "@lit/context", "lit"])],
+]);
 const BUILTIN_MODULES = new Set(builtinModules.map((moduleId) => moduleId.replace(/^node:/, "")));
 const OPTIONAL_UNDECLARED_RUNTIME_IMPORTS = new Map<string, Set<string>>([
   [
@@ -128,6 +136,13 @@ function listPackageManifests(root: string): string[] {
 
 function shouldSkipRuntimeFile(filePath: string): boolean {
   const normalized = toRepoPath(filePath);
+  if (
+    [...BUNDLED_BUILD_SOURCE_ROOTS].some(
+      (root) => normalized === root || normalized.startsWith(`${root}/`),
+    )
+  ) {
+    return true;
+  }
   if (
     normalized.includes("/node_modules/") ||
     normalized.includes("/dist/") ||
@@ -332,6 +347,17 @@ describe("extension runtime dependency manifests", () => {
       expect([...dependencies].filter((dependencyName) => !declared.has(dependencyName))).toEqual(
         [],
       );
+    });
+  }
+
+  for (const [extensionDir, dependencies] of BUNDLED_BUILD_ONLY_DEPENDENCIES) {
+    it(`${extensionDir} keeps bundled browser dependencies build-only`, () => {
+      const manifest = readPackageManifest(path.join(extensionDir, "package.json"));
+      const runtimeDependencies = runtimeDependencyNames(manifest);
+      const devDependencies = new Set(Object.keys(manifest.devDependencies ?? {}));
+
+      expect([...dependencies].filter((name) => runtimeDependencies.has(name))).toStrictEqual([]);
+      expect([...dependencies].filter((name) => !devDependencies.has(name))).toStrictEqual([]);
     });
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users enabling the bundled Canvas plugin on a fresh production install would get no Canvas routes or node commands because plugin dependency health rejected three packages that are only needed while building the browser bundle.

## Why This Change Was Made

The Canvas A2UI source is compiled into a self-contained static browser asset before packaging. This change keeps `@a2ui/lit`, `@lit/context`, and `lit` available as build dependencies while removing them from the packaged plugin runtime dependency gate. The extension dependency contract now identifies Canvas's asset scripts and browser-bundle sources as build-only and prevents those three packages from moving back into runtime dependencies.

This does not change Canvas commands, gateway authentication, plugin activation policy, or the generated A2UI bundle.

## User Impact

Fresh production installs can load an enabled Canvas plugin using the runtime packages that are actually required by the plugin. Canvas can then register its HTTP routes, host service, CLI, and native node commands without a manual dependency repair inside the installed package.

## Evidence

- Pre-fix production-style dependency check: `requiredInstalled: false`, with `@a2ui/lit`, `@lit/context`, and `lit` reported missing when only true runtime packages were installed.
- Post-fix production-style dependency check: `requiredInstalled: true`, `missing: []`, with `chokidar`, `typebox`, and `ws` checked.
- Regression proof: the pre-fix manifest failed 2 of 449 plugin contract tests, including a new contract that identified all three misplaced packages. The fixed manifest passed all 449 tests, including a fresh run after rebasing onto current `main`.
- `oxfmt --check src/plugins/contracts/extension-runtime-dependencies.contract.test.ts` passed.
- `git diff --check` passed, and the Canvas manifest parsed with every declared package present in its lockfile importer.
- Live affected-package validation after completing the same missing dependencies: Canvas imported with three HTTP routes, registered the `canvas-host` service and all eight native Canvas commands, rendered an A2UI surface in the native Canvas window, and returned a valid PNG snapshot.
- Independent read-only diff review reported no actionable findings.

Full current-main extension integration is left to PR CI because this clean worktree intentionally has no dependency installation. The repository autoreview wrapper could not run locally because its required TruffleHog binary is unavailable and the skill forbids automatic installation; a public `@codex` review will be requested on this PR.
