### PR TITLE
fix(ui): abort stale destructive session confirmations on reconnect

### DIFF
--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -183,6 +183,11 @@ export type SidebarSessionMutationScope = {
   sessions: SessionCapability;
   client: GatewayBrowserClient;
   selectedAgentId: string;
+  // Owner-scoped abort signal for this epoch's destructive confirmations. A
+  // retired epoch aborts it so any open dialog dismisses itself instead of
+  // surviving a reconnect; scopes built outside SessionDataController may
+  // leave this unset and keep their own stale-guard behavior.
+  signal?: AbortSignal;
 };
 
 export type SidebarSessionMutationResult = "completed" | "failed" | "stale";

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -97,6 +97,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   private gatewayConnected = false;
   // Bind mutation completions to one epoch so stale failures cannot cross reconnects.
   private sessionMutationEpoch = 0;
+  // Owns the abort signal handed to every epoch-scoped destructive confirm dialog.
+  // Retiring the epoch aborts it so a dialog open across a reconnect dismisses
+  // itself instead of confirming into a mutation scope that no longer applies.
+  private sessionMutationAbortController = new AbortController();
   private readonly scroll = new SessionDataScrollController(() => this.notify());
   private approvalBadgeQueue: ApplicationContext<RouteId>["overlays"]["snapshot"]["approvalQueue"] =
     [];
@@ -721,6 +725,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   private invalidateSessionMutations(): void {
     this.sessionMutationEpoch += 1;
     this.sessionMutationError = null;
+    // Dismiss any confirm dialog still open under the retired epoch before a
+    // new one can be issued; otherwise it stays modal until manually closed.
+    this.sessionMutationAbortController.abort();
+    this.sessionMutationAbortController = new AbortController();
     this.notify();
   }
 
@@ -743,6 +751,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       sessions: context.sessions,
       client,
       selectedAgentId: this.host.selectedAgentIdForSessions(),
+      signal: this.sessionMutationAbortController.signal,
     };
   }
 

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -22,6 +22,7 @@ import { patchSessionRows } from "./session-organizer-batch-mutations.ts";
 import type { SessionOrganizerControllerHost } from "./session-organizer-controller.ts";
 import {
   deleteSession,
+  deleteSessionGroup,
   deleteSessionsBatch,
   stopCloudWorker,
 } from "./session-organizer-operations.runtime.ts";
