### PR TITLE
refactor(test): prove release validation through its harness

### DIFF
--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -401,20 +401,31 @@ describe("full-release-validation-at-sha", () => {
         ),
       );
       const dispatch = ghCalls.find((args) => args[0] === "workflow" && args[1] === "run");
-      expect(dispatch).toEqual(
-        expect.arrayContaining([
-          "--ref",
-          workflowBranch,
-          "-f",
-          `ref=${targetBranch}`,
-          "-f",
-          `expected_sha=${fixture.targetSha}`,
-          "-f",
-          `target_context_ref=${fixture.releaseRef}`,
-          "-f",
-          "allow_unreleased_changelog=false",
-        ]),
-      );
+      expect(dispatch?.slice(0, 5)).toEqual([
+        "workflow",
+        "run",
+        "full-release-validation.yml",
+        "--ref",
+        workflowBranch,
+      ]);
+      const inputArgs = dispatch?.slice(5) ?? [];
+      expect(inputArgs.length % 2).toBe(0);
+      const dispatchInputs: Record<string, string> = {};
+      for (let index = 0; index < inputArgs.length; index += 2) {
+        expect(inputArgs[index]).toBe("-f");
+        const assignment = inputArgs[index + 1];
+        const separatorIndex = assignment?.indexOf("=") ?? -1;
+        if (!assignment || separatorIndex <= 0) {
+          throw new Error(`invalid workflow input assignment: ${String(assignment)}`);
+        }
+        dispatchInputs[assignment.slice(0, separatorIndex)] = assignment.slice(separatorIndex + 1);
+      }
+      expect(dispatchInputs).toMatchObject({
+        ref: targetBranch,
+        expected_sha: fixture.targetSha,
+        target_context_ref: fixture.releaseRef,
+        allow_unreleased_changelog: "false",
+      });
       expect(ghCalls).toContainEqual(["api", "repos/openclaw/openclaw/actions/runs/123"]);
       expect(ghCalls.some((args) => args[0] === "graphql")).toBe(false);
       expect(ghCalls.some((args) => args[0] === "run" && args[1] === "watch")).toBe(false);

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -199,15 +199,6 @@ describe("full-release-validation-at-sha", () => {
     expect(releaseProfileForTarget("a".repeat(40), readVersion("2026.7.1-1"))).toBe("stable");
   });
 
-  it("keeps release context separate from the exact target SHA", () => {
-    const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
-    expect(source).toContain("ref: targetBranch");
-    expect(source).toContain("target_context_ref: targetContextRef");
-    expect(source).toContain(
-      'args.inputs.allow_unreleased_changelog ??= args.targetRef ? "false" : "true"',
-    );
-  });
-
   it("rejects missing option values", () => {
     expect(() => parseArgs(["--sha", "--dry-run"])).toThrow("--sha requires a value");
     expect(() => parseArgs(["--sha", "-h"])).toThrow("--sha requires a value");
@@ -293,11 +284,10 @@ describe("full-release-validation-at-sha", () => {
     expect(() => releaseEvidenceVerificationArgs("")).toThrow("positive decimal");
   });
 
-  it("polls the exact workflow run without GraphQL quota use", () => {
+  it("bounds polling for the exact workflow run", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES).toBe(720);
     expect(FULL_RELEASE_WAIT_POLL_INTERVAL_MS).toBe(45_000);
-    expect(source).toContain("actions/runs/${parentRunId}");
     expect(source).toContain("workflowRun.head_sha !== workflowSha");
     expect(source).toContain("return suite;");
     expect(source).toContain("Date.now() + FULL_RELEASE_WAIT_TIMEOUT_MINUTES * 60_000");
@@ -307,8 +297,6 @@ describe("full-release-validation-at-sha", () => {
       "Timed out after ${FULL_RELEASE_WAIT_TIMEOUT_MINUTES} minutes waiting for Full Release Validation",
     );
     expect(source).not.toContain("attempt < 480");
-    expect(source).not.toContain('"graphql"');
-    expect(source).not.toContain('["run", "watch"');
   });
 
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {
@@ -348,11 +336,6 @@ describe("full-release-validation-at-sha", () => {
         () => "on:\n  workflow_dispatch:\n    inputs: {}\n",
       ),
     ).toThrow(`Tooling SHA ${"b".repeat(40)} is missing workflow_dispatch input expected_sha`);
-
-    const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
-    expect(source.indexOf("assertTrustedWorkflowHarness(workflowSha);")).toBeLessThan(
-      source.indexOf('run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`]'),
-    );
   });
 
   it("retains a failed parent workflow ref for GitHub reruns", () => {
@@ -428,8 +411,13 @@ describe("full-release-validation-at-sha", () => {
           `expected_sha=${fixture.targetSha}`,
           "-f",
           `target_context_ref=${fixture.releaseRef}`,
+          "-f",
+          "allow_unreleased_changelog=false",
         ]),
       );
+      expect(ghCalls).toContainEqual(["api", "repos/openclaw/openclaw/actions/runs/123"]);
+      expect(ghCalls.some((args) => args[0] === "graphql")).toBe(false);
+      expect(ghCalls.some((args) => args[0] === "run" && args[1] === "watch")).toBe(false);
       expect(result.stdout).toContain(`Validation SHA: ${fixture.targetSha}`);
       expect(result.stdout).toContain(`Tooling SHA: ${fixture.workflowSha}`);
       expect(result.stdout).toContain(


### PR DESCRIPTION
## What Problem This Solves

The full-release validation tests partially re-read `scripts/full-release-validation-at-sha.mts` and searched for implementation strings. Those assertions broke under behavior-preserving refactors and duplicated behavior already observable through the repository's executable dispatch fixture.

## Why This Change Was Made

Release context, candidate SHA, unreleased-changelog policy, exact REST polling, and the absence of GraphQL or `gh run watch` are now asserted from the real subprocess's recorded `git`/`gh` calls. The old source-order check is removed because the existing old-schema fixture already proves zero remote pushes and zero GitHub calls before trusted-harness validation succeeds.

The bounded 720-minute deadline, 45-second poll interval, bounded remaining sleep, retry cap removal, and dispatch timeout distinction remain independently guarded.

This PR is AI-assisted as part of the maintainer-requested repository test-value audit.

## User Impact

No release behavior changes. Maintainers keep the same release-safety coverage with less coupling to source layout and local expression spelling.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts` — 19 passed after the review correction
- The executable fixture parses every trailing workflow input as an adjacent `-f` / `key=value` pair before asserting the required release fields
- `node scripts/check-changed.mjs -- test/scripts/full-release-validation-at-sha.test.ts` — passed via the documented local fallback; test typecheck, formatting, lint, and tooling guards were green
- `git diff --check` — passed
- Structured autoreview after the pairwise assertion correction — clean

Production/tooling delta: 0. Test delta: -1 net line. No docs, changelog, release behavior, schema, protocol, or operator-state change is required.
