### PR TITLE
fix(ui): commit queued-message reorders as one durable batch write

### DIFF
--- a/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
@@ -1,9 +1,21 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
-import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import {
+  captureUiProofEnabled,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 const QUEUED = ["review the migration", "then update the docs", "finally run the smoke"] as const;
+const failureReloadProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "queue-reorder-failure-reload",
+);
 
 suite.define(() => {
   it("reorders offline queued messages from the keyboard-focused handle", async () => {
@@ -46,6 +58,111 @@ suite.define(() => {
       await page.keyboard.press("ArrowUp");
 
       await expect.poll(queueText, { timeout: 10_000 }).toEqual([QUEUED[2], QUEUED[0], QUEUED[1]]);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps the queue order consistent through a reload after a mid-reorder storage failure", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(failureReloadProofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 15_000 });
+
+      await gateway.setOnline(false);
+      await gateway.closeLatest();
+      for (const message of QUEUED) {
+        await composer.fill(message);
+        await composer.press("Enter");
+        await page.locator(".chat-queue__item", { hasText: message }).waitFor({ timeout: 10_000 });
+      }
+
+      const queueText = () => page.locator(".chat-queue__item .chat-queue__text").allTextContents();
+      expect(await queueText()).toEqual([...QUEUED]);
+      if (captureUiProofEnabled) {
+        await page.screenshot({ path: `${failureReloadProofDir}/01-queued-before-failure.png` });
+      }
+
+      // Break durable storage for the rest of this page's lifetime, then attempt
+      // a reorder. A real `sessionStorage.setItem` failure (quota, private mode,
+      // disabled storage) landing mid-batch must reject the whole permutation
+      // instead of applying it partway, so the order has to stay exactly what
+      // it was — never a mix of the attempted and original arrangements.
+      await page.evaluate(() => {
+        window.sessionStorage.setItem = () => {
+          throw new DOMException("quota exceeded", "QuotaExceededError");
+        };
+      });
+
+      await page.locator(".chat-queue__item").nth(2).locator(".chat-queue__grip").focus();
+      await page.keyboard.press("ArrowUp");
+
+      // Give the failed move a moment to settle, then confirm nothing moved.
+      await page.waitForTimeout(300);
+      expect(await queueText()).toEqual([...QUEUED]);
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          path: `${failureReloadProofDir}/02-order-unchanged-after-failure.png`,
+        });
+      }
+
+      // A fresh load reads back only what actually made it to storage. Seeing the
+      // same order here (not a mix of the attempted and original permutations)
+      // is the proof: the failed batch never left a half-applied reorder behind.
+      // The app only mounts its session UI once the Gateway connects, so the
+      // storage-level readback below runs first, while this reload is still
+      // offline, exactly as the cold-reload offline-queue proof elsewhere does.
+      await page.reload();
+      const storedQueueOrder = () =>
+        page.evaluate(() =>
+          Object.entries(sessionStorage)
+            .filter(([key]) => key.startsWith("openclaw.control.chatComposer.v2:"))
+            .flatMap(([, value]) => {
+              try {
+                const parsed = JSON.parse(value) as {
+                  sessions?: Record<
+                    string,
+                    { queue?: { text?: unknown; orderKey?: unknown; createdAt?: unknown }[] }
+                  >;
+                };
+                return Object.values(parsed.sessions ?? {}).flatMap(
+                  (session) => session.queue ?? [],
+                );
+              } catch {
+                return [];
+              }
+            })
+            .toSorted(
+              (left, right) =>
+                (typeof left.orderKey === "number" ? left.orderKey : Number(left.createdAt)) -
+                (typeof right.orderKey === "number" ? right.orderKey : Number(right.createdAt)),
+            )
+            .map((item) => item.text),
+        );
+      expect(await storedQueueOrder()).toEqual([...QUEUED]);
+
+      // Bringing the Gateway back lets the app mount its session UI so the same
+      // order can be confirmed rendered, not just stored.
+      await gateway.setOnline(true);
+      await page.locator("openclaw-chat-pane").waitFor({ state: "attached", timeout: 15_000 });
+      await page.locator(".chat-queue__item", { hasText: QUEUED[0] }).waitFor({ timeout: 10_000 });
+      expect(await queueText()).toEqual([...QUEUED]);
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          path: `${failureReloadProofDir}/03-consistent-order-after-reload.png`,
+        });
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-queue-reorder.test.ts
+++ b/ui/src/pages/chat/chat-queue-reorder.test.ts
@@ -5,7 +5,11 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { admitQueuedMessageForSession, subscribeChatOutboxProjection } from "./chat-queue.ts";
 import { moveQueuedChatMessage } from "./chat-send-actions.ts";
-import { listStoredChatOutboxes } from "./composer-persistence.ts";
+import {
+  listStoredChatOutboxes,
+  updateStoredChatComposerQueueItem,
+  updateStoredChatComposerQueueItems,
+} from "./composer-persistence.ts";
 
 const SESSION_KEY = "agent:main";
 
@@ -138,5 +142,62 @@ describe("queued message reorder", () => {
     expect(host.chatQueue.map((item) => item.id)).toEqual(storedOrder(host));
     expect(host.lastError).not.toBeNull();
     unsubscribe();
+  });
+
+  it("rejects a two-row batch instead of committing a mixed permutation when one row went stale", () => {
+    // `moveQueuedChatMessage` always re-reads storage immediately before it
+    // writes, so it can never observe a mid-flight race by itself. This test
+    // exercises the batch CAS primitive directly with a snapshot captured
+    // before a concurrent write lands, which is what a real cross-tab race
+    // looks like: the caller's `expected` rows were read before the other
+    // writer's commit, then presented to the write after it.
+    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    unsubscribe();
+
+    const storedById = (id: string) =>
+      listStoredChatOutboxes(host as never)
+        .flatMap(({ queue }) => queue)
+        .find((entry) => entry.id === id)!;
+    // Snapshot taken "before" the concurrent write, matching what a caller
+    // would have read prior to another writer's commit.
+    const expectedQueued2 = storedById("queued-2");
+    const expectedQueued3 = storedById("queued-3");
+
+    // A second tab/writer lands a durable change to queued-2 (a retry attempt
+    // bump) after that snapshot was taken.
+    const concurrentWrite = updateStoredChatComposerQueueItem(
+      host as never,
+      SESSION_KEY,
+      expectedQueued2,
+      {
+        ...expectedQueued2,
+        sendAttempts: (expectedQueued2.sendAttempts ?? 0) + 1,
+      },
+    );
+    expect(concurrentWrite).toBe(true);
+
+    // The reorder permutation this batch represents: an adjacent swap that
+    // changes exactly queued-2 and queued-3's orderKey and leaves queued-1
+    // untouched, mirroring what `moveQueuedChatMessage("queued-3", 1)` computes.
+    const applied = updateStoredChatComposerQueueItems(host as never, SESSION_KEY, [
+      {
+        expected: expectedQueued3,
+        next: { ...expectedQueued3, orderKey: expectedQueued2.createdAt },
+      },
+      {
+        expected: expectedQueued2,
+        next: { ...expectedQueued2, orderKey: expectedQueued3.createdAt },
+      },
+    ]);
+
+    // queued-3's own compare-and-set would have succeeded alone; the batch must
+    // still reject in full because its sibling row, queued-2, went stale using
+    // the pre-concurrent-write snapshot. Any stored order other than the
+    // untouched original (aside from the concurrent writer's own sendAttempts
+    // bump) would mean the batch committed part of the permutation.
+    expect(applied).toBe(false);
+    expect(storedOrder(host)).toEqual(["queued-1", "queued-2", "queued-3"]);
+    expect(storedById("queued-3").orderKey).toBe(expectedQueued3.orderKey);
+    expect(storedById("queued-2").sendAttempts).toBe((expectedQueued2.sendAttempts ?? 0) + 1);
   });
 });

