### PR TITLE
fix(ui): use native placement for the lobster dismiss menu

### DIFF
--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -14,18 +14,9 @@ export function renderLobsterPetDismissMenu(params: {
   if (!position) {
     return nothing;
   }
-  // wa-dropdown's `size` (auto-size) middleware runs after `flip` and clamps
-  // `#menu` to `--auto-size-available-height` for whatever placement flip
-  // lands on (Web Awesome 3.10.0 popup source, chunk.7MPIABXH.js:197-273), so
-  // a popup anchored near a viewport edge can still get shrunk in place
-  // rather than flipped away from it — flip's own bestFit candidates
-  // (floating-ui/core 1.8.0 flip middleware, dist/floating-ui.core.mjs:444)
-  // are evaluated against the anchor's transient position, not the menu's
-  // real measured content. The pet always sits on the footer's bottom edge,
-  // so rather than depend on flip picking correctly, `top-start` is set as
-  // the preferred placement directly — it structurally has room by
-  // construction; `shift` and `auto-size` (already on for every wa-dropdown)
-  // then react to the menu's real measured content instead of a guess.
+  // Auto-size clamps the menu to whatever placement flip picks rather than
+  // relocating it, so top-start is forced directly since the footer always
+  // has clear room above — leaving it to flip risks a shrunk-in-place menu.
   return html`
     <openclaw-menu-surface>
       <wa-dropdown

--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -14,13 +14,18 @@ export function renderLobsterPetDismissMenu(params: {
   if (!position) {
     return nothing;
   }
-  // wa-dropdown enables `flip` but never sets `flip-fallback-placements`, so
-  // its fallback list stays empty and `flip` can never move the popup off its
-  // preferred placement (confirmed in the installed Web Awesome 3.10.0
-  // popup source). The pet lives on the footer ledge, always the bottom
-  // edge, so `top-start` is the placement that actually has room; `shift`
-  // and `auto-size` (already on for every wa-dropdown) then react to the
-  // menu's real measured content instead of a guessed width/height.
+  // wa-dropdown's `size` (auto-size) middleware runs after `flip` and clamps
+  // `#menu` to `--auto-size-available-height` for whatever placement flip
+  // lands on (Web Awesome 3.10.0 popup source, chunk.7MPIABXH.js:197-273), so
+  // a popup anchored near a viewport edge can still get shrunk in place
+  // rather than flipped away from it — flip's own bestFit candidates
+  // (floating-ui/core 1.8.0 flip middleware, dist/floating-ui.core.mjs:444)
+  // are evaluated against the anchor's transient position, not the menu's
+  // real measured content. The pet always sits on the footer's bottom edge,
+  // so rather than depend on flip picking correctly, `top-start` is set as
+  // the preferred placement directly — it structurally has room by
+  // construction; `shift` and `auto-size` (already on for every wa-dropdown)
+  // then react to the menu's real measured content instead of a guess.
   return html`
     <openclaw-menu-surface>
       <wa-dropdown

--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -14,22 +14,19 @@ export function renderLobsterPetDismissMenu(params: {
   if (!position) {
     return nothing;
   }
-  // Web Awesome caps `#menu` to `--auto-size-available-height` and its `size`
-  // middleware runs after `flip`, so a popup anchored near a viewport edge is
-  // shrunk in place instead of flipping and silently scrolls its own items.
-  // The pet lives on the footer ledge, i.e. always at the bottom edge, so the
-  // anchor is clamped like every other pointer-anchored menu (session-menu.ts,
-  // catalog-session-menu.ts, native-link-menu.ts, sidebar-menus-controller.ts).
-  const menuWidth = 264;
-  const menuHeight = 80;
-  const x = Math.max(8, Math.min(position.x, window.innerWidth - menuWidth - 8));
-  const y = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8));
+  // wa-dropdown enables `flip` but never sets `flip-fallback-placements`, so
+  // its fallback list stays empty and `flip` can never move the popup off its
+  // preferred placement (confirmed in the installed Web Awesome 3.10.0
+  // popup source). The pet lives on the footer ledge, always the bottom
+  // edge, so `top-start` is the placement that actually has room; `shift`
+  // and `auto-size` (already on for every wa-dropdown) then react to the
+  // menu's real measured content instead of a guessed width/height.
   return html`
     <openclaw-menu-surface>
       <wa-dropdown
         class="session-menu lobster-pet-dismiss-menu"
         .open=${true}
-        placement="bottom-start"
+        placement="top-start"
         .distance=${0}
         aria-label=${t("quickSettings.appearance.lobsterVisits")}
         @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
@@ -48,7 +45,7 @@ export function renderLobsterPetDismissMenu(params: {
           tabindex="-1"
           aria-hidden="true"
           aria-label=${t("quickSettings.appearance.lobsterVisits")}
-          style="position: fixed; left: ${x}px; top: ${y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
         ></button>
         <wa-dropdown-item class="session-menu__item" value="dismiss"
           >${t("common.dismiss")}</wa-dropdown-item

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -311,6 +311,29 @@ describe("lobster pet element", () => {
     expect(getLobsterdexEntries().get(look.palette.id)?.name).toBeTruthy();
   });
 
+  it("anchors the dismiss menu at the raw pointer position with a top-start placement", async () => {
+    vi.useFakeTimers();
+    const element = createPet(42);
+    await arrive(element);
+
+    // Coordinates deliberately exceed a guessed 264x80 pre-clamp: a
+    // reintroduced clamp would move the trigger away from these exact values.
+    const clientX = 1200;
+    const clientY = 850;
+    element
+      .querySelector(".lobster-pet")
+      ?.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX, clientY }),
+      );
+    await element.updateComplete;
+
+    const dropdown = element.querySelector(".lobster-pet-dismiss-menu");
+    expect(dropdown?.getAttribute("placement")).toBe("top-start");
+    const trigger = element.querySelector<HTMLElement>('[slot="trigger"]');
+    expect(trigger?.style.left).toBe(`${clientX}px`);
+    expect(trigger?.style.top).toBe(`${clientY}px`);
+  });
+
   it("offers a temporary dismissal from the right-click menu", async () => {
     vi.useFakeTimers();
     const element = createPet(42);

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -82,7 +82,25 @@ async function measureDismissMenu(currentPage: Page) {
     const menuRect = menu.getBoundingClientRect();
     const host = document.querySelector<HTMLElement>("openclaw-lobster-pet");
     const hostStyle = host ? getComputedStyle(host) : null;
+    const firstItem = dropdown.querySelector("wa-dropdown-item");
+    const firstItemLabel = firstItem?.shadowRoot?.querySelector<HTMLElement>("#label") ?? null;
     return {
+      // The item's rendered label size comes from the app's own
+      // .session-menu__item light-DOM class (ui/src/styles/layout.css),
+      // which sets an explicit font-size from --control-ui-text-scale —
+      // not from wa-dropdown-item's shadow styles. Captured here so tests
+      // can prove the text-scale token actually reached the label instead
+      // of trusting an unrelated Web Awesome token override.
+      firstItemFontSizePx: firstItem
+        ? Number.parseFloat(getComputedStyle(firstItem).fontSize)
+        : null,
+      // The label's own unclamped box height: .session-menu__item's
+      // min-height design floor (28px, ui/src/styles/base.css) keeps a
+      // single short line and a single modestly-scaled line at the same
+      // 28px row height, so the row height alone can't tell a real
+      // font-size increase from a no-op. The label's own height isn't
+      // floor-clamped and grows with font-size regardless.
+      firstItemLabelHeightPx: firstItemLabel?.getBoundingClientRect().height ?? null,
       scrollHeight: menu.scrollHeight,
       clientHeight: menu.clientHeight,
       offsetHeight: menu.offsetHeight,
@@ -113,15 +131,26 @@ async function measureDismissMenu(currentPage: Page) {
   });
 }
 
-/** Rewrites the two dismissal items to long, wide labels and scales up the
- *  font/line-height tokens they read from. Stands in for a locale whose
- *  strings and type-scale are both larger than the pinned English default,
- *  without depending on the app's network-loaded locale chunks. */
+// The largest text-scale stop a user can actually pick from Appearance
+// settings (TEXT_SCALE_STOPS in ui/src/app/settings.ts), applied the same
+// way ui/src/app/bootstrap.ts:79 applies it at runtime.
+const ENLARGED_TEXT_SCALE = "1.4";
+
+/** Rewrites the two dismissal items to long, wide labels and applies the
+ *  real "enlarged type scale" setting. The dismiss menu's items render
+ *  through the app's own `.session-menu__item` light-DOM class
+ *  (ui/src/styles/layout.css), which sets an explicit
+ *  `font-size: calc(13px * var(--control-ui-text-scale))` — that wins over
+ *  wa-dropdown-item's inherited shadow-DOM styles, which never set
+ *  font-size themselves (confirmed in the installed Web Awesome 3.10.0
+ *  dropdown-item styles). So --control-ui-text-scale, not any
+ *  --wa-font-size-* token, is the lever that actually changes what the
+ *  operator sees. Stands in for a locale whose strings and type-scale are
+ *  both larger than the pinned English default, without depending on the
+ *  app's network-loaded locale chunks. */
 async function useOversizedDismissLabels(currentPage: Page) {
-  await currentPage.addStyleTag({
-    content: `:root { --wa-font-size-smaller: 22px; --wa-line-height-condensed: 2.4; }`,
-  });
-  await currentPage.evaluate(() => {
+  await currentPage.evaluate((scale) => {
+    document.documentElement.style.setProperty("--control-ui-text-scale", scale);
     const labels = [
       "Postpone this lobster visit notice until the next scheduled maintenance window",
       "Permanently suppress every future lobster visit notice across all workspaces",
@@ -131,7 +160,7 @@ async function useOversizedDismissLabels(currentPage: Page) {
       .forEach((item, index) => {
         item.textContent = labels[index] ?? item.textContent;
       });
-  });
+  }, ENLARGED_TEXT_SCALE);
 }
 
 suite.define(() => {
@@ -188,6 +217,9 @@ suite.define(() => {
 
     await sprite.click({ button: "right" });
     await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+    await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+    const baseline = await measureDismissMenu(page);
+
     await useOversizedDismissLabels(page);
 
     // Web Awesome's popup tracks anchor/floating element size with a
@@ -202,12 +234,17 @@ suite.define(() => {
     const measurement = await measureDismissMenu(page);
     await page.screenshot({ path: path.join(artifactDir, "long-labels-enlarged-scale.png") });
 
-    // Guards against the style/text injection silently no-opping: the
-    // enlarged content must actually be taller than the old guessed 80px
-    // pre-clamp, or this test would pass without exercising the fix.
-    for (const itemHeight of measurement.itemHeights) {
-      expect(itemHeight).toBeGreaterThan(40);
-    }
+    // Guards against --control-ui-text-scale/the label injection silently
+    // no-opping: the rendered label font-size and its unclamped box height
+    // must both actually grow, or this test would pass without exercising
+    // the real type-scale token (the row's own height can't tell a real
+    // increase from a no-op — see firstItemLabelHeightPx above).
+    expect(measurement.firstItemFontSizePx).not.toBeNull();
+    expect(measurement.firstItemFontSizePx).toBeGreaterThan(baseline.firstItemFontSizePx ?? 0);
+    expect(measurement.firstItemLabelHeightPx).not.toBeNull();
+    expect(measurement.firstItemLabelHeightPx).toBeGreaterThan(
+      baseline.firstItemLabelHeightPx ?? 0,
+    );
   });
 
   it("keeps the popup within the viewport at a compact footer-edge viewport height", async () => {

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -33,10 +33,22 @@ const artifactDir = path.resolve(
 let context: BrowserContext;
 let page: Page;
 
+/** Shared setup for a fresh page: mock gateway, load, and park the clock so
+ *  the pet's own timers don't fire mid-assertion. Reused across the default
+ *  1280x900 context and the per-test contexts below (compact/edge/theme). */
+async function loadControlUiPage(currentPage: Page) {
+  await currentPage.clock.install({ time: new Date("2026-07-09T12:00:00") });
+  await installMockGateway(currentPage);
+  await currentPage.goto(suite.server.baseUrl);
+  await currentPage.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
+  const loadedAt = await currentPage.evaluate(() => Date.now());
+  await currentPage.clock.pauseAt(loadedAt + 1_000);
+}
+
 /** Mounts the pet inside the real sidebar footer ledge so production CSS
  *  (`openclaw-lobster-pet { height: 52px; overflow: hidden }`) applies. */
-async function mountPetInRealFooter(seed: number) {
-  await page.evaluate(async (petSeed) => {
+async function mountPetInRealFooter(currentPage: Page, seed: number) {
+  await currentPage.evaluate(async (petSeed) => {
     const footer = document.querySelector(".sidebar-shell__footer");
     if (!footer) {
       throw new Error("sidebar footer ledge not found");
@@ -52,9 +64,10 @@ async function mountPetInRealFooter(seed: number) {
   }, seed);
 }
 
-/** Reads the geometry that decides whether the popup scrolls. */
-async function measureDismissMenu() {
-  return await page.evaluate(() => {
+/** Reads the geometry that decides whether the popup scrolls or overflows
+ *  the viewport. */
+async function measureDismissMenu(currentPage: Page) {
+  return await currentPage.evaluate(() => {
     const dropdown = document.querySelector("wa-dropdown.lobster-pet-dismiss-menu");
     if (!dropdown?.shadowRoot) {
       throw new Error("dismiss menu dropdown not found");
@@ -66,6 +79,7 @@ async function measureDismissMenu() {
       throw new Error("dismiss menu #menu part not found");
     }
     const menuStyle = getComputedStyle(menu);
+    const menuRect = menu.getBoundingClientRect();
     const host = document.querySelector<HTMLElement>("openclaw-lobster-pet");
     const hostStyle = host ? getComputedStyle(host) : null;
     return {
@@ -82,6 +96,11 @@ async function measureDismissMenu() {
       resolvedPlacement: popup?.getAttribute("data-current-placement") ?? "(none)",
       anchorTop: dropdown.querySelector<HTMLElement>('[slot="trigger"]')?.style.top ?? "(none)",
       viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      menuLeft: menuRect.left,
+      menuRight: menuRect.right,
+      menuTop: menuRect.top,
+      menuBottom: menuRect.bottom,
       popupIsTopLayer: popupBox ? popupBox.matches(":popover-open") : null,
       menuSurfaceIsTopLayer:
         document.querySelector("openclaw-menu-surface")?.matches(":popover-open") ?? null,
@@ -94,21 +113,37 @@ async function measureDismissMenu() {
   });
 }
 
+/** Rewrites the two dismissal items to long, wide labels and scales up the
+ *  font/line-height tokens they read from. Stands in for a locale whose
+ *  strings and type-scale are both larger than the pinned English default,
+ *  without depending on the app's network-loaded locale chunks. */
+async function useOversizedDismissLabels(currentPage: Page) {
+  await currentPage.addStyleTag({
+    content: `:root { --wa-font-size-smaller: 22px; --wa-line-height-condensed: 2.4; }`,
+  });
+  await currentPage.evaluate(() => {
+    const labels = [
+      "Postpone this lobster visit notice until the next scheduled maintenance window",
+      "Permanently suppress every future lobster visit notice across all workspaces",
+    ];
+    document
+      .querySelectorAll("wa-dropdown.lobster-pet-dismiss-menu wa-dropdown-item")
+      .forEach((item, index) => {
+        item.textContent = labels[index] ?? item.textContent;
+      });
+  });
+}
+
 suite.define(() => {
   beforeEach(async () => {
     context = await suite.newBrowserContext({ viewport: { width: 1280, height: 900 } });
     page = await context.newPage();
-    await page.clock.install({ time: new Date("2026-07-09T12:00:00") });
-    await installMockGateway(page);
-    await page.goto(suite.server.baseUrl);
-    await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
-    const loadedAt = await page.evaluate(() => Date.now());
-    await page.clock.pauseAt(loadedAt + 1_000);
+    await loadControlUiPage(page);
     await mkdir(artifactDir, { recursive: true });
   });
 
   it("does not scroll its two dismissal items in the real sidebar footer", async () => {
-    await mountPetInRealFooter(42);
+    await mountPetInRealFooter(page, 42);
     const sprite = page.locator(".lobster-pet");
     await sprite.waitFor();
 
@@ -116,7 +151,7 @@ suite.define(() => {
     await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
     await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
 
-    const measurement = await measureDismissMenu();
+    const measurement = await measureDismissMenu(page);
     await page.screenshot({ path: path.join(artifactDir, "real-footer-context.png") });
 
     // Asserting on the whole measurement so a regression prints the anchor
@@ -127,7 +162,7 @@ suite.define(() => {
   // Control: the identical menu content, anchored away from the bottom edge.
   // Isolates the anchor position as the cause rather than the menu's content.
   it("has room for the same two items when the ledge is not at the viewport edge", async () => {
-    await mountPetInRealFooter(42);
+    await mountPetInRealFooter(page, 42);
     await page.evaluate(() => {
       const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
       if (footer) {
@@ -140,9 +175,116 @@ suite.define(() => {
     await sprite.click({ button: "right" });
     await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
 
-    const measurement = await measureDismissMenu();
+    const measurement = await measureDismissMenu(page);
     await page.screenshot({ path: path.join(artifactDir, "control-away-from-edge.png") });
 
     expect(measurement).toMatchObject({ overflowPx: 0 });
+  });
+
+  it("keeps both items fully visible under long labels and an enlarged type scale", async () => {
+    await mountPetInRealFooter(page, 42);
+    const sprite = page.locator(".lobster-pet");
+    await sprite.waitFor();
+
+    await sprite.click({ button: "right" });
+    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+    await useOversizedDismissLabels(page);
+
+    // Web Awesome's popup tracks anchor/floating element size with a
+    // ResizeObserver, so the label swap above reflows the popup
+    // asynchronously; poll for settlement instead of asserting immediately
+    // after the DOM write.
+    await expect
+      .poll(async () => (await measureDismissMenu(page)).overflowPx, {
+        message: "menu did not settle",
+      })
+      .toBe(0);
+    const measurement = await measureDismissMenu(page);
+    await page.screenshot({ path: path.join(artifactDir, "long-labels-enlarged-scale.png") });
+
+    // Guards against the style/text injection silently no-opping: the
+    // enlarged content must actually be taller than the old guessed 80px
+    // pre-clamp, or this test would pass without exercising the fix.
+    for (const itemHeight of measurement.itemHeights) {
+      expect(itemHeight).toBeGreaterThan(40);
+    }
+  });
+
+  it("keeps the popup within the viewport at a compact footer-edge viewport height", async () => {
+    await suite.withPage(
+      { viewport: { width: 1280, height: 420 } },
+      async ({ page: shortPage }) => {
+        await loadControlUiPage(shortPage);
+        await mountPetInRealFooter(shortPage, 42);
+        const sprite = shortPage.locator(".lobster-pet");
+        await sprite.waitFor();
+
+        await sprite.click({ button: "right" });
+        await shortPage.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+        await shortPage.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+
+        const measurement = await measureDismissMenu(shortPage);
+        await shortPage.screenshot({ path: path.join(artifactDir, "compact-viewport-height.png") });
+
+        // At this height even the "top" placement may run short, so Web
+        // Awesome's own vertical auto-size may still shrink the menu in place
+        // (an accepted last-resort fallback). What must hold regardless is
+        // that the popup itself never renders outside the viewport.
+        expect(measurement.menuTop).toBeGreaterThanOrEqual(0);
+        expect(measurement.menuBottom).toBeLessThanOrEqual(measurement.viewportHeight);
+      },
+    );
+  });
+
+  for (const edge of ["left", "right"] as const) {
+    it(`keeps the popup within the viewport when the footer sits near the ${edge} edge`, async () => {
+      await mountPetInRealFooter(page, 42);
+      // Slide the footer so the sprite's click point lands 12px from the
+      // named edge, computed from its live layout rather than a guessed
+      // translate distance, so the sprite stays actionable for Playwright.
+      await page.evaluate((direction) => {
+        const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
+        const sprite = document.querySelector<HTMLElement>(".lobster-pet");
+        if (!footer || !sprite) {
+          throw new Error("footer or sprite not found");
+        }
+        const rect = sprite.getBoundingClientRect();
+        const targetCenterX = direction === "left" ? 12 : window.innerWidth - 12;
+        const dx = targetCenterX - (rect.left + rect.width / 2);
+        footer.style.transform = `translateX(${dx}px)`;
+      }, edge);
+      const sprite = page.locator(".lobster-pet");
+      await sprite.waitFor();
+
+      await sprite.click({ button: "right" });
+      await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+
+      const measurement = await measureDismissMenu(page);
+      await page.screenshot({ path: path.join(artifactDir, `edge-${edge}.png`) });
+
+      expect(measurement.menuLeft).toBeGreaterThanOrEqual(0);
+      expect(measurement.menuRight).toBeLessThanOrEqual(measurement.viewportWidth);
+    });
+  }
+
+  it("does not scroll its two dismissal items under a dark color scheme", async () => {
+    await suite.withPage(
+      { viewport: { width: 1280, height: 900 }, colorScheme: "dark" },
+      async ({ page: darkPage }) => {
+        await loadControlUiPage(darkPage);
+        await mountPetInRealFooter(darkPage, 42);
+        const sprite = darkPage.locator(".lobster-pet");
+        await sprite.waitFor();
+
+        await sprite.click({ button: "right" });
+        await darkPage.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+        await darkPage.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+
+        const measurement = await measureDismissMenu(darkPage);
+        await darkPage.screenshot({ path: path.join(artifactDir, "dark-theme.png") });
+
+        expect(measurement).toMatchObject({ overflowPx: 0 });
+      },
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #124239.

The lobster dismiss menu pre-clamped its pointer anchor against a hard-coded `menuWidth = 264` / `menuHeight = 80` guess before opening the dropdown (`ui/src/components/lobster-pet-dismiss-menu.ts:23`, prior to this change). Those numbers are not stable under localization, custom fonts, or Web Awesome token changes, so a longer translated label or a larger type scale could overflow the guessed box and the menu's own content would scroll inside a visible scrollbar instead of the popup simply moving.

## Why This Change Was Made

I inspected the installed Web Awesome 3.10.0 dropdown/popup source and the pinned `@floating-ui/core` 1.8.0 source directly (see Evidence) to find the actual supported contract before changing anything, per the review on the issue.

- `wa-dropdown` has no `anchor`/virtual-element property of its own. Its internal `<wa-popup>` is always anchored to whatever DOM element is slotted into `slot="trigger"` (`dropdown.js` render output: `<slot name="trigger" slot="anchor">`). `wa-popup.anchor` *does* accept a `VirtualElement`, but `wa-dropdown` never exposes that — so a virtual-anchor rewrite wasn't actually available through this component; the existing hidden-DOM-trigger pattern (already used by every other pointer-anchored menu in this codebase) is the real contract.
- `wa-dropdown` always enables `flip`, `shift`, and (via the render template) `auto-size="vertical"`, and never sets `flip-fallback-placements`, which defaults to `""`. An earlier version of this PR claimed that empty string made floating-ui's `flip` middleware treat the fallback list as empty, so `flip` could never move the popup. That's wrong: in `@floating-ui/core` 1.8.0's `flip` middleware, an empty/falsy `fallbackPlacements` isn't "no fallback" — it falls through to a *computed* default (`dist/floating-ui.core.mjs:444`), and for an aligned placement like `bottom-start`/`top-start` that computed default is `getExpandedPlacements(initialPlacement)`, a real 3-item list. For `bottom-start` that's `[bottom-end, top-start, top-end]`, so `flip` genuinely can and does have somewhere else to go. `wa-dropdown`'s `size` (auto-size) middleware, however, runs *after* `flip` in the pipeline and clamps `#menu` to `--auto-size-available-height` for whatever placement `flip` settled on (`chunk.7MPIABXH.js:197-273`) — so a popup that `flip` leaves at (or returns to) a cramped edge placement still gets shrunk in place by `auto-size` rather than visibly failing to fit, which is the actual "shrink instead of relocate" behavior the original 264x80 clamp was papering over.

