### PR TITLE
fix(ci): unblock Performance on current source builds

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -72,8 +72,8 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OCM_VERSION: v0.2.29
-  OCM_LINUX_X64_SHA256: d966098d6ba2bc10891be3c76e162a37b07f28c4f51da75d2eb509886eb7e1cf
+  OCM_VERSION: v0.2.32
+  OCM_LINUX_X64_SHA256: 5b20c21b2825f69b89eb37baa657f0f0062124517e6e6828e9857c7e9bbd3070
   KOVA_REPOSITORY: openclaw/Kova
   KOVA_CANONICAL_CONFIG_REF: 0f9e678e239b45db46d2bd930b7983203580df78
   KOVA_LEGACY_LIST_CONFIG_REF: 0f9e678e239b45db46d2bd930b7983203580df78
@@ -387,29 +387,6 @@ jobs:
           EOF
           chmod 0755 "$HOME/.local/bin/kova"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Configure OCM local workspace dependencies
-        if: steps.lane.outputs.run == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mts"
-          npm_adapter="${RUNNER_TEMP}/openclaw-ocm-npm"
-          workspace_dependency_dirs=""
-          if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then
-            workspace_dependency_dirs="${GITHUB_WORKSPACE}/packages/ai"
-          fi
-          cat > "$npm_adapter" <<'EOF'
-          #!/usr/bin/env bash
-          exec node --import tsx "$OPENCLAW_OCM_NPM_WRAPPER" "$@"
-          EOF
-          chmod 0755 "$npm_adapter"
-          {
-            echo "OCM_INTERNAL_NPM_BIN=$npm_adapter"
-            echo "OPENCLAW_OCM_NPM_WRAPPER=$npm_wrapper"
-            echo "OPENCLAW_OCM_REAL_NPM_BIN=$(command -v npm)"
-            echo "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS=$workspace_dependency_dirs"
-          } >> "$GITHUB_ENV"
 
       - name: Kova version and plan sanity
         if: steps.lane.outputs.run == 'true'

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -232,9 +232,9 @@ describe("OpenClaw performance workflow", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
     const installRun = findStep("Install OCM and Kova").run ?? "";
 
-    expect(workflow).toContain("OCM_VERSION: v0.2.29");
+    expect(workflow).toContain("OCM_VERSION: v0.2.32");
     expect(workflow).toContain(
-      "OCM_LINUX_X64_SHA256: d966098d6ba2bc10891be3c76e162a37b07f28c4f51da75d2eb509886eb7e1cf",
+      "OCM_LINUX_X64_SHA256: 5b20c21b2825f69b89eb37baa657f0f0062124517e6e6828e9857c7e9bbd3070",
     );
     expect(installRun).toContain(
       '"https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"',
@@ -1076,22 +1076,19 @@ esac
     expect(publish.run).not.toContain("report_jsons");
   });
 
-  it("installs local workspace packages beside the OCM root tarball", () => {
-    const workflow = readWorkflow();
-    const configure = findStep("Configure OCM local workspace dependencies");
+  it("lets OCM discover its native workspace dependency adapter", () => {
+    const workflowText = readFileSync(WORKFLOW, "utf8");
+    const steps = readWorkflow().jobs?.kova?.steps ?? [];
+    const installIndex = steps.findIndex((step) => step.name === "Install OCM and Kova");
 
-    expect(workflow.jobs?.kova?.env).not.toHaveProperty("OPENCLAW_OCM_RUNTIME_BUILD_PROFILE");
-    expect(configure.run).toContain(
-      'npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mts"',
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(steps.map((step) => step.name)).not.toContain(
+      "Configure OCM local workspace dependencies",
     );
-    expect(configure.run).toContain("OCM_INTERNAL_NPM_BIN=$npm_adapter");
-    expect(configure.run).toContain("OPENCLAW_OCM_NPM_WRAPPER=$npm_wrapper");
-    expect(configure.run).toContain(
-      'if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then',
-    );
-    expect(configure.run).toContain(
-      "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS=$workspace_dependency_dirs",
-    );
+    expect(workflowText).not.toContain("OCM_INTERNAL_NPM_BIN");
+    expect(workflowText).not.toContain("OPENCLAW_OCM_NPM_WRAPPER");
+    expect(workflowText).not.toContain("OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS");
+    expect(steps[installIndex + 1]?.name).toBe("Kova version and plan sanity");
   });
 
   it("fails selected live Kova lanes when live auth is missing", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw Performance release validation stopped before running any Kova scenario when benchmarking current source builds. OCM v0.2.29 passed the repository's TypeScript npm adapter through a Bash/tsx trampoline, and tsx rejected its complex hashbang with `idx: 148`.

Affected runs:

- https://github.com/openclaw/openclaw/actions/runs/31870866801
- https://github.com/openclaw/openclaw/actions/runs/31871544450

## Why This Change Was Made

Pin OCM v0.2.32, the first signed release containing the upstream current-OpenClaw build-local repair, and let OCM own native `.mts` adapter discovery, transitive workspace dependency closure, and trusted npm lifecycle execution. The obsolete workflow-local trampoline is removed rather than preserved as a second execution path.

Upstream fix and release:

- https://github.com/shakkernerd/ocm/commit/c34c7072bf2802beb46385ed5d9fb05b44e5ce1b
- https://github.com/shakkernerd/ocm/releases/tag/v0.2.32

## User Impact

Release and scheduled performance validation can once again exercise current OpenClaw source builds. There is no shipped OpenClaw runtime or package behavior change.

## Evidence

- GitHub-verified signed OCM tag `v0.2.32` points to `2a283cc2756c76cb10852584a44ed8efeb5cc559` and contains the upstream fix.
- Linux asset SHA-256 independently matches both the GitHub asset digest and published `SHA256SUMS`: `5b20c21b2825f69b89eb37baa657f0f0062124517e6e6828e9857c7e9bbd3070`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` — 34 passed.
- `node scripts/check-changed.mjs -- .github/workflows/openclaw-performance.yml test/scripts/openclaw-performance-workflow.test.ts` — passed on Blacksmith Testbox `tbx_01m044a2m703h3ycrt1r15bmkz` (run https://github.com/openclaw/openclaw/actions/runs/31920549610).
- `git diff --check` and `actionlint .github/workflows/openclaw-performance.yml` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
