### PR TITLE
test(ui): consolidate dynamic route startup coverage

### DIFF
--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -119,14 +119,16 @@ describe("Dynamic route startup bridge", () => {
     "loads the $label once while publishing its real location",
     async ({ routeId, location: initialLocation }) => {
       let location: RouteLocation = { ...initialLocation };
+      const push = vi.fn((next: RouteLocation) => {
+        location = next;
+      });
+      const replace = vi.fn((next: RouteLocation) => {
+        location = next;
+      });
       const history: RouterHistory = {
         location: () => location,
-        push: vi.fn((next: RouteLocation) => {
-          location = next;
-        }),
-        replace: vi.fn((next: RouteLocation) => {
-          location = next;
-        }),
+        push,
+        replace,
         listen: () => () => undefined,
       };
       const router = createApplicationRouter();
@@ -146,8 +148,9 @@ describe("Dynamic route startup bridge", () => {
         } as unknown as ApplicationContext);
 
         expect(loader).toHaveBeenCalledOnce();
-        expect(router.getState().location).toEqual(initialLocation);
         expect(router.getState().matches[0]?.location).toEqual(initialLocation);
+        expect(push).not.toHaveBeenCalled();
+        expect(replace).not.toHaveBeenCalled();
       } finally {
         router.stop();
         route.loader = originalLoader;
@@ -183,7 +186,7 @@ describe("Dynamic route startup bridge", () => {
     if (!route) {
       throw new Error("Chat route missing");
     }
-    const loader = vi.fn(async () => ({}));
+    const loader = vi.fn<NonNullable<typeof route.loader>>(async () => ({}));
     const originalLoader = route.loader;
     const originalComponent = route.component;
     try {
@@ -204,7 +207,7 @@ describe("Dynamic route startup bridge", () => {
 
       await vi.waitFor(() => {
         expect(loader).toHaveBeenCalledTimes(2);
-        expect(router.getState().location).toEqual(location);
+        expect(loader.mock.calls[1]?.[1].location).toEqual(location);
       });
     } finally {
       router.stop();
@@ -372,57 +375,6 @@ describe("Agent panel route paths", () => {
     expect(agentRouteFromPath("/settings/agents/research/tools/extra")).toBeNull();
   });
 
-  it("publishes the real dynamic pathname after the exact-match startup bridge", async () => {
-    let location: RouteLocation = {
-      pathname: "/settings/agents/team%2Ewriter/tools",
-      search: "?probe=1",
-      hash: "#catalog",
-    };
-    const push = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const replace = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const history: RouterHistory = {
-      location: () => location,
-      push,
-      replace,
-      listen: () => () => undefined,
-    };
-    const router = createApplicationRouter();
-    const agentsRoute = router.getRoute("agents");
-    if (!agentsRoute) {
-      throw new Error("Agents route missing");
-    }
-    agentsRoute.component = async () => ({ render: () => null });
-    const agentsList = {
-      defaultId: "main",
-      mainKey: "main",
-      scope: "agent",
-      agents: [{ id: "main" }, { id: "team.writer" }],
-    };
-    const context = {
-      basePath: "",
-      gateway: { snapshot: { phase: "stopped", client: null } },
-      agents: {
-        state: { agentsList, agentsError: null },
-        ensureList: () => Promise.resolve(agentsList),
-      },
-    } as unknown as ApplicationContext;
-
-    await startApplicationRouter(router, history, "", context);
-
-    expect(router.getState().location).toEqual(location);
-    expect(router.getState().matches[0]?.location).toEqual(location);
-    expect(location.pathname).toBe("/settings/agents/team%2Ewriter/tools");
-    expect(location.search).toBe("?probe=1");
-    expect(location.hash).toBe("#catalog");
-    expect(push).not.toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
-    router.stop();
-  });
-
   it("normalizes an invalid panel once before the startup bridge", async () => {
     let location: RouteLocation = {
       pathname: "/settings/agents/main/unknown",
@@ -504,48 +456,6 @@ describe("Memory tab route paths", () => {
     expect(routeIdFromPath("/settings/memory/unknown")).toBeNull();
     expect(routeIdFromPath("/settings/memory/dreams/extra")).toBeNull();
   });
-
-  it("publishes the real dynamic pathname after the exact-match startup bridge", async () => {
-    let location: RouteLocation = {
-      pathname: "/settings/memory/settings",
-      search: "",
-      hash: "#memory-backend",
-    };
-    const push = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const replace = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const history: RouterHistory = {
-      location: () => location,
-      push,
-      replace,
-      listen: () => () => undefined,
-    };
-    const router = createApplicationRouter();
-    const memoryRoute = router.getRoute("memory");
-    if (!memoryRoute) {
-      throw new Error("Memory route missing");
-    }
-    memoryRoute.component = async () => ({ render: () => null });
-    const context = {
-      basePath: "",
-      runtimeConfig: {
-        ensureLoaded: () => Promise.resolve(),
-        ensureSchemaLoaded: () => Promise.resolve(),
-      },
-    } as unknown as ApplicationContext;
-
-    await startApplicationRouter(router, history, "", context);
-
-    expect(router.getState().location).toEqual(location);
-    expect(router.getState().matches[0]?.location).toEqual(location);
-    expect(location.pathname).toBe("/settings/memory/settings");
-    expect(push).not.toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
-    router.stop();
-  });
 });
 
 describe("Plugins hub tab route paths", () => {
@@ -573,48 +483,5 @@ describe("Plugins hub tab route paths", () => {
     expect(pluginsHubTabFromPath("/settings/plugins/discover/extra")).toBeNull();
     expect(routeIdFromPath("/settings/plugins/unknown")).toBeNull();
     expect(routeIdFromPath("/settings/plugins/discover/extra")).toBeNull();
-  });
-
-  it("publishes the real dynamic pathname after the exact-match startup bridge", async () => {
-    let location: RouteLocation = {
-      pathname: "/settings/plugins/discover",
-      search: "?query=calendar",
-      hash: "#featured",
-    };
-    const push = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const replace = vi.fn((next: RouteLocation) => {
-      location = next;
-    });
-    const history: RouterHistory = {
-      location: () => location,
-      push,
-      replace,
-      listen: () => () => undefined,
-    };
-    const router = createApplicationRouter();
-    const pluginsRoute = router.getRoute("plugins");
-    if (!pluginsRoute) {
-      throw new Error("Plugins route missing");
-    }
-    pluginsRoute.component = async () => ({ render: () => null });
-    const context = {
-      basePath: "",
-      gateway: {
-        snapshot: { phase: "reconnecting", client: null },
-      },
-    } as unknown as ApplicationContext;
-
-    await startApplicationRouter(router, history, "", context);
-
-    expect(router.getState().location).toEqual(location);
-    expect(router.getState().matches[0]?.location).toEqual(location);
-    expect(location.pathname).toBe("/settings/plugins/discover");
-    expect(location.search).toBe("?query=calendar");
-    expect(location.hash).toBe("#featured");
-    expect(push).not.toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
-    router.stop();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`ui/src/app-route-paths.test.ts` repeated three full Agent, Memory, and Plugins startup harnesses after a generic dynamic-route startup matrix had already absorbed those route families. Five assertions also read the router's top-level `location`, even though the Control UI consumes the active match location; four duplicated stronger companion assertions, while the later-history case tested the right behavior through the wrong state surface.

## Why This Change Was Made

The generic six-route startup matrix now owns the shared invariants: one loader invocation, the real active-match location, and no browser-history writes. The duplicate Agent, Memory, and Plugins startup blocks are removed. The later-history test now asserts the second loader call's `options.location`, which is the actual page input and the independently typed `@openclaw/uirouter` loader contract.

## User Impact

None. This is a test-only consolidation; Control UI routing behavior and production code are unchanged.

## Evidence

- Seven focused UI owner suites — 126 tests passed.
- `ui/src/e2e/dynamic-route-loader-count.e2e.test.ts` — 1 real-browser test passed.
- `node scripts/check-changed.mjs -- ui/src/app-route-paths.test.ts` — passed through the documented local fallback because no remote provider was ready.
- `git diff --check` — passed.
- Structured autoreview — clean, no accepted/actionable findings.
- Test delta: -133 lines. No production, docs, changelog, schema, protocol, migration, or operator-state change.
