### PR TITLE
fix: keep Codex plugin aligned during stable upgrades

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -45,6 +45,7 @@ export type DownloadableInstallCandidate = {
   expectedIntegrity?: string;
   trustedSourceLinkedOfficialInstall?: boolean;
   defaultChoice?: PluginPackageInstall["defaultChoice"];
+  versionBoundToOpenClaw?: boolean;
 };
 
 export type BundledPluginPackageDescriptor = {
@@ -285,7 +286,10 @@ export function collectDownloadableInstallCandidates(params: {
     if (params.blockedPluginIds?.has(entry.pluginId)) {
       continue;
     }
-    if (!candidates.has(entry.pluginId)) {
+    const existing = candidates.get(entry.pluginId);
+    if (existing && entry.versionBoundToOpenClaw) {
+      candidates.set(entry.pluginId, { ...existing, versionBoundToOpenClaw: true });
+    } else if (!existing) {
       candidates.set(entry.pluginId, entry);
     }
   }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -149,6 +149,7 @@ export async function installCandidate(params: {
           ? parseRegistryNpmSpec(candidate.npmSpec)?.name
           : undefined,
         coreVersion: resolveCompatibilityHostVersion(params.env),
+        versionBoundToCore: candidate.versionBoundToOpenClaw,
       })
     : null;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? candidate.clawhubSpec;
@@ -452,6 +453,7 @@ export function resolveCandidateInstallSpec(params: {
         ? parseRegistryNpmSpec(params.candidate.npmSpec)?.name
         : undefined,
       coreVersion: params.coreVersion,
+      versionBoundToCore: params.candidate.versionBoundToOpenClaw,
     }).installSpec;
   }
   if (params.candidate.clawhubSpec) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -2332,7 +2332,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: `@openclaw/codex@${VERSION}`,
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2351,7 +2351,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(result.repairedPluginIds).toEqual(["codex"]);
@@ -2394,7 +2394,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     expect(mocks.resolveProviderInstallCatalogEntries).toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: `@openclaw/codex@${VERSION}`,
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2410,7 +2410,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
     ]);
     expect(result.warnings).toStrictEqual([]);
   });
