### PR TITLE
feat(ui): grid picker for session icons

### DIFF
--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -303,6 +303,9 @@ describe("session menu", () => {
     (submenu as SessionMenuItem & { submenuOpen: boolean }).submenuOpen = true;
 
     const choices = iconChoices(submenu);
+    expect(submenu.querySelector(".session-menu__icon-grid")?.getAttribute("role")).toBe(
+      "radiogroup",
+    );
     expect(choices.map((choice) => choice.textContent?.trim())).toEqual([
       "🦞",
       "🚀",
@@ -321,7 +324,7 @@ describe("session menu", () => {
     if (!current) {
       throw new Error("Expected the first icon choice");
     }
-    expect(current.getAttribute("role")).toBe("menuitemradio");
+    expect(current.getAttribute("role")).toBe("radio");
     expect(current.getAttribute("aria-checked")).toBe("true");
     expect(choices.filter((choice) => choice.tabIndex === 0)).toEqual([current]);
 

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -116,6 +116,10 @@ function menuItem(menu: ParentNode, label: string): SessionMenuItem {
   return item;
 }
 
+function iconChoices(menu: ParentNode): HTMLButtonElement[] {
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>(".session-menu__icon-choice"));
+}
+
 describe("session menu", () => {
   it("disables only denied mutation actions and ignores forced selection", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
@@ -292,34 +296,67 @@ describe("session menu", () => {
     expect(onAction).toHaveBeenCalledWith({ kind: "new-group" });
   });
 
-  it("offers emoji-only icon choices, marks the current icon, and dispatches set and remove", async () => {
+  it("renders the icon grid, marks the current icon, and dispatches set and remove", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
     const menu = await mountMenu({ session: { icon: "🦞" }, onAction });
     const submenu = menuItem(menu, "Set icon");
     (submenu as SessionMenuItem & { submenuOpen: boolean }).submenuOpen = true;
 
-    expect(menuItemLabels(submenu)).toEqual([
+    const choices = iconChoices(submenu);
+    expect(choices.map((choice) => choice.textContent?.trim())).toEqual([
       "🦞",
       "🚀",
       "🐛",
       "✅",
       "🔥",
-      "📝",
-      "⭐",
       "📦",
-      "Remove icon",
+      "🧪",
+      "📝",
+      "🔍",
+      "⚡",
+      "🎯",
+      "⭐",
     ]);
-    const current = menuItem(submenu, "🦞");
-    await current.updateComplete;
-    await Promise.resolve();
+    const current = choices[0];
+    if (!current) {
+      throw new Error("Expected the first icon choice");
+    }
     expect(current.getAttribute("role")).toBe("menuitemradio");
     expect(current.getAttribute("aria-checked")).toBe("true");
-    expect(current.querySelector(".session-menu__check")).not.toBeNull();
+    expect(choices.filter((choice) => choice.tabIndex === 0)).toEqual([current]);
 
-    menuItem(submenu, "🚀").click();
+    choices[1]?.click();
     expect(onAction).toHaveBeenCalledWith({ kind: "set-icon", icon: "🚀" });
-    menuItem(submenu, "Remove icon").click();
+    const remove = submenu.querySelector<HTMLButtonElement>(".session-menu__icon-remove");
+    expect(remove?.textContent?.trim()).toBe("Remove icon");
+    remove?.click();
     expect(onAction).toHaveBeenCalledWith({ kind: "set-icon", icon: null });
+  });
+
+  it("only renders Remove icon for a session with an icon", async () => {
+    const menu = await mountMenu();
+    const submenu = menuItem(menu, "Set icon");
+
+    expect(iconChoices(submenu)).toHaveLength(12);
+    expect(submenu.querySelector(".session-menu__icon-separator")).toBeNull();
+    expect(submenu.querySelector(".session-menu__icon-remove")).toBeNull();
+  });
+
+  it("moves icon-grid focus by cell and row with arrow keys", async () => {
+    const menu = await mountMenu({ session: { icon: "🚀" } });
+    const submenu = menuItem(menu, "Set icon");
+    const choices = iconChoices(submenu);
+    choices[1]?.focus();
+
+    choices[1]?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }),
+    );
+    expect(document.activeElement).toBe(choices[2]);
+    choices[2]?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+    );
+    expect(document.activeElement).toBe(choices[8]);
+    expect(choices.filter((choice) => choice.tabIndex === 0)).toEqual([choices[8]]);
   });
 
   it("omits Remove from group when the session has no category", async () => {

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -303,9 +303,7 @@ describe("session menu", () => {
     (submenu as SessionMenuItem & { submenuOpen: boolean }).submenuOpen = true;
 
     const choices = iconChoices(submenu);
-    expect(submenu.querySelector(".session-menu__icon-grid")?.getAttribute("role")).toBe(
-      "radiogroup",
-    );
+    expect(submenu.querySelector(".session-menu__icon-grid")?.getAttribute("role")).toBe("group");
     expect(choices.map((choice) => choice.textContent?.trim())).toEqual([
       "🦞",
       "🚀",
@@ -324,8 +322,10 @@ describe("session menu", () => {
     if (!current) {
       throw new Error("Expected the first icon choice");
     }
-    expect(current.getAttribute("role")).toBe("radio");
-    expect(current.getAttribute("aria-checked")).toBe("true");
+    // Click/Enter-only activation: pressed-state action grid, not radio semantics,
+    // so arrow keys may move focus without changing the persisted selection.
+    expect(current.getAttribute("role")).toBeNull();
+    expect(current.getAttribute("aria-pressed")).toBe("true");
     expect(choices.filter((choice) => choice.tabIndex === 0)).toEqual([current]);
 
     choices[1]?.click();

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -294,7 +294,7 @@ class SessionMenu extends OpenClawLightDomElement {
       <div slot="submenu" class="session-menu__icon-picker">
         <div
           class="session-menu__icon-grid"
-          role="radiogroup"
+          role="group"
           aria-label=${t("sessionsView.setIconMenu")}
           @keydown=${this.handleIconGridKeydown}
         >
@@ -304,8 +304,7 @@ class SessionMenu extends OpenClawLightDomElement {
               <button
                 type="button"
                 class="session-menu__icon-choice"
-                role="radio"
-                aria-checked=${String(checked)}
+                aria-pressed=${String(checked)}
                 tabindex=${icon === tabStop ? "0" : "-1"}
                 ?disabled=${this.actionDisabled("set-icon")}
                 title=${this.actionTitle("set-icon")}

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -291,15 +291,20 @@ class SessionMenu extends OpenClawLightDomElement {
     const tabStop =
       SESSION_ICON_CHOICES.find((icon) => icon === currentIcon) ?? SESSION_ICON_CHOICES[0];
     return html`
-      <div slot="submenu" class="session-menu__icon-picker" role="group">
-        <div class="session-menu__icon-grid" @keydown=${this.handleIconGridKeydown}>
+      <div slot="submenu" class="session-menu__icon-picker">
+        <div
+          class="session-menu__icon-grid"
+          role="radiogroup"
+          aria-label=${t("sessionsView.setIconMenu")}
+          @keydown=${this.handleIconGridKeydown}
+        >
           ${SESSION_ICON_CHOICES.map((icon) => {
             const checked = currentIcon === icon;
             return html`
               <button
                 type="button"
                 class="session-menu__icon-choice"
-                role="menuitemradio"
+                role="radio"
                 aria-checked=${String(checked)}
                 tabindex=${icon === tabStop ? "0" : "-1"}
                 ?disabled=${this.actionDisabled("set-icon")}
@@ -317,7 +322,6 @@ class SessionMenu extends OpenClawLightDomElement {
               <button
                 type="button"
                 class="session-menu__icon-remove"
-                role="menuitem"
                 ?disabled=${this.actionDisabled("set-icon")}
                 title=${this.actionTitle("set-icon")}
                 @click=${this.removeIcon}

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -59,7 +59,21 @@ const EMPTY_SESSION: SessionMenuData = {
   categoryClearReturnsToGroups: false,
 };
 
-const SESSION_ICON_CHOICES = ["🦞", "🚀", "🐛", "✅", "🔥", "📝", "⭐", "📦"] as const;
+const SESSION_ICON_CHOICES = [
+  "🦞",
+  "🚀",
+  "🐛",
+  "✅",
+  "🔥",
+  "📦",
+  "🧪",
+  "📝",
+  "🔍",
+  "⚡",
+  "🎯",
+  "⭐",
+] as const;
+const SESSION_ICON_GRID_COLUMNS = 6;
 
 class SessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) session: SessionMenuData = EMPTY_SESSION;
@@ -274,44 +288,102 @@ class SessionMenu extends OpenClawLightDomElement {
 
   private renderIconSubmenu() {
     const currentIcon = this.session.icon;
+    const tabStop =
+      SESSION_ICON_CHOICES.find((icon) => icon === currentIcon) ?? SESSION_ICON_CHOICES[0];
     return html`
-      ${SESSION_ICON_CHOICES.map((icon) => {
-        const checked = currentIcon === icon;
-        return html`
-          <wa-dropdown-item
-            slot="submenu"
-            class="session-menu__item"
-            value=${`set-icon:${encodeURIComponent(icon)}`}
-            role="menuitemradio"
-            aria-checked=${String(checked)}
-            ${ref((element) => syncDropdownItemRadio(element, checked))}
-            ?disabled=${this.actionDisabled("set-icon")}
-            title=${this.actionTitle("set-icon")}
-          >
-            <span class="session-menu__text">${icon}</span>
-            ${checked
-              ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-                  >${icons.check}</span
-                >`
-              : nothing}
-          </wa-dropdown-item>
-        `;
-      })}
-      ${currentIcon
-        ? html`
-            <wa-dropdown-item
-              slot="submenu"
-              class="session-menu__item"
-              value="set-icon:"
-              ?disabled=${this.actionDisabled("set-icon")}
-              title=${this.actionTitle("set-icon")}
-            >
-              <span class="session-menu__text">${t("sessionsView.removeIcon")}</span>
-            </wa-dropdown-item>
-          `
-        : nothing}
+      <div slot="submenu" class="session-menu__icon-picker" role="group">
+        <div class="session-menu__icon-grid" @keydown=${this.handleIconGridKeydown}>
+          ${SESSION_ICON_CHOICES.map((icon) => {
+            const checked = currentIcon === icon;
+            return html`
+              <button
+                type="button"
+                class="session-menu__icon-choice"
+                role="menuitemradio"
+                aria-checked=${String(checked)}
+                tabindex=${icon === tabStop ? "0" : "-1"}
+                ?disabled=${this.actionDisabled("set-icon")}
+                title=${this.actionTitle("set-icon")}
+                @click=${(event: MouseEvent) => this.selectIcon(event, icon)}
+              >
+                ${icon}
+              </button>
+            `;
+          })}
+        </div>
+        ${currentIcon
+          ? html`
+              <div class="session-menu__icon-separator" role="separator"></div>
+              <button
+                type="button"
+                class="session-menu__icon-remove"
+                role="menuitem"
+                ?disabled=${this.actionDisabled("set-icon")}
+                title=${this.actionTitle("set-icon")}
+                @click=${this.removeIcon}
+              >
+                ${t("sessionsView.removeIcon")}
+              </button>
+            `
+          : nothing}
+      </div>
     `;
   }
+
+  private readonly selectIcon = (event: MouseEvent, icon: string) => {
+    event.stopPropagation();
+    this.runAction({ kind: "set-icon", icon });
+  };
+
+  private readonly removeIcon = (event: MouseEvent) => {
+    event.stopPropagation();
+    this.runAction({ kind: "set-icon", icon: null });
+  };
+
+  private readonly handleIconGridKeydown = (event: KeyboardEvent) => {
+    const choice = event.target;
+    if (!(choice instanceof HTMLButtonElement)) {
+      return;
+    }
+    const offsets: Partial<Record<string, number>> = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+      ArrowUp: -SESSION_ICON_GRID_COLUMNS,
+      ArrowDown: SESSION_ICON_GRID_COLUMNS,
+    };
+    const offset = offsets[event.key];
+    if (offset === undefined) {
+      return;
+    }
+    const grid = event.currentTarget;
+    if (!(grid instanceof HTMLElement)) {
+      return;
+    }
+    const choices = Array.from(
+      grid.querySelectorAll<HTMLButtonElement>(".session-menu__icon-choice:not(:disabled)"),
+    );
+    const index = choices.indexOf(choice);
+    if (index < 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const nextIndex = (index + offset + choices.length) % choices.length;
+    choices.forEach((button, buttonIndex) => {
+      button.tabIndex = buttonIndex === nextIndex ? 0 : -1;
+    });
+    choices[nextIndex]?.focus();
+  };
+
+  private readonly focusIconGridOnOpen = (event: CustomEvent<{ item: HTMLElement }>) => {
+    const item = event.currentTarget;
+    if (!(item instanceof HTMLElement) || event.detail.item !== item) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      item.querySelector<HTMLButtonElement>('.session-menu__icon-choice[tabindex="0"]')?.focus();
+    });
+  };
 
   override render() {
     const menuWidth = 240;
@@ -414,6 +486,7 @@ class SessionMenu extends OpenClawLightDomElement {
                 aria-keyshortcuts="I"
                 ?disabled=${this.actionDisabled("set-icon")}
                 title=${this.actionTitle("set-icon")}
+                @submenu-opening=${this.focusIconGridOnOpen}
               >
                 <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.star}</span>
                 <span class="session-menu__text">${t("sessionsView.setIconMenu")}</span>

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2849,7 +2849,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   outline-offset: -2px;
 }
 
-.session-menu__icon-choice[aria-checked="true"] {
+.session-menu__icon-choice[aria-pressed="true"] {
   background: color-mix(in srgb, var(--accent) 14%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2814,6 +2814,75 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
+.session-menu__icon-picker {
+  padding: 2px;
+}
+
+.session-menu__icon-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 28px);
+  gap: 3px;
+}
+
+.session-menu__icon-choice {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--menu-item-radius);
+  background: transparent;
+  cursor: var(--cursor-action);
+  font-size: 17px;
+  line-height: 1;
+}
+
+.session-menu__icon-choice:hover,
+.session-menu__icon-choice:focus-visible {
+  background: var(--bg-hover);
+}
+
+.session-menu__icon-choice:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  outline-offset: -2px;
+}
+
+.session-menu__icon-choice[aria-checked="true"] {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.session-menu__icon-separator {
+  margin: 5px 4px 3px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+}
+
+.session-menu__icon-remove {
+  width: 100%;
+  min-height: 28px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: var(--menu-item-radius);
+  background: transparent;
+  color: var(--text);
+  cursor: var(--cursor-action);
+  font: inherit;
+  font-size: calc(13px * var(--control-ui-text-scale));
+  text-align: left;
+}
+
+.session-menu__icon-remove:hover,
+.session-menu__icon-remove:focus-visible {
+  background: var(--bg-hover);
+}
+
+.session-menu__icon-remove:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  outline-offset: -2px;
+}
+
 /* Nav rail entries are anchors (for middle-click/new-tab) but read as app
    chrome: override the UA link pointer back to the default arrow. */
 .nav-item {


### PR DESCRIPTION
Related: #124034

## What Problem This Solves

#124034 shipped Set icon as a single column of menu rows; the intended design is a compact grid. One emoji per row wastes space and scales poorly.

## Why This Change Was Made

This is the maintainer-requested design pass: a 6x2 grid of 12 emoji (all RGI-valid), roving-tabindex arrow-key navigation, accent highlighting on the active emoji, and a conditional Remove icon row. This is presentation-only; the set-icon action contract, gateway field, and agent tool are unchanged from #124034.

## User Impact

The Set icon submenu is now a compact grid, and the available emoji choices grew from 8 to 12.

## Evidence

![Session icon grid picker](https://github.com/user-attachments/assets/9480c9af-7d2d-4a98-9b0c-26025176680d)

https://github.com/user-attachments/assets/1130b658-9471-478e-9af5-81538ca202ca

- Session-menu tests: 34/34 passed.
- Focused session-menu and Web Awesome ownership tests after the CI repair: 37/37 passed.
- `check-changed`: exit 0 on the original implementation (local fallback; remote providers unavailable).
- Autoreview: clean (0.99) on the implementation and the CI repair.
- LOC: +233/-47 across 3 files, all in the Control UI.