Given that, the correct fix is not a virtual anchor (unsupported) and not bigger magic constants (same guessing problem), and not leaning harder on `flip`'s reactive best-fit either — `flip` decides against the anchor's current position each time `reposition()` runs, before `shift`/`auto-size` have adjusted anything, so it isn't guaranteed to land on the placement that structurally has the most room. Since the pet always sits on the footer/bottom edge, `top-start` is that placement by construction, so I switched to it directly and deleted the pre-clamp entirely. `shift` and `auto-size`, already enabled on every `wa-dropdown`, now size and reposition the popup from its real measured content instead of a guess, and `flip` remains available as a secondary safety net for the rare case where even `top-start` runs short.

## User Impact

The lobster dismiss menu's two options ("Dismiss" / "Dismiss and don't show again") now stay fully visible and never internally scroll, regardless of translated label length or an enlarged type scale. No behavior change for selection, keyboard dismissal, or the after-hide lifecycle.

## Evidence

Dependency files/lines personally inspected in this checkout's `node_modules/@awesome.me/webawesome` (version confirmed via `package.json`: `"version": "3.10.0"`) and `node_modules/@floating-ui/core` + `node_modules/@floating-ui/utils` (version confirmed: `"version": "1.8.0"`):
- `dist/components/dropdown/dropdown.d.ts` — `WaDropdown` has `placement`, `distance`, `skidding`; no `anchor` property.
- `dist/chunks/chunk.2IJXO5LR.js:346-348` — `getTrigger() { return this.querySelector('[slot="trigger"]'); }`.
- `dist/chunks/chunk.2IJXO5LR.js:571-605` — dropdown's `render()`: `<wa-popup ... flip flip-fallback-strategy="best-fit" shift shift-padding="10" auto-size="vertical" auto-size-padding="10"><slot name="trigger" slot="anchor" ...>`.
- `dist/components/popup/popup.d.ts:3-6,54-58` — `wa-popup.anchor: Element | string | VirtualElement`, confirming the virtual-anchor contract exists only on the lower-level popup primitive, not on `wa-dropdown`.
- `@awesome.me/webawesome` `dist/chunks/chunk.7MPIABXH.js:52` — `this.flipFallbackPlacements = ""` (default); line 225 passes it straight through as `fallbackPlacements: this.flipFallbackPlacements` with a `// @ts-expect-error - We're converting a string attribute to an array here` acknowledging the raw-string handoff; lines 197-273 confirm `reposition()`'s middleware order is `offset` → `flip(...)` → `shift(...)` → `size` (auto-size).
- `@floating-ui/core` `dist/floating-ui.core.mjs:426-449` (`flip` middleware `fn`) — `const fallbackPlacements = specifiedFallbackPlacements || (isBasePlacement || !flipAlignment ? [getOppositePlacement(initialPlacement)] : getExpandedPlacements(initialPlacement));`. `""` is JS-falsy, so this does **not** produce an empty list; `wa-dropdown` never overrides `flipAlignment` (defaults `true`) and `bottom-start`/`top-start` aren't base placements, so the branch taken is `getExpandedPlacements(initialPlacement)`.
- `@floating-ui/utils` `dist/floating-ui.utils.mjs:61-64` (`getExpandedPlacements`) — confirms the actual candidate list for `bottom-start` is `[bottom-end, top-start, top-end]` (plus the initial placement itself), not an empty array.

