### PR TITLE
test(tooling): deduplicate release timeout evaluators

### DIFF
--- a/test/helpers/release-workflow-timeouts.ts
+++ b/test/helpers/release-workflow-timeouts.ts
@@ -1,0 +1,79 @@
+type ReleaseTimeoutProfile = "beta" | "stable" | "full";
+type ReleaseWorkflowJob = { needs?: string | string[]; "timeout-minutes"?: number | string };
+type ReleaseWorkflow = { jobs?: Record<string, ReleaseWorkflowJob> };
+
+export function releaseWorkflowJobNeeds(job: ReleaseWorkflowJob): string[] {
+  return Array.isArray(job.needs) ? job.needs : job.needs ? [job.needs] : [];
+}
+
+export function releaseTimeoutForProfile(
+  timeout: number | string | undefined,
+  profile: ReleaseTimeoutProfile,
+): number {
+  if (typeof timeout === "number") {
+    return timeout;
+  }
+  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
+    return 60;
+  }
+  const match = timeout?.match(
+    /^\$\{\{ inputs\.(?:release_profile|release_test_profile) == 'full' && ([0-9]+) \|\| ([0-9]+) \}\}$/u,
+  );
+  if (!match) {
+    throw new Error(`Unsupported release timeout expression: ${String(timeout)}`);
+  }
+  return Number(profile === "full" ? match[1] : match[2]);
+}
+
+function requireWorkflowJob(workflow: ReleaseWorkflow, jobName: string): ReleaseWorkflowJob {
+  const job = workflow.jobs?.[jobName];
+  if (!job) {
+    throw new Error(`Missing release workflow job: ${jobName}`);
+  }
+  return job;
+}
+
+function requireWorkflowNeeds(
+  job: ReleaseWorkflowJob,
+  required: readonly string[],
+  exact = false,
+): void {
+  const needs = releaseWorkflowJobNeeds(job);
+  if (
+    !required.every((name) => needs.includes(name)) ||
+    (exact && needs.length !== required.length)
+  ) {
+    throw new Error(`Invalid release dependency chain: ${needs.join(",")}`);
+  }
+}
+
+export function pluginPrereleaseTimeoutComponents(params: {
+  pluginPrerelease: ReleaseWorkflow;
+  liveE2e: ReleaseWorkflow;
+  profile: ReleaseTimeoutProfile;
+}) {
+  const jobs = {
+    preflight: requireWorkflowJob(params.pluginPrerelease, "preflight"),
+    dockerSuite: requireWorkflowJob(params.pluginPrerelease, "plugin-prerelease-docker-suite"),
+    suite: requireWorkflowJob(params.pluginPrerelease, "plugin-prerelease-suite"),
+    validateSelectedRef: requireWorkflowJob(params.liveE2e, "validate_selected_ref"),
+    prepareImage: requireWorkflowJob(params.liveE2e, "prepare_docker_e2e_image"),
+    imageReady: requireWorkflowJob(params.liveE2e, "docker_e2e_image_ready"),
+    dockerLanes: requireWorkflowJob(params.liveE2e, "validate_docker_lanes"),
+  };
+  requireWorkflowNeeds(jobs.dockerSuite, ["preflight"]);
+  requireWorkflowNeeds(jobs.prepareImage, ["validate_selected_ref"], true);
+  requireWorkflowNeeds(jobs.imageReady, ["prepare_docker_e2e_image"], true);
+  requireWorkflowNeeds(jobs.dockerLanes, ["prepare_docker_e2e_image", "docker_e2e_image_ready"]);
+  requireWorkflowNeeds(jobs.suite, ["plugin-prerelease-docker-suite"]);
+  const timeout = (job: ReleaseWorkflowJob) =>
+    releaseTimeoutForProfile(job["timeout-minutes"], params.profile);
+  return {
+    preflight: timeout(jobs.preflight),
+    validateSelectedRef: timeout(jobs.validateSelectedRef),
+    prepareImage: timeout(jobs.prepareImage),
+    imageReady: timeout(jobs.imageReady),
+    dockerLanes: timeout(jobs.dockerLanes),
+    suite: timeout(jobs.suite),
+  };
+}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -13,6 +13,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { FULL_RELEASE_WAIT_TIMEOUT_MINUTES } from "../../scripts/full-release-validation-at-sha.mts";
 import { createReleaseWorkflowMatrixPlan } from "../../scripts/plan-release-workflow-matrix.mjs";
