### PR TITLE
fix(control-ui): new-session picker reads the configured models.list catalog (#124008)

### DIFF
--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -37,6 +37,7 @@ function requestHasParam(request: { params?: unknown }, key: string, value: unkn
 const TERMINAL_START_FEATURE_METHODS = [
   "chat.metadata",
   "chat.startup",
+  "models.list",
   "sessions.catalog.list",
   "sessions.catalog.startTerminal",
   "sessions.create",
@@ -450,7 +451,7 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       agentModel: "openai/gpt-5.6-luna",
       methodResponses: {
-        "chat.metadata": {
+        "models.list": {
           sequence: [
             {
               __mockError: {
@@ -458,7 +459,7 @@ suite.define(() => {
                 message: "metadata request timed out",
               },
             },
-            { commands: [], models },
+            { models },
           ],
         },
       },
@@ -467,7 +468,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
-      await gateway.waitForRequest("chat.metadata");
+      await gateway.waitForRequest("models.list");
 
       const modelSelect = page.locator('[data-chat-model-select="true"]');
       await expect.poll(() => modelSelect.textContent()).toContain("Models unavailable");
@@ -479,7 +480,7 @@ suite.define(() => {
 
       await page.locator('[data-chat-model-catalog-retry="true"]').click();
 
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
       await expect.poll(() => page.locator("[data-chat-model-option]").count()).toBe(3);
       expect(await page.locator('[data-chat-model-catalog-state="error"]').count()).toBe(0);
     } finally {
@@ -503,7 +504,7 @@ suite.define(() => {
     };
     const gateway = await installMockGateway(page, {
       methodResponses: {
-        "chat.metadata": {
+        "models.list": {
           sequence: [
             {
               __mockError: {
@@ -514,7 +515,7 @@ suite.define(() => {
                 retryAfterMs: 100,
               },
             },
-            { commands: [], models: [recoveredModel] },
+            { models: [recoveredModel] },
           ],
         },
       },
@@ -522,7 +523,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
 
       const modelSelect = page.locator(
         '.new-session-page__composer [data-chat-model-select="true"]',
@@ -532,9 +533,9 @@ suite.define(() => {
         .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
         .toContain(recoveredModel.name);
 
-      expect(await gateway.getRequests("chat.metadata")).toEqual([
-        expect.objectContaining({ params: { agentId: "main" } }),
-        expect.objectContaining({ params: { agentId: "main" } }),
+      expect(await gateway.getRequests("models.list")).toEqual([
+        expect.objectContaining({ params: { agentId: "main", view: "configured" } }),
+        expect.objectContaining({ params: { agentId: "main", view: "configured" } }),
       ]);
     } finally {
       await context.close();

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -18,6 +18,7 @@ export { controlUiSessionPath, controlUiSessionUrl, waitForConfirmModal };
 const NEW_SESSION_FEATURE_METHODS = [
   "chat.metadata",
   "chat.startup",
+  "models.list",
   "sessions.create",
   "sessions.dispatch",
 ] as const;

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -501,6 +501,7 @@ suite.define(() => {
       featureMethods: [
         "chat.metadata",
         "chat.startup",
+        "models.list",
         "projects.list",
         "sessions.create",
         "users.prefs.get",
@@ -599,6 +600,7 @@ suite.define(() => {
           featureMethods: [
             "chat.metadata",
             "chat.startup",
+            "models.list",
             "fs.listDir",
             "projects.list",
             "sessions.create",
@@ -701,6 +703,7 @@ suite.define(() => {
         featureMethods: [
           "chat.metadata",
           "chat.startup",
+          "models.list",
           "sessions.create",
           "users.prefs.get",
           "users.prefs.set",
@@ -750,15 +753,15 @@ suite.define(() => {
 
       await navigateInApp(page, "chat");
       await waitForCommittedChatRoute(page);
-      const metadataRequests = (await gateway.getRequests("chat.metadata")).length;
+      const catalogRequests = (await gateway.getRequests("models.list")).length;
       const branchRequests = (await gateway.getRequests("worktrees.branches")).length;
-      await gateway.deferNext("chat.metadata");
+      await gateway.deferNext("models.list");
       await gateway.deferNext("worktrees.branches");
       await navigateInApp(page, "new-session");
       await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
       await expect
-        .poll(async () => (await gateway.getRequests("chat.metadata")).length)
-        .toBe(metadataRequests + 1);
+        .poll(async () => (await gateway.getRequests("models.list")).length)
+        .toBe(catalogRequests + 1);
       await expect
         .poll(async () => (await gateway.getRequests("worktrees.branches")).length)
         .toBe(branchRequests + 1);
@@ -767,7 +770,7 @@ suite.define(() => {
       const start = page.getByRole("button", { name: "Start session" });
       await expect.poll(() => start.isDisabled()).toBe(true);
 
-      await gateway.resolveDeferred("chat.metadata", { models });
+      await gateway.resolveDeferred("models.list", { models });
       await expect.poll(() => start.isDisabled()).toBe(true);
       await gateway.rejectDeferred("worktrees.branches", {
         code: "UNAVAILABLE",
@@ -850,6 +853,7 @@ suite.define(() => {
         featureMethods: [
           "chat.metadata",
           "chat.startup",
+          "models.list",
           "fs.listDir",
           "sessions.create",
           "worktrees.branches",

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -234,7 +234,7 @@ describe("new-session model runtime", () => {
     pending.resolve({ models: [] });
   });
 
-  it("waits for selected-agent defaults after chat metadata resolves", async () => {
+  it("waits for selected-agent defaults after the model catalog resolves", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", reasoning: true },
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
@@ -336,7 +336,7 @@ describe("new-session model runtime", () => {
 
   it.each([
     ["generic transport error", new Error("metadata unavailable")],
-    ["request timeout", new Error("gateway request timeout for chat.metadata")],
+    ["request timeout", new Error("gateway request timeout for models.list")],
   ])("renders %s as unavailable instead of a default-only catalog", async (_label, error) => {
     const { context, request } = contextWith([]);
     request.mockRejectedValueOnce(error);
@@ -765,8 +765,8 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
     await vi.waitFor(() =>
       expect(request).toHaveBeenCalledWith(
-        "chat.metadata",
-        { agentId: "main" },
+        "models.list",
+        { agentId: "main", view: "configured" },
         expect.objectContaining({
           signal: expect.any(AbortSignal),
         }),
@@ -779,6 +779,36 @@ describe("new-session model runtime", () => {
         cloudPlacementSupported: true,
         source: "model",
       });
+    });
+  });
+
+  it("requests the configured catalog so dynamically discovered providers reach the picker", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "zai-fast", name: "ZAI Fast", provider: "zai" },
+      { id: "gemini-3-pro", name: "Gemini 3 Pro", provider: "google" },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+    ];
+    const { context, request } = contextWith(models);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        "models.list",
+        { agentId: "main", view: "configured" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+    await vi.waitFor(() => {
+      const container = renderControl(control, context);
+      expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(3);
+      expect(
+        container.querySelector('[data-chat-model-option="google/gemini-3-pro"]'),
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-chat-model-option="openai/gpt-5.6-sol"]'),
+      ).not.toBeNull();
     });
   });
 
@@ -938,16 +968,16 @@ describe("new-session model runtime", () => {
     expect(attemptTimes.at(-1)).toBe(startedAt + 58_000);
     expect(request).toHaveBeenNthCalledWith(
       1,
-      "chat.metadata",
-      { agentId: "main" },
+      "models.list",
+      { agentId: "main", view: "configured" },
       {
         signal: expect.any(AbortSignal),
         timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
       },
     );
     expect(request).toHaveBeenLastCalledWith(
-      "chat.metadata",
-      { agentId: "main" },
+      "models.list",
+      { agentId: "main", view: "configured" },
       {
         signal: expect.any(AbortSignal),
         timeoutMs: 2_000,

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -87,7 +87,7 @@ function waitForMetadataRetry(delayMs: number, signal: AbortSignal): Promise<voi
   });
 }
 
-async function requestNewSessionMetadata(
+async function requestNewSessionModelCatalog(
   client: NewSessionMetadataClient,
   agentId: string,
   signal: AbortSignal,
@@ -105,13 +105,17 @@ async function requestNewSessionMetadata(
       if (latestStartupError !== undefined) {
         throw latestStartupError;
       }
-      throw new Error("New-session metadata retry deadline elapsed");
+      throw new Error("New-session model catalog retry deadline elapsed");
     }
 
     try {
+      // The picker needs the same configured inventory as the explicit control-plane
+      // read. chat.metadata stays prepared-only so a slow provider cannot delay chat
+      // startup; models.list view=configured performs discovery when the prepared
+      // catalog lacks dynamically discovered providers.
       return await client.request<{ models?: ModelCatalogEntry[] }>(
-        "chat.metadata",
-        { agentId },
+        "models.list",
+        { agentId, view: "configured" },
         {
           signal,
           timeoutMs: Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, remainingMs),
@@ -335,7 +339,7 @@ export class NewSessionModelControl {
       status: this.metadataState.hasSnapshot ? "refreshing" : "loading",
     });
 
-    void requestNewSessionMetadata(client, agentId, controller.signal).then(
+    void requestNewSessionModelCatalog(client, agentId, controller.signal).then(
       (result) => {
         // Aborted transports may still resolve. Only the request that still
         // owns the control may publish catalog data or restore preferences.
@@ -620,7 +624,7 @@ export class NewSessionModelControl {
       loading: false,
       modelCatalog: this.catalog,
       modelCatalogState: {
-        // chat.metadata and agents.list hydrate independently. Do not expose a
+        // The model catalog and agents.list hydrate independently. Do not expose a
         // ready catalog until the selected agent can supply its concrete defaults.
         hasSnapshot: agentDefaultsAvailable && this.metadataState.hasSnapshot,
         ...(this.metadataState.status === "error" ? { onRetry: this.retryMetadata } : {}),

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -206,6 +206,7 @@ const defaultControlUiFeatureMethods = [
   "config.set",
   "device.scopes.requestUpgrade",
   "device.scopes.waitUpgrade",
+  "models.list",
   "session.members.add",
   "session.members.list",
   "session.members.remove",


### PR DESCRIPTION
## What Problem

The New Session model picker reads `chat.metadata`, whose model catalog projection is intentionally prepared-only (`preloadedOnly: true` in `src/gateway/server-methods/chat-metadata-runtime.ts`). That projection only contains rows present in the prepared runtime snapshot — statically authored models. Providers configured without authored model rows (e.g. Google with auth but no authored rows, OpenAI via an OAuth/Codex route) are discovered only by the explicit control-plane catalog read, so the New Session page shows a subset of the usable models while `models.list view=configured` returns the full set (37 vs 15 in the report).

`ui/src/pages/new-session/model-control.ts` is the only New Session consumer of `chat.metadata`, and it uses only the `models` field of the response — the picker's selectable catalog.

## Why

`chat.metadata` must stay fast and prepared-only: live provider discovery on chat startup would let a slow provider delay chat startup (the explicit contract documented at `chat-metadata-runtime.ts:225-226`). The picker, however, needs the same configured inventory that the explicit control-plane read (`models.list view=configured`) already returns for the same agent. Reusing that read for this picker fixes the gap without changing chat startup timing. `models.list` is already advertised by the Gateway, already consumed by other Control UI surfaces (cron, gateway diagnostics, model providers), and returns the identical `ModelChoice` projection shape the picker already renders.

## User Impact

Operators configuring providers without authored model rows (Google auth-only, OpenAI OAuth/Codex routes) now see those dynamically discovered models in the New Session model picker, matching `models.list view=configured`. No change to `chat.metadata` semantics for the chat page or startup; no new gateway methods.

## Evidence

Focused unit suite (34/34 pass, including the new regression test asserting the picker requests `models.list` with `view: "configured"` and renders google/openai/zai entries):

```text
 RUN  v4.1.10 /home/0668001400/AI/code/openclaw

 ✓  unit  src/pages/new-session/model-control.test.ts (34 tests) 1937ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
   Start at  08:36:04
   Duration  5.48s (transform 1.40s, setup 131ms, import 1.57s, tests 1.94s, environment 1.63s)
```

Full new-session unit suite (23 files, 225 tests, all green):

```text
 Test Files  23 passed (23)
      Tests  225 passed (225)
   Start at  08:36:55
   Duration  9.57s (transform 8.39s, setup 1.11s, import 11.72s, tests 7.37s, environment 33.59s)
```

Red/green: with the production change stashed, the new regression test fails (request went to `chat.metadata` with `{ agentId }` only):

```text
 Test Files  1 failed (1)
      Tests  1 failed | 33 skipped (34)
```

Typecheck (`tsc --noEmit`), `oxlint` (0 warnings / 0 errors on the 5 changed files), and `oxfmt --check` (all matched files use the correct format) all clean.

[AI-assisted]