### PR TITLE
fix(ui): reject blank required strings in Control UI update readers

### DIFF
--- a/ui/src/app/update-overlay-helpers.test.ts
+++ b/ui/src/app/update-overlay-helpers.test.ts
@@ -1,6 +1,11 @@
+import { Value } from "typebox/value";
+import { afterEach, describe, expect, it, vi } from "vitest";
 // @vitest-environment node
 // Control UI tests cover localized update and recovery status copy.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  UpdateAvailableSchema,
+  UpdateScheduleStateSchema,
+} from "../../../packages/gateway-protocol/src/schema/config.js";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../api/gateway.ts";
 import { i18n } from "../i18n/index.ts";
 import type {
@@ -12,7 +17,12 @@ import {
   formatUpdateCampaignLabel,
   resolveUpdateStatusBanner,
 } from "./update-overlay-helpers.ts";
-import { readUpdateAvailable, readUpdateSchedule } from "./update-schedule-dto.ts";
+import {
+  readUpdateAvailable,
+  readUpdateAvailableValue,
+  readUpdateSchedule,
+  readUpdateScheduleValue,
+} from "./update-schedule-dto.ts";
 
 const translations: Record<string, string> = {
   "updates.status": "Update {status}: {reason}. {guidance}",
@@ -208,6 +218,178 @@ describe("update schedule hydration", () => {
         1_000,
       ),
     ).toBe("Update held · resumes in 12:41");
+  });
+
+  it.each([
+    [
+      "availability channel",
+      { currentVersion: "2026.8.1", latestVersion: "2026.8.2", channel: "" },
+    ],
+    [
+      "availability currentVersion",
+      { currentVersion: "", latestVersion: "2026.8.2", channel: "s" },
+    ],
+  ])("rejects a blank required %s, as the canonical schema does", (_label, payload) => {
+    expect(readUpdateAvailableValue(payload)).toBeNull();
+    expect(Value.Check(UpdateAvailableSchema, payload)).toBe(false);
+  });
+
+  it("rejects a blank required schedule channel, as the canonical schema does", () => {
+    const blankSchedule = { channel: "", autoEnabled: true };
+    expect(readUpdateScheduleValue(blankSchedule)).toBeNull();
+    expect(Value.Check(UpdateScheduleStateSchema, blankSchedule)).toBe(false);
+  });
+
+  it("drops blank optional strings instead of discarding the whole payload", () => {
+    expect(
+      readUpdateAvailableValue({
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.2",
+        channel: "stable",
+        currentSha: "",
+        upstreamRef: "",
+      }),
+    ).toEqual({ currentVersion: "2026.8.1", latestVersion: "2026.8.2", channel: "stable" });
+  });
+
+  // The canonical schemas are closed, but they are a producer-side contract the
+  // Gateway enforces on its own outbound results. A service-worker-cached
+  // document keeps an older bundle across a Gateway upgrade, so an additive
+  // field must never blank the overlay.
+  it("keeps rendering when a newer Gateway adds an unknown field", () => {
+    const withFutureField = {
+      currentVersion: "2026.8.1",
+      latestVersion: "2026.8.2",
+      channel: "stable",
+      releaseNotesUrl: "https://example.invalid/notes",
+    };
+    expect(readUpdateAvailableValue(withFutureField)).toEqual({
+      currentVersion: "2026.8.1",
+      latestVersion: "2026.8.2",
+      channel: "stable",
+    });
+
+    const scheduleWithFutureField = {
+      channel: "dev",
+      autoEnabled: true,
+      install: { kind: "git", git: { status: "current", futureNested: 1 } },
+      rolloutCohort: "canary",
+    };
+    expect(readUpdateScheduleValue(scheduleWithFutureField)).toEqual({
+      channel: "dev",
+      autoEnabled: true,
+      install: { kind: "git", git: { status: "current" } },
+    });
+  });
+
+  it("ignores prototype-named wire keys without polluting the result", () => {
+    const hostile = JSON.parse(
+      '{"currentVersion":"2026.8.1","latestVersion":"2026.8.2","channel":"stable","__proto__":{"polluted":true},"constructor":"x","toString":"y"}',
+    );
+    const parsed = readUpdateAvailableValue(hostile);
+    expect(parsed).toEqual({
+      currentVersion: "2026.8.1",
+      latestVersion: "2026.8.2",
+      channel: "stable",
+    });
+    expect(Object.hasOwn(parsed as object, "toString")).toBe(false);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  // Canonical maxLength counts grapheme clusters; String#length counts UTF-16
+  // code units, so a length-based copy of that rule drops valid emoji subjects.
+  it("preserves a commit subject the canonical schema accepts but String#length overcounts", () => {
+    const subject = "\u{1F44D}".repeat(100);
+    const payload = {
+      currentVersion: "2026.8.1",
+      latestVersion: "2026.8.2",
+      channel: "stable",
+      commits: [{ sha: "abc1234", subject }],
+    };
+    expect(subject.length).toBeGreaterThan(120);
+    expect(Value.Check(UpdateAvailableSchema, payload)).toBe(true);
+    expect(readUpdateAvailableValue(payload)?.commits).toEqual([{ sha: "abc1234", subject }]);
+  });
+
+  it("keeps valid commits when a sibling entry is malformed", () => {
+    expect(
+      readUpdateAvailableValue({
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.2",
+        channel: "stable",
+        commits: [{ sha: "", subject: "dropped" }, { sha: "abc", subject: "kept" }, { sha: 7 }],
+      })?.commits,
+    ).toEqual([{ sha: "abc", subject: "kept" }]);
+  });
+
+  // Drift guard: whatever the canonical schema accepts must still reach the
+  // overlay. This fails if a schema change outgrows the reader.
+  it.each([
+    [
+      "availability",
+      { currentVersion: "2026.8.1", latestVersion: "2026.8.2", channel: "stable" },
+      UpdateAvailableSchema,
+      readUpdateAvailableValue,
+    ],
+    [
+      "availability with git detail",
+      {
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.2",
+        channel: "dev",
+        currentSha: "aaa",
+        upstreamRef: "origin/main",
+        upstreamSha: "bbb",
+        commitsBehind: 3,
+        commits: [{ sha: "abc", subject: "fix things" }],
+      },
+      UpdateAvailableSchema,
+      readUpdateAvailableValue,
+    ],
+    [
+      "schedule with package target",
+      {
+        channel: "beta",
+        autoEnabled: true,
+        install: { kind: "package" },
+        target: { kind: "package", version: "2026.8.1-beta.1" },
+      },
+      UpdateScheduleStateSchema,
+      readUpdateScheduleValue,
+    ],
+    [
+      "schedule with diverged git install and campaign",
+      {
+        channel: "dev",
+        autoEnabled: false,
+        install: {
+          kind: "git",
+          git: {
+            status: "diverged",
+            currentSha: "aaa",
+            commitAtMs: 1,
+            installedAtMs: 2,
+            commitsAhead: 1,
+            commitsBehind: 2,
+          },
+        },
+        target: { kind: "git", upstreamRef: "origin/main", upstreamSha: "bbb", commitsBehind: 2 },
+        campaign: {
+          id: "c1",
+          state: "countdown",
+          announcedAtMs: 1,
+          applyAtMs: 2,
+          holdUntilMs: 3,
+          forceAtMs: 4,
+          updatedAtMs: 5,
+        },
+      },
+      UpdateScheduleStateSchema,
+      readUpdateScheduleValue,
+    ],
+  ])("round-trips canonical-valid %s unchanged", (_label, payload, schema, read) => {
+    expect(Value.Check(schema, payload)).toBe(true);
+    expect(read(payload)).toEqual(payload);
   });
 });
 

