### PR TITLE
refactor(gateway): one owner for the submitted-config validation pipeline

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -516,42 +516,18 @@ function parseValidateConfigFromRawOrRespond(
         createMergePatch(snapshot.config, restored.result),
       )
     : restored.result;
-  const validationCandidate = normalizeSubmittedConfigModelRefs(
-    stripBundledProviderRuntimeDefaults({
-      candidate: projectedValidationCandidate,
-      sourceConfig: snapshot.sourceConfig,
-    }) as OpenClawConfig,
+  const validatedSubmission = validateSubmittedConfigOrRespond({
+    candidate: projectedValidationCandidate,
+    sourceConfig: snapshot.sourceConfig,
     modelIdNormalizationPolicies,
-  );
-  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
-  if (!sourceValidated.ok) {
-    respond(
-      false,
-      undefined,
-      errorShape(
-        ErrorCodes.INVALID_REQUEST,
-        summarizeConfigValidationIssues(sourceValidated.issues),
-        {
-          details: { issues: sourceValidated.issues },
-        },
-      ),
-    );
-    return null;
-  }
-  const validated = validateConfigObjectWithPlugins(validationCandidate);
-  if (!validated.ok) {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
-        details: { issues: validated.issues },
-      }),
-    );
+    respond,
+  });
+  if (!validatedSubmission) {
     return null;
   }
   return {
-    config: validated.config,
-    writeConfig: validationCandidate as OpenClawConfig,
+    config: validatedSubmission.config,
+    writeConfig: validatedSubmission.validationCandidate,
     schema,
   };
 }
@@ -593,6 +569,42 @@ function rejectDroppedAgentRosterEntries(params: {
     ),
   );
   return true;
+}
+
+/** Shared normalize -> raw-validate -> plugin-validate pipeline for submitted configs; responds on failure. */
+function validateSubmittedConfigOrRespond(params: {
+  candidate: unknown;
+  sourceConfig: OpenClawConfig | undefined;
+  modelIdNormalizationPolicies: Parameters<typeof normalizeSubmittedConfigModelRefs>[1];
+  respond: RespondFn;
+}): { validationCandidate: OpenClawConfig; config: OpenClawConfig } | null {
+  const validationCandidate = normalizeSubmittedConfigModelRefs(
+    stripBundledProviderRuntimeDefaults({
+      candidate: params.candidate,
+      sourceConfig: params.sourceConfig,
+    }) as OpenClawConfig,
+    params.modelIdNormalizationPolicies,
+  );
+  const respondInvalid = (issues: ReadonlyArray<ConfigValidationIssue>) => {
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(issues), {
+        details: { issues },
+      }),
+    );
+  };
+  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+  if (!sourceValidated.ok) {
+    respondInvalid(sourceValidated.issues);
+    return null;
+  }
+  const validated = validateConfigObjectWithPlugins(validationCandidate);
+  if (!validated.ok) {
+    respondInvalid(validated.issues);
+    return null;
+  }
+  return { validationCandidate: validationCandidate as OpenClawConfig, config: validated.config };
 }
 
 function summarizeConfigValidationIssues(issues: ReadonlyArray<ConfigValidationIssue>): string {
@@ -1080,48 +1092,25 @@ export const configHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    const validationCandidate = normalizeSubmittedConfigModelRefs(
-      stripBundledProviderRuntimeDefaults({
-        candidate: restoredMerge.result,
-        sourceConfig: snapshot.sourceConfig,
-      }) as OpenClawConfig,
+    const validatedSubmission = validateSubmittedConfigOrRespond({
+      candidate: restoredMerge.result,
+      sourceConfig: snapshot.sourceConfig,
       modelIdNormalizationPolicies,
-    );
-    const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
-    if (!sourceValidated.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          summarizeConfigValidationIssues(sourceValidated.issues),
-          {
-            details: { issues: sourceValidated.issues },
-          },
-        ),
-      );
+      respond,
+    });
+    if (!validatedSubmission) {
       return;
     }
-    const writeConfig = validationCandidate as OpenClawConfig;
-    const validated = validateConfigObjectWithPlugins(validationCandidate);
-    if (!validated.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
-          details: { issues: validated.issues },
-        }),
-      );
-      return;
-    }
+    const writeConfig = validatedSubmission.validationCandidate;
+    const validatedConfig = validatedSubmission.config;
     const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
-      config: validated.config,
+      config: validatedConfig,
       respond,
     });
     if (!preparedSecretsSnapshot) {
       return;
     }
-    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+    const changedPaths = diffConfigPaths(snapshot.config, validatedConfig);
 
     // No-op: if the validated config is identical to the current config,
     // skip the file write and SIGUSR1 restart entirely. This avoids a full
@@ -1130,7 +1119,7 @@ export const configHandlers: GatewayRequestHandlers = {
     if (changedPaths.length === 0) {
       respondConfigPatchNoop({
         snapshot,
-        config: validated.config,
+        config: validatedConfig,
         uiHints: schemaPatch.uiHints,
         actor,
         context,
@@ -1147,7 +1136,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
       prevConfig: snapshot.config,
       prevSourceConfig: snapshot.sourceConfig,
-      nextConfig: validated.config,
+      nextConfig: validatedConfig,
       preparedSecretsSnapshot,
     });
     const writeResult = await commitGatewayConfigWriteOrRespond({


### PR DESCRIPTION
## What Problem This Solves

`config.set` and `config.patch` each hand-rolled the same submitted-config validation pipeline — normalize model refs → strip bundled provider runtime defaults → raw-validate with plugins → plugin-validate → respond with summarized issues + structured details. Two copies of the same policy meant every change (like round-5's error-text improvement in #124127) had to be made twice, and the two blocks had already accumulated cosmetic drift.

## Why This Change Was Made

`validateSubmittedConfigOrRespond` now owns the pipeline; both handlers consume `{ validationCandidate, config }`. Behavior-neutral: same validators in the same order, same error shapes with `details.issues`, pinned by the existing 26 config tests (including the round-5 error-text regressions).

## User Impact

None visible — pure consolidation. Future validation-error improvements land in one place.

## Evidence

- `node scripts/run-vitest.mjs run src/gateway/server-methods/config.test.ts src/gateway/server-methods/server-methods.test.ts` — 238/238 green with **zero test edits** (the strongest behavior-neutrality proof for a consolidation).
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.99: "preserves the existing normalization and validation order, failure responses, and successful values").

Production LOC +56/−67 (net −11).
