### PR TITLE
fix(qa): restore Buzz canary selection

### DIFF
--- a/extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts
@@ -156,6 +156,23 @@ describe("live transport QA scenario selection", () => {
     },
   );
 
+  it.each([
+    {
+      channelId: "buzz",
+      scenarioIds: ["channel-canary", "channel-mention-gating"],
+    },
+    { channelId: "msteams", scenarioIds: ["channel-canary"] },
+  ])("keeps the $channelId plugin defaults eligible", ({ channelId, scenarioIds }) => {
+    expect(
+      resolveCatalogLiveTransportQaScenarioIds({
+        ...MOCK_LANE,
+        channelId,
+        channelDriver: "live",
+        scenarioIds,
+      }),
+    ).toEqual(scenarioIds);
+  });
+
   it("rejects the shared channel canary on unsupported Discord drivers", () => {
     expect(() =>
       resolveCatalogLiveTransportQaScenarioIds({
@@ -165,7 +182,7 @@ describe("live transport QA scenario selection", () => {
         scenarioIds: ["channel-canary"],
       }),
     ).toThrow(
-      "selected QA scenario(s) do not match the current QA lane: channel-canary (channel=qa-channel|telegram)",
+      "selected QA scenario(s) do not match the current QA lane: channel-canary (channel=qa-channel|telegram|buzz|msteams)",
     );
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -230,10 +230,10 @@ describe("qa scenario catalog channel contracts", () => {
     expect(scenario.gatewayConfigPatch).not.toHaveProperty("channels.telegram.groups");
   });
 
-  it("keeps the shared channel canary eligible for QA Channel and Telegram", () => {
+  it("keeps the shared channel canary eligible for its supported channels", () => {
     const scenario = requireFlowScenario(readQaScenarioById("channel-canary"));
 
-    expect(scenario.execution.channels).toEqual(["qa-channel", "telegram"]);
+    expect(scenario.execution.channels).toEqual(["qa-channel", "telegram", "buzz", "msteams"]);
   });
 
   it("keeps transcript-role delivery on the Crabline driver", () => {

--- a/qa/scenarios/channels/channel-canary.yaml
+++ b/qa/scenarios/channels/channel-canary.yaml
@@ -24,6 +24,8 @@ scenario:
     channels:
       - qa-channel
       - telegram
+      - buzz
+      - msteams
     summary: Run the shared channel canary through QA Channel, Crabline, or a live adapter.
     transportPolicy:
       requireGroupMention: true


### PR DESCRIPTION
## What

Restore the shared channel canary's catalog eligibility for the Buzz and Microsoft Teams live QA adapters, and protect the exact Buzz release scenario pair at the catalog-selection owner.

## Why

Full Release Validation run `31871527419`, child `31871544784`, job `94981215179` requested `channel-canary,channel-mention-gating`. The wrapper expanded both IDs correctly, but `channel-canary` failed catalog partitioning before Buzz execution because its channel allowlist named only `qa-channel|telegram`. `channel-mention-gating` then passed, and the complete suite correctly exited 1 for one pass and one failure. The stale catalog contract—not parsing, aggregation, or exit ownership—caused the release failure.

## Changes

- Declare Buzz canary eligibility
- Declare Microsoft Teams canary eligibility
- Cover exact Buzz scenario pair
- Preserve unsupported Discord rejection

## Testing

- Pre-fix owner regression on Blacksmith Testbox `tbx_01m030t9bt8n3mnnnzscd9q610`:
  - `pnpm test extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts`
  - Buzz and Microsoft Teams assertions failed with `channel=qa-channel|telegram`; 12 sibling assertions passed.
- Fixed owner regression on fresh Testbox `tbx_01m030z58fqh42wd9ptqeahe6a`:
  - `pnpm test extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts`
  - 14/14 passed.
- Adjacent caller and workflow coverage on the same Testbox:
  - `pnpm test extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts extensions/buzz/src/qa/cli.test.ts extensions/msteams/src/qa/cli.test.ts test/scripts/package-acceptance-workflow.test.ts`
  - 209/209 passed.
- Catalog contract follow-up on fresh Testbox `tbx_01m0336vaxh81kv8smcphnvzeb`:
  - `pnpm test extensions/qa-lab/src/scenario-catalog-channels.test.ts extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts`
  - 30/30 passed after aligning the second exact allowlist assertion found by PR CI.
- Changed-path gate on the same Testbox:
  - `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`
  - Passed guards, formatting, typechecks, lint, and import-cycle checks.
- Autoreview:
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1`
  - Clean; no accepted or actionable findings.

## Release proof

- [Full Release Validation `31895168506`](https://github.com/openclaw/openclaw/actions/runs/31895168506) completed successfully for exact PR head `8436c680b1ca8f0ebe43f89d9dea8b9371b73e29` with `rerun_group=qa-live` and `live_suite_filter=qa-live-buzz`.
- [Release Checks child `31895190393`](https://github.com/openclaw/openclaw/actions/runs/31895190393) completed successfully through the repository release wrapper.
- Artifact [`9249696902`](https://github.com/openclaw/openclaw/actions/runs/31895190393/artifacts/9249696902) records requested scenarios `channel-canary` and `channel-mention-gating` in order, with `2` total, `2` passed, `0` failed, and `0` skipped.
- The full evidence file contains two entries. Both identify live Buzz and have `result.status=pass`.
- The wrapper kept `allow_frozen_target_scenario_omissions=false`; no missing scenario or failure was coerced to success.

## Scope

Production runtime LOC is unchanged. QA catalog metadata is `+2`; tests are `+20/-3`. Result aggregation, assertions, timeouts, and nonzero exit handling are unchanged.

## Remaining gaps

- The first fixed-after Testbox became mixed after a full resync and failed frozen installation on an existing lockfile override mismatch. It was stopped; no dependency or lockfile checks were weakened.
- Setup-only release-proof dispatches with invalid temporary ref shapes were rejected before Buzz ran. The canonical exact-head run above used the required 12-hex-plus-numeric identity and completed successfully.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":3,"toolOutputsDropped":3,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":27}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’ll own the repair through a pushed PR. I’m starting with the mandated release/testing/test-audit workflow and a read-only state/artifact inspection; I’ll preserve Pebbles as local-only state and won’t merge.

The named skills are shaping the order here: release-CI/testing first for artifact and wrapper proof, test-audit before adding the regression, then autoreview/prepare-PR/transcript/technical-writing for publication. I’m reading those instructions in full before acting.

The worktree is clean and detached at `c0824d284e95`; I have not changed source. I’m splitting read-only evidence gathering into two lanes required by the repair doctrine: exact failed-run artifacts/log ownership, and sibling multi-scenario caller/history audit. I’ll independently verify consequential evidence before editing.

The failed validation ran target SHA `079bb3419613`; this app worktree was provisioned at `c0824d284e95`, while `origin/main` has advanced to `7ce902c8b600`. Before creating a branch, I’m checking whether that newer main already contains the canonical fix, as required, and downloading only the failed Buzz job’s evidence.

Current `main` is not fixed. The exact artifact records both requested IDs, but `channel-canary` is converted into a partition failure before adapter execution because its catalog allows only `qa-channel|telegram`; `channel-mention-gating` reaches Buzz and passes. The shared suite then correctly sets exit 1 from the failed result. I’m preserving that result gate and repairing the catalog-owned applicability contract, not the exit status.

The investigation is captured at `/tmp/openclaw-buzz-qa-selection-investigation.md`. Per the Pebbles skill and repository workflow, I’m now translating it into an epic plus ordered regression, repair, and validation/publication tasks before any source edit. Pebbles data remains local and will never be staged or synced.

Pebbles is not initialized inside this linked app worktree. I’m checking the repository’s canonical local Pebbles store first; if it exists, I’ll point `PEBBLES_DIR` there so the worktree shares workflow state without creating duplicate tracked-looking data.

The feature branch is now `oc-2f4/repair-buzz-qa-selection` from exact current `origin/main`. The shared Pebbles database was briefly locked by concurrent local activity while adding relationships; no source was touched. I’m verifying the four created records and will apply the relationships one command at a time.

The regression will sit at the catalog-selection owner, not in the workflow parser. It protects the exact Buzz pair and the connected Microsoft Teams default; existing tests already protect Discord rejection, so the allowlist remains selective. This test requires no production seam and will fail on pre-fix `main` for the same mismatch as CI.

The worktree has no local `tsx`/dependency install, so the testing skill routes this focused trusted-source proof to the repository’s remote wrapper. That invokes the Crabbox skill; I’m reading its backend and cleanup rules before provisioning a task-owned box.

Pre-fix proof is exact: Blacksmith Testbox `tbx_01m030t9bt8n3mnnnzscd9q610` ran the new owner-boundary test; Buzz and Microsoft Teams both failed with the same `channel=qa-channel|telegram` mismatch, while the other 12 selection tests passed. I’m now applying the two-line canonical metadata repair.

The metadata repair makes the new Buzz/Microsoft Teams assertions pass. One existing negative test now fails only because it intentionally names the complete allowlist in its error string; Discord is still rejected. I’m updating that contract assertion to the new exact allowlist, then rerunning the same focused file.

The second rerun exposed Testbox state, not a code failure: delegated full sync removed the remote dependency tree, so `tsx` was missing before Vitest started. The testing rules permit one remote `pnpm install` retry. I’m rebuilding dependencies only on this disposable box, then rerunning the same test in that command.

The remote install failed closed because the hydrated Testbox’s package overrides no longer match its lockfile, consistent with its unexpected 1,576-file resync. I will not weaken frozen-lockfile checks. Per the Crabbox rules, I’m stopping this mixed-provenance lease and checking whether `main` advanced before deciding whether to rebase and warm a fresh box.

Fixed-after proof is green on fresh Testbox `tbx_01m030z58fqh42wd9ptqeahe6a`: all 14 owner-selection tests pass, including the exact Buzz pair and Microsoft Teams sibling. Next I’m classifying the diff and running the adjacent CLI/workflow contracts before the live release-wrapper proof.

The adjacent four-shard suite is green: 209 tests across workflow routing, Buzz CLI, Microsoft Teams CLI, and shared catalog selection. The changed gate is still running its all-lanes typecheck/lint tail on the same Testbox; all completed guards and formatting checks are green so far.

The changed gate remains healthy but quiet in the serial core typecheck shards; no failure output has appeared. I’m leaving the task-owned process running as required rather than interrupting a long typecheck.

The all-lanes gate is still inside `run-tsgo-core-test-shards.mjs`; it has been quiet for several minutes but remains attached and has not emitted an error or timeout. I’m continuing to wait within the Testbox job’s bounded execution window.

Typecheck completed and lint is now running; the changed gate has progressed through core, extension, script, and root-test type graphs without errors.

Core lint finished clean (`0 warnings, 0 errors`); extension lint is the remaining long shard before import-cycle checks.

I’m continuing from the completed investigation and fixed-after Testbox proof. I’ll preserve the fail-closed aggregate behavior, finish Pebbles bookkeeping, run the required review/PR workflow, then dispatch the exact Buzz release-wrapper proof against the pushed head. The testing, test-audit, release-CI, autoreview, prepare-PR, transcript, writing, and Pebbles skills govern those remaining steps.

The investigation and implementation tasks are now closed under epic `oc-2f4`; validation/publishing is `oc-2f4.3` and in progress. The branch’s base has fallen behind `origin/main` during validation, so I’m checking whether that advancement intersects this repair before final review and publication.

The final diff is confined to the catalog owner and its regression: QA metadata `+2`, tests `+18/-1`; production runtime code is unchanged. `origin/main` advanced by one unrelated test-fixture commit and does not touch the repair surfaces, so I’m keeping the validated base for the first structured review and will sync once before publication.

The structured review is clean at P1, and the full changed-path Testbox already proved formatting/type/lint. The repository hook cannot run in this node_modules-less worktree (“cannot run oxfmt”), so I’m using the documented worktree exception to commit without the local hook; I’m not installing or reconciling dependencies here.

After syncing onto the latest main commit, the exact branch diff received a second clean P1 autoreview. I’m publishing this single commit now, then I’ll create the PR with sanitized transcript provenance and run the focused release wrapper from the PR head—not a hand-written substitute.

[tool summary]
3 other; raw tool outputs dropped: 3
````

</details>
<!-- agent-transcript:end -->
