### PR TITLE
fix(ui): keep session context menus on dragged sessions

### DIFF
--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -753,6 +753,13 @@ suite.define(() => {
         )
         .toEqual(["Already pinned", "Pin me"]);
       await expect.poll(() => researchGroup.locator(".sidebar-recent-session").count()).toBe(0);
+
+      const pinnedCandidate = page.locator(
+        '[data-sidebar-entry="session:agent:main:candidate"] .sidebar-recent-session',
+      );
+      await pinnedCandidate.click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Unpin session" }).waitFor();
+      expect(await page.getByRole("menuitem", { name: "Reset pinned items" }).count()).toBe(0);
       await captureUiProof(page, "sidebar-session-dropped-into-pinned.png");
     } finally {
       await context.close();

--- a/ui/src/lib/keyboard-shortcuts.ts
+++ b/ui/src/lib/keyboard-shortcuts.ts
@@ -6,30 +6,26 @@ export function handleContextMenuEvent(
   event: MouseEvent | KeyboardEvent,
   trigger: HTMLElement | null,
   open: (trigger: HTMLElement | null, x: number, y: number) => void,
-): boolean {
+): void {
   if (event instanceof MouseEvent) {
     event.preventDefault();
+    event.stopPropagation();
     open(trigger, event.clientX, event.clientY);
-    return true;
+    return;
   }
-  if (
-    event.altKey ||
-    event.ctrlKey ||
-    event.metaKey ||
-    (event.key !== "ContextMenu" && (event.key !== "F10" || !event.shiftKey))
-  ) {
-    return false;
+  const shortcutKey = event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey);
+  if (event.altKey || event.ctrlKey || event.metaKey || !shortcutKey) {
+    return;
   }
   if (!trigger && !(event.target instanceof HTMLElement)) {
-    return false;
+    return;
   }
-  // Chromium on macOS needs the keyboard path; preventing the key default also
-  // keeps platforms that synthesize `contextmenu` from opening the menu twice.
+  // Prevent the shortcut default so macOS Chromium does not synthesize a second context menu.
   event.preventDefault();
+  event.stopPropagation();
   const resolvedTrigger = trigger ?? (event.target as HTMLElement);
   const rect = resolvedTrigger.getBoundingClientRect();
   open(resolvedTrigger, rect.right, rect.bottom + 4);
-  return true;
 }
 
 export function resolveAsciiShortcutKey(event: KeyboardEvent): string | null {

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -1456,7 +1456,8 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
         props.onToggleDetails(row.key);
       }}
       @keydown=${(e: KeyboardEvent) => {
-        if (openMenuFromEvent(e)) {
+        openMenuFromEvent(e);
+        if (e.defaultPrevented) {
           return;
         }
         if (isRowControlTarget(e.target)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who dragged a session into the interleaved Pages area would get the Pages customization menu when right-clicking that session instead of the session menu.

## Why This Change Was Made

Handled context-menu events now claim propagation at the shared keyboard/mouse context-menu boundary, so the most specific UI surface remains the owner. The sessions table now uses the standard `defaultPrevented` event signal instead of a parallel boolean return contract.

Production code is net -3 lines; the change removes the duplicate handled-state contract rather than adding a session-specific exception.

## User Impact

Right-clicking a session always opens session actions, including after the session is dragged among Pages entries. Page and session context menus no longer compete for the same event.

## Evidence

The existing mocked-Gateway browser flow now drags **Pin me** from **Research** into the interleaved Pages area, right-clicks it, and asserts that **Unpin session** is visible while **Reset pinned items** is absent.

**Before drag**

![Session in Research before drag](https://github.com/user-attachments/assets/15016b99-3dc1-4b91-875d-fbc93ade6051)

**After drag and right-click**

![Dragged session showing its session menu](https://github.com/user-attachments/assets/057d7f6a-a42f-4607-a544-ae69cd49d3bc)

https://github.com/user-attachments/assets/c947f58e-8ae0-4d47-a59b-1140af39160b

Focused proof:

- Pre-fix regression: the focused E2E timed out waiting for **Unpin session** because the Pages menu replaced the session menu.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.sidebar.e2e.test.ts -t 'pins a session dropped below an existing row in the interleaved sidebar zone'` — 1 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/pages/sessions/view.test.ts -t 'opens the session menu from the kebab and row context-menu shortcuts'` — 1 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/lib/keyboard-shortcuts.test.ts` — 3 passed.
- Targeted oxfmt, oxlint, and `git diff --check` pass.
- Black-box artifact validation passed the complete Research → Pages → session-menu contract.
- Mandatory Codex autoreview: clean, no accepted/actionable findings.