Test output (this checkout, via `node scripts/run-vitest.mjs ui/src/components/lobster-pet.test.ts`):
```
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

Regression proof (Repair Doctrine): stashed the production fix, reran the same file — the new `anchors the dismiss menu at the raw pointer position with a top-start placement` test failed for the intended reason (`expected 'bottom-start' to be 'top-start'`), then restored the fix and it passed again.

`node scripts/check-changed.mjs -- ui/src/components/lobster-pet-dismiss-menu.ts ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts`: typecheck (core + UI), lint (core + UI), format, dead-export scan, and the Control UI i18n catalog check all passed, `exit=0`.

`.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.

Extended `ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts` with real-browser Playwright coverage beyond the original pinned 1280x900/English case: long/pseudo-localized labels combined with the app's real `--control-ui-text-scale` type-scale setting (`ui/src/app/bootstrap.ts`, same 140% stop a user can pick in Appearance settings), a compact viewport height near the footer edge, left/right viewport-edge anchoring, and a dark color-scheme run. Ran the full suite locally against this exact head (`node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts`), 7/7 passing:
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

An earlier revision of the "enlarged type scale" test overrode `--wa-font-size-smaller`/`--wa-line-height-condensed` (Web Awesome tokens), which CI caught as a no-op: this menu's items render through the app's own `.session-menu__item` light-DOM class (`ui/src/styles/layout.css`), which sets an explicit `font-size: calc(13px * var(--control-ui-text-scale))` that wins over `wa-dropdown-item`'s shadow-DOM styles — `--wa-font-size-smaller` isn't consumed by the item's own label at all. The test now sets `--control-ui-text-scale` the same way `ui/src/app/bootstrap.ts` does at runtime, and asserts the label's computed font-size and its own unclamped rendered height both grow versus a pre-scale baseline (the row's `min-height: 28px` design floor absorbs small growth, so it can't tell a real increase from a no-op on its own).
