### PR TITLE
fix(cli): read node liveness from the recorded node.list fact and drop dead nodes-CLI guards

### DIFF
--- a/src/cli/nodes-cli/register.pairing.ts
+++ b/src/cli/nodes-cli/register.pairing.ts
@@ -211,13 +211,6 @@ export function registerNodesPairingCommands(nodes: Command) {
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("remove", async () => {
           const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
-          if (!nodeId) {
-            defaultRuntime.error(
-              `--node is required. Run ${formatCliCommand("openclaw nodes pending")} to choose a node request.`,
-            );
-            defaultRuntime.exit(1);
-            return;
-          }
           const result = await callNodesGatewayCli("node.pair.remove", opts, { nodeId });
           if (opts.json) {
             defaultRuntime.writeJson(result);
@@ -239,9 +232,9 @@ export function registerNodesPairingCommands(nodes: Command) {
         await runNodesCommand("rename", async () => {
           const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const name = normalizeOptionalString(opts.name) ?? "";
-          if (!nodeId || !name) {
+          if (!name) {
             defaultRuntime.error(
-              `--node and --name are required. Run ${formatCliCommand("openclaw nodes pending")} to choose a node, then rerun with --name <displayName>.`,
+              `--name must not be empty. Run ${formatCliCommand("openclaw nodes list")} to see paired nodes, then rerun with --name <displayName>.`,
             );
             defaultRuntime.exit(1);
             return;

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -256,26 +256,17 @@ export function registerNodesStatusCommands(nodes: Command) {
           const tableWidth = getTerminalTableWidth();
           const now = Date.now();
           const nodesLocal = parseNodeList(result);
-          const lastConnectedById =
-            sinceMs !== undefined
-              ? new Map(
-                  parsePairingList(
-                    await callNodesGatewayCli("node.pair.list", opts, {}),
-                  ).paired.map((entry) => [entry.nodeId, entry]),
-                )
-              : null;
           const filtered = nodesLocal.filter((n) => {
             if (connectedOnly && !n.connected) {
               return false;
             }
             if (sinceMs !== undefined) {
-              const paired = lastConnectedById?.get(n.nodeId);
-              const lastConnectedAtMs =
-                typeof paired?.lastConnectedAtMs === "number"
-                  ? paired.lastConnectedAtMs
-                  : typeof n.connectedAtMs === "number"
-                    ? n.connectedAtMs
-                    : undefined;
+              // The gateway records lastConnectedAtMs on every node.list row
+              // (max of stored pairing history and live connection); joining a
+              // second pairing-scoped RPC re-derived that fact and made
+              // --last-connected fail for read-scoped callers. connectedAtMs
+              // covers gateways predating the recorded field.
+              const lastConnectedAtMs = n.lastConnectedAtMs ?? n.connectedAtMs;
               if (typeof lastConnectedAtMs !== "number") {
                 return false;
               }
@@ -532,7 +523,9 @@ export function registerNodesStatusCommands(nodes: Command) {
           const tableWidth = getTerminalTableWidth();
           const now = Date.now();
           const hasFilters = connectedOnly || sinceMs !== undefined;
-          const pendingRows = hasFilters ? [] : pending;
+          // Pending requests carry no connection state to filter on; hiding
+          // them under --connected printed "Pending: 0" while requests waited.
+          const pendingRows = pending;
           const effectiveNodes = hasFilters
             ? parseNodeList(await callNodesGatewayCli("node.list", opts, {}))
             : await tryReadNodeList(opts);

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -358,25 +358,23 @@ describe("cli program (nodes basics)", () => {
     expect(output).toContain("Catalog Only");
   });
 
-  it("runs nodes status --last-connected and filters by age", async () => {
+  it("runs nodes status --last-connected using the recorded node.list fact", async () => {
     const now = Date.now();
+    const methods: string[] = [];
     programGatewayCallMock.mockImplementation(async (...args: unknown[]) => {
       const opts = (args[0] ?? {}) as { method?: string };
+      methods.push(opts.method ?? "");
       if (opts.method === "node.list") {
         return {
           ts: now,
           nodes: [
-            { nodeId: "n1", displayName: "One", connected: false },
-            { nodeId: "n2", displayName: "Two", connected: false },
-          ],
-        };
-      }
-      if (opts.method === "node.pair.list") {
-        return {
-          pending: [],
-          paired: [
-            { nodeId: "n1", lastConnectedAtMs: now - 1_000 },
-            { nodeId: "n2", lastConnectedAtMs: now - 2 * 24 * 60 * 60 * 1000 },
+            { nodeId: "n1", displayName: "One", connected: false, lastConnectedAtMs: now - 1_000 },
+            {
+              nodeId: "n2",
+              displayName: "Two",
+              connected: false,
+              lastConnectedAtMs: now - 2 * 24 * 60 * 60 * 1000,
+            },
           ],
         };
       }
@@ -384,7 +382,9 @@ describe("cli program (nodes basics)", () => {
     });
     await runProgram(["nodes", "status", "--last-connected", "24h"]);
 
-    expectGatewayRequest("node.pair.list", {});
+    // The gateway records lastConnectedAtMs on node.list rows; re-joining
+    // node.pair.list broke --last-connected for read-scoped callers.
+    expect(methods).not.toContain("node.pair.list");
     const output = getRuntimeOutput();
     expect(output).toContain("One");
     expect(output).not.toContain("Two");

--- a/src/commands/status.node-mode.test.ts
+++ b/src/commands/status.node-mode.test.ts
@@ -30,7 +30,7 @@ describe("resolveNodeOnlyGatewayInfo", () => {
           installed: true,
           loaded: true,
           externallyManaged: false,
-          runtimeShort: "running (pid 4321)",
+          runtime: { status: "running", pid: 4321 },
         },
       }),
     ).resolves.toEqual({
@@ -60,7 +60,6 @@ describe("resolveNodeOnlyGatewayInfo", () => {
           loaded: false,
           externallyManaged: false,
           runtime: { status: "stopped" },
-          runtimeShort: "stopped",
         },
       }),
     ).resolves.toBeNull();
@@ -76,7 +75,6 @@ describe("resolveNodeOnlyGatewayInfo", () => {
           installed: true,
           loaded: true,
           externallyManaged: false,
-          runtimeShort: "running (pid 4321)",
         },
       }),
     ).resolves.toEqual({

--- a/src/commands/status.node-mode.ts
+++ b/src/commands/status.node-mode.ts
@@ -14,7 +14,6 @@ type NodeOnlyServiceLike = {
         pid?: number;
       }
     | undefined;
-  runtimeShort?: string | null;
 };
 
 export type NodeOnlyGatewayInfo = {
@@ -51,10 +50,7 @@ function isNodeServiceActive(node: NodeOnlyServiceLike): boolean {
   if (node.loaded === true) {
     return true;
   }
-  if (hasRunningRuntime(node.runtime)) {
-    return true;
-  }
-  return typeof node.runtimeShort === "string" && node.runtimeShort.startsWith("running");
+  return hasRunningRuntime(node.runtime);
 }
 
 /** Returns node-only gateway context when node is active and the local gateway is intentionally absent. */


### PR DESCRIPTION
## What Problem This Solves

Four nodes-CLI defects found by the round-6 TUI/CLI lane, all in the "stale/multi-signal derivation and dead-end guidance" class:

1. **`nodes status --last-connected` re-derived a recorded fact and broke for read-scoped callers.** The gateway records `lastConnectedAtMs` on every `node.list` row (max of stored pairing history and live connection, since 2dcd47d4f45). The CLI ignored it and joined a second pairing-scoped RPC (`node.pair.list`) — re-implementing the merge *worse* (preferring stored history over a live connection instead of taking the max) and making the whole command fail for callers whose auth grants `operator.read` but not `operator.pairing`, even though the needed fact was already in the response in hand.
2. **`nodes list --connected` printed "Pending: 0" while requests waited** — the filter blanked pending rows and the header then asserted a fact it never checked, in both human and `--json` output, contradicting `nodes pending`.
3. **`nodes remove`/`rename` carried unreachable guards with wrong advice.** `resolveCliNodeId` throws `"node required"` on blank input and every parse layer drops id-less rows, so the `!nodeId` guards were dead — and their text pointed at `nodes pending`, which lists pairing *requests*, not the paired nodes these commands target. The reachable empty-`--name` branch now hints at `nodes list`.
4. **`status.node-mode` derived node-service liveness from the formatted `runtimeShort` display string** — parsing a fact back out of its own projection; dead in all first-party call paths (both callers pass the `runtime` object the string is derived from). Field and branch deleted.

## Why This Change Was Made

"Record facts where they happen; read them where they are needed" — the `--last-connected` filter now reads the recorded row fact with `connectedAtMs` covering gateways that predate it. Pending rows carry no connection state to filter on, so they always show. Dead guards and display-string parsing go per the lean-code doctrine.

## User Impact

`nodes status --last-connected` works for read-scoped callers and no longer under-reports live connections; `nodes list --connected` stops lying about pending requests; error text points at commands that actually help.

## Evidence

- e2e test updated to pin the single-RPC shape: asserts `node.pair.list` is **not** called and the age filter works off `node.list` rows (the old test cemented the double-RPC join).
- `node scripts/run-vitest.mjs run src/commands/status.node-mode.test.ts src/shared/node-list-parse.test.ts` — green; node-mode fixtures now use the production shape (runtime object).
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.99).

Production LOC +12/−30 (net −18); tests +14/−16.
