### PR TITLE
fix(ui): recover authorized deep links after Control UI updates

### DIFF
--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -50,7 +50,10 @@ export function isStaleChunkImportError(error: unknown): boolean {
 }
 
 function reloadControlUiDocument(): void {
-  window.location.reload();
+  const url = new URL(window.location.href);
+  // The pre-app mount recovery strips this one-shot cache buster before bootstrap.
+  url.searchParams.set("openclaw_mount_recovery", String(Date.now()));
+  window.location.replace(url.href);
 }
 
 function sessionStorageOrNull(): Pick<Storage, "getItem" | "setItem"> | null {

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -100,14 +100,14 @@ suite.define(() => {
       await route.abort("internetdisconnected");
     };
     await page.route(frenchLocaleModule, abortFrenchLocale);
-    let navigationCount = 0;
+    let documentRequestCount = 0;
 
     try {
       const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
-      page.on("framenavigated", (frame) => {
-        if (frame === page.mainFrame()) {
-          navigationCount += 1;
+      page.on("request", (request) => {
+        if (request.resourceType() === "document") {
+          documentRequestCount += 1;
         }
       });
       await page.locator(".settings-row__title", { hasText: "Language" }).waitFor();
@@ -128,7 +128,7 @@ suite.define(() => {
       await page.locator(".settings-row__title", { hasText: "Language" }).waitFor();
       await page.locator(".settings-page").waitFor();
       expect(await documentMarker(page)).toBe("same-document");
-      expect(navigationCount).toBe(0);
+      expect(documentRequestCount).toBe(0);
 
       await page.unroute(frenchLocaleModule, abortFrenchLocale);
       await reconnect(page, gateway);
@@ -137,14 +137,14 @@ suite.define(() => {
         .locator(".settings-row__title", { hasText: "Langue" })
         .waitFor({ timeout: 10_000 });
       expect(await documentMarker(page)).toBeUndefined();
-      expect(navigationCount).toBe(1);
+      expect(documentRequestCount).toBe(1);
       expect(
         await page.evaluate(() =>
           sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId"),
         ),
       ).toBe("e2e");
       await page.waitForTimeout(500);
-      expect(navigationCount).toBe(1);
+      expect(documentRequestCount).toBe(1);
       expect(new URL(page.url()).pathname).toBe("/settings/appearance");
     } finally {
       await page.unroute(frenchLocaleModule, abortFrenchLocale);

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -78,7 +78,10 @@ suite.define(() => {
       }
       await route.continue();
     });
-    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["connect"],
+      sessionKey: "agent:example-agent:example-session",
+    });
     const mismatch = {
       code: "UNAVAILABLE",
       message: "Control UI updated; reload this page to continue",

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -59,6 +59,59 @@ async function closeContext(context: BrowserContext): Promise<void> {
 }
 
 suite.define(() => {
+  it("cache-busts stale-build recovery on a first dashboard navigation", async () => {
+    const context = await suite.browser.newContext({
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const documentRequests: Array<{ fresh: boolean; pathname: string }> = [];
+    const appOrigin = new URL(suite.server.baseUrl).origin;
+    await page.route(`${appOrigin}/**`, async (route) => {
+      const request = route.request();
+      if (request.resourceType() === "document") {
+        const url = new URL(request.url());
+        documentRequests.push({
+          fresh: url.searchParams.has("openclaw_mount_recovery"),
+          pathname: url.pathname,
+        });
+      }
+      await route.continue();
+    });
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const mismatch = {
+      code: "UNAVAILABLE",
+      message: "Control UI updated; reload this page to continue",
+      details: {
+        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        gatewayBuildId: "replacement-build",
+        reloadRequired: true,
+      },
+      retryable: false,
+    };
+    const target = new URL("dashboard/example-agent/example-session", suite.server.baseUrl);
+
+    try {
+      await page.goto(target.href);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", mismatch);
+
+      await expect.poll(() => documentRequests.length).toBe(2);
+      await gateway.waitForRequest("connect");
+      expect(documentRequests).toEqual([
+        { fresh: false, pathname: target.pathname },
+        { fresh: true, pathname: target.pathname },
+      ]);
+      await gateway.resolveDeferred("connect");
+
+      await page.locator("openclaw-app-shell").waitFor();
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+      await expect.poll(() => page.url()).toBe(target.href);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
   it("reloads once for a build rejection, then keeps visible recovery guidance", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();

--- a/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
+++ b/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
@@ -100,10 +100,10 @@ suite.define(() => {
           path: path.join(artifactDir, "failure.png"),
         });
 
-        let navigationCount = 0;
-        page.on("framenavigated", (frame) => {
-          if (frame === page.mainFrame()) {
-            navigationCount += 1;
+        let documentRequestCount = 0;
+        page.on("request", (request) => {
+          if (request.resourceType() === "document") {
+            documentRequestCount += 1;
           }
         });
         markDocumentReachable();
@@ -112,13 +112,13 @@ suite.define(() => {
         await alert.waitFor();
         await page.waitForTimeout(500);
         expect(await alert.count()).toBe(1);
-        expect(navigationCount).toBe(1);
+        expect(documentRequestCount).toBe(1);
 
         await alert.getByRole("button", { name: "Reload" }).click();
         await page.locator(".logbook").waitFor();
         expect(await alert.count()).toBe(0);
         expect(assetRequests).toBeGreaterThan(2);
-        expect(navigationCount).toBe(2);
+        expect(documentRequestCount).toBe(2);
         await gateway.waitForRequest("logbook.status");
         await page.screenshot({
           fullPage: true,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening a hosted deep-dashboard URL after a Gateway or Control UI update could see the generic connection/login screen even though their existing browser device authorization remained valid.

## Why This Change Was Made

The stale-document recovery first probed the document with `no-store`, but then used an ordinary reload that could reuse the same stale representation. The one-per-build guard then suppressed another automatic repair. Canonical document recovery now uses the already-owned one-shot `openclaw_mount_recovery` cache buster and replacement navigation; the pre-app shell strips the temporary parameter before bootstrap.

## User Impact

Existing authorized browser sessions recover automatically after an update instead of asking users for Gateway credentials. The original deep dashboard path is preserved and the final URL remains clean.

## Evidence

- Sanitized live observation: the first load of a hosted deep dashboard fell through to the generic connection/login form, while a hard reload immediately restored the already-authorized application shell without credentials.
- Mocked-Gateway browser regression: the first deep dashboard navigation receives `CONTROL_UI_BUILD_MISMATCH`; the second document request carries the one-shot cache buster; reconnect succeeds; the authenticated app shell appears without the login gate; the deep path is preserved; and the temporary query parameter is removed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/login-gate.e2e.test.ts ui/src/e2e/mount-recovery.e2e.test.ts` — 10/10 passed on the original patch.
- After the first exact-head CI run exposed history-cleanup events in sibling navigation counters, the focused four-suite browser run passed 13/13. The sibling tests now count real document requests, and the deep route fixture names the session owned by the mock Gateway.
- `node scripts/run-vitest.mjs ui/src/app/stale-chunk-reload.test.ts ui/src/app/mount-fallback.test.ts ui/src/app/gateway-store.test.ts ui/src/app/app-host.test.ts` — 113/113 passed.
- Source-blind behavior validation reran the login-gate E2E twice — 9/9 passed on both runs.
- `node scripts/check-changed.mjs -- ui/src/app/stale-chunk-reload.ts ui/src/e2e/login-gate.e2e.test.ts` — passed all selected gates. Crabbox/Testbox routing found no ready remote provider, so the approved trusted-source fallback ran locally.
- `git diff --check` passed. Fresh uncommitted autoreview was clean on the original patch and again after the CI repair, with no accepted or actionable findings.
- Production LOC: +4/-1 (net +3). Tests: +69/-13 (net +56). The small production growth applies the existing pre-bootstrap recovery contract at the stale-document owner boundary.

The original screenshot is conversation-only and cannot be safely attached from this environment. This is a navigation/cache semantic change rather than a visual redesign; the mocked-Gateway browser regression included in this PR is the executable behavior proof. No before/after images are claimed.

Release-note context for future generated changelog: the Control UI now recovers authorized deep-dashboard sessions after deployments without prompting users for Gateway credentials.
