### PR TITLE
fix(outbound): keep email addresses in plain-text replies

### DIFF
--- a/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test-support.ts
@@ -1,4 +1,5 @@
 // Imessage test support covers sanitize outbound plugin behavior.
+import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it } from "vitest";
 import {
   protectIMessageFencedRoleMarkers,
@@ -95,6 +96,14 @@ describe("sanitizeOutboundText", () => {
     ]) {
       expect(sanitizeIMessageFinalOutboundText(source).text).toBe(source);
     }
+  });
+
+  it("strips colon-qualified tags before the final security projection", () => {
+    const text = sanitizeForPlainText("<vendor:note>visible</vendor:note>", {
+      style: "markdown",
+    });
+
+    expect(sanitizeIMessageFinalOutboundText(text).text).toBe("visible");
   });
 
   it.each([

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -25,7 +25,7 @@ const PRIVATE_USE_START = 0xe000;
 const PRIVATE_USE_END = 0xf8ff;
 const MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES = 32;
 // Mirror the private shared plain-text HTML grammar to inspect every destructive removal stage.
-const PLAIN_TEXT_HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
+const PLAIN_TEXT_HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*(?=[\s/>])[^>]*>/gi;
 const PRIVATE_PROVIDER_TAG_NAMES = [
   "think",
   "thinking",

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -25,7 +25,7 @@ const PRIVATE_USE_START = 0xe000;
 const PRIVATE_USE_END = 0xf8ff;
 const MAX_PRIVATE_MARKDOWN_UNWRAP_PASSES = 32;
 // Mirror the private shared plain-text HTML grammar to inspect every destructive removal stage.
-const PLAIN_TEXT_HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*(?=[\s/>])[^>]*>/gi;
+const PLAIN_TEXT_HTML_TAG_RE = /<\/?[a-z][a-z0-9_.:-]*(?=[\s/>])[^>]*>/gi;
 const PRIVATE_PROVIDER_TAG_NAMES = [
   "think",
   "thinking",

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -82,6 +82,12 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText('<a href="https://example.com">link</a>')).toBe("link");
   });
 
+  it("strips colon- and dot-qualified tags", () => {
+    expect(
+      sanitizeForPlainText("<vendor:note>one</vendor:note><vendor.note>two</vendor.note>"),
+    ).toBe("onetwo");
+  });
+
   it("keeps stripping tags exposed by malformed tag text", () => {
     const sanitized = sanitizeForPlainText(
       "before <<script>script>alert(1)</<script>script> after",

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -174,17 +174,9 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("Contact us at Support <support@example.com> or reply here")).toBe(
       "Contact us at Support <support@example.com> or reply here",
     );
-    expect(sanitizeForPlainText("Ping <alice@example.org> and <bob@example.net>")).toBe(
-      "Ping <alice@example.org> and <bob@example.net>",
-    );
   });
 
   it("still strips tags whose name ends at a tag boundary", () => {
-    // The angle-addr carve-out keys on the character after the tag name, so
-    // real markup, mention aliases, and scaffolding must keep stripping.
-    expect(sanitizeForPlainText('Mail <a href="mailto:support@example.com">us</a> now')).toBe(
-      "Mail us now",
-    );
     expect(sanitizeForPlainText("Ping <users/abc> for access")).toBe("Ping  for access");
   });
 

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -170,6 +170,24 @@ describe("sanitizeForPlainText", () => {
     );
   });
 
