### PR TITLE
fix(state): doctor --fix loops on "migration required" for older state databases

### DIFF
--- a/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
+++ b/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
@@ -1,5 +1,5 @@
-// Covers doctor repair of databases missing first-use additive columns while
-// the STRICT migration rebuilds their tables.
+// Covers doctor repair and writable cold open for databases missing first-use
+// additive columns while the STRICT migration rebuilds their tables.
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
@@ -16,44 +16,76 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
+/**
+ * Rebuild one canonical table as a pre-STRICT database that never gained the
+ * given first-use columns, then drop the whole database to schema version 2.
+ */
+function makePreStrictDatabaseWithoutColumns(params: {
+  stateDir: string;
+  tableName: string;
+  indexNames: readonly string[];
+  columnNames: readonly string[];
+  seed?: (database: InstanceType<ReturnType<typeof requireNodeSqlite>["DatabaseSync"]>) => void;
+}): string {
+  const options = { env: { OPENCLAW_STATE_DIR: params.stateDir } };
+  const databasePath = openOpenClawStateDatabase(options).path;
+  closeOpenClawStateDatabaseForTest();
+
+  const { DatabaseSync } = requireNodeSqlite();
+  const legacy = new DatabaseSync(databasePath);
+  const strictCreateSql = (
+    legacy
+      .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
+      .get(params.tableName) as { sql: string }
+  ).sql;
+  const dropped = new Set(params.columnNames);
+  const lines = strictCreateSql.replace(/\s+STRICT$/u, "").split("\n");
+  const kept = lines.filter((line) => {
+    const columnName = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s/u.exec(line)?.[1];
+    return !(columnName && dropped.has(columnName));
+  });
+  // The removed column may have been last, so re-fix the trailing separator.
+  const legacyCreateSql = kept
+    .join("\n")
+    .replace(/,(\s*\n\s*\))/u, "$1")
+    .replace(/([^,(\s])(\s*\n\s*[A-Za-z_][A-Za-z0-9_]*\s+[A-Z])/u, "$1,$2");
+  for (const columnName of params.columnNames) {
+    expect(legacyCreateSql).not.toContain(columnName);
+  }
+  expect(legacyCreateSql).not.toBe(strictCreateSql);
+
+  const dropIndexes = params.indexNames.map((name) => `DROP INDEX ${name};`).join("\n");
+  legacy.exec(`
+    ${dropIndexes}
+    ALTER TABLE ${params.tableName} RENAME TO ${params.tableName}_strict;
+    ${legacyCreateSql};
+    DROP TABLE ${params.tableName}_strict;
+    PRAGMA user_version = 2;
+    UPDATE schema_meta SET schema_version = 2 WHERE meta_key = 'primary';
+  `);
+  params.seed?.(legacy);
+  legacy.close();
+  return databasePath;
+}
+
 describe("first-use additive column STRICT migration", () => {
   it("repairs device_bootstrap_tokens without setup_id while migrating to STRICT", () => {
     const stateDir = tempDirs.make("openclaw-state-first-use-column-");
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = openOpenClawStateDatabase(options).path;
-    closeOpenClawStateDatabaseForTest();
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
-    const strictCreateSql = (
-      legacy
-        .prepare(
-          "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'device_bootstrap_tokens'",
-        )
-        .get() as { sql: string }
-    ).sql;
-    // Reproduce a database created before setup_id shipped: no STRICT, no setup_id.
-    const legacyCreateSql = strictCreateSql
-      .replace(/\s+STRICT$/u, "")
-      .replace(/\n\s*setup_id TEXT,/u, "");
-    expect(legacyCreateSql).not.toBe(strictCreateSql);
-    expect(legacyCreateSql).not.toContain("setup_id");
-
-    legacy.exec(`
-      DROP INDEX idx_device_bootstrap_tokens_ts;
-      ALTER TABLE device_bootstrap_tokens RENAME TO device_bootstrap_tokens_strict;
-      ${legacyCreateSql};
-      DROP TABLE device_bootstrap_tokens_strict;
-      PRAGMA user_version = 2;
-      UPDATE schema_meta SET schema_version = 2 WHERE meta_key = 'primary';
-    `);
-    legacy
-      .prepare(
-        `INSERT INTO device_bootstrap_tokens (token_key, token, ts, issued_at_ms)
-         VALUES (?, ?, ?, ?)`,
-      )
-      .run("bootstrap", "token-value", 1_000, 1_000);
-    legacy.close();
+    makePreStrictDatabaseWithoutColumns({
+      stateDir,
+      tableName: "device_bootstrap_tokens",
+      indexNames: ["idx_device_bootstrap_tokens_ts"],
+      columnNames: ["setup_id"],
+      seed: (database) => {
+        database
+          .prepare(
+            `INSERT INTO device_bootstrap_tokens (token_key, token, ts, issued_at_ms)
+             VALUES (?, ?, ?, ?)`,
+          )
+          .run("bootstrap", "token-value", 1_000, 1_000);
+      },
+    });
 
     // Before the fix this returns a warning and applies nothing, which leaves the
     // whole repair rolled back and re-reports an unrelated audit-events migration.
@@ -73,5 +105,62 @@ describe("first-use additive column STRICT migration", () => {
     expect(
       migrated.db.prepare("SELECT token_key, token, setup_id FROM device_bootstrap_tokens").all(),
     ).toEqual([{ token_key: "bootstrap", token: "token-value", setup_id: null }]);
+  });
+
+  it("repairs session_groups without the folder default columns", () => {
+    const stateDir = tempDirs.make("openclaw-state-first-use-group-");
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    makePreStrictDatabaseWithoutColumns({
+      stateDir,
+      tableName: "session_groups",
+      indexNames: [],
+      columnNames: ["cwd", "worktree"],
+    });
+
+    expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+
+    const migrated = openOpenClawStateDatabase(options);
+    expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+    expect(
+      migrated.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'session_groups'")
+        .get(),
+    ).toEqual({ strict: 1 });
+    const columns = migrated.db
+      .prepare("SELECT name FROM pragma_table_info('session_groups')")
+      .all()
+      .map((row) => (row as { name: string }).name);
+    expect(columns).toContain("cwd");
+    expect(columns).toContain("worktree");
+  });
+
+  it("migrates on a writable cold open without a doctor repair", () => {
+    const stateDir = tempDirs.make("openclaw-state-first-use-cold-open-");
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    makePreStrictDatabaseWithoutColumns({
+      stateDir,
+      tableName: "device_bootstrap_tokens",
+      indexNames: ["idx_device_bootstrap_tokens_ts"],
+      columnNames: ["setup_id"],
+    });
+
+    // The gateway upgrades the same database on a normal writable open, so that
+    // path has to clear the STRICT rebuild without doctor running first.
+    const opened = openOpenClawStateDatabase(options);
+    expect(opened.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+    expect(
+      opened.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'device_bootstrap_tokens'")
+        .get(),
+    ).toEqual({ strict: 1 });
+    const columns = opened.db
+      .prepare("SELECT name FROM pragma_table_info('device_bootstrap_tokens')")
+      .all()
+      .map((row) => (row as { name: string }).name);
+    expect(columns).toContain("setup_id");
   });
 });

--- a/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
+++ b/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
@@ -3,12 +3,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS } from "./openclaw-state-db-additive-columns.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
   OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
 } from "./openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -67,6 +69,40 @@ function makePreStrictDatabaseWithoutColumns(params: {
   legacy.close();
   return databasePath;
 }
