### PR TITLE
fix(ui): no-op the second reconcile of the same sessions.changed event

### DIFF
--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -89,6 +89,33 @@ test("sessions.changed removes a label when the event carries null", () => {
   expect(reconciled.result?.sessions[0]?.displayName).toBeUndefined();
 });
 
+test("reconciling the same sessions.changed twice keeps result identity on the second pass", () => {
+  const result: SessionsListResult = {
+    ts: 1,
+    path: "",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 1 }],
+  };
+  const payload = {
+    sessionKey: "agent:main:main",
+    reason: "patch",
+    updatedAt: 2,
+    label: "Renamed",
+  };
+
+  const first = reconcileSessionChanged(result, payload);
+  expect(first.applied).toBe(true);
+  expect(first.result).not.toBe(result);
+  expect(first.result?.sessions[0]?.label).toBe("Renamed");
+
+  // The capability handler and the chat page both drive the same event; the
+  // second reconcile must return the identical result object so downstream
+  // result === state.result publish gates skip the duplicate re-render.
+  const second = reconcileSessionChanged(first.result ?? null, payload);
+  expect(second.result).toBe(first.result);
+});
+
 test("sessions.changed deletes every null-tombstoned field, not a hand-kept list", () => {
   // The gateway tombstones more fields than the old per-field cascade knew
   // about; these five leaked literal null into rows typed optional-not-null.

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -195,6 +195,27 @@ function stripThinkingMetadata<T extends ThinkingMetadataCarrier>(value: T): T {
   return next;
 }
 
+/** Same-content merge detection; row values are wire scalars/plain objects, so one level suffices. */
+function isShallowEqualSessionRow(
+  incoming: GatewaySessionRow,
+  existing: GatewaySessionRow,
+): boolean {
+  const incomingKeys = Object.keys(incoming);
+  if (incomingKeys.length !== Object.keys(existing).length) {
+    return false;
+  }
+  return incomingKeys.every((key) => {
+    const a = (incoming as Record<string, unknown>)[key];
+    const b = (existing as Record<string, unknown>)[key];
+    return (
+      a === b ||
+      (a !== null && b !== null && typeof a === "object" && typeof b === "object"
+        ? JSON.stringify(a) === JSON.stringify(b)
+        : false)
+    );
+  });
+}
+
 function isOlderSessionSnapshot(
   incoming: GatewaySessionRow,
   existing: GatewaySessionRow | undefined,
@@ -549,6 +570,16 @@ export function reconcileSessionHistory(
   if (isStaleForActiveSession(visibleSession, existing)) {
     // Keep result identity when nothing changed so the caller's
     // result === state.result publish gate can skip a spurious re-render.
+    return defaults ? { ...result, defaults: nextDefaults } : result;
+  }
+  if (
+    existing &&
+    isShallowEqualSessionRow(visibleSession, existing) &&
+    sessionMatchesArchivedFilter(visibleSession, archivedFilter)
+  ) {
+    // The same event reconciled twice (capability handler + chat page) must
+    // no-op the second pass; a fresh array here defeats every downstream
+    // result === state.result publish gate and re-renders per event.
     return defaults ? { ...result, defaults: nextDefaults } : result;
   }
   const sessions = sessionMatchesArchivedFilter(visibleSession, archivedFilter)


### PR DESCRIPTION
## What Problem This Solves

Every `sessions.changed` event is reconciled twice in the Control UI — once by the session capability's own `subscribeEvents` handler and once by the chat page's `reconcileSessionEvent` (both drive `reconcileChanged` on the same payload). `reconcileSessionHistory` always built a fresh sessions array, so the second, content-identical pass produced a new result object every time — defeating every downstream `result === state.result` publish gate and firing a duplicate sidebar re-render (full listener storm) per event. The existing `isOlderSessionSnapshot` strict-`<` guard cannot catch this: the duplicate pass carries the same `updatedAt`.

## Why This Change Was Made

The merge now returns the original result identity when the merged visible row is content-equal to the existing row. One equality gate at the owner (the merge) fixes all consumers, instead of teaching each caller to dedupe. Comparison is shallow with a structural fallback for nested values — rows are wire scalars and plain objects, so one level suffices; the helper documents that contract.

## User Impact

One sidebar re-render per session event instead of two; idle viewers with busy sessions stop paying a duplicate publish/listener pass per message.

## Evidence

- New regression test drives the same `sessions.changed` payload through `reconcileSessionChanged` twice and asserts second-pass result identity — **fails pre-fix** (stash proof), passes post-fix.
- `node scripts/run-vitest.mjs run ui/src/lib/sessions ui/src/pages/chat/chat-state.test.ts` — full sweep: 9082 UI tests green (633 files).
- `pnpm tsgo:ui`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.99).

Production LOC +31 (the equality gate + contract comments); tests +27.
