### PR TITLE
refactor(feishu): remove thread-binding test reset

### DIFF
--- a/extensions/feishu/session-binding-contract-api.ts
+++ b/extensions/feishu/session-binding-contract-api.ts
@@ -1,3 +1,2 @@
 // Feishu API module exposes the plugin public contract.
 export { createFeishuThreadBindingManager } from "./src/thread-bindings.js";
-export { testing as feishuThreadBindingTesting } from "./src/thread-bindings.js";

--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -3,19 +3,26 @@ import {
   getRequiredHookHandler,
   registerHookHandlersForTest,
 } from "openclaw/plugin-sdk/channel-test-helpers";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ClawdbotConfig, OpenClawPluginApi } from "../runtime-api.js";
 import { registerFeishuSubagentHooks } from "../subagent-hooks-api.js";
 import { handleFeishuSubagentSpawning } from "./subagent-hooks.js";
-import {
-  createFeishuThreadBindingManager,
-  testing as threadBindingTesting,
-} from "./thread-bindings.js";
+import { createFeishuThreadBindingManager as createFeishuThreadBindingManagerImpl } from "./thread-bindings.js";
 
 const baseConfig: ClawdbotConfig = {
   session: { mainKey: "main", scope: "per-sender" },
   channels: { feishu: {} },
 };
