### PR TITLE
fix(workboard): start cards with current context after handoff

### DIFF
--- a/ui/src/lib/workboard/execution.ts
+++ b/ui/src/lib/workboard/execution.ts
@@ -39,6 +39,10 @@ const WORKBOARD_ENGINE_MODELS = {
   claude: "anthropic/claude-sonnet-4-6",
 } as const;
 const WORKBOARD_SESSION_LABEL_MAX_CHARS = 512;
+// Match the native Workboard worker context so Control UI starts receive the
+// same bounded slice of the newest operator comments.
+const WORKBOARD_PROMPT_COMMENT_LIMIT = 12;
+const WORKBOARD_PROMPT_COMMENT_MAX_CHARS = 400;
 
 function engineModel(engine: WorkboardExecutionEngine | null | undefined): string | undefined {
   return engine === "codex"
@@ -49,9 +53,24 @@ function engineModel(engine: WorkboardExecutionEngine | null | undefined): strin
 }
 
 function buildCardPrompt(card: WorkboardCard): string {
-  const lines = [`Work on this OpenClaw Workboard card: ${card.title}`];
+  const lines = [`Work on this OpenClaw Workboard card: ${card.title}`, `Card ID: ${card.id}`];
   if (card.notes?.trim()) {
     lines.push("", card.notes.trim());
+  }
+  const comments = (card.metadata?.comments ?? [])
+    .map((comment) => ({ body: comment.body.trim(), createdAt: comment.createdAt }))
+    .filter((comment) => comment.body)
+    .toSorted((left, right) => left.createdAt - right.createdAt)
+    .slice(-WORKBOARD_PROMPT_COMMENT_LIMIT);
+  if (comments.length > 0) {
+    lines.push("", "Recent comments (oldest to newest):");
+    for (const comment of comments) {
+      const body =
+        comment.body.length <= WORKBOARD_PROMPT_COMMENT_MAX_CHARS
+          ? comment.body
+          : `${truncateUtf16Safe(comment.body, WORKBOARD_PROMPT_COMMENT_MAX_CHARS - 1).trimEnd()}…`;
+      lines.push(`- ${body}`);
+    }
   }
   if (card.labels.length > 0) {
     lines.push("", `Labels: ${card.labels.join(", ")}`);
@@ -93,11 +112,11 @@ function sanitizeSessionSegment(value: string | undefined, fallback: string): st
   return (sanitized || fallback).slice(0, 96);
 }
 
-function buildCardTaskSessionKey(card: WorkboardCard): string {
+function buildCardTaskSessionKey(card: WorkboardCard, runAgentId?: string | null): string {
   const boardId = sanitizeSessionSegment(card.metadata?.automation?.boardId, "default");
   const cardId = sanitizeSessionSegment(card.id, "card");
   const suffix = `subagent:workboard-${boardId}-${cardId}`;
-  const agentId = card.agentId?.trim();
+  const agentId = normalizeString(runAgentId === undefined ? card.agentId : runAgentId);
   // Unassigned cards stay unscoped on purpose: the gateway canonicalizes a bare
   // suffix onto the configured default agent, while normalizeAgentId maps an
   // empty id to "main" and would target the wrong agent when the default differs.
@@ -227,6 +246,7 @@ export async function startWorkboardCard(params: {
   host: WorkboardHost;
   client: GatewayBrowserClient | null;
   card: WorkboardCard;
+  runAgentId?: string | null;
   engine?: WorkboardExecutionEngine;
   mode?: WorkboardExecutionMode;
   requestUpdate?: () => void;
@@ -255,6 +275,11 @@ export async function startWorkboardCard(params: {
   let preflightCard: WorkboardCard | null = null;
   let createdSessionKey: string | null = null;
   let createdRunId: string | undefined;
+  const originalAgentId = normalizeString(params.card.agentId);
+  const runAgentId =
+    params.runAgentId === undefined ? originalAgentId : normalizeString(params.runAgentId);
+  const shouldReassignRunAgent =
+    params.runAgentId !== undefined && originalAgentId !== null && originalAgentId !== runAgentId;
   try {
     const shouldClearManualSchedule =
       mode === "manual" && params.card.metadata?.automation?.scheduledAt !== undefined;
@@ -266,7 +291,10 @@ export async function startWorkboardCard(params: {
     if (mode === "autonomous") {
       const preflightPayload = await params.client.request("workboard.cards.update", {
         id: params.card.id,
-        patch: { status: nextCardStatus },
+        patch: {
+          status: nextCardStatus,
+          ...(shouldReassignRunAgent ? { agentId: runAgentId } : {}),
+        },
       });
       preflightCard = normalizeCardPayload(preflightPayload);
       if (preflightCard) {
@@ -277,8 +305,8 @@ export async function startWorkboardCard(params: {
     const created =
       mode === "autonomous"
         ? await params.client.request("agent", {
-            sessionKey: buildCardTaskSessionKey(card),
-            ...(card.agentId ? { agentId: card.agentId } : {}),
+            sessionKey: buildCardTaskSessionKey(card, runAgentId),
+            ...(runAgentId ? { agentId: runAgentId } : {}),
             label: buildCardSessionLabel(card),
             ...(model ? { model } : {}),
             message: buildCardPrompt(card),
@@ -287,7 +315,7 @@ export async function startWorkboardCard(params: {
             idempotencyKey: buildCardRunIdempotencyKey(card),
           })
         : await requestSessionCreate(params.client, {
-            ...(card.agentId ? { agentId: card.agentId } : {}),
+            ...(runAgentId ? { agentId: runAgentId } : {}),
             label: buildCardSessionLabel(card),
             ...(model ? { model } : {}),
           });
@@ -297,7 +325,7 @@ export async function startWorkboardCard(params: {
         : isRecord(created) && typeof created.key === "string" && created.key.trim()
           ? created.key.trim()
           : mode === "autonomous"
-            ? buildCardTaskSessionKey(card)
+            ? buildCardTaskSessionKey(card, runAgentId)
             : null;
     const runId =
       isRecord(created) && typeof created.runId === "string" && created.runId.trim()
@@ -321,6 +349,7 @@ export async function startWorkboardCard(params: {
       id: params.card.id,
       patch: {
         status: nextCardStatus,
+        ...(shouldReassignRunAgent ? { agentId: runAgentId } : {}),
         ...(shouldClearManualSchedule ? { scheduledAt: null } : {}),
         ...(sessionKey ? { sessionKey } : {}),
         runId: runId ?? null,
@@ -364,6 +393,7 @@ export async function startWorkboardCard(params: {
           id: params.card.id,
           patch: {
             status: params.card.status,
+            ...(shouldReassignRunAgent ? { agentId: params.card.agentId ?? null } : {}),
             startedAt: params.card.startedAt ?? null,
             completedAt: params.card.completedAt ?? null,
             ...(params.card.execution !== undefined ? { execution: params.card.execution } : {}),

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -3332,6 +3332,61 @@ describe("workboard controller", () => {
     expect(client.request.mock.calls[3]?.[1]).toHaveProperty("patch.execution", null);
   });
 
+  it("includes the card id and recent comments in the task prompt", async () => {
+    const card = makeCard({
+      notes: "Waiting for the site URL.",
+      metadata: {
+        comments: [
+          { id: "comment-2", body: "https://example.com/site", createdAt: 3 },
+          { id: "comment-1", body: "The URL is ready; review related sites too.", createdAt: 2 },
+        ],
+      },
+    });
+    const client = createClient({
+      agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
+      "tasks.list": { tasks: [sampleTask] },
+      "workboard.cards.update": { card: { ...card, status: "running" } },
+    });
+
+    await startCard(client, { card });
+
+    const prompt = (requestCalls(client, "agent")[0]?.[1] as { message?: string }).message ?? "";
+    expect(prompt).toContain("Card ID: card-1");
+    expect(prompt).toContain("Waiting for the site URL.");
+    expect(prompt).toContain("Recent comments (oldest to newest):");
+    expect(prompt.indexOf("The URL is ready; review related sites too.")).toBeLessThan(
+      prompt.indexOf("https://example.com/site"),
+    );
+  });
+
+  it("bounds task prompt comments while retaining the newest context", async () => {
+    const card = makeCard({
+      metadata: {
+        comments: [
+          ...Array.from({ length: 12 }, (_, index) => ({
+            id: `comment-${index}`,
+            body: `older-${index}-${"y".repeat(1000)}`,
+            createdAt: index,
+          })),
+          { id: "comment-newest", body: `newest-${"x".repeat(1000)}`, createdAt: 20 },
+        ],
+      },
+    });
+    const client = createClient({
+      agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
+      "tasks.list": { tasks: [sampleTask] },
+      "workboard.cards.update": { card: { ...card, status: "running" } },
+    });
+
+    await startCard(client, { card });
+
+    const prompt = (requestCalls(client, "agent")[0]?.[1] as { message?: string }).message ?? "";
+    expect(prompt).toContain("newest-");
+    expect(prompt).toContain("…");
+    expect(prompt).not.toContain("older-0");
+    expect(prompt.length).toBeLessThan(5400);
+  });
+
   it("keeps bounded task session labels on a UTF-16 boundary", async () => {
     const title = `${"a".repeat(499)}🚀tail`;
     const client = createClient({
@@ -3387,6 +3442,76 @@ describe("workboard controller", () => {
         sessionKey: expectedSessionKey,
       }),
     );
+  });
+
+  it("hands an unconfigured assignee to an explicit runtime agent", async () => {
+    const expectedSessionKey = "agent:default-agent:subagent:workboard-default-card-1";
+    const staleAssigned = makeCard({ agentId: "removed-agent" });
+    const running = {
+      ...staleAssigned,
+      agentId: "default-agent",
+      status: "running",
+      sessionKey: expectedSessionKey,
+      runId: "run-1",
+      taskId: "task-1",
+    } satisfies WorkboardCard;
+    const client = createClient({
+      agent: { sessionKey: expectedSessionKey, runId: "run-1" },
+      "tasks.list": {
+        tasks: [makeTask({ childSessionKey: expectedSessionKey })],
+      },
+      "workboard.cards.update": { card: running },
+    });
+
+    await startCard(client, {
+      card: staleAssigned,
+      runAgentId: "default-agent",
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "workboard.cards.update",
+      expect.objectContaining({
+        patch: { status: "running", agentId: "default-agent" },
+      }),
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "agent",
+      expect.objectContaining({
+        agentId: "default-agent",
+        sessionKey: expectedSessionKey,
+      }),
+    );
+    expect(getWorkboardState(host).cards[0]?.agentId).toBe("default-agent");
+  });
+
+  it("restores an unconfigured assignee when the runtime handoff fails", async () => {
+    const staleAssigned = makeCard({ agentId: "removed-agent" });
+    const running = {
+      ...staleAssigned,
+      agentId: "default-agent",
+      status: "running",
+    } satisfies WorkboardCard;
+    const client = createSequencedClient({
+      "workboard.cards.update": [{ card: running }, { card: staleAssigned }],
+      agent: [new Error("gateway disconnected")],
+    });
+
+    const sessionKey = await startCard(client, {
+      card: staleAssigned,
+      runAgentId: "default-agent",
+    });
+
+    expect(sessionKey).toBeNull();
+    expect(client.request).toHaveBeenNthCalledWith(
+      3,
+      "workboard.cards.update",
+      expect.objectContaining({
+        patch: expect.objectContaining({ status: "todo", agentId: "removed-agent" }),
+      }),
+    );
+    expect(getWorkboardState(host).cards[0]?.agentId).toBe("removed-agent");
   });
 
   // Cards persist whatever agent id they were created with, so the worker key

--- a/ui/src/pages/workboard/view-card-actions.ts
+++ b/ui/src/pages/workboard/view-card-actions.ts
@@ -18,6 +18,7 @@ import {
   type WorkboardExecutionMode,
   type WorkboardStatus,
 } from "../../lib/workboard/index.ts";
+import { findCardAgent } from "./agent-filter.ts";
 import { openEditModal } from "./view-card-modal.ts";
 import {
   canMutate,
@@ -311,6 +312,11 @@ export function renderStartExecutionButton(
         ? t("workboard.runEngine", { engine: engineName })
         : t("workboard.openEngine", { engine: engineName })
       : t("workboard.runDefaultAgent");
+  const explicitAgentId = card.agentId?.trim();
+  const runAgentId =
+    props.agentsList && explicitAgentId && !findCardAgent(card, props.agentsList)
+      ? props.agentsList.defaultId?.trim() || null
+      : undefined;
   const button = html`
     <button
       class="btn btn--xs workboard-card__start workboard-card__start--${mode} ${options.iconOnly
@@ -324,6 +330,7 @@ export function renderStartExecutionButton(
           host: props.host,
           client: props.client,
           card,
+          runAgentId,
           ...(engine ? { engine } : {}),
           mode,
           requestUpdate: props.onRequestUpdate,

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -1318,6 +1318,69 @@ describe("renderWorkboard", () => {
     ]);
   });
 
+  it("hands an unconfigured assignee to the configured default runtime agent", async () => {
+    const sessionKey = "agent:default-agent:subagent:workboard-default-card-1";
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "agent") {
+          return { sessionKey, runId: "run-1" };
+        }
+        if (method === "tasks.list") {
+          return {
+            tasks: [
+              {
+                id: "task-1",
+                taskId: "task-1",
+                status: "running",
+                childSessionKey: sessionKey,
+                runId: "run-1",
+              },
+            ],
+          };
+        }
+        return {
+          card: createWorkboardCard({
+            agentId: "default-agent",
+            status: "running",
+            sessionKey,
+            runId: "run-1",
+          }),
+        };
+      }),
+    };
+    const onOpenSession = vi.fn();
+    const { state, container, renderView } = createWorkboardView({
+      client: client as unknown as GatewayBrowserClient,
+      agentsList: {
+        defaultId: "default-agent",
+        mainKey: "agent:default-agent:main",
+        scope: "test",
+        agents: [{ id: "default-agent", name: "Default Agent" }],
+      },
+      onOpenSession,
+    });
+    state.cards = [
+      createWorkboardCard({
+        title: "Resume with current context",
+        agentId: "removed-agent",
+      }),
+    ];
+    renderView();
+
+    buttonByLabel(container, "Run default agent")?.click();
+    await vi.waitFor(() => expect(onOpenSession).toHaveBeenCalledWith(sessionKey));
+    expect(client.request).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({ agentId: "default-agent", sessionKey }),
+    );
+    expect(client.request).toHaveBeenCalledWith(
+      "workboard.cards.update",
+      expect.objectContaining({
+        patch: { status: "running", agentId: "default-agent" },
+      }),
+    );
+  });
+
   it("shows unfinished parent dependencies without blocking stale local starts", () => {
     const { state, container, renderView } = createWorkboardView({
       onRequestUpdate: () => undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who added unblock information to a Workboard card and clicked **Start** could either see the card return from Running without a session when its stored agent was no longer configured, or launch a worker without the card's newest comments.

## Why This Change Was Made

The Control UI now resolves an obsolete explicit assignee to the Gateway's configured default agent at launch, persists that handoff with the running preflight, and restores the previous assignment if launch fails. Started workers also receive the card ID and a bounded window of the newest comments; valid configured assignments and unassigned/default behavior remain unchanged.

## User Impact

Operators can add the note that unblocks a card and click **Start**. Workboard will hand the card to a valid runtime agent and start a new run with the current card context, without requiring a separate manual reassignment.

## Evidence

- Before the fix, four focused regression tests failed: the prompt omitted the card ID/comments, and an obsolete assignee was neither handed off nor restored correctly after a failed launch.
- After the fix: `node scripts/run-vitest.mjs ui/src/lib/workboard/index.test.ts` — 191 passed.
- `node_modules/.bin/oxfmt --check ui/src/lib/workboard/execution.ts ui/src/lib/workboard/index.test.ts ui/src/pages/workboard/view-card-actions.ts ui/src/pages/workboard/view.test.ts` — passed.
- `git diff --check` — passed.
- Added a Control UI interaction regression covering the configured-default handoff. Its local run is a known proof gap because the reusable dependency tree predates current `@awesome.me/webawesome`; exact-lockfile PR CI is expected to run it.
- Redacted live validation reproduced the no-session rollback on the stock Control UI and confirmed a persisted Workboard run after the local fix.
- Automated review was attempted, but the local Codex CLI returned an authentication error before reviewing the diff.

AI-assisted: yes. I understand the behavior and the code in this change. No transcript is attached because the originating workflow contains private household context.
