### PR TITLE
fix(gateway): report device worker capacity distinctly from disconnection

### DIFF
--- a/src/gateway/server.worker-placement-startup-context.test.ts
+++ b/src/gateway/server.worker-placement-startup-context.test.ts
@@ -29,7 +29,7 @@ test(
     expect(context?.workerEnvironmentService).toBeDefined();
     await expect(
       resolveDeviceWorkerAvailability(context?.workerEnvironmentService, "missing-device"),
-    ).resolves.toEqual({ available: false });
+    ).resolves.toEqual({ available: false, unavailableReason: "unpaired" });
     const placements = context?.workerSessionPlacementService as
       | WorkerSessionPlacementStore
       | undefined;

--- a/src/gateway/worker-environments/device-provider.test.ts
+++ b/src/gateway/worker-environments/device-provider.test.ts
@@ -121,24 +121,30 @@ describe("device worker provider", () => {
       name: "missing pairing",
       getPairedDevice: async () => null,
       listCurrentNodes: async () => [connectedNode()],
+      expectedMessage: `device worker is not a paired node host: ${DEVICE_ID}`,
     },
     {
       name: "offline device",
       getPairedDevice: async () => pairedDevice(),
       listCurrentNodes: async () => [],
+      expectedMessage: `device worker node is not connected: ${DEVICE_ID}`,
     },
     {
-      name: "connected node without worker session hosting",
+      name: "connected node at capacity",
       getPairedDevice: async () => pairedDevice(),
       listCurrentNodes: async () => [connectedNode(DEVICE_ID, null)],
+      expectedMessage: `device worker is at capacity (all worker slots in use): ${DEVICE_ID}; retry after a running turn completes`,
     },
-  ])("rejects $name during provision", async ({ getPairedDevice, listCurrentNodes }) => {
-    const provider = deviceRuntime({ getPairedDevice, listCurrentNodes }).provider;
+  ])(
+    "rejects $name during provision",
+    async ({ getPairedDevice, listCurrentNodes, expectedMessage }) => {
+      const provider = deviceRuntime({ getPairedDevice, listCurrentNodes }).provider;
+      const provision = provider.provision({ device: DEVICE_ID }, "operation");
 
-    await expect(provider.provision({ device: DEVICE_ID }, "operation")).rejects.toBeInstanceOf(
-      WorkerProviderError,
-    );
-  });
+      await expect(provision).rejects.toBeInstanceOf(WorkerProviderError);
+      await expect(provision).rejects.toMatchObject({ message: expectedMessage });
+    },
+  );
 
   it("returns the exact update-and-reconnect recovery for an outdated connected node", async () => {
     const provider = deviceRuntime({

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -27,6 +27,7 @@ type DeviceWorkerRuntimeOptions = {
 type DeviceWorkerAvailability = {
   available: boolean;
   issue?: NodeRunnerInventoryIssue;
+  unavailableReason?: "unpaired" | "disconnected" | "at-capacity";
 };
 type DeviceWorkerAvailabilityResolver = (deviceId: string) => Promise<DeviceWorkerAvailability>;
 type DeviceWorkerReconciliation = (deviceId: string) => Promise<readonly string[]>;
@@ -99,19 +100,24 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
   const launchAdapter = createNodeWorkerLaunchAdapter({ getTransport: () => nodeTransport });
   const findConnectedNode = async (deviceId: string) =>
     (await nodeTransport?.listCurrentNodes())?.find((node) => node.nodeId === deviceId);
-  const findAvailableNode = async (deviceId: string) => {
-    const node = await findConnectedNode(deviceId);
-    return node && isSessionCapableNode(node) ? node : undefined;
-  };
   const resolveAvailability = async (deviceId: string): Promise<DeviceWorkerAvailability> => {
     const [paired, connected] = await Promise.all([
       options.getPairedDevice(deviceId),
-      findAvailableNode(deviceId),
+      findConnectedNode(deviceId),
     ]);
+    // NodeWorkerSupervisorNodeProof.workerRuns is omitted while a connected node is at capacity.
+    const unavailableReason = !hasPairedNodeRole(paired)
+      ? "unpaired"
+      : !connected
+        ? "disconnected"
+        : !isSessionCapableNode(connected)
+          ? "at-capacity"
+          : undefined;
     const issue = nodeTransport?.getIssue?.(deviceId);
     return {
-      available: hasPairedNodeRole(paired) && Boolean(connected),
+      available: unavailableReason === undefined,
       ...(issue ? { issue } : {}),
+      ...(unavailableReason ? { unavailableReason } : {}),
     };
   };
   const isAvailable = async (deviceId: string) => (await resolveAvailability(deviceId)).available;
@@ -122,10 +128,19 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
       const deviceId = requireDeviceId(profile);
       const availability = await resolveAvailability(deviceId);
       if (!availability.available) {
+        if (availability.issue) {
+          throw new WorkerProviderError(
+            formatNodeRunnerUpdateRequired(deviceId, availability.issue),
+          );
+        }
+        if (availability.unavailableReason === "unpaired") {
+          throw new WorkerProviderError(`device worker is not a paired node host: ${deviceId}`);
+        }
+        if (availability.unavailableReason === "disconnected") {
+          throw new WorkerProviderError(`device worker node is not connected: ${deviceId}`);
+        }
         throw new WorkerProviderError(
-          availability.issue
-            ? formatNodeRunnerUpdateRequired(deviceId, availability.issue)
-            : `device worker is not a connected session-capable paired node: ${deviceId}`,
+          `device worker is at capacity (all worker slots in use): ${deviceId}; retry after a running turn completes`,
         );
       }
       return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full-capacity device dispatch rejections were mislabeled as disconnection with `device worker is not a connected session-capable paired node`. This surfaced in a node-hosting stress run after #123869 separated capacity from identity by omitting `workerRuns` while all worker slots are occupied.

## Why This Change Was Made

The device provider now threads a closed `unavailableReason` through its existing `resolveAvailability` result, using one paired-device and connected-node discovery pass. Provisioning reports distinct unpaired, disconnected, and at-capacity failures while preserving #124037's node-runner update-required precedence.

The old conflation was in `src/gateway/worker-environments/device-provider.ts`: every unavailable result without an inventory issue fell through to the same connected/session-capable/paired-node message. The capacity contract is owned by `NodeWorkerSupervisorNodeProof.workerRuns`, which is omitted while the connected node has no free worker slot.

## User Impact

Operators can now distinguish a device that is unpaired, disconnected, or simply busy. At-capacity failures explicitly say to retry after a running turn completes instead of sending operators toward connection troubleshooting.

AI-assisted. No changelog entry is needed for this normal PR, and there is no UI change requiring screenshots.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/gateway/worker-environments/device-provider.test.ts` failed all three rejection cases because each received the old conflated message.
- Focused regression proof on this head: the same command passed 11/11 tests in one Vitest shard.
- `node_modules/.bin/oxfmt src/gateway/worker-environments/device-provider.ts src/gateway/worker-environments/device-provider.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Source-blind behavior validation passed 5/5 scenarios with varied device IDs: unpaired, disconnected, at-capacity, update-required precedence, and successful availability.
