### PR TITLE
test(amazon-bedrock-mantle): remove cache resets

### DIFF
--- a/extensions/amazon-bedrock-mantle/api.ts
+++ b/extensions/amazon-bedrock-mantle/api.ts
@@ -8,8 +8,6 @@ export {
   getCachedIamToken,
   MANTLE_IAM_TOKEN_MARKER,
   mergeImplicitMantleProvider,
-  resetIamTokenCacheForTest,
-  resetMantleDiscoveryCacheForTest,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,
   resolveMantleRuntimeBearerToken,

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -27,8 +27,6 @@ const {
   getCachedIamToken,
   MANTLE_IAM_TOKEN_MARKER,
   mergeImplicitMantleProvider,
-  resetIamTokenCacheForTest,
-  resetMantleDiscoveryCacheForTest,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,
   resolveMantleRuntimeBearerToken,
@@ -90,20 +88,19 @@ function modelDiscoveryResponse(body: unknown, init?: ResponseInit): Response {
 
 describe("bedrock mantle discovery", () => {
   const originalEnv = process.env;
+  let testRegionIndex = 0;
+  let testRegion = "";
 
   beforeEach(() => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
     discoveryDebugSpy.mockClear();
     discoveryLoggerState.debugEnabled = true;
-    resetMantleDiscoveryCacheForTest();
-    resetIamTokenCacheForTest();
+    testRegion = `test-region-${++testRegionIndex}`;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    resetMantleDiscoveryCacheForTest();
-    resetIamTokenCacheForTest();
     process.env = originalEnv;
   });
 
@@ -140,13 +137,13 @@ describe("bedrock mantle discovery", () => {
     const tokenProviderFactory = createTokenProviderFactory(tokenProvider);
 
     const token = await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       tokenProviderFactory,
     });
 
     expect(token).toBe("bedrock-api-key-generated");
     expect(tokenProviderFactory).toHaveBeenCalledWith({
-      region: "us-east-1",
+      region: testRegion,
       expiresInSeconds: 7200,
     });
     expect(tokenProvider).toHaveBeenCalledTimes(1);
@@ -158,13 +155,13 @@ describe("bedrock mantle discovery", () => {
     let now = 1000;
 
     const t1 = await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => now,
       tokenProviderFactory,
     });
     now += 1800_000; // 30 min — within 2hr cache TTL
     const t2 = await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => now,
       tokenProviderFactory,
     });
@@ -179,14 +176,15 @@ describe("bedrock mantle discovery", () => {
       .mockResolvedValueOnce("bedrock-api-key-east") // pragma: allowlist secret
       .mockResolvedValueOnce("bedrock-api-key-west"); // pragma: allowlist secret
     const tokenProviderFactory = createTokenProviderFactory(tokenProvider);
+    const otherRegion = `${testRegion}-other`;
 
     const east = await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 1000,
       tokenProviderFactory,
     });
     const west = await generateBearerTokenFromIam({
-      region: "us-west-2",
+      region: otherRegion,
       now: () => 2000,
       tokenProviderFactory,
     });
@@ -194,11 +192,11 @@ describe("bedrock mantle discovery", () => {
     expect(east).toBe("bedrock-api-key-east");
     expect(west).toBe("bedrock-api-key-west");
     expect(tokenProviderFactory).toHaveBeenNthCalledWith(1, {
-      region: "us-east-1",
+      region: testRegion,
       expiresInSeconds: 7200,
     });
     expect(tokenProviderFactory).toHaveBeenNthCalledWith(2, {
-      region: "us-west-2",
+      region: otherRegion,
       expiresInSeconds: 7200,
     });
     expect(tokenProvider).toHaveBeenCalledTimes(2);
@@ -210,7 +208,7 @@ describe("bedrock mantle discovery", () => {
     });
 
     await expect(
-      generateBearerTokenFromIam({ region: "us-east-1", tokenProviderFactory }),
+      generateBearerTokenFromIam({ region: testRegion, tokenProviderFactory }),
     ).resolves.toBeUndefined();
   });
 
@@ -226,17 +224,17 @@ describe("bedrock mantle discovery", () => {
       });
 
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 0,
       tokenProviderFactory,
     });
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 1,
       tokenProviderFactory,
     });
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 7200_001,
       tokenProviderFactory,
     });
@@ -245,12 +243,12 @@ describe("bedrock mantle discovery", () => {
     expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
       1,
       "Mantle IAM token generation unavailable",
-      { region: "us-east-1", error: "same failure" },
+      { region: testRegion, error: "same failure" },
     );
     expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
       2,
       "Mantle IAM token generation unavailable",
-      { region: "us-east-1", error: "same failure" },
+      { region: testRegion, error: "same failure" },
     );
   });
 