@@ -2491,13 +2491,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(mocks.resolveDirectBundledProviderPolicySurface).toHaveBeenCalledWith("openai");
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: `@openclaw/codex@${VERSION}`,
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
       mode: "update",
     });
     expect(result.changes).toEqual([
-      `Refreshed stale configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Refreshed stale configured plugin "codex" from @openclaw/codex@${VERSION}.`,
     ]);
     expectRecordFields(result.records.codex, {
       source: "npm",
@@ -2796,7 +2796,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: `@openclaw/codex@${VERSION}`,
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2812,7 +2812,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env,
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(Object.keys(result.records)).toEqual(["codex"]);

--- a/src/plugins/install-channel-specs.test.ts
+++ b/src/plugins/install-channel-specs.test.ts
@@ -60,6 +60,21 @@ describe("resolveNpmInstallSpecsForUpdateChannel", () => {
     ).toThrow("requires an exact core version");
   });
 
+  it("targets the exact core version for a stable version-bound plugin", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/codex",
+        updateChannel: "stable",
+        officialPackageName: "@openclaw/codex",
+        coreVersion: "2026.8.1",
+        versionBoundToCore: true,
+      }),
+    ).toEqual({
+      installSpec: "@openclaw/codex@2026.8.1",
+      recordSpec: "@openclaw/codex",
+    });
+  });
+
   it("preserves beta behavior", () => {
     expect(
       resolveNpmInstallSpecsForUpdateChannel({

--- a/src/plugins/install-channel-specs.ts
+++ b/src/plugins/install-channel-specs.ts
@@ -40,14 +40,20 @@ export function resolveNpmInstallSpecsForUpdateChannel(params: {
   updateChannel?: UpdateChannel;
   officialPackageName?: string;
   coreVersion?: string;
+  versionBoundToCore?: boolean;
 }): ChannelInstallSpecs {
-  if (params.updateChannel === "extended-stable") {
+  if (
+    params.updateChannel === "extended-stable" ||
+    (params.updateChannel === "stable" && params.versionBoundToCore)
+  ) {
     const target = resolveDefaultNpmSpec(params.spec);
     if (target && params.officialPackageName === target.name) {
       const coreVersion = params.coreVersion?.trim();
       if (!coreVersion || !isExactSemverVersion(coreVersion)) {
+        const policy =
+          params.updateChannel === "extended-stable" ? "Extended-stable" : "Version-bound";
         throw new Error(
-          `Extended-stable plugin resolution for ${target.name} requires an exact core version.`,
+          `${policy} plugin resolution for ${target.name} requires an exact core version.`,
         );
       }
       return {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where stable package upgrades could report a configured Codex
plugin as repaired while npm had installed an older `latest` package. The next
Gateway start then loaded code from the wrong OpenClaw release cohort and could
fail before becoming ready.

## Why This Change Was Made

Configured runtime policy already marks Codex as `versionBoundToOpenClaw`.
Doctor now carries that policy through candidate collection and both install
spec paths. Stable default-package intent resolves to the exact core version,
while the persisted install record keeps the operator's bare package intent.
Beta, extended-stable, explicit-version, and unrelated plugin behavior remain
unchanged.

This PR is the canonical repair for the plugin-version convergence blocker
identified by Vincent Koc's hosted evidence on #120703. It does not replace
that draft's process-group and retry work, and #120703 remains the successor to
#120086. The separate packaged-upgrade `setup_id` repair and the shipped Plugin
SDK compatibility repair in #124086 remain independent fixes.

## User Impact

Stable upgrades install the Codex plugin version built for the candidate
OpenClaw package. Doctor no longer declares convergence after resolving a
lagging `latest` tag.

## Evidence

- Full Release Validation `31871527419`, child `31871544784`: native Linux,
  Windows, and macOS package replacement completed before the separate
  `setup_id` failure in jobs `94981280920`, `94981280928`, and `94981281041`.
- Current-main reproduction: [run 31893634060](https://github.com/openclaw/openclaw/actions/runs/31893634060)
  tested `a5603681c617f60fe2bb8ca87d25b183131f1ca7`. `upgrade-survivor`
  completed install, update, Doctor, and state assertions, then loaded stale
  published `@openclaw/codex@2026.7.1-1` at Gateway startup.
- Pre-fix regression: [run 31895154281](https://github.com/openclaw/openclaw/actions/runs/31895154281)
  failed `targets the exact core version for a stable version-bound plugin`.
  Expected `@openclaw/codex@2026.8.1`; received bare `@openclaw/codex`.
- Fixed regression: [run 31895200127](https://github.com/openclaw/openclaw/actions/runs/31895200127)
  passed 99 tests across the shared resolver and Doctor configured-plugin
  owner suites.
- Codex migration negative control: [run 31894284108](https://github.com/openclaw/openclaw/actions/runs/31894284108)
  passed all 31 migration tests on current main. The migration is not the
  producer of the stale package.
- Exact-head changed gate: [run 31895319203](https://github.com/openclaw/openclaw/actions/runs/31895319203)
  passed formatting, core and test typechecking, changed-file lint, import-cycle
  checks, plugin boundaries, and repository policy guards in 10m11s.
- Exact-head targeted package acceptance:
  [run 31895805872](https://github.com/openclaw/openclaw/actions/runs/31895805872)
  ran `upgrade-survivor` and `published-upgrade-survivor` against the ref-backed
  package and matching prerelease plugin registry. `upgrade-survivor` passed on
  its first attempt with zero retries, including startup, readiness, and Gateway
  RPC status. The published-baseline variant completed the candidate package
  swap, then Doctor stopped on the independent `device_bootstrap_tokens`
  `setup_id` schema defect before plugin repair ran.
- Exact-head cross-OS packaged upgrade:
  [run 31895807894](https://github.com/openclaw/openclaw/actions/runs/31895807894)
  completed the package swap from `2026.7.1-2` to `2026.8.1` on Linux,
  Windows, and macOS, then stopped only on the same independent `setup_id`
  schema defect.
- Final autoreview on `8f86b47df8e`: no actionable findings, confidence 0.98.
- Codex contract check at `openai/codex@c4941302c73c`: app-server
  `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:59` and `:327`, plus
  `codex-rs/app-server/src/request_processors/thread_processor.rs:1052` and
  `:3405`, carry Codex thread identity and runtime overrides. They do not own
  OpenClaw configured-agent selection.

Commands used for the focused red/green and closeout proof:

```bash
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- \
  pnpm test \
  src/plugins/install-channel-specs.test.ts \
  src/commands/doctor/shared/missing-configured-plugin-install.test.ts
# Pre-fix source: 1 failed, 11 passed in the first shard.
# Repaired source: 99 passed across 2 shards.

node scripts/check-changed.mjs
# Passed every selected gate in 10m11s.

.agents/skills/autoreview/scripts/autoreview \
  --mode branch --base origin/main --stream-engine-output
# No actionable findings; patch correct at 0.98 confidence.
```

Production LOC is `+15/-3` (net `+12`), which adds the version-bound policy
propagation and stable exact-version capability. Tests are `+23/-8` (net
`+15`). No retry, fallback, timeout, migration shim, or assertion weakening is
added.

Remaining gap: published-baseline and native cross-OS proof cannot advance
past the separately owned `device_bootstrap_tokens.setup_id` Doctor failure.
That still reproduces after #123276 and is tracked locally as `oc-809`; this PR
does not duplicate or mask it.

## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
[user]
Repair the package-upgrade failures that still block stable evidence. Separate
the already-fixed setup_id defect, preserve the useful work and attribution in
#120703/#120086, reproduce current main, repair the canonical owner, prove
upgrade-survivor and cross-OS behavior, run autoreview, and open a PR without
merging it.

[assistant]
The native package jobs failed on the separate setup_id defect. The original
survivor job then exposed shipped Plugin SDK imports repaired by #124086. A new
current-main upgrade-survivor run completed update and Doctor, then loaded a
stale published Codex package. Candidate Codex source already handles the same
multi-agent state, so the remaining failure belongs to stable install-spec
production, not the migration or survivor retry harness.

[assistant]
Configured runtime policy already marks Codex version-bound to OpenClaw. The
repair carries that fact through candidate collection and both Doctor install
paths, resolves stable default intent to the exact core version, and preserves
the bare recorded package intent. Beta and unrelated plugins keep their prior
behavior.

[assistant]
The regression failed against pre-fix source because stable resolution returned
bare @openclaw/codex, then passed with the exact core version. Focused tests,
the changed gate, and exact-head autoreview are green. Targeted package and
cross-OS upgrade workflows are attached above.
```

</details>
