### PR TITLE
refactor(cli): remove unsupported Node 24 cache workaround

### DIFF
--- a/src/entry.compile-cache.test-support.ts
+++ b/src/entry.compile-cache.test-support.ts
@@ -5,8 +5,6 @@ import "./entry.compile-cache.js";
 type CompileCacheParams = {
   env?: NodeJS.ProcessEnv;
   installRoot: string;
-  nodeVersion?: string;
-  platform?: NodeJS.Platform;
 };
 
 type CompileCacheRespawnPlan = {
@@ -25,7 +23,6 @@ type CompileCacheTestApi = {
     installRoot: string;
     argv?: string[];
     compileCacheDir?: string;
-    nodeVersion?: string;
     platform?: NodeJS.Platform;
   }): CompileCacheRespawnPlan | undefined;
   isSourceCheckoutInstallRoot(installRoot: string): boolean;

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -58,16 +58,12 @@ describe("entry compile cache", () => {
       shouldEnableOpenClawCompileCache({
         env: {},
         installRoot: root,
-        nodeVersion: "24.15.0",
-        platform: "win32",
       }),
     ).toBe(true);
     expect(
       shouldEnableOpenClawCompileCache({
         env: { NODE_DISABLE_COMPILE_CACHE: "1" },
         installRoot: root,
-        nodeVersion: "24.15.0",
-        platform: "win32",
       }),
     ).toBe(false);
   });
@@ -204,7 +200,7 @@ describe("entry compile cache", () => {
     expect(plan?.detachForProcessTree).toBe(false);
   });
 
