### PR TITLE
fix(workers): restore cloud workspace sync after bundle cutover

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -132,7 +132,7 @@ const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/version.json",
 ]);
 const MACOS_APP_CI_PATH_RE =
-  /^(?:apps\/(?:macos|macos-mlx-tts|shared|swabble)\/|Swabble\/|src\/(?:worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$|scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh$|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh$|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts$)/u;
+  /^(?:apps\/(?:macos|macos-mlx-tts|shared|swabble)\/|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$|scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh$|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh$|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts$)/u;
 let corepackPnpmShimDir: string | undefined;
 let corepackPnpmShimCleanupRegistered = false;
 let cachedGeneratedExtensionAssetPaths: Set<string> | undefined;

--- a/scripts/check-cli-bootstrap-imports.mts
+++ b/scripts/check-cli-bootstrap-imports.mts
@@ -6,9 +6,16 @@ import module from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse, type Node as AcornNode } from "acorn";
+import {
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+} from "../src/shared/worker-bundle-hash.js";
 
 const DEFAULT_ENTRYPOINTS = ["dist/entry.js", "dist/cli/run-main.js"];
-const WORKER_DEPLOY_ENTRYPOINT = "dist/worker/worker.mjs";
+const WORKER_DEPLOY_ENTRYPOINTS = [
+  `dist/worker/${WORKER_BUNDLE_ENTRY_PATH}`,
+  `dist/worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`,
+] as const;
 const DEFAULT_GATEWAY_RUN_CHUNK_MAX_BYTES = 70 * 1024;
 const GATEWAY_RUN_CHUNK_MARKER_SETS = [
   ["const GATEWAY_AUTH_MODES", "function addGatewayRunCommand"],
@@ -31,7 +38,6 @@ type CliBootstrapCheckParams = {
   entrypoints?: string[];
   distDir?: string;
   gatewayRunChunkMaxBytes?: number;
-  workerEntrypoint?: string;
   fs?: typeof fs;
   logger?: { error(message: string): void };
 };
@@ -350,26 +356,36 @@ export function collectGatewayRunChunkBudgetErrors(params: CliBootstrapCheckPara
 export function collectWorkerDeployArtifactErrors(params: CliBootstrapCheckParams = {}) {
   const rootDir = params.rootDir ?? process.cwd();
   const fsImpl = params.fs ?? fs;
-  const entrypoint = path.resolve(rootDir, params.workerEntrypoint ?? WORKER_DEPLOY_ENTRYPOINT);
-  const artifactDir = path.dirname(entrypoint);
-  const relativeEntrypoint = path.relative(rootDir, entrypoint) || entrypoint;
+  const entrypoints = WORKER_DEPLOY_ENTRYPOINTS.map((entrypoint) =>
+    path.resolve(rootDir, entrypoint),
+  );
+  const artifactDir = path.dirname(entrypoints[0]!);
+  const artifactNames = new Set(
+    entrypoints.flatMap((entrypoint) => {
+      const name = path.basename(entrypoint);
+      return [name, `${name}.map`];
+    }),
+  );
   const errors: string[] = [];
-  let source: string;
-  try {
-    const stats = fsImpl.lstatSync(entrypoint);
-    if (stats.isSymbolicLink() || !stats.isFile()) {
-      return [`Worker deploy artifact ${relativeEntrypoint} must be a regular file.`];
+  const sources: Array<{ relativeEntrypoint: string; source: string }> = [];
+  for (const entrypoint of entrypoints) {
+    const relativeEntrypoint = path.relative(rootDir, entrypoint) || entrypoint;
+    try {
+      const stats = fsImpl.lstatSync(entrypoint);
+      if (stats.isSymbolicLink() || !stats.isFile()) {
+        return [`Worker deploy artifact ${relativeEntrypoint} must be a regular file.`];
+      }
+      sources.push({
+        relativeEntrypoint,
+        source: fsImpl.readFileSync(entrypoint, "utf8"),
+      });
+    } catch {
+      return [`Worker deploy artifact ${relativeEntrypoint} is missing. Run pnpm build first.`];
     }
-    source = fsImpl.readFileSync(entrypoint, "utf8");
-  } catch {
-    return [`Worker deploy artifact ${relativeEntrypoint} is missing. Run pnpm build first.`];
   }
   try {
     for (const entry of fsImpl.readdirSync(artifactDir, { withFileTypes: true })) {
-      if (
-        entry.name === path.basename(entrypoint) ||
-        entry.name === `${path.basename(entrypoint)}.map`
-      ) {
+      if (artifactNames.has(entry.name)) {
         continue;
       }
       if (entry.name === "package.json") {
@@ -392,20 +408,23 @@ export function collectWorkerDeployArtifactErrors(params: CliBootstrapCheckParam
       `Worker deploy artifact directory ${path.relative(rootDir, artifactDir)} is unreadable.`,
     );
   }
-  try {
-    for (const specifier of listRuntimeImportSpecifiers(source)) {
-      if (!isBuiltinSpecifier(specifier)) {
+  for (const { relativeEntrypoint, source } of sources) {
+    try {
+      for (const specifier of listRuntimeImportSpecifiers(source)) {
+        if (isBuiltinSpecifier(specifier)) {
+          continue;
+        }
         errors.push(
           `Worker deploy artifact ${relativeEntrypoint} retains runtime import "${specifier}" instead of bundling it.`,
         );
       }
+    } catch (error) {
+      errors.push(
+        `Worker deploy artifact ${relativeEntrypoint} is not parseable JavaScript: ${
+          error instanceof Error ? error.message : String(error)
+        }.`,
+      );
     }
-  } catch (error) {
-    errors.push(
-      `Worker deploy artifact ${relativeEntrypoint} is not parseable JavaScript: ${
-        error instanceof Error ? error.message : String(error)
-      }.`,
-    );
   }
   return errors.toSorted((left, right) => left.localeCompare(right));
 }

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -48,7 +48,7 @@ const MACOS_NATIVE_RE =
 const MACOS_SCRIPT_SCOPE_RE =
   /^(?:scripts\/(?:check-swift-tools|codesign-mac-app|create-dmg|format-swift|install-swift-tools|install-xcodegen|lint-swift|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts)$/;
 const WORKSPACE_RSYNC_RECEIVER_SCOPE_RE =
-  /^src\/(?:worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$/;
+  /^src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$/;
 const IOS_BUILD_RE =
   /^(apps\/ios\/|apps\/shared\/|apps\/swabble\/|Swabble\/|scripts\/(?:check-swift-tools|format-swift|install-swift-tools|install-xcodegen|lint-swift)\.sh$|scripts\/(?:ios-(?:configure-signing|screenshots|team-id|write-version-xcconfig)\.sh|ios-write-swift-filelist\.m[jt]s|ios-version\.ts)$|scripts\/lib\/(?:ios-fastlane\.sh|ios-version\.ts|release-version\.mjs|version-script-args\.ts)$)/;
 const IOS_SCREENSHOT_APP_SCOPE_RE =

--- a/src/gateway/worker-environments/bootstrap.test.ts
+++ b/src/gateway/worker-environments/bootstrap.test.ts
@@ -188,7 +188,9 @@ describe("bootstrapWorker", () => {
     expect(runner.calls[2]?.options.input).toContain("lock=$lock_root/$hash");
     expect(runner.calls[2]?.options.input).toContain('ln -s "$lock_identity" "$lock"');
     expect(runner.calls[2]?.options.input).toContain("worker bundle archive digest mismatch");
-    expect(runner.calls[2]?.options.input).toContain('addFile("worker.mjs")');
+    expect(runner.calls[2]?.options.input).toContain(
+      'const artifactPaths = ["worker.mjs","workspace-rsync-receiver.mjs"]',
+    );
     expect(runner.calls[2]?.options.input).not.toContain('npm install --prefix "$staging"');
     expect(runner.calls[2]?.options.input).toContain("worker install content does not match");
     expect(runner.calls[2]?.options.input).toContain(
@@ -417,6 +419,9 @@ describe("bootstrapWorker", () => {
     expect(npmRunner.calls[1]?.options.input).not.toContain("npm install");
     expect(npmRunner.calls[1]?.options.input).toContain("--registry=https://registry.npmjs.org/");
     expect(npmRunner.calls[1]?.options.input).toContain("package/dist/worker/worker.mjs");
+    expect(npmRunner.calls[1]?.options.input).toContain(
+      "package/dist/worker/workspace-rsync-receiver.mjs",
+    );
     expect(npmRunner.calls[1]?.options.input).not.toContain("node_modules");
     expect(npmRunner.calls[1]?.argv.at(-1)).toContain(`openclaw@${VERSION}`);
   });
@@ -611,6 +616,11 @@ describe("bootstrapWorker", () => {
         await fs.writeFile(path.join(packageRoot, "dist/worker/worker.mjs"), "export {};\n", {
           mode: 0o755,
         });
+        await fs.writeFile(
+          path.join(packageRoot, "dist/worker/workspace-rsync-receiver.mjs"),
+          "export {};\n",
+          { mode: 0o755 },
+        );
         const artifact = await createWorkerBundleProducer({
           packageRoot,
           cacheDir: path.join(root, "cache"),
@@ -857,6 +867,11 @@ describe("bootstrapWorker", () => {
         await fs.writeFile(path.join(packageRoot, "dist/worker/worker.mjs"), "export {};\n", {
           mode: 0o755,
         });
+        await fs.writeFile(
+          path.join(packageRoot, "dist/worker/workspace-rsync-receiver.mjs"),
+          "export {};\n",
+          { mode: 0o755 },
+        );
         const bundle = await createWorkerBundleProducer({
           packageRoot,
           cacheDir: path.join(root, "cache"),
@@ -882,6 +897,11 @@ describe("bootstrapWorker", () => {
           path.join(installRoot, "worker.mjs"),
         );
         await fs.chmod(path.join(installRoot, "worker.mjs"), 0o700);
+        await fs.copyFile(
+          path.join(packageRoot, "dist", "worker", "workspace-rsync-receiver.mjs"),
+          path.join(installRoot, "workspace-rsync-receiver.mjs"),
+        );
+        await fs.chmod(path.join(installRoot, "workspace-rsync-receiver.mjs"), 0o700);
         await fs.writeFile(path.join(installRoot, "bootstrap-receipt.json"), `${receiptJson}\n`);
         const runCommand: WorkerBootstrapCommandRunner = async (_argv, options) => {
           const isPreflight =

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -15,6 +15,10 @@ import {
   type CommandOptions,
   type SpawnResult,
 } from "../../process/exec.js";
+import {
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+} from "../../shared/worker-bundle-hash.js";
 import { WORKER_BUNDLE_MANIFEST_VERSION, type WorkerInstallationArtifact } from "./bundle.js";
 import {
   prepareWorkerSsh,
@@ -42,6 +46,10 @@ const NPM_MISSING_MARKER = "OPENCLAW_WORKER_NPM_MISSING";
 const BOOTSTRAP_OUTPUT_TAG = "OPENCLAW_WORKER_BOOTSTRAP_V1";
 const BUNDLE_HASH_PATTERN = /^[a-f0-9]{64}$/u;
 const NPM_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const WORKER_BUNDLE_ARTIFACT_PATHS = [
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+] as const;
 
 // Scale transfer time for congested uplinks (~243 MB at <4 Mbps exceeds 10 minutes).
 // The base timeout remains the floor; the cap keeps transfer bounded and fail-closed.
@@ -140,6 +148,7 @@ const path = require("node:path");
 const root = process.argv[1];
 const expected = process.argv[2];
 const install = process.argv[3];
+const artifactPaths = ${JSON.stringify(WORKER_BUNDLE_ARTIFACT_PATHS)};
 const entries = [];
 function fail(message) {
   throw new Error(message);
@@ -170,7 +179,7 @@ function addFile(relative) {
     fail("unsafe worker file: " + relative);
   }
   const contents = fs.readFileSync(absolute);
-  const mode = relative === "worker.mjs" || (stats.mode & 0o111) !== 0 ? 0o700 : 0o600;
+  const mode = artifactPaths.includes(relative) || (stats.mode & 0o111) !== 0 ? 0o700 : 0o600;
   fs.chmodSync(absolute, mode);
   entries.push({
     path: relative,
@@ -182,12 +191,13 @@ function addFile(relative) {
 try {
   assertRoot();
   if (install === "npm" || install === "bundle") {
+    const allowedPaths = new Set([...artifactPaths, "bootstrap-receipt.json"]);
     for (const name of fs.readdirSync(root)) {
-      if (name !== "worker.mjs" && name !== "bootstrap-receipt.json") {
+      if (!allowedPaths.has(name)) {
         fail("unexpected worker bundle path: " + name);
       }
     }
-    addFile("worker.mjs");
+    for (const artifactPath of artifactPaths) addFile(artifactPath);
   } else {
     fail("invalid worker install channel");
   }
@@ -448,7 +458,9 @@ case "$install" in
       printf '%s\n' 'worker npm package integrity mismatch' >&2
       exit 2
     fi
-    tar -xzf "$package_archive" -C "$staging" --strip-components=3 package/dist/worker/worker.mjs
+    tar -xzf "$package_archive" -C "$staging" --strip-components=3 \
+      package/dist/worker/${WORKER_BUNDLE_ENTRY_PATH} \
+      package/dist/worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}
     rm -f "$npm_pack_json" "$package_archive"
     ;;
   *)

--- a/src/gateway/worker-environments/bundle-staging.ts
+++ b/src/gateway/worker-environments/bundle-staging.ts
@@ -2,9 +2,15 @@ import { createHash } from "node:crypto";
 import { constants as fsConstants, type BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { WORKER_BUNDLE_ENTRY_PATH } from "../../shared/worker-bundle-hash.js";
+import {
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+} from "../../shared/worker-bundle-hash.js";
 
-const WORKER_DEPLOY_ARTIFACT_PATH = "dist/worker/worker.mjs";
+const WORKER_DEPLOY_ARTIFACT_PATHS = [
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+] as const;
 
 export type WorkerBundleManifestEntry = {
   path: string;
@@ -39,11 +45,13 @@ function sourceIdentityStats(stats: BigIntStats) {
 async function stageWorkerDeployArtifact(params: {
   sourceRoot: string;
   stagingRoot: string;
+  artifactPath: (typeof WORKER_DEPLOY_ARTIFACT_PATHS)[number];
 }): Promise<{
   entry: WorkerBundleManifestEntry;
   sourceIdentity: WorkerBundleSourceIdentityEntry;
 }> {
-  const sourcePath = path.join(params.sourceRoot, WORKER_DEPLOY_ARTIFACT_PATH);
+  const relativeSourcePath = `dist/worker/${params.artifactPath}`;
+  const sourcePath = path.join(params.sourceRoot, relativeSourcePath);
   let expectedRealPath: string;
   try {
     expectedRealPath = await fs.realpath(sourcePath);
@@ -53,13 +61,13 @@ async function stageWorkerDeployArtifact(params: {
       { cause: error },
     );
   }
-  const expectedPath = path.resolve(params.sourceRoot, WORKER_DEPLOY_ARTIFACT_PATH);
+  const expectedPath = path.resolve(params.sourceRoot, relativeSourcePath);
   if (expectedRealPath !== expectedPath) {
-    throw new Error(`Unsafe worker deploy artifact: ${WORKER_DEPLOY_ARTIFACT_PATH}`);
+    throw new Error(`Unsafe worker deploy artifact: ${relativeSourcePath}`);
   }
   const initialStats = await fs.lstat(sourcePath);
   if (initialStats.isSymbolicLink() || !initialStats.isFile()) {
-    throw new Error(`Unsafe worker deploy artifact: ${WORKER_DEPLOY_ARTIFACT_PATH}`);
+    throw new Error(`Unsafe worker deploy artifact: ${relativeSourcePath}`);
   }
   const handle = await fs.open(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
   let contents: Buffer;
@@ -76,20 +84,18 @@ async function stageWorkerDeployArtifact(params: {
       currentStats.dev !== openedStats.dev ||
       currentStats.ino !== openedStats.ino
     ) {
-      throw new Error(
-        `Worker deploy artifact changed while packaging: ${WORKER_DEPLOY_ARTIFACT_PATH}`,
-      );
+      throw new Error(`Worker deploy artifact changed while packaging: ${relativeSourcePath}`);
     }
     contents = await handle.readFile();
   } finally {
     await handle.close();
   }
-  const stagedPath = path.join(params.stagingRoot, WORKER_BUNDLE_ENTRY_PATH);
+  const stagedPath = path.join(params.stagingRoot, params.artifactPath);
   await fs.writeFile(stagedPath, contents, { mode: 0o700 });
   await fs.chmod(stagedPath, 0o700);
   return {
     entry: {
-      path: WORKER_BUNDLE_ENTRY_PATH,
+      path: params.artifactPath,
       mode: 0o700,
       size: contents.byteLength,
       sha256: createHash("sha256").update(contents).digest("hex"),
@@ -103,12 +109,20 @@ async function stageWorkerDeployArtifact(params: {
   };
 }
 
+async function stageWorkerDeployArtifacts(sourceRoot: string, stagingRoot: string) {
+  const staged = [];
+  for (const artifactPath of WORKER_DEPLOY_ARTIFACT_PATHS) {
+    staged.push(await stageWorkerDeployArtifact({ sourceRoot, stagingRoot, artifactPath }));
+  }
+  return staged;
+}
+
 export async function collectWorkerBundleManifest(
   sourceRoot: string,
   stagingRoot: string,
 ): Promise<WorkerBundleManifestEntry[]> {
-  const staged = await stageWorkerDeployArtifact({ sourceRoot, stagingRoot });
-  return [staged.entry];
+  const staged = await stageWorkerDeployArtifacts(sourceRoot, stagingRoot);
+  return staged.map((artifact) => artifact.entry);
 }
 
 export async function collectWorkerBundleManifestWithSourceIdentity(
@@ -118,6 +132,9 @@ export async function collectWorkerBundleManifestWithSourceIdentity(
   manifest: WorkerBundleManifestEntry[];
   sourceIdentity: WorkerBundleSourceIdentityEntry[];
 }> {
-  const staged = await stageWorkerDeployArtifact({ sourceRoot, stagingRoot });
-  return { manifest: [staged.entry], sourceIdentity: [staged.sourceIdentity] };
+  const staged = await stageWorkerDeployArtifacts(sourceRoot, stagingRoot);
+  return {
+    manifest: staged.map((artifact) => artifact.entry),
+    sourceIdentity: staged.map((artifact) => artifact.sourceIdentity),
+  };
 }

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -9,6 +9,7 @@ import {
   resolveWorkerNpmInstallationArtifact,
   type WorkerInstallationArtifact,
 } from "./bundle.js";
+import { workerWorkspaceRsyncReceiverEntryPath } from "./workspace-sync-helpers.js";
 
 type WorkerBundleArtifact = Extract<WorkerInstallationArtifact, { install: "bundle" }>;
 
@@ -32,6 +33,11 @@ async function writeFixture(
     encoding: "utf8",
     mode: 0o755,
   });
+  await fs.writeFile(
+    path.join(packageRoot, "dist", "worker", "workspace-rsync-receiver.mjs"),
+    "export const receiver = true;\n",
+    { encoding: "utf8", mode: 0o755 },
+  );
 }
 
 async function listTarball(tarballPath: string): Promise<string[]> {
@@ -59,7 +65,25 @@ function bundleArtifact(overrides: Partial<WorkerBundleArtifact> = {}): WorkerBu
 }
 
 describe("worker bundle producer", () => {
-  it("hashes and archives only the dedicated deploy artifact", async () => {
+  it("stages the workspace rsync receiver at the path used by transfers", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-receiver-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      await writeFixture(packageRoot);
+      const artifact = await createWorkerBundleProducer({
+        packageRoot,
+        cacheDir: path.join(root, "cache"),
+      }).prepare();
+      const installPrefix = `.openclaw-worker/${artifact.bundleHash}/`;
+      const receiverPath = workerWorkspaceRsyncReceiverEntryPath(artifact.bundleHash);
+
+      expect(receiverPath.startsWith(installPrefix)).toBe(true);
+      await expect(listTarball(artifact.tarballPath)).resolves.toContain(
+        receiverPath.slice(installPrefix.length),
+      );
+    });
+  });
+
+  it("hashes and archives only the dedicated deploy artifacts", async () => {
     await withTestDir({ prefix: "openclaw-worker-bundle-" }, async (root) => {
       const packageA = path.join(root, "package-a");
       const packageB = path.join(root, "package-b");
@@ -107,13 +131,19 @@ describe("worker bundle producer", () => {
         openclawVersion: first.openclawVersion,
         protocolFeatures: first.protocolFeatures,
       });
-      await expect(listTarball(first.tarballPath)).resolves.toEqual(["worker.mjs"]);
+      await expect(listTarball(first.tarballPath)).resolves.toEqual([
+        "worker.mjs",
+        "workspace-rsync-receiver.mjs",
+      ]);
       const extractRoot = path.join(root, "extract");
       await fs.mkdir(extractRoot);
       await tar.extract({ file: first.tarballPath, cwd: extractRoot });
       await expect(fs.readFile(path.join(extractRoot, "worker.mjs"), "utf8")).resolves.toContain(
         "worker = true",
       );
+      await expect(
+        fs.readFile(path.join(extractRoot, "workspace-rsync-receiver.mjs"), "utf8"),
+      ).resolves.toContain("receiver = true");
       await expect(fs.access(path.join(extractRoot, "package.json"))).rejects.toThrow();
       await expect(fs.access(path.join(extractRoot, "node_modules"))).rejects.toThrow();
     });
@@ -139,6 +169,13 @@ describe("worker bundle producer", () => {
       );
       const changed = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
       expect(changed.bundleHash).not.toBe(first.bundleHash);
+
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "worker", "workspace-rsync-receiver.mjs"),
+        "export const receiver = false;\n",
+      );
+      const receiverChanged = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+      expect(receiverChanged.bundleHash).not.toBe(changed.bundleHash);
     });
   });
 
@@ -293,22 +330,30 @@ describe("worker bundle producer", () => {
       const repaired = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
 
       expect(repaired.bundleHash).toBe(first.bundleHash);
-      await expect(listTarball(repaired.tarballPath)).resolves.toEqual(["worker.mjs"]);
+      await expect(listTarball(repaired.tarballPath)).resolves.toEqual([
+        "worker.mjs",
+        "workspace-rsync-receiver.mjs",
+      ]);
     });
   });
 
-  it.skipIf(process.platform === "win32")("rejects a symlinked deploy artifact", async () => {
-    await withTestDir({ prefix: "openclaw-worker-bundle-symlink-" }, async (root) => {
-      const packageRoot = path.join(root, "package");
-      await writeFixture(packageRoot);
-      const artifactPath = path.join(packageRoot, "dist", "worker", "worker.mjs");
-      await fs.rename(artifactPath, `${artifactPath}.target`);
-      await fs.symlink("worker.mjs.target", artifactPath);
+  it.skipIf(process.platform === "win32")("rejects symlinked deploy artifacts", async () => {
+    for (const artifactName of ["worker.mjs", "workspace-rsync-receiver.mjs"]) {
+      await withTestDir({ prefix: "openclaw-worker-bundle-symlink-" }, async (root) => {
+        const packageRoot = path.join(root, "package");
+        await writeFixture(packageRoot);
+        const artifactPath = path.join(packageRoot, "dist", "worker", artifactName);
+        await fs.rename(artifactPath, `${artifactPath}.target`);
+        await fs.symlink(`${artifactName}.target`, artifactPath);
 
-      await expect(
-        createWorkerBundleProducer({ packageRoot, cacheDir: path.join(root, "cache") }).prepare(),
-      ).rejects.toThrow("Unsafe worker deploy artifact");
-    });
+        await expect(
+          createWorkerBundleProducer({
+            packageRoot,
+            cacheDir: path.join(root, "cache"),
+          }).prepare(),
+        ).rejects.toThrow("Unsafe worker deploy artifact");
+      });
+    }
   });
 });
 

--- a/src/gateway/worker-environments/tunnel.test-support.ts
+++ b/src/gateway/worker-environments/tunnel.test-support.ts
@@ -97,9 +97,7 @@ export async function prepareLocalWorkspaceRsyncBoundary(
     throw new Error("test rsync transfer is missing its bundled receiver invocation");
   }
   const receiverEntry = path.join(remoteHome, invocation.receiverEntryPath);
-  const installRoot = path.join(remoteHome, ".openclaw-worker", BUNDLE_HASH);
   await fs.mkdir(path.dirname(receiverEntry), { recursive: true });
-  await fs.writeFile(path.join(installRoot, "package.json"), '{"type":"module"}\n');
   const tsxApi = import.meta.resolve("tsx/esm/api");
   const sourceEntry = pathToFileURL(path.resolve("src/worker/workspace-rsync-receiver.ts")).href;
   await fs.writeFile(

--- a/src/gateway/worker-environments/workspace-rsync-path.test.ts
+++ b/src/gateway/worker-environments/workspace-rsync-path.test.ts
@@ -38,10 +38,8 @@ describe.skipIf(process.platform === "win32")("workspace rsync receiver path", (
     const remoteRelative = path.posix.relative(canonicalHome, canonicalWorkspace);
     const nonce = "b".repeat(32);
     const receiverEntryPath = workerWorkspaceRsyncReceiverEntryPath(BUNDLE_HASH);
-    const installRoot = path.join(canonicalHome, ".openclaw-worker", BUNDLE_HASH);
     const receiverEntry = path.join(canonicalHome, receiverEntryPath);
     await fs.mkdir(path.dirname(receiverEntry), { recursive: true });
-    await fs.writeFile(path.join(installRoot, "package.json"), '{"type":"module"}\n');
     const tsxApi = import.meta.resolve("tsx/esm/api");
     const sourceEntry = pathToFileURL(path.resolve("src/worker/workspace-rsync-receiver.ts")).href;
     await fs.writeFile(

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -6,6 +6,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
 import { redactSensitiveText } from "../../logging/redact.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
+import { WORKER_BUNDLE_RSYNC_RECEIVER_PATH } from "../../shared/worker-bundle-hash.js";
 import {
   type PreparedWorkerSsh,
   workerSshCommandOptions,
@@ -167,7 +168,7 @@ export function workerWorkspaceRsyncReceiverEntryPath(bundleHash: string): strin
   if (!/^[a-f0-9]{64}$/u.test(bundleHash)) {
     throw new Error("Worker workspace rsync receiver bundle hash is invalid");
   }
-  return `.openclaw-worker/${bundleHash}/dist/worker/workspace-rsync-receiver.js`;
+  return `.openclaw-worker/${bundleHash}/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`;
 }
 
 export function workerWorkspaceSshArgv(

--- a/src/scripts/ci-changed-scope.contract-fixtures.test.ts
+++ b/src/scripts/ci-changed-scope.contract-fixtures.test.ts
@@ -20,6 +20,7 @@ describe("shared Apple contract fixture CI scope", () => {
   });
 
   it.each([
+    "src/shared/worker-bundle-hash.ts",
     "src/worker/workspace-rsync-receiver.ts",
     "src/gateway/worker-environments/workspace-sync.ts",
     "src/gateway/worker-environments/workspace-sync-helpers.ts",

--- a/src/shared/worker-bundle-hash.ts
+++ b/src/shared/worker-bundle-hash.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 export const WORKER_BUNDLE_MANIFEST_VERSION = "openclaw-worker-bundle-v1";
 export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";
+export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";
 
 export function compareWorkerBundlePaths(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -28,6 +28,10 @@ import { resolveNodeWorkerInstallation } from "../../../../src/node-host/node-wo
 import { NodeWorkerBundleInstaller } from "../../../../src/node-host/node-worker-bundle-installer.js";
 import { createNodeWorkerSupervisor } from "../../../../src/node-host/node-worker-supervisor.js";
 import { NodeWorkerWorkspaceRuntime } from "../../../../src/node-host/node-worker-workspace.js";
+import {
+  WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
+} from "../../../../src/shared/worker-bundle-hash.js";
 import { VERSION } from "../../../../src/version.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 import {
@@ -134,11 +138,11 @@ async function createSourceWorkerInstallation(root: string): Promise<NodeWorkerI
   const packageRoot = path.join(root, "local-install");
   const repoRoot = process.cwd();
   await fs.mkdir(path.join(packageRoot, "dist", "worker"), { recursive: true });
-  await fs.copyFile(
-    path.join(repoRoot, "dist", "worker", "worker.mjs"),
-    path.join(packageRoot, "dist", "worker", "worker.mjs"),
-  );
-  await fs.chmod(path.join(packageRoot, "dist", "worker", "worker.mjs"), 0o700);
+  for (const artifactPath of [WORKER_BUNDLE_ENTRY_PATH, WORKER_BUNDLE_RSYNC_RECEIVER_PATH]) {
+    const target = path.join(packageRoot, "dist", "worker", artifactPath);
+    await fs.copyFile(path.join(repoRoot, "dist", "worker", artifactPath), target);
+    await fs.chmod(target, 0o700);
+  }
   return await resolveNodeWorkerInstallation({
     packageRoot,
     openclawVersion: VERSION,

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2042,6 +2042,7 @@ describe("scripts/changed-lanes", () => {
 
   it("runs macOS CI tests for workspace rsync receiver owners", () => {
     for (const changedPath of [
+      "src/shared/worker-bundle-hash.ts",
       "src/worker/workspace-rsync-receiver.ts",
       "src/gateway/worker-environments/workspace-sync.ts",
       "src/gateway/worker-environments/workspace-sync-helpers.ts",

--- a/test/scripts/check-cli-bootstrap-imports.test.ts
+++ b/test/scripts/check-cli-bootstrap-imports.test.ts
@@ -129,12 +129,17 @@ describe("check-cli-bootstrap-imports", () => {
     ]);
   });
 
-  it("accepts one self-contained worker executable with builtin imports", () => {
+  it("accepts the self-contained worker deploy artifacts with builtin imports", () => {
     const root = makeTempRoot();
     writeFixture(
       root,
       "dist/worker/worker.mjs",
       'import fs from "node:fs";\nexport const worker = Boolean(fs);\n',
+    );
+    writeFixture(
+      root,
+      "dist/worker/workspace-rsync-receiver.mjs",
+      'import path from "node:path";\nexport const receiver = Boolean(path);\n',
     );
 
     expect(collectWorkerDeployArtifactErrors({ rootDir: root })).toEqual([]);
@@ -153,6 +158,7 @@ describe("check-cli-bootstrap-imports", () => {
         'moduleNamespace.createRequire(import.meta.url)("@openclaw/fs-safe/temp");',
       ].join("\n"),
     );
+    writeFixture(root, "dist/worker/workspace-rsync-receiver.mjs", "export {};\n");
     writeFixture(root, "dist/worker/lazy.mjs", "export {};\n");
     writeFixture(
       root,

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -16,15 +16,24 @@ const configs = Array.isArray(config) ? config : [config];
 type TsdownConfig = (typeof configs)[number];
 type OutExtensions = NonNullable<TsdownConfig["outExtensions"]>;
 
-function isWorkerDeployConfig(config: TsdownConfig): boolean {
+function hasWorkerEntry(config: TsdownConfig, name: string, source: string): boolean {
   const entry = config.entry;
   if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
     return false;
   }
-  return (
-    (entry as Record<string, unknown>)["worker/worker"] === "src/worker/worker-deploy-entry.ts"
-  );
+  return (entry as Record<string, unknown>)[name] === source;
 }
+
+const isWorkerDeployConfig = (config: TsdownConfig) =>
+  hasWorkerEntry(config, "worker/worker", "src/worker/worker-deploy-entry.ts");
+const isWorkerRsyncReceiverConfig = (config: TsdownConfig) =>
+  hasWorkerEntry(
+    config,
+    "worker/workspace-rsync-receiver",
+    "src/worker/workspace-rsync-receiver.ts",
+  );
+const isWorkerBuildConfig = (config: TsdownConfig) =>
+  isWorkerDeployConfig(config) || isWorkerRsyncReceiverConfig(config);
 
 describe("tsdown config", () => {
   it.each(["tsdown.config.ts", "tsdown.ai.config.ts"])(
@@ -96,12 +105,15 @@ describe("tsdown config", () => {
     expect(privateDeclarationSources).toContain("src/plugin-sdk/tts-runtime.ts");
   });
 
-  it("builds one worker-only executable with every package dependency bundled", () => {
+  it("builds self-contained worker deploy executables with every dependency bundled", () => {
     const workerConfig = configs.find(isWorkerDeployConfig);
+    const receiverConfig = configs.find(isWorkerRsyncReceiverConfig);
     expect(workerConfig?.entry).toEqual({
       "worker/worker": "src/worker/worker-deploy-entry.ts",
     });
-    expect(workerConfig?.dts).toBe(false);
+    expect(receiverConfig?.entry).toEqual({
+      "worker/workspace-rsync-receiver": "src/worker/workspace-rsync-receiver.ts",
+    });
     const packageVersion = (
       JSON.parse(fs.readFileSync("package.json", "utf8")) as {
         version: string;
@@ -129,26 +141,35 @@ describe("tsdown config", () => {
       codeSplitting: false,
       assetFileNames: "worker/[name][extname]",
     });
-    expect(workerConfig?.deps?.onlyBundle).toBe(false);
-    expect(workerConfig?.deps?.alwaysBundle).toBeTypeOf("function");
-    const alwaysBundle = workerConfig?.deps?.alwaysBundle;
-    if (typeof alwaysBundle !== "function") {
-      throw new Error("worker deploy config must define dependency bundling");
-    }
-    expect(alwaysBundle("json5", undefined)).toBe(true);
-    expect(alwaysBundle("node:fs", undefined)).toBe(false);
+    expect(receiverConfig?.define).toBeUndefined();
+    expect(receiverConfig?.alias).toBeUndefined();
+    expect(receiverConfig?.plugins).toBeUndefined();
+    expect(receiverConfig?.outputOptions).toEqual({ codeSplitting: false });
 
     const context = {
       format: "es",
       options: {},
       pkgType: "module",
     } as Parameters<OutExtensions>[0];
-    expect(workerConfig?.outExtensions?.(context)).toEqual({ js: ".mjs", dts: ".d.ts" });
+    for (const config of [workerConfig, receiverConfig]) {
+      expect(config?.dts).toBe(false);
+      expect(config?.outDir).toBe("dist");
+      expect(config?.shims).toBe(true);
+      expect(config?.deps?.onlyBundle).toBe(false);
+      expect(config?.deps?.alwaysBundle).toBeTypeOf("function");
+      const alwaysBundle = config?.deps?.alwaysBundle;
+      if (typeof alwaysBundle !== "function") {
+        throw new Error("worker deploy config must define dependency bundling");
+      }
+      expect(alwaysBundle("json5", undefined)).toBe(true);
+      expect(alwaysBundle("node:fs", undefined)).toBe(false);
+      expect(config?.outExtensions?.(context)).toEqual({ js: ".mjs", dts: ".d.ts" });
+    }
   });
 
   it("keeps node package artifacts on the declared js and dts extensions", () => {
     const nodePackageConfigs = configs.filter(
-      (entry) => entry.fixedExtension === false && !isWorkerDeployConfig(entry),
+      (entry) => entry.fixedExtension === false && !isWorkerBuildConfig(entry),
     );
     expect(nodePackageConfigs).not.toHaveLength(0);
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -205,6 +205,26 @@ function workerDeployBuildConfig(): UserConfig {
   };
 }
 
+function workerRsyncReceiverBuildConfig(): UserConfig {
+  return {
+    name: TSDOWN_UNIFIED_CONFIG_GROUP,
+    entry: { "worker/workspace-rsync-receiver": "src/worker/workspace-rsync-receiver.ts" },
+    outDir: "dist",
+    dts: false,
+    env,
+    deps: {
+      alwaysBundle: (id) => !isBuiltin(id),
+      onlyBundle: false,
+    },
+    fixedExtension: false,
+    outExtensions: () => ({ js: ".mjs", dts: ".d.ts" }),
+    outputOptions: { codeSplitting: false },
+    shims: true,
+    sourcemap: OUTPUT_SOURCE_MAPS,
+    inputOptions: (options) => buildInputOptions(options, { bundleAllDependencies: true }),
+  };
+}
+
 function nodeWorkspacePackageBuildConfig(packageDir: string, config: UserConfig = {}): UserConfig {
   return {
     ...config,
@@ -352,7 +372,6 @@ function buildCoreDistEntries(): Record<string, string> {
     "server-close.runtime": "src/gateway/server-close.runtime.ts",
     "gateway/plugin-channel-reload-targets": "src/gateway/plugin-channel-reload-targets.ts",
     "gateway/worker-environments/runtime": "src/gateway/worker-environments/runtime.ts",
-    "worker/workspace-rsync-receiver": "src/worker/workspace-rsync-receiver.ts",
     "plugins/hook-runner-global": "src/plugins/hook-runner-global.ts",
     "plugins/memory-state": "src/plugins/memory-state.ts",
     "plugins/synthetic-auth.runtime": "src/plugins/synthetic-auth.runtime.ts",
@@ -725,6 +744,7 @@ const configs = [
     false,
   ),
   workerDeployBuildConfig(),
+  workerRsyncReceiverBuildConfig(),
   ...(TSDOWN_DECLARATIONS
     ? buildUnifiedDeclarationPartitions(unifiedDistEntries).map(({ name, sources }) =>
         nodeBuildConfig(


### PR DESCRIPTION
Related: #124037

## What Problem This Solves

Fixes an issue where every cloud worker dispatch failed during workspace sync after the Gateway-bundle cutover. The live failure was:

`Worker workspace sync failed: ... Cannot find module '/home/crabbox/.openclaw-worker/<bundleHash>/dist/worker/workspace-rsync-receiver.js' (MODULE_NOT_FOUND)`

The bundle installed only `worker.mjs`, while rsync still launched a receiver file that the bundle no longer shipped.

## Why This Change Was Made

The workspace rsync receiver is now built as its own self-contained single-entry artifact, staged beside `worker.mjs`, included in the content-addressed manifest, and extracted and verified identically by both bundle and npm install channels. Keeping it separate avoids parsing the roughly 65 MB worker executable for every rsync transfer. The obsolete unified `.js` output and remote path are removed without compatibility handling because the broken layout was unreleased and bundle hashes retire old artifacts.

The bundle producer and workspace consumer are cross-checked by a regression assertion so their layouts cannot drift independently again. The build bootstrap guard also validates both standalone artifacts and rejects unexpected runtime sidecars.

## User Impact

Cloud worker sessions can sync their workspace and proceed to execution again. Operators do not need to change configuration or repair existing workers; the changed bundle hash provisions the corrected layout automatically.

## Evidence

- Live repro before the fix: real Hetzner cloud worker on 2026-08-15 with a development Gateway built from `main` at `60babddd626`; every dispatch failed with the `MODULE_NOT_FOUND` error above.
- Regression proof before production edits: `node scripts/run-vitest.mjs src/gateway/worker-environments/bundle.test.ts` failed because the staged tarball contained only `worker.mjs` while the transfer receiver path resolved outside the manifest.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/` — 231 files passed, 2,277 tests passed.
- `node scripts/run-vitest.mjs test/scripts/worker-deploy-build-plugin.test.ts test/scripts/tsdown-config.test.ts test/scripts/check-cli-bootstrap-imports.test.ts` — 3 files passed, 21 tests passed on Blacksmith Testbox.
- `pnpm build` — passed on Blacksmith Testbox; `dist/worker/workspace-rsync-receiver.mjs` exists, contains no relative imports, and a bogus invocation exits nonzero with `invalid worker workspace rsync receiver invocation`.
- `pnpm check:changed` — passed on Blacksmith Testbox, including full typecheck, lint, import-cycle, package, formatting, and boundary guards.
- Blacksmith Testbox: `tbx_01m042yjgvk4tz58wgd861e12f`, https://github.com/openclaw/openclaw/actions/runs/31919645985
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

AI-assisted implementation; the change and its generated shell/bootstrap boundaries were manually inspected and exercised through the tests above.