@@ -268,13 +266,13 @@ describe("bedrock mantle discovery", () => {
       });
 
     const pendingOlderFailure = generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 0,
       tokenProviderFactory,
     });
     await expect(
       generateBearerTokenFromIam({
-        region: "us-east-1",
+        region: testRegion,
         now: () => 1,
         tokenProviderFactory,
       }),
@@ -285,14 +283,14 @@ describe("bedrock mantle discovery", () => {
     expect(discoveryDebugSpy).not.toHaveBeenCalled();
 
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 7_200_001,
       tokenProviderFactory,
     });
 
     expect(discoveryDebugSpy).toHaveBeenCalledOnce();
     expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
-      region: "us-east-1",
+      region: testRegion,
       error: "same failure",
     });
   });
@@ -315,12 +313,12 @@ describe("bedrock mantle discovery", () => {
       });
 
     const pendingOlderSuccess = generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 0,
       tokenProviderFactory,
     });
     const pendingNewerFailure = generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 1,
       tokenProviderFactory,
     });
@@ -332,14 +330,14 @@ describe("bedrock mantle discovery", () => {
     expect(discoveryDebugSpy).not.toHaveBeenCalled();
 
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 7_200_001,
       tokenProviderFactory,
     });
 
     expect(discoveryDebugSpy).toHaveBeenCalledOnce();
     expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
-      region: "us-east-1",
+      region: testRegion,
       error: "same failure",
     });
   });
@@ -359,7 +357,7 @@ describe("bedrock mantle discovery", () => {
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       await generateBearerTokenFromIam({
-        region: "us-east-1",
+        region: testRegion,
         tokenProviderFactory,
       });
     }
@@ -368,11 +366,11 @@ describe("bedrock mantle discovery", () => {
     expect(discoveryDebugSpy.mock.calls).toEqual([
       [
         "Mantle IAM token generation unavailable",
-        { region: "us-east-1", error: "credentials unavailable" },
+        { region: testRegion, error: "credentials unavailable" },
       ],
       [
         "Mantle IAM token generation unavailable",
-        { region: "us-east-1", error: "credentials expired" },
+        { region: testRegion, error: "credentials expired" },
       ],
     ]);
   });
@@ -384,21 +382,21 @@ describe("bedrock mantle discovery", () => {
 
     discoveryLoggerState.debugEnabled = false;
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       tokenProviderFactory,
     });
     expect(discoveryDebugSpy).not.toHaveBeenCalled();
 
     discoveryLoggerState.debugEnabled = true;
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       tokenProviderFactory,
     });
 
     expect(tokenProviderFactory).toHaveBeenCalledTimes(2);
     expect(discoveryDebugSpy).toHaveBeenCalledOnce();
     expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
-      region: "us-east-1",
+      region: testRegion,
       error: "no credentials",
     });
   });
