### PR TITLE
test(ui): assert positive New Session draft behavior

### DIFF
--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -80,10 +80,16 @@ suite.define(() => {
         agentId: "main",
         message: "fix the flaky draft test",
       });
-      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+
+      // Wait for the same canonical settle signal the neighboring submission
+      // test uses (navigation to the created session route) before counting
+      // requests: the exactly-once assert must observe the submission flow
+      // after it has fully resolved, not mid-flight, or a late duplicate
+      // sessions.create could land after a premature pass.
       await expect
         .poll(() => new URL(page.url()).pathname)
         .toBe(controlUiSessionPath("agent:main:draft-e2e"));
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -8,7 +8,6 @@ import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
   captureProjectUiProof,
-  captureUiProof,
   captureUiProofEnabled,
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
@@ -23,14 +22,14 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
-  it("keeps the pre-creation draft on the composer surface", async () => {
+  it("keeps the pre-submit draft on the composer and creates exactly one session", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       methodResponses: {
         "agents.list": {
           agents: [
@@ -47,17 +46,44 @@ suite.define(() => {
           scope: "agent",
         },
         "sessions.list": createdSessionListResult("agent:main:existing"),
+        "sessions.create": { key: "agent:main:draft-e2e" },
       },
     });
 
     try {
       await page.goto(`${suite.server.baseUrl}new?agent=main`);
       await page.getByRole("heading", { name: "Main" }).waitFor();
-      await page.locator(".new-session-page__message").waitFor();
-      await expect.poll(() => page.locator(".sidebar-recent-session--draft").count()).toBe(0);
-      await captureUiProof(page, "draft-row-after-light.png");
-      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
-      await captureUiProof(page, "draft-row-after-dark.png");
+      const message = page.locator(".new-session-page__message");
+      await message.waitFor();
+      await message.fill("fix the flaky draft test");
+
+      // Owner boundary: the New Session page (new-session-page.ts:228) keeps
+      // the draft message on DraftSubmissionFlow until the composer submits,
+      // so the route, the typed text, and the sidebar's canonical
+      // sessions.list row must all stay put with zero sessions.create
+      // requests before that happens.
+      expect(new URL(page.url()).pathname).toBe("/new");
+      expect(new URL(page.url()).search).toBe("?agent=main");
+      expect(await message.inputValue()).toBe("fix the flaky draft test");
+      expect(
+        await page
+          .locator('.sidebar-recent-session[data-session-key="agent:main:existing"]')
+          .count(),
+      ).toBe(1);
+      expect(await page.locator(".sidebar-recent-session").count()).toBe(1);
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+
+      await page.getByRole("button", { name: "Start session" }).click();
+
+      const createRequest = await gateway.waitForRequest("sessions.create");
+      expect(createRequest.params).toMatchObject({
+        agentId: "main",
+        message: "fix the flaky draft test",
+      });
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(controlUiSessionPath("agent:main:draft-e2e"));
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Fixes #124237

## What Problem This Solves

The first case in `ui/src/e2e/new-session-page.places.e2e.test.ts` boots the full mocked New Session page but its only assertion is `expect.poll(() => page.locator(".sidebar-recent-session--draft").count()).toBe(0)`. That selector does not appear anywhere in production code, so the check is vacuous: it passes regardless of whether the pre-creation draft actually stays on the composer, the sidebar reflects real session data, or the composer avoids creating a session before submit.

## Why This Change Was Made

Replaced the vacuous selector check with positive assertions inside the same mocked-Gateway suite, reusing the existing submission pattern from the neighboring test case: after typing a draft on `/new?agent=main`, the test now confirms the route and agent query param stay put, the composer textarea holds the typed value, the sidebar shows exactly the one canonical session `sessions.list` returned (no phantom draft row), and zero `sessions.create` requests have fired. It then submits and confirms exactly one `sessions.create` request with the expected params plus navigation to the canonical session route. The change is test-only; no production code was touched.

Review follow-up: the exactly-once `sessions.create` assertion originally ran immediately after `gateway.waitForRequest("sessions.create")` resolved, before waiting for the navigation-settle signal the neighboring submission test uses. That ordering could pass prematurely if a late duplicate create landed after the count check but before navigation finished. Reordered so the test polls for navigation to the canonical session route first, then asserts the request count, matching the neighboring test's wait pattern.

## User Impact

No user-facing behavior changes. This closes a coverage gap so a real regression in the New Session draft-preservation flow (draft-navigation-handoff.ts / new-session-page.ts) would now fail this test instead of passing silently.

## Evidence

- **Pre-fix browser proof (not vacuous):** on a Blacksmith Testbox lease (`tbx_01m03mdvkmyakbab0e4w4xsncz`), temporarily changed `expect(await page.locator(".sidebar-recent-session").count()).toBe(1)` to `.toBe(2)` and ran the test with real Chromium/Playwright. It failed for the right reason: `AssertionError: expected 1 to be 2` at the sidebar-count assertion line. Restored the correct value and reran: passed. This proves the new positive assertion is wired to real DOM state, not vacuous like the selector it replaced.
- **Full-suite Testbox run:** `node scripts/run-vitest.mjs ui/src/e2e/new-session-page.places.e2e.test.ts` on the same Testbox lease — all 10 tests in the file pass, including the reordered exactly-once assertion.
- **CI diagnosis (`checks-ui` and `checks-ui-e2e (4/12)` on the exact-head rollup):** both failures are pre-existing, unrelated flakes, not caused by this test-only change:
  - `checks-ui-e2e (4/12)` failed in `ui/src/e2e/agent-file-lifecycle.e2e.test.ts:294` (`AssertionError: expected '# Real main instructions\n# Saved thr…' to be '# Saved through real Gateway\n'`) — a different file entirely. The identical assertion failed on unrelated, concurrently open PRs at different shard indices: `brzezowski/sharing-identity-kind` shard 10/12 (run [31908362789](https://github.com/openclaw/openclaw/actions/runs/31908362789)) and another run at shard 6/12 (run [31904182917](https://github.com/openclaw/openclaw/actions/runs/31904182917)). Two more unrelated PRs failed `checks-ui-e2e` at yet other shards on different tests (`config-safe-write.e2e.test.ts` timeout at shard 6/12 in run 31908362789, `lobster-pet-dismiss-menu-overflow.e2e.test.ts` assertion at shard 8/12 in run 31904527461) — consistent with general `checks-ui-e2e` lane flakiness rather than anything in this PR's diff.
  - `checks-ui` failed in `src/pages/chat/chat-responsive.browser.test.ts` (`Error: page.evaluate: Resulting promise was garbage collected`) — an unrelated browser-mode test for the chat responsive layout, in a file this PR never touches. The error is a Playwright/GC timing artifact, not a content assertion tied to this change.
- `node scripts/check-changed.mjs -- ui/src/e2e/new-session-page.places.e2e.test.ts` — delegated through Testbox, exit 0. Conflict markers, max-lines ratchet, changelog attributions, doctor deprecation registry, extension/plugin-sdk wildcard re-export guards, duplicate scan coverage, coercion helper guard, dependency pin guard, formatting (`oxfmt --check`), package patch guard, dead-export scan, Control UI i18n catalog, and core-test typecheck all passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean: "no accepted/actionable findings reported", overall correctness 0.99.
- Direct `oxfmt` run on the changed file: "All matched files use the correct format."
