### PR TITLE
test(tooling): deduplicate updater deployment fixtures

### DIFF
--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -246,6 +246,28 @@ function managedTimeoutError() {
   return Object.assign(new Error("managed timeout"), { code: "ETIMEDOUT" });
 }
 
+function createManagedLaunchAgentFixture(root: string, mirror: string) {
+  const lockPath = path.join(root, "maintenance.lock");
+  const plistPath = path.join(root, "ai.openclaw.gateway.plist");
+  const entrypoint = path.join(mirror, "dist/index.js");
+  writeFileSync(plistPath, "plist\n", { mode: 0o600 });
+  return {
+    lockPath,
+    plistPath,
+    deployment: {
+      configPath: path.join(root, "openclaw.json"),
+      entrypoint,
+      entrypointIndex: 1,
+      executable: process.execPath,
+      invocationPrefix: [entrypoint],
+      label: "ai.openclaw.gateway",
+      plistPath,
+      port: 18789,
+      runtime: process.execPath,
+    },
+  };
+}
+
 function createGatewaySuspensionCliStub(
   root: string,
   requestError: { code: string; message: string; retryable: boolean; type: string },
@@ -1859,20 +1881,7 @@ console.log(JSON.stringify({ ok: true, channels: {} }));
   test("recovers the previous service after a post-stop install timeout", async () => {
     const { root, mirror } = makeFixture();
     writeBuild(mirror);
-    const lockPath = path.join(root, "maintenance.lock");
-    const plistPath = path.join(root, "ai.openclaw.gateway.plist");
-    writeFileSync(plistPath, "plist\n", { mode: 0o600 });
-    const deployment = {
-      configPath: path.join(root, "openclaw.json"),
-      entrypoint: path.join(mirror, "dist/index.js"),
-      entrypointIndex: 1,
-      executable: process.execPath,
-      invocationPrefix: [path.join(mirror, "dist/index.js")],
-      label: "ai.openclaw.gateway",
-      plistPath,
-      port: 18789,
-      runtime: process.execPath,
-    };
+    const { deployment, lockPath, plistPath } = createManagedLaunchAgentFixture(root, mirror);
     const events: string[] = [];
 
     await expect(
@@ -1945,20 +1954,7 @@ console.log(JSON.stringify({ ok: true, channels: {} }));
     async () => {
       const { root, mirror } = makeFixture();
       writeBuild(mirror);
-      const lockPath = path.join(root, "maintenance.lock");
-      const plistPath = path.join(root, "ai.openclaw.gateway.plist");
-      writeFileSync(plistPath, "plist\n", { mode: 0o600 });
-      const deployment = {
-        configPath: path.join(root, "openclaw.json"),
-        entrypoint: path.join(mirror, "dist/index.js"),
-        entrypointIndex: 1,
-        executable: process.execPath,
-        invocationPrefix: [path.join(mirror, "dist/index.js")],
-        label: "ai.openclaw.gateway",
-        plistPath,
-        port: 18789,
-        runtime: process.execPath,
-      };
+      const { deployment, lockPath } = createManagedLaunchAgentFixture(root, mirror);
       const blocker = spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
         detached: true,
         stdio: "ignore",
@@ -2048,20 +2044,7 @@ console.log(JSON.stringify({ ok: true, channels: {} }));
   test("retains a manual-recovery lock when Windows timeout cleanup is unverified", async () => {
     const { root, mirror } = makeFixture();
     writeBuild(mirror);
-    const lockPath = path.join(root, "maintenance.lock");
-    const plistPath = path.join(root, "ai.openclaw.gateway.plist");
-    writeFileSync(plistPath, "plist\n", { mode: 0o600 });
-    const deployment = {
-      configPath: path.join(root, "openclaw.json"),
-      entrypoint: path.join(mirror, "dist/index.js"),
-      entrypointIndex: 1,
-      executable: process.execPath,
-      invocationPrefix: [path.join(mirror, "dist/index.js")],
-      label: "ai.openclaw.gateway",
-      plistPath,
-      port: 18789,
-      runtime: process.execPath,
-    };
+    const { deployment, lockPath } = createManagedLaunchAgentFixture(root, mirror);
     const events: string[] = [];
 
     await expect(


### PR DESCRIPTION
## What Problem This Solves

Three adjacent live-updater tests repeated the same maintenance lock path, LaunchAgent plist creation and mode, and managed gateway deployment object. The tests protect distinct recovery outcomes, but their deployment setup was maintenance-only duplication.

## Why This Change Was Made

A file-local `createManagedLaunchAgentFixture` now creates a fresh deployment object and plist for each test. The successful post-timeout recovery, live POSIX process-group fail-closed path, and Windows indeterminate-cleanup manual-recovery path remain separate and retain all outcome, ordering, process, and lock assertions.

## User Impact

None. This is test-only fixture deduplication; updater behavior and production code are unchanged.

## Evidence

- Three focused timeout/recovery cases — passed.
- Changed-file gates — passed through the documented local fallback because no remote provider was ready.
- Root test typecheck, formatting, Docker E2E boundary lint, and raw HTTP/2 import guard — passed.
- `git diff --check` and structured autoreview — clean.
- Test delta: -17 lines. No production, workflow, docs, changelog, schema, protocol, migration, or operator-state change.
