### PR TITLE
fix(compaction): trust fresh provider context usage

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -10,6 +10,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
+  estimateLlmBoundaryTokenPressure,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "../embedded-agent-runner/run/preemptive-compaction.js";
+import {
   resetCliCompactionTestDeps,
   runCliTurnCompactionLifecycle,
   setCliCompactionTestDeps,
@@ -252,6 +256,108 @@ describe("runCliTurnCompactionLifecycle", () => {
 
     expect(scenario.compactCalls).toEqual([]);
     expect(updatedEntry).toBe(scenario.sessionEntry);
+  });
+
+  it("trusts fresh provider usage over a larger transcript estimate", async () => {
+    const measuredMessages = [
+      {
+        role: "toolResult",
+        toolCallId: "call-large-read",
+        toolName: "read",
+        content: [{ type: "text", text: "x".repeat(483_458) }],
+        isError: false,
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        usage: {
+          contextUsage: {
+            state: "available",
+            promptTokens: 179_933,
+            totalTokens: 180_000,
+          },
+        },
+        timestamp: 2,
+      },
+    ];
+    expect(
+      estimateLlmBoundaryTokenPressure({ messages: measuredMessages as never, prompt: "" }),
+    ).toBe(290_136);
+    const scenario = await prepareCompactionScenario({
+      suffix: "fresh-provider-usage",
+      tmpDir,
+      sessionEntry: {
+        contextTokens: 272_000,
+        totalTokens: 179_933,
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+      },
+      deps: {
+        openSessionManager: () =>
+          ({
+            getBranch: () => measuredMessages.map((message) => ({ type: "message", message })),
+          }) as never,
+        createPreparedEmbeddedAgentSettingsManager: async () => ({
+          getCompactionReserveTokens: () => 32_000,
+          getCompactionKeepRecentTokens: () => 0,
+          applyOverrides: () => {},
+        }),
+        shouldPreemptivelyCompactBeforePrompt,
+      },
+    });
+
+    const updatedEntry = await scenario.run();
+
+    expect(scenario.compactCalls).toEqual([]);
+    expect(updatedEntry).toBe(scenario.sessionEntry);
+  });
+
+  it("adds transcript items after fresh provider usage to the compaction decision", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "measured answer" }],
+        usage: {
+          contextUsage: {
+            state: "available",
+            promptTokens: 239_800,
+            totalTokens: 239_900,
+          },
+        },
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: "unmeasured follow-up ".repeat(100),
+        timestamp: 2,
+      },
+    ];
+    const scenario = await prepareCompactionScenario({
+      suffix: "fresh-provider-usage-with-tail",
+      tmpDir,
+      sessionEntry: {
+        contextTokens: 272_000,
+        totalTokens: 239_800,
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+      },
+      deps: {
+        openSessionManager: () =>
+          ({ getBranch: () => messages.map((message) => ({ type: "message", message })) }) as never,
+        createPreparedEmbeddedAgentSettingsManager: async () => ({
+          getCompactionReserveTokens: () => 32_000,
+          getCompactionKeepRecentTokens: () => 0,
+          applyOverrides: () => {},
+        }),
+        shouldPreemptivelyCompactBeforePrompt,
+      },
+    });
+
+    await scenario.run();
+
+    expect(scenario.compactCalls).toHaveLength(1);
+    expect(scenario.compactCalls[0]?.currentTokenCount).toBeGreaterThan(240_000);
   });
 
   it("accepts no compactable entries only from a successful compaction result", async () => {

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.js";
 /**
  * CLI turn compaction lifecycle.
@@ -189,6 +190,42 @@ function getSessionBranchMessages(sessionManager: SessionManagerLike): AgentMess
 
 function resolveSessionTokenSnapshot(sessionEntry: SessionEntry | undefined): number | undefined {
   return resolvePositiveInteger(resolveFreshSessionTotalTokens(sessionEntry));
+}
+
+function resolveFreshProviderContextBoundary(params: {
+  messages: AgentMessage[];
+  sessionEntry: SessionEntry | undefined;
+}): { accountedPromptTokens: number; trailingMessages: AgentMessage[] } | undefined {
+  const freshPromptTokens = resolveSessionTokenSnapshot(params.sessionEntry);
+  if (freshPromptTokens === undefined) {
+    return undefined;
+  }
+  for (let index = params.messages.length - 1; index >= 0; index -= 1) {
+    const message = params.messages[index] as unknown;
+    if (!isRecord(message) || message.role !== "assistant" || !isRecord(message.usage)) {
+      continue;
+    }
+    const contextUsage = message.usage.contextUsage;
+    if (!isRecord(contextUsage) || contextUsage.state !== "available") {
+      continue;
+    }
+    const promptTokens = resolvePositiveInteger(
+      typeof contextUsage.promptTokens === "number" ? contextUsage.promptTokens : undefined,
+    );
+    const totalTokens = resolvePositiveInteger(
+      typeof contextUsage.totalTokens === "number" ? contextUsage.totalTokens : undefined,
+    );
+    if (promptTokens !== freshPromptTokens || totalTokens === undefined) {
+      continue;
+    }
+    // Matching the persisted prompt snapshot pins the exact provider boundary;
+    // only later local items are absent from that provider's total-token count.
+    return {
+      accountedPromptTokens: Math.max(promptTokens, totalTokens),
+      trailingMessages: params.messages.slice(index + 1),
+    };
+  }
+  return undefined;
 }
 
 function isNativeHarnessCompactionSession(
@@ -608,9 +645,15 @@ export async function runCliTurnCompactionLifecycle(params: {
     contextTokenBudget,
   });
 
+  const branchMessages = getSessionBranchMessages(sessionManager);
+  const freshProviderBoundary = resolveFreshProviderContextBoundary({
+    messages: branchMessages,
+    sessionEntry: params.sessionEntry,
+  });
   const preemptiveCompaction = cliCompactionDeps.shouldPreemptivelyCompactBeforePrompt({
-    messages: getSessionBranchMessages(sessionManager),
+    messages: freshProviderBoundary?.trailingMessages ?? branchMessages,
     prompt: "",
+    accountedPromptTokens: freshProviderBoundary?.accountedPromptTokens,
     contextTokenBudget,
     reserveTokens: settingsManager.getCompactionReserveTokens(),
     toolResultMaxChars: cliCompactionDeps.resolveLiveToolResultMaxChars({
@@ -618,10 +661,9 @@ export async function runCliTurnCompactionLifecycle(params: {
     }),
   });
   const tokenSnapshot = resolveSessionTokenSnapshot(params.sessionEntry);
-  const currentTokenCount = Math.max(
-    preemptiveCompaction.estimatedPromptTokens,
-    tokenSnapshot ?? 0,
-  );
+  const currentTokenCount = freshProviderBoundary
+    ? preemptiveCompaction.estimatedPromptTokens
+    : Math.max(preemptiveCompaction.estimatedPromptTokens, tokenSnapshot ?? 0);
   if (
     !preemptiveCompaction.shouldCompact &&
     currentTokenCount <= preemptiveCompaction.promptBudgetBeforeReserve

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -131,6 +131,20 @@ describe("preemptive-compaction", () => {
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
   });
 
+  it("adds exact provider-accounted context to only the locally estimated tail", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("tail")],
+      prompt: "",
+      accountedPromptTokens: 179_933,
+      contextTokenBudget: 272_000,
+      reserveTokens: 32_000,
+    });
+
+    expect(result.estimatedPromptTokens).toBe(179_971);
+    expect(result.promptBudgetBeforeReserve).toBe(240_000);
+    expect(result.route).toBe("fits");
+  });
+
   it("formats all-route pre-prompt diagnostics for a fits decision", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory("short history")],

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -276,6 +276,8 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   unwindowedMessages?: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
+  /** Exact provider-counted context preceding `messages`; local estimates cover only the tail. */
+  accountedPromptTokens?: number;
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
@@ -285,20 +287,30 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   const llmBoundaryTokenPressure = normalizeLlmBoundaryTokenPressure(
     params.llmBoundaryTokenPressure,
   );
+  const accountedPromptTokensRaw = params.accountedPromptTokens;
+  const accountedPromptTokens = Math.max(
+    0,
+    typeof accountedPromptTokensRaw === "number" && Number.isFinite(accountedPromptTokensRaw)
+      ? Math.floor(accountedPromptTokensRaw)
+      : 0,
+  );
   let estimatedPromptTokens =
-    llmBoundaryTokenPressure?.estimatedPromptTokens ??
-    estimateLlmBoundaryTokenPressure({
-      messages: params.messages,
-      systemPrompt: params.systemPrompt,
-      prompt: params.prompt,
-    });
+    accountedPromptTokens +
+    (llmBoundaryTokenPressure?.estimatedPromptTokens ??
+      estimateLlmBoundaryTokenPressure({
+        messages: params.messages,
+        systemPrompt: params.systemPrompt,
+        prompt: params.prompt,
+      }));
   let pressureSource = llmBoundaryTokenPressure?.source ?? "transcript_estimate";
   if (params.unwindowedMessages && params.unwindowedMessages !== params.messages) {
-    const unwindowedEstimatedPromptTokens = estimateLlmBoundaryTokenPressure({
-      messages: params.unwindowedMessages,
-      systemPrompt: params.systemPrompt,
-      prompt: params.prompt,
-    });
+    const unwindowedEstimatedPromptTokens =
+      accountedPromptTokens +
+      estimateLlmBoundaryTokenPressure({
+        messages: params.unwindowedMessages,
+        systemPrompt: params.systemPrompt,
+        prompt: params.prompt,
+      });
     if (unwindowedEstimatedPromptTokens > estimatedPromptTokens) {
       estimatedPromptTokens = unwindowedEstimatedPromptTokens;
       messagesForPressure = params.unwindowedMessages;


### PR DESCRIPTION
## Summary

- align fresh persisted provider usage with its assistant `contextUsage` boundary
- treat provider-accounted tokens as the measured base
- estimate only transcript items created after that boundary
- retain the conservative full-transcript fallback when provenance cannot be aligned

## Root cause

The CLI compaction lifecycle used `Math.max(fullTranscriptEstimate, freshProviderSnapshot)`. A stale/inflated local estimate of 290,136 therefore overrode fresh provider usage near 179,933 and triggered false compaction against a 272k budget.

## Tests

- RED: [1 failed / 30 passed; false 290,136 reproduced](https://github.com/openclaw/openclaw/actions/runs/31871318007)
- GREEN: [32 / 32 CLI tests](https://github.com/openclaw/openclaw/actions/runs/31871563774)
- siblings: [23 / 23 preemptive + 32 / 32 CLI](https://github.com/openclaw/openclaw/actions/runs/31872246518)
- changed-file gate: [format, tsgo, lint, and guards clean](https://github.com/openclaw/openclaw/actions/runs/31871721280)

## Dependency contract

Verified against OpenAI Codex at `d5e256ceb210dacbab9d8dcc7eafda58f90f6e51`:

- [`context_window.rs`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/core/src/session/context_window.rs#L23-L79): active usage drives compaction
- [`history.rs`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/core/src/context_manager/history.rs#L400-L430): last provider total plus only items after the model output
- [`session/mod.rs`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/core/src/session/mod.rs#L3846-L3929): provider update versus explicit recompute fallback
- [`protocol.rs`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/protocol/src/protocol.rs#L2068-L2123): last versus cumulative usage semantics

## Visual proof

<img width="1600" height="900" alt="pr124206-provider-usage-live" src="https://github.com/user-attachments/assets/cfff74c4-eaf8-4a0a-a2a8-d100ed62646e" />

Real Crabbox user-path proof on exact head `f10e56374a78242b3ab4815928d6455b7d308a1b`: OpenClaw ran `openai/gpt-5.6-sol` with a 272,000-token active context budget. After a genuine 1.2M-character exec-tool turn and successful continuations, fresh prompt usage was 58,205, routing remained `fits`, `shouldCompact` was `false`, and `compactionCount` remained 0. The session then completed another continuation successfully.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Sanitized, scoped Codex transcript</summary>

```text
[user]
Use subagents to get red/green TDD matching this behavior, then open one PR for each issue with visual proof.

[assistant]
The provider-usage lane is isolated: persisted provider prompt usage and transcript estimation are both treated as lower bounds, so `Math.max` promotes an inflated estimate.

[assistant]
The regression reproduces provider usage 179,933 versus local estimate 290,136. It is intentionally red before production changes.

[assistant]
The fix aligns the persisted provider total to its assistant `contextUsage` boundary, estimates only later items, and preserves the conservative fallback when provenance cannot align.

[assistant]
Proof complete: red 1 failed / 30 passed; green CLI 32/32; sibling suites 55/55; changed-file gate passed. The upstream Codex usage contract was inspected directly.
```

</details>
<!-- agent-transcript:end -->