### PR TITLE
fix(ui): GitHub link hovercard closes before the pointer can reach it

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -10,7 +10,9 @@ import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import {
   GITHUB_HOVERCARD_OPEN_DELAY_MS,
+  gitHubFilesChangedUrl,
   githubLinkAnchorFromEvent,
+  gitHubProfileUrl,
   parseGitHubLinkTarget,
   type GitHubLinkTarget,
 } from "./github-link-target.ts";
@@ -126,23 +128,39 @@ function appendMetric(parent: HTMLElement, className: string, text: string): voi
   appendTextElement(parent, "span", `github-link-hovercard__metric ${className}`, text);
 }
 
+function appendCardLink(
+  parent: HTMLElement,
+  className: string,
+  href: string,
+  text: string,
+): HTMLAnchorElement {
+  const link = document.createElement("a");
+  link.className = className;
+  link.href = href;
+  link.target = EXTERNAL_LINK_TARGET;
+  link.rel = buildExternalLinkRel();
+  link.textContent = text;
+  parent.append(link);
+  return link;
+}
+
 function renderLoading(card: HTMLDivElement): void {
   card.replaceChildren();
   card.dataset.loading = "true";
   card.removeAttribute("data-state");
-  appendTextElement(card, "div", "github-link-hovercard__loading", t("githubPreview.loading"));
+  const label = t("githubPreview.loading");
+  // The card is a dialog, so every render state has to leave it with a name.
+  card.setAttribute("aria-label", label);
+  appendTextElement(card, "div", "github-link-hovercard__loading", label);
 }
 
 function renderUnavailable(card: HTMLDivElement): void {
   card.replaceChildren();
   card.dataset.loading = "false";
   card.dataset.state = "unavailable";
-  appendTextElement(
-    card,
-    "div",
-    "github-link-hovercard__unavailable",
-    t("githubPreview.unavailable"),
-  );
+  const label = t("githubPreview.unavailable");
+  card.setAttribute("aria-label", label);
+  appendTextElement(card, "div", "github-link-hovercard__unavailable", label);
 }
 
 function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
@@ -161,10 +179,12 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
   stateDot.setAttribute("aria-hidden", "true");
   badge.append(stateDot, document.createTextNode(state.label));
   header.append(badge);
