### PR TITLE
refactor(version): remove obsolete define injection

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,4 +1,5 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it without owner approval.
 # Worker bundle installation no longer injects OPENCLAW_STATE_DIR into a remote npm process.
-502
+# The retired compile-time version define no longer contributes OPENCLAW_VERSION.
+501

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -8,8 +8,8 @@ import { parseViewerPayloadJson } from "./viewer-payload.js";
 // oxlint-disable-next-line eslint/no-underscore-dangle -- Bundled builds replace this compile-time define identifier.
 declare const __OPENCLAW_DIFFS_LANGUAGE_PACK__: boolean | undefined;
 
-// Build-time esbuild define; typeof guard keeps the module loadable where the
-// define is absent (vitest/node), matching the __OPENCLAW_VERSION__ pattern.
+// Build-time esbuild define; the typeof guard keeps the module loadable when
+// the define is absent under Vitest or direct Node execution.
 function readInjectedLanguagePackFlag(): boolean | undefined {
   return typeof __OPENCLAW_DIFFS_LANGUAGE_PACK__ === "boolean"
     ? __OPENCLAW_DIFFS_LANGUAGE_PACK__

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,7 +1,7 @@
 // Tests package version resolution and generated version metadata.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createSuiteTempRootTracker } from "./test-helpers/temp-dir.js";
 import {
@@ -52,14 +52,6 @@ function expectVersionMetadataToBeMissing(moduleUrl: string) {
 }
 
 describe("version resolution", () => {
-  it("keeps bundled version injection as a direct define identifier", async () => {
-    const source = await fs.readFile(fileURLToPath(new URL("./version.ts", import.meta.url)), {
-      encoding: "utf-8",
-    });
-    expect(source).toContain("typeof __OPENCLAW_VERSION__");
-    expect(source).toContain("? __OPENCLAW_VERSION__");
-  });
-
   it("resolves package version from nested dist/plugin-sdk module URL", async () => {
     await withVersionFixtureDir(async (root) => {
       await writeJsonFixture(root, "package.json", { name: "openclaw", version: "1.2.3" });
@@ -130,14 +122,6 @@ describe("version resolution", () => {
     await withVersionFixtureDir(async (root) => {
       await writeJsonFixture(root, "package.json", { name: "openclaw", version: "2.3.4" });
       const moduleUrl = await ensureModuleFixture(root);
-      expect(
-        resolveBinaryVersion({
-          moduleUrl,
-          injectedVersion: "9.9.9",
-          bundledVersion: "8.8.8",
-          fallback: "0.0.0",
-        }),
-      ).toBe("9.9.9");
       expect(
         resolveBinaryVersion({
           moduleUrl,

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,8 +2,6 @@
 import { createRequire } from "node:module";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-// oxlint-disable-next-line eslint/no-underscore-dangle -- Bundled builds replace this compile-time define identifier.
-declare const __OPENCLAW_VERSION__: string | undefined;
 const CORE_PACKAGE_NAME = "openclaw";
 
 const PACKAGE_JSON_CANDIDATES = [
@@ -77,10 +75,6 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
   return undefined;
 }
 
-function readInjectedVersion(): string | undefined {
-  return typeof __OPENCLAW_VERSION__ === "string" ? __OPENCLAW_VERSION__ : undefined;
-}
-
 export function readVersionFromPackageJsonForModuleUrl(moduleUrl: string): string | null {
   return readVersionFromJsonCandidates(moduleUrl, PACKAGE_JSON_CANDIDATES, {
     requirePackageName: true,
@@ -104,12 +98,10 @@ export function resolveVersionFromModuleUrl(moduleUrl: string): string | null {
 
 export function resolveBinaryVersion(params: {
   moduleUrl: string;
-  injectedVersion?: string;
   bundledVersion?: string;
   fallback?: string;
 }): string {
   return (
-    firstNonEmpty(params.injectedVersion) ||
     resolveVersionFromModuleUrl(params.moduleUrl) ||
     firstNonEmpty(params.bundledVersion) ||
     params.fallback ||
@@ -186,10 +178,9 @@ export function resolveCompatibilityHostVersion(
 }
 
 // Single source of truth for the current OpenClaw version.
-// - Embedded/bundled builds: injected define or env var.
+// - Embedded/bundled builds: bundled-version env var.
 // - Dev/npm builds: package.json.
 export const VERSION = resolveBinaryVersion({
   moduleUrl: import.meta.url,
-  injectedVersion: readInjectedVersion(),
   bundledVersion: process.env.OPENCLAW_BUNDLED_VERSION,
 });

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -239,7 +239,6 @@ describe("production lint suppressions", () => {
         "src/tasks/task-registry.sqlite.shared.ts|typescript/no-unnecessary-type-parameters|1",
         "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/version.ts|eslint/no-underscore-dangle|1",
         "ui/public/sw.js|unicorn/require-post-message-target-origin|1",
         // oxlint misreads CanvasRenderingContext2D.fill(path) as Array.fill.
         "ui/src/components/mascot-canvas.ts|unicorn/no-array-fill-with-reference-type|1",


### PR DESCRIPTION
## What Problem This Solves

`src/version.ts` retained a compile-time `__OPENCLAW_VERSION__` define from the removed Bun/macOS relay packaging path. No tracked build, packaging, application, or script supplies that define anymore, but a source-string test and an injected helper argument kept the dead branch alive.

## Why This Change Was Made

The obsolete declaration, reader, resolver argument/precedence branch, and source-mirror test are deleted. Supported version ownership remains unchanged: package/build-info metadata for normal builds and `OPENCLAW_BUNDLED_VERSION` for the Node launcher/bundled path. After `main` independently lowered the env-surface ratchet to 502, this removal lowers it again to 501; the diffs viewer comment also no longer cites the removed pattern.

## User Impact

None for supported builds. Package, build-info, launcher, and bundled-environment version resolution remain intact.

## Evidence

- Version, CLI fast-path, and entrypoint owner suites — 19 passed.
- Lint-suppression ratchet guard — 4 passed after removing the retired `src/version.ts` expectation.
- Changed-file gates, core/extension typechecks, lint, boundaries, native schema guard, and env ratchet — passed through the documented local fallback.
- Full `pnpm build` — passed.
- Real `pnpm openclaw --version` wrapper — `OpenClaw 2026.8.1`.
- Structured autoreview — clean at 0.98 for the branch and 0.99 for the CI repair; `git diff --check` is clean.
- Exact-head CI — green on `0b813e45b5fc26f2725289892b04079437b626a9` in run [31918806828](https://github.com/openclaw/openclaw/actions/runs/31918806828). The preceding run exposed and motivated the stale lint-suppression allowlist deletion.
- Production delta: -9 lines. Tests: -17 lines. Tooling ratchet/comments: -2 net lines. No docs, changelog, schema, protocol, migration, or operator-state change.
