### PR TITLE
test(agents): assert real ACP task-row ownership contract

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -911,10 +911,11 @@ describe("spawnAcpDirect", () => {
     // Native/in-process spawn forwards "required" instead (subagent-spawn.ts);
     // if ACP ever claimed "required" here, a failed task-row write would abort
     // an ACP run the registry never actually owns.
-    const registeredAcpRun = hoisted.registerSubagentRunMock.mock.calls[0]?.[0] as
-      | { taskRowOwnership?: unknown }
-      | undefined;
-    expect(registeredAcpRun?.taskRowOwnership).toBeUndefined();
+    const registeredAcpRun = expectRecordFields(
+      firstMockCall(hoisted.registerSubagentRunMock, "ACP subagent registration")[0],
+      {},
+    );
+    expect(registeredAcpRun.taskRowOwnership).toBeUndefined();
     const initInput = expectInitializeSessionFields({
       agent: "codex",
       mode: "persistent",

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -906,9 +906,15 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.deliver).toBe(true);
     expect(agentCall?.params?.lane).toBe("subagent");
     expect(agentCall?.params?.acpTurnSource).toBe("manual_spawn");
-    expect(hoisted.registerSubagentRunMock.mock.calls[0]?.[0]).not.toHaveProperty(
-      "requiresTaskRow",
-    );
+    // ACP registration must leave taskRowOwnership absent so the registry
+    // falls back to best-effort task-row creation (subagent-registry-run-launch.ts).
+    // Native/in-process spawn forwards "required" instead (subagent-spawn.ts);
+    // if ACP ever claimed "required" here, a failed task-row write would abort
+    // an ACP run the registry never actually owns.
+    const registeredAcpRun = hoisted.registerSubagentRunMock.mock.calls[0]?.[0] as
+      | { taskRowOwnership?: unknown }
+      | undefined;
+    expect(registeredAcpRun?.taskRowOwnership).toBeUndefined();
     const initInput = expectInitializeSessionFields({
       agent: "codex",
       mode: "persistent",

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1188,6 +1188,9 @@ describe("spawnSubagentDirect seam flow", () => {
     });
     const registerInput = firstRegisteredSubagentRun();
     const requesterOrigin = requireRecord(registerInput.requesterOrigin);
+    // Out-of-process dispatch leaves the Gateway-owned task row in place, so
+    // registration must not also claim it (contrast with the in-process case above).
+    expect(registerInput.taskRowOwnership).toBe("gateway_best_effort");
     expect(registerInput.runId).toBe("run-1");
     expect(registerInput.childSessionKey).toBe(childSessionKey);
     expect(registerInput.requesterSessionKey).toBe("agent:main:main");
@@ -1269,6 +1272,9 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(agentParams.provider).toBeUndefined();
     expect(agentParams.model).toBeUndefined();
     expect(agentOptions.allowSyntheticModelOverride).toBeUndefined();
+    // In-process dispatch claims the task row directly, unlike ACP's best-effort
+    // registration (see acp-spawn.test.ts).
+    expect(firstRegisteredSubagentRun().taskRowOwnership).toBe("required");
   });
 
   it("authorizes explicit model overrides for in-process child launches", async () => {


### PR DESCRIPTION
## What Problem This Solves

`src/agents/subagents/spawn/acp-spawn.test.ts` asserted that ACP spawn registration lacks a field named `requiresTaskRow`. That field has never existed anywhere in production — a repository-wide search turns up zero occurrences outside this one test. The assertion protected nothing: it could never fail against the current or any plausible future ACP implementation, because the field it checks for was never real.

## Why This Change Was Made

The real contract at this seam is `taskRowOwnership?: "required" | "gateway_best_effort"`, defined in `src/agents/subagents/registry/subagent-registry-run-launch.ts`. ACP registration (`src/agents/subagents/spawn/acp-spawn.ts`) intentionally omits this field, so the registry defaults to best-effort task-row creation — a failed task-row write only logs a warning. Native/in-process spawn (`src/agents/subagents/spawn/subagent-spawn.ts`) instead derives and forwards an explicit value (`"required"` for in-process dispatch, `"gateway_best_effort"` for out-of-process fallback), and the registry throws if a `"required"` registration fails to create its task row.

This PR replaces the stale assertion with one that checks the real invariant: ACP registration must leave `taskRowOwnership` undefined. If ACP were ever changed to claim `"required"` ownership, a task-row write failure would incorrectly abort an ACP run that the registry does not actually own end-to-end. I also strengthened the native/in-process spawn suite with the missing positive-path assertions so both sides of the contract (ACP omits the field; native forwards `"required"` in-process and `"gateway_best_effort"` out-of-process) are directly proven against the real registration payload rather than inferred.

No production code changed.

## User Impact

None. This is a test-only correction; it does not change runtime behavior. It closes a coverage gap so a future accidental regression in ACP's task-row ownership claim would be caught by CI instead of silently landing.

## Evidence

Focused suites, both green:

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs src/agents/subagents/spawn/acp-spawn.test.ts
 Test Files  1 passed (1)
      Tests  71 passed (71)

$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs src/agents/subagents/spawn/subagent-spawn.test.ts
 Test Files  1 passed (1)
      Tests  54 passed (54)
```

Flip-proof (required by review before landing): temporarily changed ACP's `buildRegistration` in `acp-spawn.ts` to add `taskRowOwnership: "required"`, reran the ACP suite, and confirmed the new assertion — and only that assertion — fails for the intended reason, then reverted the production change (`git diff` on `acp-spawn.ts` is empty):

```
FAIL  |agents-support| src/agents/subagents/spawn/acp-spawn.test.ts > spawnAcpDirect > spawns ACP session, binds a new thread, and dispatches initial task
AssertionError: expected 'required' to be undefined
- Expected: undefined
+ Received: "required"
 ❯ src/agents/subagents/spawn/acp-spawn.test.ts:917:48
    expect(registeredAcpRun?.taskRowOwnership).toBeUndefined();
 Test Files  1 failed (1)
      Tests  1 failed | 70 passed (71)
```

Repository search confirms no remaining `requiresTaskRow` occurrence anywhere:

```
$ rg -n "requiresTaskRow"
(no matches)
```

Changed-path gate (`node scripts/check-changed.mjs -- src/agents/subagents/spawn/acp-spawn.test.ts src/agents/subagents/spawn/subagent-spawn.test.ts`): wrapper shadowing guard passed, package patch guard passed, Knip dead-export scans passed with 0 entries, core typecheck and lint (0 warnings/errors) passed via Testbox, exit 0.

`autoreview --mode uncommitted`: clean, no accepted/actionable findings, overall confidence 0.99.

Production LOC delta: 0. Test LOC delta: +15/-3 across the two touched files (test-only).

Fixes #124236
