### PR TITLE
test: remove redundant subset assertions

### DIFF
--- a/packages/ai/src/api-registry.test.ts
+++ b/packages/ai/src/api-registry.test.ts
@@ -45,7 +45,6 @@ describe("LLM API registry", () => {
     );
 
     const provider = registry.getApiProvider("test-api");
-    expect(provider).toBeDefined();
     expect(() => provider?.streamSimple({ ...model, api: "other-api" }, { messages: [] })).toThrow(
       "Mismatched api: other-api expected test-api",
     );

--- a/packages/ai/src/host.test.ts
+++ b/packages/ai/src/host.test.ts
@@ -58,7 +58,6 @@ describe("AI transport host configuration", () => {
     configureAiTransportHost({ registerCustomApi: registrar });
 
     const provider = registry.getApiProvider(CUSTOM_API);
-    expect(provider).toBeDefined();
     expect(registrar).toHaveBeenCalledOnce();
     expect(provider).toMatchObject({
       api: CUSTOM_API,

--- a/packages/model-catalog-core/src/remote-catalog-bundle.test.ts
+++ b/packages/model-catalog-core/src/remote-catalog-bundle.test.ts
@@ -34,7 +34,6 @@ describe("remote model catalog bundle", () => {
   it("accepts schema v1 and deeply strips endpoint and header fields", () => {
     const parsed = validateAndSanitizeRemoteModelCatalogBundle(validBundle);
     const anthropic = parsed.providers.anthropic;
-    expect(anthropic).toBeDefined();
     if (!anthropic) {
       throw new Error("expected anthropic provider");
     }

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -9,7 +9,6 @@ import {
   discoverStaticExtensionAssets,
 } from "../../scripts/lib/static-extension-assets.mts";
 import {
-  listStaticExtensionAssetOutputs,
   rewriteRootRuntimeImportsToStableAliases,
   runRuntimePostBuild,
   writeLegacyCliExitCompatChunks,
@@ -69,21 +68,6 @@ async function writeExportHtmlBuildFixture(rootDir: string): Promise<void> {
 }
 
 describe("runtime postbuild static assets", () => {
-  it("tracks plugin-owned static assets that release packaging must ship", () => {
-    expect(listStaticExtensionAssetOutputs()).toEqual([
-      "dist/extensions/acpx/mcp-command-line.mjs",
-      "dist/extensions/acpx/mcp-proxy.mjs",
-      "dist/extensions/diffs-language-pack/assets/viewer-runtime.js",
-      "dist/extensions/diffs/assets/viewer-runtime.js",
-      "dist/extensions/discord/assets/embedded-app-sdk.mjs",
-      "dist/extensions/onepassword/onepassword-op-path.js",
-      "dist/extensions/onepassword/onepassword-secret-id.js",
-      "dist/extensions/onepassword/onepassword-secret-ref-resolver.js",
-      "dist/extensions/vault/vault-secret-id.js",
-      "dist/extensions/vault/vault-secret-ref-resolver.js",
-    ]);
-  });
-
   it("discovers repo static asset metadata without scanning extension directories", () => {
     const payload = expectNoNodeFsScans<{
       outputs: string[];

--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -18,7 +18,6 @@ const settingsRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.route
 describe("sidebar entries", () => {
   it("keeps operational destinations visible by default", () => {
     expect(DEFAULT_SIDEBAR_ENTRIES).toEqual(["route:cron", "route:plugins"]);
-    expect(DEFAULT_SIDEBAR_ENTRIES).not.toContain("route:usage");
   });
 
   it("drops retired routes from persisted entries", () => {

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -314,7 +314,6 @@ describe("pathForRoute", () => {
   it("returns correct path without base", () => {
     expect(pathForRoute("chat")).toBe("/chat");
     expect(pathForRoute("apps")).toBe("/apps");
-    expect(pathForRoute("portals")).toBe("/portals");
     expect(pathForRoute("dashboards")).toBe("/dashboards");
     expect(pathForRoute("custodian")).toBe("/custodian");
     expect(pathForRoute("connection")).toBe("/settings/connection");
@@ -323,7 +322,6 @@ describe("pathForRoute", () => {
     expect(pathForRoute("plugins")).toBe("/settings/plugins");
     expect(pathForRoute("approvals")).toBe("/settings/approvals");
     expect(pathForRoute("labs")).toBe("/settings/labs");
-    expect(pathForRoute("secrets")).toBe("/settings/secrets");
   });
 
   it("prepends base path", () => {
@@ -353,7 +351,6 @@ describe("routeIdFromPath", () => {
     expect(routeIdFromPath("/connection")).toBeNull();
     expect(routeIdFromPath("/activity")).toBe("activity");
     expect(routeIdFromPath("/apps")).toBe("apps");
-    expect(routeIdFromPath("/portals")).toBe("portals");
     expect(routeIdFromPath("/dashboards")).toBe("dashboards");
     expect(routeIdFromPath("/sessions")).toBe("sessions");
     expect(routeIdFromPath("/debug")).toBe("debug");
@@ -532,7 +529,6 @@ describe("SIDEBAR_NAV_ROUTES", () => {
       "apps",
       "portals",
     ]);
-    expect(new Set(SIDEBAR_NAV_ROUTES).size).toBe(SIDEBAR_NAV_ROUTES.length);
   });
 
   it("collapses the plugins hub to a single sidebar entry", () => {

--- a/ui/src/app-routes.test.ts
+++ b/ui/src/app-routes.test.ts
@@ -12,7 +12,6 @@ describe("application router registration", () => {
 
   it("registers every route id exactly once", () => {
     const routeIds = router.routes.map((route) => route.id);
-    expect(routeIds).toContain("portals");
     expect([...routeIds].toSorted()).toEqual([...APP_ROUTE_IDS].toSorted());
   });
 


### PR DESCRIPTION
## What Problem This Solves

Several tests carried weaker assertions immediately beside stronger assertions that already fail for every meaningful regression. One tooling test also duplicated the exact static-asset inventory owned by the executable metadata-discovery test.

## Why This Change Was Made

Tests should protect behavior or an independent contract, not add maintenance-only assertions that must be updated alongside stronger neighboring proof. This removes strict subsets while retaining the exact route inventories, structural package assertions, explicit provider guards, owner-colocated route-path coverage, and the runtime postbuild discovery/no-filesystem-scan contract.

## User Impact

No production behavior changes. The test suite has less duplicated maintenance surface while preserving the same behavioral and packaging coverage.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts test/scripts/bundled-plugin-assets.test.ts` — 51 passed
- `node scripts/run-vitest.mjs ui/src/app-routes.test.ts ui/src/app-navigation-groups.test.ts ui/src/app-navigation.test.ts ui/src/app-route-paths.test.ts` — 137 passed
- `node scripts/run-vitest.mjs packages/model-catalog-core/src/remote-catalog-bundle.test.ts packages/ai/src/host.test.ts packages/ai/src/api-registry.test.ts` — 8 passed
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback because no remote provider was available
- `git diff --check` — passed
- Structured autoreview — clean

Production delta: 0 lines. Test delta: -25 lines.
