### PR TITLE
fix(ui): sidebar sort selection is forgotten after a reload

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -53,10 +53,13 @@ import { SessionPullRequestIndicatorsController } from "./app-sidebar-session-pr
 import { projectSessionTree } from "./app-sidebar-session-tree.ts";
 import { loadStoredHiddenSessionCatalogIds } from "./app-sidebar-session-types.ts";
 import {
+  loadStoredSidebarSessionSortMode,
   loadStoredSidebarSessionStatusFilter,
   loadStoredSidebarSessionsGrouping,
   loadStoredSidebarSessionsShowCron,
   loadStoredSidebarSessionsShowSystem,
+  resolveSidebarSessionSortMode,
+  storeSidebarSessionSortMode,
   type SidebarRecentSession,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
@@ -69,7 +72,7 @@ import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 
 /** Session-row projection, selection, sorting, and agent scope navigation. */
 export class AppSidebarSessionNavigationElement extends AppSidebarBase {
-  @state() sessionSortMode: SidebarSessionSortMode = "created";
+  @state() sessionSortMode: SidebarSessionSortMode = loadStoredSidebarSessionSortMode();
 
   readonly sessionData = new SessionDataController(this);
   private readonly sessionPullRequestIndicators = new SessionPullRequestIndicatorsController(this, {
@@ -109,14 +112,11 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   effectiveSessionSortMode(): SidebarSessionSortMode {
     // A reconnect can temporarily hide the capability. Render Created without
     // discarding People until an authoritative single-identity hello arrives.
-    return this.sessionSortMode === "people" && !this.sessionPeopleSortAvailable()
-      ? "created"
-      : this.sessionSortMode;
+    return resolveSidebarSessionSortMode(this.sessionSortMode, this.sessionPeopleSortAvailable());
   }
 
   setSessionSortMode(mode: SidebarSessionSortMode) {
-    this.sessionSortMode =
-      mode === "people" && this.sessionPeopleSortCapability() === false ? "created" : mode;
+    this.sessionSortMode = storeSidebarSessionSortMode(mode, this.sessionPeopleSortCapability());
   }
 
   @state() sessionCreatorFilterId: string | null = null;

--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -3,8 +3,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   loadStoredHiddenSessionCatalogIds,
+  loadStoredSidebarSessionSortMode,
   loadStoredSidebarSessionStatusFilter,
   setStoredSessionCatalogHidden,
+  storeSidebarSessionSortMode,
   storeSidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 
@@ -54,6 +56,26 @@ describe("sidebar session status preference", () => {
     expect(loadStoredSidebarSessionStatusFilter()).toBe("archived");
     storeSidebarSessionStatusFilter("all");
     expect(loadStoredSidebarSessionStatusFilter()).toBe("all");
+  });
+});
+
+describe("sidebar session sort preference", () => {
+  it("defaults absent and unknown stored values to created", () => {
+    expect(loadStoredSidebarSessionSortMode()).toBe("created");
+    localStorage.setItem("openclaw:sidebar:sessions:sort-mode", "unexpected");
+    expect(loadStoredSidebarSessionSortMode()).toBe("created");
+  });
+
+  it("round-trips updated and people modes", () => {
+    expect(storeSidebarSessionSortMode("updated", undefined)).toBe("updated");
+    expect(loadStoredSidebarSessionSortMode()).toBe("updated");
+    expect(storeSidebarSessionSortMode("people", true)).toBe("people");
+    expect(loadStoredSidebarSessionSortMode()).toBe("people");
+  });
+
+  it("stores created instead of a people sort the gateway denied", () => {
+    expect(storeSidebarSessionSortMode("people", false)).toBe("created");
+    expect(loadStoredSidebarSessionSortMode()).toBe("created");
   });
 });
 

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -213,6 +213,7 @@ const SIDEBAR_SESSION_CATALOG_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:
 const SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY = "openclaw:sidebar:sessions:show-cron";
 const SIDEBAR_SESSION_SHOW_SYSTEM_STORAGE_KEY = "openclaw:sidebar:sessions:show-system";
 const SIDEBAR_SESSION_STATUS_FILTER_STORAGE_KEY = "openclaw:sidebar:sessions:status-filter";
+const SIDEBAR_SESSION_SORT_MODE_STORAGE_KEY = "openclaw:sidebar:sessions:sort-mode";
 const SIDEBAR_SESSION_COLLAPSED_SECTIONS_STORAGE_KEY =
   "openclaw:sidebar:sessions:collapsed-sections";
 const SIDEBAR_HIDDEN_SESSION_CATALOGS_STORAGE_KEY = "openclaw:sidebar:sessions:hidden-catalogs";
@@ -259,6 +260,13 @@ export function loadStoredSidebarSessionsShowSystem(): boolean {
 export function loadStoredSidebarSessionStatusFilter(): SidebarSessionStatusFilter {
   const stored = getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_STATUS_FILTER_STORAGE_KEY);
   return stored === "archived" || stored === "all" ? stored : "active";
+}
+
+export function loadStoredSidebarSessionSortMode(): SidebarSessionSortMode {
+  const stored = getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SORT_MODE_STORAGE_KEY);
+  // "people" stays readable here even when the gateway later hides the
+  // capability; effectiveSessionSortMode() downgrades it at render time.
+  return stored === "updated" || stored === "people" ? stored : "created";
 }
 
 export function loadStoredCollapsedSessionSections(): ReadonlySet<string> {
@@ -313,6 +321,30 @@ export function storeSidebarSessionsShowSystem(show: boolean) {
 
 export function storeSidebarSessionStatusFilter(value: SidebarSessionStatusFilter) {
   getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_STATUS_FILTER_STORAGE_KEY, value);
+}
+
+/** People collapses to Created only where the gateway has authoritatively
+ *  denied the capability; an undefined capability (reconnect) keeps the mode. */
+export function resolveSidebarSessionSortMode(
+  mode: SidebarSessionSortMode,
+  keepPeople: boolean,
+): SidebarSessionSortMode {
+  return mode === "people" && !keepPeople ? "created" : mode;
+}
+
+/** Persists the resolved mode, never the rejected request, so a reload cannot
+ *  restore a People sort the gateway already refused. Returns what was stored. */
+export function storeSidebarSessionSortMode(
+  mode: SidebarSessionSortMode,
+  peopleCapability: boolean | undefined,
+): SidebarSessionSortMode {
+  const resolved = resolveSidebarSessionSortMode(mode, peopleCapability !== false);
+  try {
+    getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_SORT_MODE_STORAGE_KEY, resolved);
+  } catch {
+    // Keep the in-memory preference when storage is unavailable.
+  }
+  return resolved;
 }
 
 export function storeCollapsedSessionSections(sections: ReadonlySet<string>) {

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SidebarSessionSortMode } from "../../components/app-sidebar-session-types.ts";
 import {
   createContext,
   createGateway,
@@ -14,6 +15,30 @@ import {
 } from "../app-sidebar.ts";
 import "./session-pagination.ts";
 import "./session-navigation.ts";
+
+type SidebarSortModeHost = {
+  sessionSortMode: SidebarSessionSortMode;
+  setSessionSortMode: (mode: SidebarSessionSortMode) => void;
+};
+
+describe("AppSidebar session sort persistence", () => {
+  it("restores the selected sort mode on a later mount", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const first = await mountSidebar(gateway, createSessions("main", ["agent:main:session-a"]));
+    const firstSidebar = first.sidebar as unknown as SidebarSortModeHost;
+    expect(firstSidebar.sessionSortMode).toBe("created");
+
+    firstSidebar.setSessionSortMode("updated");
+    expect(localStorage.getItem("openclaw:sidebar:sessions:sort-mode")).toBe("updated");
+
+    // A remount is what a reload does to this element; the preference must
+    // survive it like every other stored sidebar choice.
+    document.body.replaceChildren();
+    const second = await mountSidebar(gateway, createSessions("main", ["agent:main:session-a"]));
+
+    expect((second.sidebar as unknown as SidebarSortModeHost).sessionSortMode).toBe("updated");
+  });
+});
 
 describe("AppSidebar session pagination", () => {
   it("does not show pagination controls at the ten-session boundary", async () => {


### PR DESCRIPTION
Fixes #124273

## What Problem This Solves

Fixes an issue where users who pick a sessions-sidebar sort order would silently lose that choice on the next page load. Selecting "Last updated" (or People) in the sidebar's "Sort sessions" menu reorders rows immediately, but the selection is dropped on reload and the sidebar returns to "Created" ordering.

Every other preference in the same sidebar — grouping, Show cron, Show system, the archived/active filter, collapsed sections, and hidden catalogs — already survives a reload, so the sort control was the one odd surface that forgot what the user asked for. Because the revert is silent, the sidebar can look like it is ignoring recent activity when the user believes they already opted into activity-first ordering.

## Why This Change Was Made

The sort mode is now stored under `openclaw:sidebar:sessions:sort-mode` and read back when the sidebar initializes, using the same `localStorage` load/store pair and `openclaw:sidebar:sessions:*` key namespace the sibling preferences already use. No new persistence path was introduced, and no migration is needed: the key is new, and its absence resolves to the existing default.

The default is deliberately unchanged. A fresh profile still starts on "Created", which remains the intended stable ordering; this change only makes an explicit user choice durable.

Two smaller decisions worth calling out for reviewers:

- The "People" mode is only collapsed to "Created" when the gateway has authoritatively denied the capability. That rule previously existed twice, in slightly different forms, in the render path and the setter. It now lives in one shared `resolveSidebarSessionSortMode` helper, so a reconnect that temporarily hides the capability still cannot persist a downgrade the user never asked for.
- The storage write is guarded once inside the store helper rather than at each call site, so a browser with storage disabled keeps the in-memory preference instead of throwing.

Consolidating that duplicated resolution is what kept `app-sidebar-session-navigation.ts` net-neutral in lines; it sits exactly at the 700-line lint ceiling, and no `max-lines` suppression was added.

Non-goal: this PR does not change how sessions are ordered, and does not touch the recency machinery. That path already works — `updatedAt` is stamped at turn admission in `src/gateway/server-methods/agent-session-patch.ts`, projected in `src/gateway/session-utils-row.ts`, carried on the live change event, and consumed by `compareSessionRowsByUpdatedAt`. When "Last updated" is selected, a session that receives a new turn already moves to the top. The only gap being closed here is that the user's choice did not survive a reload.

## User Impact

Pick a sidebar sort order once and it stays. Users who prefer activity-first ordering can select "Last updated" and keep it across reloads and restarts instead of re-applying it every session.

Existing users are unaffected until they change the setting: with no stored value, the sidebar behaves exactly as it does today.

## Evidence

Regression test fails before the fix and passes after. Verified by stashing only the two production files and re-running the same test:

```
# pre-fix (production changes stashed)
$ node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts -t "restores the selected sort mode"
 - Expected: "updated"
 + Received: null
   Tests  1 failed | 261 skipped (262)

# post-fix
$ node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts
   Tests  262 passed (262)
```

The component-level case mounts the sidebar, selects "Last updated", tears the element down, and remounts it — the remount is what a reload does to this element — then asserts the mode stuck. Store-layer coverage in `app-sidebar-session-types.test.ts` adds the default-on-unknown-value case and the gateway-denied People case:

```
$ node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-types.test.ts
   Tests  8 passed (8)
```

Changed-files gate green, including UI typecheck, core test typecheck, lint, formatting, and the max-lines ratchet:

```
$ node scripts/check-changed.mjs -- <the four changed files>
exit=0
```

Pre-commit review (`autoreview --mode uncommitted`) reported no accepted or actionable findings.

LOC delta: production is +32 in `app-sidebar-session-types.ts` (storage key, load, resolve, and store helpers, including doc comments) and net 0 in `app-sidebar-session-navigation.ts`, where the deduplicated resolution paid for the new wiring. Tests are +47 across two files.
