### PR TITLE
fix: agents delete leaves no stale database registry row

### DIFF
--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -286,23 +286,6 @@ export async function cleanupClawAgentFilesystem(params: {
   return errors;
 }
 
-/** Release deleted-agent database discovery only after Claw filesystem cleanup succeeds. */
-export function releaseClawAgentDatabaseRegistry(
-  agentId: string,
-  cleanupErrors: string[],
-  env?: NodeJS.ProcessEnv,
-): void {
-  if (cleanupErrors.length > 0) {
-    return;
-  }
-  try {
-    unregisterOpenClawAgentDatabases({ agentId, env });
-  } catch (error) {
-    // The partial install record owns retry, so a registry failure must keep removal incomplete.
-    cleanupErrors.push(coerceErrorMessage(error));
-  }
-}
-
 export const clawRemoveQuietRuntime: RuntimeEnv = {
   log: (..._args: unknown[]) => undefined,
   error: (..._args: unknown[]) => undefined,
@@ -479,6 +462,10 @@ export function releaseClawRemoveRows(
   complete: boolean,
   options: OpenClawStateDatabaseOptions,
 ): void {
+  if (complete) {
+    // Keep the install record as the retry owner until database discovery is released.
+    unregisterOpenClawAgentDatabases({ agentId, env: options.env });
+  }
   runOpenClawStateWriteTransaction(({ db }) => {
     if (clawStateTableExists(db, "claw_workspace_files")) {
       for (const file of files.filter((candidate) => candidate.action !== "error")) {

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -25,6 +25,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -283,6 +284,23 @@ export async function cleanupClawAgentFilesystem(params: {
     errors.push(`Could not trash session transcripts ${params.targets.sessionsDir}.`);
   }
   return errors;
+}
+
+/** Release deleted-agent database discovery only after Claw filesystem cleanup succeeds. */
+export function releaseClawAgentDatabaseRegistry(
+  agentId: string,
+  cleanupErrors: string[],
+  env?: NodeJS.ProcessEnv,
+): void {
+  if (cleanupErrors.length > 0) {
+    return;
+  }
+  try {
+    unregisterOpenClawAgentDatabases({ agentId, env });
+  } catch (error) {
+    // The partial install record owns retry, so a registry failure must keep removal incomplete.
+    cleanupErrors.push(coerceErrorMessage(error));
+  }
 }
 
 export const clawRemoveQuietRuntime: RuntimeEnv = {

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -5,6 +5,10 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import {
+  listOpenClawRegisteredAgentDatabases,
+  registerOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
+import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
@@ -478,6 +482,14 @@ describe("Claw status and remove", () => {
 
   it("removes the agent and unchanged files but only releases package refs", async () => {
     const current = await addFixture({ withFile: true });
+    const databasePath = join(
+      current.env.OPENCLAW_STATE_DIR,
+      "agents",
+      "worker",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    registerOpenClawAgentDatabase({ agentId: "worker", path: databasePath, env: current.env });
     persistClawPackageRef(
       current.plan,
       {
@@ -509,6 +521,9 @@ describe("Claw status and remove", () => {
       workspaceFiles: [{ path: "SOUL.md", action: "deleted" }],
     });
     expect(config.agents?.entries?.worker).toBeUndefined();
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env: current.env }).map((entry) => entry.agentId),
+    ).not.toContain("worker");
     await expect(readFile(join(current.plan.agent.workspace, "SOUL.md"), "utf8")).rejects.toThrow();
     await expect(readClawStatus("worker", { env: current.env, config })).resolves.toMatchObject({
       summary: { claws: 0 },

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -31,6 +31,7 @@ import {
   cleanupClawAgentFilesystem,
   deletionEffects,
   readAttachedCronJobs,
+  releaseClawAgentDatabaseRegistry,
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
   workspaceContainsUntrackedEntries,
@@ -675,6 +676,7 @@ export async function applyClawRemovePlan(
       })),
     );
   }
+  releaseClawAgentDatabaseRegistry(agentId, cleanupErrors, options.env);
   const complete = cleanupErrors.length === 0;
   if (!complete) {
     updateClawInstallRecordStatus(agentId, "partial", options);

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -31,7 +31,6 @@ import {
   cleanupClawAgentFilesystem,
   deletionEffects,
   readAttachedCronJobs,
-  releaseClawAgentDatabaseRegistry,
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
   workspaceContainsUntrackedEntries,
@@ -676,7 +675,6 @@ export async function applyClawRemovePlan(
       })),
     );
   }
-  releaseClawAgentDatabaseRegistry(agentId, cleanupErrors, options.env);
   const complete = cleanupErrors.length === 0;
   if (!complete) {
     updateClawInstallRecordStatus(agentId, "partial", options);

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -5,6 +5,10 @@ import {
   isSharedAuthStoreOwner,
 } from "../agents/agent-delete-safety.js";
 import {
+  beginAgentDeletion,
+  claimCompletedAgentDeletion,
+} from "../agents/agent-lifecycle-registry.js";
+import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   tryResolveSoleAgentId,
@@ -38,6 +42,8 @@ import {
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { createQuietRuntime } from "./agents.command-shared.js";
@@ -113,12 +119,25 @@ export async function agentsDeleteCommand(
   if (agentId !== input) {
     runtime.log(`Normalized agent id to "${agentId}".`);
   }
-  const agentDir = resolveAgentDir(cfg, agentId);
+  const configured = findAgentEntryIndex(listAgentEntries(cfg), agentId) >= 0;
+  let existingJournal = configured ? undefined : readAgentDeletionJournal(agentId);
+  if (!configured && (!existingJournal || existingJournal.cleanupCompleted)) {
+    runtime.error(
+      `Agent "${agentId}" not found. Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
+    );
+    runtime.exit(1);
+    return;
+  }
+  const configuredAgentDir = configured ? resolveAgentDir(cfg, agentId) : undefined;
+  const safetyAgentDir = existingJournal?.agentDir ?? configuredAgentDir;
+  if (!safetyAgentDir) {
+    throw new Error(`Agent "${agentId}" deletion has no state directory.`);
+  }
   const sharedAuthOwnership = resolveSharedAuthStoreOwnership();
   if (
     isSharedAuthStoreOwner({
       ownership: sharedAuthOwnership,
-      agentAuthDbPath: resolveAuthProfileDatabasePath(agentDir),
+      agentAuthDbPath: resolveAuthProfileDatabasePath(safetyAgentDir),
       sharedAuthDbPath: resolveSharedAuthStorePath(),
     })
   ) {
@@ -126,14 +145,8 @@ export async function agentsDeleteCommand(
     runtime.exit(1);
     return;
   }
-  if (findAgentEntryIndex(listAgentEntries(cfg), agentId) < 0) {
-    runtime.error(
-      `Agent "${agentId}" not found. Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
-    );
-    runtime.exit(1);
-    return;
-  }
-  if (agentId === tryResolveSoleAgentId(cfg)) {
+
+  if (configured && agentId === tryResolveSoleAgentId(cfg)) {
     runtime.error(`Agent "${agentId}" is the only configured agent and cannot be deleted.`);
     runtime.exit(1);
     return;
@@ -148,6 +161,20 @@ export async function agentsDeleteCommand(
     );
     runtime.exit(1);
     return;
+  }
+
+  if (configured) {
+    existingJournal = readAgentDeletionJournal(agentId);
+    if (existingJournal?.cleanupCompleted) {
+      if (!claimCompletedAgentDeletion(agentId, existingJournal.operationId)) {
+        throw new Error(`Agent "${agentId}" deletion tombstone changed before fresh deletion.`);
+      }
+      existingJournal = undefined;
+    }
+  }
+  const agentDir = existingJournal?.agentDir ?? configuredAgentDir;
+  if (!agentDir) {
+    throw new Error(`Agent "${agentId}" deletion has no state directory.`);
   }
 
   if (!opts.force) {
@@ -167,9 +194,11 @@ export async function agentsDeleteCommand(
     }
   }
 
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
-  const result = pruneAgentConfig(cfg, agentId);
+  const workspaceDir = existingJournal?.workspaceDir ?? resolveAgentWorkspaceDir(cfg, agentId);
+  const sessionsDir = existingJournal?.sessionsDir ?? resolveSessionTranscriptsDirForAgent(agentId);
+  const result = configured
+    ? pruneAgentConfig(cfg, agentId)
+    : { config: cfg, removedBindings: 0, removedAllow: 0, clearedOwnerRefs: [] };
 
   const gatewayResult = await maybeDeleteAgentThroughGateway({
     agentId,
@@ -206,16 +235,30 @@ export async function agentsDeleteCommand(
     return;
   }
 
-  await replaceConfigFile({
-    nextConfig: result.config,
-    ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: {
-      allowedAgentRosterRemovals: [agentId],
-      ...(opts.json ? { skipOutputLogs: true } : {}),
-    },
-  });
-  if (!opts.json) {
-    logConfigUpdated(runtime);
+  const deleteFiles = existingJournal?.deleteFiles ?? true;
+  const deletion = beginAgentDeletion(
+    existingJournal ?? { agentId, agentDir, workspaceDir, sessionsDir, deleteFiles },
+  );
+  try {
+    if (configured) {
+      await replaceConfigFile({
+        nextConfig: result.config,
+        ...(baseHash !== undefined ? { baseHash } : {}),
+        writeOptions: {
+          allowedAgentRosterRemovals: [agentId],
+          ...(opts.json ? { skipOutputLogs: true } : {}),
+        },
+      });
+      if (!opts.json) {
+        logConfigUpdated(runtime);
+      }
+    }
+    deletion.commit();
+  } catch (error) {
+    if (!existingJournal) {
+      deletion.rollback();
+    }
+    throw error;
   }
 
   // Purge session store entries for this agent so orphaned sessions cannot be targeted (#65524).
@@ -226,14 +269,15 @@ export async function agentsDeleteCommand(
   const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
   const workspaceRetained = workspaceSharedWith.length > 0;
   let workspaceCleanupError: Error | undefined;
-  if (workspaceRetained) {
+  let workspaceRemoved = workspaceRetained || !deleteFiles;
+  if (deleteFiles && workspaceRetained) {
     quietRuntime.log(
       `Skipped workspace removal (shared with other agents: ${workspaceSharedWith.join(", ")}): ${workspaceDir}`,
     );
-  } else {
+  } else if (deleteFiles) {
     const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
     const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
-    const workspaceRemoved = await moveToTrash(workspaceDir, quietRuntime);
+    workspaceRemoved = await moveToTrash(workspaceDir, quietRuntime);
     if (workspaceRemoved) {
       try {
         const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
@@ -246,10 +290,18 @@ export async function agentsDeleteCommand(
       }
     }
   }
-  await moveToTrash(agentDir, quietRuntime);
-  await moveToTrash(sessionsDir, quietRuntime);
+  const agentDirRemoved = !deleteFiles || (await moveToTrash(agentDir, quietRuntime));
+  const sessionsDirRemoved = !deleteFiles || (await moveToTrash(sessionsDir, quietRuntime));
   if (workspaceCleanupError) {
     throw workspaceCleanupError;
+  }
+  if (workspaceRemoved && agentDirRemoved && sessionsDirRemoved) {
+    if (deleteFiles) {
+      // Keep registry ownership until every cleanup target is terminal. A crash before journal
+      // completion leaves this idempotent deregistration reachable on the next delete attempt.
+      unregisterOpenClawAgentDatabases({ agentId });
+    }
+    deletion.finish();
   }
 
   if (opts.json) {

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -19,7 +19,12 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  registerOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
@@ -449,6 +454,76 @@ describe("agents delete command", () => {
       expectSessionStore(cfg, {
         "agent:main:main": { sessionId: "sess-main", updatedAt: now + 3 },
       });
+    });
+  });
+
+  it("deregisters the agent database after offline deletion", async () => {
+    await withStateDirEnv("openclaw-agents-delete-registry-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+      const databasePath = path.join(stateDir, "agents", "ops", "agent", "openclaw-agent.sqlite");
+      registerOpenClawAgentDatabase({ agentId: "ops", path: databasePath });
+      expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).toContain("ops");
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).not.toContain(
+        "ops",
+      );
+      expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(true);
+    });
+  });
+
+  it("resumes offline deletion after cleanup was interrupted", async () => {
+    await withStateDirEnv("openclaw-agents-delete-recovery-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+      const databasePath = path.join(stateDir, "agents", "ops", "agent", "openclaw-agent.sqlite");
+      registerOpenClawAgentDatabase({ agentId: "ops", path: databasePath });
+      workspaceStateMocks.deleteWorkspaceState.mockImplementationOnce(() => {
+        throw new Error("interrupted after filesystem cleanup");
+      });
+
+      await expect(
+        agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime),
+      ).rejects.toThrow("interrupted after filesystem cleanup");
+      expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(false);
+      expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).toContain("ops");
+
+      const writeCalls = configMocks.replaceConfigFile.mock.calls as unknown as Array<
+        [{ nextConfig?: OpenClawConfig }]
+      >;
+      const firstWrite = writeCalls[0]?.[0];
+      const nextConfig = firstWrite?.nextConfig;
+      expect(nextConfig).toBeDefined();
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        config: nextConfig,
+        runtimeConfig: nextConfig,
+        sourceConfig: nextConfig,
+        resolved: nextConfig,
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).not.toContain(
+        "ops",
+      );
+      expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(true);
     });
   });
 

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -695,3 +695,21 @@ export function unregisterOpenClawAgentDatabase(params: {
   );
   invalidateRegisteredAgentDatabasesMemo({ env: params.env });
 }
+
+/** Remove every durable database registration owned by a deleted agent. */
+export function unregisterOpenClawAgentDatabases(params: {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db.deleteFrom("agent_databases").where("agent_id", "=", params.agentId),
+      );
+    },
+    { env: params.env },
+  );
+  invalidateRegisteredAgentDatabasesMemo({ env: params.env });
+}


### PR DESCRIPTION
Related: #109956 (deleted-agent registry leak only; this does not address the separate phantom-writer or retained-present-database policy questions)

## What Problem This Solves

Fixes an issue where `openclaw agents delete --force` could leave the deleted agent's durable `agent_databases` row behind when no usable Gateway was reachable and the CLI used its local fallback. The database files were gone, but registry discovery still reported them until an operator happened to run `openclaw doctor`.

The live report showed the long-term effect clearly: 3 configured agents versus 15 registry rows after ordinary churn, with doctor later emitting `Removed missing agent database registry entry` and `Skipped missing registered agent database` for state the delete owner should have finalized itself.

## Why This Change Was Made

The Gateway RPC deletion path already had the correct architecture: begin a durable deletion journal, remove roster authority, finish filesystem cleanup, deregister exact database ownership through the registry owner, and only then complete the journal. The leak was the CLI transport/credential fallback, which was a separate non-journaled implementation.

The fallback now joins the same lifecycle model. It records or resumes the deletion journal before roster mutation, retains database registration while any file cleanup is incomplete, atomically deregisters every row for the deleted agent through the registry owner's `unregisterOpenClawAgentDatabases` API, and completes the journal last. A crash before deregistration leaves the row plus unfinished journal; a crash after deregistration but before completion retries the idempotent deregistration and completes. No schema or schema-version change is involved.

The independent `claws remove` agent-deletion path now releases database registration through the same registry owner only after its existing removal state reaches complete. Doctor reconciliation remains unchanged as the safety net for old versions, crashes, and manual file removal.

## User Impact

Completed agent deletion now leaves no stale database registry entry, including when the Gateway is unavailable or requires credentials and the CLI falls back locally. Interrupted local deletions can be retried by agent id even after the roster entry was already removed.

This deliberately does not remove the harmless empty `agents/<id>/` container: the journal owns the agent and sessions subdirectories, while safely claiming the parent would require a separate empty/default-layout ownership check. Completed deletion-journal rows also remain durable one-row-per-agent tombstones until recreation claims them; changing that authority-retention contract is outside this repair.

Production LOC: +103/-28 (net +75) | Tests: +90/-0. The production growth is the durable offline deletion/recovery boundary that was previously absent, plus one registry-owner bulk removal operation; it replaces the non-resumable fallback rather than adding a second policy path.

AI-assisted implementation; the resulting lifecycle and failure semantics were reviewed directly and with the repository autoreview workflow.

## Evidence

### Before

Live reproduction on 2026-08-15 at `eb13f5719f0`:

```text
before agents add                 0
after  agents add                 0
after  one agent turn             1
after  agents delete --force      1
```

Accumulated profile state: 3 configured agents, 15 `agent_databases` rows. Doctor then repaired the 12 deleted-agent rows downstream.

### After

Exact built-tree macOS proof with isolated `OPENCLAW_STATE_DIR`, `OPENCLAW_SKIP_CHANNELS=1`, no Gateway port, and read-only local Ollama `qwen3:4b-instruct`:

```text
before agents add                 0
after  agents add                 0
after  successful agent turn      1
after  agents delete --force      0
after  doctor --fix               0
```

The Ollama turn returned `OK` (30,260 input tokens, 2 output tokens). The subsequent doctor run completed without either registry reconciliation message.

### Automated validation

- `node scripts/run-vitest.mjs src/commands/agents.delete.test.ts src/claws/lifecycle-state.test.ts src/infra/state-migrations.media-persistence-targets.test.ts src/gateway/server-methods/agents-mutate.test.ts` — 155 tests passed across 4 shards.
- The new command regression registers an actual database row, exercises the no-Gateway fallback, and asserts the row is gone. It fails on the pre-fix implementation because that fallback never called the registry owner.
- The interrupted-delete regression fails cleanup after roster commit, verifies the journal and registry row remain, retries with the roster entry absent, and verifies deregistration plus journal completion.
- Existing synthetic-orphan doctor coverage remains green and still asserts both repair messages plus row removal.
- `node scripts/check-changed.mjs` — green on Blacksmith Testbox (`tbx_01m043kxmskdhv8cp9pmw298sy`, Actions run 31920094059).
- `pnpm build` equivalent through the hydrated Testbox — green in 3m25s (`tbx_01m044wgf3trv1yd6ebbrdpqsb`, Actions run 31920942565; wrapper exit 0).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings.
