### PR TITLE
refactor(channels): own thread binding cleanup in managers

### DIFF
--- a/extensions/matrix/session-binding-contract-api.ts
+++ b/extensions/matrix/session-binding-contract-api.ts
@@ -1,6 +1,3 @@
 // Matrix API module exposes the plugin public contract.
-export {
-  createMatrixThreadBindingManager,
-  resetMatrixThreadBindingsForTests,
-} from "./src/matrix/thread-bindings.js";
+export { createMatrixThreadBindingManager } from "./src/matrix/thread-bindings.js";
 export { setMatrixRuntime } from "./src/runtime.js";

--- a/extensions/matrix/src/matrix/thread-bindings-shared.ts
+++ b/extensions/matrix/src/matrix/thread-bindings-shared.ts
@@ -197,11 +197,3 @@ export function setMatrixThreadBindingMaxAgeBySessionKey(params: {
     }),
   );
 }
-
-export function resetMatrixThreadBindingsForTests(): void {
-  for (const { manager } of MANAGERS_BY_ACCOUNT_ID.values()) {
-    manager.stop();
-  }
-  MANAGERS_BY_ACCOUNT_ID.clear();
-  BINDINGS_BY_ACCOUNT_CONVERSATION.clear();
-}

--- a/extensions/matrix/src/matrix/thread-bindings.test.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.test.ts
@@ -23,11 +23,9 @@ import type { MatrixAuth, MatrixStoragePaths } from "./client/types.js";
 import {
   setMatrixThreadBindingIdleTimeoutBySessionKey,
   setMatrixThreadBindingMaxAgeBySessionKey,
+  type MatrixThreadBindingManager,
 } from "./thread-bindings-shared.js";