+
+type FeishuThreadBindingManager = ReturnType<typeof createFeishuThreadBindingManagerImpl>;
+let trackedManager: FeishuThreadBindingManager | null = null;
+
+function createFeishuThreadBindingManager(
+  params: Parameters<typeof createFeishuThreadBindingManagerImpl>[0],
+): FeishuThreadBindingManager {
+  trackedManager = createFeishuThreadBindingManagerImpl(params);
+  return trackedManager;
+}
 
 function registerHandlersForTest(config: Record<string, unknown> = baseConfig) {
   return registerHookHandlersForTest<OpenClawPluginApi>({
@@ -87,8 +94,9 @@ function managedHookFixture() {
 }
 
 describe("feishu subagent hook handlers", () => {
-  beforeEach(() => {
-    threadBindingTesting.resetFeishuThreadBindingsForTests();
+  afterEach(() => {
+    trackedManager?.stop();
+    trackedManager = null;
   });
 
   it("binds a Feishu DM conversation on subagent_spawning", async () => {

--- a/extensions/feishu/src/thread-bindings.test.ts
+++ b/extensions/feishu/src/thread-bindings.test.ts
@@ -1,19 +1,27 @@
 // Feishu tests cover thread bindings plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing, createFeishuThreadBindingManager } from "./thread-bindings.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFeishuThreadBindingManager as createFeishuThreadBindingManagerImpl } from "./thread-bindings.js";
 
 const baseCfg = {
   session: { mainKey: "main", scope: "per-sender" },
 } satisfies OpenClawConfig;
 
-describe("Feishu thread bindings", () => {
-  beforeEach(() => {
-    testing.resetFeishuThreadBindingsForTests();
-  });
+type FeishuThreadBindingManager = ReturnType<typeof createFeishuThreadBindingManagerImpl>;
+let trackedManager: FeishuThreadBindingManager | null = null;
 
+function createFeishuThreadBindingManager(
+  params: Parameters<typeof createFeishuThreadBindingManagerImpl>[0],
+): FeishuThreadBindingManager {
+  trackedManager = createFeishuThreadBindingManagerImpl(params);
+  return trackedManager;
+}
+
+describe("Feishu thread bindings", () => {
   afterEach(() => {
+    trackedManager?.stop();
+    trackedManager = null;
     vi.restoreAllMocks();
   });
 

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -349,13 +349,3 @@ export function getFeishuThreadBindingManager(
 ): FeishuThreadBindingManager | null {
   return getState().managersByAccountId.get(normalizeAccountId(accountId)) ?? null;
 }
-
-export const testing = {
-  resetFeishuThreadBindingsForTests() {
-    for (const manager of getState().managersByAccountId.values()) {
-      manager.stop();
-    }
-    getState().managersByAccountId.clear();
-    getState().bindingsByAccountConversation.clear();
-  },
-};

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -162,6 +162,7 @@ type ChannelConversationBindingManager = Awaited<
   ReturnType<ChannelConversationBindingManagerFactory>
 >;
 let discordSessionBindingManager: ChannelConversationBindingManager | null = null;
+let feishuSessionBindingManager: ChannelConversationBindingManager | null = null;
 let matrixSessionBindingManager: ChannelConversationBindingManager | null = null;
 let telegramSessionBindingManager: ChannelConversationBindingManager | null = null;
 
@@ -173,10 +174,7 @@ type FeishuContractApi = {
   createFeishuThreadBindingManager: (params: {
     accountId?: string;
     cfg: OpenClawConfig;
-  }) => unknown;
-  feishuThreadBindingTesting: {
-    resetFeishuThreadBindingsForTests: () => void;
-  };
+  }) => ChannelConversationBindingManager;
 };
 
 type IMessageContractApi = {
@@ -251,6 +249,11 @@ async function stopDiscordSessionBindingManager() {
   discordSessionBindingManager = null;
 }
 
+async function stopFeishuSessionBindingManager() {
+  await feishuSessionBindingManager?.stop();
+  feishuSessionBindingManager = null;
+}
+
 async function stopMatrixSessionBindingManager() {
   await matrixSessionBindingManager?.stop();
   matrixSessionBindingManager = null;
@@ -276,8 +279,7 @@ async function prepareDiscordSessionBindingContract() {
 }
 
 async function prepareFeishuSessionBindingContract() {
-  const api = await getContractApi<FeishuContractApi>("feishu");
-  api.feishuThreadBindingTesting.resetFeishuThreadBindingsForTests();
+  await stopFeishuSessionBindingManager();
 }
 
 async function prepareIMessageSessionBindingContract() {
@@ -411,11 +413,12 @@ const sessionBindingContractEntries = {
     ensureManager: async () => {
       const { createFeishuThreadBindingManager } =
         await getContractApi<FeishuContractApi>("feishu");
-      createFeishuThreadBindingManager({
+      feishuSessionBindingManager ??= createFeishuThreadBindingManager({
         accountId: "default",
         cfg: baseSessionBindingCfg,
       });
     },
+    stopManager: stopFeishuSessionBindingManager,
   }),
   imessage: createSessionBindingContractEntry({
     id: "imessage",


### PR DESCRIPTION
## What Problem This Solves

Feishu thread-binding tests and the shared channel contract depended on an aggregate reset export that stopped every manager and cleared global maps. The real manager `stop()` already owns account-scoped binding and adapter cleanup, so the reset was a test-only production facade.

## Why This Change Was Made

Tests now retain and stop the Feishu managers they create. The registry-backed contract tracks its Feishu manager just like Discord, Matrix, and Telegram. The aggregate `testing.resetFeishuThreadBindingsForTests` object and its contract-sidecar export are deleted.

This PR is AI-assisted as part of the maintainer-requested repository test-value audit.

## User Impact

No user-visible behavior changes. Feishu lifecycle coverage now exercises manager-owned cleanup instead of a global test reset.

## Evidence

- Feishu owner suites and registry-backed session-binding contract — 24 passed
- `node scripts/check-changed.mjs -- <changed files>` — passed via the documented local fallback; core/extension typechecks, lint, dead exports, sidecar boundaries, import cycles, and guards were green
- `pnpm build` — passed
- `git diff --check` — passed
- Structured autoreview — clean

Production delta: -11 net lines. Test/test-support delta: +19 net lines; the support growth makes created-manager ownership explicit across the three test owners. No docs, changelog, schema, protocol, migration, or operator-state change is required.
