### PR TITLE
fix(ui): make file-link label disambiguation near-linear

### DIFF
--- a/ui/src/components/file-kind.ts
+++ b/ui/src/components/file-kind.ts
@@ -108,6 +108,42 @@ export function fileKindForPath(path: string): FileKind {
   return FILE_KIND_BY_EXTENSION[extension] ?? "file";
 }
 
+type SuffixTrieNode = {
+  pathCount: number;
+  children: Map<string, SuffixTrieNode>;
+};
+
+// One reversed-segment trie indexes every path's suffixes together, so the
+// per-path depth search below never rescans the other paths: it descends one
+// child lookup per depth instead of comparing against every other path at
+// every depth. Model-controlled Markdown can carry thousands of distinct
+// paths, so this keeps label derivation near-linear in total path length
+// rather than quadratic in path count.
+function insertReversedSegments(root: SuffixTrieNode, segments: readonly string[]): void {
+  let node = root;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i]!;
+    let child = node.children.get(segment);
+    if (!child) {
+      child = { pathCount: 0, children: new Map() };
+      node.children.set(segment, child);
+    }
+    node = child;
+    node.pathCount += 1;
+  }
+}
+
+function shortestUniqueSuffixDepth(root: SuffixTrieNode, segments: readonly string[]): number {
+  let node = root;
+  for (let depth = 1; depth <= segments.length; depth++) {
+    node = node.children.get(segments[segments.length - depth]!) ?? node;
+    if (node.pathCount === 1 || depth === segments.length) {
+      return depth;
+    }
+  }
+  return segments.length;
+}
+
 /**
  * Shortest unambiguous label per path: the basename alone when it is unique
  * among the supplied paths, otherwise the smallest trailing run of segments
@@ -119,22 +155,14 @@ export function shortestFileLabels(paths: readonly string[]): Map<string, string
   const segmentsByPath = new Map(
     unique.map((path) => [path, path.split(PATH_SEPARATOR_RE).filter(Boolean)]),
   );
-  const suffixKey = (segments: readonly string[], depth: number) =>
-    segments.slice(-depth).join("/");
+  const suffixTrie: SuffixTrieNode = { pathCount: 0, children: new Map() };
+  for (const segments of segmentsByPath.values()) {
+    insertReversedSegments(suffixTrie, segments);
+  }
   const labels = new Map<string, string>();
   for (const path of unique) {
     const segments = segmentsByPath.get(path) ?? [];
-    let depth = 1;
-    while (
-      depth < segments.length &&
-      unique.some(
-        (other) =>
-          other !== path &&
-          suffixKey(segmentsByPath.get(other) ?? [], depth) === suffixKey(segments, depth),
-      )
-    ) {
-      depth += 1;
-    }
+    const depth = shortestUniqueSuffixDepth(suffixTrie, segments);
     // Render the suffix with the separator the path itself used so a Windows
     // path never reads as a POSIX one.
     labels.set(path, segments.slice(-depth).join(path.includes("\\") ? "\\" : "/"));

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover markdown link rendering: autolinking, file links, and link marks.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { shortestFileLabels } from "./file-kind.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
@@ -448,6 +448,38 @@ describe("toSanitizedMarkdownHtml links", () => {
       for (const path of collidingPaths) {
         expect(collidingLabels.get(path)).toBe(path);
       }
+    });
+
+    it("keeps per-path lookup cost linear as path count grows (performance contract)", () => {
+      // Wall-clock timing flakes under CI load, so this asserts the actual
+      // performance contract structurally: count every Map#get call made while
+      // shortestFileLabels runs. The trie makes a fixed number of child
+      // lookups per path segment (one per segment on insert, one per resolved
+      // suffix depth on lookup), so total lookups scale with path count, not
+      // its square. The pre-fix full-list rescan (#124230) re-read every other
+      // path's segments inside `unique.some(...)` at every depth, which cost
+      // O(n^2) lookups for this same all-unique-basename shape -- 8x the paths
+      // there costs ~64x the lookups, far outside the linear band asserted
+      // below, so a regression back to that scan fails this test every run.
+      const countMapLookups = (pathCount: number): number => {
+        const paths = Array.from(
+          { length: pathCount },
+          (_, i) => `src/pkg${i % 50}/mod${i}/file${i}.ts`,
+        );
+        const getSpy = vi.spyOn(Map.prototype, "get");
+        try {
+          shortestFileLabels(paths);
+          return getSpy.mock.calls.length;
+        } finally {
+          getSpy.mockRestore();
+        }
+      };
+
+      const small = countMapLookups(500);
+      const large = countMapLookups(4000); // 8x the paths
+
+      expect(large).toBeGreaterThan(small * 4);
+      expect(large).toBeLessThan(small * 16);
     });
 
     it.each([

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -1,5 +1,6 @@
 // Control UI tests cover markdown link rendering: autolinking, file links, and link marks.
 import { describe, expect, it } from "vitest";
+import { shortestFileLabels } from "./file-kind.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
@@ -422,6 +423,31 @@ describe("toSanitizedMarkdownHtml links", () => {
         "api/src/app.ts",
         "work\\app.ts",
       ]);
+    });
+
+    it("keeps labels correct and distinct across thousands of paths", () => {
+      // A model-controlled message can reference thousands of distinct files.
+      // The regression this guards against is quadratic label derivation, so
+      // this pairs an all-unique-basename set (no repeated suffix growth)
+      // with a colliding-basename set (forced suffix growth) at the same
+      // cardinality; both must resolve correctly, not just quickly.
+      const distinctPaths = Array.from(
+        { length: 4000 },
+        (_, i) => `src/pkg${i % 50}/mod${i}/file${i}.ts`,
+      );
+      const distinctLabels = shortestFileLabels(distinctPaths);
+      expect(distinctLabels.size).toBe(distinctPaths.length);
+      for (const path of distinctPaths) {
+        expect(distinctLabels.get(path)).toBe(path.slice(path.lastIndexOf("/") + 1));
+      }
+
+      const collidingPaths = Array.from({ length: 4000 }, (_, i) => `pkg${i}/shared/index.ts`);
+      const collidingLabels = shortestFileLabels(collidingPaths);
+      expect(collidingLabels.size).toBe(collidingPaths.length);
+      expect(new Set(collidingLabels.values()).size).toBe(collidingPaths.length);
+      for (const path of collidingPaths) {
+        expect(collidingLabels.get(path)).toBe(path);
+      }
     });
 
     it.each([


### PR DESCRIPTION
## What Problem This Solves

`shortestFileLabels` in `ui/src/components/file-kind.ts` computes the shortest unambiguous label for each file link rendered in a Markdown message. For every path, it repeatedly scans the entire path list at each suffix depth to check for collisions. A message with a dense list of distinct file references drives this into roughly quadratic time and can visibly stall the chat renderer.

Fixes #124230

## Why This Change Was Made

The label routine is the sole owner of this computation (called once per render from `ui/src/components/markdown-parser.ts:463`, reached by default from `ui/src/components/chat-message-bubble.ts:296` and `ui/src/pages/chat/components/chat-sidebar.ts:521`), so the fix stays inside it rather than adding a parser-level guard or a cross-render cache that would just relocate the cost or introduce a new caching boundary. The rewrite replaces the repeated full-list scan with one reversed-segment suffix trie built once per render: each path's minimal unique suffix depth is then found with one child lookup per depth instead of a comparison against every other path. Output is unchanged — same shortest-suffix selection, same separator preservation, same full-path fallback — only the algorithmic complexity changes.

## User Impact

Chat and file-preview surfaces that render Markdown with file links (default-on chat message bubbles, and the detail panel) no longer risk a renderer stall when a message references a large number of distinct files. Existing labels are byte-for-byte identical; this is a scaling fix, not a behavior change.

## Evidence

### Reachable cardinality (revised from the earlier benchmark)

Both surfaces that call `shortestFileLabels` (`chat-message-bubble.ts:296`, `chat-sidebar.ts:521`) render with `mode` defaulting to `"message"` (`markdown-render-options.ts:22`). For that mode, `renderSanitizedMarkdown` never reaches the file-link parse path at all above `MARKDOWN_PARSE_LIMIT` (40,000 characters, `ui/src/components/markdown.ts:90,510-515`) — text past that length is escaped and rendered as plain text, no markdown parsing, no file-link decoration, no call into `shortestFileLabels`. So the true producer-side ceiling on `n` is not an independent "path count" — it's however many distinct file references fit inside a single 40,000-character message.

The original benchmark's 16,000-path row (using the ~27-char-average synthetic paths from the fixture) needs roughly 432,000 characters of message text — over 10x the parse cap. That workload can never reach this function in the shipped product; the earlier "~1500x" framing was measured past the point the code path can be entered. Real repository paths make the reachable ceiling tighter still: `git ls-files '*.ts' '*.tsx' | head -900` averages 48.8 characters/path, so 900 of those already total ~43,900 characters, at the cap.

### Benchmark, re-run at reachable scale

Same methodology as before (`shortestFileLabels` called directly, all-unique-basename paths, the shape that defeats the pre-fix algorithm's early exit), now bounded to what a single 40,000-character message can actually carry:

| Path count | Total message chars (this shape) | Pre-fix | Post-fix |
|---|---|---|---|
| 500 | 13,180 | 74–82 ms | 0.6–1.1 ms |
| 1,000 | 26,580 (well inside the 40k cap) | 74–107 ms | 0.6–1.1 ms |
| 1,400 | 38,100 (at the practical edge of the 40k cap) | 137–181 ms | 0.7–1.6 ms |

(3 local runs per size; ranges cover the observed spread.) Corroborating run against 900 real repository `.ts`/`.tsx` paths (43,877 chars, i.e. already past the cap on their own): pre-fix 105.76 ms, post-fix 1.04 ms.

Reframed claim: within the range this code path can actually be entered, the pre-fix implementation costs roughly 75–180 ms — not the 20+ second, 16,000-path figure from the original benchmark, which described a workload the UI cannot produce. That range is still a real, user-visible stall (blocking the render of a single chat message for 100+ ms is noticeable jank), and the quadratic shape means it gets worse the closer a message gets to the 40k cap — so the fix is still warranted, just not for the reason originally stated. The post-fix implementation stays under ~2 ms across the same range: a ~70–170x improvement at reachable cardinality, not the previously claimed ~1500x at an unreachable one.

### Performance contract: deterministic, not timing-based

The previous version of this PR only asserted output correctness at high cardinality, so the pre-fix quadratic implementation also passed it. Per review, `ui/src/components/markdown-links.test.ts` now has a dedicated test, `keeps per-path lookup cost linear as path count grows (performance contract)`, that asserts the actual complexity contract instead of wall-clock time:

- It counts every `Map#get` call made while `shortestFileLabels` runs (`vi.spyOn(Map.prototype, "get")`, restored via `mockRestore()`), at 500 and 4,000 paths (8x).
- The current trie makes a fixed number of child lookups per path segment — one per segment on insert, one per resolved suffix depth on lookup — so total lookups scale with path count: empirically exactly 6x per path for this fixture, so 8x the paths costs ~8x the lookups.
- The pre-fix full-list rescan re-read every other path's segments inside `unique.some(...)` at every depth, which is O(n²) lookups for this same shape: verified locally at exactly n² (e.g. 4,000,000 lookups at n=2,000), so 8x the paths there costs ~64x the lookups.
- The test asserts the lookup count stays inside a generous band (`> small * 4` and `< small * 16`) — comfortably containing the true ~8x linear growth while excluding the ~64x quadratic signature. Verified by temporarily reverting `shortestFileLabels` to the pre-fix implementation locally: the test fails deterministically (`expected 16000000 to be less than 4000000`), then reverted the file back and reran clean.
- No timers, no CI-load-dependent thresholds — the count is exact and reproducible every run.

Focused test run against the fix:

```
$ node scripts/run-vitest.mjs ui/src/components/markdown-links.test.ts
 Test Files  1 passed (1)
      Tests  74 passed (74)
```

`node scripts/check-changed.mjs -- ui/src/components/file-kind.ts ui/src/components/markdown-links.test.ts` passed after fixing an `oxlint(no-extend-native)`/`unbound-method` finding in the new test (switched from directly reassigning `Map.prototype.get` to `vi.spyOn`): format, lint, typecheck (core + UI), dead-export scan, dependency/patch guards, and the delegated Testbox lint run all green.

## CI

`checks-ui-e2e (6/12)` failed on the prior head (`c985d533b4c`) in `ui/src/e2e/agent-file-lifecycle.e2e.test.ts` ("reads and saves the selected agent workspace through an isolated Gateway") — a stale/duplicated file-content assertion (`'# Real main instructions\n# Saved thr…'` vs `'# Saved through real Gateway\n'`) in a test unrelated to this PR's Control UI markdown/file-label code. That test file is not touched by this diff.

This looks like a pre-existing, sitewide E2E flake, not caused by this PR: sibling open PRs from the same day each hit exactly one failing `checks-ui-e2e` shard, each a different, unrelated test — #124285 failed shard 11/12 in `new-session-page.prompt-attachments.e2e.test.ts` (textarea line-count assertion), #124264 failed shard 2/12 in `session-management.sidebar.e2e.test.ts` (missing "Selected session recovered" text), and this PR failed shard 6/12 in `agent-file-lifecycle.e2e.test.ts`. Different tests, different shards, no shared code path with this diff — consistent with CI-load-driven flake in the isolated-Gateway E2E lane rather than a regression from this change. Pushing the new commit reruns this lane fresh on the new head.
