### PR TITLE
test: trim residual subset assertions

### DIFF
--- a/packages/ai/src/api-registry.test.ts
+++ b/packages/ai/src/api-registry.test.ts
@@ -8,7 +8,6 @@ import {
 } from "./index.js";
 import {
   defaultApiRegistry,
-  getApiProvider,
   streamSimple as streamSimpleDefault,
 } from "./internal/default-runtime.js";
 
@@ -80,8 +79,6 @@ describe("LLM API registry", () => {
       },
       TEST_SOURCE_ID,
     );
-
-    expect(getApiProvider("test-api")).toBeDefined();
 
     streamSimpleDefault(model, { messages: [] });
 

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -654,7 +654,6 @@ describe("google-shared convertMessages", () => {
     const toolResponsePart = contents[0]?.parts?.find(
       (part) => typeof part === "object" && part !== null && "functionResponse" in part,
     );
-    expect(toolResponsePart).toBeDefined();
     const toolResponse = requireRecordProperty(assertRecord(toolResponsePart), "functionResponse");
     expect(assertRecord(toolResponse.response).output).toBe(
       '{"type":"json","payload":{"sessionKey":"current","status":"ok"}}',

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -686,7 +686,6 @@ describe("Mistral provider", () => {
       messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
     };
     const toolMessage = payload.messages.find((message) => message.role === "tool");
-    expect(toolMessage).toBeDefined();
     const toolContent = Array.isArray(toolMessage?.content) ? toolMessage.content : [];
     const textBlock = toolContent.find((block) => block.type === "text");
     expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource"'));
@@ -733,7 +732,6 @@ describe("Mistral provider", () => {
       messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
     };
     const toolMessage = payload.messages.find((message) => message.role === "tool");
-    expect(toolMessage).toBeDefined();
     const toolContent = Array.isArray(toolMessage?.content) ? toolMessage.content : [];
     const textBlock = toolContent.find((block) => block.type === "text");
     // Structured blocks should provide the output, not an empty fallback

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -777,7 +777,6 @@ describe("anthropic transport stream", () => {
     // Despite stop_reason=end_turn, the turn carries a toolCall, so the narration
     // text must be tagged commentary (phase:commentary) and route to 💬.
     const textBlock = findRecord(result.content, (record) => record.type === "text");
-    expect(textBlock.textSignature).toBeDefined();
     expect(String(textBlock.textSignature)).toContain('"phase":"commentary"');
     expect(result.content.some((block) => (block as { type?: string }).type === "toolCall")).toBe(
       true,

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -124,7 +124,6 @@ describe("OpenAI Responses continuation", () => {
 
   it("ignores turn correlation headers but isolates explicit authorization", () => {
     const first = claim({ turn: "1" });
-    expect(first).toBeDefined();
     first?.commit(continuationState().lastRequest, {
       id: "resp_1",
       output: continuationState().lastResponseItems,
@@ -145,7 +144,6 @@ describe("OpenAI Responses continuation", () => {
 
   it("grants one claim and prevents a concurrent non-owner from overwriting it", () => {
     const owner = claim({});
-    expect(owner).toBeDefined();
     expect(claim({})).toBeUndefined();
 
     owner?.commit(continuationState().lastRequest, {

--- a/packages/ai/src/transports/openai-transport-params.session-header.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.session-header.test.ts
@@ -26,7 +26,6 @@ describe("buildOpenAIClientHeaders session_id affinity header", () => {
       longSessionId,
     );
     const sessionHeader = headers.session_id;
-    expect(sessionHeader).toBeDefined();
     expect(Array.from(sessionHeader ?? "").length).toBeLessThanOrEqual(
       OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH,
     );

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -725,7 +725,6 @@ describe("session cost usage", () => {
         const row = readSessionCostUsageRollupRows("main").find(
           (candidate) => candidate.key === sessionFile,
         );
-        expect(row).toBeDefined();
         expect(Buffer.byteLength(row?.valueJson ?? "")).toBeLessThan(32 * 1024);
         expect(JSON.parse(row?.valueJson ?? "null")).toMatchObject({
           pricingFingerprint,

--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -24,35 +24,14 @@ describe("sidebar entries", () => {
     expect(normalizeSidebarEntries(["route:overview", "route:usage"])).toEqual(["route:usage"]);
   });
 
-  it("keeps management surfaces in the workspace, not settings", () => {
-    for (const routeId of ["sessions", "activity"] as const) {
-      expect(SIDEBAR_NAV_ROUTES).toContain(routeId);
-      expect(settingsRoutes).not.toContain(routeId);
-    }
-    expect(settingsRoutes).not.toContain("worktrees");
-    expect(settingsRoutes).not.toContain("memory-import");
-  });
-
   it("treats worktrees as a sessions hub tab without its own pin", () => {
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("worktrees");
     expect(isSessionsHubRoute("sessions")).toBe(true);
     expect(isSessionsHubRoute("worktrees")).toBe(true);
     expect(isSessionsHubRoute("chat")).toBe(false);
     expect(normalizeSidebarEntries(["route:worktrees", "route:usage"])).toEqual(["route:usage"]);
   });
 
-  it("keeps settings pages out of the customizable sidebar", () => {
-    for (const routeId of [
-      "custodian",
-      "channels",
-      "security",
-      "secrets",
-      "notifications",
-      "advanced",
-    ] as const) {
-      expect(SIDEBAR_NAV_ROUTES).not.toContain(routeId);
-      expect(settingsRoutes).toContain(routeId);
-    }
+  it("recognizes every settings navigation route", () => {
     expect(settingsRoutes.every((routeId) => isSettingsNavigationRoute(routeId))).toBe(true);
   });
 
@@ -71,36 +50,26 @@ describe("sidebar entries", () => {
   });
 
   it("keeps model setup as a settings subpage without a sidebar entry", () => {
-    expect(settingsRoutes).not.toContain("model-setup");
     expect(isSettingsNavigationRoute("model-setup")).toBe(true);
     expect(settingsNavigationOwnerRoute("model-setup")).toBe("model-providers");
   });
 
   it("keeps Agent Defaults routed as an Agents subpage without a sidebar entry", () => {
-    expect(settingsRoutes).not.toContain("ai-agents");
     expect(isSettingsNavigationRoute("ai-agents")).toBe(true);
     expect(settingsNavigationOwnerRoute("ai-agents")).toBe("agents");
   });
 
-  it("keeps devices in connection settings and drops stale pinned entries", () => {
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("devices");
-    expect(settingsRoutes).toContain("devices");
+  it("drops stale device pins", () => {
     expect(normalizeSidebarEntries(["route:nodes", "route:usage"])).toEqual(["route:usage"]);
   });
 
-  it("keeps the apps promo page unpinned by default but customizable", () => {
-    expect(SIDEBAR_NAV_ROUTES).toContain("apps");
-    expect(DEFAULT_SIDEBAR_ENTRIES).not.toContain("route:apps");
+  it("keeps the apps promo page available in More", () => {
     expect(sidebarMoreRoutes(DEFAULT_SIDEBAR_ENTRIES)).toContain("apps");
-    expect(settingsRoutes).not.toContain("apps");
     expect(isSettingsNavigationRoute("apps")).toBe(false);
   });
 
-  it("keeps Portals as a first-class customizable workspace route", () => {
-    expect(SIDEBAR_NAV_ROUTES).toContain("portals");
-    expect(DEFAULT_SIDEBAR_ENTRIES).not.toContain("route:portals");
+  it("keeps Portals available in More", () => {
     expect(sidebarMoreRoutes(DEFAULT_SIDEBAR_ENTRIES)).toContain("portals");
-    expect(settingsRoutes).not.toContain("portals");
     expect(isSettingsNavigationRoute("portals")).toBe(false);
   });
 
@@ -110,7 +79,6 @@ describe("sidebar entries", () => {
       "route:usage",
     ]);
     expect(sidebarMoreRoutes(["route:usage", "session:agent:main:test"])).toContain("plugins");
-    expect(settingsRoutes).not.toContain("plugins");
   });
 
   it("round-trips route, Workboard, and session entries", () => {
@@ -143,9 +111,7 @@ describe("sidebar entries", () => {
     expect(normalizeSidebarEntries([])).toEqual([]);
   });
 
-  it("keeps OpenClaw only in Settings and drops stale sidebar pins", () => {
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("custodian");
-    expect(settingsRoutes).toContain("custodian");
+  it("recognizes OpenClaw settings and drops stale sidebar pins", () => {
     expect(isSettingsNavigationRoute("custodian")).toBe(true);
     expect(normalizeSidebarEntries(["route:custodian", "route:usage"])).toEqual(["route:usage"]);
   });

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -506,17 +506,10 @@ describe("plugin tabs route", () => {
     // Distinct plugins with the same local tab id stay distinct.
     expect(pluginTabKey({ pluginId: "other", id: "logbook" })).not.toBe(pluginTabKey(ref));
   });
-
-  it("stays out of the customizable static sidebar routes", () => {
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("plugin");
-    expect(SIDEBAR_NAV_ROUTES).toContain("plugins");
-    expect(routeIdFromPath("/settings/plugins")).toBe("plugins");
-    expect(routeIdFromPath("/plugins")).toBeNull();
-  });
 });
 
 describe("SIDEBAR_NAV_ROUTES", () => {
-  it("all routes are unique", () => {
+  it("keeps the canonical sidebar route order", () => {
     expect(SIDEBAR_NAV_ROUTES).toEqual([
       "workboard",
       "dashboards",
@@ -531,18 +524,15 @@ describe("SIDEBAR_NAV_ROUTES", () => {
     ]);
   });
 
-  it("collapses the plugins hub to a single sidebar entry", () => {
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("skills");
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("skill-workshop");
+  it("recognizes plugin hub routes", () => {
     expect(isPluginsHubRoute("plugins")).toBe(true);
     expect(isPluginsHubRoute("skills")).toBe(true);
     expect(isPluginsHubRoute("skill-workshop")).toBe(true);
     expect(isPluginsHubRoute("sessions")).toBe(false);
   });
 
-  it("keeps detailed settings slices routed but out of the customizable sidebar", () => {
+  it("keeps the canonical settings navigation order", () => {
     const settingsRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes);
-    expect(SIDEBAR_NAV_ROUTES).not.toContain("config");
     expect(settingsRoutes).toEqual([
       "custodian",
       "profile",
@@ -571,9 +561,7 @@ describe("SIDEBAR_NAV_ROUTES", () => {
     ]);
   });
 
-  it("keeps settings sidebar groups unique with personal settings first", () => {
-    const settingsRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes);
-    expect(new Set(settingsRoutes).size).toBe(settingsRoutes.length);
+  it("keeps personal settings first and labels remaining groups", () => {
     const [firstGroup] = SETTINGS_NAVIGATION_GROUPS;
     expect(firstGroup?.labelKey).toBeNull();
     expect(firstGroup?.routes).toEqual(["custodian", "profile", "appearance", "notifications"]);


### PR DESCRIPTION
## What Problem This Solves

Several tests still carried definedness, route-membership, exclusion, and uniqueness assertions whose failure sets were strict subsets of stronger neighboring behavior or exact inventory contracts.

## Why This Change Was Made

These assertions added maintenance cost without detecting an independent regression. The retained tests still invoke the provider, continuation, header, and rollup behavior; assert exact sidebar and settings inventories; exercise derived route ownership and More-section behavior; and verify normalization and hub routing.

## User Impact

No production behavior changes. The tests keep the same behavioral coverage with less duplicated feature-local bookkeeping.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/api-registry.test.ts packages/ai/src/providers/google-shared.convert.test.ts packages/ai/src/providers/mistral.test.ts packages/ai/src/transports/anthropic-transport-stream.test.ts packages/ai/src/transports/openai-responses-continuation.test.ts packages/ai/src/transports/openai-transport-params.session-header.test.ts` — 199 passed
- `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts` — 58 passed
- `node scripts/run-vitest.mjs ui/src/app-navigation-groups.test.ts ui/src/app-navigation.test.ts ui/src/app-route-paths.test.ts ui/src/app-routes.test.ts` — 135 passed
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback because no remote provider was available
- `git diff --check` — passed
- Structured autoreview — clean

Production delta: 0 lines. Test delta: -57 net lines.