+
+describe("first-use additive column definitions", () => {
+  // Materializing these columns early is only safe while every one of them is
+  // bare and nullable: the pre-STRICT rebuild adds them to tables that already
+  // hold rows, so anything NOT NULL, defaulted, constrained, or key-bearing
+  // would fail or silently rewrite existing data. Enforce that here rather than
+  // leaving it to the convention documented on the definition list.
+  it.each(
+    CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS.map((definition) => [
+      `${definition.tableName}.${definition.columnName}`,
+      definition,
+    ]),
+  )("keeps %s bare and nullable in the canonical schema", (_label, definition) => {
+    const { columnName, dataType, tableName } = definition as {
+      columnName: string;
+      dataType: string;
+      tableName: string;
+    };
+    const tableStart = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+      `CREATE TABLE IF NOT EXISTS ${tableName} (`,
+    );
+    expect(tableStart).toBeGreaterThanOrEqual(0);
+    const tableBody = OPENCLAW_STATE_SCHEMA_SQL.slice(
+      tableStart,
+      OPENCLAW_STATE_SCHEMA_SQL.indexOf(") STRICT;", tableStart),
+    );
+    const declaration = tableBody
+      .split("\n")
+      .find((line) => new RegExp(`^\\s*${columnName}\\s`, "u").test(line))
+      ?.trim()
+      .replace(/,$/u, "");
+    expect(declaration).toBe(`${columnName} ${dataType}`);
+  });
+});
 
 describe("first-use additive column STRICT migration", () => {
   it("repairs device_bootstrap_tokens without setup_id while migrating to STRICT", () => {

--- a/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
+++ b/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
@@ -1,0 +1,77 @@
+// Covers doctor repair of databases missing first-use additive columns while
+// the STRICT migration rebuilds their tables.
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  repairOpenClawStateDatabaseSchema,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("first-use additive column STRICT migration", () => {
+  it("repairs device_bootstrap_tokens without setup_id while migrating to STRICT", () => {
+    const stateDir = tempDirs.make("openclaw-state-first-use-column-");
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = openOpenClawStateDatabase(options).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    const strictCreateSql = (
+      legacy
+        .prepare(
+          "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'device_bootstrap_tokens'",
+        )
+        .get() as { sql: string }
+    ).sql;
+    // Reproduce a database created before setup_id shipped: no STRICT, no setup_id.
+    const legacyCreateSql = strictCreateSql
+      .replace(/\s+STRICT$/u, "")
+      .replace(/\n\s*setup_id TEXT,/u, "");
+    expect(legacyCreateSql).not.toBe(strictCreateSql);
+    expect(legacyCreateSql).not.toContain("setup_id");
+
+    legacy.exec(`
+      DROP INDEX idx_device_bootstrap_tokens_ts;
+      ALTER TABLE device_bootstrap_tokens RENAME TO device_bootstrap_tokens_strict;
+      ${legacyCreateSql};
+      DROP TABLE device_bootstrap_tokens_strict;
+      PRAGMA user_version = 2;
+      UPDATE schema_meta SET schema_version = 2 WHERE meta_key = 'primary';
+    `);
+    legacy
+      .prepare(
+        `INSERT INTO device_bootstrap_tokens (token_key, token, ts, issued_at_ms)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run("bootstrap", "token-value", 1_000, 1_000);
+    legacy.close();
+
+    // Before the fix this returns a warning and applies nothing, which leaves the
+    // whole repair rolled back and re-reports an unrelated audit-events migration.
+    expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+
+    const migrated = openOpenClawStateDatabase(options);
+    expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+    expect(
+      migrated.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'device_bootstrap_tokens'")
+        .get(),
+    ).toEqual({ strict: 1 });
+    // The rebuilt table comes from canonical SQL, so the column exists afterwards
+    // and the pre-existing row survives with a NULL correlation id.
+    expect(
+      migrated.db.prepare("SELECT token_key, token, setup_id FROM device_bootstrap_tokens").all(),
+    ).toEqual([{ token_key: "bootstrap", token: "token-value", setup_id: null }]);
+  });
+});

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS } from "./openclaw-state-db-additive-columns.js";
+import {
+  CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS,
+  CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS,
+} from "./openclaw-state-db-additive-columns.js";
 import {
   backfillAcpReplayEstimatedBytes,
   backfillCronJobsFromJobJson,
@@ -208,6 +211,27 @@ function ensureWorkerSessionToolStateSchema(db: DatabaseSync): void {
         REFERENCES worker_session_placements(session_id) ON DELETE CASCADE
     ) STRICT;
   `);
+}
+
+/**
+ * Add the feature-owned first-use columns that a STRICT rebuild cannot skip.
+ *
+ * These columns normally stay absent until their owning feature first writes
+ * them, and the persistent schema contract accepts that shape. The STRICT
+ * table rebuild is the one caller that cannot: it recreates each table from
+ * canonical SQL, which already declares these columns, so a database missing
+ * them fails the canonical column check and rolls the entire repair back.
+ * Ensuring them immediately before that rebuild matches the shape the rebuild
+ * produces anyway, and stays scoped to databases old enough to need it.
+ */
+export function ensureFirstUseAdditiveStateColumnsForStrictMigration(db: DatabaseSync): void {
+  for (const {
+    columnName,
+    dataType,
+    tableName,
+  } of CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS) {
+    ensureColumn(db, tableName, `${columnName} ${dataType}`);
+  }
 }
 
 export function ensureAdditiveStateColumns(db: DatabaseSync): void {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -61,7 +61,10 @@ import {
 } from "./openclaw-state-db-maintenance.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
-import { ensureAdditiveStateColumns } from "./openclaw-state-db-schema-additive.js";
+import {
+  ensureAdditiveStateColumns,
+  ensureFirstUseAdditiveStateColumnsForStrictMigration,
+} from "./openclaw-state-db-schema-additive.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import {
   assertCanonicalStateSchemaShape,
@@ -218,6 +221,7 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
           });
           if (previousVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
             repairLegacyGatewayRestartHandoffsForStrictMigration(db);
+            ensureFirstUseAdditiveStateColumnsForStrictMigration(db);
           }
           const strictMigration = migrateSqliteSchemaToStrictInTransaction(
             db,
@@ -386,6 +390,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
         migrateLegacyCronRunLogsToTaskRuns(db);
         if (previousVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
           repairLegacyGatewayRestartHandoffsForStrictMigration(db);
+          ensureFirstUseAdditiveStateColumnsForStrictMigration(db);
           migrateSqliteSchemaToStrictInTransaction(
             db,
             getOpenClawStateRuntimeSchema({


### PR DESCRIPTION
> 🤖 **AI-assisted PR** (Claude Opus 5, via Claude Code). Root cause, fix, and tests were reviewed and verified by me against a real affected database.

## What Problem This Solves

Fixes an issue where operators upgrading an older install would hit an unbreakable `openclaw doctor --fix` loop and a gateway that never starts, when their shared state database predates a first-use additive column.

`openclaw doctor --fix` reports:

```
OpenClawStateDatabaseSchemaMigrationRequiredError: OpenClaw state database schema
migration required (audit-events-v2) at ~/.openclaw/state/openclaw.sqlite;
run openclaw doctor --fix to migrate it.
```

That is the command that produced the message. `--force`, `--non-interactive`, `openclaw update --channel beta`, and reinstalling all fail the same way in about 8 seconds. The gateway stays in a `status=78/CONFIG` restart loop.

The reported migration is not the failing one. The real failure is:

```
SQLite table device_bootstrap_tokens does not match its canonical columns (missing setup_id)
```

## Why This Change Was Made

A database at `user_version < 3` must run the STRICT table rebuild. That rebuild validates every canonical table against its full canonical column set, but `device_bootstrap_tokens.setup_id` (and now `session_groups.cwd` / `.worktree`) are intentionally excluded from the startup additive columns and deferred to first use, so they are absent on older databases.

Because the repair runs in a single transaction, that failure rolls back the `audit-events-v2` work that had already succeeded. The next open re-detects the legacy audit ledger and reports *that* migration instead, which is why the surfaced error names an unrelated table and never converges.

It also has a second effect: `runLegacyStateMigrations` early-returns when the state schema step warns, which skips `migrateLegacyConfigMachineState`. Retired config keys are therefore never moved into `config_machine_state`, `openclaw.json` is never rewritten, and the gateway keeps failing config validation — so the visible symptom looks like a config problem while the state error is logged fail-open at boot.

`STATE_PERSISTENT_SCHEMA_COMPATIBILITY.allowedMissingColumns` already declares these columns legitimately absent, so the persistent schema contract and the STRICT rebuild disagreed about the same database.

The fix ensures the first-use additive columns immediately before the STRICT rebuild, in both paths that run it, gated on `previousVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION`. This mirrors `repairLegacyGatewayRestartHandoffsForStrictMigration` directly above it, added for the same class of bug (#110237).

This is not a semantic change: the rebuild recreates each table from canonical SQL that already declares these columns, so the resulting shape is identical either way. Ensuring them first only stops the rebuild refusing to start, and scoping to pre-STRICT databases preserves absent-until-first-use for every normal open.

Non-goal: `src/infra/sqlite-strict.ts` is deliberately untouched. It is generic infra shared with agent databases, and its exact-canonical-columns contract is the safer default. The first-use deferral is state-schema policy, so the state layer reconciles it before invoking the generic migrator. Happy to move it there instead if maintainers prefer.

## User Impact

Operators whose state database predates `setup_id` can upgrade normally: `openclaw doctor --fix` completes, the config migration that was being skipped now runs, and the gateway starts. Previously the only way through was to add the column manually with `ALTER TABLE`. No behaviour change for databases already at the current schema version.

## Evidence

New regression test `src/state/openclaw-state-db-first-use-column-strict-migration.test.ts` reproduces the exact production error on `main`:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [
+   "Failed migrating shared state database schema at ...: Error: SQLite table
+    device_bootstrap_tokens does not match its canonical columns (missing setup_id)",
+ ]
```

and passes with the fix.

Focused suites:

```
pnpm vitest run src/state/ src/infra/sqlite-strict.test.ts
  → Test Files 40 passed | 1 skipped, Tests 511 passed | 7 skipped
```

Wider run across the areas this touches (`src/state/`, `src/infra/sqlite-strict.test.ts`, `src/cli/plugins-cli.list.test.ts`, `src/skills/workshop/`, `src/flows/doctor-core-checks.test.ts`) → **972 passed, 0 failed**.

Replayed against a real affected database (75 MB, `user_version = 1`, 55,381 `audit_events`, no `setup_id`), which previously required a manual `ALTER TABLE` to get through. With this change and no manual intervention:

```
changes: [
  'Retired shared state commitments table and indexes',
  'Migrated shared state audit event ledger → versioned message lifecycle schema',
  'Migrated shared state tables to SQLite STRICT typing (70)'
]
warnings: []
detect after: []
```

Post-migration: `user_version` 1 → 8, all 55,381 audit rows preserved, `PRAGMA integrity_check` → `ok`, 123 STRICT tables, `device_bootstrap_tokens.setup_id` present.

`oxfmt --check` and `oxlint` pass on all changed files. Full-repo `tsc --noEmit` was not run locally (it OOMs on the 15 GB machine used); relying on CI for that.

`CHANGELOG.md` intentionally untouched per CONTRIBUTING.

Related: #110186 and #110237 are the same family (STRICT migration blocked on real-world databases), but distinct root causes.
