### PR TITLE
test(telegram): remove probe cache reset

### DIFF
--- a/extensions/telegram/api.ts
+++ b/extensions/telegram/api.ts
@@ -139,12 +139,7 @@ export {
   parseTelegramReplyToMessageId,
   parseTelegramThreadId,
 } from "./src/outbound-params.js";
-export {
-  probeTelegram,
-  resetTelegramProbeFetcherCacheForTests,
-  type TelegramProbe,
-  type TelegramProbeOptions,
-} from "./src/probe.js";
+export { probeTelegram, type TelegramProbe, type TelegramProbeOptions } from "./src/probe.js";
 export {
   type ResolvedReactionLevel,
   resolveTelegramReactionLevel,

--- a/extensions/telegram/src/probe.abort-signal.integration.test.ts
+++ b/extensions/telegram/src/probe.abort-signal.integration.test.ts
@@ -3,7 +3,7 @@
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+import { probeTelegram } from "./probe.js";
 
 describe("probeTelegram startup retry loop honors abortSignal", () => {
   let server: Server;
@@ -60,7 +60,6 @@ describe("probeTelegram startup retry loop honors abortSignal", () => {
   });
 
   afterAll(async () => {
-    resetTelegramProbeFetcherCacheForTests();
     vi.unstubAllEnvs();
     for (const socket of liveSockets) {
       socket.destroy();

--- a/extensions/telegram/src/probe.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/probe.response-body-timeout.integration.test.ts
@@ -3,7 +3,7 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+import { probeTelegram } from "./probe.js";
 
 type ResponseMode = "stall" | "trickle";
 
@@ -62,7 +62,6 @@ describe("probeTelegram response body deadlines over real sockets", () => {
   });
 
   afterAll(async () => {
-    resetTelegramProbeFetcherCacheForTests();
     vi.unstubAllEnvs();
     for (const interval of activeIntervals) {
       clearInterval(interval);
@@ -75,12 +74,14 @@ describe("probeTelegram response body deadlines over real sockets", () => {
     });
   });
 
+  let probeIndex = 0;
+
   async function expectDeadlineFailure(mode: ResponseMode, expectedError: RegExp) {
     responseMode = mode;
     const previousRequestCount = requestCount;
     const previousClosedSocketCount = closedSocketCount;
 
-    const result = await probeTelegram("placeholder", 200, {
+    const result = await probeTelegram(`deadline-${mode}-${++probeIndex}`, 200, {
       apiRoot,
       includeWebhookInfo: false,
     });

--- a/extensions/telegram/src/probe.response-body-timeout.test.ts
+++ b/extensions/telegram/src/probe.response-body-timeout.test.ts
@@ -1,6 +1,6 @@
 // Telegram tests cover stalled diagnostic response body handling.
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
-import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+import { probeTelegram } from "./probe.js";
 
 const resolveTelegramTransport = vi.hoisted(() => vi.fn());
 const makeProxyFetch = vi.hoisted(() => vi.fn());
@@ -85,8 +85,10 @@ function makeTricklingJsonResponse(cancel: (reason?: unknown) => void): Response
 }
 
 describe("probeTelegram response body timeouts", () => {
+  let tokenIndex = 0;
+  const nextToken = () => `response-body-${++tokenIndex}`;
+
   afterEach(() => {
-    resetTelegramProbeFetcherCacheForTests();
     resolveTelegramTransport.mockReset();
     makeProxyFetch.mockReset();
     vi.useRealTimers();
@@ -107,7 +109,7 @@ describe("probeTelegram response body timeouts", () => {
     );
 
     vi.useFakeTimers();
-    const probePromise = probeTelegram("placeholder", 50, {
+    const probePromise = probeTelegram(nextToken(), 50, {
       includeWebhookInfo: false,
     });
     await vi.advanceTimersByTimeAsync(0);
@@ -127,7 +129,7 @@ describe("probeTelegram response body timeouts", () => {
     vi.useFakeTimers();
     fetchMock.mockResolvedValueOnce(makeTricklingJsonResponse(cancel));
 
-    const probePromise = probeTelegram("placeholder", 100, {
+    const probePromise = probeTelegram(nextToken(), 100, {
       includeWebhookInfo: false,
     });
     await vi.advanceTimersByTimeAsync(0);
@@ -155,7 +157,7 @@ describe("probeTelegram response body timeouts", () => {
     );
 
     vi.useFakeTimers();
-    const probePromise = probeTelegram("placeholder", 50);
+    const probePromise = probeTelegram(nextToken(), 50);
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(60);
 

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -1,7 +1,7 @@
 // Telegram tests cover probe plugin behavior.
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
-import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { probeTelegram } from "./probe.js";
 
 const resolveTelegramTransport = vi.hoisted(() => vi.fn());
 const makeProxyFetch = vi.hoisted(() => vi.fn());
@@ -31,8 +31,9 @@ vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => 
 });
 
 describe("probeTelegram retry logic", () => {
-  const token = "test-token";
   const timeoutMs = 5000;
+  let tokenIndex = 0;
+  let token = "";
   const originalFetch = global.fetch;
   let forceFallbackMock: Mock;
 
@@ -92,11 +93,13 @@ describe("probeTelegram retry logic", () => {
     expect(result.bot?.username).toBe("test_bot");
   }
 
+  beforeEach(() => {
+    token = `test-token-${++tokenIndex}`;
+  });
+
   afterEach(() => {
-    resetTelegramProbeFetcherCacheForTests();
     resolveTelegramTransport.mockReset();
     makeProxyFetch.mockReset();
-    vi.unstubAllEnvs();
     vi.clearAllMocks();
     if (originalFetch) {
       global.fetch = originalFetch;
@@ -237,7 +240,7 @@ describe("probeTelegram retry logic", () => {
       allows_users_to_create_topics: false,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls.at(0)?.[0]).toBe("https://api.telegram.org/bottest-token/getMe");
+    expect(fetchMock.mock.calls.at(0)?.[0]).toBe(`https://api.telegram.org/bot${token}/getMe`);
   });
 
   it("uses resolver-scoped Telegram fetch with probe network options", async () => {
@@ -264,9 +267,6 @@ describe("probeTelegram retry logic", () => {
 
   it("reuses probe fetcher across repeated probes for the same account transport settings", async () => {
     const fetchMock = installFetchMock();
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "production");
-
     mockGetMeSuccess(fetchMock);
     mockGetWebhookInfoSuccess(fetchMock);
     await probeTelegram(`${token}-cache`, timeoutMs, {
@@ -290,9 +290,6 @@ describe("probeTelegram retry logic", () => {
 
   it("does not reuse probe fetcher cache when network settings differ", async () => {
     const fetchMock = installFetchMock();
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "production");
-
     mockGetMeSuccess(fetchMock);
     mockGetWebhookInfoSuccess(fetchMock);
     await probeTelegram(`${token}-cache-variant`, timeoutMs, {
@@ -327,9 +324,6 @@ describe("probeTelegram retry logic", () => {
         close,
       };
     });
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "production");
-
     for (let i = 0; i < 65; i += 1) {
       mockGetMeSuccess(fetchMock);
       mockGetWebhookInfoSuccess(fetchMock);
@@ -349,9 +343,6 @@ describe("probeTelegram retry logic", () => {
 
   it("reuses probe fetcher cache across token rotation when accountId is stable", async () => {
     const fetchMock = installFetchMock();
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "production");
-
     mockGetMeSuccess(fetchMock);
     mockGetWebhookInfoSuccess(fetchMock);
     await probeTelegram(`${token}-old`, timeoutMs, {

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -49,10 +49,6 @@ const MAX_PROBE_TRANSPORT_CACHE_SIZE = 64;
 // 4 MiB guards against a misbehaving or hostile API endpoint streaming an oversized payload.
 const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 
-export function resetTelegramProbeFetcherCacheForTests(): void {
-  probeTransportCache.clear();
-}
-
 function resolveProbeOptions(
   proxyOrOptions?: string | TelegramProbeOptions,
 ): TelegramProbeOptions | undefined {
@@ -63,10 +59,6 @@ function resolveProbeOptions(
     return { proxyUrl: proxyOrOptions };
   }
   return proxyOrOptions;
-}
-
-function shouldUseProbeTransportCache(): boolean {
-  return !process.env.VITEST && process.env.NODE_ENV !== "test";
 }
 
 function buildProbeTransportCacheKey(token: string, options?: TelegramProbeOptions): string {
@@ -98,13 +90,10 @@ function setCachedProbeTransport(
 }
 
 function resolveProbeTransport(token: string, options?: TelegramProbeOptions): TelegramTransport {
-  const cacheEnabled = shouldUseProbeTransportCache();
-  const cacheKey = cacheEnabled ? buildProbeTransportCacheKey(token, options) : null;
-  if (cacheKey) {
-    const cached = probeTransportCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
+  const cacheKey = buildProbeTransportCacheKey(token, options);
+  const cached = probeTransportCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
 
   const proxyUrl = options?.proxyUrl?.trim();
@@ -113,10 +102,7 @@ function resolveProbeTransport(token: string, options?: TelegramProbeOptions): T
     network: options?.network,
   });
 
-  if (cacheKey) {
-    return setCachedProbeTransport(cacheKey, transport);
-  }
-  return transport;
+  return setCachedProbeTransport(cacheKey, transport);
 }
 
 function normalizeBoolean(value: unknown): boolean | null {


### PR DESCRIPTION
## What Problem This Solves

Telegram’s production probe cache was disabled under Vitest and exposed a reset function solely for tests. That meant tests bypassed the transport reuse, fallback promotion, bounded eviction, and close behavior used in production while keeping a test-only function in the public plugin barrel.

## Why This Change Was Made

The probe transport cache is now unconditional. Unit tests receive a unique token per test; response-deadline and socket tests use file-specific unique identities; cache reuse, network-variant separation, stable-account token rotation, and 64-entry eviction deliberately reuse production keys inside their cases.

The probe reset is removed from the owner and public API. Two unrelated reset exports (`resetTelegramForumFlagCacheForTest` and `resetMissingDefaultWarnFlag`) remain in the broad barrel because removing them would leave owner-module test-only exports and requires separate cache-owner refactors.

## User Impact

No production runtime behavior changes: production already used this cache. Tests now exercise the same path rather than switching it off.

## Evidence

- Four focused probe/deadline/abort suites together — 21 passed
- Each focused file independently with `--isolate=false` — 13, 3, 3, and 2 tests passed
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback; extension type checks, lint, dead exports, plugin boundaries, import cycles, and doctor contract guards were green
- `pnpm build` — passed, including published package and plugin surface generation
- `git diff --check` — passed
- Structured autoreview — clean

A combined four-file `--isolate=false` invocation exposed an existing cross-file mock conflict: the real-socket files load the real transport module while the unit files replace it, so unit mocks were not installed. This is independent of probe cache state; the normal four-file project run passed, and each file passed in shared-worker mode separately.

Production delta: -19 net lines. Test delta: -7 net lines.
