### PR TITLE
fix(telegram): route model-confirmation edit through rich funnel

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -1,0 +1,147 @@
+// Telegram callback message action tests: rich/legacy edit routing.
+import type { Message } from "grammy/types";
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramCallbackMessageActions } from "./bot-handlers.callback-actions.js";
+
+const callbackMessage = {
+  chat: { id: 111, type: "private" },
+  message_id: 222,
+} as unknown as Message;
+
+function buildBot(params: { rawEditMessageText?: ReturnType<typeof vi.fn> } = {}) {
+  const editMessageText = vi.fn(async () => true as const);
+  const api: Record<string, unknown> = { editMessageText };
+  if (params.rawEditMessageText) {
+    api.raw = { editMessageText: params.rawEditMessageText };
+  }
+  return { bot: { api } as never, api, editMessageText };
+}
+
+describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
+  it("uses the legacy edit funnel when richMessages is not enabled", async () => {
+    const { bot, editMessageText } = buildBot();
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+    });
+
+    await actions.editCallbackMessage("hello");
+
+    expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
+  });
+
+  it("routes through the rich raw API when richMessages is enabled", async () => {
+    const rawEditMessageText = vi.fn(async () => true as const);
+    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("**hello**");
+
+    expect(rawEditMessageText).toHaveBeenCalledOnce();
+    expect(rawEditMessageText.mock.calls[0][0]).toMatchObject({
+      chat_id: 111,
+      message_id: 222,
+    });
+    expect(editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("keeps parse_mode HTML edits on the legacy funnel even when richMessages is enabled", async () => {
+    const rawEditMessageText = vi.fn(async () => true as const);
+    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("<b>hello</b>", { parse_mode: "HTML" });
+
+    expect(editMessageText).toHaveBeenCalledWith(111, 222, "<b>hello</b>", { parse_mode: "HTML" });
+    expect(rawEditMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy edit when the rich edit fails for a non-terminal reason", async () => {
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: some other failure");
+    });
+    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("hello");
+
+    expect(rawEditMessageText).toHaveBeenCalledOnce();
+    expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
+  });
+
+  it("re-raises 'message is not modified' from a rich edit without a legacy retry", async () => {
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: message is not modified");
+    });
+    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await expect(actions.editCallbackMessage("hello")).rejects.toThrow("message is not modified");
+    expect(editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy edit when the rich raw API is unavailable", async () => {
+    const { bot, editMessageText } = buildBot();
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("hello");
+
+    expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
+  });
+
+  it("routes a parse_mode HTML edit through the rich raw API when richTextOverride is supplied", async () => {
+    // Regression for #123886: a caller editing a message that was itself
+    // sent as rich (e.g. the /model picker's final confirmation) must opt
+    // back onto the rich funnel even though it authors HTML, since a
+    // legacy-text edit there leaves the prior rich body's markup visible
+    // underneath the new plain text instead of replacing it.
+    const rawEditMessageText = vi.fn(async () => true as const);
+    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage(
+      "<b>hello</b>",
+      { parse_mode: "HTML" },
+      { blocks: [{ type: "paragraph", text: "hello" }] },
+    );
+
+    expect(rawEditMessageText).toHaveBeenCalledOnce();
+    expect(rawEditMessageText.mock.calls[0][0]).toMatchObject({
+      chat_id: 111,
+      message_id: 222,
+      rich_message: { blocks: [{ type: "paragraph", text: "hello" }] },
+    });
+    expect(editMessageText).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -26,11 +26,13 @@ function buildBot(
   params: { rawEditMessageText?: ReturnType<typeof vi.fn<RichEditMessageText>> } = {},
 ) {
   const editMessageText = vi.fn(async () => true as const);
-  const api: Record<string, unknown> = { editMessageText };
+  const deleteMessage = vi.fn(async () => true as const);
+  const sendMessage = vi.fn(async () => ({ message_id: 333 }) as unknown as Message);
+  const api: Record<string, unknown> = { editMessageText, deleteMessage, sendMessage };
   if (params.rawEditMessageText) {
     api.raw = { editMessageText: params.rawEditMessageText };
   }
-  return { bot: { api } as never, api, editMessageText };
+  return { bot: { api } as never, api, editMessageText, deleteMessage, sendMessage };
 }
 
 describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
@@ -85,11 +87,15 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     expect(rawEditMessageText).not.toHaveBeenCalled();
   });
 
-  it("falls back to the legacy edit when the rich edit fails for a non-terminal reason", async () => {
+  it("deletes and replies instead of legacy-editing when the rich edit fails for a non-terminal reason", async () => {
+    // Regression for ClawSweeper's follow-up P2 finding: richTextOverride is only ever
+    // supplied for a message that was itself sent as rich (the /model picker's
+    // confirmation), so a legacy-text retry on raw-edit failure would reproduce the exact
+    // stale-rich-markup symptom #123886 reported. Delete-and-reply must be used instead.
     const rawEditMessageText = vi.fn(async () => {
       throw new Error("400: Bad Request: some other failure");
     });
-    const { bot, editMessageText } = buildBot({ rawEditMessageText });
+    const { bot, editMessageText, deleteMessage, sendMessage } = buildBot({ rawEditMessageText });
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
@@ -100,7 +106,9 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
 
     expect(rawEditMessageText).toHaveBeenCalledOnce();
-    expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
+    expect(deleteMessage).toHaveBeenCalledWith(111, 222);
+    expect(sendMessage).toHaveBeenCalledWith(111, "hello", {});
+    expect(editMessageText).not.toHaveBeenCalled();
   });
 
   it("re-raises 'message is not modified' from a rich edit without a legacy retry", async () => {
@@ -121,8 +129,8 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     expect(editMessageText).not.toHaveBeenCalled();
   });
 
-  it("falls back to the legacy edit when the rich raw API is unavailable", async () => {
-    const { bot, editMessageText } = buildBot();
+  it("deletes and replies instead of legacy-editing when the rich raw API is unavailable", async () => {
+    const { bot, editMessageText, deleteMessage, sendMessage } = buildBot();
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
@@ -132,7 +140,9 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
 
     await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
 
-    expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
+    expect(deleteMessage).toHaveBeenCalledWith(111, 222);
+    expect(sendMessage).toHaveBeenCalledWith(111, "hello", {});
+    expect(editMessageText).not.toHaveBeenCalled();
   });
 
   it("routes a parse_mode HTML edit through the rich raw API when richTextOverride is supplied", async () => {
@@ -164,6 +174,37 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
       message_id: 222,
       rich_message: { blocks: [{ type: "paragraph", text: "hello" }] },
     });
+    expect(editMessageText).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTelegramCallbackMessageActions editCallbackMessageWithButtons", () => {
+  it("deletes and replies, through the real /model-picker-confirmation call shape, when the rich edit fails", async () => {
+    // editCallbackMessageWithButtons is what bot-handlers.model-callback.ts's final
+    // confirmation actually calls (with richTextOverride, parse_mode: "HTML", and an empty
+    // buttons array). Its own catch block must not re-introduce a legacy-edit fallback for
+    // that path once editCallbackMessage's inner catch stops doing so.
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: some other failure");
+    });
+    const { bot, editMessageText, deleteMessage, sendMessage } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessageWithButtons(
+      "hello",
+      [],
+      { parse_mode: "HTML" },
+      helloBlocksOverride,
+    );
+
+    expect(rawEditMessageText).toHaveBeenCalledOnce();
+    expect(deleteMessage).toHaveBeenCalledWith(111, 222);
+    expect(sendMessage).toHaveBeenCalledWith(111, "hello", { parse_mode: "HTML" });
     expect(editMessageText).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -111,6 +111,50 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     expect(editMessageText).not.toHaveBeenCalled();
   });
 
+  it("sends the replacement before deleting the picker, so a send failure never destroys it", async () => {
+    // Regression for ClawSweeper's follow-up P2 finding on #124222: deleteAndReplyCallbackMessage
+    // used to delete the rich picker first and only then await the reply. By this point the
+    // model selection is already applied, so a send failure after that delete would leave the
+    // user with neither the picker nor a confirmation despite the change having taken effect --
+    // a silent-failure outcome. The order must be reversed, and a send failure must propagate
+    // without ever touching deleteMessage.
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: some other failure");
+    });
+    const { bot, deleteMessage, sendMessage } = buildBot({ rawEditMessageText });
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
+
+    expect(sendMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      requireValue(deleteMessage.mock.invocationCallOrder[0], "deleteMessage invocation order"),
+    );
+  });
+
+  it("propagates a replacement send failure without deleting the picker", async () => {
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: some other failure");
+    });
+    const { bot, deleteMessage, sendMessage } = buildBot({ rawEditMessageText });
+    sendMessage.mockRejectedValueOnce(new Error("network error"));
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await expect(
+      actions.editCallbackMessage("hello", undefined, helloBlocksOverride),
+    ).rejects.toThrow("network error");
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+
   it("re-raises 'message is not modified' from a rich edit without a legacy retry", async () => {
     const rawEditMessageText = vi.fn(async () => {
       throw new Error("400: Bad Request: message is not modified");

--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -8,7 +8,23 @@ const callbackMessage = {
   message_id: 222,
 } as unknown as Message;
 
-function buildBot(params: { rawEditMessageText?: ReturnType<typeof vi.fn> } = {}) {
+const helloBlocksOverride = { blocks: [{ type: "paragraph" as const, text: "hello" }] };
+
+// rich-message.ts's TelegramRichRawApi/editMessageText param type isn't exported (it's an
+// internal facade shape); mirror its call signature here so vi.fn infers a single-argument
+// mock instead of a zero-arg one, which is what makes `.mock.calls[0][0]` type-check.
+type RichEditMessageText = (params: Record<string, unknown>) => Promise<Message | true>;
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`expected ${label}`);
+  }
+  return value;
+}
+
+function buildBot(
+  params: { rawEditMessageText?: ReturnType<typeof vi.fn<RichEditMessageText>> } = {},
+) {
   const editMessageText = vi.fn(async () => true as const);
   const api: Record<string, unknown> = { editMessageText };
   if (params.rawEditMessageText) {
@@ -31,7 +47,13 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
   });
 
-  it("routes through the rich raw API when richMessages is enabled", async () => {
+  it("keeps plain-text edits with no richTextOverride on the legacy funnel even when richMessages is enabled", async () => {
+    // Regression for #123886's follow-up finding: richMessages must not make
+    // editCallbackMessage auto-markdown-parse arbitrary un-authored text (approval
+    // receipts, plugin respond.editMessage, the model picker's own intermediate
+    // pagination/list/error edits). Only an explicit richTextOverride opts into rich
+    // routing; everything else keeps sending its text unparsed, exactly like richMessages
+    // never existed.
     const rawEditMessageText = vi.fn(async () => true as const);
     const { bot, editMessageText } = buildBot({ rawEditMessageText });
     const actions = createTelegramCallbackMessageActions({
@@ -43,12 +65,8 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
 
     await actions.editCallbackMessage("**hello**");
 
-    expect(rawEditMessageText).toHaveBeenCalledOnce();
-    expect(rawEditMessageText.mock.calls[0][0]).toMatchObject({
-      chat_id: 111,
-      message_id: 222,
-    });
-    expect(editMessageText).not.toHaveBeenCalled();
+    expect(editMessageText).toHaveBeenCalledWith(111, 222, "**hello**", undefined);
+    expect(rawEditMessageText).not.toHaveBeenCalled();
   });
 
   it("keeps parse_mode HTML edits on the legacy funnel even when richMessages is enabled", async () => {
@@ -79,7 +97,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
       richMessages: true,
     });
 
-    await actions.editCallbackMessage("hello");
+    await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
 
     expect(rawEditMessageText).toHaveBeenCalledOnce();
     expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
@@ -97,7 +115,9 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
       richMessages: true,
     });
 
-    await expect(actions.editCallbackMessage("hello")).rejects.toThrow("message is not modified");
+    await expect(
+      actions.editCallbackMessage("hello", undefined, helloBlocksOverride),
+    ).rejects.toThrow("message is not modified");
     expect(editMessageText).not.toHaveBeenCalled();
   });
 
@@ -110,7 +130,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
       richMessages: true,
     });
 
-    await actions.editCallbackMessage("hello");
+    await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
 
     expect(editMessageText).toHaveBeenCalledWith(111, 222, "hello", undefined);
   });
@@ -121,7 +141,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     // back onto the rich funnel even though it authors HTML, since a
     // legacy-text edit there leaves the prior rich body's markup visible
     // underneath the new plain text instead of replacing it.
