### PR TITLE
[AI-assisted] docs(android): clarify fork/source builds need own signing identity

### DIFF
--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -63,7 +63,7 @@ Google Play and standalone APK installs use different update channels and may ha
 </Warning>
 
 <Note>
-Building a release APK from source or a fork requires your own Android signing identity. Debug builds work without one. The official OpenClaw release key is not included in the repository. See [Sign your app](https://developer.android.com/studio/publish/app-signing) for how to generate and configure a signing key for release builds.
+Building a release artifact (APK or app bundle) from source or a fork requires your own Android signing identity. Debug builds work without one. The official OpenClaw release key is not included in the repository. See [Sign your app](https://developer.android.com/studio/publish/app-signing) for how to generate and configure a signing key for release builds.
 </Note>
 
 ## Mirror and control Android from a remote Mac

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -62,6 +62,10 @@ gh attestation verify OpenClaw-Android.apk \
 Google Play and standalone APK installs use different update channels and may have different signing identities. Android may require uninstalling the existing app before switching channels, which removes its local app data. Stay on one channel for normal updates.
 </Warning>
 
+<Note>
+Building a release APK from source or a fork requires your own Android signing identity. Debug builds work without one. The official OpenClaw release key is not included in the repository. See [Sign your app](https://developer.android.com/studio/publish/app-signing) for how to generate and configure a signing key for release builds.
+</Note>
+
 ## Mirror and control Android from a remote Mac
 
 [scrcpy](https://github.com/Genymobile/scrcpy) mirrors an Android screen in a macOS window and

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -63,7 +63,7 @@ Google Play and standalone APK installs use different update channels and may ha
 </Warning>
 
 <Note>
-Building a release artifact (APK or app bundle) from source or a fork requires your own Android signing identity. Debug builds work without one. The official OpenClaw release key is not included in the repository. See [Sign your app](https://developer.android.com/studio/publish/app-signing) for how to generate and configure a signing key for release builds.
+Building a release artifact (APK or app bundle) from source or a fork requires your own Android signing identity. Debug builds use an automatically generated debug signing key. The official OpenClaw release key is not included in the repository. See [Sign your app](https://developer.android.com/studio/publish/app-signing) for how to generate and configure a signing key for release builds.
 </Note>
 
 ## Mirror and control Android from a remote Mac


### PR DESCRIPTION
## What Problem This Solves

Source and fork builders could follow the Android platform guide without learning that release APKs and app bundles require their own signing identity. The repository does not contain the official release key. Related: #119609.

## Why This Change Was Made

Add a short note beside the existing installation and signing guidance, covering both release artifact types and linking Android's primary signing instructions. Clarify that debug builds use an automatically generated debug signing key. The official release-owner workflow remains separate.

## Evidence

The phone Gradle owner reads four local signing properties and rejects release tasks when they are missing. Its debug variant has no dependency on that release identity. The Wear module reuses the phone release signing configuration. Stable v2026.8.1 has the same signing guard and debug separation. Android's [Sign your app](https://developer.android.com/studio/publish/app-signing) documentation confirms release signing and generated debug certificates.

Trusted docs inventory, MDX compilation, explicit-config formatting, and complete-diff whitespace checks passed for the revised page. Independent full-candidate Codex P0 review passed without findings. [CI 33367630190](https://github.com/openclaw/openclaw/actions/runs/33367630190) and [Workflow Sanity 33367630185](https://github.com/openclaw/openclaw/actions/runs/33367630185) passed on c54bb5dd69fbd80c86d633fed81588c06843a947. [The documentation job](https://github.com/openclaw/openclaw/actions/runs/33367630190/job/99411707024) passed formatting, docs/template lint, MDX compilation, link audit and config-example checks. The complete added note is byte-identical in the CI merge; its surrounding page includes newer main content. The glossary coverage subcheck skipped because the shallow checkout lacked a merge base; this note adds no glossary terms or title changes. No key generation, signing, app upload, or Android runtime build is claimed for this documentation-only change.

Production and test LOC are unchanged; documentation is +4/-0. Thanks @santhiprakash.

Latest ClawSweeper review (August 31, 07:20 UTC) covers this exact head, reports no actionable findings and only requested the documentation check to finish; that check is now green.
