### PR TITLE
perf(test): shorten Vault timeout regression

### DIFF
--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -15,10 +15,11 @@ const packagePath = fileURLToPath(new URL("../package.json", import.meta.url));
 function runResolver(params: {
   request: unknown;
   env?: Record<string, string>;
+  resolverExecutablePath?: string;
   timeoutMs?: number;
 }): Promise<{ stdout: string; stderr: string; code: number | null; timedOut: boolean }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [resolverPath], {
+    const child = spawn(process.execPath, [params.resolverExecutablePath ?? resolverPath], {
       stdio: ["pipe", "pipe", "pipe"],
       env: {
         ...process.env,
@@ -66,6 +67,19 @@ function runResolver(params: {
 
 const servers: Array<{ close: () => Promise<void> }> = [];
 const tempDirs: string[] = [];
+
+async function writeTimeoutResolver(): Promise<string> {
+  const staged = path.join(path.dirname(resolverPath), `.vault-timeout-${process.pid}.js`);
+  tempDirs.push(staged);
+  const source = readFileSync(resolverPath, "utf8");
+  const stagedSource = source.replace(
+    "const VAULT_FETCH_TIMEOUT_MS = 5000;",
+    "const VAULT_FETCH_TIMEOUT_MS = 500;",
+  );
+  expect(stagedSource).not.toBe(source);
+  await writeFile(staged, stagedSource, "utf8");
+  return staged;
+}
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
@@ -996,7 +1010,8 @@ describe("vault SecretRef resolver", () => {
         VAULT_ADDR: fixture.vaultAddr,
         VAULT_TOKEN: "not-a-real-auth-header",
       },
-      timeoutMs: 6_500,
+      resolverExecutablePath: await writeTimeoutResolver(),
+      timeoutMs: 2_500,
     });
 
     expect(result).toMatchObject({ code: 1, stderr: "", timedOut: false });


### PR DESCRIPTION
## What Problem This Solves

The Vault SecretRef resolver suite spent the full five-second production fetch timeout proving that a stalled JSON response body is aborted. That deterministic wait dominated the focused suite even though the contract under test is cancellation behavior, not the production timeout duration.

## Why This Change Was Made

The regression now stages the real resolver executable beside its static asset and rewrites only the timeout constant to 500 ms for this one test. The test still crosses the real subprocess and loopback HTTP boundaries, stalls an incomplete JSON response body, requires the production abort signal to terminate the read, and verifies that the outer process watchdog did not fire. Production code and timeout behavior are unchanged.

A mutation removing the fetch abort signal makes the regression fail with the child reaching the outer timeout, confirming that the faster test still protects the intended cancellation owner boundary.

## User Impact

No runtime behavior changes. Maintainers get materially faster Vault extension feedback while preserving the security-sensitive timeout regression.

## Evidence

Controlled same-Testbox A/B measurement used one excluded warmup and two retained samples per state, one worker, distinct Vitest filesystem caches, import diagnostics, and `/usr/bin/time -v`:

- Wall mean: 9.75s to 5.24s, down 46.3%.
- Vitest mean: 6.83s to 2.35s, down 65.6%.
- Test-body mean: 6.19s to 1.69s, down 72.7%.
- The stalled-body case: about 5.03s to about 0.53s.
- Import cost and peak RSS were flat; no CPU or memory improvement is claimed.

Validation:

- 28/28 focused resolver tests passed after rebasing onto current main.
- 46/46 Vault owner tests passed during candidate validation, including CLI coverage.
- 28/28 extension-boundary tests passed during candidate validation.
- The full 18-step extension changed gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31920834628
- Fresh structured autoreview reported no accepted or actionable findings.
- Production LOC: +0/-0. Test LOC: +17/-2.
