### PR TITLE
test(discord): remove thread cache reset

### DIFF
--- a/extensions/discord/src/monitor/threading.cache.ts
+++ b/extensions/discord/src/monitor/threading.cache.ts
@@ -11,10 +11,6 @@ const DISCORD_THREAD_STARTER_CACHE_MAX = 500;
 
 const DISCORD_THREAD_STARTER_CACHE = new Map<string, DiscordThreadStarterCacheEntry>();
 
-export function resetDiscordThreadStarterCacheForTest() {
-  DISCORD_THREAD_STARTER_CACHE.clear();
-}
-
 export function getCachedThreadStarter(key: string, now: number): DiscordThreadStarter | undefined {
   const entry = DISCORD_THREAD_STARTER_CACHE.get(key);
   if (!entry) {

--- a/extensions/discord/src/monitor/threading.starter.test.ts
+++ b/extensions/discord/src/monitor/threading.starter.test.ts
@@ -1,10 +1,11 @@
 // Discord tests cover threading.starter plugin behavior.
 import { StickerFormatType } from "discord-api-types/v10";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ChannelType, type Client } from "../internal/discord.js";
-import { resetDiscordThreadStarterCacheForTest, resolveDiscordThreadStarter } from "./threading.js";
+import { resolveDiscordThreadStarter } from "./threading.js";
 
 type ResolvedThreadStarter = NonNullable<Awaited<ReturnType<typeof resolveDiscordThreadStarter>>>;
+let threadIdIndex = 0;
 
 type ThreadStarterRestMessage = {
   content?: string | null;
@@ -92,23 +93,20 @@ async function resolveStarter(params: {
 }) {
   const get = vi.fn().mockResolvedValue(params.message);
   const client = { rest: { get } } as unknown as Client;
+  const threadId = `thread-${++threadIdIndex}`;
 
   const result = await resolveDiscordThreadStarter({
-    channel: { id: "thread-1" },
+    channel: { id: threadId },
     client,
     parentId: params.parentId ?? "parent-1",
     parentType: params.parentType ?? ChannelType.GuildText,
     resolveTimestampMs: params.resolveTimestampMs ?? (() => undefined),
   });
 
-  return { get, result };
+  return { get, result, threadId };
 }
 
 describe("resolveDiscordThreadStarter", () => {
-  beforeEach(() => {
-    resetDiscordThreadStarterCacheForTest();
-  });
-
   it("falls back to joined embed title and description when content is empty", async () => {
     const { result } = await resolveStarter({
       message: createStarterMessage({
@@ -277,7 +275,7 @@ describe("resolveDiscordThreadStarter", () => {
   });
 
   it("uses the thread id as the message channel id for forum parents", async () => {
-    const { get, result } = await resolveStarter({
+    const { get, result, threadId } = await resolveStarter({
       message: createStarterMessage({ content: "starter content" }),
       parentId: undefined,
       parentType: ChannelType.GuildForum,
@@ -285,7 +283,7 @@ describe("resolveDiscordThreadStarter", () => {
 
     expect(requireThreadStarter(result).text).toBe("starter content");
     expect(get).toHaveBeenCalledTimes(1);
-    expect(firstRestGetPath(get)).toBe("/channels/thread-1/messages/thread-1");
+    expect(firstRestGetPath(get)).toBe(`/channels/${threadId}/messages/${threadId}`);
   });
 
   it("returns null when content, embeds, and snapshots are all empty", async () => {

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -4,7 +4,6 @@ export {
   resolveDiscordAutoThreadContext,
   resolveDiscordAutoThreadReplyPlan,
 } from "./threading.auto-thread.js";
-export { resetDiscordThreadStarterCacheForTest } from "./threading.cache.js";
 export {
   resolveDiscordReplyDeliveryPlan,
   resolveDiscordReplyTarget,


### PR DESCRIPTION
## What Problem This Solves

Discord thread-starter tests exported a production cache-reset function solely to erase module state between cases. That made the production barrel and cache owner carry a test-only API, while the tests depended on an implementation detail rather than the cache's real thread-ID identity.

## Why This Change Was Made

Each test resolution now uses a unique synthetic thread ID, which isolates cases through the production cache key. The test-only reset implementation and barrel export can therefore be deleted without changing cache behavior or weakening the existing starter-content assertions.

## User Impact

None. This is an internal test cleanup; Discord thread-starter behavior and cache policy are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/threading.starter.test.ts` — 11 passed.
- `node scripts/check-changed.mjs -- extensions/discord/src/monitor/threading.cache.ts extensions/discord/src/monitor/threading.ts extensions/discord/src/monitor/threading.starter.test.ts` — passed through the documented local fallback because no remote provider was ready.
- `git diff --check` — passed.
- Structured autoreview — clean, no accepted/actionable findings.
- Production delta: -5 lines. Test delta: -2 lines. No docs, changelog, schema, protocol, migration, or operator-state change.
