### PR TITLE
fix(ui): stop inferring session sharing identity kind from ID strings

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -493,9 +493,9 @@ suite.define(() => {
         label: `Member ${index + 1}`,
       })),
     ];
-    const channelIdentities = [
-      { type: "human" as const, id: "channel:chn_design", label: "Design" },
-      { type: "human" as const, id: "discord:channel:operations", label: "Operations" },
+    const nonHumanIdentities = [
+      { type: "agent" as const, id: "agent-design", label: "Design" },
+      { type: "system" as const, id: "system-operations", label: "Operations" },
     ];
     const gateway = await installMockGateway(currentPage, {
       sessionKey: "agent:main:ada",
@@ -544,7 +544,7 @@ suite.define(() => {
         "session.members.list": {
           sessionKey: "agent:main:ada",
           members: [{ identityId: longMemberId, addedBy: "profile-ada", addedAt: 1 }],
-          identities: [...humanIdentities, ...channelIdentities],
+          identities: [...humanIdentities, ...nonHumanIdentities],
           role: "owner",
           allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
         },
@@ -677,7 +677,9 @@ suite.define(() => {
     await expectBrowser(
       dropdown.locator(".chat-pane__sharing-member openclaw-session-owner-chip"),
     ).toHaveCount(30);
-    await expectBrowser(dropdown.locator(".chat-pane__sharing-channel-icon")).toHaveCount(2);
+    // Agent and system identities render the non-human icon from identity.type,
+    // not from an ID-string heuristic; owner-chip presentation is human-only.
+    await expectBrowser(dropdown.locator(".chat-pane__sharing-member-icon > svg")).toHaveCount(2);
     expect(
       await longNameItem.locator(".chat-pane__sharing-member-label").getAttribute("title"),
     ).toBe(longMemberLabel);

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -88,8 +88,9 @@ describe("chat session sharing menu", () => {
             members: [],
             identities: [
               { type: "human", id: "profile-vyctor", label: "Vyctor Brzezowski" },
-              // Channel-shaped IDs are canonical for human profiles too; the
-              // recorded type, not the ID string, must drive presentation.
+              // Human identity IDs are opaque (e.g. an inbound SenderId) and
+              // can contain "channel:" as a substring; the recorded type,
+              // not the ID string, must drive presentation.
               { type: "human", id: "channel:chn_design", label: "Design" },
               { type: "agent", id: "discord:channel:operations", label: "Operations" },
               { type: "system", id: "channel:audit", label: "Audit" },

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -71,7 +71,7 @@ describe("chat session sharing menu", () => {
     expect(onMemberChange).toHaveBeenCalledWith("alice", true);
   });
 
-  it("distinguishes people from channel-backed members", () => {
+  it("renders member presentation from identity.type, not from ID spelling", () => {
     const root = mount(
       renderChatSessionSharing({
         session: {
@@ -88,8 +88,11 @@ describe("chat session sharing menu", () => {
             members: [],
             identities: [
               { type: "human", id: "profile-vyctor", label: "Vyctor Brzezowski" },
+              // Channel-shaped IDs are canonical for human profiles too; the
+              // recorded type, not the ID string, must drive presentation.
               { type: "human", id: "channel:chn_design", label: "Design" },
-              { type: "human", id: "discord:channel:operations", label: "Operations" },
+              { type: "agent", id: "discord:channel:operations", label: "Operations" },
+              { type: "system", id: "channel:audit", label: "Audit" },
             ],
             role: "owner",
             allowedVisibilities: ["shared"],
@@ -101,16 +104,21 @@ describe("chat session sharing menu", () => {
       }),
     );
 
-    const human = root.querySelector('wa-dropdown-item[value="member:profile-vyctor"]');
-    const channels = [
+    const humans = [
+      root.querySelector('wa-dropdown-item[value="member:profile-vyctor"]'),
       root.querySelector('wa-dropdown-item[value="member:channel:chn_design"]'),
+    ];
+    const nonHumans = [
       root.querySelector('wa-dropdown-item[value="member:discord:channel:operations"]'),
+      root.querySelector('wa-dropdown-item[value="member:channel:audit"]'),
     ];
 
-    expect(human?.querySelector("openclaw-session-owner-chip")).not.toBeNull();
-    for (const channel of channels) {
-      expect(channel?.querySelector("openclaw-session-owner-chip")).toBeNull();
-      expect(channel?.querySelector(".chat-pane__sharing-channel-icon svg")).not.toBeNull();
+    for (const human of humans) {
+      expect(human?.querySelector("openclaw-session-owner-chip")).not.toBeNull();
+    }
+    for (const nonHuman of nonHumans) {
+      expect(nonHuman?.querySelector("openclaw-session-owner-chip")).toBeNull();
+      expect(nonHuman?.querySelector(".chat-pane__sharing-member-icon svg")).not.toBeNull();
     }
   });
 

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -43,10 +43,6 @@ function sharingIcon(visibility: SessionVisibility): TemplateResult {
   return visibility === "shared" ? icons.users : icons.lock;
 }
 
-function isChannelIdentity(identityId: string): boolean {
-  return identityId.startsWith("channel:") || identityId.includes(":channel:");
-}
-
 export function canManageChatSessionSharing(
   session: Pick<GatewaySessionRow, "sharingRole">,
 ): boolean {
@@ -162,7 +158,6 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
                     const disabledReason = members.has(identity.id)
                       ? props.memberRemoveDisabledReason
                       : props.memberAddDisabledReason;
-                    const channelIdentity = isChannelIdentity(identity.id);
                     return html`
                       <wa-dropdown-item
                         class="session-menu__item chat-pane__sharing-member"
@@ -170,18 +165,10 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
                         ?disabled=${Boolean(disabledReason)}
                         title=${disabledReason ?? nothing}
                       >
-                        <span
-                          slot="icon"
-                          class="chat-pane__sharing-member-icon ${channelIdentity
-                            ? "chat-pane__sharing-channel-icon"
-                            : ""}"
-                          aria-hidden="true"
-                        >
-                          ${channelIdentity
-                            ? icons.messageSquare
-                            : identity.type === "human"
-                              ? renderSessionOwnerChip(identity, "header")
-                              : icons.bot}
+                        <span slot="icon" class="chat-pane__sharing-member-icon" aria-hidden="true">
+                          ${identity.type === "human"
+                            ? renderSessionOwnerChip(identity, "header")
+                            : icons.bot}
                         </span>
                         <span
                           class="chat-pane__sharing-member-label"

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -629,17 +629,6 @@ openclaw-chat-pane {
   justify-content: center;
 }
 
-.chat-pane__sharing-channel-icon {
-  border-radius: var(--radius-full);
-  background: var(--bg-muted);
-  color: var(--muted);
-}
-
-.chat-pane__sharing-channel-icon svg {
-  width: 13px;
-  height: 13px;
-}
-
 .chat-pane__sharing-member-label {
   display: block;
   overflow: hidden;


### PR DESCRIPTION
Fixes #124234

## What Problem This Solves

Resolves a problem where the chat sharing menu misrendered a human member as a channel whenever their identity ID happened to contain the substring `channel:`. A profile ID like `channel:chn_design` or `discord:channel:operations` triggered the channel glyph instead of the person's owner chip, even though the Gateway recorded the member as a human.

## Why This Change Was Made

The sharing menu classified members with an ID-string heuristic (`isChannelIdentity`) before ever looking at the identity's actual type. The Gateway sharing protocol only defines `human`, `agent`, and `system` identity types — there is no channel identity kind for the UI to infer, so any ID-shaped guess was necessarily wrong for some inputs. The fix removes the heuristic entirely and renders presentation from `identity.type` directly: human identities get the owner chip, agent and system identities get the existing non-human icon. No protocol or authorization behavior changes.

## User Impact

Members with channel-like profile IDs are now shown correctly as people in the sharing menu, using their real owner chip. There is no other behavior change; the sharing menu's compact layout and scrolling are unaffected.

## Evidence

Focused component test (rewritten to assert on `identity.type` rather than ID spelling, including a human identity with a `channel:`-shaped ID) run via `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-session-sharing.test.ts`:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The rewritten regression case was verified to fail on pre-fix code (`expected null not to be null` on the human-with-channel-shaped-ID assertion) before the fix was applied, then confirmed passing after.

`node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-session-sharing.ts ui/src/pages/chat/components/chat-session-sharing.test.ts ui/src/e2e/session-ownership.e2e.test.ts ui/src/styles/chat/split-view.css` passed end to end (formatting, lint, dead-export scan, i18n catalog, and UI/core typecheck), exit code 0.

Pre-commit review reported no accepted or actionable findings.


Control UI proof (built mock, real `renderChatSessionSharing`): the sharing menu's Members list renders two human identities with the owner chip — including `channel:chn_design`, a human ID that contains the `channel:` substring — while the agent and system identities (`discord:channel:operations`, `channel:audit`) render the non-human icon, all driven purely by `identity.type`.

![Control UI: human identities with channel-shaped IDs get the owner chip; agent/system get the non-human icon](https://github.com/user-attachments/assets/bfac59e7-43ef-437b-9a81-bf8d3a450002)

`LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-session-sharing.test.ts` — 9 passed after correcting the test comment (per review) to describe the fixture ID as opaque rather than a canonical human-profile shape.

`node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-session-sharing.test.ts` — delegated Testbox run (`tbx_01m03k7563z55v99k7yw7z10zd`) passed formatting, lint, dead-export scan, i18n catalog, and core-test typecheck, exit code 0.

Autoreview (`--mode uncommitted`, Codex/gpt-5.6-sol): clean, no accepted/actionable findings.