+import {
+  pluginPrereleaseTimeoutComponents,
+  releaseTimeoutForProfile as timeoutForProfile,
+  releaseWorkflowJobNeeds as jobNeeds,
+} from "../helpers/release-workflow-timeouts.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const PACKAGE_ACCEPTANCE_WORKFLOW = ".github/workflows/package-acceptance.yml";
@@ -208,29 +213,6 @@ function workflowStep(job: WorkflowJob, stepName: string): WorkflowStep {
   return step;
 }
 
-function jobNeeds(job: WorkflowJob): string[] {
-  return Array.isArray(job.needs) ? job.needs : job.needs ? [job.needs] : [];
-}
-
-function timeoutForProfile(
-  timeout: number | string | undefined,
-  profile: "beta" | "stable" | "full",
-): number {
-  if (typeof timeout === "number") {
-    return timeout;
-  }
-  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
-    return 60;
-  }
-  const match = timeout?.match(
-    /^\$\{\{ inputs\.(?:release_profile|release_test_profile) == 'full' && ([0-9]+) \|\| ([0-9]+) \}\}$/u,
-  );
-  if (!match) {
-    throw new Error(`Unsupported release timeout expression: ${String(timeout)}`);
-  }
-  return Number(profile === "full" ? match[1] : match[2]);
-}
-
 function evaluatedJobTimeouts(path: string, jobName: string, job: WorkflowJob): number[] {
   const timeout = job["timeout-minutes"];
   if (typeof timeout === "number") {
@@ -284,41 +266,8 @@ function pluginPrereleaseTimeoutFloor(
   liveE2e: Workflow,
   profile: "beta" | "stable" | "full",
 ): number {
-  const preflight = pluginPrerelease.jobs?.preflight;
-  const dockerSuite = pluginPrerelease.jobs?.["plugin-prerelease-docker-suite"];
-  const suite = pluginPrerelease.jobs?.["plugin-prerelease-suite"];
-  const validateSelectedRef = liveE2e.jobs?.validate_selected_ref;
-  const prepareImage = liveE2e.jobs?.prepare_docker_e2e_image;
-  const imageReady = liveE2e.jobs?.docker_e2e_image_ready;
-  const dockerLanes = liveE2e.jobs?.validate_docker_lanes;
-  if (
-    !preflight ||
-    !dockerSuite ||
-    !suite ||
-    !validateSelectedRef ||
-    !prepareImage ||
-    !imageReady ||
-    !dockerLanes
-  ) {
-    throw new Error("Missing plugin prerelease timeout-chain job");
-  }
-
-  expect(jobNeeds(dockerSuite)).toContain("preflight");
-  expect(jobNeeds(prepareImage)).toEqual(["validate_selected_ref"]);
-  expect(jobNeeds(imageReady)).toEqual(["prepare_docker_e2e_image"]);
-  expect(jobNeeds(dockerLanes)).toEqual(
-    expect.arrayContaining(["prepare_docker_e2e_image", "docker_e2e_image_ready"]),
-  );
-  expect(jobNeeds(suite)).toContain("plugin-prerelease-docker-suite");
-
-  return [
-    timeoutForProfile(preflight["timeout-minutes"], profile),
-    timeoutForProfile(validateSelectedRef["timeout-minutes"], profile),
-    timeoutForProfile(prepareImage["timeout-minutes"], profile),
-    timeoutForProfile(imageReady["timeout-minutes"], profile),
-    timeoutForProfile(dockerLanes["timeout-minutes"], profile),
-    timeoutForProfile(suite["timeout-minutes"], profile),
-  ].reduce((total, value) => total + value, 0);
+  const components = pluginPrereleaseTimeoutComponents({ pluginPrerelease, liveE2e, profile });
+  return Object.values(components).reduce((total, value) => total + value, 0);
 }
 
 function runFullReleaseInputValidation(releaseProfile: string, skipTelegram: string) {

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -10,6 +10,10 @@ import {
   assertPluginPrereleaseTestPlanComplete,
   createPluginPrereleaseTestPlan,
 } from "../../scripts/lib/plugin-prerelease-test-plan.mts";
+import {
+  pluginPrereleaseTimeoutComponents,
+  releaseTimeoutForProfile,
+} from "../helpers/release-workflow-timeouts.js";
 
 const CHECKOUT_V6 = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
@@ -42,56 +46,13 @@ function readLiveE2eWorkflow() {
   return parse(readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"));
 }
 
-function jobNeeds(job: { needs?: string | string[] }): string[] {
-  return Array.isArray(job.needs) ? job.needs : job.needs ? [job.needs] : [];
-}
-
-function timeoutForProfile(
-  timeout: number | string | undefined,
-  profile: "beta" | "stable" | "full",
-): number {
-  if (typeof timeout === "number") {
-    return timeout;
-  }
-  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
-    return 60;
-  }
-  const match = timeout?.match(
-    /^\$\{\{ inputs\.(?:release_profile|release_test_profile) == 'full' && ([0-9]+) \|\| ([0-9]+) \}\}$/u,
-  );
-  if (!match) {
-    throw new Error(`Unsupported release timeout expression: ${String(timeout)}`);
-  }
-  return Number(profile === "full" ? match[1] : match[2]);
-}
-
 function pluginPrereleaseTimeoutFloor(profile: "beta" | "stable" | "full"): number {
-  const plugin = readPluginPrereleaseWorkflow();
-  const liveE2e = readLiveE2eWorkflow();
-  const preflight = plugin.jobs.preflight;
-  const dockerSuite = plugin.jobs["plugin-prerelease-docker-suite"];
-  const suite = plugin.jobs["plugin-prerelease-suite"];
-  const validateSelectedRef = liveE2e.jobs.validate_selected_ref;
-  const prepareImage = liveE2e.jobs.prepare_docker_e2e_image;
-  const imageReady = liveE2e.jobs.docker_e2e_image_ready;
-  const dockerLanes = liveE2e.jobs.validate_docker_lanes;
-
-  expect(jobNeeds(dockerSuite)).toContain("preflight");
-  expect(jobNeeds(prepareImage)).toEqual(["validate_selected_ref"]);
-  expect(jobNeeds(imageReady)).toEqual(["prepare_docker_e2e_image"]);
-  expect(jobNeeds(dockerLanes)).toEqual(
-    expect.arrayContaining(["prepare_docker_e2e_image", "docker_e2e_image_ready"]),
-  );
-  expect(jobNeeds(suite)).toContain("plugin-prerelease-docker-suite");
-
-  return [
-    timeoutForProfile(preflight["timeout-minutes"], profile),
-    timeoutForProfile(validateSelectedRef["timeout-minutes"], profile),
-    timeoutForProfile(prepareImage["timeout-minutes"], profile),
-    timeoutForProfile(imageReady["timeout-minutes"], profile),
-    timeoutForProfile(dockerLanes["timeout-minutes"], profile),
-    timeoutForProfile(suite["timeout-minutes"], profile),
-  ].reduce((total, value) => total + value, 0);
+  const components = pluginPrereleaseTimeoutComponents({
+    pluginPrerelease: readPluginPrereleaseWorkflow(),
+    liveE2e: readLiveE2eWorkflow(),
+    profile,
+  });
+  return Object.values(components).reduce((total, value) => total + value, 0);
 }
 
 function getDockerLane(name: string) {
@@ -762,9 +723,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       full: pluginPrereleaseTimeoutFloor("full"),
     };
     const parentTimeouts = {
-      beta: timeoutForProfile(pluginMonitorTimeout, "beta"),
-      stable: timeoutForProfile(pluginMonitorTimeout, "stable"),
-      full: timeoutForProfile(pluginMonitorTimeout, "full"),
+      beta: releaseTimeoutForProfile(pluginMonitorTimeout, "beta"),
+      stable: releaseTimeoutForProfile(pluginMonitorTimeout, "stable"),
+      full: releaseTimeoutForProfile(pluginMonitorTimeout, "full"),
     };
     expect(childTimeoutFloors).toEqual({ beta: 175, stable: 175, full: 205 });
     expect(parentTimeouts).toEqual({ beta: 240, stable: 240, full: 300 });


### PR DESCRIPTION
## What Problem This Solves

Two independently selected release-workflow suites carried copies of the same `needs` normalization, profile timeout-expression parser, plugin-prerelease job lookup, dependency-chain validation, and timeout-floor calculation. The tests protect different change-routing boundaries, but the copied evaluator itself was maintenance-only and could drift.

## Why This Change Was Made

A narrow shared test helper now owns timeout parsing and the named plugin-prerelease critical-path components. It also validates the required dependency chain. Both owning suites remain in place and still assert their exact child totals, parent monitor values, and safety margins, so workflow-specific change selection remains covered without two algorithm copies.

## User Impact

None. This is test-support deduplication; workflows and production behavior are unchanged.

## Evidence

- Plugin prerelease, package acceptance, and test-project routing suites — 475 passed.
- Changed-file gates — passed through the documented local fallback because no remote provider was ready.
- Root test typecheck, formatting, Docker E2E boundary lint, and raw HTTP/2 import guard — passed.
- `git diff --check` and structured autoreview — clean.
- Test/test-support delta: -11 lines. No production, workflow, docs, changelog, schema, protocol, migration, or operator-state change.
