### PR TITLE
fix(gateway): discard prepared media when a hook blocks the turn

### DIFF
--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -18,7 +18,10 @@ import type { ChatRunTiming } from "../server-chat-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
-import type { prepareChatSendAttachments } from "./chat-send-attachments.js";
+import {
+  discardPreparedChatSendAttachments,
+  type prepareChatSendAttachments,
+} from "./chat-send-attachments.js";
 import {
   resolveWebchatPromptCacheKey,
   scheduleChatDashboardSessionTitle,
@@ -507,6 +510,13 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     .catch(dispatchErrorLifecycle.handleError)
     .finally(() => {
       dispatchErrorLifecycle.finalize();
+      if (userTurnRecorder.isBlocked() && attachments.offloadedRefs.length > 0) {
+        // A blocked turn persists only the redacted block reason — no media
+        // markers — so the prepared inbound media stays unreferenced forever
+        // (sweep is off by default). Same custody rule as the pre-ACK owner
+        // in chat-send-admission.ts: unreferenced staged media is discarded.
+        void discardPreparedChatSendAttachments(attachments.offloadedRefs);
+      }
       // Cosmetic title work starts only after the accepted turn finishes. Starting it
       // before dispatch can make a cold utility runtime starve the user's real turn.
       scheduleChatDashboardSessionTitle({

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2112,6 +2112,60 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.send discards prepared inbound media when a hook blocks the turn", async () => {
+    openDirectChatSession();
+    try {
+      await writeStoredMainSession({
+        modelProvider: "test-provider",
+        model: "vision-model",
+      });
+      const context = createDirectChatContext({ getRuntimeConfig: () => ({}) });
+      const inboundDir = path.join(getMediaDir(), "inbound");
+      const inboundBaseline = new Set(await fs.readdir(inboundDir).catch(() => []));
+      // A before_agent_run block persists only the redacted reason — no media
+      // markers — so dispatch must discard the prepared refs on settle.
+      dispatchInboundMessageMock.mockImplementationOnce(async (params: unknown) => {
+        const recorder = (
+          params as {
+            replyOptions?: { userTurnTranscriptRecorder?: { markBlocked: () => void } };
+          }
+        ).replyOptions?.userTurnTranscriptRecorder;
+        recorder?.markBlocked();
+      });
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      await callDirectChat("chat.send", {
+        id: "blocked-turn-media",
+        params: makeChatSendParams({
+          message: "blocked turn with media",
+          idempotencyKey: "idem-blocked-turn-media",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "text/plain",
+              fileName: "notes.txt",
+              content: Buffer.from("offloaded inbound media").toString("base64"),
+            },
+          ],
+        }),
+        client: {
+          connId: "conn-owner",
+          connect: { device: { id: "dev-owner" }, scopes: ["operator.write"] },
+        } as never,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+      });
+      expect(responses[0]?.ok).toBe(true);
+      await waitForFast(async () => {
+        const remaining = await fs.readdir(inboundDir).catch(() => []);
+        expect(remaining.filter((name) => !inboundBaseline.has(name))).toEqual([]);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      resetDirectChatSession();
+    }
+  });
+
   test("chat.send discards prepared inbound media when setup throws before the ACK", async () => {
     openDirectChatSession();
     try {


### PR DESCRIPTION
## What Problem This Solves

#124100 moved prepared-media abandonment custody to the admission cleanup owner, disarmed at the ACK on the invariant that dispatch persists the referencing transcript on every post-ACK path. The round-6 media lane found the path that breaks that invariant: **a `before_agent_run` hook block**. The blocked path persists only the redacted block reason — no `[media attached: …]` markers, no media facts (`persistBlocked` with the redacted message) — so the offloaded inbound refs in `~/.openclaw/media/inbound` stay unreferenced forever. The inbound sweep is off unless `attachments.ttlHours` is set, so default installs orphan the files permanently — the exact #123983/#124100 bug class.

## Why This Change Was Made

Dispatch settle (the `finally` that already owns `dispatchErrorLifecycle.finalize()`) now discards the prepared refs when the recorder ended blocked, applying the same custody rule as the pre-ACK owner: unreferenced staged media is discarded. This is the gateway-side owner point — it covers every block source (embedded and CLI runners both funnel through the same recorder `markBlocked`/`persistBlocked` semantics) without touching the redaction policy, which intentionally strips everything but the block reason.

## User Impact

Operators running content-blocking hooks no longer accumulate permanently orphaned media files for every blocked send that carried attachments.

## Evidence

- New regression test drives a blocked dispatch (`markBlocked` via the recorder handed to `dispatchInboundMessage`) with an offloaded attachment and asserts the inbound dir returns to baseline — **fails pre-fix** (stash proof), passes post-fix.
- Full `node scripts/run-vitest.mjs run src/gateway/server.chat.gateway-server-chat-b.test.ts` — 102/102 (includes the #124100 and #123983 custody regressions, proving no double-discard or referenced-media deletion).
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.98).

Production LOC +11/−1 (the settle-point discard + custody comment); tests +54.
