### PR TITLE
fix(ui): keep GitHub deep-link labels destination-specific

### DIFF
--- a/ui/src/components/github-link-target.ts
+++ b/ui/src/components/github-link-target.ts
@@ -56,6 +56,16 @@ export function formatGitHubItemReference(target: GitHubItemTarget): string {
   return `${target.owner}/${target.repo}#${target.number}`;
 }
 
+// Compaction to `owner/repo#N` is only safe when the URL names the generic
+// item root: any trailing path segment (/files, /commits, an issue comment
+// anchor) or query/fragment is a more specific destination than the compact
+// label communicates, even though `parseGitHubItemPath` still resolves an
+// identity for it (hovercards and navigation need that deep identity intact).
+export function isGitHubItemRootPath(url: URL): boolean {
+  const segments = url.pathname.split("/").filter(Boolean);
+  return segments.length === 4 && !url.search && !url.hash;
+}
+
 export function githubLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   for (const candidate of event.composedPath()) {
     if (candidate instanceof HTMLAnchorElement) {

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -510,6 +510,23 @@ describe("toSanitizedMarkdownHtml links", () => {
     });
 
     it.each([
+      ["a files-tab path", "https://github.com/openclaw/openclaw/pull/3434/files"],
+      ["a commits path", "https://github.com/openclaw/openclaw/pull/3434/commits"],
+      [
+        "an issue comment fragment",
+        "https://github.com/openclaw/openclaw/issues/3434#issuecomment-1",
+      ],
+      ["a review comment query", "https://github.com/openclaw/openclaw/pull/3434?tab=files"],
+      ["a diff anchor", "https://github.com/openclaw/openclaw/pull/3434/files#diff-abc123"],
+    ])("keeps the specific destination visible for %s", (_kind, input) => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(input));
+      const link = fragment.querySelector<HTMLAnchorElement>("a");
+      expect(link?.classList.contains("markdown-github-link")).toBe(true);
+      expect(link?.textContent).toBe(input);
+      expect(link?.getAttribute("href")).toBe(input);
+    });
+
+    it.each([
       ["non-github host", "[docs](https://example.com/openclaw)"],
       ["lookalike host", "[docs](https://notgithub.com/openclaw)"],
       ["github in query", "[docs](https://example.com/?to=https://github.com/openclaw)"],

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -3,7 +3,11 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import type Token from "markdown-it/lib/token.mjs";
 import { t } from "../i18n/index.ts";
 import { fileKindForPath, shortestFileLabels } from "./file-kind.ts";
-import { formatGitHubItemReference, parseGitHubItemPath } from "./github-link-target.ts";
+import {
+  formatGitHubItemReference,
+  isGitHubItemRootPath,
+  parseGitHubItemPath,
+} from "./github-link-target.ts";
 import {
   installAssistantTranscriptRoleImageRenderer,
   installAssistantTranscriptRoleMarkdown,
@@ -514,7 +518,7 @@ export function createMarkdownParser(): MarkdownIt {
             break;
           }
         }
-        if (generatedUrlLabel && itemTarget && labelToken) {
+        if (generatedUrlLabel && itemTarget && labelToken && isGitHubItemRootPath(url)) {
           labelToken.content = formatGitHubItemReference(itemTarget);
         }
       }


### PR DESCRIPTION
Fixes #124241

## What Problem This Solves

Fixes an issue where Control UI chat would collapse GitHub deep links — pull request `/files` and `/commits` tabs, issue comment anchors, and links with a query string — down to a generic `owner/repo#123` label. The link still navigated to the correct destination, but the visible label no longer told the reader which specific page it pointed to, making deep references indistinguishable from plain issue/PR links when scanning a conversation.

## Why This Change Was Made

The Markdown renderer's GitHub-link pass reused the same parsed item identity both for deciding "does this link point at a GitHub issue or PR" and for deciding "is it safe to shorten this label to `owner/repo#N`." Any URL with a recognizable owner/repo/issue-or-pull/number prefix qualified for compaction, even when it carried a more specific trailing path segment, query string, or fragment. This change adds a narrow `isGitHubItemRootPath()` check and only compacts the label when the URL is exactly the item root (`/owner/repo/issues/N` or `/owner/repo/pull/N`, no extra segments/query/fragment). Item-identity parsing itself is untouched, so hovercard previews and navigation continue to resolve deep links normally — only the label-compaction decision is narrowed. Authored Markdown labels were never rewritten by this pass and remain unaffected.

## User Impact

Deep GitHub links (files tab, commits tab, comment anchors, query strings) now keep their full generated label so readers can see exactly what a link points to. Plain issue and pull request root links keep compacting to `owner/repo#123` as before.

## Evidence

- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/components/markdown-links.test.ts` — 77 passed (72 existing + 5 new destination-specific cases covering `/files`, `/commits`, an issue-comment fragment, a query string, and a diff anchor).
- Verified the 5 new cases fail against the pre-fix parser for the intended reason (compact `openclaw/openclaw#3434` instead of the full deep URL), then pass after the fix.
- `node scripts/check-changed.mjs -- ui/src/components/github-link-target.ts ui/src/components/markdown-parser.ts ui/src/components/markdown-links.test.ts` — delegated Testbox run (`tbx_01m03ds1xa7p1cyexqvqvrbzec`) passed formatting, dead-export scan, i18n verification, core-test/UI typechecks, and changed-file lint, exit code 0.
- `oxfmt --check` on the changed files — all matched files use the correct format.

- Control UI proof (built mock, `node --import tsx scripts/control-ui-mock-dev.ts`): a chat message with a `/files` deep link, an `#issuecomment` fragment, and a `?diff=` query link all keep their full destination-specific URL as the label, while a plain item-root PR link in the same message still compacts to `openclaw/openclaw#124252`.

  ![Control UI: deep links keep full labels, item-root link compacts](https://github.com/user-attachments/assets/89c5b436-8678-4287-a0dd-82b6586590f3)

  A live pre-fix "before" screenshot isn't practical from this branch (the fix and the mock share this checkout); the before-state is proven instead by the 5 new test cases in `markdown-links.test.ts`, each confirmed failing against the pre-fix parser (compacting to `openclaw/openclaw#3434` instead of the full deep URL) before this change, and passing after.