@@ -424,14 +422,14 @@ describe("bedrock mantle discovery", () => {
     const tokenProviderFactory = createTokenProviderFactory(tokenProvider);
 
     // Generate a token to populate the cache
-    await generateBearerTokenFromIam({ region: "us-east-1", tokenProviderFactory });
+    await generateBearerTokenFromIam({ region: testRegion, tokenProviderFactory });
 
     // Sync read should return the cached token
-    expect(getCachedIamToken("us-east-1")).toBe("bedrock-cached-token");
+    expect(getCachedIamToken(testRegion)).toBe("bedrock-cached-token");
   });
 
   it("getCachedIamToken returns undefined when cache is empty", () => {
-    expect(getCachedIamToken("us-east-1")).toBeUndefined();
+    expect(getCachedIamToken(testRegion)).toBeUndefined();
   });
 
   it("getCachedIamToken returns undefined when cache is expired", async () => {
@@ -440,14 +438,14 @@ describe("bedrock mantle discovery", () => {
 
     // Generate with a time far in the past so it's already expired
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 1000,
       tokenProviderFactory,
     });
 
     // The cache entry exists but expiresAt is 1000 + 3600000 = 3601000
     // Current Date.now() is way past that, so it should be expired
-    expect(getCachedIamToken("us-east-1")).toBeUndefined();
+    expect(getCachedIamToken(testRegion)).toBeUndefined();
   });
 
   it("does not cache generated IAM tokens when ttl expiry overflows", async () => {
@@ -459,16 +457,16 @@ describe("bedrock mantle discovery", () => {
 
     await expect(
       generateBearerTokenFromIam({
-        region: "us-east-1",
+        region: testRegion,
         now: () => 8_640_000_000_000_000,
         tokenProviderFactory,
       }),
     ).resolves.toBe("bedrock-overflow-token-1");
-    expect(getCachedIamToken("us-east-1")).toBeUndefined();
+    expect(getCachedIamToken(testRegion)).toBeUndefined();
 
     await expect(
       generateBearerTokenFromIam({
-        region: "us-east-1",
+        region: testRegion,
         now: () => 8_640_000_000_000_000,
         tokenProviderFactory,
       }),
@@ -492,7 +490,7 @@ describe("bedrock mantle discovery", () => {
     );
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -509,7 +507,9 @@ describe("bedrock mantle discovery", () => {
     expect(models[2]?.reasoning).toBe(true); // GPT-OSS 120B supports reasoning
 
     // Verify correct endpoint and auth header
-    expect(stringArgAt(mockFetch, 0, 0)).toBe("https://bedrock-mantle.us-east-1.api.aws/v1/models");
+    expect(stringArgAt(mockFetch, 0, 0)).toBe(
+      `https://bedrock-mantle.${testRegion}.api.aws/v1/models`,
+    );
     expect(recordField(objectArgAt(mockFetch, 0, 1).headers, "headers").Authorization).toBe(
       "Bearer test-token",
     );
@@ -529,7 +529,7 @@ describe("bedrock mantle discovery", () => {
     );
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -550,7 +550,7 @@ describe("bedrock mantle discovery", () => {
     const mockFetch = vi.fn().mockResolvedValue(response);
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -563,7 +563,7 @@ describe("bedrock mantle discovery", () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -583,7 +583,7 @@ describe("bedrock mantle discovery", () => {
     );
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -602,7 +602,7 @@ describe("bedrock mantle discovery", () => {
     );
 
     await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -623,7 +623,7 @@ describe("bedrock mantle discovery", () => {
     const mockFetch = vi.fn().mockResolvedValue(response);
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
     });
@@ -646,7 +646,7 @@ describe("bedrock mantle discovery", () => {
 
     // First call — hits the network
     const first = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
       now: () => now,
@@ -657,7 +657,7 @@ describe("bedrock mantle discovery", () => {
     // Second call within refresh interval — uses cache
     now += 60_000; // 1 minute later
     const second = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
       now: () => now,
@@ -668,7 +668,7 @@ describe("bedrock mantle discovery", () => {
     // Third call after refresh interval — re-fetches
     now += 3600_000; // 1 hour later
     const third = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
       now: () => now,
@@ -690,7 +690,7 @@ describe("bedrock mantle discovery", () => {
 
     // First call — succeeds
     await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
       now: () => now,
@@ -699,7 +699,7 @@ describe("bedrock mantle discovery", () => {
     // Second call after expiry — fails but returns stale cache
     now += 7200_000;
     const stale = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
       fetchFn: mockFetch as unknown as typeof fetch,
       now: () => now,
@@ -722,12 +722,12 @@ describe("bedrock mantle discovery", () => {
     const provider = await resolveImplicitMantleProvider({
       env: {
         AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
-        AWS_REGION: "us-east-1",
+        AWS_REGION: "ap-northeast-1",
       } as NodeJS.ProcessEnv,
       fetchFn: mockFetch as unknown as typeof fetch,
     });
 
-    expect(provider?.baseUrl).toBe("https://bedrock-mantle.us-east-1.api.aws/v1");
+    expect(provider?.baseUrl).toBe("https://bedrock-mantle.ap-northeast-1.api.aws/v1");
     expect(provider?.api).toBe("openai-completions");
     expect(provider?.auth).toBe("api-key");
     expect(provider?.apiKey).toBe("env:AWS_BEARER_TOKEN_BEDROCK");
@@ -792,7 +792,7 @@ describe("bedrock mantle discovery", () => {
       const provider = await resolveImplicitMantleProvider({
         env: {
           AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
-          AWS_REGION: "us-east-1",
+          AWS_REGION: "ap-south-1",
         } as NodeJS.ProcessEnv,
         fetchFn: mockFetch as unknown as typeof fetch,
       });
@@ -838,7 +838,7 @@ describe("bedrock mantle discovery", () => {
     const provider = await resolveImplicitMantleProvider({
       env: {
         AWS_PROFILE: "default",
-        AWS_REGION: "us-east-1",
+        AWS_REGION: "ap-southeast-3",
       } as NodeJS.ProcessEnv,
       fetchFn: mockFetch as unknown as typeof fetch,
       tokenProviderFactory,
@@ -846,7 +846,9 @@ describe("bedrock mantle discovery", () => {
 
     expect(provider?.apiKey).toBe(MANTLE_IAM_TOKEN_MARKER);
     expect(tokenProvider).toHaveBeenCalledTimes(1);
-    expect(stringArgAt(mockFetch, 0, 0)).toBe("https://bedrock-mantle.us-east-1.api.aws/v1/models");
+    expect(stringArgAt(mockFetch, 0, 0)).toBe(
+      "https://bedrock-mantle.ap-southeast-3.api.aws/v1/models",
+    );
     expect(recordField(objectArgAt(mockFetch, 0, 1).headers, "headers").Authorization).toBe(
       "Bearer bedrock-api-key-iam",
     );
@@ -857,7 +859,7 @@ describe("bedrock mantle discovery", () => {
     const tokenProviderFactory = createTokenProviderFactory(tokenProvider);
 
     await generateBearerTokenFromIam({
-      region: "us-east-1",
+      region: testRegion,
       now: () => 1000,
       tokenProviderFactory,
     });
@@ -865,7 +867,7 @@ describe("bedrock mantle discovery", () => {
     const resolved = await resolveMantleRuntimeBearerToken({
       apiKey: MANTLE_IAM_TOKEN_MARKER,
       env: {
-        AWS_REGION: "us-east-1",
+        AWS_REGION: testRegion,
       } as NodeJS.ProcessEnv,
       now: () => 2000,
       tokenProviderFactory,
@@ -882,7 +884,7 @@ describe("bedrock mantle discovery", () => {
     const resolved = await resolveMantleRuntimeBearerToken({
       apiKey: MANTLE_IAM_TOKEN_MARKER,
       env: {
-        AWS_REGION: "us-east-1",
+        AWS_REGION: testRegion,
       } as NodeJS.ProcessEnv,
       now: () => 5000,
       tokenProviderFactory,
@@ -899,7 +901,7 @@ describe("bedrock mantle discovery", () => {
     const resolved = await resolveMantleRuntimeBearerToken({
       apiKey: MANTLE_IAM_TOKEN_MARKER,
       env: {
-        AWS_REGION: "us-east-1",
+        AWS_REGION: testRegion,
       } as NodeJS.ProcessEnv,
       now: () => Number.NaN,
       tokenProviderFactory,
@@ -945,11 +947,6 @@ describe("bedrock mantle discovery", () => {
       name: "the fallback region when the primary env is blank",
       env: { AWS_REGION: "   ", AWS_DEFAULT_REGION: "eu-west-1" },
       expectedRegion: "eu-west-1",
-    },
-    {
-      name: "the default region when both env values are blank",
-      env: { AWS_REGION: "", AWS_DEFAULT_REGION: "\t" },
-      expectedRegion: "us-east-1",
     },
   ])("uses $name", async ({ env, expectedRegion }) => {
     const mockFetch = vi

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -242,13 +242,6 @@ export async function resolveMantleRuntimeBearerToken(params: {
     ...(expiresAt === undefined ? {} : { expiresAt }),
   };
 }
-/** Clear the IAM token cache for tests. */
-export function resetIamTokenCacheForTest(): void {
-  iamTokenCache.clear();
-  iamTokenFailureDetailByRegion.clear();
-  iamTokenSuccessEpochByRegion.clear();
-}
-
 // ---------------------------------------------------------------------------
 // OpenAI-format model list response
 // ---------------------------------------------------------------------------
@@ -317,11 +310,6 @@ type MantleDiscoveryConfig = {
 };
 
 const discoveryCache = new Map<string, MantleCacheEntry>();
-
-/** Clear the Mantle discovery cache for tests. */
-export function resetMantleDiscoveryCacheForTest(): void {
-  discoveryCache.clear();
-}
 
 // ---------------------------------------------------------------------------
 // Model discovery


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock Mantle exposed two production reset functions so tests could clear IAM-token and model-discovery maps. That made internal test isolation part of the published plugin API even though region is already the real cache owner.

## Why This Change Was Made

Each direct IAM/discovery test now receives a unique test region. Cache, recovery-epoch, failure-deduplication, stale-fallback, expiry, overflow, and runtime-auth tests keep one region inside the case where shared state is the behavior under test. Implicit-provider tests use distinct supported AWS regions; the duplicate “both values blank” default row is removed because the dedicated no-region test already protects the `us-east-1` default while the remaining table row covers blank-primary fallback.

Both test-only reset exports are removed from the owner and public barrel. The non-test-named `getCachedIamToken` API and its valid, empty, and expired behavior remain intact.

## User Impact

No runtime behavior changes. Mantle keeps the same IAM token TTL, failure diagnostics, concurrency recovery, discovery cache, stale fallback, supported-region checks, and provider catalog behavior without test-owned cache mutation.

## Evidence

- `node scripts/run-vitest.mjs extensions/amazon-bedrock-mantle/discovery.test.ts extensions/amazon-bedrock-mantle/index.test.ts extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts` — 58 passed
- The same command with `--isolate=false` — 58 passed
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback; extension type checks, lint, dead-export scan, plugin boundaries, import cycles, and doctor contract guards were green
- `pnpm build` — passed, including published package and plugin surface generation
- `git diff --check` — passed
- Structured autoreview — clean

An initial focused-test command referenced a stale, no-longer-present `stream.runtime.lifecycle.test.ts` path and failed before test execution; the current Mantle test inventory above passed without source changes.

Production delta: -14 lines. Test delta: -3 net lines.
