### PR TITLE
fix(gateway): omit internal class names from RPC failures

### DIFF
--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -16,9 +16,11 @@ describe("formatErrorMessage", () => {
   it("walks and deduplicates Error cause chains while preserving codes", () => {
     const root = Object.assign(new Error("socket closed"), { code: "ECONNRESET" });
     const inner = new Error("request failed", { cause: root });
-    const outer = new Error("request failed", { cause: inner });
+    const outer = Object.assign(new Error("request failed", { cause: inner }), {
+      code: "REQUEST_FAILED",
+    });
 
-    expect(format(outer)).toBe("request failed | socket closed | ECONNRESET");
+    expect(format(outer)).toBe("request failed | REQUEST_FAILED | socket closed | ECONNRESET");
   });
 
   it("formats status/code records and structured non-Error causes", () => {

--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -20,7 +20,10 @@ describe("formatErrorMessage", () => {
       code: "REQUEST_FAILED",
     });
 
-    expect(format(outer)).toBe("request failed | REQUEST_FAILED | socket closed | ECONNRESET");
+    expect(format(outer)).toBe("request failed | socket closed | ECONNRESET");
+    expect(formatErrorMessage(outer, { includeCode: true, redact: keepText })).toBe(
+      "request failed | REQUEST_FAILED | socket closed | ECONNRESET",
+    );
   });
 
   it("formats status/code records and structured non-Error causes", () => {

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -1,6 +1,7 @@
 // Structural formatting stays policy-free. Core and memory-host adapters intentionally inject
 // owner-specific redactors; bypassing them would weaken redaction and break one-argument APIs.
 export type FormatErrorMessageOptions = {
+  includeCode?: boolean;
   redact: (text: string) => string;
 };
 
@@ -79,29 +80,33 @@ export function formatErrorMessage(value: unknown, options: FormatErrorMessageOp
     let cause = readProperty(value, "cause");
     const seen = new Set<unknown>([value]);
     const seenMessages = new Set<string>([formatted]);
-    const appendDetail = (detail: unknown): void => {
-      if (typeof detail !== "string" && typeof detail !== "number") {
+    const appendCauseMessage = (message: string | undefined): void => {
+      if (!message || seenMessages.has(message)) {
         return;
       }
-      const text = String(detail);
-      if (!text || seenMessages.has(text)) {
-        return;
-      }
-      formatted += ` | ${text}`;
-      seenMessages.add(text);
+      formatted += ` | ${message}`;
+      seenMessages.add(message);
     };
-    appendDetail(readProperty(value, "code"));
+    if (options.includeCode) {
+      const code = readProperty(value, "code");
+      if (typeof code === "string" || typeof code === "number") {
+        appendCauseMessage(String(code));
+      }
+    }
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {
-        appendDetail(cause.message);
-        appendDetail(readProperty(cause, "code"));
+        appendCauseMessage(cause.message);
+        const code = readProperty(cause, "code");
+        if (typeof code === "string" || typeof code === "number") {
+          appendCauseMessage(String(code));
+        }
         cause = readProperty(cause, "cause");
       } else if (typeof cause === "string") {
-        appendDetail(cause);
+        appendCauseMessage(cause);
         break;
       } else {
-        appendDetail(formatStatusAndCode(cause));
+        appendCauseMessage(formatStatusAndCode(cause));
         break;
       }
     }

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -79,27 +79,29 @@ export function formatErrorMessage(value: unknown, options: FormatErrorMessageOp
     let cause = readProperty(value, "cause");
     const seen = new Set<unknown>([value]);
     const seenMessages = new Set<string>([formatted]);
-    const appendCauseMessage = (message: string | undefined): void => {
-      if (!message || seenMessages.has(message)) {
+    const appendDetail = (detail: unknown): void => {
+      if (typeof detail !== "string" && typeof detail !== "number") {
         return;
       }
-      formatted += ` | ${message}`;
-      seenMessages.add(message);
+      const text = String(detail);
+      if (!text || seenMessages.has(text)) {
+        return;
+      }
+      formatted += ` | ${text}`;
+      seenMessages.add(text);
     };
+    appendDetail(readProperty(value, "code"));
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {
-        appendCauseMessage(cause.message);
-        const code = readProperty(cause, "code");
-        if (typeof code === "string" || typeof code === "number") {
-          appendCauseMessage(String(code));
-        }
+        appendDetail(cause.message);
+        appendDetail(readProperty(cause, "code"));
         cause = readProperty(cause, "cause");
       } else if (typeof cause === "string") {
-        appendCauseMessage(cause);
+        appendDetail(cause);
         break;
       } else {
-        appendCauseMessage(formatStatusAndCode(cause));
+        appendDetail(formatStatusAndCode(cause));
         break;
       }
     }

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -14,7 +14,7 @@ describe("live model error helpers", () => {
     expect(isModelNotFoundErrorMessage("The model gpt-foo does not exist.")).toBe(true);
     expect(
       isModelNotFoundErrorMessage(
-        "FailoverError: The selected model was not found by the provider. Check the model id or choose a different model.",
+        "The selected model was not found by the provider. Check the model id or choose a different model.",
       ),
     ).toBe(true);
     expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1670,7 +1670,7 @@ describe("capability cli", () => {
       runCapability("image", "describe", "--file", "photo.jpg", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
-      `Error: No description returned for image: ${path.resolve("photo.jpg")}`,
+      `No description returned for image: ${path.resolve("photo.jpg")}`,
     ]);
   });
 
@@ -1877,7 +1877,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "Error: --output-format must be one of png, jpeg, or webp",
+      "--output-format must be one of png, jpeg, or webp",
     );
 
     mocks.runtime.error.mockClear();
@@ -1893,7 +1893,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "Error: --openai-background must be one of transparent, opaque, or auto",
+      "--openai-background must be one of transparent, opaque, or auto",
     );
 
     mocks.runtime.error.mockClear();
@@ -1909,7 +1909,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "Error: --background must be one of transparent, opaque, or auto",
+      "--background must be one of transparent, opaque, or auto",
     );
 
     mocks.runtime.error.mockClear();
@@ -1925,7 +1925,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "Error: --quality must be one of low, medium, high, or auto",
+      "--quality must be one of low, medium, high, or auto",
     );
 
     mocks.runtime.error.mockClear();
@@ -1941,7 +1941,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "Error: --openai-moderation must be one of low or auto",
+      "--openai-moderation must be one of low or auto",
     );
   });
 
@@ -2662,7 +2662,7 @@ describe("capability cli", () => {
       runCapability("audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
-      `Error: No transcript returned for audio: ${path.resolve("memo.m4a")}`,
+      `No transcript returned for audio: ${path.resolve("memo.m4a")}`,
     ]);
   });
 
@@ -2691,7 +2691,7 @@ describe("capability cli", () => {
     await expect(
       runCapability("audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
-    expect(runtimeErrorMessages()).toEqual(["Error: Audio transcription response missing text"]);
+    expect(runtimeErrorMessages()).toEqual(["Audio transcription response missing text"]);
   });
 
   it("forwards transcription prompt and language hints", async () => {

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -55,7 +55,8 @@ describe("runCommandWithRuntime", () => {
     );
 
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toContain("TypeError: fetch failed");
+    expect(messages[0]).toContain("fetch failed");
+    expect(messages[0]).not.toContain("TypeError:");
     expect(messages[0]).toContain("invalid onRequestStart method");
     expect(messages[0]).toContain("UND_ERR_INVALID_ARG");
     expect(exits).toEqual([1]);

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -32,13 +32,6 @@ export async function withManager<T>(params: {
   }
 }
 
-function formatCommandRuntimeError(err: unknown): string {
-  if (err instanceof Error) {
-    return formatErrorMessage(new Error(String(err), { cause: err.cause }));
-  }
-  return formatErrorMessage(err);
-}
-
 export async function runCommandWithRuntime(
   runtime: { error: (message: string) => void; exit: (code: number) => void },
   action: () => Promise<void>,
@@ -51,7 +44,7 @@ export async function runCommandWithRuntime(
       onError(err);
       return;
     }
-    runtime.error(formatCommandRuntimeError(err));
+    runtime.error(formatErrorMessage(err));
     runtime.exit(1);
   }
 }

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -156,7 +156,20 @@ describe("gateway-cli coverage", () => {
     await expectGatewayExit(["gateway", "call", "health", "--timeout", "1000ms", "--json"]);
 
     expect(callGateway).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Gateway call failed: Error: Invalid --timeout");
+    expect(runtimeErrors.join("\n")).toContain("Gateway call failed: Invalid --timeout");
+  });
+
+  it("renders gateway request failures without the client error class in human mode", async () => {
+    const error = Object.assign(new Error("invalid audit.activity.list params"), {
+      name: "GatewayClientRequestError",
+      gatewayCode: "INVALID_REQUEST",
+    });
+    callGateway.mockRejectedValueOnce(error);
+
+    await expectGatewayExit(["gateway", "call", "audit.activity.list"]);
+
+    expect(runtimeErrors.join("\n")).toContain("invalid audit.activity.list params");
+    expect(runtimeErrors.join("\n")).not.toContain("GatewayClientRequestError");
   });
 
   it("registers gateway probe and routes to gatewayStatusCommand", async () => {

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -329,7 +329,7 @@ describe("gateway register option collisions", () => {
 
     expect(callGatewayCli).not.toHaveBeenCalled();
     expect(defaultRuntime.error).toHaveBeenCalledWith(
-      "Gateway call failed: Error: Use either --url or --port, not both.",
+      "Gateway call failed: Use either --url or --port, not both.",
     );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
 import type { HealthSummary } from "../../commands/health.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import type {
   DiagnosticStabilityBundle,
@@ -151,7 +152,7 @@ async function runGatewayCommand(
         return;
       }
     }
-    const message = String(err);
+    const message = formatErrorMessage(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);
     defaultRuntime.exit(1);
   }

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -391,9 +391,7 @@ describe("rejected CLI process state isolation", () => {
       pristineHome: true,
     });
 
-    expect(result.stderr).toContain(
-      "--gateway-port must be an integer between 1 and 65535.",
-    );
+    expect(result.stderr).toContain("--gateway-port must be an integer between 1 and 65535.");
     await expect(fs.access(path.join(result.root, `.openclaw-${profile}`))).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -392,7 +392,7 @@ describe("rejected CLI process state isolation", () => {
     });
 
     expect(result.stderr).toContain(
-      "Error: --gateway-port must be an integer between 1 and 65535.",
+      "--gateway-port must be an integer between 1 and 65535.",
     );
     await expect(fs.access(path.join(result.root, `.openclaw-${profile}`))).rejects.toMatchObject({
       code: "ENOENT",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -434,6 +434,7 @@ describe("agent command registration", () => {
         "The selected model was not found by the provider. Check the model id or choose a different model.";
       const error = Object.assign(new Error(message), {
         name: "GatewayClientRequestError",
+        code: "UNAVAILABLE",
         gatewayCode: "UNAVAILABLE",
         details: { reason: "model_not_found" },
       });
@@ -441,7 +442,7 @@ describe("agent command registration", () => {
 
       await runCli(args);
 
-      expect(runtime.error).toHaveBeenCalledWith(message);
+      expect(runtime.error).toHaveBeenCalledWith(`${message} | UNAVAILABLE`);
       expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("Error:"));
       expect(runtime.exit).toHaveBeenCalledWith(1);
     },

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -420,16 +420,30 @@ describe("agent command registration", () => {
 
     await runCli(["agents"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: list failed");
+    expect(runtime.error).toHaveBeenCalledWith("list failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("reports errors via runtime when agent command fails", async () => {
-    agentCliCommandMock.mockRejectedValueOnce(new Error("agent failed"));
+  it.each([
+    { label: "human", args: ["agent", "--message", "hello"] },
+    { label: "JSON", args: ["agent", "--message", "hello", "--json"] },
+  ])(
+    "renders gateway request errors without internal class names in $label mode",
+    async ({ args }) => {
+      const message =
+        "The selected model was not found by the provider. Check the model id or choose a different model.";
+      const error = Object.assign(new Error(message), {
+        name: "GatewayClientRequestError",
+        gatewayCode: "UNAVAILABLE",
+        details: { reason: "model_not_found" },
+      });
+      agentCliCommandMock.mockRejectedValueOnce(error);
 
-    await runCli(["agent", "--message", "hello"]);
+      await runCli(args);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: agent failed");
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-  });
+      expect(runtime.error).toHaveBeenCalledWith(message);
+      expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("Error:"));
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    },
+  );
 });

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -442,7 +442,7 @@ describe("agent command registration", () => {
 
       await runCli(args);
 
-      expect(runtime.error).toHaveBeenCalledWith(`${message} | UNAVAILABLE`);
+      expect(runtime.error).toHaveBeenCalledWith(message);
       expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("Error:"));
       expect(runtime.exit).toHaveBeenCalledWith(1);
     },

--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -60,7 +60,7 @@ describe("registerConfigureCommand", () => {
 
     await runCli(["configure"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: configure failed");
+    expect(runtime.error).toHaveBeenCalledWith("configure failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -107,7 +107,7 @@ describe("registerMaintenanceCommands doctor action", () => {
 
     await runMaintenanceCli(["doctor"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: doctor failed");
+    expect(runtime.error).toHaveBeenCalledWith("doctor failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(runtime.exit).not.toHaveBeenCalledWith(0);
   });
@@ -517,7 +517,7 @@ describe("registerMaintenanceCommands doctor action", () => {
 
     await runMaintenanceCli(["dashboard"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: dashboard failed");
+    expect(runtime.error).toHaveBeenCalledWith("dashboard failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -158,7 +158,7 @@ describe("registerOnboardCommand", () => {
       await runCli(["onboard", "--gateway-port", gatewayPort]);
 
       expect(runtime.error).toHaveBeenCalledWith(
-        "Error: --gateway-port must be an integer between 1 and 65535.",
+        "--gateway-port must be an integer between 1 and 65535.",
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(setupWizardCommandMock).not.toHaveBeenCalled();
@@ -269,7 +269,7 @@ describe("registerOnboardCommand", () => {
 
     await runCli(["onboard"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: setup failed");
+    expect(runtime.error).toHaveBeenCalledWith("setup failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -402,7 +402,7 @@ describe("registerSetupCommand", () => {
       await runCli(["setup", "--gateway-port", gatewayPort]);
 
       expect(runtime.error).toHaveBeenCalledWith(
-        "Error: --gateway-port must be an integer between 1 and 65535.",
+        "--gateway-port must be an integer between 1 and 65535.",
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(setupWizardCommandMock).not.toHaveBeenCalled();
@@ -544,7 +544,7 @@ describe("registerSetupCommand", () => {
 
     await runCli(["setup"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: setup failed");
+    expect(runtime.error).toHaveBeenCalledWith("setup failed");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -321,7 +321,7 @@ describe("audit command gateway compatibility", () => {
 
     await runCommandWithRuntime(runtime, () => auditListCommand({ limit: "10" }, runtime));
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: invalid audit activity params");
+    expect(runtime.error).toHaveBeenCalledWith("invalid audit activity params");
     expect(String(vi.mocked(runtime.error).mock.calls[0]?.[0])).not.toContain(
       "GatewayClientRequestError",
     );
@@ -340,7 +340,7 @@ describe("audit command gateway compatibility", () => {
     await runCommandWithRuntime(runtime, () => auditListCommand({ cursor: "abc" }, runtime));
 
     expect(runtime.error).toHaveBeenCalledWith(
-      "Error: --cursor must be a continuation token returned by a previous audit result.",
+      "--cursor must be a continuation token returned by a previous audit result.",
     );
     expect(String(vi.mocked(runtime.error).mock.calls[0]?.[0])).not.toContain(
       "audit.activity.list",

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -16,7 +16,7 @@ import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-termi
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
-import { readErrorName } from "../../infra/errors.js";
+import { formatErrorMessage, readErrorName } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import { mapAgentRunTerminalOutcomeToTaskStatus } from "../../tasks/task-registry-common.js";
@@ -296,7 +296,7 @@ export function dispatchAgentRunFromGateway(params: {
     })
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
-      const renderedErr = formatForLog(err);
+      const renderedErr = formatErrorMessage(err);
       const stopReason = aborted
         ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
         : isAbortError(err)
@@ -352,7 +352,7 @@ export function dispatchAgentRunFromGateway(params: {
       persistTerminalDedupe(settled);
       params.io.emitFinal([aborted && settled, payload, aborted && settled ? undefined : error], {
         runId: params.runId,
-        ...(aborted ? {} : { error: formatForLog(err) }),
+        ...(aborted ? {} : { error: renderedErr }),
       });
     })
     .finally(() => {

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -16,7 +16,7 @@ import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-termi
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
-import { formatErrorMessage, readErrorName } from "../../infra/errors.js";
+import { formatErrorMessageWithCode, readErrorName } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import { mapAgentRunTerminalOutcomeToTaskStatus } from "../../tasks/task-registry-common.js";
@@ -296,7 +296,7 @@ export function dispatchAgentRunFromGateway(params: {
     })
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
-      const renderedErr = formatErrorMessage(err, { includeCode: true });
+      const renderedErr = formatErrorMessageWithCode(err);
       const stopReason = aborted
         ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
         : isAbortError(err)

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -296,7 +296,7 @@ export function dispatchAgentRunFromGateway(params: {
     })
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
-      const renderedErr = formatErrorMessage(err);
+      const renderedErr = formatErrorMessage(err, { includeCode: true });
       const stopReason = aborted
         ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
         : isAbortError(err)

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -520,7 +520,7 @@ export function startAgentRunExecution(params: {
         claimId: execApprovalFollowupHandoffClaimId,
       });
     } catch (err) {
-      const renderedErr = formatErrorMessage(err);
+      const renderedErr = formatErrorMessage(err, { includeCode: true });
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       const payload = {
         runId: params.runId,

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -30,6 +30,7 @@ import {
 } from "../../auto-reply/reply/source-turn-id.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
@@ -519,11 +520,12 @@ export function startAgentRunExecution(params: {
         claimId: execApprovalFollowupHandoffClaimId,
       });
     } catch (err) {
-      const error = errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err));
+      const renderedErr = formatErrorMessage(err);
+      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       const payload = {
         runId: params.runId,
         status: "error" as const,
-        summary: formatForLog(err),
+        summary: renderedErr,
       };
       setGatewayDedupeEntries({
         dedupe: params.context.dedupe,
@@ -532,7 +534,7 @@ export function startAgentRunExecution(params: {
       });
       params.io.emitFinal([false, payload, error], {
         runId: params.runId,
-        error: formatForLog(err),
+        error: renderedErr,
       });
     } finally {
       if (!dispatched) {

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -30,7 +30,7 @@ import {
 } from "../../auto-reply/reply/source-turn-id.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { formatErrorMessage } from "../../infra/errors.js";
+import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
@@ -520,7 +520,7 @@ export function startAgentRunExecution(params: {
         claimId: execApprovalFollowupHandoffClaimId,
       });
     } catch (err) {
-      const renderedErr = formatErrorMessage(err, { includeCode: true });
+      const renderedErr = formatErrorMessageWithCode(err);
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       const payload = {
         runId: params.runId,

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { registerExecApprovalFollowupRuntimeHandoff } from "../../agents/bash-tools.exec-approval-followup-state.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import {
   addSubagentRunForTests,
@@ -694,7 +695,7 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           childSessionKey: "agent:main:main",
           status: "failed",
-          error: "Error: agent unavailable",
+          error: "agent unavailable",
         });
       });
     });
@@ -1077,7 +1078,7 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           childSessionKey: "agent:main:main",
           status: "cancelled",
-          error: "AbortError: This operation was aborted",
+          error: "This operation was aborted",
         });
         expectRecordFields(
           context.dedupe.get("agent:task-registry-agent-run-abort-error")?.payload,
@@ -1095,7 +1096,7 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("classifies an unsignaled AbortError task as cancelled without changing the error wire", async () => {
+  it("classifies an unsignaled AbortError task as cancelled without changing failure status", async () => {
     await withTestDir({ prefix: "openclaw-gateway-agent-task-plain-abort-" }, async (root) => {
       useTestStateDir(root);
       resetAgentTaskRegistryForTests();
@@ -1120,12 +1121,12 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           childSessionKey: "agent:main:main",
           status: "cancelled",
-          error: "AbortError: This operation was aborted",
+          error: "This operation was aborted",
         });
         expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
           runId,
           status: "error",
-          summary: "AbortError: This operation was aborted",
+          summary: "This operation was aborted",
         });
         expect(context.dedupe.get(`agent:${runId}`)?.ok).toBe(false);
       });
@@ -1201,7 +1202,7 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           childSessionKey: "agent:main:main",
           status: "timed_out",
-          error: "TimeoutError: chat run timed out",
+          error: "chat run timed out",
         });
         expectRecordFields(
           context.dedupe.get("agent:task-registry-agent-run-timeout-error")?.payload,
@@ -1251,7 +1252,7 @@ describe("gateway agent handler", () => {
             runtime: "cli",
             childSessionKey: "agent:main:main",
             status: "timed_out",
-            error: "FailoverError: fallback result classified terminal abort",
+            error: "fallback result classified terminal abort",
           });
           expectRecordFields(
             context.dedupe.get("agent:task-registry-agent-run-wrapped-timeout-error")?.payload,
@@ -1294,14 +1295,14 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           childSessionKey: "agent:main:main",
           status: "timed_out",
-          error: "TimeoutError: provider request timed out",
+          error: "provider request timed out",
         });
         expectRecordFields(
           context.dedupe.get("agent:task-registry-agent-run-provider-timeout")?.payload,
           {
             runId: "task-registry-agent-run-provider-timeout",
             status: "error",
-            summary: "TimeoutError: provider request timed out",
+            summary: "provider request timed out",
           },
         );
         expect(context.dedupe.get("agent:task-registry-agent-run-provider-timeout")?.ok).toBe(
@@ -1442,11 +1443,51 @@ describe("gateway agent handler", () => {
         terminalOutcome: {
           reason: "failed",
           status: "error",
-          error: "Error: provider request failed",
+          error: "provider request failed",
         },
         onRecovered: expect.any(Function),
       });
       expect(respond).toHaveBeenCalled();
+    });
+  });
+
+  it("emits provider failure messages without the internal error class name", async () => {
+    const message =
+      "The selected model was not found by the provider. Check the model id or choose a different model.";
+    mocks.agentCommand.mockRejectedValueOnce(
+      new FailoverError(message, {
+        reason: "model_not_found",
+        provider: "ollama",
+        model: "definitely-not-a-real-model:latest",
+      }),
+    );
+    const context = makeContext();
+    const respond = vi.fn();
+    const runId = "agent-run-model-not-found";
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "hi",
+        sessionKey: "agent:badmodel:main",
+        allowModelOverride: false,
+      },
+      runId,
+      dedupeKeys: [`agent:${runId}`],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      io: createAgentTurnIo(respond),
+      context,
+      taskTrackingMode: "none",
+    });
+
+    await waitForAssertion(() => {
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        { runId, status: "error", summary: message },
+        expect.objectContaining({ code: ErrorCodes.UNAVAILABLE, message }),
+        { runId, error: message },
+      );
+      expect(context.dedupe.get(`agent:${runId}`)?.error?.message).toBe(message);
     });
   });
 

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -5,6 +5,7 @@ import {
   collectErrorGraphCandidates,
   extractErrorCode,
   formatErrorMessage,
+  formatErrorMessageWithCode,
   formatUncaughtError,
   hasErrnoCode,
   isErrno,
@@ -150,9 +151,8 @@ describe("error helpers", () => {
   it("redacts sensitive tokens from formatted error messages", () => {
     const token = "sk-abcdefghijklmnopqrstuv";
     const formatted = formatErrorMessage(new Error(`Authorization: Bearer ${token}`));
-    const codeFormatted = formatErrorMessage(
+    const codeFormatted = formatErrorMessageWithCode(
       Object.assign(new Error("request failed"), { code: `token=${token}` }),
-      { includeCode: true },
     );
     expect(formatted).toContain("Authorization: Bearer");
     expect(formatted).not.toContain(token);

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -150,8 +150,14 @@ describe("error helpers", () => {
   it("redacts sensitive tokens from formatted error messages", () => {
     const token = "sk-abcdefghijklmnopqrstuv";
     const formatted = formatErrorMessage(new Error(`Authorization: Bearer ${token}`));
+    const codeFormatted = formatErrorMessage(
+      Object.assign(new Error("request failed"), { code: `token=${token}` }),
+      { includeCode: true },
+    );
     expect(formatted).toContain("Authorization: Bearer");
     expect(formatted).not.toContain(token);
+    expect(codeFormatted).toContain("request failed");
+    expect(codeFormatted).not.toContain(token);
   });
 
   it("redacts HTTP client config secrets from formatted error chains", () => {

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -54,11 +54,12 @@ export function collectErrorGraphCandidates(
   return candidates;
 }
 
-export function formatErrorMessage(err: unknown, options?: { includeCode?: boolean }): string {
-  return formatSharedErrorMessage(err, {
-    includeCode: options?.includeCode,
-    redact: redactSensitiveText,
-  });
+export function formatErrorMessage(err: unknown): string {
+  return formatSharedErrorMessage(err, { redact: redactSensitiveText });
+}
+
+export function formatErrorMessageWithCode(err: unknown): string {
+  return formatSharedErrorMessage(err, { includeCode: true, redact: redactSensitiveText });
 }
 
 export { stringifyNonErrorCause, toErrorObject } from "@openclaw/normalization-core/error-coercion";

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -54,8 +54,11 @@ export function collectErrorGraphCandidates(
   return candidates;
 }
 
-export function formatErrorMessage(err: unknown): string {
-  return formatSharedErrorMessage(err, { redact: redactSensitiveText });
+export function formatErrorMessage(err: unknown, options?: { includeCode?: boolean }): string {
+  return formatSharedErrorMessage(err, {
+    includeCode: options?.includeCode,
+    redact: redactSensitiveText,
+  });
 }
 
 export { stringifyNonErrorCause, toErrorObject } from "@openclaw/normalization-core/error-coercion";

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -340,6 +340,26 @@ describe("command queue", () => {
     ).toBe(true);
   });
 
+  it("logs error types separately from the actionable lane failure message", async () => {
+    const error = new Error("provider request failed");
+    error.name = "FailoverError";
+
+    await expect(
+      enqueueCommandInLane(CommandLane.Main, async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(diagnosticMocks.diag.error).toHaveBeenCalledWith(
+      expect.not.stringContaining("FailoverError:"),
+      expect.objectContaining({ errorName: "FailoverError" }),
+    );
+    expect(diagnosticMocks.diag.error).toHaveBeenCalledWith(
+      expect.stringContaining('error="provider request failed"'),
+      expect.any(Object),
+    );
+  });
+
   it.each([
     "session:probe-setup-inference:openai",
     "session:temp:setup-inference:probe-setup-inference-test-uuid",

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -1,6 +1,7 @@
 // Command queue serializes and limits process execution for shared command lanes.
 import { AsyncLocalStorage } from "node:async_hooks";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { formatErrorMessage, readErrorName } from "../infra/errors.js";
 import {
   diagnosticLogger as diag,
   logLaneDequeue,
@@ -465,7 +466,8 @@ function drainLane(lane: string) {
             const isProbeLane = isQuietProbeLane(lane);
             if (!isProbeLane && !isExpectedNonErrorLaneFailure(err)) {
               diag.error(
-                `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+                `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${formatErrorMessage(err)}"`,
+                { errorName: readErrorName(err) || undefined },
               );
             } else if (!isProbeLane) {
               diag.debug(


### PR DESCRIPTION
Related: #123929
Related: #124075

## What Problem This Solves

Gateway-backed CLI commands could surface internal JavaScript error class names before the useful failure message. A mistyped model id, for example, rendered as `GatewayClientRequestError: FailoverError: The selected model was not found by the provider...` in normal and `--json` modes.

The first repair removed those class names, but review caught a real regression: an `AcpRuntimeError` kept its message, cause, and redaction while losing the structured `ACP_TURN_FAILED` code that identifies the operator-visible failure.

## Why This Change Was Made

The agent Gateway producer was using the WebSocket diagnostic formatter as wire text; that formatter intentionally includes error names. The producer now uses the canonical redacting message formatter for response messages and summaries, while lane diagnostics retain the error type in a separate `errorName` field.

The shared CLI command wrapper also wrapped `String(err)` in a new error before formatting it, hiding the same prefix leak from earlier CLI sweeps. It now formats the original typed error directly. Generic Gateway subcommands keep their separate structured JSON path, including `code`, `details`, retryability, and retry delay fields.

Structured-code preservation uses the scoped producer approach (option 2). The normalization-core formatter supports opt-in top-level code inclusion, but the public core adapter remains a callback-safe one-argument `formatErrorMessage`; a dedicated `formatErrorMessageWithCode` helper is used only by the two Gateway agent-failure producers. The formatter appends the code before applying the owner redactor, so even a secret-bearing arbitrary code cannot bypass redaction.

The default asymmetry is intentional: nested cause codes remain useful chain detail everywhere, while a primary code is usually carried separately by its typed/JSON/protocol owner. The agent wire boundary is different because its generic protocol envelope is `UNAVAILABLE`; embedding the ACP runtime code in the human message is necessary to distinguish `ACP_TURN_FAILED`. Scoping that behavior preserves exact output for roughly 1,700 existing shared formatter calls and avoids adding `UNAVAILABLE`, errno, and transport suffixes to unrelated CLI messages.

## User Impact

Gateway and shared CLI failures begin with the actionable sentence instead of internal class names. ACP agent failures retain identifiers such as `ACP_TURN_FAILED`, cause details still reach the operator, and secrets remain redacted.

## Evidence

Before the original fix, a live isolated Ollama request produced:

```text
GatewayClientRequestError: FailoverError: The selected model was not found by the provider. Check the model id or choose a different model.
```

The follow-up ACP regression reproduced as:

```text
Internal error | upstream rejected token=sk-abc…3456
```

The final Gateway response contains `Internal error`, `ACP_TURN_FAILED`, and the redacted upstream cause without the original token. The JavaScript class name remains absent.

Final validation used rebased head `e4f375269f60f99c4bdc3d865e433f60dcd95f38`; its stable patch ID exactly matches merged commit `4b8ca98a940a76ebb2263b1448d539f7b7377dd0`.

- Focused Vitest command across normalization, infra, every changed CLI/Gateway/process surface, all three previously failing shard files, audit, and remaining direct formatter consumers: 887 tests passed across 9 shards.
- `node scripts/check-changed.mjs`: green formatting, production/test typechecks, lint, dead code, dependency/plugin boundaries, database-first, import cycles, schema, and policy guards on Blacksmith Testbox `tbx_01m04748tqw709mgrc0ad7fs4p` ([run](https://github.com/openclaw/openclaw/actions/runs/31922481715)).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted/actionable findings; patch judged correct at 0.99 confidence.
- Code-preservation sweep: default shared output changed in zero exact-string assertions and zero snapshots. One new exact assertion covers opt-in primary-code ordering. The prefix cleanup updated 19 stale generic `Error: ` expectations across CLI suites; each now matches canonical user-facing output.
- `help-exit.process` verdict: the reported third-shard failure was collateral exact-text drift, not a separate formatter defect. All 23 tests pass in the secretless CI-equivalent environment.
- `git diff --check`: clean. `CHANGELOG.md` is untouched.

Production LOC: +25/-16 (net +9), justified by the opt-in structured-code capability and callback-safe owner boundary. Tests/test support: +141/-42 (net +99).
