### PR TITLE
[AI-assisted] docs(azure-speech): fix broken Azure Speech product page link

### DIFF
--- a/docs/providers/azure-speech.md
+++ b/docs/providers/azure-speech.md
@@ -15,7 +15,7 @@ output format through the `X-Microsoft-OutputFormat` header.
 | Detail                  | Value                                                                                                          |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
 | Provider ID             | `azure-speech` (alias: `azure`)                                                                                |
-| Website                 | [Azure AI Speech](https://azure.microsoft.com/products/ai-services/ai-speech)                                  |
+| Website                 | [Azure Speech Service](https://learn.microsoft.com/azure/ai-services/speech-service/)                          |
 | Docs                    | [Speech REST text-to-speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech) |
 | Auth                    | `AZURE_SPEECH_KEY` plus `AZURE_SPEECH_REGION`                                                                  |
 | Default voice           | `en-US-JennyNeural`                                                                                            |


### PR DESCRIPTION
## What Problem This Solves

The Azure AI Speech product page URL in the `azure-speech` provider docs table
(`https://azure.microsoft.com/products/ai-services/ai-speech`) returns **HTTP
404**. Microsoft rebranded Azure AI Services to "Foundry Tools" and the
individual product page was removed. Users clicking "Website" in the provider
reference hit a dead end.

## Evidence

- Old URL: `curl -sI -L https://azure.microsoft.com/products/ai-services/ai-speech` → **404 Not Found**
- New URL: `curl -sI -L https://learn.microsoft.com/azure/ai-services/speech-service/` → **200 OK**

The replacement is the Azure Speech Service learn docs landing page, which
is the canonical home for Azure Speech documentation. The more specific
REST text-to-speech docs link in the "Docs" column already pointed to a
working URL under the same learn.microsoft.com path.

## Fix

Changed the "Website" cell in `docs/providers/azure-speech.md` from the dead
product page to the learn docs overview page.

## Notes / Risks

- Minimal one-line URL swap; no content or logic change.
- The "Docs" column already links to `learn.microsoft.com/...speech-service/rest-text-to-speech`, so the new "Website" link is consistent with the docs hierarchy.