### PR TITLE
fix: restore native OpenAI web search in packaged runs

### DIFF
--- a/scripts/e2e/lib/openai-web-search-minimal/scenario.sh
+++ b/scripts/e2e/lib/openai-web-search-minimal/scenario.sh
@@ -41,6 +41,7 @@ trap cleanup EXIT
 
 dump_debug_logs() {
   local status="$1"
+  local failed_command="$2"
   echo "OpenAI web_search minimal Docker E2E failed with exit code $status" >&2
   for file in \
     "$GATEWAY_LOG" \
@@ -51,11 +52,12 @@ dump_debug_logs() {
     "$OPENCLAW_STATE_DIR/openclaw.json"; do
     if [ -f "$file" ]; then
       echo "--- $file ---" >&2
-      openclaw_e2e_print_log "$file" >&2
+      OPENCLAW_E2E_LOG_TAIL_BYTES=8192 openclaw_e2e_print_log "$file" >&2
     fi
   done
+  echo "OpenAI web_search minimal failed command: $failed_command" >&2
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+trap 'status=$?; dump_debug_logs "$status" "$BASH_COMMAND"; exit "$status"' ERR
 
 entry="$(openclaw_e2e_resolve_entrypoint)"
 mkdir -p "$OPENCLAW_STATE_DIR" "$TLS_DIR"

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -77,6 +77,34 @@ function resolveSelectedMemoryPluginIds(params: {
     : [];
 }
 
+// Every selected model provider must join the immutable run generation before
+// request-time hooks resolve; late provider loading is intentionally forbidden.
+function resolveSelectedProviderOwnerPluginIds(params: {
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+}): string[] {
+  const providerOwnerPluginIds = dedupePluginIds(
+    resolveOwningPluginIdsForProviderRef(params) ?? [],
+  );
+  if (providerOwnerPluginIds.length === 0) {
+    return [];
+  }
+  const safeProviderOwnerPluginIds = dedupePluginIds([
+    ...resolveBundledProviderCompatPluginIds({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      onlyPluginIds: providerOwnerPluginIds,
+    }),
+    ...resolveActivatableProviderOwnerPluginIds({
+      pluginIds: providerOwnerPluginIds,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+    }),
+  ]);
+  return providerOwnerPluginIds.filter((pluginId) => safeProviderOwnerPluginIds.includes(pluginId));
+}
+
 /** Resolve manifest owners required by one selected non-core harness runtime. */
 export function resolveAgentHarnessOwnerPluginIds(params: {
   runtime: string;
@@ -98,29 +126,13 @@ export function resolveAgentHarnessOwnerPluginIds(params: {
   ) {
     return harnessPluginIds;
   }
-  const providerOwnerPluginIds = dedupePluginIds(
-    resolveOwningPluginIdsForProviderRef(params) ?? [],
-  );
+  const providerOwnerPluginIds = resolveSelectedProviderOwnerPluginIds(params);
   if (providerOwnerPluginIds.length === 0) {
     return harnessPluginIds;
   }
-  const safeProviderOwnerPluginIds = dedupePluginIds([
-    ...resolveBundledProviderCompatPluginIds({
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      onlyPluginIds: providerOwnerPluginIds,
-    }),
-    ...resolveActivatableProviderOwnerPluginIds({
-      pluginIds: providerOwnerPluginIds,
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-    }),
-  ]);
   return dedupePluginIds([
     ...harnessPluginIds,
-    ...providerOwnerPluginIds.filter(
-      (pluginId) => pluginId !== "codex" && safeProviderOwnerPluginIds.includes(pluginId),
-    ),
+    ...providerOwnerPluginIds.filter((pluginId) => pluginId !== "codex"),
   ]);
 }
 
@@ -196,6 +208,13 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
   for (const selection of params.selections) {
     const runtime = resolveSelectedAgentHarnessRuntime(selection, config);
     if (!requiresAgentHarnessPluginSelection(selection, config)) {
+      const providerOwnerPluginIds = resolveSelectedProviderOwnerPluginIds({
+        provider: selection.provider,
+        config,
+        workspaceDir: params.workspaceDir,
+      });
+      pluginIds.push(...providerOwnerPluginIds);
+      forceActivatedPluginIds.push(...providerOwnerPluginIds);
       continue;
     }
     const harnessPluginIds = resolveAgentHarnessOwnerPluginIds({

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -171,8 +171,8 @@ export function resolveSelectedAgentHarnessRuntime(
       }).runtime;
 }
 
-/** Returns whether a selection needs a plugin-owned harness in its prepared generation. */
-export function requiresAgentHarnessPluginSelection(
+// Returns whether a selection needs a plugin-owned harness in its prepared generation.
+function requiresAgentHarnessPluginSelection(
   selection: AgentHarnessPluginSelection,
   config?: OpenClawConfig,
 ): boolean {

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -111,6 +111,7 @@ export function resolveAgentHarnessOwnerPluginIds(params: {
   provider: string;
   config?: OpenClawConfig;
   workspaceDir: string;
+  providerOwnerPluginIds?: readonly string[];
 }): string[] {
   const harnessPluginIds = resolveManifestActivationPlan({
     trigger: { kind: "agentHarness", runtime: params.runtime },
@@ -126,7 +127,8 @@ export function resolveAgentHarnessOwnerPluginIds(params: {
   ) {
     return harnessPluginIds;
   }
-  const providerOwnerPluginIds = resolveSelectedProviderOwnerPluginIds(params);
+  const providerOwnerPluginIds =
+    params.providerOwnerPluginIds ?? resolveSelectedProviderOwnerPluginIds(params);
   if (providerOwnerPluginIds.length === 0) {
     return harnessPluginIds;
   }
@@ -207,14 +209,14 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
   const forceActivatedPluginIds = [...memoryPluginIds, ...contextEnginePluginIds];
   for (const selection of params.selections) {
     const runtime = resolveSelectedAgentHarnessRuntime(selection, config);
+    const providerOwnerPluginIds = resolveSelectedProviderOwnerPluginIds({
+      provider: selection.provider,
+      config,
+      workspaceDir: params.workspaceDir,
+    });
+    pluginIds.push(...providerOwnerPluginIds);
+    forceActivatedPluginIds.push(...providerOwnerPluginIds);
     if (!requiresAgentHarnessPluginSelection(selection, config)) {
-      const providerOwnerPluginIds = resolveSelectedProviderOwnerPluginIds({
-        provider: selection.provider,
-        config,
-        workspaceDir: params.workspaceDir,
-      });
-      pluginIds.push(...providerOwnerPluginIds);
-      forceActivatedPluginIds.push(...providerOwnerPluginIds);
       continue;
     }
     const harnessPluginIds = resolveAgentHarnessOwnerPluginIds({
@@ -222,6 +224,7 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
       provider: selection.provider,
       config,
       workspaceDir: params.workspaceDir,
+      providerOwnerPluginIds,
     });
     pluginIds.push(...harnessPluginIds);
     const allowedHarnessPluginIds =

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -100,6 +100,20 @@ describe("harness runtime plugins", () => {
     expect(plan.config?.plugins?.entries?.openai).toEqual({ enabled: true });
   });
 
+  it("includes the selected provider owner when policy selects an omitted harness", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(["openai"]);
+    mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce(["openai"]);
+    mocks.resolveManifestActivationPlan.mockReturnValueOnce({ entries: [] });
+    const plan = resolveAgentRuntimePluginLoadPlan({
+      config: { plugins: { allow: ["openai"] } },
+      workspaceDir: "/tmp/workspace",
+      selections: [{ provider: "openai", modelId: "gpt-5" }],
+    });
+
+    expect(plan.pluginIds).toEqual(["openai"]);
+    expect(plan.config?.plugins?.entries?.openai).toEqual({ enabled: true });
+  });
+
   it("includes and enables the context-engine owner in the prepared load plan", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
       config: { plugins: { slots: { contextEngine: "custom-context-engine" } } },

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -87,6 +87,19 @@ describe("harness runtime plugins", () => {
     expect(plan.config?.plugins?.entries?.codex).toEqual({ enabled: true });
   });
 
+  it("includes the selected provider owner for the default runtime", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(["openai"]);
+    mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce(["openai"]);
+    const plan = resolveAgentRuntimePluginLoadPlan({
+      config: { plugins: { allow: ["openai"] } },
+      workspaceDir: "/tmp/workspace",
+      selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "openclaw" }],
+    });
+
+    expect(plan.pluginIds).toEqual(["openai"]);
+    expect(plan.config?.plugins?.entries?.openai).toEqual({ enabled: true });
+  });
+
   it("includes and enables the context-engine owner in the prepared load plan", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
       config: { plugins: { slots: { contextEngine: "custom-context-engine" } } },

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -153,6 +153,29 @@ describe("prepared model runtime owner selection", () => {
     ).rejects.toThrow("prepared model runtime owner was not published");
   });
 
+  it("publishes provider selections kept on the core runtime by request parameters", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5",
+          models: {
+            "openai/gpt-5": { params: { transport: "sse", openaiWsWarmup: false } },
+          },
+        },
+      },
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      catalogMode: "static",
+      gatewayLifecycle: true,
+    });
+
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.map((call) => call[0].selections),
+    ).toContainEqual([{ provider: "openai", modelId: "gpt-5", runtime: "openclaw" }]);
+  });
+
   it("reuses the configured owner for its prepared plugin harness selections", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -11,10 +11,7 @@ import {
   resolveAgentWorkspaceDir,
 } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import {
-  requiresAgentHarnessPluginSelection,
-  resolveSelectedAgentHarnessRuntime,
-} from "./harness/runtime-plugin-load-plan.js";
+import { resolveSelectedAgentHarnessRuntime } from "./harness/runtime-plugin-load-plan.js";
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import { resolveDefaultModelForAgent } from "./model-selection-config.js";
@@ -222,7 +219,6 @@ export function normalizePreparedModelRuntimeInput(
   const runtimePluginSelections = input.runtimePluginSelections
     ? Object.freeze(
         [...input.runtimePluginSelections]
-          .filter((selection) => requiresAgentHarnessPluginSelection(selection, input.config))
           .map((selection) => {
             const runtime = resolveSelectedAgentHarnessRuntime(selection, input.config);
             const { agentId: _agentId, ...normalized } = selection;

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -361,7 +361,13 @@ describe("prepared model runtime Gateway catalog mode", () => {
     });
 
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle.mock.calls[0]?.[0]).not.toHaveProperty(
+      "selections",
+    );
+    expect(mocks.loadAgentRuntimePluginRegistryHandle.mock.calls[1]?.[0]).toMatchObject({
+      selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "openclaw" }],
+    });
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         providerDiscoveryProviderIds: ["openai"],
@@ -414,7 +420,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     await snapshot?.loadFullModelCatalog?.();
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
 
     await expect(snapshot?.loadFullModelCatalog?.()).resolves.toEqual({
       entries: [],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where packaged OpenAI runs with authored request parameters sent a function-shaped `web_search` tool instead of the native Responses API tool. The Docker `openai-web-search-minimal` lane and the package acceptance verifier failed even though candidate, package, image, and registry identity checks passed.

## Why This Change Was Made

Prepared runtime normalization discarded provider selections whenever policy kept execution on the core OpenClaw runtime. The immutable generation therefore omitted the OpenAI provider owner, so its request wrapper could not replace the managed search function with native `web_search`.

The load plan now resolves every selected provider owner before optional harness activation, reuses that result for Codex harness planning, and retains core-runtime provider selections in the prepared owner. Provider eligibility, restrictive allowlists, artifact identity, and provenance checks remain unchanged.

## User Impact

OpenAI users can enable web search with authored transport parameters and receive native Responses API web search instead of a schema-invalid managed function. Failed Docker scenarios also retain the exact failed shell command and bounded component diagnostics.

## Evidence

### Failure before the fix

- Full Release Validation [run 31871527419](https://github.com/openclaw/openclaw/actions/runs/31871527419), child `31871544784`, failed the shared Docker acceptance surface.
- Exact candidate Docker [run 31894585693](https://github.com/openclaw/openclaw/actions/runs/31894585693), job `95037366045`, passed candidate and image identity gates but failed `assert-success-request`. Its request contained `{ "type": "function", "name": "web_search" }` and no native search tool.
- The core-runtime owner regression failed before the fix with `selections` equal to `[undefined]`.

```text
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.owner-selection.test.ts
Test Files  1 failed (1)
Tests       1 failed | 21 passed (22)
```

### Fixed behavior

- Exact-head Docker [run 31896547746](https://github.com/openclaw/openclaw/actions/runs/31896547746), job `95041503551`: `openai-web-search-minimal` passed against selected ref `850d256bd656627e0cd055b793d021a0f0bb0604`.
- Exact-head Package Acceptance [run 31896549014](https://github.com/openclaw/openclaw/actions/runs/31896549014):
  - package ref `850d256bd656627e0cd055b793d021a0f0bb0604`
  - package SHA-256 `82ec8fa4db44926cdaddf786f01ea63133401124485d65327d903e452b3dd6d0`
  - package artifact id `9250046695`
  - Docker job `95042331675` passed
  - verifier job `95042589551` passed
- Focused owner and sibling proof passed 93 tests:

```text
node scripts/run-vitest.mjs \
  src/agents/harness/runtime-plugin.test.ts \
  src/agents/runtime-plugins.test.ts \
  src/agents/prepared-model-runtime.owner-selection.test.ts \
  src/agents/prepared-model-runtime.inbound-registry.test.ts \
  src/agents/prepared-model-runtime.test.ts
Test Files  5 passed (5)
Tests       93 passed (93)
```

- Remote `core, coreTests` changed gate passed in 10m16s: [run 31896566202](https://github.com/openclaw/openclaw/actions/runs/31896566202).
- Final autoreview was clean:

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.97)
```

### Contract and scope

Codex commit `97729885d4` defines hosted search as `ToolSpec::WebSearch` and serializes it with `type: "web_search"` in `codex-rs/core/src/tools/hosted_spec.rs:14`, `codex-rs/tools/src/tool_spec.rs:18`, and `codex-rs/protocol/src/models.rs:979`. A function named `web_search` is not that protocol tool.

Production runtime delta is +18 lines: +22 in generation planning and -4 in prepared-owner normalization. The added planning code centralizes the existing provider-owner safety decision and carries the result into both core and Codex runtime paths. Test delta is +50 lines. Docker diagnostics add 2 net tooling lines.

This PR reruns only the affected Docker lane and package acceptance verifier. The frozen Codex resolver, onboarding prompt, and package-upgrade convergence failures remain in their independently owned repair lanes.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":9,"toolOutputsDropped":9,"web":0,"redactions":4,"omittedUnsafe":0,"rawEntries":49}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’m taking this as an end-to-end release-CI repair. I’ll first preserve and inventory the worktree, read the required release/testing/review/PR skills, and reconstruct the failing jobs before creating the required Pebbles epic and tasks. I’ll use parallel evidence lanes where the repository’s Repair Doctrine calls for independent job/history analysis, while personally verifying the owner boundary and final proof.

The app-provisioned worktree is clean but detached at `c0824d284e…`; I’ll branch only after the investigation creates its Pebbles IDs. The requested skills now govern the workflow: release-CI/testing for evidence selection, test-audit for regression quality, autoreview/prepare-PR for ship gates, and agent-transcript/technical-writing for the PR artifact.

The release-CI skill classifies this as a candidate harness/tooling/provenance repair until the logs prove product code is at fault; that keeps the frozen candidate identity intact. I’m now splitting the five failures into independent read-only evidence lanes (Docker core/plugins, package/update, and scheduler/history), then I’ll reconcile them against the exact candidate SHA and current `main`.

The evidence now separates two facts: package/image binding succeeded, and the aggregate verifier only propagated Docker failures. One package-update failure was the shipped Plugin SDK bridge already repaired on `main` by PR #124086; the independently owned onboarding, Codex, and upgrade-convergence failures are excluded. The only unresolved lane is `openai-web-search-minimal`, whose uploaded artifact lost its actual assertion behind a 64 KiB tail. I’m dispatching that exact lane against the current `main` SHA before deciding whether any patch is still warranted.

The investigation document is complete enough to plan. The repository’s Pebbles workflow now requires an epic and dependency-ordered tasks before any implementation decision. I’m creating local-only tracking for (1) exact-main reproduction, (2) canonical-fix verification, and (3) release-lane closeout; no `.pebbles` data will be staged or pushed.

This Codex worktree has no Pebbles store, so the skill paused creation rather than initializing a second tracker. I’m resolving the repository’s existing local Pebbles directory from the main checkout and will point `PEBBLES_DIR` there explicitly; this keeps workflow state local and avoids adding files to the worktree.

Pebbles accepted the epic (`oc-e13`) but this installed CLI does not support `--parent` on `pb create`, despite the skill’s example. No subtasks were created by those failed commands. I’m using the CLI’s supported two-step form: create each task, then attach it with `pb update --parent`.

I’m continuing from the exact-main reproduction. The artifact and provenance gates passed; I’m now isolating the failed `openai-web-search-minimal` assertion, then I’ll trace its owner boundary before deciding whether current main needs a patch. The required release/testing/review skills are already active from the prior work.

The fresh failure is real but diagnostically obscured: the lane writes a 143 KB transcript and only emits its last 64 KB, which contains config but not the failed assertion. I’m tracing both the scenario and its log-capture owner now; I won’t treat truncation alone as the product failure unless it explains the lane exit.

The diagnostic rerun is now on an isolated Pebbles branch. It changes only bounded failure reporting: each component contributes at most 8 KiB and the exact failed shell command is printed last, so the outer 64 KiB artifact remains bounded while preserving the initiating failure. No acceptance or provenance check changed.

The diagnostic workflow is dispatched as run `[REDACTED_PHONE]` against commit `a84fd4fc135`. GitHub’s selected-ref validation job is unusually slow in checkout, so I’m watching it while independently checking the branch/ref and recent lane history; no test result is available yet.

The retained request itself now narrows the failure: it contains `OPENCLAW_SCHEMA_E2E_OK` with `reasoning.effort="low"`, but the only search tool is function-shaped (`type:"function", name:"web_search"`), not the required native Responses tool. So the lane is failing its native-tool assertion, not artifact preparation or scheduling. I’m tracing why the OpenAI plugin wrapper did not replace the managed tool.

The canonical defect is now identified: the attempt had already prepared the OpenAI provider runtime handle, but the stream-wrapper installation dropped it and tried to rediscover the plugin inside the active Gateway generation. That generation intentionally contained only fully loaded plugins, so discovery failed closed and the native-search wrapper never ran. I’ve changed the owner boundary to carry the prepared handle into normal turns and compaction; the commit hook paused because this linked worktree has no dependencies, as expected by policy. I’m using the normal checkout only for read-only formatting proof, not reconciling this worktree.

A history lane found a deeper lifecycle constraint, so I’m pausing the first patch’s verdict before treating the green lane as sufficient. The Aug 13 generation guard intentionally prevents cold-loading a provider outside the active plugin generation; carrying a pre-generation handle may cross that boundary. I’m now checking the generation load planner, where the default OpenClaw runtime appears to omit the selected provider owner entirely. If confirmed, I’ll replace the interim handoff patch with the generation-owner fix rather than weakening lifecycle isolation.

I’m resuming from the checkpoint, first validating the uncommitted canonical load-plan diff and branch state. I’ll preserve the diagnostic commit, remove the superseded lifecycle-crossing approach from PR history, then run exact-head Docker/package proof before review and PR publication.

The resumed diff matches the diagnosed owner boundary: selected provider owners are missing only from default-runtime immutable generations. The prior request-handle edits are now purely a reversal of the superseded commit; I’m checking the complete load-plan context, test quality, and the mandated review/release workflows before rewriting the branch history.

The test protects an observable preparation contract: the selected OpenAI provider owner must be present and activated before the immutable run generation is built. It needs no production-only seam, and the known pre-fix Docker request proves the credible regression. I’m running the focused owner test now, then I’ll temporarily evaluate the same test against the pre-fix load planner without changing tracked history.

The app-provisioned worktree’s test wrapper can see the main checkout’s packages only after a temporary `node_modules` link; the worktree has none and I’m not installing or reconciling dependencies. I’ll create that validated symlink for focused proof and remove it before handoff.

The focused test exposed a test setup flaw, not a product failure: this repository’s implicit policy selects the Codex harness for that model, so the case was not exercising the default OpenClaw runtime. I’m correcting the case to select `runtime: "openclaw"` explicitly and tightening the implementation so provider ownership is resolved once per selection.

The regression now fails against `a84fd4fc135` for the intended reason (`pluginIds` is absent) and passes with the owner-boundary repair. I removed the isolated pre-fix worktree after proof. Next I’m preserving a local backup ref, rewriting only this task branch to drop the superseded commit, and committing the two canonical load-plan files.

The branch now contains only the bounded diagnostic commit and the canonical load-plan repair. The discarded implementation remains recoverable at local backup ref `backup/oc-e13-pre-load-plan-rewrite-20260815`; I’m force-updating the task branch with an exact remote lease, then dispatching proof against `6adcef1382a`.

Two exact-head proofs are running: Docker lane [[REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]) and Package Acceptance [[REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]), both targeting `6adcef1382a`. While they build immutable artifacts, I’m completing the required Codex sibling contract check and blame-backed owner evidence.

The required sibling Codex checkout is absent. The repository policy makes that a hard gate even though this repair targets the default OpenClaw runtime, so I’m checking for an existing maintained Codex clone first; if none exists, I’ll create the mandated sibling checkout and inspect the native web-search/tool specification directly.

The corrected focused test is green locally, and the classified `core, coreTests` gate is now running on Blacksmith Testbox as [[REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]). The Codex contract check confirms native search is a distinct `ToolSpec::WebSearch` serialized as `type: "web_search"`; a managed function named `web_search` is not equivalent.

The remote changed gate has cleared formatting, dependency/architecture guards, dead exports, and core typecheck; core-test typecheck is the remaining phase. No gate has weakened or skipped the immutable artifact checks in either acceptance workflow.

Core-test typecheck is still running without errors or a no-output watchdog failure. I’m keeping this single remote gate and the two exact acceptance runs as the only active proof surfaces.

The typecheck shard remains silent but active; the wrapper’s watchdog owns termination if it stalls. I’m not restarting or duplicating it.

The remote typecheck has produced no error output for several minutes. I’m letting the bounded wrapper decide completion while checking the GitHub acceptance transitions independently.

The pre-canonical interim Docker run also failed at `assert-success-request`, confirming that carrying a prepared provider handle across the generation boundary did not repair the actual lifecycle owner. The final branch’s remote gate has completed both core typecheck phases and entered changed-file lint.

The complete remote changed gate passed in 10m15s and its Testbox lease was stopped. I’m starting the mandatory isolated autoreview while the two acceptance workflows prepare their candidate packages and images; any actionable finding will be resolved before final exact-head proof.

Autoreview is clean with no accepted or actionable findings. The branch delta is three files: +19 net production lines in the canonical load planner, +13 regression lines, and +2 net bounded failure diagnostics. The production growth centralizes the existing provider-owner eligibility rule so both Codex and default runtimes use the same safety decision.

Both acceptance runs have passed package validation and are building or packing the exact `6adcef1382a` functional image. The direct lane has reached artifact packing; Package Acceptance has validated its downloaded package identity and is building from that bound artifact.

The direct run has emitted and verified its immutable candidate tuple; the targeted `openai-web-search-minimal` job is now validating the bound package and image artifact before execution.

The final exact-head Docker lane still fails after all identity gates passed. I’m treating that as a real repair miss, not a flaky lane: I’m extracting the bounded command and request artifact now, then I’ll trace why the selected OpenAI owner still did not enter the generation before making any further edit.

The failing artifact identifies the deeper producer: `normalizePreparedModelRuntimeInput` discards every selection whose harness is the default OpenClaw runtime. The load planner therefore never receives the OpenAI selection in a real prepared generation, even though the isolated planner test passes. I’m moving the regression to the prepared-runtime owner boundary and retaining normalized provider selections there; the generation guard remains unchanged.

I’m continuing from the exact-head failure, first cleaning up the disproven experiment and confirming the branch, workflow, and scoped instructions before changing the load-plan owner. I’ll use the requested testing, test-audit, release-CI, autoreview, prepare-PR, agent-transcript, and technical-writing workflows for the remaining proof and publication.

The failed Docker request confirms the immutable candidate and image are correct; the missing behavior is generation preparation. The real edge is a Codex-policy selection whose restrictive allowlist admits the OpenAI provider owner but excludes the Codex harness owner. I’m encoding that exact configuration before moving provider-owner inclusion ahead of harness activation.

The regression failed on the prior head with `pluginIds` absent and now passes with the OpenAI owner enabled. The change keeps harness availability semantics intact while passing the already-resolved provider owner into the Codex helper, so preparation performs provider discovery once per selection. I’m publishing this exact head next, then the Docker lane and package verifier will test the immutable candidate end to end.

Both release proofs are queued against source SHA `72fc34d3901`; the workflow runner’s own `headSha` is trusted `main`, while each input pins the candidate SHA. The changed gate is also running remotely for the `core` and `coreTests` lanes.

The focused behavior suite is green: 87 tests across the load-plan owner, runtime-registry caller, and prepared-runtime generation. The remote changed gate has cleared formatting, dependency, plugin-boundary, dead-export, and core type checks; core-test type checking is still running.

The changed gate and final autoreview are clean, but the fresh Docker lane still fails. That means the load plan now includes OpenAI in the generation, yet the real packaged path still does not register or apply the native search hook. I’m pulling the exact job artifact and logs before making any further edit; the package verifier is still building the same candidate and is expected to expose the same boundary.

The new artifact gave the missing detail: the scenario’s authored `transport` parameters intentionally select the core OpenClaw runtime, so normalization discarded the provider selection before the repaired load plan ever saw it. The canonical producer fix is now in place: prepared generations retain every selected provider, while runtime normalization still records `openclaw` or `codex` explicitly. The exact regression failed with only an undefined selection and now passes.

The final changed gate found one real cleanup: removing the normalization filter left `requiresAgentHarnessPluginSelection` exported without any external production consumer. I made it private, reran both owner tests, and pushed the resulting exact head. This changes package bytes, so I’m starting one final artifact-bound Docker and package pass at `850d256bd65`; earlier in-flight runs remain diagnostic only.

The exact-head changed gate now clears the dead-export scan and has entered core type checking. Final Docker and package workflows are building immutable artifacts; Blacksmith queueing is the remaining time cost, not a new failure signal.

The final exact-head Docker run is green, including the `openai-web-search-minimal` lane. That proves the prepared OpenAI owner now contributes native `web_search` to the packaged request. The exact-head package acceptance run is still progressing through its artifact-only child; the remote changed gate and final autoreview are both clean.

All required proof is now green at `850d256bd65`: the focused Docker lane, the package-integrity and artifact-only Docker child, and `Verify package acceptance`. I’m assembling the PR with the exact failure and recovery runs, immutable package identity, Codex native-tool contract, LOC classification, remaining scope, and the requested redacted transcript.

The agent-transcript workflow is now adding a sanitized local session excerpt to the PR body. It removes raw tool output, system prompts, secrets, and unrelated turns before anything is uploaded.

[tool summary]
3 read, 6 other; raw tool outputs dropped: 9
````

</details>
<!-- agent-transcript:end -->
