### PR TITLE
refactor(test): remove duplicate ClawHub archive case

### DIFF
--- a/test/scripts/clawhub-bootstrap-artifact.test.ts
+++ b/test/scripts/clawhub-bootstrap-artifact.test.ts
@@ -393,41 +393,6 @@ describe("ClawHub packed artifact identity", () => {
     });
   });
 
-  it("rejects a whitespace-bearing alias before a later package.json", async () => {
-    const pack = writeClawPack([
-      {
-        name: " package.json ",
-        prefix: " package ",
-        contents: JSON.stringify({
-          name: "@openclaw/meta-provider",
-          version: "2026.7.1-beta.3",
-        }),
-      },
-      {
-        name: "package/package.json",
-        contents: JSON.stringify({
-          name: "@openclaw/other",
-          version: "9.9.9",
-        }),
-      },
-      {
-        name: "package/openclaw.plugin.json",
-        contents: JSON.stringify({ id: "meta" }),
-      },
-    ]);
-
-    await expect(
-      verifyClawHubPackedArtifactIdentity({
-        artifactPath: pack.artifactPath,
-        expectedSha256: pack.sha256,
-        expectedSize: String(pack.bytes.byteLength),
-        expectedDir: "extensions/meta",
-        expectedName: "@openclaw/meta-provider",
-        expectedVersion: "2026.7.1-beta.3",
-      }),
-    ).rejects.toThrow("changes under the pinned ClawHub path normalization");
-  });
-
   it("rejects a whitespace-bearing alias after a canonical package.json", async () => {
     const pack = writeClawPack([
       {


### PR DESCRIPTION
## What Problem This Solves

The ClawHub bootstrap suite repeated a hostile USTAR whitespace case already covered more completely by the canonical plugin-publication parser tests. Maintaining the consumer-local copy duplicated TAR construction and assertions without protecting a distinct behavior.

## Why This Change Was Made

The duplicated “whitespace alias before package.json” case is removed from the ClawHub bootstrap suite. The parser-owner test remains table-driven across both USTAR name and prefix fields and proves rejection before manifest selection. The consumer-local “alias after canonical package.json” case remains because it independently proves the parser scans the entire archive.

This PR is AI-assisted as part of the maintainer-requested repository test-value audit.

## User Impact

No user-visible or release behavior changes. The release test suite keeps the stronger security proof with less duplicated fixture code.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/clawhub-bootstrap-artifact.test.ts test/scripts/plugin-publication-artifact.test.ts` — 60 passed
- `node scripts/check-changed.mjs -- test/scripts/clawhub-bootstrap-artifact.test.ts` — passed via the documented local fallback; test typecheck, formatting, lint, and tooling guards were green
- `git diff --check` — passed
- Structured autoreview — clean

Production/tooling delta: 0. Test delta: -35 lines. No docs, changelog, release, schema, protocol, or operator-state change is required.