--- a/ui/src/app/update-overlay-helpers.test.ts
+++ b/ui/src/app/update-overlay-helpers.test.ts
@@ -322,6 +322,24 @@ describe("update schedule hydration", () => {
     ).toEqual([{ sha: "abc", subject: "kept" }]);
   });
 
+  // The canonical schema caps commits at 5 entries (maxItems: 5) and the
+  // Updates page renders every entry this reader returns. An out-of-contract
+  // producer payload past that cap must not grow the rendered list.
+  it("caps commits at five entries even when every entry is valid", () => {
+    const commits = Array.from({ length: 8 }, (_, index) => ({
+      sha: `sha${index}`,
+      subject: `commit ${index}`,
+    }));
+    expect(
+      readUpdateAvailableValue({
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.2",
+        channel: "stable",
+        commits,
+      })?.commits,
+    ).toEqual(commits.slice(0, 5));
+  });
+
   // Drift guard: whatever the canonical schema accepts must still reach the
   // overlay. This fails if a schema change outgrows the reader.
   it.each([

--- a/ui/src/app/update-schedule-dto.ts
+++ b/ui/src/app/update-schedule-dto.ts
@@ -27,6 +27,13 @@ function isBoundedInteger(value: unknown, minimum: number): value is number {
   return Number.isInteger(value) && (value as number) >= minimum;
 }
 
+// Mirrors commits: Type.Array(UpdateCommitSchema, { maxItems: 5 }) in
+// packages/gateway-protocol/src/schema/config.ts. The Updates page renders
+// every entry this reader returns, so the render-side cap is the protocol's
+// own contract, not extra strictness: keep it even though the rest of this
+// reader is tolerant of out-of-range producer data.
+const MAX_COMMITS = 5;
+
 export function readUpdateAvailable(hello: GatewayHelloOk | null): UpdateAvailable | null {
   const snapshot = hello?.snapshot;
   if (!isRecord(snapshot)) {
@@ -48,7 +55,10 @@ export function readUpdateAvailableValue(update: unknown): UpdateAvailable | nul
   // Per-entry filtering rather than all-or-nothing: one malformed commit should
   // not hide the rest of the list. Subject length stays unbounded here because
   // the canonical maxLength counts grapheme clusters, which a String#length
-  // check silently misreads for emoji and combining marks.
+  // check silently misreads for emoji and combining marks. The MAX_COMMITS
+  // slice below still applies after filtering: the Updates page renders every
+  // returned entry, so an out-of-range producer payload must not grow the
+  // rendered list past the protocol's own cap.
   const rawCommits = update.commits;
   const commits = Array.isArray(rawCommits)
     ? rawCommits
@@ -59,6 +69,7 @@ export function readUpdateAvailableValue(update: unknown): UpdateAvailable | nul
             typeof commit.subject === "string",
         )
         .map((commit) => ({ sha: commit.sha, subject: commit.subject }))
+        .slice(0, MAX_COMMITS)
     : undefined;
   return {
     currentVersion: update.currentVersion,

--- a/ui/src/app/update-schedule-dto.ts
+++ b/ui/src/app/update-schedule-dto.ts
@@ -1,9 +1,31 @@
 // Normalizes the Gateway's update-availability and update-schedule payloads into
 // the shapes the Control UI renders. These readers are the trust boundary for
 // wire data, so they stay separate from the lifecycle controllers that consume them.
+//
+// Deliberately NOT a copy of UpdateAvailableSchema/UpdateScheduleStateSchema
+// (packages/gateway-protocol/src/schema/config.ts). Those are closed
+// producer-side contracts the Gateway enforces on its own outbound results
+// (src/gateway/server-methods/update.ts), so re-deriving them here would be a
+// second contract that drifts. Rejecting unknown keys would also turn every
+// additive protocol field into a blank update overlay: the Control UI is
+// service-worker cached, so an already-open document keeps an older bundle
+// across a Gateway upgrade (ui/src/app/sw-refresh.runtime.ts). This reader
+// narrows only what the overlay renders, tolerates unknown and out-of-range
+// producer data, and enforces the one rule whose violation renders blank UI:
+// canonical NonEmptyString fields that are required must be non-empty.
+// update-overlay-helpers.test.ts pins that against Value.Check over the
+// canonical schemas; typebox stays out of this module because it sits in the
+// Control UI startup graph, which has a hard gzip budget
+// (scripts/check-control-ui-performance.mts).
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { isNonEmptyProtocolString } from "../../../packages/gateway-protocol/src/protocol-value-normalization.js";
 import type { GatewayHelloOk } from "../api/gateway.ts";
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+
+/** Narrows wire counters and timestamps declared as Type.Integer({ minimum }). */
+function isBoundedInteger(value: unknown, minimum: number): value is number {
+  return Number.isInteger(value) && (value as number) >= minimum;
+}
 
 export function readUpdateAvailable(hello: GatewayHelloOk | null): UpdateAvailable | null {
   const snapshot = hello?.snapshot;
@@ -15,84 +37,75 @@ export function readUpdateAvailable(hello: GatewayHelloOk | null): UpdateAvailab
 }
 
 export function readUpdateAvailableValue(update: unknown): UpdateAvailable | null {
-  if (!isRecord(update)) {
+  if (
+    !isRecord(update) ||
+    !isNonEmptyProtocolString(update.currentVersion) ||
+    !isNonEmptyProtocolString(update.latestVersion) ||
+    !isNonEmptyProtocolString(update.channel)
+  ) {
     return null;
   }
+  // Per-entry filtering rather than all-or-nothing: one malformed commit should
+  // not hide the rest of the list. Subject length stays unbounded here because
+  // the canonical maxLength counts grapheme clusters, which a String#length
+  // check silently misreads for emoji and combining marks.
   const rawCommits = update.commits;
-  const commits =
-    Array.isArray(rawCommits) &&
-    rawCommits.length <= 5 &&
-    rawCommits.every(
-      (commit): commit is { sha: string; subject: string } =>
-        isRecord(commit) &&
-        typeof commit.sha === "string" &&
-        commit.sha.length > 0 &&
-        typeof commit.subject === "string" &&
-        commit.subject.length <= 120,
-    )
-      ? rawCommits.map((commit) => ({ sha: commit.sha, subject: commit.subject }))
-      : undefined;
-  return typeof update.currentVersion === "string" &&
-    typeof update.latestVersion === "string" &&
-    typeof update.channel === "string"
-    ? {
-        currentVersion: update.currentVersion,
-        latestVersion: update.latestVersion,
-        channel: update.channel,
-        ...(typeof update.currentSha === "string" ? { currentSha: update.currentSha } : {}),
-        ...(typeof update.upstreamRef === "string" ? { upstreamRef: update.upstreamRef } : {}),
-        ...(typeof update.upstreamSha === "string" ? { upstreamSha: update.upstreamSha } : {}),
-        ...(Number.isInteger(update.commitsBehind) && Number(update.commitsBehind) >= 0
-          ? { commitsBehind: Number(update.commitsBehind) }
-          : {}),
-        ...(commits ? { commits } : {}),
-      }
-    : null;
+  const commits = Array.isArray(rawCommits)
+    ? rawCommits
+        .filter(
+          (commit): commit is { sha: string; subject: string } =>
+            isRecord(commit) &&
+            isNonEmptyProtocolString(commit.sha) &&
+            typeof commit.subject === "string",
+        )
+        .map((commit) => ({ sha: commit.sha, subject: commit.subject }))
+    : undefined;
+  return {
+    currentVersion: update.currentVersion,
+    latestVersion: update.latestVersion,
+    channel: update.channel,
+    ...(isNonEmptyProtocolString(update.currentSha) ? { currentSha: update.currentSha } : {}),
+    ...(isNonEmptyProtocolString(update.upstreamRef) ? { upstreamRef: update.upstreamRef } : {}),
+    ...(isNonEmptyProtocolString(update.upstreamSha) ? { upstreamSha: update.upstreamSha } : {}),
+    ...(isBoundedInteger(update.commitsBehind, 0) ? { commitsBehind: update.commitsBehind } : {}),
+    ...(commits?.length ? { commits } : {}),
+  };
 }
 
 function readScheduleTarget(value: unknown): UpdateScheduleState["target"] | null {
   if (!isRecord(value)) {
     return null;
   }
-  if (value.kind === "package" && typeof value.version === "string") {
-    return { kind: "package", version: value.version };
+  if (value.kind === "package") {
+    return isNonEmptyProtocolString(value.version)
+      ? { kind: "package", version: value.version }
+      : null;
   }
-  if (
-    value.kind === "git" &&
-    typeof value.upstreamRef === "string" &&
-    typeof value.upstreamSha === "string" &&
-    Number.isInteger(value.commitsBehind) &&
-    Number(value.commitsBehind) >= 0
-  ) {
-    return {
-      kind: "git",
-      upstreamRef: value.upstreamRef,
-      upstreamSha: value.upstreamSha,
-      commitsBehind: Number(value.commitsBehind),
-    };
+  if (value.kind === "git") {
+    return isNonEmptyProtocolString(value.upstreamRef) &&
+      isNonEmptyProtocolString(value.upstreamSha) &&
+      isBoundedInteger(value.commitsBehind, 0)
+      ? {
+          kind: "git",
+          upstreamRef: value.upstreamRef,
+          upstreamSha: value.upstreamSha,
+          commitsBehind: value.commitsBehind,
+        }
+      : null;
   }
   return null;
 }
 
+/** Optional install metadata: a malformed entry is dropped, never fatal to the status. */
 function readGitInstallMetadata(value: Record<string, unknown>): {
   currentSha?: string;
   commitAtMs?: number;
   installedAtMs?: number;
-} | null {
-  if (
-    (value.currentSha !== undefined &&
-      (typeof value.currentSha !== "string" || value.currentSha.length === 0)) ||
-    (value.commitAtMs !== undefined &&
-      (!Number.isInteger(value.commitAtMs) || Number(value.commitAtMs) < 0)) ||
-    (value.installedAtMs !== undefined &&
-      (!Number.isInteger(value.installedAtMs) || Number(value.installedAtMs) < 0))
-  ) {
-    return null;
-  }
+} {
   return {
-    ...(typeof value.currentSha === "string" ? { currentSha: value.currentSha } : {}),
-    ...(value.commitAtMs === undefined ? {} : { commitAtMs: Number(value.commitAtMs) }),
-    ...(value.installedAtMs === undefined ? {} : { installedAtMs: Number(value.installedAtMs) }),
+    ...(isNonEmptyProtocolString(value.currentSha) ? { currentSha: value.currentSha } : {}),
+    ...(isBoundedInteger(value.commitAtMs, 0) ? { commitAtMs: value.commitAtMs } : {}),
+    ...(isBoundedInteger(value.installedAtMs, 0) ? { installedAtMs: value.installedAtMs } : {}),
   };
 }
 
@@ -103,38 +116,25 @@ function readGitUpdateStatus(
     return null;
   }
   const metadata = readGitInstallMetadata(value);
-  if (!metadata) {
-    return null;
-  }
   if (value.status === "current") {
     return { ...metadata, status: "current" };
   }
-  if (
-    value.status === "behind" &&
-    Number.isInteger(value.commitsBehind) &&
-    Number(value.commitsBehind) > 0
-  ) {
-    return { ...metadata, status: "behind", commitsBehind: Number(value.commitsBehind) };
+  if (value.status === "behind" && isBoundedInteger(value.commitsBehind, 1)) {
+    return { ...metadata, status: "behind", commitsBehind: value.commitsBehind };
   }
-  if (
-    value.status === "ahead" &&
-    Number.isInteger(value.commitsAhead) &&
-    Number(value.commitsAhead) > 0
-  ) {
-    return { ...metadata, status: "ahead", commitsAhead: Number(value.commitsAhead) };
+  if (value.status === "ahead" && isBoundedInteger(value.commitsAhead, 1)) {
+    return { ...metadata, status: "ahead", commitsAhead: value.commitsAhead };
   }
   if (
     value.status === "diverged" &&
-    Number.isInteger(value.commitsAhead) &&
-    Number(value.commitsAhead) > 0 &&
-    Number.isInteger(value.commitsBehind) &&
-    Number(value.commitsBehind) > 0
+    isBoundedInteger(value.commitsAhead, 1) &&
+    isBoundedInteger(value.commitsBehind, 1)
   ) {
     return {
       ...metadata,
       status: "diverged",
-      commitsAhead: Number(value.commitsAhead),
-      commitsBehind: Number(value.commitsBehind),
+      commitsAhead: value.commitsAhead,
+      commitsBehind: value.commitsBehind,
     };
   }
   if (
@@ -153,38 +153,31 @@ function readGitUpdateStatus(
 function readScheduleCampaign(value: unknown): UpdateScheduleState["campaign"] | null {
   if (
     !isRecord(value) ||
-    typeof value.id !== "string" ||
+    !isNonEmptyProtocolString(value.id) ||
     (value.state !== "waiting-for-idle" &&
       value.state !== "countdown" &&
       value.state !== "applying") ||
-    !Number.isInteger(value.announcedAtMs) ||
-    Number(value.announcedAtMs) < 0 ||
-    !Number.isInteger(value.forceAtMs) ||
-    Number(value.forceAtMs) < 0 ||
-    !Number.isInteger(value.updatedAtMs) ||
-    Number(value.updatedAtMs) < 0 ||
-    (value.applyAtMs !== undefined &&
-      (!Number.isInteger(value.applyAtMs) || Number(value.applyAtMs) < 0)) ||
-    (value.holdUntilMs !== undefined &&
-      (!Number.isInteger(value.holdUntilMs) || Number(value.holdUntilMs) < 0))
+    !isBoundedInteger(value.announcedAtMs, 0) ||
+    !isBoundedInteger(value.forceAtMs, 0) ||
+    !isBoundedInteger(value.updatedAtMs, 0)
   ) {
     return null;
   }
   return {
     id: value.id,
     state: value.state,
-    announcedAtMs: Number(value.announcedAtMs),
-    ...(value.applyAtMs === undefined ? {} : { applyAtMs: Number(value.applyAtMs) }),
-    ...(value.holdUntilMs === undefined ? {} : { holdUntilMs: Number(value.holdUntilMs) }),
-    forceAtMs: Number(value.forceAtMs),
-    updatedAtMs: Number(value.updatedAtMs),
+    announcedAtMs: value.announcedAtMs,
+    ...(isBoundedInteger(value.applyAtMs, 0) ? { applyAtMs: value.applyAtMs } : {}),
+    ...(isBoundedInteger(value.holdUntilMs, 0) ? { holdUntilMs: value.holdUntilMs } : {}),
+    forceAtMs: value.forceAtMs,
+    updatedAtMs: value.updatedAtMs,
   };
 }
 
 export function readUpdateScheduleValue(value: unknown): UpdateScheduleState | null {
   if (
     !isRecord(value) ||
-    typeof value.channel !== "string" ||
+    !isNonEmptyProtocolString(value.channel) ||
     typeof value.autoEnabled !== "boolean"
   ) {
     return null;


### PR DESCRIPTION
Fixes #124232

> Reworked after review. The first revision of this PR hand-rolled a closed-key-set decoder that mirrored the canonical schema. Review rejected that approach, and the review was right: it was a second contract, and it had already drifted in two ways of its own. This revision deletes it. See "What changed after review" below.

## What Problem This Solves

The Control UI update readers accept `""` for fields the canonical protocol declares as `NonEmptyString`. `UpdateAvailableSchema` requires non-empty `currentVersion`, `latestVersion`, and `channel` (`packages/gateway-protocol/src/schema/config.ts:72-76`, via `NonEmptyString` at `packages/gateway-protocol/src/schema/primitives.ts:24`), but `ui/src/app/update-schedule-dto.ts` only checked `typeof x === "string"`. An operator could be shown an update banner with blank version text built from a payload the protocol itself considers invalid.

The same gap repeated on the schedule root, the package/git schedule targets, and the campaign id, and the file was inconsistent with itself: `readGitInstallMetadata` enforced non-emptiness while `readScheduleTarget` did not.

## Why This Change Was Made

The fix is at the boundary that owns the invariant, using the protocol's own dependency-free primitive:

- Required `NonEmptyString` fields now reject the payload when blank, via `isNonEmptyProtocolString` (`packages/gateway-protocol/src/protocol-value-normalization.ts`). That module has zero imports, so it is safe for the Control UI startup graph.
- Optional `NonEmptyString` fields are now dropped when blank rather than discarding the whole payload. A missing `currentSha` renders fine; a blanked overlay does not.
- Repeated `Number.isInteger(x) && Number(x) >= n` chains collapse into one `isBoundedInteger` helper, which also removes the `Number(...)` re-casts.

Deliberately **not** done: re-deriving the canonical schema in the browser. Three independent reasons, each verified against source rather than assumed:

**1. Closed-object checking is a producer-side contract, and enforcing it client-side breaks additive tolerance.** `closedObject` sets `additionalProperties: false`, and the only place that runs against these schemas at runtime is the Gateway validating *its own outbound result* (`src/gateway/server-methods/update.ts:203-207`). The `hello.snapshot` path the UI actually reads has no compiled validator at all — `HelloOkSchema` is exported but never compiled. Meanwhile the protocol is additive-first (`AGENTS.md`; `docs/gateway/clients.md:237-243`), its own guards "intentionally allow additive payload fields" (`packages/gateway-protocol/README.md:78-80`), and an additive field does not move `PROTOCOL_VERSION`, so the `4..4` handshake cannot catch it. The Control UI is service-worker cached, so an already-open document keeps an older bundle across a Gateway upgrade (`ui/src/app/sw-refresh.runtime.ts:18-21`) — older-UI/newer-Gateway is a routine transient state, not a hypothetical. A client-side closed check would turn every additive field into a silently blank update overlay. Every other snapshot/event decoder in the Control UI does tolerant field extraction; `GatewayHelloOk` even re-types `snapshot` as `unknown` on purpose (`ui/src/api/gateway.ts:102-106`).

**2. The canonical `maxLength` cannot be hand-copied.** typebox 1.3.6 measures `minLength`/`maxLength` in **grapheme clusters** (`node_modules/typebox/build/guard/string.mjs`, `IsMaxLength` over `NextGraphemeClusterIndex`), while `String#length` counts UTF-16 code units. So the previous `subject.length <= 120` check rejected commit subjects the canonical schema accepts:

```
100 emoji     | .length = 200 | Value.Check = true | .length <= 120 = false
20 family ZWJ | .length = 220 | Value.Check = true | .length <= 120 = false
```

That bound is producer-side hygiene, so it is now gone rather than approximated. This is the concrete reason a hand-written mirror of the schema is not viable at all: it silently diverges on the rules that are hardest to notice.

**3. typebox cannot enter this module.** `update-schedule-dto.ts` is statically reachable from the entry point (`main.ts` → `app-host.ts` → `sidebar-update-card.ts` → `update-overlay-helpers.ts` → here), so it is inside the measured startup graph. The UI's existing `Value.Check` callers (`ui/src/lib/tasks/data.ts`, `task-summary.ts`) sit behind route-level dynamic imports and are *not* measured — the constraint comments say "startup bundle" precisely, and they are correct.

## User Impact

Operators no longer see an update banner or schedule state with blank version text. Payloads from a newer Gateway carrying additive fields keep rendering instead of silently disappearing, and commit subjects containing emoji are no longer dropped.

## Evidence

**Regression proof (fails before, passes after).** New boundary cases were run against three trees:

| Tree | Result |
| --- | --- |
| `main` (`8f807ae912d`) | **6 failed**, 15 passed — includes all three blank-required-string cases, the Unicode subject case, and blank-optional handling |
| first revision of this PR (`400183a4a59`) | **4 failed**, 17 passed — additive-field tolerance, Unicode subject, blank-optional, per-entry commit filtering |
| this revision | **21 passed** |

- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/app/update-overlay-helpers.test.ts` — 21 passed.
- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/app/overlays.test.ts ui/src/app/overlays-update-campaign.test.ts ui/src/app/overlays-update-race.test.ts ui/src/app/update-confirmation.runtime.test.ts ui/src/app/update-success-notice.test.ts ui/src/pages/config/updates.test.ts` — 92 passed across the consuming surfaces.
- `node scripts/check-changed.mjs -- ui/src/app/update-schedule-dto.ts ui/src/app/update-overlay-helpers.test.ts` — exit 0: UI typecheck, core test typecheck, lint, i18n catalog, dead-export scan, formatting.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.

**Bundle budget.** The startup gate is `scripts/check-control-ui-performance.mts`, ratcheted against `config/control-ui-startup-budget-baseline.json` (`startupJsGzipBytes: 334391`, cap 350 KiB, tolerance 1056 B → effective limit 335,447 B). This change adds **no** import to the startup graph: `isNonEmptyProtocolString` comes from an already-reachable zero-dependency module, and `ui/package.json` / `packages/gateway-protocol/package.json` are untouched.

For the record, importing typebox here was measured rather than asserted. Bundling `Value.Check(UpdateAvailableSchema, …)` with esbuild (`--bundle --minify --format=esm --platform=browser`) produces **38,697 B gzip** — about 37x the 1,056 B of headroom, and well past the 4,096 B-per-step ratchet. That matches the precedent in `packages/gateway-protocol/src/schema/session-placement-state.ts`, whose comment records a prior incident where pulling the protocol barrel into startup took the bundle to 395 KiB against a 370 KiB budget.

**Drift protection.** Production no longer carries a copy of the schema to drift, so drift is pinned where it costs nothing: `update-overlay-helpers.test.ts` imports the canonical schemas and asserts the one direction that matters — every canonical-valid fixture must satisfy `Value.Check` *and* round-trip through the reader unchanged. If a schema change outgrows the reader, that fails in CI.

## What changed after review

| Review finding | Disposition |
| --- | --- |
| +159 production LOC duplicating the canonical schema | **Fixed by deletion.** `isClosedRecord` and all eight `KeySet` constants are gone. Production is now **net −7 lines against `main`** (`+91 / −98`), down from +159. |
| Rejects valid Unicode | **Fixed.** Traced to `subject.length <= 120` vs typebox's grapheme-cluster `maxLength`; verified in typebox source and reproduced. The producer-side bound is removed, with a regression test using a 100-emoji subject. |
| Accepts prototype-named keys (`key in keys`) | **Moot — the closed check is gone.** A test still pins that `__proto__` / `constructor` / `toString` wire keys neither reach the result nor pollute `Object.prototype`. |
| Breaks additive protocol tolerance | **Fixed.** Verified the protocol's additive contract; closed-object rejection was wrong for a client decoder. A regression test asserts an unknown future field still renders. |
| Merge risk: stricter payload handling lacks upgrade-path proof | **Largely withdrawn.** The only payloads now rejected are ones with blank *required* strings, which could not render meaningfully anyway. Additive and unknown-key payloads that the first revision would have rejected now render. |

One follow-up spotted while reading and not fixed here, since it belongs to a different owner: `scripts/check-control-ui-performance.mts:386-394` — `--update-baseline` without `--startup-js-bytes` writes the locally measured value and skips `validateExplicitStartupJsBytes`, so the 4096 B ratchet only guards the CI-measured path.

## Second round: restored commit cap, CI diagnosis

**ClawSweeper P2 — five-entry commit bound.** The rework above switched
`readUpdateAvailableValue`'s commit handling from all-or-nothing rejection to
per-entry `filter().map()`, and that dropped the existing `rawCommits.length
<= 5` bound along with it. The canonical schema still caps `commits` at 5
entries (`commits: Type.Array(UpdateCommitSchema, { maxItems: 5 })`,
`packages/gateway-protocol/src/schema/config.ts:80`), and the Updates page
renders every entry this reader returns, so an out-of-contract payload past
the cap could grow into an unbounded rendered list. Fixed by slicing to a
named `MAX_COMMITS = 5` after filtering, so a malformed entry still doesn't
hide the rest of the list (unchanged tolerant behavior) but the render bound
holds regardless of how many valid-looking entries a producer sends. Added
`caps commits at five entries even when every entry is valid` in
`update-overlay-helpers.test.ts` (8-entry payload, asserts `.slice(0, 5)`).

**CI: `checks-ui-e2e (2/12)` failure was unrelated CI flake, not this diff.**
The run at push time failed
`ui/src/e2e/session-management.sidebar.e2e.test.ts` > "retains the selected
session and one observer while reconnecting across route changes"
(`expect.poll` timeout waiting for sidebar row text to read "Selected
session recovered";
https://github.com/openclaw/openclaw/actions/runs/31908289886/job/95069436970).

Checked whether this diff could plausibly affect it: this PR only touches
`ui/src/app/update-schedule-dto.ts` and its test. The only importers of
`update-schedule-dto.ts` are `update-overlay-helpers.ts` (and its test) and
`overlays.ts`; the failing test never references sessions/update overlays and
its mocked `sessions.list`/`sessions.subscribe` fixtures carry no
`updateAvailable`/`updateSchedule` snapshot data, so the changed code path
cannot execute in that test. Confirmed via `git diff --stat
$(git merge-base origin/main HEAD) HEAD` that the PR touches exactly those
two files.

Checked for a same-window CI flake pattern instead: this happened during the
same evening CI window as
https://github.com/openclaw/openclaw/issues/124290, an open P1 documenting
`ui/src/e2e/agent-file-lifecycle.e2e.test.ts` failing with the identical
"Matcher did not succeed in time." shape across three unrelated PRs
(#124253, #124256, #124257) that don't touch the failing path either. One of
those occurrences (PR #124257, shard 10/12,
https://github.com/openclaw/openclaw/actions/runs/31908362789) ran in the
same CI run as another unrelated `checks-ui-e2e` shard failure
(`config-safe-write.e2e.test.ts`, shard 6/12, same run), and a fourth
unrelated PR in the same window
(https://github.com/openclaw/openclaw/actions/runs/31908722207, shard
11/12) failed a `new-session-page.prompt-attachments.e2e.test.ts` assertion.
Four different `checks-ui-e2e` test files failed across four unrelated PRs
in the same short CI window, none of them importing or exercising this PR's
diff — consistent with shared-runner timing flakiness in the mocked-Gateway
E2E matrix that evening rather than a regression from this change.

Reran the failed job: `gh run rerun 31908289886 --failed`.

## Gates (this round)

- `LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/app/update-overlay-helpers.test.ts` — 22 passed (was 21; +1 new cap test).
- `node scripts/check-changed.mjs -- ui/src/app/update-schedule-dto.ts ui/src/app/update-overlay-helpers.test.ts` — exit 0: UI/core typecheck, lint, i18n catalog, dead-export scan, formatting.
- `oxfmt` — no changes needed on either file.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