-    const rawEditMessageText = vi.fn(async () => true as const);
+    const rawEditMessageText = vi.fn<RichEditMessageText>(async () => true as const);
     const { bot, editMessageText } = buildBot({ rawEditMessageText });
     const actions = createTelegramCallbackMessageActions({
       bot,
@@ -137,7 +157,9 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     );
 
     expect(rawEditMessageText).toHaveBeenCalledOnce();
-    expect(rawEditMessageText.mock.calls[0][0]).toMatchObject({
+    expect(
+      requireValue(rawEditMessageText.mock.calls.at(0), "rawEditMessageText call")[0],
+    ).toMatchObject({
       chat_id: 111,
       message_id: 222,
       rich_message: { blocks: [{ type: "paragraph", text: "hello" }] },

--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -27,12 +27,25 @@ function buildBot(
 ) {
   const editMessageText = vi.fn(async () => true as const);
   const deleteMessage = vi.fn(async () => true as const);
+  const deleteBusinessMessages = vi.fn(async () => true as const);
   const sendMessage = vi.fn(async () => ({ message_id: 333 }) as unknown as Message);
-  const api: Record<string, unknown> = { editMessageText, deleteMessage, sendMessage };
+  const api: Record<string, unknown> = {
+    editMessageText,
+    deleteMessage,
+    deleteBusinessMessages,
+    sendMessage,
+  };
   if (params.rawEditMessageText) {
     api.raw = { editMessageText: params.rawEditMessageText };
   }
-  return { bot: { api } as never, api, editMessageText, deleteMessage, sendMessage };
+  return {
+    bot: { api } as never,
+    api,
+    editMessageText,
+    deleteMessage,
+    deleteBusinessMessages,
+    sendMessage,
+  };
 }
 
 describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
@@ -153,6 +166,39 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
       actions.editCallbackMessage("hello", undefined, helloBlocksOverride),
     ).rejects.toThrow("network error");
     expect(deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("deletes a business callback's picker via deleteBusinessMessages, not the businessless deleteMessage", async () => {
+    // Regression for ClawSweeper's second follow-up P2 finding on #124222: deleteMessage has
+    // no business_connection_id parameter at all (unlike editMessageText/sendMessage, which the
+    // sibling helpers already forward it to). Calling plain deleteMessage on a message sent on
+    // behalf of a business account is the wrong Bot API call; Telegram's dedicated
+    // deleteBusinessMessages(business_connection_id, message_ids) must be used instead, or a
+    // rich-edit recovery on a Business callback can fail to remove the stale picker.
+    const rawEditMessageText = vi.fn(async () => {
+      throw new Error("400: Bad Request: some other failure");
+    });
+    const { bot, deleteMessage, deleteBusinessMessages, sendMessage } = buildBot({
+      rawEditMessageText,
+    });
+    const businessCallbackMessage = {
+      ...callbackMessage,
+      business_connection_id: "biz-conn-1",
+    } as unknown as Message;
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage: businessCallbackMessage,
+      isForum: false,
+      richMessages: true,
+    });
+
+    await actions.editCallbackMessage("hello", undefined, helloBlocksOverride);
+
+    expect(deleteBusinessMessages).toHaveBeenCalledWith("biz-conn-1", [222]);
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(111, "hello", {
+      business_connection_id: "biz-conn-1",
+    });
   });
 
   it("re-raises 'message is not modified' from a rich edit without a legacy retry", async () => {

--- a/extensions/telegram/src/bot-handlers.callback-actions.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.test.ts
@@ -54,7 +54,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
     });
 
     await actions.editCallbackMessage("hello");
@@ -74,7 +74,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -90,7 +90,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -112,7 +112,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -138,7 +138,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -158,7 +158,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -188,7 +188,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage: businessCallbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -209,7 +209,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -224,7 +224,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -246,7 +246,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessage", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 
@@ -281,7 +281,7 @@ describe("createTelegramCallbackMessageActions editCallbackMessageWithButtons", 
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isForum: false,
+      threadSpec: { scope: "none" },
       richMessages: true,
     });
 

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -179,6 +179,12 @@ export function createTelegramCallbackMessageActions(params: {
   };
 
   const deleteCallbackMessage = async () => {
+    // deleteMessage has no business_connection_id parameter at all (unlike editMessageText/
+    // sendMessage/editMessageReplyMarkup, which all accept one) -- Telegram's Bot API instead
+    // exposes a dedicated method, deleteBusinessMessages(business_connection_id, message_ids),
+    // for deleting a message sent on behalf of a business account. Calling plain deleteMessage
+    // on a business callback's picker fails (ClawSweeper follow-up finding on #124222), so the
+    // business case must switch methods entirely rather than merge in an extra param.
     return callbackBusinessParams
       ? await bot.api.deleteBusinessMessages(callbackBusinessParams.business_connection_id, [
           callbackMessage.message_id,

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -1,14 +1,33 @@
-import type { Message } from "grammy/types";
+import type { InlineKeyboardMarkup, Message } from "grammy/types";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
+import { isTelegramMessageNotModifiedError } from "./network-errors.js";
 import type { TelegramQuestionCallback } from "./question-callback-data.js";
+import type { InputRichBlock } from "./rich-block-model.js";
+import {
+  buildTelegramRichBlocksPlan,
+  buildTelegramRichMarkdown,
+  getTelegramRichRawApi,
+} from "./rich-message.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export type TelegramCallbackButton = {
   text: string;
   callback_data: string;
   style?: "danger" | "success" | "primary";
+};
+
+/**
+ * Hand-built rich blocks for a caller-authored edit whose interpolated content
+ * (e.g. a provider/model id) isn't guaranteed markdown-safe. Bypasses
+ * `buildTelegramRichMarkdown`'s markdown parsing entirely — same pattern as
+ * `progress-draft-preview.ts`'s `boldRichText`/`paragraphBlock` construction —
+ * so odd characters in interpolated text can't corrupt formatting or be
+ * silently swallowed by markdown link/emphasis parsing.
+ */
+export type TelegramCallbackRichTextOverride = {
+  blocks: InputRichBlock[];
 };
 
 type TelegramCallbackReplyParams = Omit<
@@ -20,7 +39,8 @@ export interface TelegramCallbackMessageActions {
   editCallbackMessage: (
     text: string,
     editParams?: Parameters<RegisterTelegramHandlerParams["bot"]["api"]["editMessageText"]>[3],
-  ) => ReturnType<RegisterTelegramHandlerParams["bot"]["api"]["editMessageText"]>;
+    richTextOverride?: TelegramCallbackRichTextOverride,
+  ) => Promise<Message | true>;
   clearCallbackButtons: () => ReturnType<
     RegisterTelegramHandlerParams["bot"]["api"]["editMessageReplyMarkup"]
   >;
@@ -31,6 +51,7 @@ export interface TelegramCallbackMessageActions {
     text: string,
     buttons: TelegramCallbackButton[][],
     extra?: { parse_mode?: "HTML" | "Markdown" | "MarkdownV2" },
+    richTextOverride?: TelegramCallbackRichTextOverride,
   ) => Promise<void>;
   deleteCallbackMessage: () => ReturnType<
     RegisterTelegramHandlerParams["bot"]["api"]["deleteMessage"]
@@ -45,8 +66,9 @@ export function createTelegramCallbackMessageActions(params: {
   bot: RegisterTelegramHandlerParams["bot"];
   callbackMessage: Message;
   threadSpec: TelegramThreadSpec;
+  richMessages?: boolean;
 }): TelegramCallbackMessageActions {
-  const { bot, callbackMessage, threadSpec } = params;
+  const { bot, callbackMessage, threadSpec, richMessages = false } = params;
   const callbackBusinessParams =
     callbackMessage.business_connection_id !== undefined
       ? { business_connection_id: callbackMessage.business_connection_id }
@@ -54,7 +76,7 @@ export function createTelegramCallbackMessageActions(params: {
   const withCallbackBusinessParams = <T extends object>(value: T) =>
     callbackBusinessParams ? { ...callbackBusinessParams, ...value } : value;
 
-  const editCallbackMessage = async (
+  const legacyEditCallbackMessage = async (
     text: string,
     editParams?: Parameters<typeof bot.api.editMessageText>[3],
   ) => {
@@ -64,6 +86,48 @@ export function createTelegramCallbackMessageActions(params: {
       text,
       editParams ? withCallbackBusinessParams(editParams) : callbackBusinessParams,
     );
+  };
+
+  const editCallbackMessage = async (
+    text: string,
+    editParams?: Parameters<typeof bot.api.editMessageText>[3],
+    richTextOverride?: TelegramCallbackRichTextOverride,
+  ) => {
+    // Rich accounts author HTML confirmations (e.g. the /model picker) directly on the
+    // legacy funnel by default: the rich wire path is blocks-only and would re-escape
+    // caller HTML. See the contract note in rich-message.ts above TelegramInputRichMessage.
+    // A caller that supplies richTextOverride opts a specific parse_mode:"HTML" edit back
+    // into the rich funnel with hand-built blocks instead — required whenever that edit
+    // targets a message that was itself sent as rich (e.g. the /model picker's final
+    // confirmation), since a legacy-text edit there leaves the prior rich body's markup
+    // visible underneath the new plain text instead of fully replacing it.
+    if (!richMessages || (editParams?.parse_mode === "HTML" && !richTextOverride)) {
+      return await legacyEditCallbackMessage(text, editParams);
+    }
+    try {
+      const richMessage = richTextOverride
+        ? buildTelegramRichBlocksPlan(richTextOverride.blocks, { skipEntityDetection: true })
+            .richMessage
+        : buildTelegramRichMarkdown(text);
+      return await getTelegramRichRawApi(bot.api).editMessageText(
+        withCallbackBusinessParams({
+          chat_id: callbackMessage.chat.id,
+          message_id: callbackMessage.message_id,
+          rich_message: richMessage,
+          ...(editParams?.reply_markup
+            ? { reply_markup: editParams.reply_markup as InlineKeyboardMarkup }
+            : {}),
+        }),
+      );
+    } catch (richErr) {
+      // "message is not modified" is a real terminal outcome (the edit target already
+      // shows this content); a legacy retry would either no-op or mask the same error
+      // differently, so it must propagate untouched instead of falling back.
+      if (isTelegramMessageNotModifiedError(richErr)) {
+        throw richErr;
+      }
+      return await legacyEditCallbackMessage(text, editParams);
+    }
   };
 
   const clearCallbackButtons = async () => {
@@ -105,11 +169,12 @@ export function createTelegramCallbackMessageActions(params: {
     text: string,
     buttons: TelegramCallbackButton[][],
     extra?: { parse_mode?: "HTML" | "Markdown" | "MarkdownV2" },
+    richTextOverride?: TelegramCallbackRichTextOverride,
   ) => {
     const keyboard = buildInlineKeyboard(buttons);
     const editParams = keyboard ? { reply_markup: keyboard, ...extra } : extra;
     try {
-      await editCallbackMessage(text, editParams);
+      await editCallbackMessage(text, editParams, richTextOverride);
     } catch (editErr) {
       const errStr = String(editErr);
       if (errStr.includes("no text in the message")) {

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -84,6 +84,25 @@ export function createTelegramCallbackMessageActions(params: {
     );
   };
 
+  // Representation-safe fallback for a message that can no longer be edited in
+  // place without leaving stale content behind: Telegram's "no text in the
+  // message" edit rejection, or a rich-edit failure on a message that was
+  // itself sent as rich (legacy-editing that leaves the prior rich body's
+  // markup visible underneath the new text — the #123886 symptom). Deleting
+  // then replying guarantees the visible result is exactly `text`, never a
+  // legacy edit overlapping the message's prior body. Delete failures (e.g.
+  // insufficient rights, message already gone) are swallowed so the reply
+  // still goes out instead of leaving the user with nothing.
+  const deleteAndReplyCallbackMessage = async (
+    text: string,
+    replyParams?: TelegramCallbackReplyParams,
+  ) => {
+    try {
+      await deleteCallbackMessage();
+    } catch {}
+    return await replyToCallbackChat(text, replyParams);
+  };
+
   const editCallbackMessage = async (
     text: string,
     editParams?: Parameters<typeof bot.api.editMessageText>[3],
@@ -124,7 +143,15 @@ export function createTelegramCallbackMessageActions(params: {
       if (isTelegramMessageNotModifiedError(richErr)) {
         throw richErr;
       }
-      return await legacyEditCallbackMessage(text, editParams);
+      // A legacy retry is not safe here: richTextOverride is only ever supplied for a
+      // message that was itself sent as rich, and this file's own invariant (see the
+      // comment above) is that legacy-editing such a message leaves its prior rich body
+      // visible underneath the new text — exactly the #123886 bug this override exists to
+      // avoid. Delete-and-reply sidesteps that by never editing the rich-sent message.
+      return await deleteAndReplyCallbackMessage(text, {
+        ...(editParams?.reply_markup ? { reply_markup: editParams.reply_markup } : {}),
+        ...(editParams?.parse_mode ? { parse_mode: editParams.parse_mode } : {}),
+      });
     }
   };
 
@@ -176,10 +203,10 @@ export function createTelegramCallbackMessageActions(params: {
     } catch (editErr) {
       const errStr = String(editErr);
       if (errStr.includes("no text in the message")) {
-        try {
-          await deleteCallbackMessage();
-        } catch {}
-        await replyToCallbackChat(text, keyboard ? { reply_markup: keyboard, ...extra } : extra);
+        await deleteAndReplyCallbackMessage(
+          text,
+          keyboard ? { reply_markup: keyboard, ...extra } : extra,
+        );
       } else if (!errStr.includes("message is not modified")) {
         throw editErr;
       }

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -88,19 +88,24 @@ export function createTelegramCallbackMessageActions(params: {
   // place without leaving stale content behind: Telegram's "no text in the
   // message" edit rejection, or a rich-edit failure on a message that was
   // itself sent as rich (legacy-editing that leaves the prior rich body's
-  // markup visible underneath the new text — the #123886 symptom). Deleting
-  // then replying guarantees the visible result is exactly `text`, never a
-  // legacy edit overlapping the message's prior body. Delete failures (e.g.
-  // insufficient rights, message already gone) are swallowed so the reply
-  // still goes out instead of leaving the user with nothing.
+  // markup visible underneath the new text — the #123886 symptom). The
+  // replacement is sent *before* the original is deleted: by the time this
+  // runs, the underlying model selection is already applied, so if delete-
+  // then-send deleted first and the send then failed, the user would be left
+  // with neither the picker nor a confirmation despite the change having
+  // taken effect — a silent-failure outcome (ClawSweeper follow-up finding on
+  // #124222). Deleting only after a successful send keeps that failure mode
+  // impossible; delete failures (e.g. insufficient rights, message already
+  // gone) are swallowed since the new message already stands on its own.
   const deleteAndReplyCallbackMessage = async (
     text: string,
     replyParams?: TelegramCallbackReplyParams,
   ) => {
+    const sent = await replyToCallbackChat(text, replyParams);
     try {
       await deleteCallbackMessage();
     } catch {}
-    return await replyToCallbackChat(text, replyParams);
+    return sent;
   };
 
   const editCallbackMessage = async (

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -137,7 +137,10 @@ export function createTelegramCallbackMessageActions(params: {
           message_id: callbackMessage.message_id,
           rich_message: richMessage,
           ...(editParams?.reply_markup
-            ? { reply_markup: editParams.reply_markup as InlineKeyboardMarkup }
+            ? {
+                // SAFETY: editParams is always the caller-authored editMessageText reply_markup (InlineKeyboardMarkup); the rich raw API's own type just hasn't re-exported it.
+                reply_markup: editParams.reply_markup as InlineKeyboardMarkup,
+              }
             : {}),
         }),
       );

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -5,11 +5,7 @@ import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helper
 import { isTelegramMessageNotModifiedError } from "./network-errors.js";
 import type { TelegramQuestionCallback } from "./question-callback-data.js";
 import type { InputRichBlock } from "./rich-block-model.js";
-import {
-  buildTelegramRichBlocksPlan,
-  buildTelegramRichMarkdown,
-  getTelegramRichRawApi,
-} from "./rich-message.js";
+import { buildTelegramRichBlocksPlan, getTelegramRichRawApi } from "./rich-message.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export type TelegramCallbackButton = {
@@ -26,7 +22,7 @@ export type TelegramCallbackButton = {
  * so odd characters in interpolated text can't corrupt formatting or be
  * silently swallowed by markdown link/emphasis parsing.
  */
-export type TelegramCallbackRichTextOverride = {
+type TelegramCallbackRichTextOverride = {
   blocks: InputRichBlock[];
 };
 
@@ -93,22 +89,24 @@ export function createTelegramCallbackMessageActions(params: {
     editParams?: Parameters<typeof bot.api.editMessageText>[3],
     richTextOverride?: TelegramCallbackRichTextOverride,
   ) => {
-    // Rich accounts author HTML confirmations (e.g. the /model picker) directly on the
-    // legacy funnel by default: the rich wire path is blocks-only and would re-escape
-    // caller HTML. See the contract note in rich-message.ts above TelegramInputRichMessage.
-    // A caller that supplies richTextOverride opts a specific parse_mode:"HTML" edit back
-    // into the rich funnel with hand-built blocks instead — required whenever that edit
+    // Rich routing is opt-in per call, not a richMessages-account-wide default: only a
+    // caller that supplies richTextOverride's hand-built blocks goes through the rich raw
+    // API. Every other caller (approval receipts, plugin respond.editMessage, the model
+    // picker's own intermediate pagination/list/error edits) stays on the legacy funnel and
+    // sends its text unparsed, exactly as it did before richMessages existed. Without this
+    // guard, `buildTelegramRichMarkdown(text)` used to run on arbitrary un-authored text for
+    // every rich account, silently reinterpreting incidental `*`/`_`/backtick/`[` characters
+    // as Markdown (#123886 follow-up finding). Opting in is required whenever an edit
     // targets a message that was itself sent as rich (e.g. the /model picker's final
     // confirmation), since a legacy-text edit there leaves the prior rich body's markup
     // visible underneath the new plain text instead of fully replacing it.
-    if (!richMessages || (editParams?.parse_mode === "HTML" && !richTextOverride)) {
+    if (!richMessages || !richTextOverride) {
       return await legacyEditCallbackMessage(text, editParams);
     }
     try {
-      const richMessage = richTextOverride
-        ? buildTelegramRichBlocksPlan(richTextOverride.blocks, { skipEntityDetection: true })
-            .richMessage
-        : buildTelegramRichMarkdown(text);
+      const richMessage = buildTelegramRichBlocksPlan(richTextOverride.blocks, {
+        skipEntityDetection: true,
+      }).richMessage;
       return await getTelegramRichRawApi(bot.api).editMessageText(
         withCallbackBusinessParams({
           chat_id: callbackMessage.chat.id,

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -1,23 +1,15 @@
-import { randomUUID } from "node:crypto";
 import type { Context } from "grammy";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
-import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { applySessionModelSelection } from "openclaw/plugin-sdk/model-session-runtime";
-import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { mergeTelegramAccountConfig } from "./account-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   hasTelegramApprovalCallbackPrefix,
   parseTelegramApprovalCallbackData,
 } from "./approval-callback-data.js";
-import { resolveAgentDir, resolveDefaultModelForAgent } from "./bot-handlers.agent.runtime.js";
 import {
   createTelegramCallbackMessageActions,
   handleTelegramQuestionCallback,
-  type TelegramCallbackMessageActions,
 } from "./bot-handlers.callback-actions.js";
 import {
   createTelegramCallbackApprovalRuntime,
@@ -30,6 +22,7 @@ import type {
   TelegramEventAuthorizationMode,
   TelegramHandlerAuthorization,
 } from "./bot-handlers.inbound-authorization.js";
+import { handleTelegramModelCallback } from "./bot-handlers.model-callback.js";
 import type {
   RegisterTelegramHandlerParams,
   TelegramCallbackRouter,
@@ -40,22 +33,12 @@ import {
 } from "./bot-processing-outcome.js";
 import {
   resolveTelegramForumFlag,
-  resolveTelegramBotHasTopicsEnabled,
   resolveTelegramMessageThreadSpec,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
-import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
+import type { TelegramGetChat } from "./bot/types.js";
 import { getTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
-import { buildCommandsPaginationKeyboard, buildTelegramModelsMenuButtons } from "./command-ui.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
-import {
-  buildModelsKeyboard,
-  calculateTotalPages,
-  getModelsPageSize,
-  parseModelCallbackData,
-  resolveModelSelection,
-  type ProviderInfo,
-} from "./model-buttons.js";
 import {
   hasTelegramOpaqueCallbackPrefix,
   parseTelegramNativeCommandCallbackData,
@@ -66,7 +49,6 @@ import {
   hasTelegramQuestionCallbackPrefix,
   parseTelegramQuestionCallbackData,
 } from "./question-callback-data.js";
-import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramConversationId } from "./topic-conversation.js";
 
 export function createTelegramCallbackRouter({
@@ -206,6 +188,7 @@ export function createTelegramCallbackRouter({
         bot,
         callbackMessage,
         threadSpec,
+        richMessages: mergeTelegramAccountConfig(authorizationCfg, accountId).richMessages === true,
       });
       const clearRoutedCallbackButtons = async () => {
         try {
@@ -408,284 +391,4 @@ export function createTelegramCallbackRouter({
       return { kind: "handled" };
     },
   };
-}
-
-async function handleTelegramModelCallback(params: {
-  data: string;
-  ctx: Pick<TelegramContext, "me">;
-  chatId: number;
-  isGroup: boolean;
-  threadSpec: ReturnType<typeof resolveTelegramMessageThreadSpec>;
-  senderId: string;
-  runtimeCfg: OpenClawConfig;
-  telegramDeps: RegisterTelegramHandlerParams["telegramDeps"];
-  actions: TelegramCallbackMessageActions;
-  messageRuntime: TelegramCallbackMessageRuntime;
-  authorizeCallback: () => Promise<boolean>;
-}): Promise<boolean> {
-  const {
-    data,
-    ctx,
-    chatId,
-    isGroup,
-    threadSpec,
-    senderId,
-    runtimeCfg,
-    telegramDeps,
-    actions,
-    messageRuntime,
-    authorizeCallback,
-  } = params;
-  const { editCallbackMessage, editCallbackMessageWithButtons: editMessageWithButtons } = actions;
-  const retryModelAction = async <T>(action: () => Promise<T>): Promise<T> => {
-    try {
-      return await action();
-    } catch (error) {
-      throw new TelegramRetryableCallbackError(error);
-    }
-  };
-
-  const paginationMatch = data.match(/^commands_page_(\d+|noop)(?::(.+))?$/);
-  if (paginationMatch) {
-    const pageValue = paginationMatch[1];
-    if (pageValue === "noop") {
-      return true;
-    }
-    const page = parseStrictPositiveInteger(pageValue);
-    if (page === undefined) {
-      return true;
-    }
-    const agentId =
-      paginationMatch[2]?.trim() ||
-      messageRuntime.resolveTelegramSessionState({
-        chatId,
-        isGroup,
-        threadSpec,
-        botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
-        senderId,
-        runtimeCfg,
-      }).agentId;
-    const result = await retryModelAction(async () => {
-      const skillCommands = telegramDeps.listSkillCommandsForAgents({
-        cfg: runtimeCfg,
-        agentIds: [agentId],
-      });
-      return buildCommandsMessagePaginated(runtimeCfg, skillCommands, {
-        page,
-        forcePaginatedList: true,
-        surface: "telegram",
-      });
-    });
-    const keyboard =
-      result.totalPages > 1
-        ? buildInlineKeyboard(
-            buildCommandsPaginationKeyboard(result.currentPage, result.totalPages, agentId),
-          )
-        : undefined;
-    try {
-      await editCallbackMessage(result.text, keyboard ? { reply_markup: keyboard } : undefined);
-    } catch (editErr) {
-      if (!String(editErr).includes("message is not modified")) {
-        throw new TelegramRetryableCallbackError(editErr);
-      }
-    }
-    return true;
-  }
-
-  const modelCallback = parseModelCallbackData(data);
-  if (!modelCallback) {
-    return false;
-  }
-  if (!(await authorizeCallback())) {
-    logVerbose(
-      `Blocked telegram model callback from ${senderId || "unknown"} (not authorized for /models)`,
-    );
-    return true;
-  }
-
-  const { sessionState, modelData } = await retryModelAction(async () => {
-    const session = messageRuntime.resolveTelegramSessionState({
-      chatId,
-      isGroup,
-      threadSpec,
-      botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
-      senderId,
-      runtimeCfg,
-    });
-    const providerData = await telegramDeps.buildModelsProviderData(runtimeCfg, session.agentId);
-    return { sessionState: session, modelData: providerData };
-  });
-  const { byProvider, providers, modelNames, resolvedDefault: activeResolvedDefault } = modelData;
-  const providerInfos: ProviderInfo[] = providers.map((provider) => ({
-    id: provider,
-    count: byProvider.get(provider)?.size ?? 0,
-  }));
-
-  if (modelCallback.type === "providers" || modelCallback.type === "back") {
-    if (providers.length === 0) {
-      await retryModelAction(() => editMessageWithButtons("No providers available.", []));
-      return true;
-    }
-    await retryModelAction(() =>
-      editMessageWithButtons(
-        "Select a provider:",
-        buildTelegramModelsMenuButtons({ providers: providerInfos }),
-      ),
-    );
-    return true;
-  }
-
-  if (modelCallback.type === "list") {
-    const { provider, page } = modelCallback;
-    const modelSet = byProvider.get(provider);
-    if (!modelSet || modelSet.size === 0) {
-      await retryModelAction(() =>
-        editMessageWithButtons(
-          `Unknown provider: ${provider}\n\nSelect a provider:`,
-          buildTelegramModelsMenuButtons({ providers: providerInfos }),
-        ),
-      );
-      return true;
-    }
-    const models = [...modelSet].toSorted((left, right) => left.localeCompare(right));
-    const pageSize = getModelsPageSize();
-    const totalPages = calculateTotalPages(models.length, pageSize);
-    const safePage = Math.max(1, Math.min(page, totalPages));
-    const currentModel =
-      sessionState.model || `${activeResolvedDefault.provider}/${activeResolvedDefault.model}`;
-    const buttons = buildModelsKeyboard({
-      provider,
-      models,
-      currentModel,
-      currentPage: safePage,
-      totalPages,
-      pageSize,
-      modelNames,
-    });
-    const text = formatModelsAvailableHeader({
-      provider,
-      total: models.length,
-      cfg: runtimeCfg,
-      agentDir: resolveAgentDir(runtimeCfg, sessionState.agentId),
-      sessionEntry: sessionState.sessionEntry,
-    });
-    await retryModelAction(() => editMessageWithButtons(text, buttons));
-    return true;
-  }
-
-  if (modelCallback.type !== "select") {
-    return true;
-  }
-  const selection = resolveModelSelection({ callback: modelCallback, providers, byProvider });
-  if (selection.kind !== "resolved") {
-    await retryModelAction(() =>
-      editMessageWithButtons(
-        `Could not resolve model "${selection.model}".\n\nSelect a provider:`,
-        buildTelegramModelsMenuButtons({ providers: providerInfos }),
-      ),
-    );
-    return true;
-  }
-  if (!byProvider.get(selection.provider)?.has(selection.model)) {
-    await retryModelAction(() =>
-      editMessageWithButtons(
-        `❌ Model "${selection.provider}/${selection.model}" is not allowed.`,
-        [],
-      ),
-    );
-    return true;
-  }
-
-  try {
-    const storePath = telegramDeps.resolveStorePath(runtimeCfg.session?.store, {
-      agentId: sessionState.agentId,
-    });
-    const resolvedDefault = resolveDefaultModelForAgent({
-      cfg: runtimeCfg,
-      agentId: sessionState.agentId,
-    });
-    const isDefaultSelection =
-      selection.provider === resolvedDefault.provider && selection.model === resolvedDefault.model;
-    const persistedSessionEntry =
-      sessionState.sessionEntry ??
-      telegramDeps.getSessionEntry?.({ storePath, sessionKey: sessionState.sessionKey }) ??
-      getSessionEntry({ storePath, sessionKey: sessionState.sessionKey });
-    const sessionEntryMissing = persistedSessionEntry === undefined;
-    const sessionEntry = persistedSessionEntry ?? {
-      sessionId: randomUUID(),
-      updatedAt: Date.now(),
-    };
-    const previousAuthProfileId = sessionEntry.authProfileOverride?.trim();
-    const sessionStore = { [sessionState.sessionKey]: sessionEntry };
-    const modelCatalog = [...byProvider.entries()].flatMap(([provider, models]) =>
-      [...models].map((model) => ({ provider, id: model, name: model })),
-    );
-    const currentModelRef = sessionState.model?.trim();
-    const currentModelSeparator = currentModelRef?.indexOf("/") ?? -1;
-    const currentProvider =
-      currentModelRef && currentModelSeparator > 0
-        ? currentModelRef.slice(0, currentModelSeparator)
-        : resolvedDefault.provider;
-    const currentModel =
-      currentModelRef && currentModelSeparator > 0
-        ? currentModelRef.slice(currentModelSeparator + 1)
-        : resolvedDefault.model;
-    const applied = await retryModelAction(() =>
-      applySessionModelSelection({
-        cfg: runtimeCfg,
-        agentId: sessionState.agentId,
-        sessionKey: sessionState.sessionKey,
-        storePath,
-        sessionEntry,
-        sessionStore,
-        allowCreate: sessionEntryMissing,
-        defaultProvider: resolvedDefault.provider,
-        defaultModel: resolvedDefault.model,
-        currentProvider,
-        currentModel,
-        allowedModelKeys: new Set(modelCatalog.map((entry) => `${entry.provider}/${entry.id}`)),
-        modelCatalog,
-        canPersistStickyModelSelection: false,
-        request: {
-          provider: selection.provider,
-          model: selection.model,
-          isDefault: isDefaultSelection,
-          runtime: { kind: "unchanged" },
-        },
-        markLiveSwitchPending: true,
-      }),
-    );
-    if (applied.status !== "applied") {
-      await editMessageWithButtons(`❌ ${applied.message}`, []);
-      return true;
-    }
-    const defaultAuthProfileNotice =
-      isDefaultSelection && previousAuthProfileId
-        ? sessionStore[sessionState.sessionKey]?.authProfileOverride?.trim() ===
-          previousAuthProfileId
-          ? "Compatible auth profile retained."
-          : "Incompatible auth profile cleared."
-        : undefined;
-    const escapeHtml = (text: string) =>
-      text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    const actionText = isDefaultSelection
-      ? "reset to default"
-      : `changed to <b>${escapeHtml(selection.provider)}/${escapeHtml(selection.model)}</b>`;
-    const runtimeText =
-      applied.runtimeChange?.kind === "clear"
-        ? "Runtime reset to configured policy."
-        : "Runtime unchanged.";
-    const scopeText = isDefaultSelection
-      ? `Session model selection cleared.${defaultAuthProfileNotice ? ` ${defaultAuthProfileNotice}` : ""} ${runtimeText} New replies use the agent's configured default.`
-      : `Session-only model selection. ${runtimeText} Use /model ${escapeHtml(selection.provider)}/${escapeHtml(selection.model)} --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`;
-    await editMessageWithButtons(`✅ Model ${actionText}\n\n${scopeText}`, [], {
-      parse_mode: "HTML",
-    });
-  } catch (err) {
-    if (err instanceof TelegramRetryableCallbackError) {
-      throw err;
-    }
-    await editMessageWithButtons(`❌ Failed to change model: ${String(err)}`, []);
-  }
-  return true;
 }

--- a/extensions/telegram/src/bot-handlers.model-callback.ts
+++ b/extensions/telegram/src/bot-handlers.model-callback.ts
@@ -295,11 +295,18 @@ export async function handleTelegramModelCallback(params: {
       runtimeReset: applied.runtimeChange?.kind === "clear",
       defaultAuthProfileNotice,
     });
-    await editMessageWithButtons(
-      confirmation.html,
-      [],
-      { parse_mode: "HTML" },
-      { blocks: confirmation.richBlocks },
+    // Runs after applySessionModelSelection has already taken effect, so a transient
+    // failure here must not be misreported as a permanent "Failed to change model"
+    // edit -- retryModelAction wraps it into TelegramRetryableCallbackError, which the
+    // outer catch below rethrows into the router's retry path instead of swallowing it
+    // (ClawSweeper follow-up finding on #124222).
+    await retryModelAction(() =>
+      editMessageWithButtons(
+        confirmation.html,
+        [],
+        { parse_mode: "HTML" },
+        { blocks: confirmation.richBlocks },
+      ),
     );
   } catch (err) {
     if (err instanceof TelegramRetryableCallbackError) {

--- a/extensions/telegram/src/bot-handlers.model-callback.ts
+++ b/extensions/telegram/src/bot-handlers.model-callback.ts
@@ -283,10 +283,10 @@ export async function handleTelegramModelCallback(params: {
           ? "Compatible auth profile retained."
           : "Incompatible auth profile cleared."
         : undefined;
-    // The picker's provider/model-list steps already edit through the rich funnel when
-    // richMessages is enabled (createTelegramCallbackMessageActions); this final
-    // confirmation edits that same rich-sent message, so it must render as rich content
-    // too — a legacy-HTML edit here leaves the prior rich body's markup visible
+    // The picker's provider/model-list steps stay on the legacy HTML funnel (no
+    // richTextOverride supplied). This final confirmation edits the same rich-sent
+    // message, so it must explicitly opt into the rich funnel via richTextOverride --
+    // a legacy-HTML edit here would leave the prior rich body's markup visible
     // underneath the new text instead of replacing it (issue #123886).
     const confirmation = buildModelSelectionConfirmation({
       isDefaultSelection,

--- a/extensions/telegram/src/bot-handlers.model-callback.ts
+++ b/extensions/telegram/src/bot-handlers.model-callback.ts
@@ -1,0 +1,311 @@
+import { randomUUID } from "node:crypto";
+import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { applySessionModelSelection } from "openclaw/plugin-sdk/model-session-runtime";
+import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveAgentDir, resolveDefaultModelForAgent } from "./bot-handlers.agent.runtime.js";
+import type { TelegramCallbackMessageActions } from "./bot-handlers.callback-actions.js";
+import {
+  type TelegramCallbackMessageRuntime,
+  TelegramRetryableCallbackError,
+} from "./bot-handlers.callback-router-controls.js";
+import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import { resolveTelegramBotHasTopicsEnabled, type TelegramThreadSpec } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
+import { buildCommandsPaginationKeyboard, buildTelegramModelsMenuButtons } from "./command-ui.js";
+import {
+  buildModelsKeyboard,
+  calculateTotalPages,
+  getModelsPageSize,
+  parseModelCallbackData,
+  resolveModelSelection,
+  type ProviderInfo,
+} from "./model-buttons.js";
+import { buildModelSelectionConfirmation } from "./model-confirmation-message.js";
+import { buildInlineKeyboard } from "./send.js";
+
+export async function handleTelegramModelCallback(params: {
+  data: string;
+  ctx: Pick<TelegramContext, "me">;
+  chatId: number;
+  isGroup: boolean;
+  threadSpec: TelegramThreadSpec;
+  senderId: string;
+  runtimeCfg: OpenClawConfig;
+  telegramDeps: RegisterTelegramHandlerParams["telegramDeps"];
+  actions: TelegramCallbackMessageActions;
+  messageRuntime: TelegramCallbackMessageRuntime;
+  authorizeCallback: () => Promise<boolean>;
+}): Promise<boolean> {
+  const {
+    data,
+    ctx,
+    chatId,
+    isGroup,
+    threadSpec,
+    senderId,
+    runtimeCfg,
+    telegramDeps,
+    actions,
+    messageRuntime,
+    authorizeCallback,
+  } = params;
+  const { editCallbackMessage, editCallbackMessageWithButtons: editMessageWithButtons } = actions;
+  const retryModelAction = async <T>(action: () => Promise<T>): Promise<T> => {
+    try {
+      return await action();
+    } catch (error) {
+      throw new TelegramRetryableCallbackError(error);
+    }
+  };
+
+  const paginationMatch = data.match(/^commands_page_(\d+|noop)(?::(.+))?$/);
+  if (paginationMatch) {
+    const pageValue = paginationMatch[1];
+    if (pageValue === "noop") {
+      return true;
+    }
+    const page = parseStrictPositiveInteger(pageValue);
+    if (page === undefined) {
+      return true;
+    }
+    const agentId =
+      paginationMatch[2]?.trim() ||
+      messageRuntime.resolveTelegramSessionState({
+        chatId,
+        isGroup,
+        threadSpec,
+        botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
+        senderId,
+        runtimeCfg,
+      }).agentId;
+    const result = await retryModelAction(async () => {
+      const skillCommands = telegramDeps.listSkillCommandsForAgents({
+        cfg: runtimeCfg,
+        agentIds: [agentId],
+      });
+      return buildCommandsMessagePaginated(runtimeCfg, skillCommands, {
+        page,
+        forcePaginatedList: true,
+        surface: "telegram",
+      });
+    });
+    const keyboard =
+      result.totalPages > 1
+        ? buildInlineKeyboard(
+            buildCommandsPaginationKeyboard(result.currentPage, result.totalPages, agentId),
+          )
+        : undefined;
+    try {
+      await editCallbackMessage(result.text, keyboard ? { reply_markup: keyboard } : undefined);
+    } catch (editErr) {
+      if (!String(editErr).includes("message is not modified")) {
+        throw new TelegramRetryableCallbackError(editErr);
+      }
+    }
+    return true;
+  }
+
+  const modelCallback = parseModelCallbackData(data);
+  if (!modelCallback) {
+    return false;
+  }
+  if (!(await authorizeCallback())) {
+    logVerbose(
+      `Blocked telegram model callback from ${senderId || "unknown"} (not authorized for /models)`,
+    );
+    return true;
+  }
+
+  const { sessionState, modelData } = await retryModelAction(async () => {
+    const session = messageRuntime.resolveTelegramSessionState({
+      chatId,
+      isGroup,
+      threadSpec,
+      botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
+      senderId,
+      runtimeCfg,
+    });
+    const providerData = await telegramDeps.buildModelsProviderData(runtimeCfg, session.agentId);
+    return { sessionState: session, modelData: providerData };
+  });
+  const { byProvider, providers, modelNames, resolvedDefault: activeResolvedDefault } = modelData;
+  const providerInfos: ProviderInfo[] = providers.map((provider) => ({
+    id: provider,
+    count: byProvider.get(provider)?.size ?? 0,
+  }));
+
+  if (modelCallback.type === "providers" || modelCallback.type === "back") {
+    if (providers.length === 0) {
+      await retryModelAction(() => editMessageWithButtons("No providers available.", []));
+      return true;
+    }
+    await retryModelAction(() =>
+      editMessageWithButtons(
+        "Select a provider:",
+        buildTelegramModelsMenuButtons({ providers: providerInfos }),
+      ),
+    );
+    return true;
+  }
+
+  if (modelCallback.type === "list") {
+    const { provider, page } = modelCallback;
+    const modelSet = byProvider.get(provider);
+    if (!modelSet || modelSet.size === 0) {
+      await retryModelAction(() =>
+        editMessageWithButtons(
+          `Unknown provider: ${provider}\n\nSelect a provider:`,
+          buildTelegramModelsMenuButtons({ providers: providerInfos }),
+        ),
+      );
+      return true;
+    }
+    const models = [...modelSet].toSorted((left, right) => left.localeCompare(right));
+    const pageSize = getModelsPageSize();
+    const totalPages = calculateTotalPages(models.length, pageSize);
+    const safePage = Math.max(1, Math.min(page, totalPages));
+    const currentModel =
+      sessionState.model || `${activeResolvedDefault.provider}/${activeResolvedDefault.model}`;
+    const buttons = buildModelsKeyboard({
+      provider,
+      models,
+      currentModel,
+      currentPage: safePage,
+      totalPages,
+      pageSize,
+      modelNames,
+    });
+    const text = formatModelsAvailableHeader({
+      provider,
+      total: models.length,
+      cfg: runtimeCfg,
+      agentDir: resolveAgentDir(runtimeCfg, sessionState.agentId),
+      sessionEntry: sessionState.sessionEntry,
+    });
+    await retryModelAction(() => editMessageWithButtons(text, buttons));
+    return true;
+  }
+
+  if (modelCallback.type !== "select") {
+    return true;
+  }
+  const selection = resolveModelSelection({ callback: modelCallback, providers, byProvider });
+  if (selection.kind !== "resolved") {
+    await retryModelAction(() =>
+      editMessageWithButtons(
+        `Could not resolve model "${selection.model}".\n\nSelect a provider:`,
+        buildTelegramModelsMenuButtons({ providers: providerInfos }),
+      ),
+    );
+    return true;
+  }
+  if (!byProvider.get(selection.provider)?.has(selection.model)) {
+    await retryModelAction(() =>
+      editMessageWithButtons(
+        `❌ Model "${selection.provider}/${selection.model}" is not allowed.`,
+        [],
+      ),
+    );
+    return true;
+  }
+
+  try {
+    const storePath = telegramDeps.resolveStorePath(runtimeCfg.session?.store, {
+      agentId: sessionState.agentId,
+    });
+    const resolvedDefault = resolveDefaultModelForAgent({
+      cfg: runtimeCfg,
+      agentId: sessionState.agentId,
+    });
+    const isDefaultSelection =
+      selection.provider === resolvedDefault.provider && selection.model === resolvedDefault.model;
+    const persistedSessionEntry =
+      sessionState.sessionEntry ??
+      telegramDeps.getSessionEntry?.({ storePath, sessionKey: sessionState.sessionKey }) ??
+      getSessionEntry({ storePath, sessionKey: sessionState.sessionKey });
+    const sessionEntryMissing = persistedSessionEntry === undefined;
+    const sessionEntry = persistedSessionEntry ?? {
+      sessionId: randomUUID(),
+      updatedAt: Date.now(),
+    };
+    const previousAuthProfileId = sessionEntry.authProfileOverride?.trim();
+    const sessionStore = { [sessionState.sessionKey]: sessionEntry };
+    const modelCatalog = [...byProvider.entries()].flatMap(([provider, models]) =>
+      [...models].map((model) => ({ provider, id: model, name: model })),
+    );
+    const currentModelRef = sessionState.model?.trim();
+    const currentModelSeparator = currentModelRef?.indexOf("/") ?? -1;
+    const currentProvider =
+      currentModelRef && currentModelSeparator > 0
+        ? currentModelRef.slice(0, currentModelSeparator)
+        : resolvedDefault.provider;
+    const currentModel =
+      currentModelRef && currentModelSeparator > 0
+        ? currentModelRef.slice(currentModelSeparator + 1)
+        : resolvedDefault.model;
+    const applied = await retryModelAction(() =>
+      applySessionModelSelection({
+        cfg: runtimeCfg,
+        agentId: sessionState.agentId,
+        sessionKey: sessionState.sessionKey,
+        storePath,
+        sessionEntry,
+        sessionStore,
+        allowCreate: sessionEntryMissing,
+        defaultProvider: resolvedDefault.provider,
+        defaultModel: resolvedDefault.model,
+        currentProvider,
+        currentModel,
+        allowedModelKeys: new Set(modelCatalog.map((entry) => `${entry.provider}/${entry.id}`)),
+        modelCatalog,
+        canPersistStickyModelSelection: false,
+        request: {
+          provider: selection.provider,
+          model: selection.model,
+          isDefault: isDefaultSelection,
+          runtime: { kind: "unchanged" },
+        },
+        markLiveSwitchPending: true,
+      }),
+    );
+    if (applied.status !== "applied") {
+      await editMessageWithButtons(`❌ ${applied.message}`, []);
+      return true;
+    }
+    const defaultAuthProfileNotice =
+      isDefaultSelection && previousAuthProfileId
+        ? sessionStore[sessionState.sessionKey]?.authProfileOverride?.trim() ===
+          previousAuthProfileId
+          ? "Compatible auth profile retained."
+          : "Incompatible auth profile cleared."
+        : undefined;
+    // The picker's provider/model-list steps already edit through the rich funnel when
+    // richMessages is enabled (createTelegramCallbackMessageActions); this final
+    // confirmation edits that same rich-sent message, so it must render as rich content
+    // too — a legacy-HTML edit here leaves the prior rich body's markup visible
+    // underneath the new text instead of replacing it (issue #123886).
+    const confirmation = buildModelSelectionConfirmation({
+      isDefaultSelection,
+      provider: selection.provider,
+      model: selection.model,
+      runtimeReset: applied.runtimeChange?.kind === "clear",
+      defaultAuthProfileNotice,
+    });
+    await editMessageWithButtons(
+      confirmation.html,
+      [],
+      { parse_mode: "HTML" },
+      { blocks: confirmation.richBlocks },
+    );
+  } catch (err) {
+    if (err instanceof TelegramRetryableCallbackError) {
+      throw err;
+    }
+    await editMessageWithButtons(`❌ Failed to change model: ${String(err)}`, []);
+  }
+  return true;
+}

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -8,6 +8,7 @@ import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runt
 import { beforeEach, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js";
+import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
 
 type AnyMock = ReturnType<typeof vi.fn>;
 type AnyAsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
@@ -381,7 +382,7 @@ type RichMessageParams = {
   chat_id?: string | number;
   message_id?: number;
   rich_message?: {
-    blocks?: Array<{ type?: string; text?: unknown }>;
+    blocks?: InputRichBlock[];
     markdown?: string;
     html?: string;
   };
@@ -394,15 +395,11 @@ function getRichMessageText(params: RichMessageParams): string {
     return "";
   }
   if (rich.blocks) {
-    // Test harness only needs a readable plain-ish projection for assertions.
-    return rich.blocks
-      .map((block) => {
-        if (typeof block.text === "string") {
-          return block.text;
-        }
-        return JSON.stringify(block.text ?? "");
-      })
-      .join("\n");
+    // Reuse the production plain-text projector so array-shaped/typed
+    // `RichText` (bold, links, etc.) flattens the same way a real Telegram
+    // client would render it, instead of a shallow string-only special case
+    // that JSON-stringifies anything else.
+    return inputRichBlocksToPlainText(rich.blocks);
   }
   return rich.markdown ?? rich.html ?? "";
 }

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2866,6 +2866,56 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-html-1");
   });
 
+  it("routes the final model selection confirmation through the rich edit funnel when richMessages is enabled", async () => {
+    // Regression for #123886: the picker's provider/model-list edits already went
+    // through the rich funnel when richMessages is enabled, but the final confirmation
+    // stayed HTML-only. Editing a rich-sent message through the legacy text API leaves
+    // the message's prior rich body visible underneath the new plain text instead of
+    // replacing it, so this edit must land on editMessageTextSpy via the rich raw path
+    // (see the harness's `raw.editMessageText` wiring), not the legacy parse_mode HTML
+    // path with no rich_message payload.
+    const storePath = createTelegramTestStorePath("model-rich");
+    const config = makeModelPickerConfig(storePath, {
+      telegram: { dmPolicy: "open", allowFrom: ["*"], richMessages: true },
+    });
+
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({
+      token: "tok",
+      config,
+    });
+    const callbackHandler = getTelegramCallbackHandlerForTests();
+
+    await callbackHandler(
+      createTelegramCallbackContext({
+        id: "cbq-model-rich-1",
+        data: "mdl_sel_openai/gpt-5.4",
+        message: { message_id: 18 },
+      }),
+    );
+
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    const editCall = mockCall(
+      editMessageTextSpy as unknown as MockCallSource,
+      0,
+      "edit message text",
+    );
+    expect(editCall[0]).toBe(1234);
+    expect(editCall[1]).toBe(18);
+    // Rendered from the harness's rich-block plain-text projection: no HTML entities
+    // (e.g. no `&lt;`/`&gt;`), and the provider/model id renders literally.
+    expect(editCall[2]).toBe(
+      `${CHECK_MARK_EMOJI} Model changed to openai/gpt-5.4\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime <runtime> -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`,
+    );
+    expect(requireRecord(editCall[3], "edit params").parse_mode).toBeUndefined();
+
+    const entry = readOnlySessionEntry(storePath);
+    expect(entry?.providerOverride).toBe("openai");
+    expect(entry?.modelOverride).toBe("gpt-5.4");
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-rich-1");
+  });
+
   it("keeps hot-reloaded model pins on the next assembled turn", async () => {
     // Regression: the callback handler used the startup `cfg` snapshot for
     // store path and default-model resolution.  If the config was reloaded

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2867,10 +2867,11 @@ describe("createTelegramBot", () => {
   });
 
   it("routes the final model selection confirmation through the rich edit funnel when richMessages is enabled", async () => {
-    // Regression for #123886: the picker's provider/model-list edits already went
-    // through the rich funnel when richMessages is enabled, but the final confirmation
-    // stayed HTML-only. Editing a rich-sent message through the legacy text API leaves
-    // the message's prior rich body visible underneath the new plain text instead of
+    // Regression for #123886: the picker's provider/model-list edits stay on the
+    // legacy HTML funnel (no richTextOverride supplied), same as every other
+    // callback step. Only this terminal confirmation opts into the rich funnel.
+    // Editing a rich-sent message through the legacy text API leaves the
+    // message's prior rich body visible underneath the new plain text instead of
     // replacing it, so this edit must land on editMessageTextSpy via the rich raw path
     // (see the harness's `raw.editMessageText` wiring), not the legacy parse_mode HTML
     // path with no rich_message payload.

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2917,6 +2917,85 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-rich-1");
   });
 
+  it("retries the rich model confirmation edit after a transient replacement-send failure instead of reporting a permanent failure", async () => {
+    // Regression for the ClawSweeper P2 finding on #124222: the rich confirmation
+    // edit runs after applySessionModelSelection has already taken effect, so a
+    // transient failure here must bubble as TelegramRetryableCallbackError into the
+    // router's retry path -- not get caught locally and rewritten into a misleading
+    // "Failed to change model" edit while the selection silently stays applied.
+    //
+    // A bare rich-edit failure alone isn't enough to reproduce the bug: editCallbackMessage
+    // (bot-handlers.callback-actions.ts) catches a non-"not modified" rich-edit error and
+    // falls back to deleteAndReplyCallbackMessage (send-then-delete), which absorbs the
+    // failure whenever the replacement send succeeds. The failure this fix protects against
+    // only surfaces when that fallback's own replacement send also fails.
+    const storePath = createTelegramTestStorePath("model-rich-retry");
+    const config = makeModelPickerConfig(storePath, {
+      telegram: { dmPolicy: "open", allowFrom: ["*"], richMessages: true },
+    });
+
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({
+      token: "tok",
+      config,
+    });
+    const callbackHandler = getTelegramCallbackHandlerForTests();
+
+    editMessageTextSpy.mockRejectedValueOnce(new Error("rich edit boom"));
+    sendMessageSpy.mockRejectedValueOnce(new Error("replacement send boom"));
+
+    await expect(
+      callbackHandler(
+        createTelegramCallbackContext({
+          id: "cbq-model-rich-retry-1",
+          data: "mdl_sel_openai/gpt-5.4",
+          message: { message_id: 19 },
+        }),
+      ),
+    ).rejects.toThrow("replacement send boom");
+
+    // The selection is already applied by the time the confirmation edit fails --
+    // this is the state the retry path must be able to re-confirm without redoing
+    // applySessionModelSelection, since it already ran to completion.
+    expect(readOnlySessionEntry(storePath)?.providerOverride).toBe("openai");
+    expect(readOnlySessionEntry(storePath)?.modelOverride).toBe("gpt-5.4");
+    // No misleading permanent-failure edit was sent for the already-applied selection.
+    expect(
+      editMessageTextSpy.mock.calls.some((call) =>
+        (typeof call[2] === "string" ? call[2] : "").includes("Failed to change model"),
+      ),
+    ).toBe(false);
+    expect(
+      sendMessageSpy.mock.calls.some((call) =>
+        (typeof call[1] === "string" ? call[1] : "").includes("Failed to change model"),
+      ),
+    ).toBe(false);
+    // The failed replacement send's original message was never deleted -- the old picker
+    // stays visible rather than leaving the chat with neither picker nor confirmation.
+    expect(deleteMessageSpy).not.toHaveBeenCalled();
+
+    await callbackHandler(
+      createTelegramCallbackContext({
+        id: "cbq-model-rich-retry-2",
+        data: "mdl_sel_openai/gpt-5.4",
+        message: { message_id: 19 },
+      }),
+    );
+
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(2);
+    const editCall = mockCall(
+      editMessageTextSpy as unknown as MockCallSource,
+      1,
+      "edit message text",
+    );
+    expect(editCall[0]).toBe(1234);
+    expect(editCall[1]).toBe(19);
+    expect(editCall[2]).toBe(
+      `${CHECK_MARK_EMOJI} Model changed to openai/gpt-5.4\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime <runtime> -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`,
+    );
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-rich-retry-2");
+  });
+
   it("keeps hot-reloaded model pins on the next assembled turn", async () => {
     // Regression: the callback handler used the startup `cfg` snapshot for
     // store path and default-model resolution.  If the config was reloaded

--- a/extensions/telegram/src/model-confirmation-message.test.ts
+++ b/extensions/telegram/src/model-confirmation-message.test.ts
@@ -1,0 +1,61 @@
+// Confirmation-body builder for the /models picker's final selection edit.
+import { describe, expect, it } from "vitest";
+import { buildModelSelectionConfirmation } from "./model-confirmation-message.js";
+import { richTextToPlainString } from "./rich-block-model.js";
+
+describe("buildModelSelectionConfirmation", () => {
+  it("renders a non-default selection with an escaped HTML body and a matching rich block", () => {
+    const confirmation = buildModelSelectionConfirmation({
+      isDefaultSelection: false,
+      provider: "openai",
+      model: "gpt-5.4",
+      runtimeReset: false,
+    });
+
+    expect(confirmation.html).toBe(
+      "\u{2705} Model changed to <b>openai/gpt-5.4</b>\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.",
+    );
+    const plain = confirmation.richBlocks
+      .map((block) => richTextToPlainString(block.text))
+      .join("\n");
+    expect(plain).toBe(
+      "\u{2705} Model changed to openai/gpt-5.4\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime <runtime> -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.",
+    );
+  });
+
+  it("escapes HTML-significant characters in provider/model ids only in the HTML body", () => {
+    // Provider/model ids are plugin-supplied and not guaranteed HTML/markdown-safe;
+    // the HTML body must escape them but the rich block must not (it isn't parsed
+    // as markup, so escaping there would corrupt the literal id).
+    const confirmation = buildModelSelectionConfirmation({
+      isDefaultSelection: false,
+      provider: "openai",
+      model: "<script>&model",
+      runtimeReset: false,
+    });
+
+    expect(confirmation.html).toContain("&lt;script&gt;&amp;model");
+    const plain = confirmation.richBlocks
+      .map((block) => richTextToPlainString(block.text))
+      .join("\n");
+    expect(plain).toContain("openai/<script>&model");
+  });
+
+  it("renders a default-selection reset with the auth-profile notice included", () => {
+    const confirmation = buildModelSelectionConfirmation({
+      isDefaultSelection: true,
+      provider: "openai",
+      model: "gpt-5.4",
+      runtimeReset: true,
+      defaultAuthProfileNotice: "Compatible auth profile retained.",
+    });
+
+    expect(confirmation.html).toBe(
+      "\u{2705} Model reset to default\n\nSession model selection cleared. Compatible auth profile retained. Runtime reset to configured policy. New replies use the agent's configured default.",
+    );
+    const plain = confirmation.richBlocks
+      .map((block) => richTextToPlainString(block.text))
+      .join("\n");
+    expect(plain).toBe(confirmation.html);
+  });
+});

--- a/extensions/telegram/src/model-confirmation-message.test.ts
+++ b/extensions/telegram/src/model-confirmation-message.test.ts
@@ -1,7 +1,7 @@
 // Confirmation-body builder for the /models picker's final selection edit.
 import { describe, expect, it } from "vitest";
 import { buildModelSelectionConfirmation } from "./model-confirmation-message.js";
-import { richTextToPlainString } from "./rich-block-model.js";
+import { inputRichBlocksToPlainText } from "./rich-block-model.js";
 
 describe("buildModelSelectionConfirmation", () => {
   it("renders a non-default selection with an escaped HTML body and a matching rich block", () => {
@@ -15,9 +15,7 @@ describe("buildModelSelectionConfirmation", () => {
     expect(confirmation.html).toBe(
       "\u{2705} Model changed to <b>openai/gpt-5.4</b>\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.",
     );
-    const plain = confirmation.richBlocks
-      .map((block) => richTextToPlainString(block.text))
-      .join("\n");
+    const plain = inputRichBlocksToPlainText(confirmation.richBlocks);
     expect(plain).toBe(
       "\u{2705} Model changed to openai/gpt-5.4\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime <runtime> -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.",
     );
@@ -35,9 +33,7 @@ describe("buildModelSelectionConfirmation", () => {
     });
 
     expect(confirmation.html).toContain("&lt;script&gt;&amp;model");
-    const plain = confirmation.richBlocks
-      .map((block) => richTextToPlainString(block.text))
-      .join("\n");
+    const plain = inputRichBlocksToPlainText(confirmation.richBlocks);
     expect(plain).toContain("openai/<script>&model");
   });
 
@@ -53,9 +49,7 @@ describe("buildModelSelectionConfirmation", () => {
     expect(confirmation.html).toBe(
       "\u{2705} Model reset to default\n\nSession model selection cleared. Compatible auth profile retained. Runtime reset to configured policy. New replies use the agent's configured default.",
     );
-    const plain = confirmation.richBlocks
-      .map((block) => richTextToPlainString(block.text))
-      .join("\n");
+    const plain = inputRichBlocksToPlainText(confirmation.richBlocks);
     expect(plain).toBe(confirmation.html);
   });
 });

--- a/extensions/telegram/src/model-confirmation-message.ts
+++ b/extensions/telegram/src/model-confirmation-message.ts
@@ -1,10 +1,11 @@
 /**
  * Builds the /models picker's final selection confirmation body in both
- * representations the callback funnel can send: legacy HTML text (used when
- * richMessages is disabled, or as a fallback) and hand-built rich blocks
- * (used when richMessages is enabled, since the picker's provider/model-list
- * edits already went through the rich funnel and this confirmation edits
- * that same rich-sent message — see the call site's #123886 note).
+ * representations the callback funnel can send: legacy HTML text (used by
+ * every other picker step, and as this confirmation's fallback) and
+ * hand-built rich blocks (used only by this terminal confirmation, which
+ * explicitly opts into the rich funnel via richTextOverride so the edit
+ * replaces the picker's rich-sent body instead of leaving it visible
+ * underneath — see the call site's #123886 note).
  */
 import { boldRichText, paragraphBlock, type InputRichBlock } from "./rich-block-model.js";
 

--- a/extensions/telegram/src/model-confirmation-message.ts
+++ b/extensions/telegram/src/model-confirmation-message.ts
@@ -14,7 +14,7 @@ function escapeModelConfirmationHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-export type ModelSelectionConfirmationParams = {
+type ModelSelectionConfirmationParams = {
   isDefaultSelection: boolean;
   provider: string;
   model: string;
@@ -22,7 +22,7 @@ export type ModelSelectionConfirmationParams = {
   defaultAuthProfileNotice?: string;
 };
 
-export type ModelSelectionConfirmation = {
+type ModelSelectionConfirmation = {
   html: string;
   richBlocks: InputRichBlock[];
 };

--- a/extensions/telegram/src/model-confirmation-message.ts
+++ b/extensions/telegram/src/model-confirmation-message.ts
@@ -1,0 +1,63 @@
+/**
+ * Builds the /models picker's final selection confirmation body in both
+ * representations the callback funnel can send: legacy HTML text (used when
+ * richMessages is disabled, or as a fallback) and hand-built rich blocks
+ * (used when richMessages is enabled, since the picker's provider/model-list
+ * edits already went through the rich funnel and this confirmation edits
+ * that same rich-sent message — see the call site's #123886 note).
+ */
+import { boldRichText, paragraphBlock, type InputRichBlock } from "./rich-block-model.js";
+
+const CHECK_MARK_EMOJI = "\u{2705}";
+
+function escapeModelConfirmationHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export type ModelSelectionConfirmationParams = {
+  isDefaultSelection: boolean;
+  provider: string;
+  model: string;
+  runtimeReset: boolean;
+  defaultAuthProfileNotice?: string;
+};
+
+export type ModelSelectionConfirmation = {
+  html: string;
+  richBlocks: InputRichBlock[];
+};
+
+export function buildModelSelectionConfirmation(
+  params: ModelSelectionConfirmationParams,
+): ModelSelectionConfirmation {
+  const { isDefaultSelection, provider, model, runtimeReset, defaultAuthProfileNotice } = params;
+  const runtimeText = runtimeReset ? "Runtime reset to configured policy." : "Runtime unchanged.";
+  // Shared between the legacy-HTML and rich confirmation bodies so the two
+  // renderings can't drift apart; only the model-id escaping and the runtime
+  // placeholder spelling differ per funnel.
+  const buildScopeText = (escapeModelId: (text: string) => string, runtimePlaceholder: string) =>
+    isDefaultSelection
+      ? `Session model selection cleared.${defaultAuthProfileNotice ? ` ${defaultAuthProfileNotice}` : ""} ${runtimeText} New replies use the agent's configured default.`
+      : `Session-only model selection. ${runtimeText} Use /model ${escapeModelId(provider)}/${escapeModelId(model)} --runtime ${runtimePlaceholder} -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`;
+
+  const scopeText = buildScopeText(escapeModelConfirmationHtml, "&lt;runtime&gt;");
+  const actionText = isDefaultSelection
+    ? "reset to default"
+    : `changed to <b>${escapeModelConfirmationHtml(provider)}/${escapeModelConfirmationHtml(model)}</b>`;
+  const html = `${CHECK_MARK_EMOJI} Model ${actionText}\n\n${scopeText}`;
+
+  const richScopeText = buildScopeText((text) => text, "<runtime>");
+  const richBlocks: InputRichBlock[] = [
+    paragraphBlock(
+      isDefaultSelection
+        ? `${CHECK_MARK_EMOJI} Model reset to default\n\n${richScopeText}`
+        : [
+            `${CHECK_MARK_EMOJI} Model changed to `,
+            boldRichText(`${provider}/${model}`),
+            `\n\n${richScopeText}`,
+          ],
+    ),
+  ];
+
+  return { html, richBlocks };
+}

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -371,18 +371,22 @@ describe("Telegram topic transport payloads", () => {
       editMessage.mockRestore();
     }
 
+    // Send-before-delete: the replacement is sent first so a send failure never
+    // destroys the picker before its replacement lands (see
+    // deleteAndReplyCallbackMessage's ordering comment in
+    // bot-handlers.callback-actions.ts).
     expect(requests.map((request) => request.method)).toEqual([
-      "deleteBusinessMessages",
       "sendMessage",
+      "deleteBusinessMessages",
     ]);
-    expect(requests[0] && parseJsonBody(requests[0])).toEqual({
-      business_connection_id: "business-media-1",
-      message_ids: [41],
-    });
-    expect(requests[1] && parseJsonBody(requests[1])).toMatchObject({
+    expect(requests[0] && parseJsonBody(requests[0])).toMatchObject({
       business_connection_id: "business-media-1",
       direct_messages_topic_id: DIRECT_TOPIC_ID,
       text: "Replacement",
+    });
+    expect(requests[1] && parseJsonBody(requests[1])).toEqual({
+      business_connection_id: "business-media-1",
+      message_ids: [41],
     });
   });
 });

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-gateway.e2e.test.ts
@@ -1,0 +1,182 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
+import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { expect, test } from "vitest";
+import {
+  startQaGatewayChild,
+  startQaMockOpenAiServer,
+  writeJson,
+} from "../../../../extensions/qa-lab/api.js";
+
+// Real-behavior proof for PR #124222 / issue #123886: a rich-enabled Telegram
+// `/models` final confirmation must replace the picker through the rich edit
+// path (grammY's `api.raw.editMessageText` carrying `rich_message`), not the
+// legacy plain-text `editMessageText` call. This exercises the real callback
+// router (`bot-handlers.callback-router.ts`) -> model callback handler
+// (`bot-handlers.model-callback.ts`) -> callback actions
+// (`bot-handlers.callback-actions.ts`) chain against a real ephemeral Gateway
+// and a local mock Telegram Bot API HTTP server -- the mock/harness-only proof
+// gap ClawSweeper's review flagged as still missing.
+const TOKEN = "100001:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const CHAT_ID = 555_444;
+const PICKER_MESSAGE_ID = 42;
+
+type EditMessageTextBody = {
+  chat_id?: number;
+  message_id?: number;
+  text?: string;
+  parse_mode?: string;
+  rich_message?: { blocks?: unknown[] };
+};
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  let text = "";
+  for await (const chunk of req) {
+    text += chunk;
+  }
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+const succeed = (res: ServerResponse, result: unknown = true) =>
+  writeJson(res, 200, { ok: true, result });
+
+async function settleCleanup(...cleanups: Array<() => Promise<void>>) {
+  const failures: unknown[] = [];
+  for (const cleanup of cleanups) {
+    await cleanup().catch((error: unknown) => failures.push(error));
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Telegram model-picker gateway cleanup failed");
+  }
+}
+
+test("routes the /models final confirmation through the rich edit funnel on a real Gateway", async () => {
+  const editMessageTextCalls: EditMessageTextBody[] = [];
+  let polled = false;
+  let callbackDelivered = false;
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
+    const [, token = "", method = ""] =
+      new URL(req.url ?? "/", "http://127.0.0.1").pathname.match(/^\/bot([^/]+)\/([^/]+)$/) ?? [];
+    if (token !== TOKEN) {
+      writeJson(res, 404, { ok: false, error_code: 404, description: "Not Found" });
+      return;
+    }
+    if (method === "getMe") {
+      succeed(res, { id: 100001, is_bot: true, first_name: "QA" });
+      return;
+    }
+    if (method === "getUpdates") {
+      // First poll returns empty so the harness observes a completed short poll
+      // before the synthetic callback is injected on the next poll, matching
+      // grammY's own confirm-before-long-poll ingress contract
+      // (telegram-ingress-worker.runtime.ts's `pollingConfirmed` gate).
+      if (!polled) {
+        polled = true;
+        succeed(res, []);
+        return;
+      }
+      if (!callbackDelivered) {
+        callbackDelivered = true;
+        succeed(res, [
+          {
+            update_id: 1,
+            callback_query: {
+              id: "qa-model-select-1",
+              from: { id: 777, is_bot: false, first_name: "QA" },
+              // Required by grammY's CallbackQuery type; unused by the router but
+              // must be present for the update to deserialize correctly.
+              chat_instance: "qa-chat-instance-1",
+              message: {
+                message_id: PICKER_MESSAGE_ID,
+                date: Math.floor(Date.now() / 1000),
+                chat: { id: CHAT_ID, type: "private" },
+              },
+              data: "mdl_sel_mock-openai/gpt-5.6-luna-alt",
+            },
+          },
+        ]);
+        return;
+      }
+      succeed(res, []);
+      return;
+    }
+    const body = await readJson(req);
+    if (method === "editMessageText") {
+      editMessageTextCalls.push(body as EditMessageTextBody);
+      succeed(res, { message_id: PICKER_MESSAGE_ID });
+      return;
+    }
+    if (method === "answerCallbackQuery" || method === "deleteWebhook") {
+      succeed(res);
+      return;
+    }
+    writeJson(res, 404, { ok: false, error_code: 404, description: "Not Found" });
+  };
+  await withServer(
+    (req, res) => {
+      void handleRequest(req, res);
+    },
+    async (apiRoot) =>
+      await withTempDir("openclaw-telegram-model-picker-", async (workspace) => {
+        let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
+        let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
+        try {
+          const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+          mock = await startQaMockOpenAiServer();
+          gateway = await startQaGatewayChild({
+            repoRoot,
+            useRepoCli: true,
+            providerBaseUrl: `${mock.baseUrl}/v1`,
+            transportBaseUrl: apiRoot,
+            transport: {
+              requiredPluginIds: ["telegram"],
+              createGatewayConfig: () => ({
+                channels: {
+                  telegram: {
+                    defaultAccount: "main",
+                    accounts: {
+                      main: {
+                        enabled: true,
+                        botToken: TOKEN,
+                        apiRoot,
+                        dmPolicy: "open",
+                        allowFrom: ["*"],
+                        richMessages: true,
+                      },
+                    },
+                  },
+                },
+              }),
+            },
+            controlUiEnabled: false,
+            mutateConfig: (cfg) => {
+              cfg.agents!.defaults!.workspace = workspace;
+              return cfg;
+            },
+          });
+          await expect
+            .poll(() => editMessageTextCalls.length > 0, { interval: 50, timeout: 30_000 })
+            .toBe(true);
+          const [confirmationCall] = editMessageTextCalls;
+          expect(confirmationCall?.chat_id).toBe(CHAT_ID);
+          expect(confirmationCall?.message_id).toBe(PICKER_MESSAGE_ID);
+          // Proves the rich-edit funnel was taken (bot-handlers.callback-actions.ts's
+          // getTelegramRichRawApi(bot.api).editMessageText call): the request body
+          // carries a rich_message.blocks payload, not the legacy positional
+          // text/parse_mode shape editMessageText would otherwise send.
+          expect(confirmationCall?.rich_message?.blocks).toBeDefined();
+          expect(Array.isArray(confirmationCall?.rich_message?.blocks)).toBe(true);
+          expect(confirmationCall?.rich_message?.blocks?.length).toBeGreaterThan(0);
+          expect(confirmationCall?.text).toBeUndefined();
+          expect(confirmationCall?.parse_mode).toBeUndefined();
+          // Exactly one edit: no legacy-funnel edit was also sent for this callback.
+          expect(editMessageTextCalls).toHaveLength(1);
+        } finally {
+          await settleCleanup(
+            async () => await gateway?.stop(),
+            async () => await mock?.stop(),
+          );
+        }
+      }),
+  );
+}, 120_000);


### PR DESCRIPTION
Closes #123886

## What Problem This Solves

Fixes an issue where users with `richMessages: true` on their Telegram account and who complete the `/models` picker would see the final "✅ Model changed to…" confirmation rendered on top of / mixed with the stale rich-text markup from the picker's prior provider/model-list step, instead of a clean confirmation message. The picker's intermediate steps (provider list, model list, pagination) already fully replace the rich body correctly; only the terminal confirmation edit was affected.

## Why This Change Was Made

The `/models` picker sends its initial body as a rich message when `richMessages` is enabled, and every lifecycle edit to that message (provider list, model list, pagination) already routes through the rich funnel in `createTelegramCallbackMessageActions`. The final selection confirmation was the one exception: it always fell back to the legacy HTML `editMessageText` path. Editing a rich-sent message through that legacy text path does not fully replace the prior rich body — Telegram renders the new plain/HTML text mixed with the stale rich markup underneath it.

The fix converts the model-confirmation call site to author rich content via hand-built `RichText`/`InputRichBlock[]` when `richMessages` is enabled, following the existing `progress-draft-preview.ts` precedent for opting a `parse_mode: "HTML"` edit back onto the rich funnel:

- `TelegramCallbackRichTextOverride` lets `editCallbackMessage`/`editCallbackMessageWithButtons` accept an optional `richTextOverride`; when supplied, the edit routes through `getTelegramRichRawApi(bot.api).editMessageText(...)` with hand-built `rich_message` blocks instead of the legacy text funnel.
- `buildModelSelectionConfirmation` (new file) builds both the HTML and rich-block confirmation bodies from one shared text-building function, so the two representations can't drift apart — only model-id HTML-escaping and the runtime placeholder spelling differ per funnel.
- Non-rich accounts (`richMessages` disabled or unset) are unaffected; the legacy HTML path is unchanged for that funnel.

As a side effect of this fix, `bot-handlers.callback-router.ts` grew past the repo's 700-line oxlint `max-lines` cap, so the pre-existing ~290-line `handleTelegramModelCallback` function was extracted verbatim into a new file, `bot-handlers.model-callback.ts`, with no logic changes — pure file-split, kept in this PR so CI stays green (`AGENTS.md`: "Split files around ~700 LOC... never add a `max-lines` suppression").

This PR supersedes closed PR #124173, which introduced rich-block sending but left the confirmation edit on the legacy HTML path — ClawSweeper's own review of that PR classified it as `partial_overlap`, i.e. it fixed the picker's rich-block plumbing but not the actual reported bug (the confirmation still overlapped stale rich text). This change closes that exact gap.

## User Impact

Telegram operators with `richMessages: true` now see a single clean confirmation message when they finish the `/models` picker — no more stale/mixed rich-text markup left behind. Operators without `richMessages` enabled see no behavior change.

## Evidence

- Targeted tests: `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts extensions/telegram/src/bot-handlers.model-callback.ts extensions/telegram/src/model-confirmation-message.test.ts extensions/telegram/src/bot.test.ts` (and related callback-router/harness specs) — 151/151 passing, including a new regression test asserting `richTextOverride` routes through the rich funnel and 3 new `buildModelSelectionConfirmation` tests asserting HTML vs rich-block parity/escaping.
- Full extension suite: `node scripts/run-vitest.mjs extensions/telegram` — 3593/3594 passing; the 1 failure (`setup-surface.test.ts > accepts numeric sender ids only`) is a pre-existing, unrelated sandbox-locale artifact (`zh`-locale string vs expected English string), reproducible on `main` before this change.
- Typecheck: `pnpm tsgo:extensions` clean.
- Lint: `node scripts/run-oxlint.mjs` on all touched/added files — exit 0, confirms the `max-lines` violation from the file-split is resolved (`bot-handlers.callback-router.ts` now 395 lines, down from 706).
- Format: `pnpm format` — no diff.
- Pre-land `$autoreview` (Codex `gpt-5.6-sol`, high reasoning): `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.96)`.
- Live Telegram bot-to-bot proof was not feasible in this environment (no bot token configured); the mock-harness/unit proof above exercises the exact changed rich-funnel edit path per the ClawSweeper Review Policy real-behavior-proof gate for channel-visible changes.

## Update (commit 6973bab29b9)

Two fixes on top of the original commit:

- **ClawSweeper P1 finding addressed** — `editCallbackMessage`'s rich-routing branch previously fell back to `buildTelegramRichMarkdown(text)` for *any* rich-account callback edit that wasn't `parse_mode: "HTML"`, not just the model-picker confirmation. That silently ran markdown parsing over arbitrary un-authored text from approval receipts (`terminalizeApprovalMessage`), the plugin SDK's `respond.editMessage`, and the model picker's own intermediate pagination/provider-list/model-list/error edits — none of which are markdown-authored, so incidental `*`/`_`/backtick/`[` characters (e.g. in provider/model ids or user-controlled error text) could be reinterpreted as formatting instead of sent literally. Fixed by making rich routing strictly opt-in per call: it now only fires when the caller explicitly supplies `richTextOverride`'s hand-built blocks (as the model-picker confirmation does); every other caller — regardless of `richMessages`/`parse_mode` — stays on the legacy literal-text funnel, exactly as before this PR. `buildTelegramRichMarkdown` is no longer imported by this file (still used correctly elsewhere: streaming draft previews and the general outbound-delivery pipeline, where callers genuinely author markdown).
- **CI fixes**: `check-test-types` (two `bot-handlers.callback-actions.test.ts` blocks needed explicit `vi.fn<T>()` typing plus a null-check helper for `noUncheckedIndexedAccess`-safe `.mock.calls.at(0)` access) and `check-dependencies`/knip (`ModelSelectionConfirmationParams`/`ModelSelectionConfirmation` had no external importer and shouldn't have been exported).

**Correction to my earlier claiming comment on #123886**: I stated "clean typecheck" there; at that point `check-test-types` and `check-dependencies` were actually failing on CI (fixed now, in this commit). Apologies for the inaccurate evidence claim — flagging it here so the record is accurate.

### Updated evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts` — 7/7 passing, including a rewritten test asserting plain-text edits with no `richTextOverride` stay on the legacy funnel even when `richMessages` is enabled (inverts the prior test, which asserted the now-fixed over-broad behavior), and updated fallback/error-path tests that now supply an explicit override to exercise the rich funnel.
- `node scripts/run-vitest.mjs extensions/telegram` (full extension suite) — 3593/3594 passing; same single pre-existing unrelated `setup-surface.test.ts` locale failure noted above, reproduced identically on this branch's pre-fix HEAD via `git stash`.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — both clean.
- `knip` production + all-exports check — clean, no new dead exports.
- `node_modules/.bin/oxfmt` — no diff. `node scripts/run-oxlint.mjs` on touched files — exit 0.
- Pre-land `$autoreview` (Codex `gpt-5.6-sol`, high reasoning) rerun on this commit: `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.98)`.
- Live Telegram bot-to-bot proof remains not feasible in this environment (no bot token configured), unchanged from the original PR evidence.

## Update (commit a0dec118a21): delete-and-reply instead of legacy-edit on rich-edit failure

ClawSweeper's follow-up P2 finding on the prior commit: `editCallbackMessage`'s
catch block fell back to `legacyEditCallbackMessage(text, editParams)` whenever
the rich raw-API edit failed for a non-terminal reason. `richTextOverride` is
only ever supplied for a message that was itself sent as rich (the model
picker's final confirmation edit), so a legacy-text retry there reproduces the
exact stale-rich-markup symptom #123886 reported — the new text lands mixed
with the prior rich body instead of replacing it.

Fixed by extracting a shared `deleteAndReplyCallbackMessage` helper (delete
the rich-sent message, then send a plain reply) and using it both for this
new failure path and for `editCallbackMessageWithButtons`'s existing "no text
in the message" recovery, which had the same delete-then-reply logic inlined
already — a small dedup alongside the fix, not just a symptom patch.

### Updated evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts`
  — 8/8 passing, including a new test ("deletes and replies instead of
  legacy-editing when the rich edit fails for a non-terminal reason") and the
  `editCallbackMessageWithButtons` describe block's "deletes and replies,
  through the real /model-picker-confirmation call shape, when the rich edit
  fails" case, now reusing the shared helper.
- `node scripts/run-vitest.mjs extensions/telegram` (full extension suite) —
  3594/3595 passing; same single pre-existing unrelated `setup-surface.test.ts`
  locale failure noted above (reproduces identically on `origin/main`, not
  touched by this branch).
- `pnpm tsgo:extensions` — clean.
- `node scripts/run-oxlint.mjs` on both touched files — exit 0.
- `node_modules/.bin/oxfmt` on both touched files — no diff.
- `knip` (production + dependencies) — clean, no new unused exports.
- Pre-land `$autoreview` (Codex `gpt-5.6-sol`, high reasoning) rerun on this
  commit: `autoreview clean: no accepted/actionable findings reported`,
  `overall: patch is correct (0.97)`.
- Live Telegram bot-to-bot proof remains not feasible in this environment (no
  bot token configured), unchanged from the original PR evidence.


## Update (commit f082965e64c): correct inline comment on rich-funnel invariant

ClawSweeper's re-review on `a0dec118a21` surfaced one actionable finding:

- **[P3] Correct the callback-funnel explanation** — `extensions/telegram/src/bot-handlers.model-callback.ts:294-298`. The inline comment claimed the picker's provider/model-list edit steps "already edit through the rich funnel when richMessages is enabled." That's inaccurate: `editCallbackMessageWithButtons` only takes the rich path when the caller explicitly supplies `richTextOverride`, and none of the list/pagination/error edit calls in this file pass one — only the terminal confirmation does.

Verified the finding against real code before fixing:
- `bot-handlers.callback-actions.ts` gates rich routing on `if (!richMessages || !richTextOverride)` falling back to legacy — both conditions are required, not just `richMessages`.
- Grepped all 10 `editMessageWithButtons`/`editCallbackMessageWithButtons` call sites in `bot-handlers.model-callback.ts`: only the final confirmation call supplies rich blocks; every provider-list/model-list/pagination/error edit omits `richTextOverride` and stays on the legacy funnel.

Fix: reworded the comment to state the true invariant — those list/pagination/error steps stay on the legacy HTML funnel, and this terminal confirmation is the one call that explicitly opts into the rich funnel via `richTextOverride`. Comment-only change, no behavior difference.

Validation:
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts extensions/telegram/src/bot.test.ts` — 149/149 passing.
- `node scripts/run-oxlint.mjs extensions/telegram/src/bot-handlers.model-callback.ts` — clean.
- `node_modules/.bin/oxfmt extensions/telegram/src/bot-handlers.model-callback.ts` — applied.
- `git diff --check` — clean.

Note: ClawSweeper's proof-confidence score on this PR is driven by the disclosed, unresolved "no bot token configured in this sandbox" limitation — real Telegram behavior proof for the rich-edit/delete-and-reply path is still outstanding and I can't produce it here. That gap remains honestly disclosed rather than worked around.



## Update (commit 952e6f88239): correct remaining rich-funnel comment (late finding)

ClawSweeper's re-review on `f082965e64c` surfaced one actionable finding:

- **[P3] Correct the remaining rich-funnel explanations** — `extensions/telegram/src/model-confirmation-message.ts:4-7`. Flagged as a late finding: the same inaccurate claim fixed at `bot-handlers.model-callback.ts:294-298` in the prior commit was still present in this file's JSDoc header ("the picker's provider/model-list edits already went through the rich funnel"), and duplicated in a regression-test comment at `bot.test.ts:2881`.

Verified before fixing: grepped every `richBlocks` usage in `extensions/telegram/src/**` — `model-confirmation-message.ts` is the sole producer, and the terminal confirmation edit in `bot-handlers.model-callback.ts` is the sole consumer. Provider/list/pagination/error edits never supply `richTextOverride` and stay legacy-only, confirming the same corrected invariant already landed in the previous commit.

Fix: reworded both comments to state that legacy HTML is used by every other picker step (and as this confirmation's fallback), while rich blocks are used only by this terminal confirmation, which explicitly opts into the rich funnel via `richTextOverride`. Comment-only change, no behavior difference.

Validation:
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts extensions/telegram/src/bot.test.ts` — 149/149 passing.
- `node_modules/.bin/oxfmt` on both touched files — clean, no reformatting needed.
- `git diff --check` — clean.

Note: the disclosed "no bot token configured in this sandbox" real-Telegram-proof gap remains unresolved and unchanged from prior updates.



## Update (commit d55b43e32ef): send fallback before deleting the picker

ClawSweeper's re-review on `952e6f88239` (reviewed_at `2026-08-16T01:39:38.304Z`) surfaced one actionable finding:

- **[P2] Send the fallback before deleting the picker** — `extensions/telegram/src/bot-handlers.callback-actions.ts:115-118`. `deleteAndReplyCallbackMessage` deleted the rich picker before awaiting `sendMessage`. If that send failed, the model selection had already been applied but the user lost both the picker and its confirmation — a silent-failure outcome per this repo's own severity doctrine (silent failure ranks above crash or missing feature).

Verified before fixing:
- Read `deleteAndReplyCallbackMessage` in full: it awaited `deleteCallbackMessage()` (swallowing its own errors) and only then called `replyToCallbackChat(text, replyParams)`. Exactly as described.
- Confirmed via `git log --oneline -- extensions/telegram/src/bot-handlers.callback-actions.ts` that this helper (and its ordering) was introduced by this PR's own commit `a0dec118a21`, not a pre-existing unrelated defect — squarely in-scope to fix here.
- Confirmed via grep that no existing test covered this ordering (only that both calls occurred, not their order or the rejection path).

Fix: reordered `deleteAndReplyCallbackMessage` to call `replyToCallbackChat` (send) first, then make `deleteCallbackMessage` best-effort only after a successful send. A send failure now propagates untouched and never triggers a delete, so the picker is never destroyed without a working replacement.

Added two regression tests in `bot-handlers.callback-actions.test.ts`:
- asserts `sendMessage`'s invocation order is before `deleteMessage`'s (fails pre-fix: order was reversed);
- asserts a `sendMessage` rejection propagates and `deleteMessage` is never called (fails pre-fix: delete already happened unconditionally before the send was even attempted).

Both new tests were confirmed to fail against the pre-fix code (via `git stash` of the production change alone) for the intended reason, then pass after the fix.

Validation:
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts extensions/telegram/src/bot.test.ts` — 151/151 passing.
- `node_modules/.bin/oxfmt` on both touched files — applied, clean.
- `git diff --check` — clean.
- `.claude/skills/autoreview/scripts/autoreview --mode local` (Codex, gpt-5.6-sol, high reasoning) — clean, no accepted/actionable findings.

Note: the disclosed "no bot token configured in this sandbox" real-Telegram-proof gap remains unresolved and unchanged from prior updates.


## Update (commit 4ebf2f18165): forward business context to the fallback picker's deletion

ClawSweeper's re-review on `d55b43e32ef` (reviewed_at `2026-08-16T03:37:58.723Z`) surfaced one actionable finding:

- **[P2] Forward business context when deleting the fallback picker** — `extensions/telegram/src/bot-handlers.callback-actions.ts:119-121`. `deleteAndReplyCallbackMessage` sends the replacement with the callback's business context but then calls `deleteCallbackMessage`, whose delete omitted it. On a Business callback whose rich edit fails, the replacement could be sent while deletion silently failed and was swallowed, leaving the stale interactive picker behind.

Verified before fixing:
- Re-read `deleteCallbackMessage`: it called `bot.api.deleteMessage(chat_id, message_id)` unconditionally, while its siblings `legacyEditCallbackMessage` and `replyToCallbackChat` both forward `business_connection_id`.
- Checked grammY's typed API surface (`node_modules/grammy/out/core/api.d.ts`): `deleteMessage(chat_id, message_id, signal?)` has **no** `business_connection_id` parameter at all — unlike `editMessageText`/`sendMessage`/`editMessageReplyMarkup`, which all accept one.
- Cross-checked against the Telegram Bot API's own method list (`@grammyjs/types/methods.d.ts`): `deleteMessage` genuinely has no such field. Telegram instead exposes a dedicated method for this exact case, `deleteBusinessMessages(business_connection_id, message_ids)`, which grammY surfaces as `bot.api.deleteBusinessMessages(...)`. Deleting a business-sent message is a different Bot API call, not `deleteMessage` plus an extra field.

Fix: `deleteCallbackMessage` now calls `bot.api.deleteBusinessMessages(business_connection_id, [message_id])` when the callback carries business context, and falls back to the existing `bot.api.deleteMessage(chat_id, message_id)` otherwise.

Added a regression test in `bot-handlers.callback-actions.test.ts` asserting that a Business callback's rich-edit-failure recovery deletes via `deleteBusinessMessages` with the right connection id and message id, and never calls `deleteMessage`. Confirmed it fails against the pre-fix code (via `git stash` of the production change alone — `deleteBusinessMessages` is never called pre-fix) for the intended reason, then passes after the fix.

Validation:
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.callback-actions.test.ts extensions/telegram/src/bot.test.ts` — 152/152 passing.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — clean.
- `node_modules/.bin/oxfmt` on both touched files — applied, clean.
- `git diff --check` — clean.
- `.claude/skills/autoreview/scripts/autoreview --mode local` (Codex, gpt-5.6-sol, high reasoning) — clean, no accepted/actionable findings ("patch is correct (0.99)").

Note: the disclosed "no bot token configured in this sandbox" real-Telegram-proof gap remains unresolved and unchanged from prior updates.


## Update (head 6328eb54392): mock-gateway harness — executed transcript + verdict JSON (real-behavior proof)

ClawSweeper's `needs real behavior proof` gate asks for the added Gateway harness to be *executed* against this head, with its terminal output **and** verdict JSON supplied together. This section supersedes and consolidates my two earlier (separately-posted, and confusingly-worded) proof updates into one honest, co-located block.

Per `AGENTS.md`'s real-behavior-proof gate — "a mock-gateway harness run (mock channel API + mock provider + ephemeral gateway, verdict JSON in the PR body) satisfies it for channel-visible changes covering the changed path; live-channel proof is stronger evidence."

Harness: `test/e2e/qa-lab/runtime/telegram-model-picker-gateway.e2e.test.ts` — a real ephemeral Gateway (`startQaGatewayChild`, `richMessages: true`) + a mock OpenAI-compatible provider (`startQaMockOpenAiServer`) + a local mock Telegram Bot API HTTP server that captures the real HTTP body of every `editMessageText` call. It drives the actual production chain end-to-end: callback router → model callback handler → callback actions → grammY `api.raw.editMessageText`.

**Executed transcript (this exact head, `6328eb5`):**

```
$ node --import tsx scripts/test-projects.mts test/e2e/qa-lab/runtime/telegram-model-picker-gateway.e2e.test.ts
[test] starting test/vitest/vitest.e2e.config.ts

 RUN  v4.1.10 /Users/chenshiyang.10/workspace/openclaw

OpenClaw 2026.8.1 (6328eb5)

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  06:15:04
   Duration  197.60s (transform 3.38s, setup 256ms, import 5.55s, tests 15.86s, environment 0ms)

[test] passed 1 Vitest shard in 198.02s
```

`OpenClaw 2026.8.1 (6328eb5)` in the gateway boot log confirms the run built and exercised the current PR head, not a stale dist. `Test Files 1 passed (1) / Tests 1 passed (1)` — the single e2e case passed. (Duration is dominated by the one-time dist rebuild the e2e config triggers when `git HEAD` changed; the assertions themselves run in ~16s.)

**Verdict JSON for the run above:**

```json
{
  "harness": "mock-gateway e2e — test/e2e/qa-lab/runtime/telegram-model-picker-gateway.e2e.test.ts",
  "head": "6328eb543924fbc92376a786a15da6f150baea5a",
  "changedPath": "Telegram /models picker callback -> model selection -> rich-edit confirmation (bot-handlers.callback-router.ts -> bot-handlers.model-callback.ts -> bot-handlers.callback-actions.ts -> grammY api.raw.editMessageText)",
  "topology": "ephemeral gateway (startQaGatewayChild, own port + state dir, richMessages: true) + mock OpenAI-responses provider (startQaMockOpenAiServer) + real local mock Telegram Bot API HTTP server (getMe/getUpdates/editMessageText/answerCallbackQuery/deleteWebhook) intercepting the real grammY HTTP client",
  "steps": [
    { "step": 1, "action": "gateway starts polling; mock server's first getUpdates responds with an empty batch", "observed": "short poll completes with no updates, matching telegram-ingress-worker.runtime.ts's pollingConfirmed gate (confirm ownership before the long poll)" },
    { "step": 2, "action": "mock server injects a synthetic callback_query on the next getUpdates poll: data=\"mdl_sel_mock-openai/gpt-5.6-luna-alt\" against the picker message (chat 555444, message_id 42)", "observed": "gateway ingests the update and dispatches it into the real callback router" },
    { "step": 3, "action": "wait for an editMessageText HTTP call to arrive at the mock server", "observed": "exactly one editMessageText POST to /bot<token>/editMessageText, chat_id=555444, message_id=42", "proves": "the callback router resolved the mdl_sel_ callback through handleTelegramModelCallback and reached the terminal confirmation edit" },
    { "step": 4, "action": "inspect the captured request body", "observed": "rich_message.blocks is present, is an array, and has length > 0; text and parse_mode are both undefined", "proves": "the edit went through getTelegramRichRawApi(bot.api).editMessageText with a rich_message payload (bot-handlers.callback-actions.ts's rich funnel), not legacyEditCallbackMessage's positional text/parse_mode shape -- the exact rich-vs-legacy distinction #123886 is about" }
  ],
  "verdict": "PASS — the changed path is proven on a real gateway: a rich-enabled account's /models final confirmation is delivered through the rich edit funnel (rich_message.blocks over the real Bot-API-shaped HTTP transport), not the legacy plain-text editMessageText path"
}
```

Known gap (honestly disclosed, unchanged): this is mock-gateway proof, not a live Telegram Desktop/bot-to-bot recording — no bot token is configured in this sandbox. Per `AGENTS.md` this harness verdict satisfies the real-behavior-proof gate for this channel-visible change; a maintainer wanting stronger live evidence can trigger Mantis with the exact comment ClawSweeper suggests (`@openclaw-mantis telegram desktop proof: verify that a rich-enabled /models selection leaves one clean confirmation without stale picker markup`).



## Update (head 6328eb54392): pre-land autoreview now run — TruffleHog + Codex, clean

ClawSweeper's latest review flagged a real gap: "Autoreview could not run because TruffleHog is unavailable in the review environment." That's an accurate finding about the review sandbox — my own local sandbox does have `trufflehog` installed, so I ran the repo's mandatory pre-land `autoreview` gate here directly against this exact branch (`fix/telegram-rich-callback-edit`, head `6328eb5`) vs `origin/main`:

```
$ .claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview target: branch
branch: fix/telegram-rich-callback-edit
engine: codex
model: gpt-5.6-sol
fallback_model: gpt-5.6-terra
thinking: high
tools: on
web_search: on
ref: origin/main
trufflehog: clean (3.1s)
bundle: 70331 bytes; review passes: 1
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
No P0 defects are demonstrated by the change bundle. The patch is narrowly scoped to
Telegram rich callback editing and does not introduce a catastrophic outage, critical
security compromise, or similarly release-blocking failure at the required reporting
threshold.
```

TruffleHog's pre-scan of the full added/modified/deleted content came back clean (no verified/unknown secrets), and Codex's structured review of the complete branch-vs-`main` bundle returned no accepted or actionable findings. This satisfies the repo's pre-land autoreview gate (`$autoreview`) for this PR; the previously-reported "TruffleHog unavailable" blocker was specific to the review environment, not this branch's content.

The remaining, correctly-identified gap is still real-Telegram-callback proof per `extensions/telegram/AGENTS.md:131` (the mock-gateway harness above is supplemental, not sufficient, per that scoped policy) — that piece requires either a maintainer-triggered Mantis run or bot-to-bot QA-lane credentials I don't have standing access to provision myself.
