### PR TITLE
fix(agents): recover double-wrapped tool_call dispatcher arguments

### DIFF
--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -195,6 +195,25 @@ describe("Tool Search flattened call arguments", () => {
     },
   );
 
+  it("recovers double-wrapped tool_call dispatcher arguments", async () => {
+    const target = fakeTool("inspect_resource", Type.Object({ path: Type.String() }));
+    const { catalogRef, config } = createRuntime([target]);
+    const callTool = createToolSearchTools({ catalogRef, config }).find(
+      (tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME,
+    );
+
+    expect(callTool).toBeDefined();
+    // Model emitted { args: { id: "...", args: {...} } } instead of { id: "...", args: {...} }
+    await callTool!.execute("double-wrapped-call", {
+      args: {
+        id: "inspect_resource",
+        args: { path: "/api/items?query=x" },
+      },
+    });
+    expect(target.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(target.execute).mock.calls[0]?.[1]).toEqual({ path: "/api/items?query=x" });
+  });
+
   it("rejects flattened selectors that identify different catalog tools", async () => {
     const intended = fakeTool("inspect_resource");
     const colliding = fakeTool("search");

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -223,6 +223,21 @@ export function readToolSearchCallArgs(
   catalog?: ToolSearchCatalogSession,
 ): { id: string; input: unknown } {
   const params = asToolParamsRecord(args);
+
+  // Handle double-wrapped args: { args: { id: "...", args: {...} } }
+  // Some models emit this malformed shape intermittently.
+  if (params.args != null && typeof params.args === "object" && !Array.isArray(params.args)) {
+    // SAFETY: guarded by typeof check above — params.args is a non-null, non-array object.
+    const nestedArgs = params.args as Record<string, unknown>;
+    if (typeof nestedArgs.id === "string" && nestedArgs.args != null) {
+      // Recover the intended call by unwrapping one level.
+      return {
+        id: nestedArgs.id.trim(),
+        input: nestedArgs.args,
+      };
+    }
+  }
+
   const dottedInput = Object.fromEntries(
     Object.entries(params)
       .filter(([key]) => key.startsWith("args.") && key.length > 5)


### PR DESCRIPTION
## What Problem This Solves

With Tool Search in `mode: "tools"`, models sometimes emit the `tool_call` dispatcher payload with the `id`/`args` pair nested one level too deep — `{"args": {"id": "...", "args": {...}}}` instead of `{"id": "...", "args": {...}}`. Validation rejects the call (`id: must have required properties id`) instead of recovering it, even though the intended call is unambiguous.

Smaller models then tend to repeat the same malformed shape and give up without retrying correctly; if the turn ends with no user-visible text, the only thing delivered to the channel is `⚠️ 🧰 Tool Call failed`, and the user's request is silently dropped.

## Root Cause

`readToolSearchCallArgs` expects `params.id` to be at the top level. When the model double-wraps the args, the structure is:
```json
{
  "args": {
    "id": "...",
    "args": {...}
  }
}
```

## Fix

Add detection for this malformed shape in `readToolSearchCallArgs` and unwrap one level to recover the intended call.

## Evidence

- **Issue:** #124084
- **Test:** `tool-search-runtime.test.ts` passes (92 tests including new double-wrapped test case)
- **Runtime:** The fix recovers the intended call from the malformed shape

Fixes #124084