### PR TITLE
fix(ui): standardize scrollbar styling across the Control UI

### DIFF
--- a/ui/src/components/browser/browser-panel.ts
+++ b/ui/src/components/browser/browser-panel.ts
@@ -11,6 +11,7 @@ import { property } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
+import { scrollbarShadowStyles } from "../../lit/scrollbar-styles.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
 import { createDockPanelLayout } from "../dock-panel-layout.ts";
 import { panelTabStripStyles } from "../panel-tab-strip.ts";
@@ -67,7 +68,12 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
   });
   private observedViewportElement: Element | null = null;
 
-  static override styles = [panelTabStripStyles, dockPanelStyles, browserPanelStyles];
+  static override styles = [
+    panelTabStripStyles,
+    dockPanelStyles,
+    browserPanelStyles,
+    scrollbarShadowStyles,
+  ];
 
   override connectedCallback(): void {
     super.connectedCallback();

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -12,6 +12,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
+import { scrollbarShadowStyles } from "../../lit/scrollbar-styles.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
 import { createDockPanelLayout } from "../dock-panel-layout.ts";
 import {
@@ -109,6 +110,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     desktopPanelLauncherStyles,
     desktopPanelStyles,
     desktopDocumentStyles,
+    scrollbarShadowStyles,
   ];
 
   override connectedCallback(): void {

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -22,6 +22,7 @@ let mobileContext: BrowserContext;
 function readUiCss(): string {
   const files = [
     "ui/src/styles/base.css",
+    "ui/src/styles/board.css",
     "ui/src/styles/layout.css",
     "ui/src/styles/layout.mobile.css",
     "ui/src/styles/components.css",
@@ -539,7 +540,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
     }
   });
 
-  it("keeps sidebars compact while preserving normal content scroll and text entry", async () => {
+  it("uses one canonical scrollbar width while preserving normal content scroll and text entry", async () => {
     const page = await desktopContext.newPage();
     try {
       await page.setViewportSize({ width: 1200, height: 800 });
@@ -562,6 +563,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
               <div style="height: 200px"></div>
             </main>
             <section class="chat-thread" style="height: 100px">Selectable transcript</section>
+            <div class="board-tabs__track">Hidden horizontal rail</div>
           </body>
         </html>
       `);
@@ -590,6 +592,11 @@ describeBrowserLayout("app chrome interaction styles", () => {
           regularSidebarSelection: style(".sidebar-shell__body").userSelect,
           settingsSidebarScrollbar: scrollbarWidth(".settings-sidebar__nav"),
           settingsSidebarSelection: style(".settings-sidebar__nav").userSelect,
+          // The board tab rail intentionally hides its scrollbar (a drag/wheel
+          // affordance, not a styling variant); the new blanket
+          // `* { scrollbar-width: thin }` rule in base.css must not win over
+          // its higher-specificity `scrollbar-width: none`.
+          hiddenRailScrollbarWidth: style(".board-tabs__track").scrollbarWidth,
         };
       });
 
@@ -597,10 +604,11 @@ describeBrowserLayout("app chrome interaction styles", () => {
         chatSelection: "text",
         chromeSelection: "none",
         contentScrollbar: "12px",
+        hiddenRailScrollbarWidth: "none",
         inputSelection: "text",
-        regularSidebarScrollbar: "6px",
+        regularSidebarScrollbar: "12px",
         regularSidebarSelection: "none",
-        settingsSidebarScrollbar: "6px",
+        settingsSidebarScrollbar: "12px",
         settingsSidebarSelection: "none",
       });
     } finally {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -11,6 +11,7 @@ import { terminalDocumentPath } from "../../app/terminal-document-mode.ts";
 import { t } from "../../i18n/index.ts";
 import { openExternalUrlSafe } from "../../lib/open-external-url.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
+import { scrollbarShadowStyles } from "../../lit/scrollbar-styles.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
 import { createDockPanelLayout, type DockPanelPlacement } from "../dock-panel-layout.ts";
 import { panelTabStripStyles } from "../panel-tab-strip.ts";
@@ -421,6 +422,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     dockPanelStyles,
     terminalPanelStyles,
     terminalPanelUploadStyles,
+    scrollbarShadowStyles,
   ];
 }
 

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -1,4 +1,4 @@
-// Control UI tests cover contextual scrollbars and native-style text selection.
+// Control UI tests cover the canonical scrollbar profile and native-style text selection.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
@@ -66,7 +66,7 @@ async function captureUiProof(page: Page, fileName: string) {
 }
 
 suite.define(() => {
-  it("uses compact sidebar scrollbars and keeps selection in chat and inputs", async () => {
+  it("uses one canonical scrollbar profile and keeps selection in chat and inputs", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
@@ -87,16 +87,28 @@ suite.define(() => {
               content: [{ type: "text", text: "Selectable transcript content" }],
             },
           ],
+          models: [
+            { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+            ...Array.from({ length: 24 }, (_value, index) => ({
+              id: `scroll-model-${index + 1}`,
+              name: `Scroll Model ${index + 1}`,
+              provider: "openai",
+            })),
+          ],
         });
 
         await page.goto(`${suite.server.baseUrl}chat`);
         const transcript = page.getByText("Selectable transcript content", { exact: true });
         await transcript.waitFor();
+        await page.locator('[data-chat-model-select="true"]').click();
+        const modelOptions = page.locator(".chat-controls__model-options");
+        await expect.poll(() => modelOptions.isVisible()).toBe(true);
         const chatStyles = await page.evaluate(() => {
           const sidebar = document.querySelector<HTMLElement>(".sidebar");
           const sessions = document.querySelector<HTMLElement>(".sidebar-shell__body");
           const thread = document.querySelector<HTMLElement>(".chat-thread");
-          if (!sidebar || !sessions || !thread) {
+          const modelPicker = document.querySelector<HTMLElement>(".chat-controls__model-options");
+          if (!sidebar || !sessions || !thread || !modelPicker) {
             throw new Error("Missing chat interaction surface");
           }
           return {
@@ -104,14 +116,21 @@ suite.define(() => {
             chatScrollbar: getComputedStyle(thread, "::-webkit-scrollbar").width,
             sidebarSelection: getComputedStyle(sidebar).userSelect,
             sidebarScrollbar: getComputedStyle(sessions, "::-webkit-scrollbar").width,
+            modelPickerScrollbar: getComputedStyle(modelPicker, "::-webkit-scrollbar").width,
           };
         });
+        // One canonical width everywhere: the sidebar no longer overrides
+        // --scrollbar-size down to 6px, and the model picker (which used to
+        // inherit the raw document default with no width of its own) now
+        // reports the same value as every other sampled surface.
         expect(chatStyles).toEqual({
           chatSelection: "text",
           chatScrollbar: "12px",
           sidebarSelection: "none",
-          sidebarScrollbar: "6px",
+          sidebarScrollbar: "12px",
+          modelPickerScrollbar: "12px",
         });
+        await page.keyboard.press("Escape");
         expect(await dragAcross(page, transcript)).toContain("Selectable transcript");
         const thread = page.locator(".chat-thread");
         expect(await readFocusOutline(thread)).toMatchObject({
@@ -177,7 +196,7 @@ suite.define(() => {
           contentScrollbar: "12px",
           contentSelection: "none",
           inputSelection: "text",
-          sidebarScrollbar: "6px",
+          sidebarScrollbar: "12px",
           sidebarSelection: "none",
         });
 
@@ -198,5 +217,88 @@ suite.define(() => {
         await captureUiProof(page, "03-settings-contextual-scrollbars.png");
       },
     );
+  });
+
+  it("resolves the scrollbar thumb from theme tokens and captures dark/light proof", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
+    const thumbColorByScheme: Record<"dark" | "light", string> = { dark: "", light: "" };
+    for (const colorScheme of ["dark", "light"] as const) {
+      await suite.withPage(
+        {
+          colorScheme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1440 },
+        },
+        async ({ page }) => {
+          await installMockGateway(page, {
+            historyMessages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "Selectable transcript content" }],
+              },
+            ],
+            models: [
+              { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+              ...Array.from({ length: 24 }, (_value, index) => ({
+                id: `scroll-model-${index + 1}`,
+                name: `Scroll Model ${index + 1}`,
+                provider: "openai",
+              })),
+            ],
+          });
+
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await page.getByText("Selectable transcript content", { exact: true }).waitFor();
+          thumbColorByScheme[colorScheme] = await page.evaluate(
+            () => getComputedStyle(document.body, "::-webkit-scrollbar-thumb").backgroundColor,
+          );
+          // Chat transcript + session sidebar together, before opening anything.
+          await captureUiProof(page, `chat-transcript-sidebar-${colorScheme}.png`);
+
+          // The headline complaint surface: the light-DOM chat model picker.
+          await page.locator('[data-chat-model-select="true"]').click();
+          const modelOptions = page.locator(".chat-controls__model-options");
+          await expect.poll(() => modelOptions.isVisible()).toBe(true);
+          await captureUiProof(page, `model-picker-${colorScheme}.png`);
+          await page.keyboard.press("Escape");
+
+          // The shadow-DOM lane: a Web Awesome ::part() menu picks up the same
+          // profile through the grouped rule in base.css.
+          const composer = page.locator(".agent-chat__input");
+          await composer.getByRole("button", { name: "Add attachment" }).click();
+          const capabilityMenu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+          await expect
+            .poll(() =>
+              capabilityMenu.evaluate((node) => (node as HTMLElement & { open: boolean }).open),
+            )
+            .toBe(true);
+          // Regression guard: base.css's ::-webkit-scrollbar* rules do not cross
+          // a shadow boundary on their own. Only the grouped ::part() rule gives
+          // this menu's shadow-root scrollbar the canonical width and a real
+          // thumb color instead of silently falling back to the UA default.
+          const shadowScrollbar = await capabilityMenu.evaluate((node) => {
+            const part = (node as HTMLElement).shadowRoot?.querySelector('[part~="menu"]');
+            if (!part) {
+              return null;
+            }
+            return {
+              width: getComputedStyle(part, "::-webkit-scrollbar").width,
+              thumbBackground: getComputedStyle(part, "::-webkit-scrollbar-thumb").backgroundColor,
+            };
+          });
+          expect(shadowScrollbar).toEqual({ width: "12px", thumbBackground: expect.any(String) });
+          expect(shadowScrollbar?.thumbBackground).not.toBe("rgba(0, 0, 0, 0)");
+          await captureUiProof(page, `capability-menu-shadow-dom-${colorScheme}.png`);
+        },
+      );
+    }
+    // Same source (--muted), different value per mode: the token derivation
+    // covers dark and light without a hand-written color pair.
+    expect(thumbColorByScheme.dark).not.toBe(thumbColorByScheme.light);
+    expect(thumbColorByScheme.dark).not.toBe("");
+    expect(thumbColorByScheme.light).not.toBe("");
   });
 });

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -292,6 +292,29 @@ suite.define(() => {
           expect(shadowScrollbar).toEqual({ width: "12px", thumbBackground: expect.any(String) });
           expect(shadowScrollbar?.thumbBackground).not.toBe("rgba(0, 0, 0, 0)");
           await captureUiProof(page, `capability-menu-shadow-dom-${colorScheme}.png`);
+
+          // Genericity guard, not a second sample of the menu above: base.css
+          // reaches these parts through bare wa-dropdown/wa-select/wa-popover
+          // selectors, so every Web Awesome scroll part rendered on this page
+          // must report the canonical width -- including the ones no stylesheet
+          // names. A class allowlist would leave some at the platform default.
+          const shadowScrollbarWidths = await page.evaluate(() => {
+            // One part per host tag, matching the base.css rule exactly: sampling
+            // whichever part came first would read a part that rule never targets.
+            const partSelectorByTag: Record<string, string> = {
+              "WA-DROPDOWN": '[part~="menu"]',
+              "WA-POPOVER": '[part~="body"]',
+              "WA-SELECT": '[part~="listbox"]',
+            };
+            const hosts = document.querySelectorAll("wa-dropdown, wa-select, wa-popover");
+            return Array.from(hosts, (host) => {
+              const partSelector = partSelectorByTag[host.tagName];
+              const part = partSelector ? host.shadowRoot?.querySelector(partSelector) : null;
+              return part ? getComputedStyle(part, "::-webkit-scrollbar").width : null;
+            }).filter((width): width is string => width !== null);
+          });
+          expect(shadowScrollbarWidths.length).toBeGreaterThan(1);
+          expect([...new Set(shadowScrollbarWidths)]).toEqual(["12px"]);
         },
       );
     }

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -108,6 +108,7 @@ suite.define(() => {
           padding: Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom),
           scrollbarWidth: style.scrollbarWidth,
           webkitScrollbarWidth: getComputedStyle(element, "::-webkit-scrollbar").width,
+          webkitThumbInset: getComputedStyle(element, "::-webkit-scrollbar-thumb").borderLeftWidth,
         };
       });
 
@@ -117,7 +118,14 @@ suite.define(() => {
       );
       expect(tenLines.overflowY).toBe("hidden");
       expect(tenLines.scrollbarWidth).toBe("thin");
-      expect(Number.parseFloat(tenLines.webkitScrollbarWidth)).toBeLessThanOrEqual(6);
+      // The composer used to buy thinness by shrinking its hit target to 6px.
+      // The canonical profile keeps the full 12px drag target and paints a 6px
+      // thumb inside it (transparent border + content-box clip), so this asserts
+      // the visible thumb stays as thin as before without a cramped grab area.
+      const composerScrollbar = Number.parseFloat(tenLines.webkitScrollbarWidth);
+      const composerThumbInset = Number.parseFloat(tenLines.webkitThumbInset);
+      expect(composerScrollbar).toBe(12);
+      expect(composerScrollbar - composerThumbInset * 2).toBe(6);
       await captureUiProof(page, "new-session-composer-ten-lines.png");
 
       const longPrompt = Array.from({ length: 14 }, (_, index) => `line ${index + 1}`).join("\n");

--- a/ui/src/lit/scrollbar-styles.ts
+++ b/ui/src/lit/scrollbar-styles.ts
@@ -1,0 +1,35 @@
+import { css } from "lit";
+
+/**
+ * Canonical scrollbar profile for OpenClaw Lit shadow roots (terminal, browser,
+ * desktop panels): base.css's ::-webkit-scrollbar rules don't cross a shadow
+ * boundary, so every shadow scroll surface includes this in `static styles`.
+ */
+export const scrollbarShadowStyles = css`
+  * {
+    scrollbar-width: thin;
+  }
+
+  ::-webkit-scrollbar {
+    width: var(--scrollbar-size);
+    height: var(--scrollbar-size);
+  }
+
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    background-clip: content-box;
+    border: var(--scrollbar-thumb-inset) solid transparent;
+    border-radius: var(--radius-full);
+  }
+
+  ::-webkit-scrollbar-thumb:hover,
+  :hover::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb-hover);
+    background-clip: content-box;
+  }
+`;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -234,6 +234,18 @@
   --radius-full: 9999px;
   --radius: 10px;
 
+  /* One profile for every scroll surface: 12px hit target, 6px visible thumb
+     (transparent border + content-box clip). Derived from --muted so every
+     theme family and both modes follow with no override. scrollbar-color is a
+     real property, not a token, but it lives here (not a second :root block)
+     to satisfy no-duplicate-selectors; it also inherits into shadow roots,
+     which is what gives Web Awesome ::part() surfaces their thumb tint. */
+  --scrollbar-size: 12px;
+  --scrollbar-thumb-inset: 3px;
+  --scrollbar-thumb: color-mix(in srgb, var(--muted) 32%, transparent);
+  --scrollbar-thumb-hover: color-mix(in srgb, var(--muted) 64%, transparent);
+  scrollbar-color: var(--scrollbar-thumb) transparent;
+
   /* Corner-scale signal: whatever the @supports block below sets this to,
      tests and other introspection can read it to learn the active multiplier
      without duplicating the @supports check. It is intentionally not part of
@@ -551,17 +563,6 @@
   color-scheme: light;
 }
 
-/* Scrollbar - visible on light backgrounds */
-:root[data-theme-mode="light"]::-webkit-scrollbar-thumb,
-:root[data-theme-mode="light"] ::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.15);
-}
-
-:root[data-theme-mode="light"]::-webkit-scrollbar-thumb:hover,
-:root[data-theme-mode="light"] ::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.25);
-}
-
 /* Theme families override accent tokens while keeping shared surfaces/layout. */
 :root[data-theme="openknot"] {
   /*
@@ -848,6 +849,9 @@
 
 * {
   box-sizing: border-box;
+  /* scrollbar-width doesn't inherit (unlike scrollbar-color above), so every
+     element needs its own declaration to stay off the wider UA default. */
+  scrollbar-width: thin;
 }
 
 .sr-only {
@@ -1102,24 +1106,73 @@ textarea,
   color: var(--selection-fg);
 }
 
-/* Main/document surfaces keep a normal scrollbar hit target. Dense sidebars
-   override this inherited size locally so their row actions retain room. */
-::-webkit-scrollbar {
-  width: var(--scrollbar-size, 12px);
-  height: var(--scrollbar-size, 12px);
+/* Canonical scrollbar for every scroll surface. scrollbar-color (:root above)
+   inherits, including into shadow roots; scrollbar-width (* above) does not.
+   Web Awesome shadow-DOM menus/listboxes are reachable via ::part(); no document
+   rule crosses that boundary on its own, so every rule below repeats this same
+   host group (:is() forbids pseudo-elements in its own argument, so ::part()
+   chains on afterward) rather than styling each surface separately. */
+::-webkit-scrollbar,
+:is(
+  .agent-chat__capability-menu,
+  .agent-select,
+  .chat-header-session-menu--compact,
+  .chat-pane__sharing-menu,
+  .model-setup-provider-select,
+  .sidebar-customize-menu
+)::part(menu)::-webkit-scrollbar,
+wa-select.settings-select::part(listbox)::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
 }
 
-::-webkit-scrollbar-track {
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner,
+:is(
+  .agent-chat__capability-menu,
+  .agent-select,
+  .chat-header-session-menu--compact,
+  .chat-pane__sharing-menu,
+  .model-setup-provider-select,
+  .sidebar-customize-menu
+)::part(menu)::-webkit-scrollbar-track,
+wa-select.settings-select::part(listbox)::-webkit-scrollbar-track {
   background: transparent;
 }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
+::-webkit-scrollbar-thumb,
+:is(
+  .agent-chat__capability-menu,
+  .agent-select,
+  .chat-header-session-menu--compact,
+  .chat-pane__sharing-menu,
+  .model-setup-provider-select,
+  .sidebar-customize-menu
+)::part(menu)::-webkit-scrollbar-thumb,
+wa-select.settings-select::part(listbox)::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  background-clip: content-box;
+  border: var(--scrollbar-thumb-inset) solid transparent;
   border-radius: var(--radius-full);
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.14);
+/* :hover::-webkit-scrollbar-thumb (container hover) is safe here because html,
+   body set overflow: clip above, so the document itself never scrolls and the
+   always-true html:hover/body:hover can't hover a document scrollbar. ::part()
+   surfaces get thumb-only hover; container hover can't chain through shadow. */
+::-webkit-scrollbar-thumb:hover,
+:hover::-webkit-scrollbar-thumb,
+:is(
+  .agent-chat__capability-menu,
+  .agent-select,
+  .chat-header-session-menu--compact,
+  .chat-pane__sharing-menu,
+  .model-setup-provider-select,
+  .sidebar-customize-menu
+)::part(menu)::-webkit-scrollbar-thumb:hover,
+wa-select.settings-select::part(listbox)::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+  background-clip: content-box;
 }
 
 /* Animations - Polished with spring feel */

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -1109,47 +1109,30 @@ textarea,
 /* Canonical scrollbar for every scroll surface. scrollbar-color (:root above)
    inherits, including into shadow roots; scrollbar-width (* above) does not.
    Web Awesome shadow-DOM menus/listboxes are reachable via ::part(); no document
-   rule crosses that boundary on its own, so every rule below repeats this same
-   host group (:is() forbids pseudo-elements in its own argument, so ::part()
-   chains on afterward) rather than styling each surface separately. */
+   rule crosses that boundary on its own, so every rule below repeats the same
+   generic host group used for the shared corner treatment above. Enumerating
+   feature classes instead would leave every unlisted dropdown, listbox, and
+   popover on the raw platform scrollbar the moment one is added. */
 ::-webkit-scrollbar,
-:is(
-  .agent-chat__capability-menu,
-  .agent-select,
-  .chat-header-session-menu--compact,
-  .chat-pane__sharing-menu,
-  .model-setup-provider-select,
-  .sidebar-customize-menu
-)::part(menu)::-webkit-scrollbar,
-wa-select.settings-select::part(listbox)::-webkit-scrollbar {
+wa-dropdown::part(menu)::-webkit-scrollbar,
+wa-select::part(listbox)::-webkit-scrollbar,
+wa-popover::part(body)::-webkit-scrollbar {
   width: var(--scrollbar-size);
   height: var(--scrollbar-size);
 }
 
 ::-webkit-scrollbar-track,
 ::-webkit-scrollbar-corner,
-:is(
-  .agent-chat__capability-menu,
-  .agent-select,
-  .chat-header-session-menu--compact,
-  .chat-pane__sharing-menu,
-  .model-setup-provider-select,
-  .sidebar-customize-menu
-)::part(menu)::-webkit-scrollbar-track,
-wa-select.settings-select::part(listbox)::-webkit-scrollbar-track {
+wa-dropdown::part(menu)::-webkit-scrollbar-track,
+wa-select::part(listbox)::-webkit-scrollbar-track,
+wa-popover::part(body)::-webkit-scrollbar-track {
   background: transparent;
 }
 
 ::-webkit-scrollbar-thumb,
-:is(
-  .agent-chat__capability-menu,
-  .agent-select,
-  .chat-header-session-menu--compact,
-  .chat-pane__sharing-menu,
-  .model-setup-provider-select,
-  .sidebar-customize-menu
-)::part(menu)::-webkit-scrollbar-thumb,
-wa-select.settings-select::part(listbox)::-webkit-scrollbar-thumb {
+wa-dropdown::part(menu)::-webkit-scrollbar-thumb,
+wa-select::part(listbox)::-webkit-scrollbar-thumb,
+wa-popover::part(body)::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
   background-clip: content-box;
   border: var(--scrollbar-thumb-inset) solid transparent;
@@ -1162,15 +1145,9 @@ wa-select.settings-select::part(listbox)::-webkit-scrollbar-thumb {
    surfaces get thumb-only hover; container hover can't chain through shadow. */
 ::-webkit-scrollbar-thumb:hover,
 :hover::-webkit-scrollbar-thumb,
-:is(
-  .agent-chat__capability-menu,
-  .agent-select,
-  .chat-header-session-menu--compact,
-  .chat-pane__sharing-menu,
-  .model-setup-provider-select,
-  .sidebar-customize-menu
-)::part(menu)::-webkit-scrollbar-thumb:hover,
-wa-select.settings-select::part(listbox)::-webkit-scrollbar-thumb:hover {
+wa-dropdown::part(menu)::-webkit-scrollbar-thumb:hover,
+wa-select::part(listbox)::-webkit-scrollbar-thumb:hover,
+wa-popover::part(body)::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
   background-clip: content-box;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -338,7 +338,6 @@ openclaw-chat-page {
   /* The transcript is document content, unlike the surrounding app chrome. */
   user-select: text;
   scrollbar-gutter: stable both-edges;
-  scrollbar-color: var(--muted-strong) transparent;
   /* The pane header owns the titlebar and native drag surface. No horizontal
      padding: macOS overlay scrollbars render inside the
      scroll container's padding, which floats the thumb away from the pane
@@ -356,14 +355,6 @@ openclaw-chat-page {
 .chat-thread:focus-visible {
   outline: 2px solid var(--muted-strong);
   outline-offset: -2px;
-}
-
-:root .chat-thread::-webkit-scrollbar-thumb {
-  background: var(--muted-strong);
-}
-
-:root .chat-thread::-webkit-scrollbar-thumb:hover {
-  background: var(--text);
 }
 
 .chat-thread-inner > :first-child {
@@ -2822,8 +2813,6 @@ button.chat-reply-preview--message:disabled {
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
-  scrollbar-width: thin;
-  scrollbar-color: var(--muted-strong) transparent;
 }
 
 .agent-chat__capability-menu-item[value="back"] {
@@ -2831,15 +2820,6 @@ button.chat-reply-preview--message:disabled {
   top: calc(-1 * var(--menu-padding));
   z-index: 1;
   background: var(--bg-elevated);
-}
-
-.agent-chat__capability-menu::part(menu)::-webkit-scrollbar {
-  width: 6px;
-}
-
-.agent-chat__capability-menu::part(menu)::-webkit-scrollbar-thumb {
-  background: var(--muted-strong);
-  border-radius: 999px;
 }
 
 .agent-chat__capability-menu-item {
@@ -3907,13 +3887,6 @@ button.chat-reply-preview--message:disabled {
   max-height: inherit;
   overflow-y: auto;
   padding: var(--menu-padding);
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--muted) 35%, transparent) transparent;
-}
-
-.slash-menu__scroll::-webkit-scrollbar-track,
-.slash-menu__scroll::-webkit-scrollbar-corner {
-  background: transparent;
 }
 
 .slash-menu-group + .slash-menu-group {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -580,7 +580,6 @@ openclaw-chat-pane {
   max-width: min(260px, calc(100vw - 24px));
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-width: thin;
 }
 
 .chat-pane__sharing-menu--capped::part(menu) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -272,7 +272,6 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
 }
 
 .settings-sidebar {
-  --scrollbar-size: 6px;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -481,7 +480,6 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   padding: 14px 12px 18px;
   overflow-y: auto;
   overflow-x: hidden;
-  scrollbar-width: thin;
 }
 
 .settings-sidebar__empty {
@@ -915,7 +913,6 @@ openclaw-settings-save-indicator {
   /* One rhythm for every group boundary in the sidebar (Pages and each
      session section) so the column reads as separate shelves, not one list. */
   --sidebar-group-gap: var(--space-4);
-  --scrollbar-size: 6px;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -1025,17 +1022,10 @@ openclaw-settings-save-indicator {
      horizontal scrollbar beside the divider. */
   overflow-x: hidden;
   overflow-y: auto;
-  scrollbar-color: color-mix(in srgb, currentColor 8%, transparent) transparent;
-  scrollbar-width: thin;
   /* Cancel the shell's horizontal padding so the thumb hugs its right edge;
      both values share --sidebar-pad-x so they cannot drift. */
   margin-right: calc(-1 * var(--sidebar-pad-x));
   padding-right: var(--sidebar-pad-x);
-}
-
-.sidebar-shell__body::-webkit-scrollbar,
-.sidebar-shell__body::-webkit-scrollbar-track {
-  background: transparent;
 }
 
 .sidebar-shell__footer {

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -492,13 +492,6 @@ wa-dropdown.new-session-page__start-menu {
 .new-session-page__composer .new-session-page__message {
   max-height: calc(10lh + var(--chat-box-inset) + var(--chat-box-inset));
   padding-left: var(--chat-box-inset);
-  --scrollbar-size: 6px;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
-}
-
-.new-session-page__composer .new-session-page__message::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--muted) 42%, transparent);
 }
 
 .new-session-page__composer::after {


### PR DESCRIPTION
## What Problem This Solves

The Control UI has no canonical scrollbar. Each scroll surface currently picks its own width and thumb color through one of three separate mechanisms (document `::-webkit-scrollbar` rules, per-component `scrollbar-width`/`scrollbar-color`, and shadow-DOM surfaces that no document rule reaches at all), producing at least five visually distinct scrollbars in a single window. The loudest sits on a popover: opening the chat model picker paints a wide, high-contrast thumb directly over the menu.

The structural root cause: `base.css` read `var(--scrollbar-size, 12px)`, but `--scrollbar-size` was never defined in the token layer — it existed only as three ad-hoc local overrides (`layout.css`, `new-session.css`). Everything downstream compensated with its own recipe: four different thumb colors and three different widths across `base.css`, `layout.css`, `chat/layout.css`, `chat/split-view.css`, and `new-session.css`.

A third, invisible variant sat underneath all of that: document-level `::-webkit-scrollbar` rules do not cross a shadow boundary, so Web Awesome menus and listboxes (the settings model picker, the model-setup provider dropdown, the composer capability menu, and others) rendered the raw platform scrollbar no matter what `base.css` said.

## Why This Change Was Made

One canonical definition, expressed through the existing theme tokens:

- `--scrollbar-size` (12px), `--scrollbar-thumb-inset` (3px), `--scrollbar-thumb`, and `--scrollbar-thumb-hover` are added to the main `:root` token block, derived from `--muted` with `color-mix()` — the same idiom already used for `--link`/`--link-hover` and `--focus-ring`. Because every theme family already redefines `--muted`, this one definition covers all six themes in both light and dark with no hand-written color pair.
- The visible thumb reads as 6px through a transparent border with `background-clip: content-box`, while the hit target stays a full 12px. This refines rather than reverses the earlier decision behind #107313 (a usable drag target on main content): one profile now delivers a full-size hit target with a thin, quiet thumb instead of the previous 12px-main/6px-sidebar split with a solid, heavy fill. The same applies to the other surfaces that bought thinness by shrinking their hit target — the settings sidebar, the session sidebar, the new-session composer, and the composer capability menu all keep a 6px-wide painted thumb while their grab area grows to the canonical 12px.
- Track and corner are explicitly transparent in every rule, on both engines — Chromium's `::-webkit-scrollbar-track`/`-corner` and Firefox's `scrollbar-color` track component. Nothing paints a visible track anywhere; only the thumb renders.
- Firefox gets the same thin profile and muted rest color through `scrollbar-width: thin` and inherited `scrollbar-color`, but no hover step — Firefox has no thumb-level hover hook, and a container-hover rule would repaint every nested scroller on the page because `scrollbar-color` inherits. This is a deliberate, accepted degradation: same tokens, one fewer state.
- Sixteen per-surface overrides across `base.css`, `layout.css`, `chat/layout.css`, `chat/split-view.css`, and `new-session.css` are deleted in the same change. The two categories that intentionally remain — hidden horizontal rails (`board-tabs__track`, the dreams day-chips, the panel tab strip) and `scrollbar-gutter` layout reservations — are untouched and covered by a regression test.
- Shadow-DOM parity ships in this same change, not deferred: a grouped rule in `base.css` reaches every Web Awesome scroll part through the generic `wa-dropdown::part(menu)`, `wa-select::part(listbox)`, and `wa-popover::part(body)` selectors — the same generic host group the shared corner treatment already uses, so a dropdown added tomorrow is covered without touching this rule — and a shared Lit `css` fragment (`ui/src/lit/scrollbar-styles.ts`) covers the terminal, browser, and desktop panels' own shadow roots, since neither `::-webkit-scrollbar*` rules nor `scrollbar-width` cross a shadow boundary on their own. Verified live: without the grouped rule, a shadow listbox's scrollbar thumb resolves to fully transparent and its width falls back to the platform default; with it, both resolve to the canonical token values.

## User Impact

Every Control UI surface with a scroll container — chat, settings, logs, activity, tables, dialogs, the command palette, native dropdowns, and the terminal/browser/desktop panels — now shares one thin, muted-at-rest, hover-emphasized scrollbar in both light and dark mode. The model picker, previously the most visible offender, now matches every other surface instead of standing out with a heavy, high-contrast bar.

## Evidence

Before/after screenshots, dark and light, captured through the mocked Gateway dev harness:

- Model picker (dark): [before](https://github.com/user-attachments/assets/d4c257cf-a2c3-4349-a0ea-d4acd2eb1bf7) → [after](https://github.com/user-attachments/assets/29c20365-353e-415e-8159-a3c2fce5b487)
- Model picker (light): [before](https://github.com/user-attachments/assets/64bd01fc-f036-44ae-9e63-320b38722804) → [after](https://github.com/user-attachments/assets/d43ce6f9-2177-42cc-a982-5653770faf69)
- Chat transcript + session sidebar (dark): [before](https://github.com/user-attachments/assets/f82d7327-8ce0-44f4-8c86-b2acec4bb9c8) → [after](https://github.com/user-attachments/assets/e6efdb8e-ac77-4bf5-99fe-182ead7619b0)
- Chat transcript + session sidebar (light): [before](https://github.com/user-attachments/assets/42a6fc37-3d35-41de-80a3-1995ffe52564) → [after](https://github.com/user-attachments/assets/1e7e6a10-a669-4f0f-8584-dcfa877d21d0)

The shadow-DOM lane (settings model picker, a `wa-select` listbox) was verified live with a `getComputedStyle` probe on the shadow part rather than a static screenshot, because the mock fixture's option list doesn't overflow that particular listbox: before the grouped `::part()` rule, its scrollbar-thumb resolved to fully transparent and its width fell back to the platform default; after, both resolve to the canonical token values (12px, the muted thumb color).

Tests:
- `ui/src/e2e/app-chrome-interaction.e2e.test.ts` — renamed and collapsed the old 12px/6px contract to one canonical width, added the model picker to the sampled surfaces, and added a dark/light pass that asserts the token-derived thumb color differs between modes and that a Web Awesome shadow-DOM menu's `::part()` scrollbar resolves to the canonical width and a real thumb color. A genericity guard walks every `wa-dropdown`/`wa-select`/`wa-popover` rendered on the chat page and asserts each one's scroll part reports the canonical width, so an unlisted component cannot silently fall back to the platform scrollbar.
- `ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts` — the composer's ten-line cap test asserted thinness as `::-webkit-scrollbar` width `<= 6px`, which was the old shrink-the-hit-target recipe. It now asserts the canonical contract directly: a 12px hit target painting a 6px thumb through the transparent border.
- `ui/src/components/form-controls.browser.test.ts` — collapsed the same 12px/6px contract and added a check that the intentionally hidden `.board-tabs__track` rail still reports `scrollbar-width: none` against the new blanket `* { scrollbar-width: thin }` rule.

Production line delta is +30 (`git diff --numstat` on the non-test files: +97/-67); tests are +141 (+150/-9). Deleting the scattered overrides removes 45 lines across `layout.css`, `chat/layout.css`, `chat/split-view.css`, and `new-session.css`; the canonical token/rule block in `base.css` nets +30 (it now also covers the shadow-DOM `::part()` group, including a full hover pass that the deleted rules never had); and the new Lit fragment plus its three-panel wiring for the terminal/browser/desktop shadow roots adds +45. The shadow-DOM lane — previously zero scrollbar styling on those surfaces — accounts for essentially all of the net addition; it is new coverage, not a rewritten existing rule. Reaching the Web Awesome parts through generic selectors rather than a per-component class list is what keeps that block small: it removed 23 production lines while widening coverage from seven named hosts to every dropdown, listbox, and popover in the UI.

Fixes #124272

