### PR TITLE
test(ios): remove low-value render and source guards

### DIFF
--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -663,25 +663,6 @@ extension RootTabsSourceGuardTests {
         #expect(source.contains("private func proposals(forLaneStatus status: String)"))
     }
 
-    @Test func `routed feature screens reuse shared pro components`() throws {
-        let source = try Self.iPadTaskFeatureScreensSource()
-        let componentsSource = try String(contentsOf: Self.proComponentsSourceURL(), encoding: .utf8)
-        let channelsSource = try String(contentsOf: Self.channelsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("ProMetricGrid(metrics: self.metrics)"))
-        #expect(source.contains("ProPanelHeader("))
-        #expect(source.contains("ProStatusRow("))
-        #expect(!source.contains("private struct ProMetricGrid"))
-        #expect(!source.contains("private struct ProMetric"))
-        #expect(!source.contains("private struct ProPanelHeader"))
-        #expect(!source.contains("private struct ProStatusRow"))
-        #expect(!channelsSource.contains("private struct SettingsChannelPanelHeader"))
-        #expect(!channelsSource.contains("private struct SettingsChannelInfoRow"))
-        #expect(componentsSource.contains("struct ProMetricGrid"))
-        #expect(componentsSource.contains("struct ProPanelHeader"))
-        #expect(componentsSource.contains("struct ProStatusRow"))
-    }
-
     @Test func `activity screen stays split from task feature screens`() throws {
         let taskSource = try Self.iPadTaskFeatureScreensSource()
         let activitySource = try String(contentsOf: Self.iPadActivityScreenSourceURL(), encoding: .utf8)
@@ -697,18 +678,6 @@ extension RootTabsSourceGuardTests {
         #expect(!taskSource.contains("struct IPadActivityScreen"))
         #expect(!taskSource.contains("import OpenClawChatUI"))
         #expect(projectSource.contains("IPadActivityScreen.swift in Sources"))
-    }
-
-    @Test func `routed feature chrome stays split from task feature screens`() throws {
-        let taskSource = try Self.iPadTaskFeatureScreensSource()
-        let chromeSource = try String(contentsOf: Self.iPadSidebarScreenChromeSourceURL(), encoding: .utf8)
-        let projectSource = try String(contentsOf: Self.xcodeProjectSourceURL(), encoding: .utf8)
-
-        #expect(chromeSource.contains("struct IPadSidebarScreenChrome<Content: View>: View"))
-        #expect(chromeSource.contains("OpenClawSidebarHeaderLeadingSlot(action: headerSidebarAction)"))
-        #expect(chromeSource.contains("OpenClawGatewayCompactPill()"))
-        #expect(!taskSource.contains("struct IPadSidebarScreenChrome"))
-        #expect(projectSource.contains("IPadSidebarScreenChrome.swift in Sources"))
     }
 
     @Test func `routed feature chrome keeps gateway pill actionable`() throws {

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -175,59 +175,6 @@ struct SwiftUIRenderSmokeTests {
         }
     }
 
-    @Test @MainActor func `markdown heading hierarchy builds with inline formatting and table`() {
-        let markdown = """
-        # First **strong** heading
-        ## Second [linked](https://example.com) heading
-        ### Third `code` heading
-        #### Fourth heading
-        ##### Fifth heading
-        ###### Sixth heading
-
-        | Surface | State |
-        | --- | --- |
-        | iOS | Native |
-        """
-        for typeSize in [DynamicTypeSize.large, .accessibility2] {
-            let root = ChatMarkdownRenderer(
-                text: markdown,
-                context: .assistant,
-                variant: .standard,
-                textColor: OpenClawChatTheme.assistantText)
-                .environment(\.dynamicTypeSize, typeSize)
-
-            _ = Self.host(root, size: CGSize(width: 393, height: 700))
-        }
-    }
-
-    @Test @MainActor func `markdown lists and thematic breaks build across appearance and type size`() {
-        let markdown = """
-        Here are the options:
-
-        9. **Option one heading** – a sentence describing it.
-        10. **Option two heading** – another sentence.
-           - Nested detail
-           - [x] Completed detail
-
-        ---
-
-        Final paragraph.
-        """
-        for scheme in [ColorScheme.light, .dark] {
-            for typeSize in [DynamicTypeSize.large, .accessibility2] {
-                let root = ChatMarkdownRenderer(
-                    text: markdown,
-                    context: .assistant,
-                    variant: .standard,
-                    textColor: OpenClawChatTheme.assistantText)
-                    .environment(\.dynamicTypeSize, typeSize)
-                    .preferredColorScheme(scheme)
-
-                _ = Self.host(root, size: CGSize(width: 320, height: 700))
-            }
-        }
-    }
-
     @Test @MainActor func `long user prompt disclosure builds across dynamic type sizes`() {
         let text = Array(repeating: "A long user-authored prompt line.", count: 13).joined(separator: "\n")
         let message = OpenClawChatMessage(
@@ -341,62 +288,6 @@ struct SwiftUIRenderSmokeTests {
             isClean: false)
 
         _ = Self.host(root, size: CGSize(width: 393, height: 400))
-    }
-
-    @Test @MainActor func `completed and streaming assistant trace headings build across type sizes`() {
-        let text = """
-        <think>
-        # Internal plan
-        </think>
-        <final>
-        # Final answer
-        </final>
-        """
-        let message = OpenClawChatMessage(
-            role: "assistant",
-            content: [OpenClawChatMessageContent(
-                type: "text",
-                text: text,
-                mimeType: nil,
-                fileName: nil,
-                content: nil)],
-            timestamp: 1)
-
-        for typeSize in [DynamicTypeSize.large, .accessibility2] {
-            let root = VStack {
-                ChatMessageBubble(
-                    message: message,
-                    style: .standard,
-                    markdownVariant: .standard,
-                    userAccent: nil,
-                    displayOptions: [.reasoning],
-                    assistantName: "OpenClaw",
-                    assistantAvatarText: "OC",
-                    assistantAvatarTint: nil,
-                    showsAssistantAvatar: true,
-                    isClean: false,
-                    contextWindowTokens: nil,
-                    userMessageExpanded: false,
-                    onToggleUserMessageExpanded: {},
-                    inlineWidgetResolverReady: true,
-                    inlineWidgetResourceResolver: { _, _ in nil },
-                    mediaArtifactResolverReady: false,
-                    mediaPlaybackAllowed: { true },
-                    loadMediaArtifact: { _, _, _ in nil })
-                ChatStreamingAssistantBubble(
-                    text: text,
-                    markdownVariant: .standard,
-                    showsReasoning: true,
-                    assistantName: "OpenClaw",
-                    assistantAvatarText: "OC",
-                    assistantAvatarTint: nil,
-                    showsAssistantAvatar: true,
-                    isClean: false)
-            }
-            .environment(\.dynamicTypeSize, typeSize)
-
-            _ = Self.host(root, size: CGSize(width: 393, height: 700))
-        }
     }
 
     @Test @MainActor func `assistant usage footer builds across dynamic type sizes`() throws {


### PR DESCRIPTION
## What Problem This Solves

The iOS suite retained three assertion-free SwiftUI construction probes after stronger semantic and visual regressions were added, plus two source-string guards that pinned private component names and file organization rather than shipped behavior. These tests failed under behavior-preserving refactors and duplicated more meaningful owner-boundary proof.

## Why This Change Was Made

The three renderer probes are deleted while preserving detailed markdown segmentation/render snapshots, semantic typography checks, generic completed/streaming bubble hosting, and the selected `TraceHeadingVisualProofTests` geometry/image regression. The two private-organization guards are deleted while preserving gateway-pill actionability, settings navigation, presentation, snapshot traversal, compilation, and generated-project membership proof.

## User Impact

None. This is a test-only cleanup; iOS behavior and production code are unchanged.

## Evidence

- `ChatMarkdownBlockSegmenterTests` — 108 passed.
- `WebChatSwiftUISmokeTests` — 12 passed.
- Selected iOS simulator suites (`SwiftUIRenderSmokeTests`, `TraceHeadingVisualProofTests`, `RootTabsSourceGuardTests`, `RootTabsPresentationTests`) — 129 passed; `TEST SUCCEEDED`.
- SwiftFormat — 0 of 366 files require formatting.
- SwiftLint — 0 violations across 366 iOS/shared files.
- Changed-file gates and native schema guard — passed through the documented local fallback because no remote provider was ready.
- `git diff --check` and structured autoreview — clean.
- Test delta: -140 lines. No production, docs, changelog, schema, protocol, migration, or operator-state change.
