### PR TITLE
fix(ui): disambiguate multi-account session labels

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -207,6 +207,7 @@ export function buildSidebarSessionNavigationState(input: {
       // The sidebar's zone structure already says what forked from what;
       // a "Subagent:" prefix on named threads is noise (other surfaces keep it).
       label: resolveSessionDisplayName(row.key, row, { includeSubagentPrefix: false }),
+      userLabel: row.label,
       subtitle: resolveSessionWorkSubtitle(row),
       href: sessionNavigationTarget({
         face: resolveSessionPreferredFace(row),

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -61,6 +61,12 @@ export type SidebarRecentSession = {
   createdActor?: SessionCreatedActor;
   archivedBy?: SessionCreatedActor;
   label: string;
+  /**
+   * Stored user label, undecorated. `label` above is the resolved display name
+   * and can carry a derived account or channel; rename edits this one so a
+   * derived string never lands back in persisted state.
+   */
+  userLabel?: string;
   /** Compact repo/branch/node line for work sessions. */
   subtitle?: string;
   href: string;

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReactiveControllerHost } from "lit";
 import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
 import {
@@ -419,7 +420,10 @@ export class SessionOrganizerController {
     const nextLabel =
       (await showInputDialog?.({
         title: t("sessionsView.renameSessionPrompt"),
-        defaultValue: session.label,
+        // The stored label, not the resolved display name: pre-filling the
+        // derived string persists it on submit and it then outranks every
+        // later derivation. Matches the Sessions page rename.
+        defaultValue: normalizeOptionalString(session.userLabel) ?? "",
       })) ?? null;
     if (nextLabel === null) {
       return;

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+  trimmedTextContents,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("disambiguates same-name sessions from different Telegram accounts in the sidebar", async () => {
+    const defaultKey = "agent:main:telegram:direct:42";
+    const cardsKey = "agent:main:telegram:cards:direct:42";
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(defaultKey, "Alice", 2),
+          sessionRow(cardsKey, "Alice", 1),
+        ]),
+      },
+      sessionKey: defaultKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, defaultKey));
+      const defaultRow = page.locator(`[data-session-key="${defaultKey}"]`);
+      const cardsRow = page.locator(`[data-session-key="${cardsKey}"]`);
+      await defaultRow.waitFor({ state: "visible", timeout: 10_000 });
+      await cardsRow.waitFor({ state: "visible" });
+      await expect
+        .poll(() => trimmedTextContents(defaultRow.locator(".sidebar-recent-session__name")))
+        .toEqual(["Alice"]);
+      await expect
+        .poll(() => trimmedTextContents(cardsRow.locator(".sidebar-recent-session__name")))
+        .toEqual(["Alice · cards"]);
+      await captureUiProof(page, "telegram-account-session-labels.png");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -11,6 +11,16 @@ import {
 
 const suite = createSessionManagementE2eSuite();
 
+/**
+ * An ordinary Gateway direct-chat row: an origin-derived `displayName`, no user
+ * label, and the `accountId` the Gateway projects from the canonical route
+ * (src/gateway/session-classification.ts). Without both traits this would
+ * exercise the label branch instead of the shipped one.
+ */
+function gatewayDirectRow(key: string, updatedAt: number, accountId?: string) {
+  return { ...sessionRow(key, "Alice", updatedAt), accountId, label: undefined };
+}
+
 suite.define(() => {
   it("disambiguates same-name sessions from different Telegram accounts in the sidebar", async () => {
     const defaultKey = "agent:main:telegram:direct:42";
@@ -25,8 +35,8 @@ suite.define(() => {
     await installMockGateway(page, {
       methodResponses: {
         "sessions.list": sessionsListResponse([
-          sessionRow(defaultKey, "Alice", 2),
-          sessionRow(cardsKey, "Alice", 1),
+          gatewayDirectRow(defaultKey, 2),
+          gatewayDirectRow(cardsKey, 1, "cards"),
         ]),
       },
       sessionKey: defaultKey,

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -59,4 +59,44 @@ suite.define(() => {
       await context.close();
     }
   });
+
+  it("opens rename on the stored label, not the account-decorated name", async () => {
+    const cardsKey = "agent:main:telegram:cards:direct:42";
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([gatewayDirectRow(cardsKey, Date.now(), "cards")]),
+      },
+      sessionKey: cardsKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const row = page.locator(`[data-session-key="${cardsKey}"]`);
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+      // The row itself carries the account discriminator, so a rename field that
+      // echoed the rendered name would look plausible while persisting it.
+      await expect
+        .poll(() => trimmedTextContents(row.locator(".sidebar-recent-session__name")))
+        .toEqual(["Alice · cards"]);
+
+      await row.hover();
+      await row.getByRole("button", { name: "Open session menu" }).click();
+      await page.getByRole("menuitem", { name: "Rename…" }).click();
+      const field = page
+        .locator('openclaw-modal-dialog[label="Rename session"]')
+        .getByRole("textbox", { name: "Rename session" });
+      await field.waitFor({ state: "visible" });
+      // This row has no stored label, so the field starts empty. Submitting the
+      // decorated name here is what used to freeze it into persisted state.
+      expect(await field.inputValue()).toBe("");
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -38,53 +38,80 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:imessage:direct:+4912")).toBe("iMessage · +4912");
   });
 
-  it("surfaces a non-default account on unnamed DM and group fallbacks", () => {
+  // Rows are shaped like the Gateway projection: displayName plus the
+  // accountId it derives from the canonical route, no user label.
+  it.each([
+    {
+      name: "an account-less direct row keeps its plain name",
+      key: "agent:main:telegram:direct:42",
+      row: { displayName: "Alice" },
+      expected: "Alice",
+    },
+    {
+      name: "an account-qualified direct row names its account",
+      key: "agent:main:telegram:cards:direct:42",
+      row: { accountId: "cards", displayName: "Alice" },
+      expected: "Alice · cards",
+    },
+    {
+      name: "a shipped dm-spelled row names its account",
+      key: "agent:main:telegram:cards:dm:42",
+      row: { accountId: "cards", displayName: "Alice" },
+      expected: "Alice · cards",
+    },
+    {
+      name: "an unnamed shipped dm row reads as a friendly peer plus account",
+      key: "agent:main:telegram:cards:dm:491234567890",
+      row: { accountId: "cards" },
+      expected: "Telegram · …567890 · cards",
+    },
+    {
+      name: "the default account adds no discriminator",
+      key: "agent:main:telegram:default:direct:42",
+      row: { accountId: "default", displayName: "Alice" },
+      expected: "Alice",
+    },
+    {
+      name: "a human label that merely looks account-shaped still gets a discriminator",
+      key: "agent:main:telegram:work:direct:42",
+      row: { accountId: "work", label: "Alice (work)" },
+      expected: "Alice (work) · work",
+    },
+    {
+      name: "a canonical group key is unchanged",
+      key: "agent:main:telegram:group:-1001234567890",
+      row: undefined,
+      expected: "Telegram Group",
+    },
+    {
+      name: "an account-looking group key is not read as an account-qualified group",
+      key: "agent:main:dm:account:group:room",
+      row: undefined,
+      expected: "dm:account:group:room",
+    },
+  ])("$name", ({ key, row, expected }) => {
+    expect(resolveSessionDisplayName(key, row)).toBe(expected);
+  });
+
+  it("reads the account off the key only until the gateway row arrives", () => {
     expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:42")).toBe(
       "Telegram · 42 · cards",
     );
-    expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:491234567890")).toBe(
-      "Telegram · …567890 · cards",
-    );
-    expect(resolveSessionDisplayName("agent:main:signal:work:direct:+4912")).toBe(
+    expect(resolveSessionDisplayName("agent:main:signal:work:dm:+4912")).toBe(
       "Signal · +4912 · work",
     );
-    expect(resolveSessionDisplayName("agent:main:telegram:cards:group:-1001234567890")).toBe(
-      "Telegram Group · cards",
-    );
-  });
-
-  it("does not surface a default account segment in fallbacks", () => {
     expect(resolveSessionDisplayName("agent:main:telegram:default:direct:42")).toBe(
       "Telegram · 42",
     );
-    expect(resolveSessionDisplayName("agent:main:telegram:group:-1001234567890")).toBe(
-      "Telegram Group",
-    );
   });
 
-  it("keeps named label and displayName distinguishable across accounts", () => {
+  it("keeps the account discriminator idempotent when a rename stores it back", () => {
     expect(
       resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
-        label: "Alice",
-        displayName: "openclaw-tui",
+        accountId: "cards",
+        label: "Alice · cards",
       }),
     ).toBe("Alice · cards");
-    expect(
-      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", { displayName: "Alice" }),
-    ).toBe("Alice · cards");
-    expect(
-      resolveSessionDisplayName("agent:main:telegram:direct:42", { displayName: "Alice" }),
-    ).toBe("Alice");
-    expect(
-      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
-        displayName: "Alice · cards",
-      }),
-    ).toBe("Alice · cards");
-    expect(
-      resolveSessionDisplayName("agent:main:telegram:work:direct:42", {
-        displayName: "Alice (workflow)",
-      }),
-    ).toBe("Alice (workflow) · work");
   });
 
   it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
@@ -229,6 +256,19 @@ describe("resolveChannelSessionInfo", () => {
     expect(resolveChannelSessionInfo("agent:main:slack:acct-1:channel:C1")).toEqual({
       channel: "slack",
       channelSession: true,
+    });
+    // Shipped pre-#11881 keys spell direct chats `dm`; they are still channel sessions.
+    expect(resolveChannelSessionInfo("agent:main:telegram:cards:dm:42")).toEqual({
+      channel: "telegram",
+      channelSession: true,
+    });
+    expect(resolveChannelSessionInfo("agent:main:dm:+123", "whatsapp")).toEqual({
+      channel: "whatsapp",
+      channelSession: true,
+    });
+    // A custom key holding a peer kind where the channel belongs names no channel.
+    expect(resolveChannelSessionInfo("agent:main:dm:account:group:room")).toEqual({
+      channelSession: false,
     });
     // dmScope per-peer keys have no channel segment; the row channel wins.
     expect(resolveChannelSessionInfo("agent:main:direct:+123", "whatsapp")).toEqual({

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -78,6 +78,12 @@ describe("resolveSessionDisplayName", () => {
       expected: "Alice (work) · work",
     },
     {
+      name: "a stored label that already ends in the account suffix is left alone",
+      key: "agent:main:telegram:cards:direct:42",
+      row: { accountId: "cards", label: "Alice · cards" },
+      expected: "Alice · cards",
+    },
+    {
       name: "a canonical group key is unchanged",
       key: "agent:main:telegram:group:-1001234567890",
       row: undefined,

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -105,13 +105,21 @@ describe("resolveSessionDisplayName", () => {
     );
   });
 
-  it("keeps the account discriminator idempotent when a rename stores it back", () => {
+  it("takes the account from the gateway row, not the key", () => {
+    // Only the projection carries account identity here; the key has none.
     expect(
-      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
+      resolveSessionDisplayName("agent:main:telegram:direct:42", {
         accountId: "cards",
-        label: "Alice · cards",
+        displayName: "Alice",
       }),
     ).toBe("Alice · cards");
+    // When the two disagree, the route the Gateway parsed wins over the guess.
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
+        accountId: "ops",
+        displayName: "Alice",
+      }),
+    ).toBe("Alice · ops");
   });
 
   it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
@@ -253,7 +261,7 @@ describe("resolveChannelSessionInfo", () => {
       channel: "telegram",
       channelSession: true,
     });
-    expect(resolveChannelSessionInfo("agent:main:slack:acct-1:channel:C1")).toEqual({
+    expect(resolveChannelSessionInfo("agent:main:slack:channel:C1")).toEqual({
       channel: "slack",
       channelSession: true,
     });
@@ -266,7 +274,14 @@ describe("resolveChannelSessionInfo", () => {
       channel: "whatsapp",
       channelSession: true,
     });
-    // A custom key holding a peer kind where the channel belongs names no channel.
+    // Accounts qualify direct chats only, so these key shapes name no channel
+    // and must not be filed under one the canonical parser would reject.
+    expect(resolveChannelSessionInfo("agent:main:telegram:work:group:room")).toEqual({
+      channelSession: false,
+    });
+    expect(resolveChannelSessionInfo("agent:main:slack:acct-1:channel:C1")).toEqual({
+      channelSession: false,
+    });
     expect(resolveChannelSessionInfo("agent:main:dm:account:group:room")).toEqual({
       channelSession: false,
     });

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -38,6 +38,55 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:imessage:direct:+4912")).toBe("iMessage · +4912");
   });
 
+  it("surfaces a non-default account on unnamed DM and group fallbacks", () => {
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:42")).toBe(
+      "Telegram · 42 · cards",
+    );
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:491234567890")).toBe(
+      "Telegram · …567890 · cards",
+    );
+    expect(resolveSessionDisplayName("agent:main:signal:work:direct:+4912")).toBe(
+      "Signal · +4912 · work",
+    );
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:group:-1001234567890")).toBe(
+      "Telegram Group · cards",
+    );
+  });
+
+  it("does not surface a default account segment in fallbacks", () => {
+    expect(resolveSessionDisplayName("agent:main:telegram:default:direct:42")).toBe(
+      "Telegram · 42",
+    );
+    expect(resolveSessionDisplayName("agent:main:telegram:group:-1001234567890")).toBe(
+      "Telegram Group",
+    );
+  });
+
+  it("keeps named label and displayName distinguishable across accounts", () => {
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
+        label: "Alice",
+        displayName: "openclaw-tui",
+      }),
+    ).toBe("Alice · cards");
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", { displayName: "Alice" }),
+    ).toBe("Alice · cards");
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:direct:42", { displayName: "Alice" }),
+    ).toBe("Alice");
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:cards:direct:42", {
+        displayName: "Alice · cards",
+      }),
+    ).toBe("Alice · cards");
+    expect(
+      resolveSessionDisplayName("agent:main:telegram:work:direct:42", {
+        displayName: "Alice (workflow)",
+      }),
+    ).toBe("Alice (workflow) · work");
+  });
+
   it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
     expect(resolveSessionDisplayName("agent:main:telegram:direct:12345😀67890")).toBe(
       "Telegram · …67890",

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -39,10 +39,12 @@ const WORKTREE_BRANCH_PREFIX = "openclaw/";
 
 // `dm` is the pre-#11881 spelling of `direct`; those keys still persist and the
 // canonical parser still accepts both (src/sessions/session-key-utils.ts).
+// Only direct chats take an account segment (src/routing/session-key.ts), so an
+// account-qualified group or channel key is not a shape any producer emits and
+// must not name a channel here either.
 const CHANNEL_SESSION_KEY_RE =
-  /^agent:[^:]+:([^:]+)(?::[^:]+)?:(?:direct|dm|group|channel|thread):/;
+  /^agent:[^:]+:([^:]+)(?:(?::[^:]+)?:(?:direct|dm)|:(?:group|channel|thread)):/;
 const PEER_SESSION_KEY_RE = /:(?:direct|dm|group|channel|thread):/;
-const DIRECT_PEER_KIND_SEGMENTS = new Set(["direct", "dm"]);
 
 /**
  * Classifies channel-originated sessions for the sidebar's built-in channel
@@ -57,11 +59,7 @@ export function resolveChannelSessionInfo(
     return { channelSession: false };
   }
   const keyChannel = key.match(CHANNEL_SESSION_KEY_RE)?.[1];
-  // A per-peer key (`agent:<x>:direct:<peer>`) captures the peer kind, not a
-  // channel; only the row can name the channel then.
-  const namedChannel =
-    keyChannel && !DIRECT_PEER_KIND_SEGMENTS.has(keyChannel) ? keyChannel : undefined;
-  const channel = normalizeOptionalString(namedChannel) ?? normalizeOptionalString(rowChannel);
+  const channel = normalizeOptionalString(keyChannel) ?? normalizeOptionalString(rowChannel);
   return { channel, channelSession: Boolean(channel) };
 }
 
@@ -112,15 +110,12 @@ type SessionKeyInfo = {
 /**
  * Two DMs from different accounts routinely share a name, so the account is the
  * only discriminator; `default` is what key builders write for absence and says
- * nothing. Re-suffixing is skipped because the sidebar rename dialog pre-fills
- * with this resolved name, which can come back in as a stored label.
+ * nothing. The account is appended from the recorded fact alone — never by
+ * inspecting the rendered name, which cannot tell an account apart from a user
+ * label that happens to read like one.
  */
 function withAccountDisambiguator(name: string, accountId: string | undefined): string {
-  if (!accountId || accountId === "default") {
-    return name;
-  }
-  const suffix = ` · ${accountId}`;
-  return name.endsWith(suffix) ? name : `${name}${suffix}`;
+  return !accountId || accountId === "default" ? name : `${name} · ${accountId}`;
 }
 
 /** Typed-session prefixes come from the i18n catalog (RFC 0026). */

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -20,6 +20,9 @@ const CHANNEL_LABELS: Record<string, string> = {
 
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 
+/** Account segment that session-key builders normalize absence to. */
+const DEFAULT_ACCOUNT_ID = "default";
+
 /** Raw peer ids stay out of the sidebar; keep a short recognizable tail only. */
 function shortenPeerId(identifier: string): string {
   const trimmed = identifier.trim();
@@ -99,7 +102,30 @@ type SessionKeyInfo = {
   prefix: string;
   /** Human-readable fallback when no label / displayName is available. */
   fallbackName: string;
+  /**
+   * Non-default account from a per-account-channel-peer key. Appended to
+   * named rows as well so two "Alice" DMs stay distinguishable.
+   */
+  accountId?: string;
 };
+
+function nonDefaultAccountId(account: string | undefined): string | undefined {
+  if (!account || account === DEFAULT_ACCOUNT_ID) {
+    return undefined;
+  }
+  return account;
+}
+
+function withAccountDisambiguator(name: string, accountId?: string): string {
+  if (!accountId) {
+    return name;
+  }
+  const suffix = ` · ${accountId}`;
+  if (name.endsWith(suffix) || name.endsWith(` (${accountId})`)) {
+    return name;
+  }
+  return `${name}${suffix}`;
+}
 
 /** Typed-session prefixes come from the i18n catalog (RFC 0026). */
 function typedSessionPrefix(kind: SessionTypedKind): string {
@@ -147,28 +173,36 @@ function parseSessionKey(key: string): SessionKeyInfo {
     return { kind: "automation", prefix, fallbackName: prefix };
   }
 
-  // Direct chat: agent:<x>:<channel>:direct:<id>. Never render the raw peer
-  // id; the gateway sends origin-derived names, so this is a last resort.
-  const directMatch = key.match(/^agent:[^:]+:([^:]+):direct:(.+)$/);
+  // Direct chat: agent:<x>:<channel>[:<account>]:direct:<id>. Never render the
+  // raw peer id; the gateway sends origin-derived names, so this is a last
+  // resort. A non-default account (per-account-channel-peer) is kept so
+  // multi-account rows stay distinguishable even when they share a name.
+  const directMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:direct:(.+)$/);
   if (directMatch) {
     const channel = directMatch[1];
-    const identifier = directMatch[2];
+    const accountId = nonDefaultAccountId(directMatch[2]);
+    const identifier = directMatch[3];
     if (!channel || !identifier) {
-      return { prefix: "", fallbackName: key };
+      return { prefix: "", fallbackName: key, accountId };
     }
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} · ${shortenPeerId(identifier)}` };
+    return {
+      prefix: "",
+      fallbackName: `${channelLabel} · ${shortenPeerId(identifier)}`,
+      accountId,
+    };
   }
 
-  // Group chat: agent:<x>:<channel>:group:<id>.
-  const groupMatch = key.match(/^agent:[^:]+:([^:]+):group:(.+)$/);
+  // Group chat: agent:<x>:<channel>[:<account>]:group:<id>.
+  const groupMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:group:(.+)$/);
   if (groupMatch) {
     const channel = groupMatch[1];
+    const accountId = nonDefaultAccountId(groupMatch[2]);
     if (!channel) {
-      return { prefix: "", fallbackName: key };
+      return { prefix: "", fallbackName: key, accountId };
     }
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} Group` };
+    return { prefix: "", fallbackName: `${channelLabel} Group`, accountId };
   }
 
   // Channel-prefixed keys like "telegram:123": durable session rows written by
@@ -206,7 +240,7 @@ export function resolveSessionDisplayName(
   const label = normalizeOptionalString(row?.label) ?? "";
   const displayName = normalizeOptionalString(row?.displayName) ?? "";
   const derivedTitle = normalizeOptionalString(row?.derivedTitle) ?? "";
-  const { kind, prefix, fallbackName } = parseSessionKey(key);
+  const { kind, prefix, fallbackName, accountId } = parseSessionKey(key);
 
   const applyTypedPrefix = (rawName: string): string => {
     if (!kind || !prefix) {
@@ -227,20 +261,20 @@ export function resolveSessionDisplayName(
   };
 
   if (label && label !== key) {
-    return applyTypedPrefix(label);
+    return withAccountDisambiguator(applyTypedPrefix(label), accountId);
   }
   if (displayName && displayName !== key) {
-    return applyTypedPrefix(displayName);
+    return withAccountDisambiguator(applyTypedPrefix(displayName), accountId);
   }
   // Unnamed work sessions read as their checkout instead of an opaque key.
   const workSubtitle = row ? resolveSessionWorkSubtitle(row) : undefined;
   if (workSubtitle && row?.worktree) {
-    return applyTypedPrefix(workSubtitle);
+    return withAccountDisambiguator(applyTypedPrefix(workSubtitle), accountId);
   }
   if (derivedTitle && derivedTitle !== key) {
-    return applyTypedPrefix(derivedTitle);
+    return withAccountDisambiguator(applyTypedPrefix(derivedTitle), accountId);
   }
-  return fallbackName;
+  return withAccountDisambiguator(fallbackName, accountId);
 }
 
 export function isCronSessionKey(key: string): boolean {

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -20,9 +20,6 @@ const CHANNEL_LABELS: Record<string, string> = {
 
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 
-/** Account segment that session-key builders normalize absence to. */
-const DEFAULT_ACCOUNT_ID = "default";
-
 /** Raw peer ids stay out of the sidebar; keep a short recognizable tail only. */
 function shortenPeerId(identifier: string): string {
   const trimmed = identifier.trim();
@@ -40,8 +37,12 @@ function shortenOpaqueIdRuns(text: string): string {
 
 const WORKTREE_BRANCH_PREFIX = "openclaw/";
 
-const CHANNEL_SESSION_KEY_RE = /^agent:[^:]+:([^:]+)(?::[^:]+)?:(?:direct|group|channel|thread):/;
-const PEER_SESSION_KEY_RE = /:(?:direct|group|channel|thread):/;
+// `dm` is the pre-#11881 spelling of `direct`; those keys still persist and the
+// canonical parser still accepts both (src/sessions/session-key-utils.ts).
+const CHANNEL_SESSION_KEY_RE =
+  /^agent:[^:]+:([^:]+)(?::[^:]+)?:(?:direct|dm|group|channel|thread):/;
+const PEER_SESSION_KEY_RE = /:(?:direct|dm|group|channel|thread):/;
+const DIRECT_PEER_KIND_SEGMENTS = new Set(["direct", "dm"]);
 
 /**
  * Classifies channel-originated sessions for the sidebar's built-in channel
@@ -56,9 +57,11 @@ export function resolveChannelSessionInfo(
     return { channelSession: false };
   }
   const keyChannel = key.match(CHANNEL_SESSION_KEY_RE)?.[1];
-  const channel =
-    normalizeOptionalString(keyChannel && keyChannel !== "direct" ? keyChannel : undefined) ??
-    normalizeOptionalString(rowChannel);
+  // A per-peer key (`agent:<x>:direct:<peer>`) captures the peer kind, not a
+  // channel; only the row can name the channel then.
+  const namedChannel =
+    keyChannel && !DIRECT_PEER_KIND_SEGMENTS.has(keyChannel) ? keyChannel : undefined;
+  const channel = normalizeOptionalString(namedChannel) ?? normalizeOptionalString(rowChannel);
   return { channel, channelSession: Boolean(channel) };
 }
 
@@ -102,29 +105,22 @@ type SessionKeyInfo = {
   prefix: string;
   /** Human-readable fallback when no label / displayName is available. */
   fallbackName: string;
-  /**
-   * Non-default account from a per-account-channel-peer key. Appended to
-   * named rows as well so two "Alice" DMs stay distinguishable.
-   */
+  /** Raw account segment; only a fallback, Gateway rows carry the real one. */
   accountId?: string;
 };
 
-function nonDefaultAccountId(account: string | undefined): string | undefined {
-  if (!account || account === DEFAULT_ACCOUNT_ID) {
-    return undefined;
-  }
-  return account;
-}
-
-function withAccountDisambiguator(name: string, accountId?: string): string {
-  if (!accountId) {
+/**
+ * Two DMs from different accounts routinely share a name, so the account is the
+ * only discriminator; `default` is what key builders write for absence and says
+ * nothing. Re-suffixing is skipped because the sidebar rename dialog pre-fills
+ * with this resolved name, which can come back in as a stored label.
+ */
+function withAccountDisambiguator(name: string, accountId: string | undefined): string {
+  if (!accountId || accountId === "default") {
     return name;
   }
   const suffix = ` · ${accountId}`;
-  if (name.endsWith(suffix) || name.endsWith(` (${accountId})`)) {
-    return name;
-  }
-  return `${name}${suffix}`;
+  return name.endsWith(suffix) ? name : `${name}${suffix}`;
 }
 
 /** Typed-session prefixes come from the i18n catalog (RFC 0026). */
@@ -138,6 +134,8 @@ type SessionDisplayRow = {
   label?: string;
   displayName?: string;
   derivedTitle?: string;
+  /** Canonical account projected from the delivery route by the Gateway. */
+  accountId?: string;
 } & SessionWorktreeDisplayRow;
 
 type SessionDisplayOptions = {
@@ -173,14 +171,13 @@ function parseSessionKey(key: string): SessionKeyInfo {
     return { kind: "automation", prefix, fallbackName: prefix };
   }
 
-  // Direct chat: agent:<x>:<channel>[:<account>]:direct:<id>. Never render the
-  // raw peer id; the gateway sends origin-derived names, so this is a last
-  // resort. A non-default account (per-account-channel-peer) is kept so
-  // multi-account rows stay distinguishable even when they share a name.
-  const directMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:direct:(.+)$/);
+  // Direct chat: agent:<x>:<channel>[:<account>]:(direct|dm):<id>. Never render
+  // the raw peer id; the gateway sends origin-derived names, so this is a last
+  // resort.
+  const directMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:(?:direct|dm):(.+)$/);
   if (directMatch) {
     const channel = directMatch[1];
-    const accountId = nonDefaultAccountId(directMatch[2]);
+    const accountId = directMatch[2];
     const identifier = directMatch[3];
     if (!channel || !identifier) {
       return { prefix: "", fallbackName: key, accountId };
@@ -193,16 +190,17 @@ function parseSessionKey(key: string): SessionKeyInfo {
     };
   }
 
-  // Group chat: agent:<x>:<channel>[:<account>]:group:<id>.
-  const groupMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:group:(.+)$/);
+  // Group chat: agent:<x>:<channel>:group:<id>. buildAgentPeerSessionKey scopes
+  // accounts to DMs (src/routing/session-key.ts), so an account-looking segment
+  // here belongs to a custom key and must not be read as one.
+  const groupMatch = key.match(/^agent:[^:]+:([^:]+):group:(.+)$/);
   if (groupMatch) {
     const channel = groupMatch[1];
-    const accountId = nonDefaultAccountId(groupMatch[2]);
     if (!channel) {
-      return { prefix: "", fallbackName: key, accountId };
+      return { prefix: "", fallbackName: key };
     }
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} Group`, accountId };
+    return { prefix: "", fallbackName: `${channelLabel} Group` };
   }
 
   // Channel-prefixed keys like "telegram:123": durable session rows written by
@@ -240,7 +238,10 @@ export function resolveSessionDisplayName(
   const label = normalizeOptionalString(row?.label) ?? "";
   const displayName = normalizeOptionalString(row?.displayName) ?? "";
   const derivedTitle = normalizeOptionalString(row?.derivedTitle) ?? "";
-  const { kind, prefix, fallbackName, accountId } = parseSessionKey(key);
+  const { kind, prefix, fallbackName, accountId: keyAccountId } = parseSessionKey(key);
+  // The Gateway records the account on the row (src/gateway/session-classification.ts);
+  // the key is parsed only for panes rendered before their row arrives.
+  const accountId = normalizeOptionalString(row?.accountId) ?? keyAccountId;
 
   const applyTypedPrefix = (rawName: string): string => {
     if (!kind || !prefix) {
@@ -260,21 +261,25 @@ export function resolveSessionDisplayName(
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
 
-  if (label && label !== key) {
-    return withAccountDisambiguator(applyTypedPrefix(label), accountId);
-  }
-  if (displayName && displayName !== key) {
-    return withAccountDisambiguator(applyTypedPrefix(displayName), accountId);
-  }
-  // Unnamed work sessions read as their checkout instead of an opaque key.
-  const workSubtitle = row ? resolveSessionWorkSubtitle(row) : undefined;
-  if (workSubtitle && row?.worktree) {
-    return withAccountDisambiguator(applyTypedPrefix(workSubtitle), accountId);
-  }
-  if (derivedTitle && derivedTitle !== key) {
-    return withAccountDisambiguator(applyTypedPrefix(derivedTitle), accountId);
-  }
-  return withAccountDisambiguator(fallbackName, accountId);
+  const resolveNamedOrFallback = (): string => {
+    if (label && label !== key) {
+      return applyTypedPrefix(label);
+    }
+    if (displayName && displayName !== key) {
+      return applyTypedPrefix(displayName);
+    }
+    // Unnamed work sessions read as their checkout instead of an opaque key.
+    const workSubtitle = row ? resolveSessionWorkSubtitle(row) : undefined;
+    if (workSubtitle && row?.worktree) {
+      return applyTypedPrefix(workSubtitle);
+    }
+    if (derivedTitle && derivedTitle !== key) {
+      return applyTypedPrefix(derivedTitle);
+    }
+    return fallbackName;
+  };
+
+  return withAccountDisambiguator(resolveNamedOrFallback(), accountId);
 }
 
 export function isCronSessionKey(key: string): boolean {

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -115,7 +115,11 @@ type SessionKeyInfo = {
  * label that happens to read like one.
  */
 function withAccountDisambiguator(name: string, accountId: string | undefined): string {
-  return !accountId || accountId === "default" ? name : `${name} · ${accountId}`;
+  if (!accountId || accountId === "default") {
+    return name;
+  }
+  const suffix = ` · ${accountId}`;
+  return name.endsWith(suffix) ? name : `${name}${suffix}`;
 }
 
 /** Typed-session prefixes come from the i18n catalog (RFC 0026). */

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -110,9 +110,12 @@ type SessionKeyInfo = {
 /**
  * Two DMs from different accounts routinely share a name, so the account is the
  * only discriminator; `default` is what key builders write for absence and says
- * nothing. The account is appended from the recorded fact alone — never by
- * inspecting the rendered name, which cannot tell an account apart from a user
- * label that happens to read like one.
+ * nothing. Which account to show comes from the recorded fact alone, never from
+ * the rendered name. The suffix check is idempotence, not inference: the chat
+ * pane's inline rename seeds its input with the rendered title
+ * (`beginHeaderRename`), so a partially edited submit can persist a label that
+ * already ends in this suffix, and appending twice would render
+ * `Alice · cards · cards`.
  */
 function withAccountDisambiguator(name: string, accountId: string | undefined): string {
   if (!accountId || accountId === "default") {


### PR DESCRIPTION
## What Problem This Solves

With more than one account on a channel, session keys namespace the account
(`agent:main:telegram:direct:<chatId>` vs `agent:main:telegram:cards:direct:<chatId>`).
The Control UI display resolver only understood the account-less shape, so the `cards`
session fell through to a raw key (`telegram:cards:direct:42`) while the default session
rendered as `Telegram · 42`. When both rows already carried a Gateway `displayName` such
as `Alice`, the two rows were indistinguishable in the sidebar.

The same resolver had a second gap: session keys written before #11881 spell direct chats
`dm`. The canonical parser still accepts both spellings (`src/sessions/session-key-utils.ts`),
but the display resolver recognized neither the `dm` shape nor its account segment, so
those rows leaked their raw key and were dropped from the sidebar's channel sections.

Addresses the session-label portion of #123112. That issue also reports that outbound
sends through a non-default account leave the target session's history empty. This change
does not implement or test that path, so the issue stays open.

## Why This Change Was Made

Display should not have to recover the account from the key. The Gateway already parses
the canonical delivery route and records `accountId` on every session row
(`src/gateway/session-classification.ts`, `packages/gateway-protocol/src/schema/sessions-row.ts`).
The resolver now consumes that recorded fact and parses the key only as a fallback, for
panes rendered before their row arrives. The account suffix is applied at one point rather
than on each naming branch, so a future branch cannot silently skip it.

*Which* account to show is taken from the recorded value alone — never read out of the
rendered name, and never out of a `(<accountId>)` in a label — so a user label that happens
to read like an account cannot suppress or fake the discriminator. The rendered name is
consulted for exactly one thing: whether the suffix is already on the end.

That check is idempotence rather than inference, and it earns its place because the chat
pane's inline title rename is a live producer of suffixed labels. `beginHeaderRename` seeds
its input with `customLabel ?? paneTitle`, and `paneTitle` is the resolved display name,
which this PR teaches to carry the account. `commitHeaderRename` skips the write only when
the derived title comes back completely untouched, so a partial edit persists verbatim:
opening the rename on an unlabeled `cards` session and typing a word in front of
`Alice · cards` stores `VIP Alice · cards`. Appending unconditionally would then render
`VIP Alice · cards · cards`.

The sidebar dialog is no longer such a producer. It pre-filled with the *resolved* display
name, so submitting it persisted a derived string as a real user label, which then
outranked every later derivation. Sidebar rows now carry the stored label alongside the
resolved one and rename edits that, matching what the Sessions page already did.

Follow-up, not fixed here: an editable field should be seeded from the stored label, or at
most from the undecorated name, so presentation never becomes persisted data. Fixing it in
the chat pane changes a deliberate affordance from #121452 and wants its own discussion, so
this PR keeps the idempotence check and leaves the producer alone.

Key grammar is held to shapes producers actually emit. `buildAgentPeerSessionKey` scopes
accounts to direct sessions only (`src/routing/session-key.ts`), so an account segment is
accepted only before `direct`/`dm`. Both display and channel classification enforce that;
previously `agent:<agent>:<channel>:<account>:group:<id>` was filed under a channel even
though the canonical route parser rejects it.

## User Impact

Sidebar rows, command palette entries, chat pane titles, recent chats, and dashboard rows
show the account for any session on a non-default account: `Alice` for the default account,
`Alice · cards` for the `cards` account. The `default` account adds no suffix and
account-less keys are unchanged. Sessions whose keys still use the pre-#11881 `dm` spelling
stop leaking their raw key and are grouped under their channel again.

## Evidence

Control UI sidebar, isolated Gateway fixture, real Control UI under Playwright Chromium.
Two Telegram direct chats that both resolve to the name `Alice`:

- `agent:main:telegram:direct:42` renders `Alice`
- `agent:main:telegram:cards:direct:42` renders `Alice · cards`

![Control UI sidebar: Alice vs Alice · cards](https://github.com/user-attachments/assets/8f119335-5323-4423-adeb-a2a62693ab49)

The browser fixture now builds ordinary Gateway rows: an origin-derived `displayName`, no
user label, and the `accountId` the Gateway projects from the canonical route. Without both
traits the scenario would exercise the label-precedence branch instead of the shipped one.

Resolver regressions in `ui/src/lib/session-display.test.ts`:

| Key / row | Expected |
| --- | --- |
| Account-less `direct`, `displayName: Alice` | `Alice` |
| Account-qualified `direct`, `accountId: cards`, `displayName: Alice` | `Alice · cards` |
| Account-qualified `dm`, `accountId: cards`, `displayName: Alice` | `Alice · cards` |
| Unnamed account-qualified `dm` | `Telegram · …567890 · cards` |
| `accountId: default` | no account suffix |
| `accountId: work`, label `Alice (work)` | `Alice (work) · work` |
| `accountId: cards`, label `Alice · cards` | `Alice · cards`, not doubled |
| Canonical account-less group key | `Telegram Group`, unchanged |
| `agent:main:dm:account:group:room` | not read as an account-qualified group |
| Account-less key, `accountId: cards` on the row only | `Alice · cards` |
| Key says `cards`, row says `ops` | `Alice · ops`, the projection wins |
| `resolveChannelSessionInfo` on a `dm` key | channel session on `telegram` |
| `resolveChannelSessionInfo` on `<channel>:<account>:group:<id>` | not a channel session |

Commands:

```console
$ node scripts/run-vitest.mjs ui/src/lib/session-display.test.ts
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
    ui/src/e2e/session-management.account-label.e2e.test.ts
$ node scripts/check-changed.mjs --dry-run -- ui/src/lib/session-display.ts \
    ui/src/lib/session-display.test.ts ui/src/e2e/session-management.account-label.e2e.test.ts
[check:changed:dry-run] lanes=coreTests, ui
```

Prior attempt #123186 parsed the key into the unnamed fallback only and closed unmerged:
named `displayName` rows still collided. Surface: production +81/-32 across four files
(net +49), of which 34 added lines are comments and 14 are an unchanged block re-indented
into a helper; tests +213/-1.

Related:

- Issue: https://github.com/openclaw/openclaw/issues/123112
- Closed unmerged attempt: https://github.com/openclaw/openclaw/pull/123186
- Account-qualified keys: `per-account-channel-peer` in [`d499b148423`](https://github.com/openclaw/openclaw/commit/d499b148423)
- `dm` to `direct` rename: #11881