-import {
-  createMatrixThreadBindingManager,
-  resetMatrixThreadBindingsForTests,
-} from "./thread-bindings.js";
+import { createMatrixThreadBindingManager } from "./thread-bindings.js";
 
 const sendMessageMatrixMock = vi.hoisted(() =>
   vi.fn(async (_to: string, _message: string, opts?: { threadId?: string }) => ({
@@ -52,10 +50,14 @@ describe("matrix thread bindings", () => {
   const accountId = "ops";
   const idleTimeoutMs = 24 * 60 * 60 * 1000;
   const matrixClient = {} as never;
+  const trackedManagers = new Set<MatrixThreadBindingManager>();
 
   function resetThreadBindingAdapters() {
+    for (const manager of trackedManagers) {
+      manager.stop();
+    }
+    trackedManagers.clear();
     testing.resetSessionBindingAdaptersForTests();
-    resetMatrixThreadBindingsForTests();
   }
 
   function currentThreadConversation(params?: {
@@ -70,7 +72,7 @@ describe("matrix thread bindings", () => {
     };
   }
 
-  function createBindingManager(
+  async function createBindingManager(
     params: {
       auth?: MatrixAuth;
       cfg?: OpenClawConfig;
@@ -81,7 +83,7 @@ describe("matrix thread bindings", () => {
       logVerboseMessage?: (message: string) => void;
     } = {},
   ) {
-    return createMatrixThreadBindingManager({
+    const manager = await createMatrixThreadBindingManager({
       cfg: params.cfg ?? {},
       accountId,
       auth: params.auth ?? auth,
@@ -92,6 +94,8 @@ describe("matrix thread bindings", () => {
       enableSweeper: params.enableSweeper ?? false,
       ...(params.logVerboseMessage ? { logVerboseMessage: params.logVerboseMessage } : {}),
     });
+    trackedManagers.add(manager);
+    return manager;
   }
 
   async function createStaticThreadBindingManager() {
@@ -217,15 +221,7 @@ describe("matrix thread bindings", () => {
   });
 
   it("creates child Matrix thread bindings from a top-level room context", async () => {
-    await createMatrixThreadBindingManager({
-      cfg: {},
-      accountId,
-      auth,
-      client: matrixClient,
-      idleTimeoutMs,
-      maxAgeMs: 0,
-      enableSweeper: false,
-    });
+    await createBindingManager();
 
     const binding = await getSessionBindingService().bind({
       targetSessionKey: "agent:ops:subagent:child",
@@ -286,13 +282,10 @@ describe("matrix thread bindings", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-08T12:00:00.000Z"));
     try {
-      await createMatrixThreadBindingManager({
-        cfg: {},
-        accountId: "ops",
-        auth,
-        client: {} as never,
+      await createBindingManager({
         idleTimeoutMs: 1_000,
         maxAgeMs: 0,
+        enableSweeper: true,
       });
 
       await getSessionBindingService().bind({
@@ -331,13 +324,10 @@ describe("matrix thread bindings", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-08T12:00:00.000Z"));
     try {
-      await createMatrixThreadBindingManager({
-        cfg: {},
-        accountId: "ops",
-        auth,
-        client: {} as never,
+      await createBindingManager({
         idleTimeoutMs: 1_000,
         maxAgeMs: 0,
+        enableSweeper: true,
       });
 
       await getSessionBindingService().bind({
@@ -389,14 +379,9 @@ describe("matrix thread bindings", () => {
   });
 
   it("sends threaded farewell messages when bindings are unbound", async () => {
-    await createMatrixThreadBindingManager({
-      cfg: {},
-      accountId: "ops",
-      auth,
-      client: {} as never,
+    await createBindingManager({
       idleTimeoutMs: 1_000,
       maxAgeMs: 0,
-      enableSweeper: false,
     });
 
     const binding = await getSessionBindingService().bind({
@@ -569,14 +554,9 @@ describe("matrix thread bindings", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-06T10:00:00.000Z"));
     try {
-      const manager = await createMatrixThreadBindingManager({
-        cfg: {},
-        accountId: "ops",
-        auth,
-        client: {} as never,
+      const manager = await createBindingManager({
         idleTimeoutMs: 24 * 60 * 60 * 1000,
         maxAgeMs: 0,
-        enableSweeper: false,
       });
 
       await getSessionBindingService().bind({

--- a/extensions/matrix/src/matrix/thread-bindings.test.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.test.ts
@@ -548,6 +548,15 @@ describe("matrix thread bindings", () => {
       conversationId: "$thread",
       targetSessionKey: "agent:ops:subagent:child",
     });
+
+    initialManager.stop();
+
+    expect(
+      replacementManager.getByConversation({
+        conversationId: "$thread-2",
+        parentConversationId: "!room:example",
+      })?.targetSessionKey,
+    ).toBe("agent:ops:subagent:replacement");
   });
 
   it("updates lifecycle windows by session key and refreshes activity", async () => {

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -25,7 +25,6 @@ import {
   getMatrixThreadBindingManagerEntry,
   listBindingsForAccount,
   removeBindingRecord,
-  resetMatrixThreadBindingsForTests,
   resolveBindingKey,
   resolveEffectiveBindingExpiry,
   setBindingRecord,
@@ -499,9 +498,10 @@ export async function createMatrixThreadBindingManager(params: {
       });
       if (getMatrixThreadBindingManagerEntry(params.accountId)?.manager === manager) {
         deleteMatrixThreadBindingManagerEntry(params.accountId);
-      }
-      for (const record of listBindingsForAccount(params.accountId)) {
-        removeBindingRecord(record);
+        // Live bindings belong to this manager generation; persisted rows reload on restart.
+        for (const record of listBindingsForAccount(params.accountId)) {
+          removeBindingRecord(record);
+        }
       }
     },
   };
@@ -708,4 +708,4 @@ export async function createMatrixThreadBindingManager(params: {
   });
   return manager;
 }
-export { getMatrixThreadBindingManager, resetMatrixThreadBindingsForTests };
+export { getMatrixThreadBindingManager };

--- a/extensions/telegram/session-binding-contract-api.ts
+++ b/extensions/telegram/session-binding-contract-api.ts
@@ -1,5 +1,0 @@
-// Telegram API module exposes the plugin public contract.
-export {
-  createTelegramThreadBindingManager,
-  resetTelegramThreadBindingsForTests,
-} from "./src/thread-bindings.js";

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -32,6 +32,7 @@ import {
 } from "./thread-bindings-store.js";
 import {
   createTelegramThreadBindingManager as createTelegramThreadBindingManagerImpl,
+  getTelegramThreadBindingManager,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
   setTelegramThreadBindingMaxAgeBySessionKey,
 } from "./thread-bindings.js";
@@ -162,6 +163,49 @@ describe("telegram thread bindings", () => {
     expect(bound.conversation.conversationId).toBe("-100200300:topic:77");
     expect(bound.targetSessionKey).toBe("agent:main:subagent:child-1");
     expect(manager.getByConversationId("-100200300:topic:77")?.boundBy).toBe("user-1");
+  });
+
+  it("drops stopped-manager bindings without clearing a replacement generation", async () => {
+    const stopped = createTelegramThreadBindingManager({
+      accountId: "manager-lifecycle",
+      persist: false,
+      enableSweeper: false,
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:subagent:stopped",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "manager-lifecycle",
+        conversationId: "stopped-thread",
+      },
+    });
+
+    stopped.stop();
+
+    const replacement = createTelegramThreadBindingManager({
+      accountId: "manager-lifecycle",
+      persist: false,
+      enableSweeper: false,
+    });
+    expect(replacement.getByConversationId("stopped-thread")).toBeUndefined();
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:subagent:replacement",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "manager-lifecycle",
+        conversationId: "replacement-thread",
+      },
+    });
+
+    stopped.stop();
+
+    expect(getTelegramThreadBindingManager("manager-lifecycle")).toBe(replacement);
+    expect(replacement.getByConversationId("replacement-thread")?.targetSessionKey).toBe(
+      "agent:main:subagent:replacement",
+    );
   });
 
   it("rejects child placement when conversationId is a bare topic ID with no group context", async () => {

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -32,7 +32,6 @@ import {
 } from "./thread-bindings-store.js";
 import {
   createTelegramThreadBindingManager as createTelegramThreadBindingManagerImpl,
-  resetTelegramThreadBindingsForTests,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
   setTelegramThreadBindingMaxAgeBySessionKey,
 } from "./thread-bindings.js";
@@ -52,14 +51,26 @@ const TELEGRAM_THREAD_BINDINGS_TEST_CFG = {
 type TelegramThreadBindingManagerParams = Parameters<
   typeof createTelegramThreadBindingManagerImpl
 >[0];
+type TelegramThreadBindingManager = ReturnType<typeof createTelegramThreadBindingManagerImpl>;
+
+const trackedManagers = new Set<TelegramThreadBindingManager>();
 
 function createTelegramThreadBindingManager(
   params: Omit<TelegramThreadBindingManagerParams, "cfg">,
 ) {
-  return createTelegramThreadBindingManagerImpl({
+  const manager = createTelegramThreadBindingManagerImpl({
     cfg: TELEGRAM_THREAD_BINDINGS_TEST_CFG,
     ...params,
   });
+  trackedManagers.add(manager);
+  return manager;
+}
+
+function stopTrackedManagers(): void {
+  for (const manager of trackedManagers) {
+    manager.stop();
+  }
+  trackedManagers.clear();
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -101,6 +112,7 @@ describe("telegram thread bindings", () => {
   }
 
   beforeEach(async () => {
+    stopTrackedManagers();
     openClawState = await createOpenClawTestState({
       layout: "state-only",
       prefix: "openclaw-telegram-bindings-",
@@ -113,12 +125,11 @@ describe("telegram thread bindings", () => {
       "openclaw/plugin-sdk/acp-runtime",
     );
     readAcpSessionEntryMock.mockImplementation(acpRuntime.readAcpSessionEntry);
-    await resetTelegramThreadBindingsForTests();
   });
 
   afterEach(async () => {
     vi.useRealTimers();
-    await resetTelegramThreadBindingsForTests();
+    stopTrackedManagers();
     clearTelegramRuntimeForTest();
     resetPluginStateStoreForTests();
     await openClawState.cleanup();
@@ -213,15 +224,14 @@ describe("telegram thread bindings", () => {
       import.meta.url,
       "./thread-bindings.js?scope=shared-b",
     );
-    await bindingsA.resetTelegramThreadBindingsForTests();
+    const managerA = bindingsA.createTelegramThreadBindingManager({
+      cfg: TELEGRAM_THREAD_BINDINGS_TEST_CFG,
+      accountId: "shared-runtime",
+      persist: false,
+      enableSweeper: false,
+    });
 
     try {
-      const managerA = bindingsA.createTelegramThreadBindingManager({
-        cfg: TELEGRAM_THREAD_BINDINGS_TEST_CFG,
-        accountId: "shared-runtime",
-        persist: false,
-        enableSweeper: false,
-      });
       const managerB = bindingsB.createTelegramThreadBindingManager({
         cfg: TELEGRAM_THREAD_BINDINGS_TEST_CFG,
         accountId: "shared-runtime",
@@ -248,7 +258,7 @@ describe("telegram thread bindings", () => {
           ?.getByConversationId("-100200300:topic:44")?.targetSessionKey,
       ).toBe("agent:main:subagent:child-shared");
     } finally {
-      await bindingsA.resetTelegramThreadBindingsForTests();
+      managerA.stop();
     }
   });
 
@@ -335,7 +345,7 @@ describe("telegram thread bindings", () => {
   });
 
   it("persists unbinds before restart so removed bindings do not come back", async () => {
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "default",
       persist: true,
       enableSweeper: false,
@@ -356,7 +366,7 @@ describe("telegram thread bindings", () => {
       reason: "test-detach",
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
 
     const reloaded = createTelegramThreadBindingManager({
       accountId: "default",
@@ -421,7 +431,7 @@ describe("telegram thread bindings", () => {
   });
 
   it("persists bindings with json-clean metadata", async () => {
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "metadata",
       persist: true,
       enableSweeper: false,
@@ -441,7 +451,7 @@ describe("telegram thread bindings", () => {
       },
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
 
     const reloaded = createTelegramThreadBindingManager({
       accountId: "metadata",
@@ -477,7 +487,7 @@ describe("telegram thread bindings", () => {
   });
 
   it("cleans up stale ACP bindings before restart routing can reuse them", async () => {
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "default",
       persist: true,
       enableSweeper: false,
@@ -493,7 +503,7 @@ describe("telegram thread bindings", () => {
       },
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
     readAcpSessionEntryMock.mockReturnValue({
       cfg: {} as never,
       storePath: "/tmp/acp-store.json",
@@ -511,12 +521,11 @@ describe("telegram thread bindings", () => {
     });
 
     expect(reloaded.getByConversationId("cleanup-me")).toBeUndefined();
-    await resetTelegramThreadBindingsForTests();
     expect(storedBindings().map((binding) => binding.conversationId)).not.toContain("cleanup-me");
   });
 
   it("keeps plugin-owned bindings when ACP cleanup runs on startup", async () => {
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "default",
       persist: true,
       enableSweeper: false,
@@ -532,7 +541,7 @@ describe("telegram thread bindings", () => {
       },
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
 
     const reloaded = createTelegramThreadBindingManager({
       accountId: "default",
@@ -547,7 +556,7 @@ describe("telegram thread bindings", () => {
   });
 
   it("keeps ACP bindings when the session store cannot be read during startup cleanup", async () => {
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "default",
       persist: true,
       enableSweeper: false,
@@ -563,7 +572,7 @@ describe("telegram thread bindings", () => {
       },
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
     readAcpSessionEntryMock.mockReturnValue({
       cfg: {} as never,
       storePath: "/tmp/acp-store.json",
@@ -585,11 +594,11 @@ describe("telegram thread bindings", () => {
     );
   });
 
-  it("flushes pending lifecycle update persists before test reset", async () => {
+  it("reloads persisted lifecycle updates after manager restart", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-06T10:00:00.000Z"));
 
-    createTelegramThreadBindingManager({
+    const manager = createTelegramThreadBindingManager({
       accountId: "persist-reset",
       persist: true,
       enableSweeper: false,
@@ -611,8 +620,14 @@ describe("telegram thread bindings", () => {
       idleTimeoutMs: 90_000,
     });
 
-    await resetTelegramThreadBindingsForTests();
+    manager.stop();
 
+    const reloaded = createTelegramThreadBindingManager({
+      accountId: "persist-reset",
+      persist: true,
+      enableSweeper: false,
+    });
+    expect(reloaded.getByConversationId("-100200300:topic:99")?.idleTimeoutMs).toBe(90_000);
     expect(
       storedBindings().find((binding) => binding.accountId === "persist-reset")?.idleTimeoutMs,
     ).toBe(90_000);
@@ -650,7 +665,7 @@ describe("telegram thread bindings", () => {
       });
       manager.touchConversation("-100200300:topic:100");
 
-      await resetTelegramThreadBindingsForTests();
+      manager.stop();
       await flushMicrotasks();
       expect(unhandled).toStrictEqual([]);
     } finally {

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -496,9 +496,16 @@ export function createTelegramThreadBindingManager(params: {
         accountId,
         adapter: sessionBindingAdapter,
       });
-      const existingManager = getThreadBindingsState().managersByAccountId.get(accountId);
+      const state = getThreadBindingsState();
+      const existingManager = state.managersByAccountId.get(accountId);
       if (existingManager === manager) {
-        getThreadBindingsState().managersByAccountId.delete(accountId);
+        state.managersByAccountId.delete(accountId);
+        // Live bindings belong to this manager generation; persisted rows reload on restart.
+        for (const binding of listBindingsForAccount(accountId)) {
+          state.bindingsByAccountConversation.delete(
+            resolveBindingKey({ accountId, conversationId: binding.conversationId }),
+          );
+        }
       }
     },
   };
@@ -781,15 +788,6 @@ export function setTelegramThreadBindingMaxAgeBySessionKey(params: {
       lastActivityAt: now,
     }),
   });
-}
-
-export function resetTelegramThreadBindingsForTests(): Promise<void> {
-  for (const manager of getThreadBindingsState().managersByAccountId.values()) {
-    manager.stop();
-  }
-  getThreadBindingsState().managersByAccountId.clear();
-  getThreadBindingsState().bindingsByAccountConversation.clear();
-  return Promise.resolve();
 }
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -126,7 +126,9 @@ function resetMatrixSessionBindingStateDir() {
 }
 
 async function createContractMatrixThreadBindingManager() {
-  resetMatrixSessionBindingStateDir();
+  if (matrixSessionBindingManager) {
+    return matrixSessionBindingManager;
+  }
   const { setMatrixRuntime, createMatrixThreadBindingManager } =
     await getContractApi<MatrixContractApi>("matrix");
   setMatrixRuntime({
@@ -136,7 +138,7 @@ async function createContractMatrixThreadBindingManager() {
       resolveStateDir: () => matrixSessionBindingStateDir,
     },
   } as never);
-  return await createMatrixThreadBindingManager({
+  const manager = await createMatrixThreadBindingManager({
     accountId: matrixSessionBindingAuth.accountId,
     auth: matrixSessionBindingAuth,
     client: {} as never,
@@ -144,6 +146,8 @@ async function createContractMatrixThreadBindingManager() {
     maxAgeMs: 0,
     enableSweeper: false,
   });
+  matrixSessionBindingManager = manager;
+  return manager;
 }
 
 const baseSessionBindingCfg = {
@@ -157,6 +161,8 @@ type ChannelConversationBindingManager = Awaited<
   ReturnType<ChannelConversationBindingManagerFactory>
 >;
 let discordSessionBindingManager: ChannelConversationBindingManager | null = null;
+let matrixSessionBindingManager: ChannelConversationBindingManager | null = null;
+let telegramSessionBindingManager: ChannelConversationBindingManager | null = null;
 
 type DiscordContractApi = {
   discordPlugin: ChannelPlugin;
@@ -187,18 +193,12 @@ type MatrixContractApi = {
     idleTimeoutMs: number;
     maxAgeMs: number;
     enableSweeper: boolean;
-  }) => Promise<unknown>;
-  resetMatrixThreadBindingsForTests: () => void;
+  }) => Promise<ChannelConversationBindingManager>;
   setMatrixRuntime: (runtime: unknown) => void;
 };
 
 type TelegramContractApi = {
-  createTelegramThreadBindingManager: (params: {
-    accountId: string;
-    persist: boolean;
-    enableSweeper: boolean;
-  }) => unknown;
-  resetTelegramThreadBindingsForTests: () => Promise<void>;
+  telegramPlugin: ChannelPlugin;
 };
 
 function setRegistryBackedConversationBindingPlugin(params: {
@@ -238,9 +238,23 @@ async function getDiscordContractApi() {
   return await getContractApi<DiscordContractApi>("discord", "channel-plugin-api");
 }
 
+async function getTelegramContractApi() {
+  return await getContractApi<TelegramContractApi>("telegram", "channel-plugin-api");
+}
+
 async function stopDiscordSessionBindingManager() {
   await discordSessionBindingManager?.stop();
   discordSessionBindingManager = null;
+}
+
+async function stopMatrixSessionBindingManager() {
+  await matrixSessionBindingManager?.stop();
+  matrixSessionBindingManager = null;
+}
+
+async function stopTelegramSessionBindingManager() {
+  await telegramSessionBindingManager?.stop();
+  telegramSessionBindingManager = null;
 }
 
 async function prepareDiscordSessionBindingContract() {
@@ -272,13 +286,22 @@ async function prepareIMessageSessionBindingContract() {
 }
 
 async function prepareMatrixSessionBindingContract() {
-  const api = await getContractApi<MatrixContractApi>("matrix");
-  api.resetMatrixThreadBindingsForTests();
+  await stopMatrixSessionBindingManager();
+  resetMatrixSessionBindingStateDir();
 }
 
 async function prepareTelegramSessionBindingContract() {
-  const api = await getContractApi<TelegramContractApi>("telegram");
-  await api.resetTelegramThreadBindingsForTests();
+  await stopTelegramSessionBindingManager();
+  const { telegramPlugin } = await getTelegramContractApi();
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "telegram",
+        plugin: telegramPlugin,
+        source: "test",
+      },
+    ]),
+  );
 }
 
 type SessionBindingContractFixture = {
@@ -430,6 +453,7 @@ const sessionBindingContractEntries = {
     ensureManager: async () => {
       await createContractMatrixThreadBindingManager();
     },
+    stopManager: stopMatrixSessionBindingManager,
   }),
   telegram: createSessionBindingContractEntry({
     id: "telegram",
@@ -439,17 +463,19 @@ const sessionBindingContractEntries = {
     targetKind: "subagent",
     label: "telegram-topic",
     placements: ["current", "child"],
-    preload: () => getContractApi<TelegramContractApi>("telegram"),
+    preload: getTelegramContractApi,
     beforeEach: prepareTelegramSessionBindingContract,
     ensureManager: async () => {
-      const { createTelegramThreadBindingManager } =
-        await getContractApi<TelegramContractApi>("telegram");
-      createTelegramThreadBindingManager({
+      telegramSessionBindingManager ??= await createContractChannelConversationBindingManager({
+        channelId: "telegram",
+        cfg: baseSessionBindingCfg,
         accountId: "default",
-        persist: false,
-        enableSweeper: false,
       });
+      if (!telegramSessionBindingManager) {
+        throw new Error("Telegram session binding manager is unavailable");
+      }
     },
+    stopManager: stopTelegramSessionBindingManager,
   }),
 } satisfies Record<SessionBindingContractChannelId, Omit<SessionBindingContractEntry, "id">>;
 

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -19,6 +19,7 @@ import {
   resetPluginStateStoreForTests,
 } from "../../../../plugin-sdk/plugin-state-test-runtime.js";
 import { setActivePluginRegistry } from "../../../../plugins/runtime.js";
+import { loadBundledPluginFacade } from "../../../../test-utils/bundled-plugin-public-surface.js";
 import { createTestRegistry } from "../../../../test-utils/channel-plugins.js";
 import { getChannelPlugin } from "../../registry.js";
 import type { ChannelPlugin } from "../../types.public.js";
@@ -239,7 +240,10 @@ async function getDiscordContractApi() {
 }
 
 async function getTelegramContractApi() {
-  return await getContractApi<TelegramContractApi>("telegram", "channel-plugin-api");
+  return await loadBundledPluginFacade<TelegramContractApi>({
+    pluginId: "telegram",
+    artifactBasename: "channel-plugin-api.js",
+  });
 }
 
 async function stopDiscordSessionBindingManager() {


### PR DESCRIPTION
## What Problem This Solves

Telegram and Matrix thread-binding tests relied on aggregate reset functions that stopped every manager and cleared global maps. Telegram’s production `stop()` removed the adapter/manager but left live account bindings behind, so the test reset—not the lifecycle owner—was responsible for invalidation. Core contract tests also loaded a Telegram test-only sidecar solely to call that reset.

## Why This Change Was Made

The currently registered manager generation now owns live binding cleanup in `stop()`. Persisted rows are intentionally untouched and reload on restart; non-persisted bindings disappear. The authoritative-manager check prevents a stale retained manager from clearing a replacement generation.

Tests retain and stop the managers they create. Telegram restart cases now stop and recreate the manager, including persisted unbinds, metadata, stale ACP cleanup, read failures, and lifecycle updates. Matrix tests use the existing `stop()` owner. The core registry contract retains Matrix/Telegram managers, loads Telegram through its real `channel-plugin-api`, and deletes Telegram’s obsolete `session-binding-contract-api.ts` sidecar.

## User Impact

Account shutdown no longer leaves stale live Telegram binding rows in process memory. Persisted binding behavior is unchanged and remains covered across restart. Matrix keeps its existing lifecycle behavior with a stronger authoritative-generation guard.

## Evidence

- Telegram owner suite, Matrix owner suite, and registry-backed session-binding contract — 32 tests passed
- The same three routed shards with `--isolate=false` — 32 passed
- The Telegram transient-cleanup regression failed against the prior implementation because the stopped manager's live binding remained
- The Matrix stale-generation regression failed against the prior implementation because a retained manager cleared the replacement generation's binding
- Telegram's registry-backed contract now loads `channel-plugin-api.js` through the standard bundled-plugin public facade
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback; core/extension type checks, lint, dead exports, runtime sidecars, plugin boundaries, auth guards, native schema guard, and import cycles were green
- `pnpm build` — passed, including bundled artifact generation after deleting the Telegram sidecar
- `git diff --check` — passed
- Structured autoreview after addressing the exact-head ClawSweeper findings — clean

Production delta: -10 net lines. Test/test-support delta: +70 net lines. Total delta: +60 lines; the test-support growth replaces reset APIs with explicit manager lifecycle ownership and adds pre-fix-failing lifecycle proof. No SQLite schema, protocol, docs, or changelog change is required.