--- a/ui/src/pages/chat/chat-queue-reorder.test.ts
+++ b/ui/src/pages/chat/chat-queue-reorder.test.ts
@@ -101,4 +101,42 @@ describe("queued message reorder", () => {
     expect(host.lastError).toBeNull();
     unsubscribe();
   });
+
+  it("commits a multi-row reorder as one durable write instead of a partial permutation", () => {
+    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    const originalSetItem = sessionStorage.setItem.bind(sessionStorage);
+    let writes = 0;
+    // Permits exactly one write to land, then fails every write after it. A
+    // per-row write loop would apply the first changed row and get stuck mid
+    // permutation; a single batch write either lands the whole reorder or none of it.
+    vi.spyOn(sessionStorage, "setItem").mockImplementation((key, value) => {
+      writes += 1;
+      if (writes > 1) {
+        throw new DOMException("quota exceeded", "QuotaExceededError");
+      }
+      originalSetItem(key, value);
+    });
+
+    moveQueuedChatMessage(host as never, "queued-3", 0);
+
+    expect(writes).toBe(1);
+    expect(storedOrder(host)).toEqual(["queued-3", "queued-1", "queued-2"]);
+    expect(host.chatQueue.map((item) => item.id)).toEqual(storedOrder(host));
+    expect(host.lastError).toBeNull();
+    unsubscribe();
+  });
+
+  it("leaves the durable and visible order unchanged when the batch write fails", () => {
+    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+
+    moveQueuedChatMessage(host as never, "queued-3", 0);
+
+    expect(storedOrder(host)).toEqual(["queued-1", "queued-2", "queued-3"]);
+    expect(host.chatQueue.map((item) => item.id)).toEqual(storedOrder(host));
+    expect(host.lastError).not.toBeNull();
+    unsubscribe();
+  });
 });

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -12,6 +12,7 @@ import {
   removeStoredChatComposerQueueItem,
   resolveStoredChatOutboxScope,
   updateStoredChatComposerQueueItem,
+  updateStoredChatComposerQueueItems,
   type ChatComposerScope,
   type StoredChatOutbox,
   type StoredChatOutboxScope,
@@ -275,6 +276,63 @@ export function updateQueuedMessageForSession(
     owner.projectLive(host, scope, id);
   }
   return nextItem;
+}
+
+/**
+ * Applies every update as one durable unit instead of one write per row, so a
+ * multi-row permutation (a reorder) can never persist partially. Rows already
+ * in a stored outbox share that outbox's single batch write; rows still
+ * volatile-only apply directly in memory since they never touch storage.
+ * Every id in `updates` comes from one caller-resolved scope, so any durable
+ * rows among them share one outbox.
+ */
+type QueuedMessageMoveRow = {
+  id: string;
+  stored: StoredChatOutbox | undefined;
+  current: ChatQueueItem;
+  next: ChatQueueItem;
+};
+
+export function updateQueuedMessagesForSession(
+  host: ChatQueueScopedSessionHost,
+  updates: readonly { id: string; update: (item: ChatQueueItem) => ChatQueueItem }[],
+): boolean {
+  const owner = chatOutboxOwner(host);
+  const rows: QueuedMessageMoveRow[] = [];
+  for (const { id, update } of updates) {
+    const stored = owner.durable(host, id);
+    const storedItem = stored?.queue.find((item) => item.id === id);
+    const current = owner.allItems(host).find((item) => item.id === id) ?? storedItem;
+    if (!current) {
+      return false;
+    }
+    rows.push({ id, stored, current, next: update(current) });
+  }
+  const durableRows = rows.filter((row) => row.stored);
+  const outbox = durableRows[0]?.stored;
+  if (outbox) {
+    const applied = updateStoredChatComposerQueueItems(
+      host,
+      outbox.sessionKey,
+      durableRows.map((row) => ({ expected: row.current, next: row.next })),
+      outbox.agentId,
+    );
+    for (const row of durableRows) {
+      if (applied) {
+        owner.change(host, row.id);
+      }
+      owner.projectLive(host, outbox, row.id);
+    }
+    if (!applied) {
+      return false;
+    }
+  }
+  for (const row of rows) {
+    if (!row.stored) {
+      owner.change(host, row.id, () => row.next);
+    }
+  }
+  return true;
 }
 
 /**

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -19,7 +19,7 @@ import {
   readChatQueueForScope,
   readQueuedMessageById,
   updateQueuedMessage,
-  updateQueuedMessageForSession,
+  updateQueuedMessagesForSession,
   updateVolatileQueuedMessage,
 } from "./chat-queue.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
@@ -140,9 +140,9 @@ export const retryReconnectableQueuedChatSends = resumeStoredChatOutboxes;
 /**
  * Moves a queued row to `toIndex` within its own movable segment. A locked row
  * ends that segment, so the move can never carry a message past work the drain
- * is still waiting on. Each changed row is persisted individually so a partial
- * storage failure leaves a readable queue and a visible error instead of a
- * silent reshuffle.
+ * is still waiting on. Every changed row commits as one durable unit, so a
+ * storage failure mid-permutation leaves the prior order intact instead of a
+ * partially reshuffled queue.
  */
 export function moveQueuedChatMessage(host: ChatHost, id: string, toIndex: number): void {
   const item = readQueuedMessageById(host, id);
@@ -152,18 +152,19 @@ export function moveQueuedChatMessage(host: ChatHost, id: string, toIndex: numbe
   const sessionKey = item.sessionKey ?? host.sessionKey;
   const scope = readChatQueueForScope(host, sessionKey, item.agentId);
   const segment = chatQueueMovableSegments(scope).find((rows) => rows.some((row) => row.id === id));
-  for (const moved of reorderChatQueueItems(segment ?? [], id, toIndex)) {
-    const applied = updateQueuedMessageForSession(
-      host,
-      moved.sessionKey ?? sessionKey,
-      moved.id,
-      (entry) => ({ ...entry, orderKey: moved.orderKey }),
-      moved.agentId,
-    );
-    if (!applied) {
-      setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-      return;
-    }
+  const moves = reorderChatQueueItems(segment ?? [], id, toIndex);
+  if (moves.length === 0) {
+    return;
+  }
+  const applied = updateQueuedMessagesForSession(
+    host,
+    moves.map((moved) => ({
+      id: moved.id,
+      update: (entry: ChatQueueItem) => ({ ...entry, orderKey: moved.orderKey }),
+    })),
+  );
+  if (!applied) {
+    setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
   }
 }
 

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -490,15 +490,28 @@ export function admitStoredChatComposerQueueItem(
   }
 }
 
-export function updateStoredChatComposerQueueItem(
+/**
+ * Batch compare-and-set for durable queue rows. A caller passing several rows
+ * (a reorder permutation) gets one fresh read, one validation pass over every
+ * expected row, one full-document write, and one read-back verification — so
+ * the whole set commits or none of it does. A mid-batch storage failure can
+ * never leave a permutation half-applied the way a per-row write loop would.
+ */
+export function updateStoredChatComposerQueueItems(
   state: ChatComposerScope,
   sessionKey: string,
-  expected: ChatQueueItem,
-  next: ChatQueueItem,
+  updates: readonly { expected: ChatQueueItem; next: ChatQueueItem }[],
   agentId?: string,
 ): boolean {
+  if (updates.length === 0) {
+    return true;
+  }
   const storage = getSafeSessionStorage();
-  if (!storage || !sessionKey.trim() || expected.id !== next.id) {
+  if (
+    !storage ||
+    !sessionKey.trim() ||
+    updates.some(({ expected, next }) => expected.id !== next.id)
+  ) {
     return false;
   }
   try {
@@ -507,40 +520,59 @@ export function updateStoredChatComposerQueueItem(
     const scope = resolveComposerStorageScope(
       state,
       sessionKey,
-      agentId ?? expected.agentId ?? next.agentId,
+      agentId ?? updates[0]!.expected.agentId ?? updates[0]!.next.agentId,
       store.mainAlias,
     );
-    const serializedNext = serializeQueueItemForScope(next, scope);
-    if (!serializedNext) {
-      return false;
-    }
     const { session, storeSessionKey } = resolveStoredComposerSession(
       store,
       state,
       sessionKey,
       scope.agentScope === UNRESOLVED_GLOBAL_AGENT_SCOPE ? undefined : scope.agentScope,
     );
-    const queue = session?.queue ?? [];
-    const index = queue.findIndex((entry) => entry.id === expected.id);
-    const stored = queue[index];
-    if (!stored || !queueItemVersionMatches(stored, expected, scope)) {
-      return false;
+    const nextQueue = (session?.queue ?? []).slice();
+    for (const { expected, next } of updates) {
+      const index = nextQueue.findIndex((entry) => entry.id === expected.id);
+      const stored = index >= 0 ? nextQueue[index] : undefined;
+      const serializedNext =
+        stored && queueItemVersionMatches(stored, expected, scope)
+          ? serializeQueueItemForScope(next, scope)
+          : null;
+      if (!serializedNext) {
+        // A missing or stale row rejects the whole batch before anything is written.
+        return false;
+      }
+      nextQueue[index] = serializedNext;
     }
-    const nextQueue = queue.slice();
-    nextQueue[index] = serializedNext;
     writeStoredComposerSession(store, storeSessionKey, session, nextQueue);
     writeStore(storage, target, store);
     notifyStoredChatOutboxChanges();
-    const persisted = resolveStoredComposerSession(
-      readStore(storage, target),
-      state,
-      sessionKey,
-      scope.agentScope === UNRESOLVED_GLOBAL_AGENT_SCOPE ? undefined : scope.agentScope,
-    ).session?.queue?.find((entry) => entry.id === serializedNext.id);
-    return Boolean(persisted && queueItemsEqual(persisted, serializedNext, scope));
+    const persistedQueue =
+      resolveStoredComposerSession(
+        readStore(storage, target),
+        state,
+        sessionKey,
+        scope.agentScope === UNRESOLVED_GLOBAL_AGENT_SCOPE ? undefined : scope.agentScope,
+      ).session?.queue ?? [];
+    return updates.every(({ next }) => {
+      const serializedNext = serializeQueueItemForScope(next, scope);
+      const persisted = persistedQueue.find((entry) => entry.id === next.id);
+      return Boolean(
+        persisted && serializedNext && queueItemsEqual(persisted, serializedNext, scope),
+      );
+    });
   } catch {
     return false;
   }
+}
+
+export function updateStoredChatComposerQueueItem(
+  state: ChatComposerScope,
+  sessionKey: string,
+  expected: ChatQueueItem,
+  next: ChatQueueItem,
+  agentId?: string,
+): boolean {
+  return updateStoredChatComposerQueueItems(state, sessionKey, [{ expected, next }], agentId);
 }
 
 export function removeStoredChatComposerQueueItem(


### PR DESCRIPTION
Fixes #124233

## What Problem This Solves

Resolves a problem where dragging several queued chat messages into a new order could leave the durable queue in a permutation the operator never asked for. The reorder path persisted each moved row with its own sessionStorage read-modify-write; if a later row's write failed (storage quota, a stale comparison), the rows already written stayed reordered while the rest did not, producing a queue order that matched neither the original nor the intended sequence on reload.

## Why This Change Was Made

Composer persistence (`ui/src/pages/chat/composer-persistence.ts`) already owns the single-row compare-and-set for a queued message. This change adds a batch compare-and-set alongside it: one fresh read, validation of every affected row against its expected version, one full-document write for the whole permutation, and one read-back verification. The single-row update now delegates to the batch primitive with a one-row list, so there is one canonical write path instead of two. The reorder caller in `ui/src/pages/chat/chat-send-actions.ts` builds the full list of changed rows up front and commits them through the new batch helper in `ui/src/pages/chat/chat-queue.ts`, instead of looping and persisting one row at a time. A row that is still local-only (not yet admitted to storage) keeps applying directly in memory, since it never touches sessionStorage and has no partial-write exposure.

## User Impact

A queue reorder now either fully lands or fully rejects. Operators no longer see a message queue that reshuffled itself into an order nobody asked for after a storage hiccup mid-drag; on failure the prior order is retained and the existing storage error is shown.

## Evidence

Added a fault-injection regression to `ui/src/pages/chat/chat-queue-reorder.test.ts` that permits exactly one `sessionStorage.setItem` call to succeed and fails every call after it, then reorders a three-row queue. Verified the new test fails against the pre-fix per-row loop (it wrote twice and landed a mixed permutation) by temporarily stashing the production changes and rerunning it, then restored the fix and reran green. A second case asserts that when the single batch write itself fails, both the durable and visible order stay unchanged and the storage error is set.

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/pages/chat/chat-queue-reorder.test.ts ui/src/pages/chat/composer-persistence.test.ts ui/src/pages/chat/chat-send.test.ts
 Test Files  3 passed (3)
      Tests  352 passed (352)
```

Pre-fix run of the new regression test (production changes stashed, test kept):
```
 FAIL  |ui| ui/src/pages/chat/chat-queue-reorder.test.ts > queued message reorder > commits a multi-row reorder as one durable write instead of a partial permutation
AssertionError: expected 2 to be 1 // Object.is equality
```

Also ran `node scripts/check-changed.mjs -- ui/src/pages/chat/composer-persistence.ts ui/src/pages/chat/chat-queue.ts ui/src/pages/chat/chat-send-actions.ts ui/src/pages/chat/chat-queue-reorder.test.ts` (typecheck, lint, format, dead-export scan, i18n catalog) — all green.

**Two-row stale-CAS regression.** Added `chat-queue-reorder.test.ts > "rejects a two-row batch instead of committing a mixed permutation when one row went stale"`. It exercises `updateStoredChatComposerQueueItems` directly with a batch snapshot captured before a second writer lands a durable change to one of the two affected rows (a cross-tab race), then presents that stale snapshot to the batch write alongside the other row's still-fresh snapshot. Verified this catches the regression: temporarily disabled the per-row version check in `updateStoredChatComposerQueueItems` (`composer-persistence.ts`), reran — the test failed (`expected true to be false`, batch applied on a stale row) — then restored the check and reran green.

**Browser failure→reload proof.** Added `chat-flow.queue-reorder.e2e.test.ts > "keeps the queue order consistent through a reload after a mid-reorder storage failure"` (Control UI E2E harness, mocked Gateway, real Chromium). It queues three offline messages, breaks `sessionStorage.setItem` in-page to always throw, attempts a reorder (rejected, order unchanged), reloads the page while still offline and reads the durable order straight out of `sessionStorage` (still the original order), then brings the mock Gateway back online and confirms the same order renders in `.chat-queue__item` once the session UI mounts.

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Screenshot of the post-reload, post-reconnect state showing the queue rendered in its original, untouched order:

https://github.com/user-attachments/assets/b0ad9a63-ddf3-4251-ae82-cab76bf497e9