-  appendTextElement(
+  // Every link on the card reuses the href it was activated with; that target is
+  // already resolved and validated by parseGitHubLinkTarget, so no reparsing here.
+  appendCardLink(
     header,
-    "span",
     "github-link-hovercard__repo",
+    preview.href,
     `${preview.owner}/${preview.repo} #${preview.number}`,
   );
   appendTextElement(
@@ -174,19 +194,14 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     formatRelativeTimestamp(Date.parse(preview.updatedAt)),
   );
 
-  const title = document.createElement("a");
-  title.className = "github-link-hovercard__title";
-  // Reuse the href the card was activated with; the target is already
-  // resolved and validated by parseGitHubLinkTarget, so no new parsing here.
-  title.href = preview.href;
-  title.target = EXTERNAL_LINK_TARGET;
-  title.rel = buildExternalLinkRel();
-  title.textContent = preview.title;
-
   const footer = document.createElement("div");
   footer.className = "github-link-hovercard__footer";
-  const author = document.createElement("span");
-  author.className = "github-link-hovercard__author";
+  const author = appendCardLink(
+    footer,
+    "github-link-hovercard__author",
+    gitHubProfileUrl(preview.login),
+    preview.login,
+  );
   if (preview.avatarDataUrl) {
     const avatar = document.createElement("img");
     avatar.className = "github-link-hovercard__avatar";
@@ -194,10 +209,8 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     avatar.decoding = "async";
     avatar.referrerPolicy = "no-referrer";
     avatar.src = preview.avatarDataUrl;
-    author.append(avatar);
+    author.prepend(avatar);
   }
-  author.append(document.createTextNode(preview.login));
-  footer.append(author);
 
   const metrics = document.createElement("span");
   metrics.className = "github-link-hovercard__metrics";
@@ -205,9 +218,12 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     appendMetric(metrics, "github-link-hovercard__metric--additions", `+${preview.additions ?? 0}`);
     appendMetric(metrics, "github-link-hovercard__metric--deletions", `−${preview.deletions ?? 0}`);
     const files = preview.changedFiles ?? 0;
-    appendMetric(
+    // The diff-size chip's natural next step is the files-changed view; issues
+    // have no such view, so their comment count stays plain text.
+    appendCardLink(
       metrics,
-      "",
+      "github-link-hovercard__metric github-link-hovercard__metric--files",
+      gitHubFilesChangedUrl(preview),
       t(files === 1 ? "githubPreview.file" : "githubPreview.files", {
         count: String(files),
       }),
@@ -223,7 +239,9 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     );
   }
   footer.append(metrics);
-  card.append(header, title, footer);
+  card.append(header);
+  appendCardLink(card, "github-link-hovercard__title", preview.href, preview.title);
+  card.append(footer);
   card.setAttribute(
     "aria-label",
     t("githubPreview.ariaLabel", {
@@ -250,7 +268,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private card: HTMLDivElement | null = null;
   private cardFocusInside = false;
   private closeTimer: number | null = null;
-  private describedBy: string | null = null;
   private focusInside = false;
   private openTimer: number | null = null;
   private pointerInside = false;
@@ -258,6 +275,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private renderedPreview: GitHubPreview | null = null;
   private renderedUnavailable = false;
   private stopI18n: (() => void) | null = null;
+  // Spans the synchronous focus() that hands focus back to the trigger, so the
+  // card the user just dismissed cannot reopen under them (handleCardKeyDown).
+  private suppressFocusOpen = false;
   private readonly previewTask = new Task(this, {
     autoRun: false,
     args: () => [this.activeTarget] as const,
@@ -392,6 +412,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleFocusIn = (event: Event) => {
+    if (this.suppressFocusOpen) {
+      return;
+    }
     const anchor = githubLinkAnchorFromEvent(event);
     const target = anchor ? parseGitHubLinkTarget(anchor.href) : null;
     if (!anchor || !target) {
@@ -447,8 +470,45 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       this.close();
+      return;
     }
+    // The card is portaled to document.body and never lands next to its trigger
+    // in the tab sequence; forward Tab in, and let the card hand focus back
+    // (handleCardKeyDown), so its links stay keyboard-reachable at all.
+    if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeAnchor) {
+      return;
+    }
+    const [first] = this.cardFocusables();
+    if (!first) {
+      return;
+    }
+    event.preventDefault();
+    first.focus();
   };
+
+  private readonly handleCardKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" && event.key !== "Tab") {
+      return;
+    }
+    // Tab moves between the card's own links normally and only exits at the edge
+    // of that run: the card has no tab-sequence neighbour, so leaving it lands on
+    // the trigger like Escape does instead of dropping focus to the document.
+    const focusables = this.cardFocusables();
+    const edge = event.shiftKey ? focusables[0] : focusables.at(-1);
+    if (event.key === "Tab" && document.activeElement !== edge) {
+      return;
+    }
+    event.preventDefault();
+    const anchor = this.activeAnchor;
+    this.close();
+    this.suppressFocusOpen = true;
+    anchor?.focus({ preventScroll: true });
+    this.suppressFocusOpen = false;
+  };
+
+  private cardFocusables(): HTMLElement[] {
+    return [...(this.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
+  }
 
   private readonly handleClick = () => {
     this.close();
@@ -476,7 +536,10 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.close();
     this.activeAnchor = anchor;
     this.activeTarget = target;
-    this.describedBy = anchor.getAttribute("aria-describedby");
+    // Announce the popup affordance as soon as the link is recognized; show()
+    // flips the state once the card exists, close() takes the whole set away.
+    anchor.setAttribute("aria-haspopup", "dialog");
+    anchor.setAttribute("aria-expanded", "false");
     this.activeAnchorObserver.observe(this, { childList: true, subtree: true });
     this.openTimer = window.setTimeout(() => {
       this.openTimer = null;
@@ -493,8 +556,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     card.id = `openclaw-github-hovercard-${nextHovercardId}`;
     card.className = "github-link-hovercard";
     card.dataset.open = "true";
-    card.setAttribute("role", "tooltip");
-    card.setAttribute("aria-live", "polite");
+    // A tooltip may not own controls: its content is flattened and unreachable.
+    // The card is a non-modal dialog instead, named by the render functions.
+    card.setAttribute("role", "dialog");
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     renderLoading(card);
@@ -504,12 +568,11 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
+    card.addEventListener("keydown", this.handleCardKeyDown);
     document.body.append(card);
     this.card = card;
-    anchor.setAttribute(
-      "aria-describedby",
-      this.describedBy ? `${this.describedBy} ${card.id}` : card.id,
-    );
+    anchor.setAttribute("aria-controls", card.id);
+    anchor.setAttribute("aria-expanded", "true");
     this.listenForViewportChanges();
     this.positionCard();
 
@@ -575,11 +638,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.activeAnchorObserver.disconnect();
     void this.previewTask.run([null]);
     if (this.activeAnchor) {
-      if (this.describedBy === null) {
-        this.activeAnchor.removeAttribute("aria-describedby");
-      } else {
-        this.activeAnchor.setAttribute("aria-describedby", this.describedBy);
-      }
+      this.activeAnchor.removeAttribute("aria-controls");
+      this.activeAnchor.removeAttribute("aria-expanded");
+      this.activeAnchor.removeAttribute("aria-haspopup");
     }
     this.card?.remove();
     this.card = null;
@@ -588,7 +649,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.activeAnchor = null;
     this.activeTarget = null;
     this.activeTrigger = null;
-    this.describedBy = null;
     this.cardFocusInside = false;
     this.focusInside = false;
     this.pointerInside = false;

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -19,6 +19,9 @@ const FAILURE_CACHE_MS = 30_000;
 const CACHE_LIMIT = 100;
 const VIEWPORT_PADDING = 12;
 const CARD_GAP = 10;
+// Traversal grace: the pointer has to cross CARD_GAP of unowned page between the
+// link and the card, and neither surface is hovered during that crossing.
+const CLOSE_DELAY_MS = 120;
 
 type GitHubPreview = GitHubLinkTarget & ControlUiGitHubPreview;
 
@@ -235,10 +238,12 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private activeAnchor: HTMLAnchorElement | null = null;
   private activeTarget: GitHubLinkTarget | null = null;
   private card: HTMLDivElement | null = null;
+  private closeTimer: number | null = null;
   private describedBy: string | null = null;
   private focusInside = false;
   private openTimer: number | null = null;
   private pointerInside = false;
+  private pointerOverCard = false;
   private renderedPreview: GitHubPreview | null = null;
   private renderedUnavailable = false;
   private stopI18n: (() => void) | null = null;
@@ -340,9 +345,17 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
       return;
     }
     this.pointerInside = false;
-    if (!this.focusInside) {
-      this.close();
-    }
+    this.scheduleClose();
+  };
+
+  private readonly handleCardPointerEnter = () => {
+    this.pointerOverCard = true;
+    this.clearCloseTimer();
+  };
+
+  private readonly handleCardPointerLeave = () => {
+    this.pointerOverCard = false;
+    this.scheduleClose();
   };
 
   private readonly handleFocusIn = (event: Event) => {
@@ -362,10 +375,41 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
       return;
     }
     this.focusInside = false;
-    if (!this.pointerInside) {
-      this.close();
-    }
+    this.scheduleClose();
   };
+
+  private clearCloseTimer(): void {
+    if (this.closeTimer !== null) {
+      window.clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
+  }
+
+  // Hover intent spans link and card: dismissal waits out the traversal grace and
+  // re-checks every surface that holds the card open, so moving from one to the
+  // other keeps it alive and only leaving both closes it.
+  private scheduleClose(): void {
+    this.clearCloseTimer();
+    if (this.hoverIntentHeld) {
+      return;
+    }
+    // Without a card there is only a pending open timer, and no gap to cross:
+    // cancel the open now instead of granting grace to a card that never showed.
+    if (!this.card) {
+      this.close();
+      return;
+    }
+    this.closeTimer = window.setTimeout(() => {
+      this.closeTimer = null;
+      if (!this.hoverIntentHeld) {
+        this.close();
+      }
+    }, CLOSE_DELAY_MS);
+  }
+
+  private get hoverIntentHeld(): boolean {
+    return this.pointerInside || this.pointerOverCard || this.focusInside;
+  }
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
@@ -420,6 +464,10 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     renderLoading(card);
+    // The card is portaled to document.body, so the provider's delegated pointer
+    // listeners never see it; it reports its own hover to keep intent shared.
+    card.addEventListener("pointerenter", this.handleCardPointerEnter);
+    card.addEventListener("pointerleave", this.handleCardPointerLeave);
     document.body.append(card);
     this.card = card;
     anchor.setAttribute(
@@ -487,6 +535,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
       window.clearTimeout(this.openTimer);
       this.openTimer = null;
     }
+    this.clearCloseTimer();
     this.activeAnchorObserver.disconnect();
     void this.previewTask.run([null]);
     if (this.activeAnchor) {
@@ -505,6 +554,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.describedBy = null;
     this.focusInside = false;
     this.pointerInside = false;
+    this.pointerOverCard = false;
     this.stopListeningForViewportChanges();
   }
 

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -6,6 +6,7 @@ import { ReactiveElement } from "lit";
 import type { ControlUiGitHubPreview } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n, t } from "../i18n/index.ts";
+import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import {
   GITHUB_HOVERCARD_OPEN_DELAY_MS,
@@ -173,8 +174,13 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     formatRelativeTimestamp(Date.parse(preview.updatedAt)),
   );
 
-  const title = document.createElement("div");
+  const title = document.createElement("a");
   title.className = "github-link-hovercard__title";
+  // Reuse the href the card was activated with; the target is already
+  // resolved and validated by parseGitHubLinkTarget, so no new parsing here.
+  title.href = preview.href;
+  title.target = EXTERNAL_LINK_TARGET;
+  title.rel = buildExternalLinkRel();
   title.textContent = preview.title;
 
   const footer = document.createElement("div");
@@ -237,7 +243,12 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private readonly cache = new Map<string, CacheEntry>();
   private activeAnchor: HTMLAnchorElement | null = null;
   private activeTarget: GitHubLinkTarget | null = null;
+  // Which surface opened the current card: gates whether focus landing inside
+  // the portaled card (e.g. clicking the title link) can hold it open, so a
+  // pointer-driven open still fully releases on mouse-out (see handleCardPointerLeave).
+  private activeTrigger: "focus" | "pointer" | null = null;
   private card: HTMLDivElement | null = null;
+  private cardFocusInside = false;
   private closeTimer: number | null = null;
   private describedBy: string | null = null;
   private focusInside = false;
@@ -355,6 +366,28 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
 
   private readonly handleCardPointerLeave = () => {
     this.pointerOverCard = false;
+    // A pointer-opened card must release fully on mouse-out even if a click
+    // inside the card (e.g. the title link) left it focused; otherwise it
+    // would stay stuck open with nothing left driving the intent.
+    if (this.activeTrigger === "pointer") {
+      this.cardFocusInside = false;
+    }
+    this.scheduleClose();
+  };
+
+  // The card is portaled to document.body, so focus landing on its title link
+  // never reaches the provider's delegated focusin/focusout listeners; track it
+  // directly so keyboard users can tab into the link without losing the card.
+  private readonly handleCardFocusIn = () => {
+    this.cardFocusInside = true;
+    this.clearCloseTimer();
+  };
+
+  private readonly handleCardFocusOut = (event: FocusEvent) => {
+    if (event.relatedTarget instanceof Node && this.card?.contains(event.relatedTarget)) {
+      return;
+    }
+    this.cardFocusInside = false;
     this.scheduleClose();
   };
 
@@ -408,7 +441,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   }
 
   private get hoverIntentHeld(): boolean {
-    return this.pointerInside || this.pointerOverCard || this.focusInside;
+    return this.pointerInside || this.pointerOverCard || this.focusInside || this.cardFocusInside;
   }
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
@@ -428,6 +461,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     delay: number,
   ): void {
     this.activate(anchor, target, delay);
+    this.activeTrigger = trigger;
     if (trigger === "pointer") {
       this.pointerInside = true;
     } else {
@@ -468,6 +502,8 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     // listeners never see it; it reports its own hover to keep intent shared.
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
+    card.addEventListener("focusin", this.handleCardFocusIn);
+    card.addEventListener("focusout", this.handleCardFocusOut);
     document.body.append(card);
     this.card = card;
     anchor.setAttribute(
@@ -551,7 +587,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.renderedUnavailable = false;
     this.activeAnchor = null;
     this.activeTarget = null;
+    this.activeTrigger = null;
     this.describedBy = null;
+    this.cardFocusInside = false;
     this.focusInside = false;
     this.pointerInside = false;
     this.pointerOverCard = false;

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -102,6 +102,11 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(card?.textContent).toContain("5m ago");
     expect(anchor.href).toBe(href);
     expect(anchor.getAttribute("aria-describedby")).toBe(card?.id);
+    const titleLink = card?.querySelector<HTMLAnchorElement>(".github-link-hovercard__title");
+    expect(titleLink?.tagName).toBe("A");
+    expect(titleLink?.getAttribute("href")).toBe(href);
+    expect(titleLink?.target).toBe("_blank");
+    expect(titleLink?.rel.split(/\s+/)).toEqual(expect.arrayContaining(["noopener", "noreferrer"]));
     expect(request).toHaveBeenCalledWith(
       "controlUi.githubPreview",
       {
@@ -158,6 +163,49 @@ describe("openclaw-github-link-hovercard-provider", () => {
     await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
     expect(hovercard()).toBeNull();
     expect(anchor.hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  it("closes on pointer-out even after the title link inside the card was clicked", async () => {
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/issues/99815",
+      "#99815",
+    );
+    provider.client = {
+      request: vi.fn().mockResolvedValue({
+        comments: 2,
+        createdAt: "2026-07-05T08:00:00Z",
+        kind: "issue",
+        login: "octocat",
+        number: 99815,
+        owner: "openclaw",
+        repo: "openclaw",
+        state: "open",
+        title: "Keep hover previews reachable",
+        updatedAt: "2026-07-05T09:55:00Z",
+      }),
+    } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+    const card = hovercard();
+    expect(card).not.toBeNull();
+
+    // Pointer travels from the link onto the card, same as the traversal test above.
+    leave(anchor, card as EventTarget);
+    card?.dispatchEvent(new MouseEvent("pointerenter"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hovercard()).toBe(card);
+
+    // Clicking the title link focuses it (a click's real-world side effect); a
+    // pointer-initiated open must still release once the pointer leaves, with no
+    // click-outside required to dismiss the card.
+    const titleLink = card?.querySelector<HTMLAnchorElement>(".github-link-hovercard__title");
+    titleLink?.addEventListener("click", (event) => event.preventDefault());
+    titleLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    titleLink?.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+
+    card?.dispatchEvent(new MouseEvent("pointerleave"));
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+    expect(hovercard()).toBeNull();
   });
 
   it("renders issue comments and supports focus plus Escape", async () => {

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -31,6 +31,40 @@ function createLink(href: string, label = "GitHub item") {
   return { anchor, provider };
 }
 
+const ISSUE_HREF = "https://github.com/openclaw/openclaw/issues/99815";
+
+function issuePreviewResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    comments: 2,
+    createdAt: "2026-07-05T08:00:00Z",
+    kind: "issue",
+    login: "octocat",
+    number: 99815,
+    owner: "openclaw",
+    repo: "openclaw",
+    state: "open",
+    title: "Keep hover previews reachable",
+    updatedAt: "2026-07-05T09:55:00Z",
+    ...overrides,
+  };
+}
+
+function createIssueLink(response: Record<string, unknown> = issuePreviewResponse()) {
+  const link = createLink(ISSUE_HREF, "#99815");
+  link.provider.client = {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GatewayBrowserClient;
+  return link;
+}
+
+function titleLinkInCard(): HTMLAnchorElement | null {
+  return document.querySelector<HTMLAnchorElement>(".github-link-hovercard__title");
+}
+
+function cardLinks(): HTMLAnchorElement[] {
+  return [...document.querySelectorAll<HTMLAnchorElement>(".github-link-hovercard a[href]")];
+}
+
 async function hover(anchor: HTMLAnchorElement): Promise<void> {
   anchor.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
   await vi.advanceTimersByTimeAsync(250);
@@ -101,12 +135,28 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(card?.textContent).toContain("3 files");
     expect(card?.textContent).toContain("5m ago");
     expect(anchor.href).toBe(href);
-    expect(anchor.getAttribute("aria-describedby")).toBe(card?.id);
-    const titleLink = card?.querySelector<HTMLAnchorElement>(".github-link-hovercard__title");
-    expect(titleLink?.tagName).toBe("A");
-    expect(titleLink?.getAttribute("href")).toBe(href);
-    expect(titleLink?.target).toBe("_blank");
-    expect(titleLink?.rel.split(/\s+/)).toEqual(expect.arrayContaining(["noopener", "noreferrer"]));
+    // A card that owns a link is an interactive popover, never an ARIA tooltip.
+    expect(card?.getAttribute("role")).toBe("dialog");
+    expect(card?.getAttribute("aria-label")).toContain(
+      "fix(agents): derive conversation scope from trusted group facts",
+    );
+    expect(anchor.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(anchor.getAttribute("aria-expanded")).toBe("true");
+    expect(anchor.getAttribute("aria-controls")).toBe(card?.id);
+    // Title, repo reference, author and the files chip are all real links, which
+    // is what makes the card a popover rather than a tooltip.
+    const cardLink = (selector: string) =>
+      card?.querySelector<HTMLAnchorElement>(`.github-link-hovercard__${selector}`);
+    expect(cardLink("title")?.getAttribute("href")).toBe(href);
+    expect(cardLink("repo")?.getAttribute("href")).toBe(href);
+    expect(cardLink("author")?.getAttribute("href")).toBe("https://github.com/steipete");
+    expect(cardLink("metric--files")?.getAttribute("href")).toBe(`${href}/files`);
+    for (const selector of ["title", "repo", "author", "metric--files"]) {
+      expect(cardLink(selector)?.target).toBe("_blank");
+      expect(cardLink(selector)?.rel.split(/\s+/)).toEqual(
+        expect.arrayContaining(["noopener", "noreferrer"]),
+      );
+    }
     expect(request).toHaveBeenCalledWith(
       "controlUi.githubPreview",
       {
@@ -126,24 +176,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
   });
 
   it("stays open while the pointer travels from the link onto the card", async () => {
-    const { anchor, provider } = createLink(
-      "https://github.com/openclaw/openclaw/issues/99815",
-      "#99815",
-    );
-    provider.client = {
-      request: vi.fn().mockResolvedValue({
-        comments: 2,
-        createdAt: "2026-07-05T08:00:00Z",
-        kind: "issue",
-        login: "octocat",
-        number: 99815,
-        owner: "openclaw",
-        repo: "openclaw",
-        state: "open",
-        title: "Keep hover previews reachable",
-        updatedAt: "2026-07-05T09:55:00Z",
-      }),
-    } as unknown as GatewayBrowserClient;
+    const { anchor } = createIssueLink();
 
     await hover(anchor);
     const card = hovercard();
@@ -162,28 +195,13 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(hovercard()).toBe(card);
     await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
     expect(hovercard()).toBeNull();
-    expect(anchor.hasAttribute("aria-describedby")).toBe(false);
+    expect(anchor.hasAttribute("aria-expanded")).toBe(false);
+    expect(anchor.hasAttribute("aria-controls")).toBe(false);
+    expect(anchor.hasAttribute("aria-haspopup")).toBe(false);
   });
 
   it("closes on pointer-out even after the title link inside the card was clicked", async () => {
-    const { anchor, provider } = createLink(
-      "https://github.com/openclaw/openclaw/issues/99815",
-      "#99815",
-    );
-    provider.client = {
-      request: vi.fn().mockResolvedValue({
-        comments: 2,
-        createdAt: "2026-07-05T08:00:00Z",
-        kind: "issue",
-        login: "octocat",
-        number: 99815,
-        owner: "openclaw",
-        repo: "openclaw",
-        state: "open",
-        title: "Keep hover previews reachable",
-        updatedAt: "2026-07-05T09:55:00Z",
-      }),
-    } as unknown as GatewayBrowserClient;
+    const { anchor } = createIssueLink();
 
     await hover(anchor);
     const card = hovercard();
@@ -198,7 +216,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
     // Clicking the title link focuses it (a click's real-world side effect); a
     // pointer-initiated open must still release once the pointer leaves, with no
     // click-outside required to dismiss the card.
-    const titleLink = card?.querySelector<HTMLAnchorElement>(".github-link-hovercard__title");
+    const titleLink = titleLinkInCard();
     titleLink?.addEventListener("click", (event) => event.preventDefault());
     titleLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
     titleLink?.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
@@ -209,33 +227,77 @@ describe("openclaw-github-link-hovercard-provider", () => {
   });
 
   it("renders issue comments and supports focus plus Escape", async () => {
-    const request = vi.fn().mockResolvedValue({
-      closedAt: null,
-      comments: 4,
-      createdAt: "2026-07-05T08:00:00Z",
-      kind: "issue",
-      login: "octocat",
-      number: 99815,
-      owner: "openclaw",
-      repo: "openclaw",
-      state: "open",
-      stateReason: null,
-      title: "Keep hover previews compact",
-      updatedAt: "2026-07-05T09:55:00Z",
-    });
-    const { anchor, provider } = createLink(
-      "https://github.com/openclaw/openclaw/issues/99815",
-      "#99815",
-    );
-    provider.client = { request } as unknown as GatewayBrowserClient;
+    const { anchor } = createIssueLink(issuePreviewResponse({ comments: 4 }));
 
     anchor.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("4 comments");
-    expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("Open");
+    expect(hovercard()?.textContent).toContain("4 comments");
+    expect(hovercard()?.textContent).toContain("Open");
+    // Issues have no files-changed view, so their metric stays plain text.
+    expect(hovercard()?.querySelector(".github-link-hovercard__metric--files")).toBeNull();
     anchor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+    expect(hovercard()).toBeNull();
+  });
+
+  it("moves keyboard focus through the card's links and hands it back at the edges", async () => {
+    const { anchor } = createIssueLink();
+
+    anchor.focus();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hovercard()).not.toBeNull();
+
+    // The card is portaled to document.body, so Tab has to be forwarded for any
+    // of its links to be reachable at all.
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+    expect(document.activeElement).toBe(cardLinks()[0]);
+
+    // Inside the run of card links Tab belongs to the browser, not to the card.
+    const middle = cardLinks()[1];
+    middle?.focus();
+    const insideTab = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" });
+    middle?.dispatchEvent(insideTab);
+    expect(insideTab.defaultPrevented).toBe(false);
+    expect(hovercard()).not.toBeNull();
+
+    // Leaving the last link returns focus to the trigger with the card closed,
+    // and that returned focus must not immediately reopen what was dismissed.
+    const last = cardLinks().at(-1);
+    last?.focus();
+    last?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+    expect(hovercard()).toBeNull();
+    expect(document.activeElement).toBe(anchor);
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS * 2);
+    expect(hovercard()).toBeNull();
+  });
+
+  it("closes on Escape from inside the card and returns focus to the link", async () => {
+    const { anchor } = createIssueLink();
+
+    anchor.focus();
+    await vi.advanceTimersByTimeAsync(0);
+    const title = titleLinkInCard();
+    title?.focus();
+    title?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+
+    expect(hovercard()).toBeNull();
+    expect(document.activeElement).toBe(anchor);
+  });
+
+  it("closes once focus leaves both the link and the card", async () => {
+    const { anchor } = createIssueLink();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+
+    anchor.focus();
+    await vi.advanceTimersByTimeAsync(0);
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+    expect(document.activeElement).toBe(cardLinks()[0]);
+
+    outside.focus();
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+    expect(hovercard()).toBeNull();
+    expect(anchor.hasAttribute("aria-expanded")).toBe(false);
   });
 
   it("ignores unsupported GitHub links and shows a quiet unavailable state", async () => {
@@ -271,17 +333,17 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(document.querySelector(".github-link-hovercard")).toBeNull();
   });
 
-  it("preserves an existing description when hover ends before opening", async () => {
+  it("leaves no popup state on the link when hover ends before opening", async () => {
     const request = vi.fn();
     const { anchor, provider } = createLink("https://github.com/openclaw/openclaw/issues/99815");
     provider.client = { request } as unknown as GatewayBrowserClient;
-    anchor.setAttribute("aria-describedby", "existing-description");
 
     anchor.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
     leave(anchor);
     await vi.advanceTimersByTimeAsync(250);
 
-    expect(anchor.getAttribute("aria-describedby")).toBe("existing-description");
+    expect(anchor.hasAttribute("aria-haspopup")).toBe(false);
+    expect(anchor.hasAttribute("aria-expanded")).toBe(false);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -290,24 +352,11 @@ describe("openclaw-github-link-hovercard-provider", () => {
       GITHUB_LINK_HOVERCARD_ELEMENT_NAME,
     ) as GitHubLinkHovercardProviderElement;
     provider.client = {
-      request: vi.fn().mockResolvedValue({
-        closedAt: null,
-        comments: 1,
-        createdAt: "2026-07-05T08:00:00Z",
-        kind: "issue",
-        login: "octocat",
-        number: 99815,
-        owner: "openclaw",
-        repo: "openclaw",
-        state: "open",
-        stateReason: null,
-        title: "Keep hover previews compact",
-        updatedAt: "2026-07-05T09:55:00Z",
-      }),
+      request: vi.fn().mockResolvedValue(issuePreviewResponse({ comments: 1 })),
     } as unknown as GatewayBrowserClient;
     const route = document.createElement("main");
     const anchor = document.createElement("a");
-    anchor.href = "https://github.com/openclaw/openclaw/issues/99815";
+    anchor.href = ISSUE_HREF;
     route.append(anchor);
     provider.append(route);
     document.body.append(provider);
@@ -319,29 +368,11 @@ describe("openclaw-github-link-hovercard-provider", () => {
     await Promise.resolve();
 
     expect(document.querySelector(".github-link-hovercard")).toBeNull();
-    expect(anchor.hasAttribute("aria-describedby")).toBe(false);
+    expect(anchor.hasAttribute("aria-expanded")).toBe(false);
   });
 
   it("rerenders an open preview when the locale changes", async () => {
-    const request = vi.fn().mockResolvedValue({
-      closedAt: null,
-      comments: 1,
-      createdAt: "2026-07-05T08:00:00Z",
-      kind: "issue",
-      login: "octocat",
-      number: 99815,
-      owner: "openclaw",
-      repo: "openclaw",
-      state: "open",
-      stateReason: null,
-      title: "Keep hover previews compact",
-      updatedAt: "2026-07-05T09:55:00Z",
-    });
-    const { anchor, provider } = createLink(
-      "https://github.com/openclaw/openclaw/issues/99815",
-      "#99815",
-    );
-    provider.client = { request } as unknown as GatewayBrowserClient;
+    const { anchor } = createIssueLink(issuePreviewResponse({ comments: 1 }));
     await hover(anchor);
 
     i18n.registerTranslation("pt-BR", {

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -5,6 +5,9 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n } from "../i18n/index.ts";
 import { GitHubLinkHovercardProvider } from "./github-link-hovercard.runtime.ts";
 
+// Mirrors CLOSE_DELAY_MS in the runtime, like the 250ms open delay used below.
+const GITHUB_HOVERCARD_CLOSE_DELAY_MS = 120;
+
 const GITHUB_LINK_HOVERCARD_ELEMENT_NAME = `test-openclaw-github-link-hovercard-provider-${crypto.randomUUID()}`;
 
 customElements.define(
@@ -33,14 +36,18 @@ async function hover(anchor: HTMLAnchorElement): Promise<void> {
   await vi.advanceTimersByTimeAsync(250);
 }
 
-function leave(anchor: HTMLAnchorElement): void {
+function leave(anchor: HTMLAnchorElement, relatedTarget: EventTarget = document.body): void {
   anchor.dispatchEvent(
     new MouseEvent("pointerout", {
       bubbles: true,
       composed: true,
-      relatedTarget: document.body,
+      relatedTarget,
     }),
   );
+}
+
+function hovercard(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".github-link-hovercard");
 }
 
 describe("openclaw-github-link-hovercard-provider", () => {
@@ -107,9 +114,50 @@ describe("openclaw-github-link-hovercard-provider", () => {
     );
 
     leave(anchor);
-    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+    expect(hovercard()).toBeNull();
     await hover(anchor);
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open while the pointer travels from the link onto the card", async () => {
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/issues/99815",
+      "#99815",
+    );
+    provider.client = {
+      request: vi.fn().mockResolvedValue({
+        comments: 2,
+        createdAt: "2026-07-05T08:00:00Z",
+        kind: "issue",
+        login: "octocat",
+        number: 99815,
+        owner: "openclaw",
+        repo: "openclaw",
+        state: "open",
+        title: "Keep hover previews reachable",
+        updatedAt: "2026-07-05T09:55:00Z",
+      }),
+    } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+    const card = hovercard();
+    expect(card).not.toBeNull();
+
+    // Crossing the gap between the link and the card leaves both unhovered.
+    leave(anchor, card as EventTarget);
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS - 1);
+    expect(hovercard()).toBe(card);
+
+    card?.dispatchEvent(new MouseEvent("pointerenter"));
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS * 10);
+    expect(hovercard()).toBe(card);
+
+    card?.dispatchEvent(new MouseEvent("pointerleave"));
+    expect(hovercard()).toBe(card);
+    await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+    expect(hovercard()).toBeNull();
+    expect(anchor.hasAttribute("aria-describedby")).toBe(false);
   });
 
   it("renders issue comments and supports focus plus Escape", async () => {

--- a/ui/src/components/github-link-target.ts
+++ b/ui/src/components/github-link-target.ts
@@ -66,6 +66,17 @@ export function isGitHubItemRootPath(url: URL): boolean {
   return segments.length === 4 && !url.search && !url.hash;
 }
 
+export function gitHubProfileUrl(login: string): string {
+  return `https://${GITHUB_HOST}/${encodeURIComponent(login)}`;
+}
+
+// Built from the parsed parts rather than the source href, which isGitHubItemRootPath
+// shows may already carry its own sub-path, query, or comment fragment.
+export function gitHubFilesChangedUrl(target: GitHubItemTarget): string {
+  const repoPath = `${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+  return `https://${GITHUB_HOST}/${repoPath}/pull/${target.number}/files`;
+}
+
 export function githubLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   for (const candidate of event.composedPath()) {
     if (candidate instanceof HTMLAnchorElement) {

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover GitHub link hover card behavior.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Locator } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -37,6 +37,66 @@ async function closeBrowsers(): Promise<void> {
 
 async function expectText(locator: Locator, text: string): Promise<void> {
   await expect.poll(() => locator.textContent()).toContain(text);
+}
+
+const pullPreviewResponse = {
+  additions: 101,
+  avatarDataUrl:
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+  changedFiles: 3,
+  closedAt: "2026-07-04T09:53:52Z",
+  createdAt: "2026-07-04T05:03:47Z",
+  deletions: 12,
+  draft: false,
+  kind: "pull",
+  login: "steipete",
+  mergedAt: "2026-07-04T09:53:52Z",
+  number: 99816,
+  owner: "openclaw",
+  repo: "openclaw",
+  state: "closed",
+  title: "fix(agents): derive conversation scope from trusted group facts",
+  updatedAt: "2026-07-04T09:53:55Z",
+};
+
+// Shared page setup for the two pointer-lifecycle cases below: both only need
+// a single previewable pull-request link, unlike the full walkthrough above.
+async function openPullPreviewPage(): Promise<{
+  card: Locator;
+  page: Page;
+  pullLink: Locator;
+}> {
+  const context = await newBrowserContext();
+  await context.route("https://github.com/**", (route) =>
+    route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><title>GitHub item</title>",
+    }),
+  );
+
+  const page = await context.newPage();
+  await installMockGateway(page, {
+    methodResponses: {
+      "controlUi.githubPreview": {
+        cases: [{ match: { kind: "pull", number: 99816 }, response: pullPreviewResponse }],
+      },
+    },
+    historyMessages: [
+      {
+        content: [
+          { type: "text", text: "Review https://github.com/openclaw/openclaw/pull/99816." },
+        ],
+        role: "assistant",
+        timestamp: Date.now(),
+      },
+    ],
+  });
+  await page.goto(`${server.baseUrl}chat`);
+
+  const pullLink = page.getByRole("link", { name: "openclaw/openclaw#99816" });
+  const card = page.locator(".github-link-hovercard");
+  await pullLink.waitFor({ state: "visible" });
+  return { card, page, pullLink };
 }
 
 describeControlUiE2e("GitHub link hover cards", () => {
@@ -251,5 +311,62 @@ describeControlUiE2e("GitHub link hover cards", () => {
     const popup = await popupPromise;
     await popup.waitForLoadState("domcontentloaded");
     expect(popup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
+  });
+
+  it("keeps the card open while the pointer crosses the gap onto it, then closes once it leaves both", async () => {
+    const { card, page, pullLink } = await openPullPreviewPage();
+
+    await pullLink.hover();
+    await expectText(card, "openclaw/openclaw #99816");
+    const linkBox = await pullLink.boundingBox();
+    expect(linkBox).not.toBeNull();
+
+    // Cross the physical gap with real intermediate pointer positions: off the
+    // link, through the unowned strip below it, then onto the card body. Each
+    // move is a fast CDP round trip, so the whole crossing lands comfortably
+    // inside CLOSE_DELAY_MS (github-link-hovercard.runtime.ts); the card must
+    // survive every step.
+    await page.mouse.move(linkBox!.x + linkBox!.width / 2, linkBox!.y + linkBox!.height / 2);
+    await page.mouse.move(linkBox!.x + linkBox!.width / 2, linkBox!.y + linkBox!.height + 5);
+    const cardBox = await card.boundingBox();
+    expect(cardBox).not.toBeNull();
+    await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + 4);
+    await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + cardBox!.height / 2);
+    expect(await card.count()).toBe(1);
+
+    // Staying on the card holds it open regardless of elapsed time, mirroring
+    // the unit test's ten-grace-window persistence check.
+    await page.waitForTimeout(300);
+    expect(await card.count()).toBe(1);
+    await expectText(card, "openclaw/openclaw #99816");
+
+    // Leaving both surfaces, with no click, still dismisses the card after the
+    // traversal grace period.
+    await page.mouse.move(1, 1);
+    await expect.poll(() => card.count()).toBe(0);
+  });
+
+  it("opens the linked pull request when the card's title link is clicked", async () => {
+    const { card, page, pullLink } = await openPullPreviewPage();
+
+    await pullLink.hover();
+    await expectText(card, "openclaw/openclaw #99816");
+    const titleLink = card.locator(".github-link-hovercard__title");
+    await expectText(titleLink, pullPreviewResponse.title);
+
+    // Mirrors the source-link popup assertion above: the title anchor reuses
+    // the same validated href, target="_blank", and safe rel.
+    const popupPromise = page.waitForEvent("popup");
+    await titleLink.click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState("domcontentloaded");
+    expect(popup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
+
+    // The click focused the title link inside the card; leaving the card still
+    // dismisses it with no click-outside required (github-link-hovercard.runtime.ts
+    // clears cardFocusInside for a pointer-opened card once the pointer leaves).
+    await popup.close();
+    await page.mouse.move(1, 1);
+    await expect.poll(() => card.count()).toBe(0);
   });
 });

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -39,6 +39,15 @@ async function expectText(locator: Locator, text: string): Promise<void> {
   await expect.poll(() => locator.textContent()).toContain(text);
 }
 
+async function captureArtifact(page: Page, name: string): Promise<void> {
+  const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  if (!artifactDir) {
+    return;
+  }
+  await mkdir(artifactDir, { recursive: true });
+  await page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
+}
+
 const pullPreviewResponse = {
   additions: 101,
   avatarDataUrl:
@@ -333,6 +342,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + 4);
     await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + cardBox!.height / 2);
     expect(await card.count()).toBe(1);
+    await captureArtifact(page, "github-hovercard-pointer-open");
 
     // Staying on the card holds it open regardless of elapsed time, mirroring
     // the unit test's ten-grace-window persistence check.
@@ -346,6 +356,39 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expect.poll(() => card.count()).toBe(0);
   });
 
+  it("exposes the card as a dialog whose title link Tab reaches and Escape leaves", async () => {
+    const { card, page, pullLink } = await openPullPreviewPage();
+
+    await pullLink.focus();
+    await expectText(card, "openclaw/openclaw #99816");
+    // The real accessibility tree has to report a dialog, not a tooltip: the card
+    // owns a link, which tooltip semantics may not contain.
+    await expect.poll(() => page.getByRole("dialog").count()).toBe(1);
+    await expect.poll(() => pullLink.getAttribute("aria-expanded")).toBe("true");
+    await expect
+      .poll(() => pullLink.getAttribute("aria-controls"))
+      .toBe(await card.getAttribute("id"));
+
+    // Tab enters the card at its first link and then walks the rest natively.
+    const focused = () => page.evaluate(() => document.activeElement?.className ?? "");
+    await page.keyboard.press("Tab");
+    await expect.poll(focused).toBe("github-link-hovercard__repo");
+    await page.keyboard.press("Tab");
+    await expect.poll(focused).toBe("github-link-hovercard__title");
+    await captureArtifact(page, "github-hovercard-keyboard-focus");
+    await page.keyboard.press("Tab");
+    await expect.poll(focused).toBe("github-link-hovercard__author");
+
+    await page.keyboard.press("Escape");
+    await expect.poll(() => card.count()).toBe(0);
+    await expect
+      .poll(() => pullLink.evaluate((element) => element === document.activeElement))
+      .toBe(true);
+    // Returning focus to the trigger must not reopen what Escape just dismissed.
+    await page.waitForTimeout(300);
+    expect(await card.count()).toBe(0);
+  });
+
   it("opens the linked pull request when the card's title link is clicked", async () => {
     const { card, page, pullLink } = await openPullPreviewPage();
 
@@ -354,6 +397,18 @@ describeControlUiE2e("GitHub link hover cards", () => {
     const titleLink = card.locator(".github-link-hovercard__title");
     await expectText(titleLink, pullPreviewResponse.title);
 
+    // The title owns the card's only underline; the other links stay quiet even
+    // under the pointer, so the card keeps reading as a preview and not a menu.
+    for (const quiet of ["repo", "author", "metric--files"]) {
+      const link = card.locator(`.github-link-hovercard__${quiet}`);
+      await link.hover();
+      expect(await link.evaluate((el) => getComputedStyle(el).textDecorationLine)).toBe("none");
+    }
+    await titleLink.hover();
+    expect(await titleLink.evaluate((el) => getComputedStyle(el).textDecorationLine)).toBe(
+      "underline",
+    );
+
     // Mirrors the source-link popup assertion above: the title anchor reuses
     // the same validated href, target="_blank", and safe rel.
     const popupPromise = page.waitForEvent("popup");
@@ -361,6 +416,14 @@ describeControlUiE2e("GitHub link hover cards", () => {
     const popup = await popupPromise;
     await popup.waitForLoadState("domcontentloaded");
     expect(popup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
+
+    // The diff-size chip is the card's deep link into the files-changed view.
+    const filesPopupPromise = page.waitForEvent("popup");
+    await card.locator(".github-link-hovercard__metric--files").click();
+    const filesPopup = await filesPopupPromise;
+    await filesPopup.waitForLoadState("domcontentloaded");
+    expect(filesPopup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816/files");
+    await filesPopup.close();
 
     // The click focused the title link inside the card; leaving the card still
     // dismisses it with no click-outside required (github-link-hovercard.runtime.ts

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -754,7 +754,9 @@ openclaw-github-link-hovercard-provider {
   box-shadow: var(--shadow-lg);
   color: var(--text);
   font-family: var(--font-body);
-  pointer-events: none;
+  /* Interactive by design: hover intent and text selection both need the card to
+     receive pointer events (see github-link-hovercard.runtime.ts). */
+  pointer-events: auto;
   opacity: 0;
   transform: translateY(-5px) scale(0.99);
   transform-origin: bottom left;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -819,11 +819,23 @@ openclaw-github-link-hovercard-provider {
   box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 14%, transparent);
 }
 
+/* The repo reference, author and files chip are links too, but the title owns
+   the card's only underline; the rest stay text until hovered or focused. */
 .github-link-hovercard__repo {
   min-width: 0;
+  color: inherit;
   overflow: hidden;
+  text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.github-link-hovercard__repo:hover,
+.github-link-hovercard__repo:focus-visible,
+.github-link-hovercard__author:hover,
+.github-link-hovercard__author:focus-visible {
+  color: var(--text-strong);
+  text-decoration: none;
 }
 
 .github-link-hovercard__time {
@@ -844,7 +856,8 @@ openclaw-github-link-hovercard-provider {
   text-decoration: none;
 }
 
-.github-link-hovercard__title:hover {
+.github-link-hovercard__title:hover,
+.github-link-hovercard__title:focus-visible {
   text-decoration: underline;
 }
 
@@ -865,6 +878,7 @@ openclaw-github-link-hovercard-provider {
   color: var(--muted);
   font-size: var(--control-ui-text-md);
   overflow: hidden;
+  text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -893,6 +907,17 @@ openclaw-github-link-hovercard-provider {
   font-size: var(--control-ui-text-sm);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+.github-link-hovercard__metric--files {
+  text-decoration: none;
+}
+
+.github-link-hovercard__metric--files:hover,
+.github-link-hovercard__metric--files:focus-visible {
+  background: var(--bg-muted);
+  color: var(--text-strong);
+  text-decoration: none;
 }
 
 .github-link-hovercard__metric--additions {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -833,6 +833,7 @@ openclaw-github-link-hovercard-provider {
 }
 
 .github-link-hovercard__title {
+  display: block;
   margin: 15px 0 17px;
   color: var(--text-strong);
   font-size: var(--control-ui-text-lg);
@@ -840,6 +841,11 @@ openclaw-github-link-hovercard-provider {
   letter-spacing: -0.012em;
   line-height: 1.35;
   overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.github-link-hovercard__title:hover {
+  text-decoration: underline;
 }
 
 .github-link-hovercard__footer {


### PR DESCRIPTION
Fixes #124270

## What Problem This Solves

Fixes an issue where users hovering a GitHub issue or pull request link in Control UI chat could see the preview card but never reach it. The card disappeared the moment the pointer left the link, so moving toward the card destroyed it before the pointer could cross the gap, and its title, author, and diffstat could not be selected or copied. Once the card was reachable, its title still had no way to open the linked issue or pull request.

## Why This Change Was Made

Hover intent now spans both surfaces the feature owns. The provider tracks pointer presence over the link, over the card, and focus, and dismissal runs through a single `scheduleClose` path that waits out a bounded 120ms traversal grace and then re-checks all tracked surfaces before closing. Because the card is portaled to `document.body`, outside the provider element, it reports its own hover through its own `pointerenter`/`pointerleave` listeners; the provider's delegated listeners could never have observed it. The card also stops declaring `pointer-events: none`, which had made it inert to the pointer regardless of lifecycle logic and blocked text selection.

The card's title is now an `<a>` reusing the exact `href` the card was activated with (the same `GitHubLinkTarget` the provider already parsed and validated; no new URL parsing was added), with `target="_blank"` and the shared `buildExternalLinkRel()`/`EXTERNAL_LINK_TARGET` helpers from `ui/src/lib/external-link.ts`, matching how other external links in Control UI open. Because the card is portaled outside the provider's delegated `focusin`/`focusout` listeners, focus landing on that link needed its own direct tracking (`cardFocusInside`), mirroring the existing `pointerenter`/`pointerleave` pattern on the card. That focus hold is released whenever the pointer leaves the card after a pointer-initiated open, so clicking the title link (which focuses it) can never leave a hover-opened card stuck open after the mouse moves away; the card still closes on pointer-out with no click-outside required. Keyboard-opened cards (tab focus on the source link) are unaffected: focus-out still closes them as before.

This follows the pattern the Control UI already uses for rich tooltips (`ui/src/components/tooltip.ts`, `shouldRemainOpen` / `maybeClose`); that logic lives inside a Lit component bound to the Web Awesome tooltip and its touch/skip-delay semantics, so it is applied here rather than extracted, which would have cost more surface than it saved.

Non-goals and preserved behavior: Escape, click-on-the-source-link, focus-out, viewport scroll/resize repositioning, and the route-removal observer dismiss exactly as before. A pending open that ends before the card exists is still cancelled immediately, so a link the pointer already left never flashes a card. The close timer is cleared on every close and on disconnect, so no timer outlives the element.

## Scope note: two commits, one lifecycle

This PR is two commits, not one. The first restores reachability: hover intent across the link and the portaled card, with a bounded traversal grace. The second is a small, separate capability I added at the maintainer's request while the traversal fix was already touching this exact focus/pointer state machine: making the card's title a real, clickable link to the issue or pull request, since a reachable, selectable card that still could not be opened felt like an unfinished half of the fix. It reuses the already-validated href and the repo's existing external-link helpers, and needed only one more piece of state (`cardFocusInside`) layered onto the same lifecycle the first commit built, which is why it rides in this PR instead of a follow-up: splitting it out would mean re-deriving the shared traversal/focus contract in a second PR.

## User Impact

Users can now move the pointer from a GitHub link onto its preview card and keep it open, select and copy the title, author, or diffstat, and read the preview at their own pace. The card's title is now a real link to the issue or pull request, opening in a new tab. The card dismisses when the pointer leaves both the link and the card, whether or not the title link was clicked first. Keyboard users are unaffected: focus still opens the card and Escape still closes it immediately.

## Evidence

### Unit-level lifecycle proof (jsdom)

Regression test `stays open while the pointer travels from the link onto the card` in `ui/src/components/github-link-hovercard.test.ts` drives the real lifecycle: hover the link, leave the link with the card as `relatedTarget`, assert the card survives the grace window, enter the card and assert it survives ten grace windows, then leave the card and assert it closes and restores `aria-describedby`.

`closes on pointer-out even after the title link inside the card was clicked` covers the added contract: pointer opens the card, pointer moves onto the card, the title link is clicked and focused, then the pointer leaves the card — the card still closes after the grace period with no click-outside needed. The existing `renders and caches pull request details` test also now asserts the title renders as an `<a>` with the activation `href`, `target="_blank"`, and `rel` containing `noopener noreferrer`.

Verified failing before the fix by restoring the previous immediate-dismiss path in `handlePointerOut`:

```
 × stays open while the pointer travels from the link onto the card 4ms
AssertionError: expected null to be <div …(10)>…(3)</div> // Object.is equality
      Tests  1 failed | 10 passed (11)
```

With the fix in place:

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

### Real-browser proof (Chromium, e2e)

The unit tests above dispatch synthetic pointer events; they cannot show the pointer physically crossing the gap between the link and the card. `ui/src/e2e/github-link-hovercard.e2e.test.ts` already drove a real Chromium page with real mouse geometry for preview rendering and source-link navigation, so this PR extends it with two more real-browser cases instead of adding a second harness:

- `keeps the card open while the pointer crosses the gap onto it, then closes once it leaves both` — hovers the real link, waits for the card, then drives `page.mouse.move` through real intermediate coordinates off the link, through the unowned strip below it, and onto the card body, asserting the card survives every step. It then holds the pointer on the card and confirms the card stays open, and finally moves the pointer off both surfaces with no click and confirms the card closes on its own after the traversal grace period.
- `opens the linked pull request when the card's title link is clicked` — opens the card by hover, clicks the title anchor inside the portaled card, and asserts the resulting popup navigates to the exact pull request URL, mirroring the existing `pullLink.click()` popup assertion for the source link.

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Run three times in a row locally with no flakes (real Chromium, no synthetic/mocked pointer events for the traversal or click).

Changed-file gates green on the touched files (`node scripts/check-changed.mjs -- ...`, exit 0), including the Knip production and full-tree unused-export scans, the coercion helper guard, and format-changed-files.

Autoreview (`.agents/skills/autoreview/scripts/autoreview --mode uncommitted`) run clean before this push, with no accepted or actionable findings remaining.

Production LOC delta is now +102/-6 across `github-link-hovercard.runtime.ts` and `components.css`, of which roughly ten lines are the invariant comments this repo asks for at cross-path lifecycle sites; tests add +217/-4 (unit tests +99/-3, e2e +118/-1 for the two cases above plus their shared setup helper). The growth is the hover-intent capability itself (tracked surfaces, a grace timer, and cleanup) plus the title-link capability described in the scope note above, neither of which any existing shared helper covers.

ClawSweeper's "Before merge" checklist on this PR:
- Production LOC growth for a bug fix (P1): the base fix's growth is inherent to portaling hover intent across an element the provider cannot otherwise observe; the title-link increment's further growth is new capability (a real link plus its focus contract), not bug-fix padding — see the LOC note above and the scope note.
- Real-browser proof of the link-to-card pointer traversal (P1): added above — two new real-Chromium e2e cases in `ui/src/e2e/github-link-hovercard.e2e.test.ts` drive the actual pointer crossing and the title-link click/navigation, run three times locally with no flakes.
- No separate ClawSweeper fix job should be created (P2): no action needed, this PR already owns the repair.


---

## Update: the card is now an interactive popover, not a tooltip

The review was right that a focusable link inside `role="tooltip"` is not a coherent contract. The tooltip semantics were the wrong half to keep, so they are gone and the card now declares what it actually is.

**Semantics.** The card is a non-modal `role="dialog"` with an accessible name in every render state (loading, unavailable, and the full preview). The trigger link carries `aria-haspopup="dialog"` plus `aria-expanded`, flipping to `true` with `aria-controls` once the card exists, and the whole set is removed on close. That replaces the previous `aria-describedby` save/restore dance, which would have flattened the card's now-interactive content into a description string. This matches the pattern already used for non-modal popovers in `ui/src/components/terminal/terminal-session-picker.ts` (trigger `aria-expanded`/`aria-haspopup="dialog"`/`aria-controls`, surface `role="dialog"` + `aria-label`).

**Keyboard.** The card is portaled to `document.body`, so it has no neighbour in the tab sequence and could never be reached by Tab on its own. Tab from the trigger now forwards focus into the card, Tab moves between the card's own links natively, and Tab past either edge — or Escape from anywhere inside — returns focus to the trigger with the card closed. The returned focus is guarded so the card the user just dismissed cannot reopen under them. Focus leaving both the trigger and the card still closes it.

**More of the card is now interactive**, which is the substance behind the semantics change: the title and the `owner/repo #number` reference open the item, the author avatar and login open that profile, and a pull request's diff-size chip deep-links to the files-changed view. Issues have no files view, so their comment count stays plain text. All of them open in a new tab through the same `EXTERNAL_LINK_TARGET` / `buildExternalLinkRel()` helpers. The title keeps the card's only underline; the rest stay quiet until hovered or focused.

**Pointer behavior is unchanged.** The traversal grace period and its repair are untouched: leaving both the link and the card still dismisses it after 120ms, with no click required to close.

### Visual proof

Pointer-opened card:

![GitHub hovercard open under the pointer](https://github.com/user-attachments/assets/fc8e6e39-745e-4f2f-8088-cb36c90db456)

Keyboard focus inside the card (Tab from the link, then Tab to the title link):

![Keyboard focus ring on the hovercard title link](https://github.com/user-attachments/assets/c1975909-8490-4ade-8960-bd31b9dc13d7)

### Validation for this change

Unit (`ui/src/components/github-link-hovercard.test.ts`, 15 passing) adds `moves keyboard focus through the card's links and hands it back at the edges`, `closes on Escape from inside the card and returns focus to the link`, and `closes once focus leaves both the link and the card`, and extends the existing preview case to assert `role="dialog"`, the trigger's popup attributes, and every card link's `href`/`target`/`rel`. Against the pre-change runtime these fail for the intended reasons:

```
 × renders and caches pull request details without changing the link
   AssertionError: expected 'tooltip' to be 'dialog'
 × moves keyboard focus into the card and hands it back ...
 × closes once focus leaves both the link and the card
      Tests  3 failed | 11 passed (14)
```

Real Chromium (`ui/src/e2e/github-link-hovercard.e2e.test.ts`, 4 passing) adds `exposes the card as a dialog whose title link Tab reaches and Escape leaves`, which reads the real accessibility tree with `page.getByRole("dialog")`, walks Tab through repo → title → author, presses Escape, and asserts focus returns to the trigger without the card reopening. The click case now also asserts the files chip's popup lands on `/pull/99816/files`, and that the repo, author, and files links report `text-decoration-line: none` while hovered whereas the title reports `underline`.

```
$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts
      Tests  15 passed (15)

$ LC_ALL=en_US.UTF-8 node scripts/run-vitest.mjs ui/src/e2e/github-link-hovercard.e2e.test.ts
      Tests  4 passed (4)
```

`node scripts/check-changed.mjs -- <touched files>` green (UI typecheck, oxlint, UI stylelint, i18n verify, Knip unused-export scans), and autoreview `--mode uncommitted` clean with no accepted or actionable findings.

This lands as a third commit on the branch; the scope note above describes the first two.