@@ -48,6 +49,10 @@ function createHarness(
 ) {
   let current = params.current ?? true;
   let requestCount = 0;
+  // Mirrors SessionDataController's own controller: retiring the scope aborts
+  // it so a dialog wired to `scope.signal` dismisses itself for real, and
+  // renewing stands in for the next `beginSessionMutation()` after a reconnect.
+  let abortController = new AbortController();
   const request = vi.fn(async (_method: string, rawParams?: unknown, _options?: unknown) => {
     const patchParams = rawParams as SessionsPatchManyParams;
     const requestFailure = params.requestFailure;
@@ -88,6 +93,7 @@ function createHarness(
   const refreshTheme = vi.fn();
   const deleteMany = vi.fn(async () => ({ deleted: [], errors: [], preservedWorktrees: [] }));
   const deleteOne = vi.fn(async () => ({ deleted: true }));
+  const groupsDelete = vi.fn(async () => "completed" as const);
   const scope = {
     epoch: 1,
     context: { agents: { state: { agentsList: null } }, theme: { refresh: refreshTheme } },
@@ -96,9 +102,11 @@ function createHarness(
       refreshReplacement,
       delete: deleteOne,
       deleteMany,
+      groupsDelete,
     } as unknown as SessionCapability,
     client,
     selectedAgentId: "main",
+    signal: abortController.signal,
   } as unknown as SidebarSessionMutationScope;
   const publishSessionMutationError = vi.fn();
   const pruneSidebarSessionEntry = vi.fn();
@@ -116,6 +124,7 @@ function createHarness(
   return {
     deleteMany,
     deleteOne,
+    groupsDelete,
     host,
     pruneSidebarSessionEntry,
     publishSessionMutationError,
@@ -126,6 +135,13 @@ function createHarness(
     // Stands in for a reconnect or agent switch landing while a confirm is open.
     retireScope: () => {
       current = false;
+      abortController.abort();
+    },
+    // Stands in for the next beginSessionMutation() a reconnect issues.
+    renewScope: () => {
+      current = true;
+      abortController = new AbortController();
+      scope.signal = abortController.signal;
     },
     scope,
   };
@@ -394,7 +410,7 @@ describe("patchSessionRows", () => {
 type OperationsHarness = ReturnType<typeof createHarness>;
 
 const destructiveHarness = {
-  methods: ["sessions.delete", "sessions.reclaim"],
+  methods: ["sessions.delete", "sessions.reclaim", "sessions.groups.delete"],
   scopes: ["operator.write", "operator.admin"],
 };
 
@@ -423,6 +439,11 @@ const destructiveOperations = [
     run: (harness: OperationsHarness) =>
       stopCloudWorker(harness.host, cloudWorkerRow(false), harness.scope),
     mutation: (harness: OperationsHarness) => harness.request,
+  },
+  {
+    name: "session-group delete",
+    run: (harness: OperationsHarness) => deleteSessionGroup(harness.host, "Group A", harness.scope),
+    mutation: (harness: OperationsHarness) => harness.groupsDelete,
   },
 ] as const;
 
@@ -469,17 +490,28 @@ describe("session organizer destructive confirmations", () => {
   });
 
   it.each(destructiveOperations)(
-    "abandons the $name when the connection is replaced while its confirm is open",
+    "aborts the $name confirm and releases the lock for a fresh one when the connection is replaced while it is open",
     async (operation) => {
       const harness = createHarness(destructiveHarness);
 
       const pending = operation.run(harness);
-      const actions = await waitForConfirmDialogActions();
+      await waitForConfirmDialogActions();
       harness.retireScope();
-      answerConfirmDialog(actions, "confirm");
       await pending;
 
       expect(operation.mutation(harness)).not.toHaveBeenCalled();
+      // The stale dialog must dismiss itself, not merely stop sending its request.
+      expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+
+      // A fresh confirmation (the reconnect's own retry) must be able to open
+      // immediately; a stale dialog holding the shared lock would block it.
+      harness.renewScope();
+      const reopened = operation.run(harness);
+      const freshActions = await waitForConfirmDialogActions();
+      answerConfirmDialog(freshActions, "confirm");
+      await reopened;
+
+      expect(operation.mutation(harness)).toHaveBeenCalledOnce();
     },
   );
 

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -8,7 +8,9 @@ import type {
 import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
 import { loadSettings, patchSettings } from "../app/settings.ts";
+import { t } from "../i18n/index.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
+import { showToast } from "../lib/toast.ts";
 import {
   answerConfirmDialog,
   installDialogPolyfill,
@@ -26,6 +28,8 @@ import {
   deleteSessionsBatch,
   stopCloudWorker,
 } from "./session-organizer-operations.runtime.ts";
+
+vi.mock("../lib/toast.ts", () => ({ showToast: vi.fn() }));
 
 function sessionRow(index: number): SidebarRecentSession {
   return {
@@ -428,22 +432,26 @@ const destructiveOperations = [
     run: (harness: OperationsHarness) =>
       deleteSessionsBatch(harness.host, [sessionRow(0), sessionRow(1)], harness.scope),
     mutation: (harness: OperationsHarness) => harness.deleteMany,
+    staleMessage: t("sessionsView.deleteSessionsStale", { count: "2" }),
   },
   {
     name: "session delete",
     run: (harness: OperationsHarness) => deleteSession(harness.host, sessionRow(0), harness.scope),
     mutation: (harness: OperationsHarness) => harness.deleteOne,
+    staleMessage: t("sessionsView.deleteSessionStale", { session: sessionRow(0).label }),
   },
   {
     name: "cloud worker stop",
     run: (harness: OperationsHarness) =>
       stopCloudWorker(harness.host, cloudWorkerRow(false), harness.scope),
     mutation: (harness: OperationsHarness) => harness.request,
+    staleMessage: t("sessionsView.stopCloudWorkerStale", { session: cloudWorkerRow(false).label }),
   },
   {
     name: "session-group delete",
     run: (harness: OperationsHarness) => deleteSessionGroup(harness.host, "Group A", harness.scope),
     mutation: (harness: OperationsHarness) => harness.groupsDelete,
+    staleMessage: t("sessionsView.deleteGroupStale", { group: "Group A" }),
   },
 ] as const;
 
@@ -452,6 +460,7 @@ describe("session organizer destructive confirmations", () => {
 
   beforeEach(() => {
     restoreDialogPolyfill = installDialogPolyfill();
+    vi.mocked(showToast).mockClear();
   });
 
   afterEach(() => {
@@ -487,6 +496,9 @@ describe("session organizer destructive confirmations", () => {
 
     expect(operation.mutation(harness)).not.toHaveBeenCalled();
     expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
+    // An ordinary cancel is expected UX and needs no announcement; only a
+    // reconnect-driven abort earns the retry notice below.
+    expect(showToast).not.toHaveBeenCalled();
   });
 
   it.each(destructiveOperations)(
@@ -502,6 +514,10 @@ describe("session organizer destructive confirmations", () => {
       expect(operation.mutation(harness)).not.toHaveBeenCalled();
       // The stale dialog must dismiss itself, not merely stop sending its request.
       expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+      // The abort resolves the dialog to `false`, same as a user cancel, so the
+      // operator needs a distinct, visible outcome or their lost intent reads
+      // as a click that simply did nothing.
+      expect(showToast).toHaveBeenCalledWith({ message: operation.staleMessage });
 
       // A fresh confirmation (the reconnect's own retry) must be able to open
       // immediately; a stale dialog holding the shared lock would block it.
@@ -535,6 +551,11 @@ describe("session organizer destructive confirmations", () => {
 
     expect(harness.request).not.toHaveBeenCalled();
     expect(harness.replaceCurrentSession).not.toHaveBeenCalled();
+    // The session delete already landed; the worktree just stays put, same as
+    // the no-access branch, so the operator learns where it went.
+    expect(showToast).toHaveBeenCalledWith({
+      message: t("sessionsView.deletePreservedWorktrees", { count: "1", branches: "feature" }),
+    });
   });
 
   it("skips the delete confirm entirely once the operator opted out", async () => {

--- a/ui/src/components/session-organizer-catalog.ts
+++ b/ui/src/components/session-organizer-catalog.ts
@@ -100,6 +100,7 @@ export async function deleteSessionGroup(
     message: t("sessionsView.deleteGroupConfirm"),
     confirmLabel: t("common.delete"),
     danger: true,
+    signal: scope.signal,
   });
   if (!confirmed) {
     return false;

--- a/ui/src/components/session-organizer-catalog.ts
+++ b/ui/src/components/session-organizer-catalog.ts
@@ -102,11 +102,14 @@ export async function deleteSessionGroup(
     danger: true,
     signal: scope.signal,
   });
-  if (!confirmed) {
-    return false;
-  }
+  // Checked ahead of `confirmed`: a retired scope aborts the dialog to `false`
+  // too, so without this order the operator's lost intent would look like an
+  // ordinary cancel instead of the reconnect that actually dropped it.
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     showToast({ message: t("sessionsView.deleteGroupStale", { group }) });
+    return false;
+  }
+  if (!confirmed) {
     return false;
   }
   try {

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -276,6 +276,7 @@ export async function deleteSessionsBatch(
     confirmLabel: t("common.delete"),
     danger: true,
     skipPreference: sessionDeleteSkipPreference(scope),
+    signal: scope.signal,
   });
   // A reconnect or a replaced sessions capability can land while the modal is
   // open, so the captured scope is revalidated before any delete leaves here.
@@ -503,6 +504,7 @@ export async function stopCloudWorker(
     message: t("sessionsView.stopCloudWorkerConfirm", { session: session.label }),
     confirmLabel: t("sessionsView.stopCloudWorkerConfirmAction"),
     danger: true,
+    signal: scope.signal,
   });
   if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
@@ -546,6 +548,7 @@ export async function deleteSession(
     confirmLabel: t("common.delete"),
     danger: true,
     ...(options.offerSkip ? { skipPreference: sessionDeleteSkipPreference(scope) } : {}),
+    signal: scope.signal,
   });
   if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
@@ -597,6 +600,7 @@ export async function deleteSession(
           message: t("sessionsView.deletePreservedWorktreeConfirm", { branch: preserved.branch }),
           confirmLabel: t("common.remove"),
           danger: true,
+          signal: scope.signal,
         });
         // Cancel needs this guard too: the delete already landed, so a scope
         // retired while the modal was open must not drive the navigation below.

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -280,7 +280,14 @@ export async function deleteSessionsBatch(
   });
   // A reconnect or a replaced sessions capability can land while the modal is
   // open, so the captured scope is revalidated before any delete leaves here.
-  if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  // Checked ahead of `confirmed`: a retired scope aborts the dialog to `false`
+  // too, so without this order the operator's lost intent would look like an
+  // ordinary cancel instead of the reconnect that actually dropped it.
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    showToast({ message: t("sessionsView.deleteSessionsStale", { count: String(rows.length) }) });
+    return;
+  }
+  if (!confirmed) {
     return;
   }
   const requests = rows.map((row) => ({
@@ -506,7 +513,14 @@ export async function stopCloudWorker(
     danger: true,
     signal: scope.signal,
   });
-  if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  // Checked ahead of `confirmed`: a retired scope aborts the dialog to `false`
+  // too, so without this order the operator's lost intent would look like an
+  // ordinary cancel instead of the reconnect that actually dropped it.
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    showToast({ message: t("sessionsView.stopCloudWorkerStale", { session: session.label }) });
+    return;
+  }
+  if (!confirmed) {
     return;
   }
   if (!requireSessionMutationAccess(host, scope, stopAction)) {
@@ -550,7 +564,14 @@ export async function deleteSession(
     ...(options.offerSkip ? { skipPreference: sessionDeleteSkipPreference(scope) } : {}),
     signal: scope.signal,
   });
-  if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  // Checked ahead of `confirmed`: a retired scope aborts the dialog to `false`
+  // too, so without this order the operator's lost intent would look like an
+  // ordinary cancel instead of the reconnect that actually dropped it.
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    showToast({ message: t("sessionsView.deleteSessionStale", { session: session.label }) });
+    return;
+  }
+  if (!confirmed) {
     return;
   }
   const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
@@ -604,7 +625,15 @@ export async function deleteSession(
         });
         // Cancel needs this guard too: the delete already landed, so a scope
         // retired while the modal was open must not drive the navigation below.
+        // A retired scope leaves the worktree exactly like the no-access branch
+        // above, so it earns the same visible outcome instead of vanishing quietly.
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+          showToast({
+            message: t("sessionsView.deletePreservedWorktrees", {
+              count: "1",
+              branches: preserved.branch,
+            }),
+          });
           return;
         }
         if (removeWorktree) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -997,11 +997,16 @@ export const en: TranslationMap = {
     stopCloudWorker: "Stop cloud worker…",
     stopCloudWorkerConfirm: 'Stop the cloud worker for "{session}"?',
     stopCloudWorkerConfirmAction: "Stop worker",
+    stopCloudWorkerStale:
+      'Gateway connection replaced before the cloud worker for "{session}" was stopped. Try again.',
     cloudWorkerStopResult: 'Cloud worker for "{session}" is {state}.',
     deleteSessionMenu: "Delete…",
     deleteSessionCount: "Delete {count}…",
     deleteSessionConfirm: 'Delete "{session}" and its transcript?',
+    deleteSessionStale: 'Gateway connection replaced before "{session}" was deleted. Try again.',
     deleteSessionsConfirm: "Delete {count} sessions and their transcripts?",
+    deleteSessionsStale:
+      "Gateway connection replaced before {count} sessions were deleted. Try again.",
     deleteSelectedConfirmOne:
       "Delete 1 session?\n\nThis will delete the session entry and archive its transcript.",
     deleteSelectedConfirm:

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -119,6 +119,13 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     this.activeChanged(value);
   }
   protected activeChanged(_active: boolean): void {}
+  // Call wherever connectionGeneration itself advances (reconnect, capability
+  // replacement, pane teardown) so a header confirm dialog open across that
+  // boundary dismisses itself instead of confirming into a retired scope.
+  protected retireHeaderSessionMutations(): void {
+    this.headerSessionMutationAbortController.abort();
+    this.headerSessionMutationAbortController = new AbortController();
+  }
   @property({ attribute: false }) draft?: string;
   @property({ attribute: false }) focusComposer = false;
   @property({ attribute: false }) routeFace: BoardFace = "chat";
@@ -171,6 +178,11 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected boardProviderLease: (BoardProviderLease & { sessionKey: string }) | undefined;
   protected boardProviderLifecycleConnected = false;
   protected connectionGeneration = 0;
+  // Owns the abort signal handed to header-scoped destructive confirm dialogs.
+  // Retiring it alongside every connectionGeneration bump lets a dialog open
+  // across a reconnect or pane teardown dismiss itself, matching
+  // SessionDataController's own epoch-scoped controller for the sidebar.
+  protected headerSessionMutationAbortController = new AbortController();
   @litState() protected headerEditing = false;
   @litState() protected headerRenameValue = "";
   @litState() protected headerPlatform: string | null = null;

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -224,6 +224,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       // A reconnect can retain the browser client. Keep async ownership tied
       // to the logical connection, not only the transport object identity.
       this.connectionGeneration += 1;
+      this.retireHeaderSessionMutations();
       invalidateChatAvatarCache(state);
       invalidateAssistantIdentityCache(state.client);
       state.assistantIdentityRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -614,6 +614,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.paneResizeObserver?.disconnect();
     this.paneResizeObserver = null;
     this.connectionGeneration += 1;
+    this.retireHeaderSessionMutations();
     this.deferredSessionHydrationRequestVersion += 1;
     this.sessionDiscussionPanels.clear();
     this.taskSuggestionsRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -226,6 +226,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       sessions: this.context.sessions,
       client,
       selectedAgentId: this.context.agentSelection.state.selectedId ?? "main",
+      signal: this.headerSessionMutationAbortController.signal,
     };
   }
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -7,7 +7,13 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
+import { t } from "../../i18n/index.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { showToast } from "../../lib/toast.ts";
+import {
+  installDialogPolyfill,
+  waitForConfirmDialogActions,
+} from "../../test-helpers/modal-dialog.ts";
 import {
   createSessionContext,
   createTestChatPane,
@@ -18,6 +24,8 @@ import { createSessionWorkspaceProps } from "./components/chat-session-workspace
 import type { SidebarContent } from "./components/chat-sidebar.ts";
 import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
 import { openSlot } from "./sidebar-layout.ts";
+
+vi.mock("../../lib/toast.ts", () => ({ showToast: vi.fn() }));
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -115,6 +123,50 @@ describe("chat pane header state", () => {
       agentId: "main",
     });
     expect(onPaneSessionChange).toHaveBeenCalledWith("single", "agent:main:forked");
+  });
+
+  it("aborts a stale header delete confirm and shows a retry notice when the connection is replaced while it is open", async () => {
+    const restoreDialogPolyfill = installDialogPolyfill();
+    try {
+      const deleteOne = vi.fn(async () => ({ deleted: true }));
+      const sessions = {
+        delete: deleteOne,
+        refreshReplacement: vi.fn(async () => undefined),
+      } as unknown as SessionCapability;
+      const client = {} as GatewayBrowserClient;
+      const { pane } = createTestChatPane({ client, sessions });
+      const session = {
+        key: "agent:main:current",
+        kind: "direct",
+        updatedAt: 0,
+        label: "Current session",
+      } satisfies GatewaySessionRow;
+
+      const pending = pane.handleHeaderSessionAction({ kind: "delete" }, session);
+      await waitForConfirmDialogActions();
+      // Mirrors a reconnect landing while the header's own confirm dialog is
+      // open: the chat header builds this scope independently of
+      // SessionDataController, so it needs its own signal retired here too.
+      pane.applyGatewaySnapshot({
+        ...pane.context.gateway.snapshot,
+        phase: "reconnecting",
+        hello: null,
+      });
+      await pending;
+
+      expect(deleteOne).not.toHaveBeenCalled();
+      // The stale dialog must dismiss itself, not merely stop sending its request.
+      expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+      // The abort resolves the dialog to `false`, same as a user cancel, so the
+      // operator needs a distinct, visible outcome or their lost intent reads
+      // as a click that simply did nothing.
+      expect(showToast).toHaveBeenCalledWith({
+        message: t("sessionsView.deleteSessionStale", { session: "Current session" }),
+      });
+    } finally {
+      document.body.replaceChildren();
+      restoreDialogPolyfill();
+    }
   });
 
   it("commits a trimmed label and clears with null", async () => {


### PR DESCRIPTION
Fixes #124227

## What Problem This Solves

Resolves a problem where a destructive confirmation (session delete, batch
delete, cloud-worker stop, preserved-worktree removal, or session-group
delete) stayed open across a Gateway reconnect, capability replacement, or
disconnect. Confirming it afterward silently did nothing, because the code
that ran on confirm re-checked the mutation scope and bailed out with no
visible outcome. The dialog also held the shared confirmation lock the whole
time it sat open, so the operator had to dismiss it manually before any other
confirmation could appear. This covers both the sidebar and the chat-header
delete/fork/archive menu, which shares the same delete operation through its
own independently-owned mutation scope.

## Why This Change Was Made

`SessionDataController` already retires the sidebar's mutation scope by
advancing an epoch on reconnect, capability replacement, and teardown, but
nothing told the open dialog about it. `confirm-dialog.ts` already accepts an
`AbortSignal` and tears itself down (and releases its lock) when that signal
fires — the same pattern the Devices page uses for its own destructive
confirms. This change gives `SessionDataController` an `AbortController`
owned by the mutation epoch, aborts it whenever the epoch advances, and
exposes the signal on `SidebarSessionMutationScope`. Every scope-bound
`showConfirmDialog` call in `session-organizer-operations.runtime.ts` and
`session-organizer-catalog.ts` now passes that signal, so a stale dialog
dismisses itself the moment its scope retires instead of waiting for the
operator.

The chat header builds its own `SidebarSessionMutationScope` from
`connectionGeneration` instead of going through `SessionDataController`, so it
had no signal to wire in and stayed uncovered. `ChatPaneBase` now owns its own
`headerSessionMutationAbortController`, retired everywhere
`connectionGeneration` advances (a reconnect in `chat-pane-context.ts` and
pane teardown in `chat-pane-lifecycle.ts`), and `captureHeaderSessionActionScope`
hands its signal to the captured scope the same way `SessionDataController`
does for the sidebar.

Separately, an aborted confirm resolves to `false`, which is indistinguishable
from an ordinary cancel click. Every destructive-confirm call site checked
`!confirmed` before checking whether the scope was still current, so an
abort's `false` short-circuited past the existing staleness check and the
operator's lost intent vanished with no notice at all — the dialog just closed
on its own with no explanation. Each site now checks scope staleness first and
shows a toast ("Gateway connection replaced ... Try again.") before falling
through to the ordinary cancel path, reusing the exact pattern
`deleteSessionGroup` already had for a narrower race (confirmed but the scope
went stale before the request went out). New i18n strings
(`deleteSessionStale`, `deleteSessionsStale`, `stopCloudWorkerStale`) follow
that same existing convention; the preserved-worktree follow-up confirm reuses
the existing `deletePreservedWorktrees` copy since the outcome is identical
(the worktree stays put).

## User Impact

A confirmation dialog left open across a reconnect — in the sidebar or the
chat header — now disappears on its own instead of sitting there until the
operator dismisses it, and a fresh confirmation can open immediately
afterward. When that happens the operator now sees a toast explaining the
action was canceled by the reconnect and inviting a retry, instead of the
dialog just vanishing with no explanation. Ordinary confirm/cancel behavior
and the "don't ask again" delete preference are unchanged.

## Evidence

Focused suites, with the fix applied:

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/components/session-organizer-batch-mutations.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)

$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)

$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts
 Test Files  1 passed (1)
      Tests  261 passed (261)
```

Regression-test proof (stashed the production fix, kept the strengthened
tests, reran the same suites):

```
 ❯ |ui| ui/src/components/session-organizer-batch-mutations.test.ts (30 tests | 5 failed)
     × aborts the 'batch delete'/'session delete'/'cloud worker stop'/'session-group delete' confirm ...
     × keeps a retired scope from navigating when the worktree prompt is cancelled
 AssertionError: expected "vi.fn()" to be called with arguments: [ Array(1) ]
 Number of calls: 0

 ❯ |ui-isolated| ui/src/pages/chat/chat-pane.test.ts (30 tests | 1 failed)
     × aborts a stale header delete confirm and shows a retry notice ...
 Error: Test timed out in 120000ms.
```

Without the header abort wiring, the header's dialog never dismisses itself
and the new test hangs the same way the original sidebar bug did. Without the
reordered staleness check, the toast assertions fail with zero calls: the
`!confirmed` branch swallows the abort before the stale-scope toast is ever
reached.

`node scripts/check-changed.mjs -- ui/src/components/session-organizer-batch-mutations.test.ts ui/src/components/session-organizer-catalog.ts ui/src/components/session-organizer-operations.runtime.ts ui/src/i18n/locales/en.ts ui/src/pages/chat/chat-pane-base.ts ui/src/pages/chat/chat-pane-context.ts ui/src/pages/chat/chat-pane-lifecycle.ts ui/src/pages/chat/chat-pane-session-menu.ts ui/src/pages/chat/chat-pane.test.ts`
passed lint/typecheck/duplicate-scan/dependency-pin/format/i18n gates
(delegated through Testbox).

`.agents/skills/autoreview/scripts/autoreview --mode uncommitted` reported no
accepted/actionable findings.

### CI diagnosis (previous head)

`checks-node-compact-large-22` and `checks-ui` both failed on the same single
test, `ui/src/components/app-sidebar.test.ts > AppSidebar group mutation
collapsed state > keeps a reconnected group delete retryable after its
confirm opened` (pre-existing on `main`, unrelated to this PR's stated
scope). That test reconnects while a group-delete confirm is open, then
clicks confirm, and expects the existing "Gateway connection replaced ..."
toast. Wiring `signal: scope.signal` into `deleteSessionGroup`'s confirm call
made the dialog auto-dismiss on reconnect before the click could land, so
`confirmed` came back `false` and the old `if (!confirmed) return false;`
ordering skipped the toast branch entirely — a real regression this PR's
earlier commits introduced into a `main` test, not a flake. The reordering
above fixes it directly; both jobs had exactly one failing test each and no
other failures. All 12 `checks-ui-e2e` shards and `checks-ui-e2e-real-gateway`
were green on this PR's own head, so there's no e2e flake to report here.

### Control UI proof (running app, head `5298bea2834`)

Drove the real sidebar through the mocked-Gateway Playwright harness
(`installMockGateway`, the same harness `session-organizer-batch-mutations.test.ts`'s
sibling e2e suite uses) with a "Projects" session group, forced a Gateway
reconnect while its delete confirm was open, and screen-recorded the result:

1. Destructive confirm open — `Delete group "Projects"`:
   https://github.com/user-attachments/assets/195c9027-f387-42e6-940f-e67fbd4d9270
2. Gateway reconnect lands while the dialog is open — it tears itself down and
   the reordered staleness check fires the retry toast in the same beat:
   https://github.com/user-attachments/assets/6adf5563-2fc6-41bb-bbff-0f8660ca7caf
3. Retry — the confirmation lock released with the stale dialog, so a fresh
   `Delete group "Projects"` opens immediately (toast still visible above it):
   https://github.com/user-attachments/assets/3740d27c-11d0-4a20-bb02-473d4639fdab
4. Retry confirmed — `sessions.groups.delete` lands and "Projects" is gone:
   https://github.com/user-attachments/assets/22c86389-294c-4efd-bd56-d228a608f5f0

Full recording (open → reconnect → dismiss/toast → retry → success):
https://github.com/user-attachments/assets/0eb46077-8980-42a9-9d5c-1be9eee08034