+  it("preserves angle-addr email addresses", () => {
+    expect(sanitizeForPlainText("Contact us at Support <support@example.com> or reply here")).toBe(
+      "Contact us at Support <support@example.com> or reply here",
+    );
+    expect(sanitizeForPlainText("Ping <alice@example.org> and <bob@example.net>")).toBe(
+      "Ping <alice@example.org> and <bob@example.net>",
+    );
+  });
+
+  it("still strips tags whose name ends at a tag boundary", () => {
+    // The angle-addr carve-out keys on the character after the tag name, so
+    // real markup, mention aliases, and scaffolding must keep stripping.
+    expect(sanitizeForPlainText('Mail <a href="mailto:support@example.com">us</a> now')).toBe(
+      "Mail us now",
+    );
+    expect(sanitizeForPlainText("Ping <users/abc> for access")).toBe("Ping  for access");
+  });
+
   // --- passthrough --------------------------------------------------------
 
   it("passes through clean text unchanged", () => {

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -8,7 +8,7 @@ import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 export { stripInternalRuntimeScaffolding };
 
 // A tag name ends at whitespace, `/`, or `>`; `<user@example.com>` is prose, not markup.
-const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*(?=[\s/>])[^>]*>/gi;
+const HTML_TAG_RE = /<\/?[a-z][a-z0-9_.:-]*(?=[\s/>])[^>]*>/gi;
 const MAY_CONTAIN_MARKDOWN_CODE_RE = /[`~]|\t| {4}/;
 const CODE_ESCAPE = "\u0000e";
 const CODE_PLACEHOLDER = "\u0000p";

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -7,7 +7,8 @@ import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 // Retained for the deprecated plugin-sdk/infra-runtime compatibility barrel.
 export { stripInternalRuntimeScaffolding };
 
-const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
+// A tag name ends at whitespace, `/`, or `>`; `<user@example.com>` is prose, not markup.
+const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*(?=[\s/>])[^>]*>/gi;
 const MAY_CONTAIN_MARKDOWN_CODE_RE = /[`~]|\t| {4}/;
 const CODE_ESCAPE = "\u0000e";
 const CODE_PLACEHOLDER = "\u0000p";


### PR DESCRIPTION
Closes #124217

## What Problem This Solves

Plain-text outbound sanitization treated an RFC 5322 angle-address such as
`Support <support@example.com>` as HTML and silently deleted the address before
delivery. This affects every caller of the shared sanitizer, including Telegram,
iMessage, WhatsApp, IRC, Google Chat, direct channel delivery, and the public
`openclaw/plugin-sdk/channel-outbound` export.

## Root cause and repair

`HTML_TAG_RE` ended tag names at `\b`. Because `@` follows a word character,
`<support@example.com>` matched as a tag and the fixpoint stripper removed it.

The shared matcher now includes the shipped XML-style `.` and `:` name
characters, then accepts only real tag-name terminators: whitespace, `/`, or
`>`. This preserves angle-address prose without adding an email parser or a
channel-specific exception. Existing HTML and namespaced-tag stripping, Google
Chat `<users/...>` aliases, autolinks, and internal scaffolding remain unchanged.

The iMessage final security projection explicitly mirrors this shared HTML
grammar. Its duplicate matcher is aligned in the same change so its inspection
model cannot drift from delivery sanitization.

Architectural owner: `src/infra/outbound/sanitize-text.ts`.

## Scope

- Shared production matcher: one-for-one functional replacement.
- iMessage security projection mirror: one-for-one alignment.
- Production delta: +1 net, solely the short boundary-invariant comment.
- Tests: +25 net. Owner-boundary regressions cover address preservation,
  slash-terminated aliases, colon/dot-qualified tags, and the iMessage final
  security path.
- No config, migration, compatibility path, dependency, or public API change.

## Evidence

Pushed head: `c5150a0f45418301a362b244a6ded4d98062591a`.

Regression proof with the new test retained and the shared matcher reverted:

```text
src/infra/outbound/sanitize-text.test.ts
1 failed, 48 passed
Expected: Contact us at Support <support@example.com> or reply here
Received: Contact us at Support  or reply here
```

Final focused test command covered the shared owner, adjacent outbound helpers,
Google Chat alias behavior, and the iMessage security projection:

```text
Test Files  7 passed (7)
Tests       411 passed (411)
Vitest shards: unit-fast, infra, extension-imessage, extension-messaging
```

The compatibility regressions also failed before the final grammar repair:

```text
shared sanitizer: 1 failed, 49 passed
Received: <vendor:note>one</vendor:note><vendor.note>two</vendor.note>
iMessage final path: 1 failed, 260 passed
Received: <vendor:note>visible</vendor:note>
```

Static proof:

```text
git diff --check                                                        pass
pnpm exec oxfmt --check <4 touched files>                               pass
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json pass
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json pass
pnpm tsgo                                                               pass
pnpm tsgo:extensions                                                    pass
pnpm check:test-types                                                   pass
```

Distill: removed eight redundant test lines; no new abstraction or special
case. Greybeard: no attributable complexity or catastrophic-backtracking
regression; the fixed-width lookahead keeps the same asymptotic cost.

## Redacted live Telegram proof

The dedicated QA user sent the changed-path prompt to a fresh exact-head Gateway
in a direct chat. The Gateway used the deterministic mock provider, then sent
the response through the real Telegram Bot API. Secrets, account ids, chat ids,
and usernames are omitted.

```text
head: c5150a0f45418301a362b244a6ded4d98062591a
sent: Reply exactly: Contact us at Support <support@example.com> or reply here
mock provider requests: 1
recordingComplete: true
SUT events: 2 typing, 1 message, 0 edits, 0 deletions
timeline: typing at 496 ms and 1548 ms; message at 1548 ms
Bot API message id: 1255; text length: 55
observed: Contact us at Support support@example.com or reply here
gateway: sendMessage succeeded, text delivery, one chunk
```

The Telegram client rendered away the angle brackets, but the reported failure
was deletion of the complete address. The recipient-visible address now remains.
Artifacts: `events.ndjson`, `summary.json`, `gateway.log`, and one recorded mock
provider request.

Desktop GIF proof was unavailable because this exact PR head predates
`scripts/e2e/telegram-desktop-recorder.ts`; no unrelated recorder code was added
to the branch. The real-user TDLib event stream above is the final changed-path
proof.

## ClawSweeper exact-head review

Local ClawSweeper passed on `c5150a0f45418301a362b244a6ded4d98062591a`:

```text
correctness: patch is correct
findings: 0
security: 0 concerns
maintainer decision required: no
Rank-up moves: 0
```
