### PR TITLE
test(runtime): consolidate exit error coverage

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -21,30 +21,23 @@ import {
 } from "./runtime.js";
 
 describe("createNonExitingRuntime", () => {
-  it("returns runtime with exit function", () => {
+  it("throws a typed exit error carrying the requested code", () => {
     const runtime = createNonExitingRuntime();
-    expect(typeof runtime.exit).toBe("function");
-  });
+    let thrown: unknown;
 
-  it("exit function throws ExitError", () => {
-    const runtime = createNonExitingRuntime();
-    expect(() => runtime.exit(1)).toThrow(ExitError);
-  });
-
-  it("ExitError includes exit code", () => {
-    const runtime = createNonExitingRuntime();
-    expect(() => runtime.exit(42)).toThrow("exit 42");
-    expect(() => runtime.exit(42)).toThrow(ExitError);
-  });
-
-  it("ExitError is distinguishable from generic Error", () => {
-    const runtime = createNonExitingRuntime();
     try {
-      runtime.exit(1);
-    } catch (err) {
-      expect(err instanceof ExitError).toBe(true);
-      expect(err instanceof Error).toBe(true);
+      runtime.exit(42);
+    } catch (error) {
+      thrown = error;
     }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toMatchObject({
+      name: "ExitError",
+      message: "exit 42",
+      code: 42,
+    });
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

`src/runtime.test.ts` used four overlapping cases to prove one `createNonExitingRuntime` contract. Three reconstructed the same runtime, one invoked the same exit twice, and the catch-only case could pass without asserting that an error was actually thrown.

## Why This Change Was Made

The four cases are replaced with one invocation that captures the thrown value and asserts the complete meaningful contract: it is both `ExitError` and `Error`, and carries the requested `name`, `message`, and `.code`. This retains the internal typed-exit guarantee while removing redundant implementation-level checks.

## User Impact

None. This is a test-only consolidation; runtime behavior and public SDK exports are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/runtime.test.ts` — 11 passed.
- `node scripts/check-changed.mjs -- src/runtime.test.ts` — passed through the documented local fallback because no remote provider was ready.
- `git diff --check` — passed.
- Structured autoreview — clean, no accepted/actionable findings.
- Test delta: -7 lines. No production, docs, changelog, schema, protocol, migration, or operator-state change.
