### PR TITLE
test: align onboarding TTY prompts

### DIFF
--- a/scripts/e2e/lib/onboard/scenario.sh
+++ b/scripts/e2e/lib/onboard/scenario.sh
@@ -243,6 +243,8 @@ send_skills_flow() {
 }
 
 send_guided_skip_ui_flow() {
+  wait_for_log "What should we call your first agent?" 120 || return $?
+  send $'\r' 0.8
   wait_for_log "How should I set things up?" 120 || return $?
   send $'\r' 0.8
   wait_for_log "Use Current model?" 120 || return $?

--- a/scripts/e2e/lib/release-typed-onboarding/scenario.sh
+++ b/scripts/e2e/lib/release-typed-onboarding/scenario.sh
@@ -105,6 +105,8 @@ exec 3>"$input_fifo"
 
 wait_for_log "Continue?" 60
 send $'y\r' 0.4
+wait_for_log "What should we call your first agent?" 60
+send $'\r' 0.4
 wait_for_log "to search" 60
 send $'ollama\r' 0.4
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -32,6 +32,7 @@ const AGENTS_DELETE_SHARED_WORKSPACE_DOCKER_E2E_PATH =
   "scripts/e2e/agents-delete-shared-workspace-docker.sh";
 const OPENWEBUI_DOCKER_E2E_PATH = "scripts/e2e/openwebui-docker.sh";
 const ONBOARD_DOCKER_E2E_PATH = "scripts/e2e/onboard-docker.sh";
+const ONBOARD_SCENARIO_PATH = "scripts/e2e/lib/onboard/scenario.sh";
 const KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH = "scripts/e2e/kitchen-sink-plugin-docker.sh";
 const KITCHEN_SINK_RPC_DOCKER_E2E_PATH = "scripts/e2e/kitchen-sink-rpc-docker.sh";
 const CODEX_ON_DEMAND_DOCKER_E2E_PATH = "scripts/e2e/codex-on-demand-docker.sh";
@@ -126,6 +127,16 @@ function extractUpgradeSurvivorPayload(script: string) {
     throw new Error("upgrade survivor bash -lc payload not found");
   }
   return quoted.slice(1, -1).replaceAll(`'"'"'`, "'");
+}
+
+// Prompt-driving scripts must consume public prompts in the order the CLI renders them.
+function expectOrderedScriptFragments(script: string, fragments: readonly string[]): void {
+  let offset = 0;
+  for (const fragment of fragments) {
+    const index = script.indexOf(fragment, offset);
+    expect(index, `missing ordered script fragment: ${fragment}`).toBeGreaterThanOrEqual(offset);
+    offset = index + fragment.length;
+  }
 }
 const BOUNDED_CLIENT_LOG_DOCKER_E2E_SCRIPTS = [
   "scripts/e2e/cron-mcp-cleanup-docker.sh",
@@ -2617,6 +2628,25 @@ docker_e2e_docker_run_cmd run demo
     expect(script).toContain("--suppress-gateway-token-output");
     expect(script).not.toContain("exec 3>&- 2>/dev/null || true");
     expect(script).not.toContain('"$HOME/.openclaw/agents/main/agent/auth-profiles.json"');
+  });
+
+  it("keeps real-TTY onboarding drivers aligned with the first-agent prompt", () => {
+    expectOrderedScriptFragments(readFileSync(RELEASE_TYPED_ONBOARDING_SCENARIO_PATH, "utf8"), [
+      'wait_for_log "Continue?"',
+      "send $'y\\r'",
+      'wait_for_log "What should we call your first agent?"',
+      "send $'\\r'",
+      'wait_for_log "to search"',
+      "send $'ollama\\r'",
+    ]);
+    expectOrderedScriptFragments(readFileSync(ONBOARD_SCENARIO_PATH, "utf8"), [
+      'wait_for_log "What should we call your first agent?"',
+      "send $'\\r'",
+      'wait_for_log "How should I set things up?"',
+      "send $'\\r'",
+      'wait_for_log "Use Current model?"',
+      "send $'\\r'",
+    ]);
   });
 
   it("keeps append-only mock E2E state under per-run scratch roots", () => {


### PR DESCRIPTION
## What

Keep the release and guided real-TTY onboarding drivers aligned with the public first-agent naming prompt. Both drivers now accept the prefilled `main` name before continuing to their existing provider or discovery prompts.

## Why

Full Release Validation run [31871527419](https://github.com/openclaw/openclaw/actions/runs/31871527419) exposed a stale prompt sequence in child run [31871544784](https://github.com/openclaw/openclaw/actions/runs/31871544784), job [94982013182](https://github.com/openclaw/openclaw/actions/runs/31871544784/job/94982013182). The packaged CLI reached `What should we call your first agent?`, but the driver waited for the later provider picker and timed out. Current `main` reproduced the same failure from a packaged tarball in a real pseudo-TTY.

The prompt was introduced by #123521 in `2a77e6e5a05d`. The release driver sequence predates it and retained its original `ebd829cffd1` blame. The guided skip-UI driver shared the same assumption because its fresh fixture has no authored agent roster.

## Changes

- Accept the default first-agent name
- Repair the guided TTY sibling flow
- Guard both ordered prompt sequences

## Testing

- Failure before: `corepack pnpm test:docker:release-typed-onboarding` at `7ce902c8b6001b94b4ac5ba39fcf1118db6ac069` failed on Testbox `tbx_01m030jf2hmy42xr4rvzfn4ckb` with `Timeout waiting for log: to search` while the PTY displayed the first-agent prompt.
- Regression before repair: `corepack pnpm test test/scripts/docker-build-helper.test.ts` failed 1 test with 194 passing because the ordered first-agent wait was absent.
- Regression after repair: the same focused command passed all 195 tests on Testbox `tbx_01m0312cneh845xcxayvzkmqax`.
- Real package and sibling proof: `corepack pnpm test:docker:release-typed-onboarding && corepack pnpm test:docker:onboard` passed on Testbox `tbx_01m0314rtnhgbm8ctmafjctb9h`. The packaged release lane completed, and the sibling lane emitted `QA_ASSERT cli.guided-onboarding pass`.
- Changed gates: `node scripts/check-changed.mjs -- scripts/e2e/lib/onboard/scenario.sh scripts/e2e/lib/release-typed-onboarding/scenario.sh test/scripts/docker-build-helper.test.ts` passed formatting, test-root typecheck, script lint, Docker boundary/catalog, dependency, patch, and related guards on Testbox `tbx_01m031h0vz6ftmzmzaa2f269yr`.
- Shell checks: `bash -n` passed for both changed shell drivers; `git diff --check` passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` reported `autoreview clean: no accepted/actionable findings reported`.

Production code delta is zero. The change adds four tooling lines and 30 test lines.

## Remaining gaps

None for this repair. Full Release Validation was not rerun because the focused packaged release lane directly exercises the failed boundary.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":4,"toolOutputsDropped":4,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":14}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’ll use the OpenClaw testing, test-audit, release-CI, autoreview, prepare-PR, agent-transcript, and technical-writing skills because this is a release-lane repair and PR handoff. I’ll first preserve/check the app worktree, reproduce current-main behavior, and complete the required investigation and Pebbles planning before editing. I’ll also delegate independent sibling/history evidence lanes as required by the repository’s Repair Doctrine, while personally verifying the consequential evidence.

The app worktree was clean but pinned to `c0824d2`; `origin/main` advanced to `7ce902c`. I’m moving the clean detached worktree to that exact default-branch tip before reproduction. The cited release run targeted `079bb34`, and its package lane resolved candidate SHA `8f382a2`; I’m treating those as historical failure evidence and will separately prove the defect still exists at `7ce902c`.

The downloaded lane artifact confirms the exact stall: the packaged CLI accepted `Continue?`, rendered `What should we call your first agent?`, and the driver timed out waiting for `to search` after 101 seconds. Current `origin/main` still has the same two-answer sequence. I’m now running the same packaged Docker lane from `7ce902c` on a disposable Blacksmith Testbox to establish the required current-main failure before any edit.

Current-main reproduction is now confirmed at exact SHA `7ce902c`: the packaged tarball installed into the bare Docker image, the real PTY reached the new agent-name prompt, and the lane failed with the same `Timeout waiting for log: to search` (`tbx_01m030…`, exit 1). The disposable Testbox stopped cleanly. The sibling audit found one shared defect in the guided onboarding PTY driver; all other PTY cases are `configure` flows and do not cross this prompt. I’m documenting the owner boundary and test design now, then I’ll create the required Pebbles epic/tasks before touching source.

The required investigation and local task plan are complete. The test-audit decision is to add one ordered script-contract regression covering both affected consumers; product unit tests already cover prompt generation, and the packaged Docker lane will prove the real boundary.

The local focused wrapper cannot start because this linked worktree has no `tsx`; per repository policy I’m not reconciling dependencies here. I’m moving the pre-fix regression proof to Testbox. This is still the test-only commit state, so a failure will demonstrate the regression before the driver repair.

The focused regression failed for the intended reason before the fix: one failure, 194 passes, with the missing first-agent wait as the assertion. Both drivers now wait for that exact documented prompt and press Enter to accept the prefilled `main`; no product code, sleeps, timeouts, retries, or flags changed. Bash syntax and `git diff --check` pass. I’m rerunning the same regression on the repaired source next.

The repaired regression now passes all 195 tests on Testbox. I’m moving to real-boundary proof: first the required packaged `release-typed-onboarding` lane, then the sibling `onboard` Docker lane in the same disposable remote command so both real-TTY consumers are exercised.

The remote lane is healthy and still in the package build phase; it has synced exactly the three changed files and is progressing through the normal build stages. No failure or stall signal so far.

Both real boundaries pass: the packaged release lane completed end-to-end, and the sibling onboarding lane emitted `QA_ASSERT cli.guided-onboarding pass` plus its other onboarding assertions. The one-shot Testbox stopped cleanly. I’m now running changed-scope classification/gates, reviewing LOC and formatting, then autoreview.

Changed-scope gates are green: formatting, test-root typecheck, script lint, Docker boundary/catalog guard, dependency/patch guards, and related checks all passed on Testbox. LOC is +4 tooling lines and +30 test lines, with zero production-code change. I’m starting the mandated autoreview now against the three-file local patch.

Autoreview is clean on the first pass: `autoreview clean: no accepted/actionable findings reported` with no findings to accept or reject. The scoped commit is `4514c6b8c4f`; the worktree is clean. I’m pushing this branch with a non-force update, then I’ll build the PR body and use the agent-transcript skill to append a sanitized, task-only transcript as explicitly requested.

[tool summary]
4 other; raw tool outputs dropped: 4
````

</details>
<!-- agent-transcript:end -->
