### PR TITLE
refactor(ui): remove unreachable assistant message expanded flag

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -19,135 +19,39 @@ const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-message-actions");
 const transportPreviewLimit = 8_000;
 
-const realisticFullAssistantContent = `# Refactor complete: one transcript-loading path
+// Neutral filler line repeated to push the fixture past the transport
+// preview limit without embedding stale implementation narrative; the
+// heading, list, code block, and path sample below exercise Markdown
+// rendering, while the repeated line only pads length.
+const FULL_ASSISTANT_CONTENT_FILLER_LINE =
+  "Repeat neutral filler text to exceed the transport preview limit while staying deterministic and readable.\n";
 
-I finished the Control UI transcript refactor. Ordinary messages render exactly as before, but a long assistant response no longer leaves the operator behind a disclosure control when the complete Markdown is available.
+const realisticFullAssistantContent = `# Deployment report
 
-## What was wrong
+## Summary
 
-The transcript list already knew the session key and stable message id, while each message group separately derived enough state to render Markdown, copy text, and build reply context. When history contained a transport-limited preview, those consumers could disagree: the bubble showed the preview, Copy used cached text, and Reply rebuilt text from the original transcript entry.
+- service: payment-gateway
+- environment: production
+- status: completed
 
-The underlying problem was ownership. Full-message loading already belonged to the thread, but visibility was controlled farther down the render tree. That meant the UI could possess the complete response and still choose to show only the preview until someone clicked Show more.
+## Rollout steps
 
-## Files reviewed
-
-### ui/src/pages/chat/chat-thread.ts
-
-The page owns the session-scoped map of assistant message expansions. Each entry records a revision and a loading, loaded, or failed result. The revision participates in row memoization, so completing a request invalidates the affected row without rebuilding the entire transcript.
-
-The cache key combines the active session and message id. Switching sessions therefore cannot leak loaded text into another conversation, even when deterministic fixtures reuse a local id.
-
-~~~ts
-type AssistantMessageExpansionState =
-  | { status: "loading"; revision: number }
-  | { status: "error"; revision: number }
-  | { status: "loaded"; expanded: boolean; markdown: string; revision: number };
-~~~
-
-This state and the existing chat.message.get request remain unchanged. The UI adjustment only removes the separate assistant disclosure decision after the loaded Markdown is present.
-
-### ui/src/pages/chat/components/chat-message-group.ts
-
-The group is the shared boundary for bubble content and message actions. It already checks the gateway suffix and transcriptMeta.truncated, looks up the stable message id, and receives the existing full-message callback from the thread.
-
-The group now starts that existing callback when it first sees an eligible entry instead of waiting for a button click. It does not introduce another cache, request type, retry timer, or transport flag. A loading or failed entry is left alone, which prevents render-driven request loops.
+1. Build the release artifact and run smoke tests.
+2. Deploy to the canary pool and watch the error budget.
+3. Promote to the full fleet.
 
 ~~~ts
