### PR TITLE
fix(gateway): prevent idle CPU spikes on multi-agent hosts

### DIFF
--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -2,7 +2,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as sessionDirs from "../../agents/session-dirs.js";
 import {
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
@@ -615,14 +616,22 @@ describe("resolveAgentSessionStoreTargetsSync", () => {
     await withTempHome(async (home) => {
       const customRoot = path.join(home, "custom-state");
       const storePaths = await createAgentSessionStores(customRoot, ["main", "codex"]);
-      const cfg = createCustomRootCfg(customRoot, "main");
-
-      expect(resolveAgentSessionStoreTargetsSync(cfg, "codex", { env: process.env })).toEqual([
-        {
-          agentId: "codex",
-          storePath: storePaths.codex,
-        },
-      ]);
+      const cfg: OpenClawConfig = {
+        ...createCustomRootCfg(customRoot, "main"),
+        agents: { list: [{ id: "main", default: true }, { id: "codex" }] },
+      };
+      const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
+      try {
+        expect(resolveAgentSessionStoreTargetsSync(cfg, "codex", { env: process.env })).toEqual([
+          {
+            agentId: "codex",
+            storePath: storePaths.codex,
+          },
+        ]);
+        expect(enumerateAgentDirs).not.toHaveBeenCalled();
+      } finally {
+        enumerateAgentDirs.mockRestore();
+      }
     });
   });
 

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -575,6 +575,12 @@ export function resolveAgentSessionStoreTargetsSync(
     }
   }
 
+  // Configured agents own canonical direct paths; broad discovery is retired/manual-only.
+  // Falling through here makes per-agent Gateway prewarm scan the full roster quadratically.
+  if (isConfiguredSessionStoreAgentId(cfg, requested)) {
+    return dedupeTargetsByStorePath(targets);
+  }
+
   const { agentsRoots } = resolveSessionStoreDiscoveryState(cfg, env);
   for (const agentsDir of agentsRoots) {
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators with several configured agents could see a freshly started Gateway consume 100–140% idle CPU and 1.8–2.7 GB RSS, with intermittent HTTP, RPC, and WebSocket handshake timeouts.

On Molty's 11-agent installation, `strace` recorded about 27,684 failed `readlink` calls in 12 seconds and 8,735 path calls in 3 seconds. Gateway dashboard prewarm resolves session stores once per configured agent, while each resolution was unnecessarily enumerating every agent root and retired `sessions.json` path.

## Why This Change Was Made

Configured agents already own deterministic canonical session-store paths. After those direct targets are validated, the resolver now returns their deduplicated paths before broad filesystem discovery. Retired and manually created agents still use the existing broad discovery path unchanged.

This repairs the discovery owner directly and avoids adding a cache or downstream Gateway workaround. It does not change config schema, storage format, API, generated baselines, or canonical session ownership.

## User Impact

Multi-agent Gateways avoid quadratic session-store discovery during startup prewarm, reducing idle filesystem churn and the CPU/RSS pressure that could delay dashboard and protocol handshakes. Retired/manual agent discovery is preserved.

## Evidence

- Live Molty evidence: 11 agent databases; 100–140% idle CPU; 1.8–2.7 GB RSS; approximately 27,684 failed `readlink` calls in 12 seconds and 8,735 path calls in 3 seconds.
- Pre-fix regression: `src/config/sessions/targets.test.ts` failed 1/40 because `resolveAgentSessionDirsFromAgentsDirSync` was called twice (configured custom root plus default state root).
- Post-fix: `node scripts/run-vitest.mjs src/config/sessions/targets.test.ts` — 40/40 passed.
- Post-fix siblings: `node scripts/run-vitest.mjs src/gateway/server-startup-handler-prewarm.test.ts src/gateway/server.sessions.list-store-materialization.test.ts` — 12/12 passed.
- Targeted type-aware Oxlint, Oxfmt, and `git diff --check` passed.
- `node scripts/check-changed.mjs --dry-run -- src/config/sessions/targets.ts src/config/sessions/targets.test.ts` selected `core, coreTests`. The remote router's installed Crabbox binary failed its version/help sanity check before execution, so the documented trusted-source local fallback ran the identical changed gate; all guards, production/test typechecks, lint, and architecture checks passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed cleanly with no accepted/actionable findings on the final rebased head.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31919883652 — passed for `cd7a9d2dfe139e43a142a9e3df8d6b23ba917fec`.
- Production LOC: +6/−0. Tests: +18/−9.
- Screenshots: not applicable; this has no visual change.

### ClawSweeper review disposition

The P1 finding and both optional rank-up moves are intentionally skipped. The proposed `Retired Agent` → configured `retired-agent` case mixes two ownership modes: once an ID is configured, its runtime-owned store path is canonical and deterministic; broad normalized-directory discovery remains available for unconfigured retired/manual owners. No public config/data contract or observed installation was identified for treating a noncanonical directory as an additional store for an actively configured owner. Preserving that speculative runtime compatibility would retain the reported hot-path scan or require a broader prewarm target-planning redesign outside this focused repair. This boundary follows the repository's canonical-runtime/no-unowned-fallback doctrine and the task's explicit configured-versus-retired/manual ownership split.

AI-assisted: yes. The implementation and evidence were reviewed; no agent transcript is included.
