### PR TITLE
fix: restore frozen Codex release validation

### DIFF
--- a/scripts/resolve-frozen-codex-live-suite.mjs
+++ b/scripts/resolve-frozen-codex-live-suite.mjs
@@ -32,10 +32,9 @@ function readTargetModelIds(targetRoot) {
     if (defaults.size !== 1) {
       throw new Error(`cannot read one frozen Codex harness default from ${harnessPath}`);
     }
-    const modelId = [...defaults][0];
-    // The Luna default changed with the complete GPT-5.6 cohort migration and
-    // remains available after the fallback catalog was removed.
-    return new Set(modelId === "gpt-5.6-luna" ? [modelId, "gpt-5.6-sol"] : [modelId]);
+    // The harness default proves only the generic lane's model. Specialized
+    // lanes need the explicit cohort declaration from the historical catalog.
+    return { modelIds: new Set(defaults), supportsGpt56Cohort: false };
   }
   const source = readFileSync(catalogPath, "utf8");
   const start = source.indexOf("export const FALLBACK_CODEX_MODELS = [");
@@ -43,22 +42,22 @@ function readTargetModelIds(targetRoot) {
   if (start < 0 || end < 0) {
     throw new Error(`cannot read the frozen Codex fallback catalog from ${catalogPath}`);
   }
-  return new Set(
+  const modelIds = new Set(
     [...source.slice(start, end).matchAll(/\bid:\s*["']([^"']+)["']/gu)].map((match) => match[1]),
   );
-}
-
-function resolveFrozenCodexCompatibility({ suiteId, targetRoot }) {
-  const modelIds = readTargetModelIds(targetRoot);
   const hasSol = modelIds.has("gpt-5.6-sol");
   const hasLuna = modelIds.has("gpt-5.6-luna");
   if (hasSol !== hasLuna) {
     throw new Error("frozen Codex GPT-5.6 capability marker is incomplete; refusing to guess");
   }
-  const supportsGpt56Cohort = hasSol && hasLuna;
+  return { modelIds, supportsGpt56Cohort: hasSol && hasLuna };
+}
+
+function resolveFrozenCodexCompatibility({ suiteId, targetRoot }) {
+  const { modelIds, supportsGpt56Cohort } = readTargetModelIds(targetRoot);
 
   if (suiteId === GENERIC_CODEX_SUITE) {
-    const model = supportsGpt56Cohort
+    const model = modelIds.has("gpt-5.6-luna")
       ? "openai/gpt-5.6-luna"
       : modelIds.has("gpt-5.5")
         ? "openai/gpt-5.5"

--- a/scripts/resolve-frozen-codex-live-suite.mjs
+++ b/scripts/resolve-frozen-codex-live-suite.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const CODEX_SUITE_PREFIX = "live-codex-harness";
@@ -19,8 +19,24 @@ function appendLine(file, line) {
   appendFileSync(file, `${line}\n`, "utf8");
 }
 
-function readFallbackModelIds(targetRoot) {
+function readTargetModelIds(targetRoot) {
   const catalogPath = path.join(targetRoot, "extensions/codex/provider-catalog.ts");
+  if (!existsSync(catalogPath)) {
+    const harnessPath = path.join(targetRoot, "scripts/test-live-codex-harness-docker.sh");
+    const source = readFileSync(harnessPath, "utf8");
+    const defaults = new Set(
+      [...source.matchAll(/\$\{OPENCLAW_LIVE_CODEX_HARNESS_MODEL:-[^/}]+\/([^}\s]+)\}/gu)].map(
+        (match) => match[1],
+      ),
+    );
+    if (defaults.size !== 1) {
+      throw new Error(`cannot read one frozen Codex harness default from ${harnessPath}`);
+    }
+    const modelId = [...defaults][0];
+    // The Luna default changed with the complete GPT-5.6 cohort migration and
+    // remains available after the fallback catalog was removed.
+    return new Set(modelId === "gpt-5.6-luna" ? [modelId, "gpt-5.6-sol"] : [modelId]);
+  }
   const source = readFileSync(catalogPath, "utf8");
   const start = source.indexOf("export const FALLBACK_CODEX_MODELS = [");
   const end = source.indexOf("] satisfies", start);
@@ -33,7 +49,7 @@ function readFallbackModelIds(targetRoot) {
 }
 
 function resolveFrozenCodexCompatibility({ suiteId, targetRoot }) {
-  const modelIds = readFallbackModelIds(targetRoot);
+  const modelIds = readTargetModelIds(targetRoot);
   const hasSol = modelIds.has("gpt-5.6-sol");
   const hasLuna = modelIds.has("gpt-5.6-luna");
   if (hasSol !== hasLuna) {

--- a/test/scripts/resolve-frozen-codex-live-suite.test.ts
+++ b/test/scripts/resolve-frozen-codex-live-suite.test.ts
@@ -14,21 +14,33 @@ afterEach(() => {
 
 function runResolver(params: {
   allow?: boolean;
+  catalog?: boolean;
+  harnessModel?: string;
   modelIds?: string[];
   selectedSha?: string;
   suiteId: string;
 }) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-frozen-codex-"));
   tempRoots.push(root);
-  const catalogDir = join(root, "extensions/codex");
-  mkdirSync(catalogDir, { recursive: true });
-  const models = (params.modelIds ?? ["gpt-5.5"])
-    .map((id) => `  { id: "${id}", model: "${id}" },`)
-    .join("\n");
-  writeFileSync(
-    join(catalogDir, "provider-catalog.ts"),
-    `export const FALLBACK_CODEX_MODELS = [\n${models}\n] satisfies unknown[];\n`,
-  );
+  if (params.catalog !== false) {
+    const catalogDir = join(root, "extensions/codex");
+    mkdirSync(catalogDir, { recursive: true });
+    const models = (params.modelIds ?? ["gpt-5.5"])
+      .map((id) => `  { id: "${id}", model: "${id}" },`)
+      .join("\n");
+    writeFileSync(
+      join(catalogDir, "provider-catalog.ts"),
+      `export const FALLBACK_CODEX_MODELS = [\n${models}\n] satisfies unknown[];\n`,
+    );
+  }
+  if (params.harnessModel) {
+    const scriptsDir = join(root, "scripts");
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      join(scriptsDir, "test-live-codex-harness-docker.sh"),
+      `model="\${OPENCLAW_LIVE_CODEX_HARNESS_MODEL:-${params.harnessModel}}"\n`,
+    );
+  }
   const output = join(root, "output");
   const envFile = join(root, "env");
   const summary = join(root, "summary");
@@ -88,6 +100,31 @@ describe("frozen Codex live-suite resolver", () => {
     expect(dedicated.output).toBe("run_lane=true\n");
     expect(generic.status).toBe(0);
     expect(generic.envFile).toBe("OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.6-luna\n");
+  });
+
+  it("uses the frozen harness contract after the target catalog was removed", () => {
+    const result = runResolver({
+      catalog: false,
+      harnessModel: "openai/gpt-5.6-luna",
+      suiteId: "live-codex-harness-docker",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toBe("run_lane=true\n");
+    expect(result.envFile).toBe("OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.6-luna\n");
+  });
+
+  it("omits GPT-5.6 suites for a catalog-free target with the older harness default", () => {
+    const result = runResolver({
+      catalog: false,
+      harnessModel: "codex/gpt-5.5",
+      suiteId: "live-codex-harness-gpt56-sol-docker",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toBe("run_lane=false\n");
+    expect(result.envFile).toBe("");
+    expect(result.summary).toContain("omitted unsupported current-only suite");
   });
 
   it("does nothing without the trusted frozen-target opt-in", () => {

--- a/test/scripts/resolve-frozen-codex-live-suite.test.ts
+++ b/test/scripts/resolve-frozen-codex-live-suite.test.ts
@@ -114,6 +114,19 @@ describe("frozen Codex live-suite resolver", () => {
     expect(result.envFile).toBe("OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.6-luna\n");
   });
 
+  it("does not infer specialized GPT-5.6 support from a catalog-free harness default", () => {
+    const result = runResolver({
+      catalog: false,
+      harnessModel: "openai/gpt-5.6-luna",
+      suiteId: "live-codex-harness-gpt56-sol-docker",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toBe("run_lane=false\n");
+    expect(result.envFile).toBe("");
+    expect(result.summary).toContain("omitted unsupported current-only suite");
+  });
+
   it("omits GPT-5.6 suites for a catalog-free target with the older harness default", () => {
     const result = runResolver({
       catalog: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could not run the Codex Docker live lane against `2026.8.1-beta.2`. The trusted release helper opened `extensions/codex/provider-catalog.ts`, although that frozen target had deliberately removed the file while retaining Codex support.

## Why This Change Was Made

The frozen-suite resolver now reads either of the two target-owned release contracts. It uses `FALLBACK_CODEX_MODELS` when the historical catalog exists, then uses the frozen target's own Codex live-harness default after the catalog migration. GPT-5.6 suite selection still requires the complete Sol/Luna cohort marker, and older or ambiguous targets continue to omit or fail closed.

The resolver owns compatibility selection between the newer trusted workflow and the older frozen target. The frozen target remains the source of truth for its supported live-harness model.

## User Impact

Release maintainers can validate beta.2 and later catalog-free frozen targets with the current trusted workflow. Targets that genuinely predate GPT-5.6 remain omitted from GPT-5.6-only lanes.

## Evidence

- Failure before: [Full Release Validation `31871527419`](https://github.com/openclaw/openclaw/actions/runs/31871527419) dispatched [Release Checks `31871544784`, job `94982721600`](https://github.com/openclaw/openclaw/actions/runs/31871544784/job/94982721600) for frozen SHA `8f382a202ff1e15833394b481615dcdda99b04d7` (`2026.8.1-beta.2`). The resolver failed with `ENOENT` for `extensions/codex/provider-catalog.ts` before the Docker Codex lane.
- Regression before: `node scripts/run-vitest.mjs test/scripts/resolve-frozen-codex-live-suite.test.ts` failed at the new catalog-free target case because the resolver opened the deleted catalog.
- Focused after: the resolver suite passed 8/8 tests, including catalog-free beta.2 support, old-target omission, and incomplete-marker rejection.
- Caller after: `node scripts/run-vitest.mjs test/scripts/release-e2e-workflow.test.ts` passed.
- Exact target after: the beta.2 archive resolved `run_lane=true` and `OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.6-luna`.
- Changed-path gate after: `node scripts/check-changed.mjs -- scripts/resolve-frozen-codex-live-suite.mjs test/scripts/resolve-frozen-codex-live-suite.test.ts` passed formatting, typecheck, lint, dependency, and Docker boundary checks on a fresh Testbox.
- Realistic after: [frozen-target live workflow `31893360520`](https://github.com/openclaw/openclaw/actions/runs/31893360520) used this branch's trusted helper against the exact beta.2 SHA. Both the initial job and one narrow rerun resolved the frozen suite to `openai/gpt-5.6-luna`, validated the bound image, started beta.2, connected Codex app-server, listed the GPT-5.6 models, and completed normal and image turns. The unchanged lane then failed in the older target's cron MCP probe because the model-driven automations call did not create the expected job. The workflow's built-in retry repeated that downstream failure.
- Autoreview: final exact-diff review reported no accepted or actionable findings.

### Codex contract checked

Sibling Codex commit `c4941302c73c6322b153bba13ac0a9f4396301d6` confirms that model support is runtime catalog state, not the presence of OpenClaw's removed fallback file:

- `codex-rs/app-server-protocol/src/protocol/v2/model.rs:50-152` defines the paginated `model/list` contract and its model identifier fields.
- `codex-rs/app-server/src/message_processor.rs:1345-1347` routes `model/list` through the catalog processor.
- `codex-rs/app-server/src/models.rs:13-65` gets supported models from `ThreadManager` and maps the returned presets.
- `codex-rs/core/src/session/mod.rs:568-590` refreshes the model manager and resolves the configured or default model at session startup.

### Scope and remaining gaps

- Production/tooling delta: `+24/-9`; test delta: `+59/-9`.
- No runtime, protocol, timeout, assertion, dependency, or coverage gate changed.
- Remaining gap: the beta.2 runtime cannot complete the cron MCP portion of the current live lane with Codex CLI `0.147.0`. This is downstream of suite resolution and reproduced after the one permitted narrow retry. It needs separate product/runtime-contract investigation; this PR does not omit the suite, disable the probe, or weaken its assertion.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":1,"toolOutputsDropped":1,"web":2,"redactions":4,"omittedUnsafe":0,"rawEntries":37}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’m taking this end to end. I’ll first load the required release/testing/review/PR-writing workflows, verify the checkout and scoped instructions, then reproduce the frozen beta.2 failure before creating the Pebbles plan or editing source. The Codex contract check will be direct against `../codex`, as required.

The first combined read was truncated, so I’m splitting the required skill and policy reads to ensure none of the workflow contracts are missed. The agent-transcript skill also requires explicit approval before insertion; because your delegation explicitly requires the transcript section, I’ll treat that as approval to generate and include the sanitized section, while still failing closed if its safety check cannot produce one.

Checkout state is clean and detached at the app-provisioned commit, so there is no unrelated work to preserve. I’m now refreshing `origin/main`, checking whether that provisioned commit is still the default-branch tip, gathering the exact failed job log, and locating the Codex runtime contract in the sibling source before I form or apply a fix.

The failure is confirmed as a tooling/harness defect, not a frozen product defect: the trusted helper from workflow SHA `079bb341…` runs against frozen target `8f382a20…` and crashes before the Codex lane because it opens `extensions/codex/provider-catalog.ts`, which that target does not contain. `origin/main` has advanced to `7ce902c8…`; I’m checking that tip for an existing canonical repair before creating any patch. The required sibling Codex checkout is absent, so the next step clones it at `../codex` and inspects the exact config/model behavior the resolver relies on.

The local beta.2 reproduction now fails with the same `ENOENT` before any edit. One shell variable name collided with zsh’s reserved `status`, so the wrapper stopped immediately after recording the expected failure; it did not alter the checkout. I’m adding the Pebbles workflow skill now because the repository process requires an epic and dependent tasks before implementation, then I’ll write the investigation record and create that plan.

Investigation is complete and records the exact failure, blame-backed history, owner boundary, direct Codex protocol/runtime evidence, compatibility contract, and proof plan. The key design is dual historical-contract support: old targets retain the literal fallback catalog path; catalog-free targets use their own live-harness default, which is the release-era marker that changed from `codex/gpt-5.5` to `openai/gpt-5.6-luna`. Unknown or contradictory markers still fail closed. I’m now using Pebbles to create the epic and ordered tasks before any source edit.

Pebbles is not initialized in this app worktree, so issue creation stopped without writing source. The local-only workflow requires initialization here; I’ll initialize its ignored state, then create and link the epic/tasks. No Pebbles data will be staged, synced, or pushed.

The canonical checkout already has initialized Pebbles state, so I will use that explicit local `PEBBLES_DIR` rather than create a second tracker in this worktree. This keeps planning visible in the established local issue graph while source control remains untouched.

The source branch is now correctly based on `origin/main` (`7ce902c8…`). Pebbles issue creation succeeded, but linking/status updates hit the shared tracker’s SQLite lock, likely from another local workflow; no source work depends on guessing its state. I’ll retry the local metadata updates serially, verify the dependency tree, and only then begin the regression test.

The shared Pebbles event log contains our issues, but concurrent updates left its disposable SQLite cache behind the append-only log; no Pebbles process currently holds the database. Because the event log is authoritative and the database is only a cache, I’ll make a timestamped backup of that cache, let Pebbles rebuild it, then finish the links. This is a reversible local workflow repair and does not touch repository source.

Pebbles is now consistent: epic `oc-c45`, investigation `oc-c45.1` closed, implementation `oc-c45.2` in progress, and proof/publication `oc-c45.3` blocked on it. The regression protects the observable release-tool boundary: a frozen target whose Codex text catalog was deliberately removed but whose own live harness selects GPT-5.6 must resolve successfully. Existing tests do not represent that post-migration target shape, and no production-only test seam is needed.

The new regression is in place, but this worktree has no installed `tsx`/Vitest dependencies, so the repository wrapper cannot execute locally and failed before loading the test. Per the testing workflow, I will not reconcile dependencies in a Codex worktree. I’m loading the Crabbox remote-proof instructions and will run the pre-fix test on a trusted Blacksmith Testbox, where it can fail for the intended missing-catalog reason.

The remote regression fails for the intended reason at `test/scripts/resolve-frozen-codex-live-suite.test.ts:112`; provider `blacksmith-testbox`, lease `tbx_01m030…`, run `[REDACTED_PHONE]`. I’m now repairing the compatibility owner. The resolver will derive one semantic support record from either historical catalog models or the target-owned harness default, normalize the old `codex/` route for the trusted current harness, and retain fail-closed checks for incomplete/ambiguous markers.

The repaired resolver now passes all seven focused tests and resolves the exact beta.2 archive to `openai/gpt-5.6-luna` with `run_lane=true`. The legacy catalog-free GPT-5.5 fixture still yields `run_lane=false` for GPT-5.6-only suites, so omission remains evidence-based. I’m broadening proof to the workflow caller contract, formatting/lint classification, and production/test LOC before review.

The first repair is correct but adds 29 net tooling lines. I found a simpler owner-preserving shape: keep one target-capability reader, use the old catalog when present, and otherwise translate the target harness default into the same model-ID set consumed by existing resolution logic. This removes the parallel support-record abstraction while retaining the same fail-closed behavior and historical contract. I’m compressing to that form before broader gates.

The Testbox’s first focused run had dependencies, but its later full checksum sync removed the prewarmed `node_modules`; the refactored test did not execute in that attempt. The testing contract allows one remote `pnpm install` retry when dependencies are missing. I’ll restore the pinned lockfile environment on the same owned lease and rerun the exact focused commands once.

The one permitted install retry hit a lockfile/config mismatch on that reused box, so I will not weaken the lockfile or run a non-frozen install. This is remote lease state, not a patch dependency change. I’m stopping the contaminated lease and warming a fresh Testbox from the branch, which is the prescribed recovery when a reused box’s dependency provenance is no longer valid.

Focused owner and workflow-caller tests pass on fresh Blacksmith Testbox `tbx_01m031…` (run `[REDACTED_PHONE]`), and the full changed-path gate is green, including formatting, root test typecheck, script lint, Docker boundary guards, and dependency checks. The final diff is +16 net tooling lines and +37 net test lines; the production growth is the one new compatibility capability for catalog-free released targets. I’m closing implementation in Pebbles and starting the mandatory structured review before commit.

Autoreview is clean on the complete uncommitted patch: Codex `gpt-5.6-sol`, high reasoning, no accepted or actionable findings. Because no review-triggered edit is needed, that is the final review run under the skill’s stop-on-clean rule. I’m rerunning the exact beta.2 archive proof against the final compressed code, then committing only the two source/test paths with the Pebbles reference.

The final beta.2 proof is green. The repository no longer contains the `scripts/committer` helper referenced by the generic PR skill, so no commit was made. While proof ran, `origin/main` advanced by one commit; I’m checking that exact delta for overlap before committing. If it does not touch this release-tool boundary, I’ll keep the verified patch based on `7ce902c8…` and use explicit-path `git add` plus a normal commit, as allowed by the repository workflow.

The commit hook correctly refused because this worktree has no local dependencies. Formatting and the complete changed-path gate already passed on the fresh Testbox, so the worktree policy explicitly permits `git commit --no-verify` here. I’ll use it without changing the staged file set.

The scoped commit is created. The only main drift deletes an unrelated diffs-plugin test, but keeping the PR head based on latest main avoids stale-base ambiguity. I’ll rebase this single clean commit onto `a5603681…`; because the upstream change has no overlapping path or behavior, the already-completed focused and review evidence remains applicable.

The branch is pushed and `git ls-remote` matches head `98613c492077…`. I’m dispatching the reusable live/E2E workflow from this branch while targeting the exact frozen beta.2 SHA, with only `live-codex-harness-docker` enabled and frozen-target omissions explicitly allowed. This exercises the patched trusted helper in the original newer-harness/older-target topology, then runs the real Docker Codex lane.

The exact-topology workflow is active at run `[REDACTED_PHONE]`, bound to PR head `98613c49…` and frozen target `8f382a20…`. The focused suite filter has validated successfully; target/ref identity resolution is still running before image preparation and the Codex lane.

I’m resuming from the pushed repair. I’ll first finish the exact beta.2 live workflow, then stop the Testbox, prepare the transcript-backed PR, verify its remote head, and close the local Pebbles work.

The realistic workflow is still validating the selected frozen ref; its suite filter has passed. While it runs, I’m applying the PR-preparation and transcript requirements to the already-reviewed exact commit.

The exact-topology workflow has cleared frozen-ref validation and is building the beta.2 live-test image. The Testbox lease is stopped cleanly. The PR body now records the failure provenance, direct Codex source contract, focused gates, LOC split, and omission semantics; I’ll publish only after the Docker Codex job is green.

The repaired resolver has now executed successfully inside the real workflow: frozen compatibility resolution and image binding are green, and the beta.2 Docker Codex harness itself is running. All unsupported sibling suites were omitted by the existing filter as intended.

The Docker Codex harness remains healthy and within its normal bounded runtime. It is past setup, auth hydration, compatibility resolution, and environment configuration; only the end-to-end Codex probe is still executing.

The realistic lane reached the repaired boundary but failed later inside the Codex probe. I’m inspecting only that failed job now to distinguish an attributable resolver defect from a frozen-target/runtime limitation before changing anything.

The resolver repair is proven in the failed run: it selected `openai/gpt-5.6-luna`, the beta.2 Gateway started, Codex `model/list` returned the expected catalog, and normal/image turns completed. The failure was later model nondeterminism in the cron MCP probe: Codex replied that its tool call failed, so the expected cron job was absent. Per the release-CI retry budget, I’m doing one narrow rerun of that failed live surface with the same code/tooling tuple; I’m not changing the resolver or weakening the probe.

The single permitted narrow retry is using the same branch SHA, beta.2 target SHA, and prepared image artifact. It has entered the replayed job and is loading the exact bound artifact before rerunning the unchanged Codex probe.

The retry has reached the live Codex harness itself with all identity and resolver checks green again. No source or workflow inputs changed between attempts; this isolates the remaining question to the nondeterministic model-driven cron probe.

The unchanged retry is still executing within the lane’s normal timeout. I’m holding the PR until it reaches a terminal result; if this one repeats the cron failure, I’ll record the realistic proof as resolver/runtime success with a clearly bounded downstream live-probe gap, not loop further retries.

The narrow retry repeated the same downstream cron-creation failure, including the workflow’s built-in retry. That makes it a stable frozen-target limitation, not a transient resolver failure. I’m tracing the beta.2 test/probe history now to determine whether the correct completion is a documented realistic-proof gap or an additional compatibility setting owned by this resolver; I will not hide the failure by weakening the live assertion.

[tool summary]
1 other; raw tool outputs dropped: 1
````

</details>
<!-- agent-transcript:end -->