-for (const details of messageActionDetails) {
-  if (
-    details?.shouldFetchFullMessage &&
-    details.messageId &&
-    !getAssistantMessageExpansion(details.messageId)
-  ) {
-    onToggleAssistantMessageExpanded(details.messageId);
-  }
+export function verifyRollout(serviceName: string): Promise<boolean> {
+  return healthCheck(serviceName);
 }
 ~~~
 
-Once the existing loader resolves, the same selected Markdown flows to the bubble, inline Copy action, Reply action, and context menu. No consumer has to infer whether a loaded response should still look collapsed.
+Reference: src/services/payment-gateway/deploy.ts:88
 
-### ui/src/pages/chat/components/chat-message-markdown.ts
+${FULL_ASSISTANT_CONTENT_FILLER_LINE.repeat(75)}
+## Final verification
 
-Assistant Markdown now renders directly. If the existing expansion record contains loaded text, that text is selected regardless of the old expanded boolean. Otherwise the transcript text is shown exactly as received.
-
-Loaded text uses document rendering mode so the chat renderer does not apply its regular large-message preview limit to a response that was explicitly recovered in full. User-authored messages keep their separate local disclosure behavior; this change only removes the assistant control.
-
-~~~ts
-const markdown = disclosure?.expanded
-  ? disclosure.markdown ?? previewMarkdown
-  : previewMarkdown;
-
-return renderMarkdownText(markdown, isStreaming, renderOptions);
-~~~
-
-There is no assistant footer, loading label, Show more button, Show less button, or inline failure banner. During the existing request, the transport text remains readable. When complete text arrives, the same bubble grows naturally to fit it.
-
-## Request lifecycle
-
-1. History supplies the transport representation of the assistant message.
-2. The existing truncation check determines whether a stored full copy can be requested.
-3. The group invokes the already-shipped full-message callback once.
-4. The thread sends chat.message.get with the stable session and message identifiers.
-5. A successful result replaces the visible Markdown in the existing bubble.
-6. Copy and Reply immediately use the same complete Markdown.
-
-The request shape remains the one already supported by the gateway:
-
-~~~json
-{
-  "sessionKey": "main",
-  "messageId": "assistant-refactor-report",
-  "maxChars": 500000
-}
-~~~
-
-Those names are deterministic fixture values. This scenario contains no production session identifiers, account data, credentials, channel addresses, provider keys, or access tokens.
-
-## Failure behavior
-
-If no complete stored message is available, the UI keeps the transcript text. It does not replace useful content with an error card or leave a dead control on screen. The existing failed state prevents the render pass from immediately issuing the same request again.
-
-This matters during reconnects and partial history imports: the operator still sees the information that actually reached the browser. The UI does not invent missing prose, infer a synthetic ending, or claim that a transport-limited message is complete.
-
-## Observable behavior covered
-
-The focused component tests protect the user-facing boundary rather than the internal call order:
-
-- eligible assistant text starts the existing full-message load without a click;
-- loaded Markdown is visible even if an older cached expanded flag is false;
-- the assistant bubble contains no Show more or Show less control;
-- Copy and Reply use the complete loaded response;
-- loading and failure continue to display the transcript text;
-- mirrored tool replies and messages without a loader remain unchanged;
-- user-message disclosure behavior stays separate and intact.
-
-The thread test verifies that one render starts one request, that the complete response replaces the preview, and that later renders do not fetch it again. A second case rejects the request and confirms that the transport text stays readable with no disclosure or error UI.
-
-## Browser proof
-
-The browser scenario boots the real Control UI against a mocked Gateway WebSocket. History contains the first 8,000 characters of this report plus the existing truncation state, while chat.message.get returns this complete Markdown document.
-
-The test waits for the final heading, checks the exact request parameters, confirms that no disclosure buttons exist, and exercises both inline and context-menu actions. Screenshots use a normal 1440×900 viewport in dark and light themes rather than zooming out to make the response look artificially short.
-
-The before view ends in the middle of the refactor explanation because that is where the transport preview stops. The after view reaches the remaining failure notes, test coverage, scope checks, and final result in the same message bubble.
-
-## Scope checks
-
-No gateway handler, protocol type, persistence model, or transport limit changed. The full-message request, expansion cache, identifiers, and response extraction all predate this change. The production diff removes presentation branches instead of adding a second way to retrieve content.
-
-The change also leaves user-authored long messages alone. Their local disclosure is a presentation choice for text the user submitted, while this assistant path is about showing the complete response once the existing loader has made it available.
-
-## Manual review notes
-
-I reviewed the transition at a normal desktop viewport and followed the text rather than relying only on request assertions. The preview remains selectable while loading, the existing headings and code blocks stay mounted, and the message grows in place when the remaining Markdown arrives.
-
-In both themes, code blocks retain their contrast, long paths wrap without covering the message actions, and the final section remains reachable with ordinary scrolling. No spinner or temporary card shifts the reading position between the preview and the full response.
-
-I also rejected the mocked full-message request and confirmed that the last received sentence stayed visible. A later host render did not create a tight retry loop, duplicate the message group, or expose an inactive assistant disclosure control.
-
-## Verification result
-
-The focused component suite and real-browser mocked-gateway scenario pass with the same structured response. The complete answer is always visible when available, message actions agree with the bubble, both themes remain readable, and the assistant UI exposes no manual expansion control.`;
+All health checks passed and the rollout is complete.`;
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -318,7 +222,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
           role: "assistant",
           content: [{ type: "text", text: truncatedPreview }],
           timestamp: Date.now() + 4,
-          __openclaw: { id: "assistant-refactor-report", seq: 5 },
+          __openclaw: { id: "assistant-full-message", seq: 5 },
         },
       ],
       methodResponses: {
@@ -474,24 +378,22 @@ describeControlUiE2e("Control UI chat message actions", () => {
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))
         .toBe(messageText);
 
-      const fullTextBubble = page.locator(
-        '.chat-bubble[data-entry-id="assistant-refactor-report"]',
-      );
+      const fullTextBubble = page.locator('.chat-bubble[data-entry-id="assistant-full-message"]');
       const fullTextGroup = fullTextBubble.locator(
         "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' chat-group ')]",
       );
       const fullMessageRequest = await gateway.waitForRequest("chat.message.get");
       expect(fullMessageRequest.params).toMatchObject({
         sessionKey: "main",
-        messageId: "assistant-refactor-report",
+        messageId: "assistant-full-message",
         maxChars: 500_000,
       });
-      const fullTail = fullTextBubble.getByRole("heading", { name: "Verification result" });
+      const fullTail = fullTextBubble.getByRole("heading", { name: "Final verification" });
       await fullTail.waitFor({ state: "visible" });
       expect(await fullTextBubble.getByRole("button", { name: "Show more" }).count()).toBe(0);
       expect(await fullTextBubble.getByRole("button", { name: "Show less" }).count()).toBe(0);
       await fullTail.scrollIntoViewIfNeeded();
-      await screenshot(page, "07-realistic-refactor-dark.png");
+      await screenshot(page, "07-full-message-dark.png");
 
       await fullTextGroup.hover();
       await fullTextGroup.getByRole("button", { name: "Copy as markdown" }).click();
@@ -502,7 +404,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
       const fullTextReplyPreview = page.locator(".chat-reply-preview");
       await expect
         .poll(() => fullTextReplyPreview.locator(".chat-reply-preview__text").textContent())
-        .toContain("# Refactor complete: one transcript-loading path");
+        .toContain("# Deployment report");
       await fullTextReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
       await fullTextBubble.click({ button: "right" });
@@ -514,12 +416,12 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await menu.getByRole("menuitem", { name: "Reply to message" }).click();
       await expect
         .poll(() => fullTextReplyPreview.locator(".chat-reply-preview__text").textContent())
-        .toContain("# Refactor complete: one transcript-loading path");
+        .toContain("# Deployment report");
       await fullTextReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
       await setThemeMode(page, "light");
       await fullTail.scrollIntoViewIfNeeded();
-      await screenshot(page, "08-realistic-refactor-light.png");
+      await screenshot(page, "08-full-message-light.png");
       expect(await gateway.getRequests("chat.message.get")).toHaveLength(1);
     } finally {
       await context.close();

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -390,7 +390,7 @@ export function getExpandedUserMessages(sessionKey: string): Map<string, boolean
 export type AssistantMessageExpansionState =
   | { status: "loading"; revision: number }
   | { status: "error"; revision: number }
-  | { status: "loaded"; expanded: boolean; markdown: string; revision: number };
+  | { status: "loaded"; markdown: string; revision: number };
 
 export function getExpandedAssistantMessages(
   sessionKey: string,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -5292,7 +5292,6 @@ describe("grouped chat rendering", () => {
   });
 
   function renderAssistantDisclosureActionFixture(
-    expanded: boolean,
     options: Partial<RenderMessageGroupOptions> = {},
   ) {
     const container = document.createElement("div");
@@ -5310,7 +5309,6 @@ describe("grouped chat rendering", () => {
         loadFullAssistantMessage: async () => null,
         getAssistantMessageExpansion: () => ({
           status: "loaded",
-          expanded,
           markdown: fullMessage,
           revision: 1,
         }),
@@ -5321,13 +5319,10 @@ describe("grouped chat rendering", () => {
     return { container, fullMessage, preview };
   }
 
-  it.each([
-    { expanded: false, label: "previously collapsed" },
-    { expanded: true, label: "expanded" },
-  ])("copies the full $label assistant message", async ({ expanded }) => {
+  it("copies the full loaded assistant message", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } } as unknown as Navigator);
-    const { container, fullMessage } = renderAssistantDisclosureActionFixture(expanded);
+    const { container, fullMessage } = renderAssistantDisclosureActionFixture();
 
     expect(container.querySelector(".chat-text")?.textContent).toContain(fullMessage);
     expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();
@@ -5338,12 +5333,9 @@ describe("grouped chat rendering", () => {
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(fullMessage));
   });
 
-  it.each([
-    { expanded: false, label: "previously collapsed" },
-    { expanded: true, label: "expanded" },
-  ])("replies with the full $label assistant message", ({ expanded }) => {
+  it("replies with the full loaded assistant message", () => {
     const onReply = vi.fn();
-    const { container, fullMessage } = renderAssistantDisclosureActionFixture(expanded, {
+    const { container, fullMessage } = renderAssistantDisclosureActionFixture({
       onReply,
     });
 
@@ -5363,7 +5355,7 @@ describe("grouped chat rendering", () => {
     "keeps the transcript preview in %s assistant-message actions",
     (status) => {
       const onReply = vi.fn();
-      const { container, preview } = renderAssistantDisclosureActionFixture(false, {
+      const { container, preview } = renderAssistantDisclosureActionFixture({
         onReply,
         getAssistantMessageExpansion: () => ({ status, revision: 1 }),
       });
@@ -5380,17 +5372,16 @@ describe("grouped chat rendering", () => {
     },
   );
 
-  it("keeps expanded assistant thinking private while bounding reply context", async () => {
+  it("keeps loaded assistant thinking private while bounding reply context", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } } as unknown as Navigator);
     const onReply = vi.fn();
-    const visibleMessage = `${"a".repeat(499)}😀 full expanded answer`;
-    const { container } = renderAssistantDisclosureActionFixture(true, {
+    const visibleMessage = `${"a".repeat(499)}😀 full loaded answer`;
+    const { container } = renderAssistantDisclosureActionFixture({
       onReply,
       getAssistantMessageExpansion: () => ({
         status: "loaded",
-        expanded: true,
-        markdown: `<thinking>private expanded reasoning</thinking>${visibleMessage}`,
+        markdown: `<thinking>private loaded reasoning</thinking>${visibleMessage}`,
         revision: 1,
       }),
     });
@@ -5415,12 +5406,11 @@ describe("grouped chat rendering", () => {
     const onReply = vi.fn();
     const onToggleAssistantMessageExpanded = vi.fn();
     const privateThinking = "private expanded reasoning only";
-    const { container, preview } = renderAssistantDisclosureActionFixture(false, {
+    const { container, preview } = renderAssistantDisclosureActionFixture({
       onReply,
       onToggleAssistantMessageExpanded,
       getAssistantMessageExpansion: () => ({
         status: "loaded",
-        expanded: false,
         markdown: `<thinking>${privateThinking}</thinking>`,
         revision: 1,
       }),

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -243,15 +243,6 @@ export function projectChatTranscript(
   };
   const toggleAssistantMessageExpanded = (messageId: string) => {
     const current = expandedAssistantMessages.get(messageId);
-    if (current?.status === "loaded") {
-      expandedAssistantMessages.set(messageId, {
-        ...current,
-        expanded: !current.expanded,
-        revision: current.revision + 1,
-      });
-      requestUpdate();
-      return;
-    }
     const loader = props.loadFullAssistantMessage;
     if (!loader || current?.status === "loading") {
       return;
@@ -278,7 +269,7 @@ export function projectChatTranscript(
           messageId,
           markdown === null
             ? { status: "error", revision: revision + 1 }
-            : { status: "loaded", expanded: true, markdown, revision: revision + 1 },
+            : { status: "loaded", markdown, revision: revision + 1 },
         );
         requestUpdate();
       },


### PR DESCRIPTION
Fixes #124235

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Loaded full assistant messages have rendered in full since #122207, but the `loaded` variant of `AssistantMessageExpansionState` still carried an `expanded` boolean and a toggle branch that flips it. Neither the automatic loader nor the exhausted-retry action can ever reach that branch, so the field and branch were dead code. The browser E2E for this surface also embedded an 8,000-plus character architectural essay — including a code sample of the very `expanded` field being removed here — solely to exceed the transport preview limit.

## Why This Change Was Made

Removed the `expanded` field from the `loaded` state and the now-unreachable toggle branch in `chat-transcript-projection.ts`; the loader always transitions directly from `loading` to `loaded`/`error`. Collapsed the component test's duplicated `expanded: true` / `expanded: false` fixture variants, which had become identical scenarios once the field disappeared. Replaced the stale E2E fixture prose with a compact, deterministic Markdown sample (heading, list, code block, path reference, neutral filler) that still clears the 8,000-character transport preview limit. The revision-checked completion guard and the exhausted-retry action/lifecycle are unchanged.

## User Impact

No behavior change. Loaded assistant messages continue to render in full automatically, and bounded automatic retry plus the exhausted-retry action continue to work exactly as before.

## Evidence

- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts` — 185 tests passed
- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/chat-thread.test.ts` — 177 tests passed
- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-message-actions.e2e.test.ts` — 1 browser E2E passed
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-message-actions.e2e.test.ts ui/src/pages/chat/chat-thread.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-projection.ts` — passed format, dead-code, i18n, typecheck (core tests + UI), and lint lanes: https://github.com/openclaw/openclaw/actions/runs/31904137933
- Autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings
- Production LOC: net -9 (chat-thread.ts +1/-1, chat-transcript-projection.ts +1/-10). Test LOC: net -108 (chat-message.test.ts +10/-20, chat-message-actions.e2e.test.ts +29/-127)
