### PR TITLE
refactor(ui): unify composer menu active-option scrolling

### DIFF
--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -245,3 +245,27 @@ export function restoreHistoryCaret(target: HTMLTextAreaElement, direction: "up"
     target.selectionEnd = caret;
   });
 }
+
+// Shared by the slash and skill composer menus, which resolve their own
+// active-option id but scroll the same ".slash-menu__scroll" viewport shape.
+export function scrollActiveMenuOptionIntoView(activeId: string | null): void {
+  if (!activeId) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    const activeOption = document.getElementById(activeId);
+    const scrollRegion = activeOption?.closest<HTMLElement>(".slash-menu__scroll");
+    if (!activeOption || !scrollRegion) {
+      return;
+    }
+    const menuBounds = scrollRegion.getBoundingClientRect();
+    const optionBounds = activeOption.getBoundingClientRect();
+    // scrollIntoView also moves the short-landscape composer and page. Keep
+    // keyboard navigation owned by the menu so textarea focus stays stable.
+    if (optionBounds.top < menuBounds.top) {
+      scrollRegion.scrollTop -= menuBounds.top - optionBounds.top;
+    } else if (optionBounds.bottom > menuBounds.bottom) {
+      scrollRegion.scrollTop += optionBounds.bottom - menuBounds.bottom;
+    }
+  });
+}

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -7,6 +7,7 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
+import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 import { paneDomId } from "./chat-composer-slash-menu.ts";
 import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
@@ -183,24 +184,7 @@ export function scrollActiveSkillMenuOptionIntoView(
   state: ChatComposerState,
   paneId: string,
 ): void {
-  const activeId = getActiveSkillMenuOptionId(state, paneId);
-  if (!activeId) {
-    return;
-  }
-  requestAnimationFrame(() => {
-    const activeOption = document.getElementById(activeId);
-    const scrollRegion = activeOption?.closest<HTMLElement>(".slash-menu__scroll");
-    if (!activeOption || !scrollRegion) {
-      return;
-    }
-    const menuBounds = scrollRegion.getBoundingClientRect();
-    const optionBounds = activeOption.getBoundingClientRect();
-    if (optionBounds.top < menuBounds.top) {
-      scrollRegion.scrollTop -= menuBounds.top - optionBounds.top;
-    } else if (optionBounds.bottom > menuBounds.bottom) {
-      scrollRegion.scrollTop += optionBounds.bottom - menuBounds.bottom;
-    }
-  });
+  scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(state, paneId));
 }
 
 export function selectSkillMention(

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -7,7 +7,6 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
-import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 import { paneDomId } from "./chat-composer-slash-menu.ts";
 import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
@@ -178,13 +177,6 @@ export function getActiveSkillMenuOptionLabel(state: ChatComposerState): string 
   }
   const command = state.skillMenuItems[state.skillMenuIndex];
   return command ? `${getSkillDisplayName(command)} ${getSlashCommandDescription(command)}` : "";