-  it("does not respawn unaffected packaged installs when NODE_COMPILE_CACHE is configured", () => {
+  it("does not respawn packaged installs when NODE_COMPILE_CACHE is configured", () => {
     const root = tempDirs.make("openclaw-compile-cache-package-respawn-");
 
     expect(
@@ -212,36 +208,8 @@ describe("entry compile cache", () => {
         currentFile: path.join(root, "dist", "entry.js"),
         env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
         installRoot: root,
-        nodeVersion: "24.1.0",
-        platform: "linux",
       }),
     ).toBeUndefined();
-  });
-
-  it("builds a no-cache respawn plan for affected Windows packaged installs", () => {
-    const root = tempDirs.make("openclaw-compile-cache-package-win24-");
-    const entryFile = path.join(root, "dist", "entry.js");
-
-    const plan = buildOpenClawCompileCacheRespawnPlan({
-      currentFile: entryFile,
-      env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
-      execArgv: ["--no-warnings"],
-      execPath: "/usr/bin/node",
-      installRoot: root,
-      argv: ["/usr/bin/node", entryFile, "doctor", "--fix", "--non-interactive"],
-      nodeVersion: "24.1.0",
-      platform: "win32",
-    });
-
-    expect(plan).toEqual({
-      command: "/usr/bin/node",
-      args: ["--no-warnings", entryFile, "doctor", "--fix", "--non-interactive"],
-      env: {
-        NODE_DISABLE_COMPILE_CACHE: "1",
-        OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED: "1",
-      },
-      detachForProcessTree: false,
-    });
   });
 
   it("does not respawn source checkouts twice", async () => {
@@ -375,73 +343,5 @@ describe("entry compile cache", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("disables compile cache for early Node 24.x versions on Windows", () => {
-    const root = tempDirs.make("openclaw-compile-cache-node24-");
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "24.1.0",
-        platform: "win32",
-      }),
-    ).toBe(false);
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "24.14.0",
-        platform: "win32",
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps compile cache enabled for early Node 24.x on non-Windows packaged installs", () => {
-    const root = tempDirs.make("openclaw-compile-cache-node24-nonwin-");
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "24.1.0",
-        platform: "linux",
-      }),
-    ).toBe(true);
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "24.14.0",
-        platform: "darwin",
-      }),
-    ).toBe(true);
-  });
-
-  it("keeps compile cache enabled for Node 24.15+ and other majors on Windows", () => {
-    const root = tempDirs.make("openclaw-compile-cache-node2415-");
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "24.15.0",
-        platform: "win32",
-      }),
-    ).toBe(true);
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "22.22.0",
-        platform: "win32",
-      }),
-    ).toBe(true);
-    expect(
-      shouldEnableOpenClawCompileCache({
-        env: {},
-        installRoot: root,
-        nodeVersion: "25.0.0",
-        platform: "win32",
-      }),
-    ).toBe(true);
   });
 });

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -5,7 +5,6 @@ import { enableCompileCache, getCompileCacheDir } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { expectDefined } from "@openclaw/normalization-core";
 import {
   isTerminalInteractiveRespawnArgv,
   shouldKeepNativeHookRelayInProcess,
@@ -16,9 +15,6 @@ import {
   type RespawnChildRuntime,
 } from "./process/respawn-child-runner.js";
 
-// Node 24.0-24.14 can deadlock during ESM module loading when compile cache is
-// enabled on Windows npm-global installs. Keep the skip scoped to that platform.
-const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
 const COMPILE_CACHE_DISABLED_RESPAWNED_ENV = "OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED";
 
 export function resolveEntryInstallRoot(entryFile: string): string {
@@ -42,38 +38,13 @@ function isNodeCompileCacheRequested(env: NodeJS.ProcessEnv | undefined): boolea
   return env?.NODE_COMPILE_CACHE !== undefined && !isNodeCompileCacheDisabled(env);
 }
 
-function isNodeVersionAffectedByCompileCacheDeadlock(nodeVersion: string | undefined): boolean {
-  if (!nodeVersion) {
-    return false;
-  }
-  const match = nodeVersion.match(/^(\d+)\.(\d+)/);
-  if (!match) {
-    return false;
-  }
-  const major = Number.parseInt(expectDefined(match[1], "compile-cache major version capture"), 10);
-  const minor = Number.parseInt(expectDefined(match[2], "compile-cache minor version capture"), 10);
-  if (major !== 24) {
-    return false;
-  }
-  return minor < MIN_COMPILE_CACHE_NODE_24_MINOR;
-}
-
 function shouldEnableOpenClawCompileCache(params: {
   env?: NodeJS.ProcessEnv;
   installRoot: string;
-  nodeVersion?: string;
-  platform?: NodeJS.Platform;
 }): boolean {
-  if (isNodeCompileCacheDisabled(params.env)) {
-    return false;
-  }
-  if (
-    (params.platform ?? process.platform) === "win32" &&
-    isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node)
-  ) {
-    return false;
-  }
-  return !isSourceCheckoutInstallRoot(params.installRoot);
+  return (
+    !isNodeCompileCacheDisabled(params.env) && !isSourceCheckoutInstallRoot(params.installRoot)
+  );
 }
 
 function sanitizeCompileCachePathSegment(value: string): string {
@@ -144,7 +115,6 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   installRoot: string;
   argv?: string[];
   compileCacheDir?: string;
-  nodeVersion?: string;
   platform?: NodeJS.Platform;
 }): OpenClawCompileCacheRespawnPlan | undefined {
   const env = params.env ?? process.env;
@@ -153,11 +123,7 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   if (shouldKeepNativeHookRelayInProcess(argv, platform)) {
     return undefined;
   }
-  const needsDisabledCompileCacheRespawn =
-    isSourceCheckoutInstallRoot(params.installRoot) ||
-    (platform === "win32" &&
-      isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node));
-  if (!needsDisabledCompileCacheRespawn) {
+  if (!isSourceCheckoutInstallRoot(params.installRoot)) {
     return undefined;
   }
   if (env[COMPILE_CACHE_DISABLED_RESPAWNED_ENV] === "1") {


### PR DESCRIPTION
## What Problem This Solves

The compile-cache entry path still carried a Windows workaround and tests for Node 24.0–24.14 even though those runtimes are now rejected before compile-cache handling. This left an unreachable production branch, version parser, test-support parameters, and four obsolete tests.

## Why This Change Was Made

The early-Node-24 deadlock workaround is removed from `src/entry.compile-cache.ts`. Compile cache is now enabled for packaged installs unless explicitly disabled, while no-cache respawn remains scoped to source checkouts. The supported-runtime guard and launcher continue rejecting Node 24 before 24.15.

This PR is AI-assisted as part of the maintainer-requested repository test-value audit.

## User Impact

No behavior changes on supported runtimes. Unsupported Node 24.0–24.14 installations still fail at the existing runtime floor instead of reaching compile-cache startup logic.

## Evidence

- `node scripts/run-vitest.mjs src/entry.compile-cache.test.ts src/infra/runtime-guard.test.ts` — 33 passed
- `node scripts/run-vitest.mjs test/openclaw-launcher.e2e.test.ts` — 37 passed, 1 skipped; includes real Node 24.14 rejection coverage
- `pnpm build` — passed
- `node scripts/check-changed.mjs -- src/entry.compile-cache.ts src/entry.compile-cache.test-support.ts src/entry.compile-cache.test.ts` — passed via the documented local fallback; core/test typechecks, lint, dead exports, boundaries, import cycles, and guards were green
- `git diff --check` — passed
- Structured autoreview — clean

Production delta: -34 net lines. Test/test-support delta: -104 net lines. No docs, changelog, schema, protocol, migration, or operator-state change is required.
