### PR TITLE
fix(doctor): follow a macOS cloud symlink when the state dir leaf is absent

### DIFF
--- a/src/commands/doctor-state-integrity.cloud-storage.test.ts
+++ b/src/commands/doctor-state-integrity.cloud-storage.test.ts
@@ -1,8 +1,16 @@
 // Doctor state integrity cloud-storage tests cover macOS cloud-synced state directory detection.
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { detectMacCloudSyncedStateDir } from "./doctor-state-integrity.js";
+
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  tempDirs.cleanup();
+});
 
 describe("detectMacCloudSyncedStateDir", () => {
   const home = "/Users/tester";
@@ -83,6 +91,53 @@ describe("detectMacCloudSyncedStateDir", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("follows a real symlink out of the sync root when the state dir leaf is absent", () => {
+    const sandbox = fs.realpathSync(tempDirs.make("openclaw-cloud-storage-symlink-"));
+    const realHome = path.join(sandbox, "home");
+    const cloudStorage = path.join(realHome, "Library", "CloudStorage");
+    const localTarget = path.join(sandbox, "local-openclaw");
+    fs.mkdirSync(cloudStorage, { recursive: true });
+    fs.mkdirSync(localTarget, { recursive: true });
+    const syncedLink = path.join(cloudStorage, "OneDrive-Personal");
+    fs.symlinkSync(localTarget, syncedLink, process.platform === "win32" ? "junction" : "dir");
+
+    const stateDir = path.join(syncedLink, "OpenClaw", ".openclaw");
+    expect(fs.existsSync(stateDir)).toBe(false);
+
+    expect(
+      detectMacCloudSyncedStateDir(stateDir, {
+        platform: "darwin",
+        homedir: realHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("still warns for a real absent leaf that stays inside the sync root", () => {
+    const sandbox = fs.realpathSync(tempDirs.make("openclaw-cloud-storage-real-"));
+    const realHome = path.join(sandbox, "home");
+    const syncedDir = path.join(
+      realHome,
+      "Library",
+      "CloudStorage",
+      "OneDrive-Personal",
+      "OpenClaw",
+    );
+    fs.mkdirSync(syncedDir, { recursive: true });
+
+    const stateDir = path.join(syncedDir, ".openclaw");
+    expect(fs.existsSync(stateDir)).toBe(false);
+
+    expect(
+      detectMacCloudSyncedStateDir(stateDir, {
+        platform: "darwin",
+        homedir: realHome,
+      }),
+    ).toEqual({
+      path: path.resolve(stateDir),
+      storage: "CloudStorage provider",
+    });
   });
 
   it("anchors cloud detection to OS homedir when OPENCLAW_HOME is overridden", () => {

--- a/src/commands/doctor-state-integrity.cloud-storage.test.ts
+++ b/src/commands/doctor-state-integrity.cloud-storage.test.ts
@@ -85,6 +85,47 @@ describe("detectMacCloudSyncedStateDir", () => {
     expect(result).toBeNull();
   });
 
+  it("ignores a symlink prefix when the state dir leaf does not exist yet", () => {
+    // A fresh install has not created the leaf, so realpath on the state dir
+    // itself fails. Resolving only the existing ancestor still follows the
+    // symlink out of the sync root, so no warning should fire.
+    const symlinkRoot = path.join(home, "Library", "CloudStorage", "OneDrive-Personal", "OpenClaw");
+    const stateDir = path.join(symlinkRoot, ".openclaw");
+    const resolvedLocalRoot = path.join(home, "local-openclaw");
+
+    const result = detectMacCloudSyncedStateDir(stateDir, {
+      platform: "darwin",
+      homedir: home,
+      resolveRealPath: (target) =>
+        target === path.resolve(symlinkRoot) ? resolvedLocalRoot : null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("still warns when a missing leaf resolves to a path inside the sync root", () => {
+    const cloudRoot = path.join(
+      home,
+      "Library",
+      "Mobile Documents",
+      "com~apple~CloudDocs",
+      "OpenClaw",
+    );
+    const stateDir = path.join(cloudRoot, ".openclaw");
+
+    const result = detectMacCloudSyncedStateDir(stateDir, {
+      platform: "darwin",
+      homedir: home,
+      resolveRealPath: (target) =>
+        target === path.resolve(cloudRoot) ? path.resolve(cloudRoot) : null,
+    });
+
+    expect(result).toEqual({
+      path: path.resolve(stateDir),
+      storage: "iCloud Drive",
+    });
+  });
+
   it("anchors cloud detection to OS homedir when OPENCLAW_HOME is overridden", () => {
     const stateDir = path.join(home, "Library", "CloudStorage", "iCloud Drive", ".openclaw");
     const originalOpenClawHome = process.env.OPENCLAW_HOME;

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -697,16 +697,14 @@ export function detectMacCloudSyncedStateDir(
       root: path.join(homedir, "Library", "CloudStorage"),
     },
   ];
-  const realPath = (deps?.resolveRealPath ?? tryResolveRealPath)(stateDir);
-  // Prefer the resolved target path when available so symlink prefixes do not
-  // misclassify local state dirs as cloud-synced.
-  const candidates = realPath ? [path.resolve(realPath)] : [path.resolve(stateDir)];
+  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
+  // Missing state leaves must still follow existing symlink ancestors, like the Linux detectors.
+  const resolvedStatePath =
+    resolvePathThroughExistingAncestor(stateDir, resolveRealPath, path) ?? path.resolve(stateDir);
 
-  for (const candidate of candidates) {
-    for (const { storage, root } of roots) {
-      if (isPathUnderRoot(candidate, root)) {
-        return { path: candidate, storage };
-      }
+  for (const { storage, root } of roots) {
+    if (isPathUnderRoot(resolvedStatePath, root)) {
+      return { path: resolvedStatePath, storage };
     }
   }
 

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -693,16 +693,18 @@ export function detectMacCloudSyncedStateDir(
       root: path.join(homedir, "Library", "CloudStorage"),
     },
   ];
-  const realPath = (deps?.resolveRealPath ?? tryResolveRealPath)(stateDir);
-  // Prefer the resolved target path when available so symlink prefixes do not
-  // misclassify local state dirs as cloud-synced.
-  const candidates = realPath ? [path.resolve(realPath)] : [path.resolve(stateDir)];
+  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
+  // A state dir that does not exist yet cannot be resolved directly, and
+  // falling back to the lexical path misreads a not-yet-created leaf beneath a
+  // symlink that actually points at local storage. Resolve through the nearest
+  // existing ancestor, as the Linux detectors in this file do, so the symlink
+  // is followed even when the leaf is absent.
+  const resolvedStatePath =
+    resolvePathThroughExistingAncestor(stateDir, resolveRealPath, path) ?? path.resolve(stateDir);
 
-  for (const candidate of candidates) {
-    for (const { storage, root } of roots) {
-      if (isPathUnderRoot(candidate, root)) {
-        return { path: candidate, storage };
-      }
+  for (const { storage, root } of roots) {
+    if (isPathUnderRoot(resolvedStatePath, root)) {
+      return { path: resolvedStatePath, storage };
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the read-only macOS state-integrity check with `openclaw doctor --lint --only core/doctor/state-integrity --json` received a false cloud-storage warning when the state directory did not exist and an apparent `~/Library/CloudStorage` ancestor was actually a symlink to local storage.

The ordinary interactive `openclaw doctor` path already initializes a missing state directory before its integrity check, so it does not reproduce this false positive. The affected public surface is the read-only lint command and its structured state-integrity health check.

## Why This Change Was Made

Reuse the existing nearest-existing-ancestor resolver already shared by both Linux storage detectors. This follows real symlinks before classifying a missing macOS state-directory leaf, removes the redundant single-candidate loop, and preserves warnings for paths that genuinely remain inside iCloud Drive or another CloudStorage provider.

Production LOC: +7/-9 (net -2). Regression tests: +56/-1 (net +55).

## User Impact

Read-only Doctor lint no longer tells operators to move a local state directory out of cloud storage merely because a symlink's spelling resembles a CloudStorage provider. Missing-state errors and genuine cloud-storage warnings continue to appear.

## Evidence

Verified on a real arm64 Mac using an actual symlink inside the current account's `~/Library/CloudStorage`, pointing to an isolated local temporary directory; the state-directory leaf was absent before every lint invocation.

```bash
openclaw doctor --lint --only core/doctor/state-integrity --json
```

Before the fix, the real local-symlink scenario incorrectly returned both findings:

```json
{"checksRun":1,"findings":[{"severity":"error","message":"State directory is missing. Sessions, credentials, logs, and config are stored there."},{"severity":"warning","message":"State directory is under macOS cloud-synced storage (CloudStorage provider), which can cause slow I/O and sync races."}]}
```

After the fix, the identical command and still-absent state leaf returned only the correct missing-state finding:

```json
{"checksRun":1,"findings":[{"severity":"error","message":"State directory is missing. Sessions, credentials, logs, and config are stored there."}]}
```

A positive-control run against an absent state leaf genuinely located inside `~/Library/CloudStorage` still returned both the expected missing-state error and the real cloud-storage warning. The lint command exits nonzero in all three cases because the state directory is intentionally absent; the proof is the presence or absence of the additional cloud warning, not the process exit code.

- Failing baseline: real-filesystem symlink regression failed with `1 failed, 7 passed` on current main.
- Fixed macOS detector suite: `node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-state-integrity.cloud-storage.test.ts` — 8 passed.
- Existing Linux sibling detector suite: `node scripts/run-vitest.mjs src/commands/doctor-state-integrity.linux-storage.test.ts` — 6 passed.
- Targeted `oxfmt --check`, `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` on both changed files, and `git diff --check` passed.
- Fresh structured pre-commit autoreview: clean; no accepted or actionable findings.
- The delegated changed-file gate could not start because the remote Testbox checkout sync timed out; the lease was stopped. Local full core/test typechecks encounter unrelated stale shared-checkout dependency errors, so exact-head hosted lint, typecheck, command tests, and the aggregate CI gate are required before merge.

Thanks to @MohammedAlkindi for the original fix and real-filesystem regression cases.