-}
-
-export function scrollActiveSkillMenuOptionIntoView(
-  state: ChatComposerState,
-  paneId: string,
-): void {
-  scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(state, paneId));
 }
 
 export function selectSkillMention(

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -10,7 +10,6 @@ import {
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
 import { exportChatMarkdown } from "../export.ts";
-import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 
@@ -258,13 +257,6 @@ export function getActiveSlashMenuOptionLabel(state: ChatComposerState): string 
   }
   const command = `/${cmd.name}${cmd.args ? ` ${cmd.args}` : ""}`;
   return `${command} ${getSlashCommandDescription(cmd)}`;
-}
-
-export function scrollActiveSlashMenuOptionIntoView(
-  state: ChatComposerState,
-  paneId: string,
-): void {
-  scrollActiveMenuOptionIntoView(getActiveSlashMenuOptionId(state, paneId));
 }
 
 function renderSlashIcon(name: string) {

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -10,6 +10,7 @@ import {
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
 import { exportChatMarkdown } from "../export.ts";
+import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 
@@ -263,26 +264,7 @@ export function scrollActiveSlashMenuOptionIntoView(
   state: ChatComposerState,
   paneId: string,
 ): void {
-  const activeId = getActiveSlashMenuOptionId(state, paneId);
-  if (!activeId) {
-    return;
-  }
-  requestAnimationFrame(() => {
-    const activeOption = document.getElementById(activeId);
-    const scrollRegion = activeOption?.closest<HTMLElement>(".slash-menu__scroll");
-    if (!activeOption || !scrollRegion) {
-      return;
-    }
-    const menuBounds = scrollRegion.getBoundingClientRect();
-    const optionBounds = activeOption.getBoundingClientRect();
-    // scrollIntoView also moves the short-landscape composer and page. Keep
-    // keyboard navigation owned by the menu so textarea focus stays stable.
-    if (optionBounds.top < menuBounds.top) {
-      scrollRegion.scrollTop -= menuBounds.top - optionBounds.top;
-    } else if (optionBounds.bottom > menuBounds.bottom) {
-      scrollRegion.scrollTop += optionBounds.bottom - menuBounds.bottom;
-    }
-  });
+  scrollActiveMenuOptionIntoView(getActiveSlashMenuOptionId(state, paneId));
 }
 
 function renderSlashIcon(name: string) {

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -17,13 +17,13 @@ import {
   replaceComposerPopoverAnchor,
   restoreHistoryCaret,
   scheduleTextareaHeightAdjustment,
+  scrollActiveMenuOptionIntoView,
 } from "./chat-composer-dom.ts";
 import {
   getActiveSkillMenuOptionId,
   getActiveSkillMenuOptionLabel,
   isSkillMenuVisible,
   resetSkillMenuState,
-  scrollActiveSkillMenuOptionIntoView,
   selectSkillMention,
   updateSkillMenu,
 } from "./chat-composer-skill-menu.ts";
@@ -34,7 +34,6 @@ import {
   isSlashMenuVisible,
   paneDomId,
   resetSlashMenuState,
-  scrollActiveSlashMenuOptionIntoView,
   selectSlashArg,
   selectSlashCommand,
   tabCompleteSlashCommand,
@@ -322,7 +321,8 @@ export function renderChatComposer(props: ChatComposerProps) {
           props.paneId,
           requestUpdate,
           (command) => selectSkillMention(command, props, requestUpdate),
-          scrollActiveSkillMenuOptionIntoView,
+          (menuState, paneId) =>
+            scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(menuState, paneId)),
           "skill",
         )
       ) {
@@ -344,7 +344,8 @@ export function renderChatComposer(props: ChatComposerProps) {
           props.paneId,
           requestUpdate,
           (arg, submit) => selectSlashArg(arg, props, requestUpdate, submit),
-          scrollActiveSlashMenuOptionIntoView,
+          (menuState, paneId) =>
+            scrollActiveMenuOptionIntoView(getActiveSlashMenuOptionId(menuState, paneId)),
         )
       ) {
         return;
@@ -363,7 +364,8 @@ export function renderChatComposer(props: ChatComposerProps) {
             submit
               ? selectSlashCommand(command, props, requestUpdate)
               : tabCompleteSlashCommand(command, props, requestUpdate),
-          scrollActiveSlashMenuOptionIntoView,
+          (menuState, paneId) =>
+            scrollActiveMenuOptionIntoView(getActiveSlashMenuOptionId(menuState, paneId)),
         )
       ) {
         return;


### PR DESCRIPTION
Fixes #124238

## What Problem This Solves

The slash-command menu and skill-mention menu each carried a byte-identical `requestAnimationFrame`-deferred algorithm for scrolling the keyboard-active option into view inside their shared `.slash-menu__scroll` viewport (`scrollActiveSlashMenuOptionIntoView` in `chat-composer-slash-menu.ts:262-286`, `scrollActiveSkillMenuOptionIntoView` in `chat-composer-skill-menu.ts:182-204`). They already had to change in lockstep once, when `.slash-menu__scroll` became the shared scroll owner, and the next layout change would require the same duplicated edit or the copies would drift.

## Why This Change Was Made

- Extracted the shared geometry into `scrollActiveMenuOptionIntoView(activeId)` in `ui/src/pages/chat/components/chat-composer-dom.ts`, the module that already owns composer DOM/geometry helpers (`adjustTextareaHeight`, `observeTextareaOverflow`, `replaceComposerPopoverAnchor`, `restoreHistoryCaret`).
- Each menu module keeps resolving its own active-option id (`getActiveSkillMenuOptionId`, `getActiveSlashMenuOptionId` — the latter also branches on `slashMenuMode === "args"`), preserving the state-specific selection ownership the issue asked to keep separate.
- Per review feedback on the first commit, removed the two thin `scrollActiveSkillMenuOptionIntoView` / `scrollActiveSlashMenuOptionIntoView` wrappers that only forwarded `(state, paneId)` to their id resolver and the shared helper. The three `handleComposerMenuKeyDown` call sites in `chat-composer.ts` now call `scrollActiveMenuOptionIntoView(getActive*MenuOptionId(state, paneId))` directly, so the state-specific id resolution and the shared geometry helper compose at the actual call site instead of through an intermediate named wrapper.
- Net production LOC across the branch is -24 (31 added / 55 removed across `chat-composer-dom.ts`, `chat-composer-skill-menu.ts`, `chat-composer-slash-menu.ts`, `chat-composer.ts`), satisfying the issue's "Production LOC should decrease" requirement more directly than the wrapper-based first cut.

## User Impact

No behavior change. Keyboard navigation in both menus still scrolls only the `.slash-menu__scroll` viewport, never the page or composer, and both menus keep their own selection/focus/keyboard behavior untouched, per the issue's "Do not" list.

## Evidence

- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/chat/chat-composer-context.test.ts ui/src/pages/chat/chat-composer-pointer-activation.test.ts ui/src/pages/chat/chat-composer-queue.test.ts ui/src/pages/chat/chat-composer-capability-host.test.ts ui/src/pages/chat/chat-composer-disabled-banner.test.ts ui/src/pages/chat/components/chat-composer-status.test.ts` — 330/330 passed, including the skill-menu scroll coverage in `chat-view.test.ts`.
- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t scroll` — 9/9 passed, covering the slash-menu scroll behavior.
- `node scripts/check-changed.mjs -- <4 changed files>` — passed (typecheck, lint, import boundaries, dead-export scan).
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean: "no accepted/actionable findings reported", overall correctness 0.99.
- `oxfmt` could not run locally in this worktree (no installed `node_modules`); CI's `check-lint`/format gate is the formatting proof for this push.

## CI: checks-ui-e2e (6/12)

This shard failed on `ui/src/e2e/agent-file-lifecycle.e2e.test.ts > ... reads and saves the selected agent workspace through an isolated Gateway`, asserting the saved file content is `# Saved through real Gateway\n` but observing `# Real main instructions\n# Saved thr…` — a stale/bled file-content assertion in a completely different subsystem (agent workspace file save through a real Gateway) that this PR's diff never touches.

This is a shared CI flake, not a regression from this diff:

- PR #124257 (unrelated: session-sharing identity kind) failed the *same test with the identical assertion and error text* at shard 10/12 in a run kicked off in the same window (run 31908362789, job 95069649756).
- PR #124274 (unrelated: GitHub link hovercard) failed shard 2/12 on a different test (`session-management.sidebar.e2e.test.ts`) with a similar "Matcher did not succeed in time" pattern.
- PR #124255 (unrelated: Discord upload-file caption) failed shard 8/12 on yet another unrelated test (`lobster-pet-dismiss-menu-overflow.e2e.test.ts`).

Multiple unrelated PRs are failing `checks-ui-e2e` at different shard numbers on different tests around the same time, which is the signature of matrix-level flakiness (timing/resource contention in the mocked/real-Gateway E2E lane) rather than something introduced by this branch. This PR's diff is scoped to `chat-composer-dom.ts`, `chat-composer-skill-menu.ts`, `chat-composer-slash-menu.ts`, and `chat-composer.ts` — none of which touch agent file lifecycle, Gateway file writes, or session management.
