### PR TITLE
refactor(test): exercise test-force through its CLI

### DIFF
--- a/scripts/test-force.ts
+++ b/scripts/test-force.ts
@@ -30,11 +30,6 @@ function parseArgs(argv: readonly string[]): { help: boolean } {
   return { help: false };
 }
 
-export const testForceTesting = {
-  parseArgs,
-  usage,
-};
-
 function killGatewayListeners(port: number): PortProcess[] {
   try {
     const killed = forceFreePort(port);
@@ -72,7 +67,7 @@ function runTests() {
   process.exit(result.status ?? 1);
 }
 
-export function main(argv: readonly string[] = process.argv.slice(2)) {
+function main(argv: readonly string[] = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
     console.log(usage());

--- a/test/scripts/test-force.test.ts
+++ b/test/scripts/test-force.test.ts
@@ -1,26 +1,32 @@
 // Test Force tests cover test force script behavior.
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { testForceTesting } from "../../scripts/test-force.js";
+
+function runTestForce(...args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "scripts/test-force.ts", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+}
 
 describe("scripts/test-force.ts", () => {
   it("prints help without clearing ports or running tests", () => {
-    const args = testForceTesting.parseArgs(["--help", "--bogus"]);
+    const result = runTestForce("--help");
 
-    expect(args).toEqual({ help: true });
-    expect(testForceTesting.usage()).toContain("Usage: node --import tsx scripts/test-force.ts");
-    expect(testForceTesting.usage()).not.toContain("test:force - clearing gateway");
-    expect(testForceTesting.usage()).not.toContain("running pnpm test");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: node --import tsx scripts/test-force.ts");
+    expect(result.stdout).not.toContain("test:force - clearing gateway");
+    expect(result.stdout).not.toContain("running pnpm test");
   });
 
   it("rejects unknown arguments before clearing ports or running tests", () => {
-    expect(() => testForceTesting.parseArgs(["--bogus"])).toThrow(
-      /unknown argument: --bogus[\s\S]*Usage: node --import tsx scripts\/test-force\.ts/u,
-    );
-    expect(() => testForceTesting.parseArgs(["bogus"])).toThrow(
-      /unknown argument: bogus[\s\S]*Usage: node --import tsx scripts\/test-force\.ts/u,
-    );
-    expect(() => testForceTesting.parseArgs(["bogus", "--help"])).toThrow(
-      /unknown argument: bogus[\s\S]*Usage: node --import tsx scripts\/test-force\.ts/u,
-    );
+    const result = runTestForce("--bogus");
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("unknown argument: --bogus");
+    expect(result.stderr).toContain("Usage: node --import tsx scripts/test-force.ts");
+    expect(result.stdout).not.toContain("test:force - clearing gateway");
+    expect(result.stdout).not.toContain("running pnpm test");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The `test:force` tests exercised a private parser/usage export instead of the documented command. That left the executable entrypoint, exit codes, output streams, and guarantee that invalid input stops before port cleanup outside the proof boundary.

## Why This Change Was Made

The tests now launch `scripts/test-force.ts` exactly as the package script does for help and invalid arguments. The production-only `testForceTesting` bag is removed, and `main` is private because the executable is its only caller.

This PR is AI-assisted as part of the maintainer-requested repository test-value audit.

## User Impact

No user-visible behavior changes. Maintainers get proof at the real CLI boundary instead of a test-only production seam.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-force.test.ts` — 2 passed
- `node --import tsx scripts/test-force.ts --help` — exited successfully and printed the documented help
- `node scripts/check-changed.mjs -- scripts/test-force.ts test/scripts/test-force.test.ts` — passed via the documented local fallback; script/test typechecks, lint, formatting, and tooling guards were green
- `git diff --check` — passed
- Structured autoreview — clean

Production/tooling delta: -5 net lines. Test delta: +6 net lines. No docs, changelog, release, schema, or protocol change is required.
