### PR TITLE
test: repair worker environment E2E fixtures

### DIFF
--- a/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
+++ b/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
@@ -39,6 +39,7 @@ import {
   testState,
   writeSessionStore,
 } from "../../../src/gateway/test-helpers.js";
+import type { WorkerEnvironmentServiceRecord } from "../../../src/gateway/worker-environments/service-contract.js";
 import { emitAgentEvent } from "../../../src/infra/agent-events.js";
 import { registerAgentRunContext } from "../../../src/infra/agent-run-registry.js";
 import { withTimeout } from "../../../src/utils/with-timeout.js";
@@ -101,17 +102,20 @@ async function closeFakeServer(server: WebSocketServer): Promise<void> {
   });
 }
 
-function workerRecord(state: "requested" | "ready" | "destroyed") {
+function workerRecord(state: "requested" | "ready" | "destroyed"): WorkerEnvironmentServiceRecord {
   return {
     environmentId: "worker-sdk-e2e",
     providerId: "testbox",
     leaseId: "lease-sdk-e2e",
+    sharedHost: null,
     state,
     ownerEpoch: 1,
     createdAtMs: 1_000,
     idleSinceAtMs: null,
     attachedSessionIds: ["session-sdk-e2e"],
-    tunnelStatus: "stopped" as const,
+    desktopAvailable: false,
+    desktopApps: [],
+    tunnelStatus: "stopped",
   };
 }
 

--- a/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
@@ -19,37 +19,15 @@ import {
   getGatewayE2ePortBlock,
 } from "../../../../src/gateway/test-helpers.e2e.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../../../../src/gateway/test-helpers.env.js";
+import type { WorkerEnvironmentServiceRecord } from "../../../../src/gateway/worker-environments/service-contract.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
 import { createTaskRecord, deleteTaskRecordById } from "../../../../src/tasks/task-registry.js";
 import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
-type WorkerRecord = {
-  environmentId: string;
-  providerId: string;
-  leaseId: string | null;
-  state:
-    | "requested"
-    | "provisioning"
-    | "bootstrapping"
-    | "ready"
-    | "attached"
-    | "idle"
-    | "draining"
-    | "destroying"
-    | "destroyed"
-    | "failed"
-    | "orphaned";
-  ownerEpoch: number;
-  createdAtMs: number;
-  idleSinceAtMs: number | null;
-  attachedSessionIds: readonly string[];
-  tunnelStatus: "stopped" | "connecting" | "connected" | "reconnecting";
-};
-
 const injectedWorkerService = vi.hoisted(() => {
-  const records = new Map<string, WorkerRecord>();
+  const records = new Map<string, WorkerEnvironmentServiceRecord>();
   const idempotency = new Map<string, string>();
   let createCount = 0;
 
@@ -63,15 +41,18 @@ const injectedWorkerService = vi.hoisted(() => {
       }
       createCount += 1;
       const environmentId = `worker-qa-${createCount}`;
-      const record: WorkerRecord = {
+      const record: WorkerEnvironmentServiceRecord = {
         environmentId,
         providerId: profileId,
         leaseId: `lease-${createCount}`,
+        sharedHost: null,
         state: "ready",
         ownerEpoch: 1,
         createdAtMs: 1_800_000_000_000,
         idleSinceAtMs: null,
         attachedSessionIds: [],
+        desktopAvailable: false,
+        desktopApps: [],
         tunnelStatus: "stopped",
       };
       records.set(environmentId, record);


### PR DESCRIPTION
## What

Repair the two worker-environment repository E2E fixtures that failed Full Release Validation by making their fake records implement the canonical `WorkerEnvironmentServiceRecord` contract.

## Why

Full Release Validation run 31871527419 failed before printing assertion stacks. A current-main Testbox rerun proved all named failures still reproduce and split them into unrelated owner clusters. The SDK composed-resource and Gateway artifact API failures share one root cause: their pre-desktop worker records omit `sharedHost`, `desktopAvailable`, and `desktopApps`, so Gateway projection throws while reading `desktopApps.length` and correctly returns `worker environment creation failed`.

## Changes

- Type E2E records against the owner contract
- Add explicit non-desktop record defaults
- Remove duplicate hand-maintained record type

## Testing

- Current-main audit (58 failures; all named surfaces reproduced):

  ```sh
  pnpm test src/agents/model-fallback.run-embedded.e2e.test.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts packages/sdk/src/app-sdk-composed-resources.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts src/claws/lifecycle.e2e.test.ts
  ```

- Focused pre-fix proof (2 files failed with `worker environment creation failed`):

  ```sh
  pnpm test packages/sdk/src/app-sdk-composed-resources.e2e.test.ts test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
  ```

- Focused post-fix and sibling proof (2 E2E tests and 33 handler tests passed):

  ```sh
  pnpm test packages/sdk/src/app-sdk-composed-resources.e2e.test.ts test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts src/gateway/server-methods/environments.test.ts
  ```

- Changed checks passed, including formatting, typecheck, lint, boundaries, and dead exports:

  ```sh
  node scripts/check-changed.mjs -- packages/sdk/src/app-sdk-composed-resources.e2e.test.ts test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
  ```

- Autoreview: no actionable findings; patch correct (0.99 confidence).
- Production LOC delta: 0. Test delta: +12/-27.

## Remaining gaps

The full repository E2E lane remains red on current main for seven unrelated clusters, recorded as named local follow-ups rather than folded into this PR:

- Provider fallback classification and cooldown persistence
- Doctor missing-state-directory module mock
- Trigger handling retired registry lifecycle
- Embedded-agent fault-sequence harness
- Telegram media locale-ledger runtime mocks
- Gateway RPC automation heartbeat observation
- Claws lifecycle config expectations

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":3,"toolOutputsDropped":3,"web":0,"redactions":2,"omittedUnsafe":0,"rawEntries":23}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’m starting with the required workflow gates: current worktree/state, the relevant skill instructions, release-run evidence, and a lightweight memory pass for prior Full Release Validation conventions. I’ll preserve Pebbles as local-only state and won’t edit until each named failure is classified on current `main`.

The app-provisioned checkout is clean and detached, so there is no unrelated work to preserve. The selected skills require a fairly strict release-evidence and PR pipeline; I’m reading them in full now before retrieving the failed job logs or creating the Pebbles plan.

The skills establish two important constraints for this task: classify each release failure before changing the Code SHA, and add only an owner-boundary regression that demonstrably fails on the pre-fix source. I’m now pulling the exact parent/child/job identities and failure log, then I’ll split independent read-only evidence lanes while I trace the shared path directly.

The release job validated product SHA `8f382a202ff1e15833394b481615dcdda99b04d7` with tooling SHA `079bb34196138313265790e6223ca8fbf4c56c74`; the parent’s displayed SHA is the tooling ref, not the candidate. I’ve moved the clean checkout to current `origin/main` (`7ce902c8b60`) and delegated three read-only history/ownership audits. I’m now running the exact named test files as one bounded current-main E2E set so their shared process order is preserved.

The local focused harness cannot start because this linked worktree has no installed `tsx`; I will not reconcile dependencies in the worktree. The testing skill therefore routes the same focused set to a task-owned Blacksmith Testbox. I’m reading the Crabbox execution contract before acquiring that backend, then I’ll reuse one lease for pre-fix/current-main and later post-fix proof.

The current-main Testbox run is active at [run [REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]) on lease `tbx_01m030r5tab1rbn2xhcpatnwd8`. It is still in the required private-QA build; no test result has been produced yet. The original job’s breadth is already a clue: many whole files failed after their first setup error, so I’m treating per-file cascades separately from distinct root failures.

All nine named surfaces still fail on current `main` in the same aggregate process, so none can be dismissed from history alone. The useful common signal is now concrete: several failures report handles bound to a retired plugin-registry generation, while Telegram sees a store object from the wrong mock shape. Both point to the custom `isolate:false` worker carrying module-owned state across files. I’m reducing this to single-file and ordered-pair repros before writing the investigation and Pebbles plan; this avoids “fixing” nine independent tests or weakening isolation.

I’m continuing from the completed current-main audit. The failures split into distinct owner clusters; I’m tracing the shared SDK/Gateway worker-environment boundary now, then I’ll formalize the investigation and Pebbles plan before any edit.

The shared failure is now pinned down: both E2E fixtures return incomplete `WorkerEnvironmentServiceRecord` objects. Desktop capability fields became mandatory, and `summarizeWorkerEnvironment()` throws on the missing `desktopApps`; the handler correctly converts that fixture exception into the identical “worker environment creation failed” response. I’ll keep the PR test-only and type the fixtures against the owner contract so future contract drift is caught statically.

The investigation is documented and the scope is fixed: one test-contract repair, with seven unrelated current-main clusters tracked as named follow-ups. I’m now creating the required local Pebbles epic/dependency graph; this does not enter source control.

The focused pre-fix run is captured: exactly both selected files failed, both at `environments.create`, with the shared owner-boundary error. The repair is now applied with zero production changes and deletes the hand-maintained duplicate record type in favor of the canonical contract.

Focused post-fix proof is green: both repository E2E tests pass, and all 33 owning environment-handler sibling tests pass. The changed-check classifier has delegated its broader verification to a fresh Testbox; I’m waiting for that gate before the release-lane run.

The first changed-check attempt exposed a formatting issue, now corrected with the repository’s `oxfmt`. Reusing the old Testbox then lost its dependency mount during full resync, so that retry was infrastructure-only (`tsx` absent), not a code failure; I’m rerunning through the repository’s normal fresh-Testbox route.

The fresh changed-check is progressing cleanly: formatting, dependency pins, plugin boundaries, dead-export scans, and policy guards all pass. It is currently in the core-test typecheck shard.

The typecheck shard is still running without output, but the Testbox session remains active and has not reported a failure. I’m keeping the gate bounded and will use its actual exit result rather than treating silence as success.

Core-test and root-test typechecks have passed. The gate has moved to the core lint shard; no code findings so far.

The complete changed-check is green after 10m17s, including both typechecks and zero-warning lint. The exact formatted patch is now rerunning through the E2E config plus all 33 owner-handler tests; the E2E build is in progress.

The exact-patch E2E build completed successfully, including all 11 TypeScript build invocations and plugin control-plane load verification. The two scenarios are now executing against that built runtime.

The exact formatted patch is fully green: both E2E scenarios and all 33 owning handler tests pass after a clean built-runtime run. With implementation proof complete, I’m invoking the required structured autoreview on the two-file test-only diff; any finding will be verified against the owner contract before action.

Autoreview is clean with no actionable findings (0.99 confidence), and the diff is test-only: 12 additions, 27 deletions, zero production LOC. The generic prepare-PR helper’s referenced `scripts/committer` does not exist in this repository, so I’m using explicit-path staging and a normal scoped commit, preserving the same safety contract.

The patch is committed at `f0a9b6f2c2c`. The commit hook could not access `node_modules` in this worktree, so I used its documented bypass only after separate `oxfmt` proof and the full changed-check gate. `origin/main` advanced by four unrelated commits after validation; none touches either changed file or the worker-environment boundary, so I’m preserving the already-proven commit rather than rebasing mechanically.

[tool summary]
3 other; raw tool outputs dropped: 3
````

</details>
<!-- agent-transcript:end -->
