### PR TITLE
refactor: remove prompt snapshot test facades

### DIFF
--- a/scripts/generate-prompt-snapshots.ts
+++ b/scripts/generate-prompt-snapshots.ts
@@ -5,10 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import {
-  CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR,
-  createHappyPathPromptSnapshotFiles,
-} from "../test/helpers/agents/happy-path-prompt-snapshots.js";
+import { createHappyPathPromptSnapshotFiles } from "../test/helpers/agents/happy-path-prompt-snapshots.js";
+import { CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR } from "../test/helpers/agents/prompt-snapshot-paths.js";
 import { coerceErrorMessage as describeError } from "./lib/error-format.mts";
 import {
   deleteStalePromptSnapshotFiles,
@@ -118,7 +116,7 @@ async function formatPromptSnapshotFiles(
   }
 }
 
-export async function createFormattedPromptSnapshotFiles(): Promise<PromptSnapshotFile[]> {
+async function createFormattedPromptSnapshotFiles(): Promise<PromptSnapshotFile[]> {
   const files = await createHappyPathPromptSnapshotFiles();
   return await formatPromptSnapshotFiles(factorCodexDynamicToolSnapshotFiles(files));
 }

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -38,8 +38,6 @@ import {
 
 // Builds Codex happy-path prompt snapshot fixtures for agent prompt regression tests.
 
-export { CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR };
-
 const WORKSPACE_DIR = "/tmp/openclaw-happy-path/workspace";
 const AGENT_DIR = "/tmp/openclaw-happy-path/agent";
 const SESSION_FILE = "/tmp/openclaw-happy-path/session.jsonl";

--- a/test/scripts/prompt-snapshots.test.ts
+++ b/test/scripts/prompt-snapshots.test.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import {
-  createFormattedPromptSnapshotFiles,
-  materializeCodexDynamicToolSnapshot,
-} from "../../scripts/generate-prompt-snapshots.js";
+import { materializeCodexDynamicToolSnapshot } from "../../scripts/generate-prompt-snapshots.js";
 import { deleteStalePromptSnapshotFiles } from "../../scripts/prompt-snapshot-files.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR as SYNC_CODEX_MODEL_PROMPT_FIXTURE_DIR,
@@ -36,10 +33,6 @@ function renderedPromptSection(content: string, heading: string, nextHeading: st
 }
 
 describe("happy path prompt snapshots", () => {
-  it("loads the generator entrypoint used by the prompt snapshot check", () => {
-    expect(createFormattedPromptSnapshotFiles).toEqual(expect.any(Function));
-  });
-
   it("reconstructs complete Codex tool catalogs from readable full-tool overrides", async () => {
     const generated = await createHappyPathPromptSnapshotFiles();
     const scenarios = [


### PR DESCRIPTION
## What Problem This Solves

Prompt snapshot maintenance retained a test that only asserted an internal generator export existed. That probe forced the formatted snapshot builder to remain public, while the generator also imported its fixture directory through a stale helper re-export instead of the owning paths module.

## Why This Change Was Made

The existence probe and helper re-export are deleted, the formatted snapshot builder is private to the executable generator again, and the generator reads the fixture directory from its canonical path owner. The real `prompt:snapshots:check` command remains the behavior boundary and continues to validate every committed generated artifact.

## User Impact

No user-visible behavior changes. Maintainers have less test-only API surface to preserve when reorganizing prompt snapshot generation.

## Evidence

- Rebased head: `0c54f337a96e6ee5035d4e542b25bc7f9a10c57a`; the three-file patch is unchanged and merges cleanly with current `main`.
- `pnpm test test/scripts/prompt-snapshots.test.ts` — 12 passed on the rebased commit.
- `pnpm prompt:snapshots:check` — 7 generated files are current.
- Changed-file formatting, prompt drift, owner tests, script/root-test typechecks, script lint, boundaries, dependency guards, and temp-file checks — passed through the documented local fallback because Testbox was unavailable on the original host.
- `git diff --check` — clean.
- Fresh structured autoreview after rebase — clean, no actionable findings.
- Exact-head CI — green in [run 32155342057](https://github.com/openclaw/openclaw/actions/runs/32155342057).
- Direct Codex source inspection confirmed dynamic-tool schema/registration and turn instruction ownership remain unchanged.
- Net change: 4 additions, 15 deletions across tooling, tests, and test support; no production runtime, docs, changelog, schema, protocol, migration, dependency, or operator-state change.

AI-assisted maintainer cleanup.