### PR TITLE
refactor(types): drain chained-assertion ledger — agents

### DIFF
--- a/scripts/oxlint-boundary-guards.mjs
+++ b/scripts/oxlint-boundary-guards.mjs
@@ -666,7 +666,17 @@ export default {
         "packages/ai",
         "src/acp/client.ts", // Node and Web ReadableStream types live in separate namespaces.
         "src/acp/server.ts", // Node and Web ReadableStream types live in separate namespaces.
-        "src/agents",
+        "src/agents/agent-hooks/compaction-safeguard.ts", // AgentMessage custom roles exceed the Copilot header message contract.
+        "src/agents/agent-model-discovery.ts", // Persisted registry rows need a fully resolved model parser owner.
+        "src/agents/embedded-agent-helpers/images.ts", // Assistant blocks cross the tool-image sanitizer's narrower block namespace.
+        "src/agents/embedded-agent-runner/run/attempt-stream.ts", // Synthetic yield stream metadata is wider than the provider model contract.
+        "src/agents/embedded-agent-runner/run/images.ts", // Provider-only video blocks cross the canonical AgentMessage namespace.
+        "src/agents/mcp-http-fetch.ts", // Undici Response crosses the DOM FetchLike type namespace.
+        "src/agents/model-auth-model.ts", // Null Authorization sentinel crosses the SDK's string-only header type.
+        "src/agents/model-provider-auth.ts", // Route-fact cache keys cross a config-only hash API.
+        "src/agents/modes/interactive/theme/theme.ts", // Global symbol registry and Proxy receiver bridge duplicate module copies.
+        "src/agents/subagents/spawn/subagent-depth.ts", // Generic session projections cross the fixed accessor entry type.
+        "src/agents/tool-search-transcript.ts", // Synthetic target turns omit provider-owned assistant metadata.
         "src/channels/plugins/config-schema.ts", // Public SDK Zod generics preserve caller schema identity.
         "src/commands/channel-test-registry.ts", // Test support.
         "src/commands/doctor/cron/legacy-repair.ts", // Partially validated legacy rows cross the canonical cron store type.
@@ -683,7 +693,9 @@ export default {
         "src/infra/net/runtime-fetch.ts", // Undici and DOM fetch types live in separate namespaces.
         "src/infra/state-migrations.meeting-transcripts-files.ts", // Legacy summary validation does not prove element types.
         "src/infra/unhandled-rejections.ts", // Global symbol registry crosses module copies.
-        "src/meeting-bot",
+        "src/meeting-bot/browser-controller.ts", // Generic health fallbacks cannot construct arbitrary platform subtypes.
+        "src/meeting-bot/platform-adapter.ts", // Generic parsers add adapter-owned health and transcript fields.
+        "src/meeting-bot/plugin-shell.ts", // Type-only plugin namespace factory has no runtime value.
         "src/plugin-sdk/channel-config-helpers.ts", // Public SDK accessor generics are intentionally decoupled.
         "src/plugin-sdk/provider-stream-shared.ts", // Untyped normalizer events need a transport stream API redesign.
         "src/plugin-sdk/qa-runtime.ts", // Public SDK lazy module exposes a narrower runtime surface.

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { URL } from "node:url";
 import { detectMime } from "@openclaw/media-core/mime";
 import { formatByteSize } from "@openclaw/normalization-core";
+import type { Static, TSchema } from "typebox";
+import { Value } from "typebox/value";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { isMissingPathError, toErrorObject } from "../infra/errors.js";
 import {
@@ -38,7 +40,7 @@ import {
   withMemoryWriteProvenance,
 } from "./memory-write-provenance.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
-import type { AgentToolResult } from "./runtime/index.js";
+import type { AgentTool, AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import {
@@ -72,6 +74,27 @@ type SkillReadContent = {
   filePath: string;
   readContent?: string;
 };
+
+/** Erase a schema-specific session tool only after its input passes that owned schema. */
+function eraseSessionFileTool<TParameters extends TSchema, TDetails>(
+  tool: AgentTool<TParameters, TDetails>,
+): AnyAgentTool {
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      if (!Value.Check(tool.parameters, params)) {
+        throw new Error(`Invalid parameters for ${tool.name}`);
+      }
+      const typedParams = params as Static<TParameters>;
+      return await tool.execute(
+        toolCallId,
+        typedParams,
+        signal,
+        onUpdate ? (update) => onUpdate(update) : undefined,
+      );
+    },
+  };
+}
 
 type ReadTruncationDetails = {
   truncated: boolean;
@@ -885,9 +908,11 @@ type SandboxToolParams = {
 export function createSandboxedReadTool(
   params: SandboxToolParams & { createTool?: typeof createReadTool },
 ) {
-  const base = (params.createTool ?? createReadTool)(params.root, {
-    operations: createSandboxReadOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseSessionFileTool(
+    (params.createTool ?? createReadTool)(params.root, {
+      operations: createSandboxReadOperations(params),
+    }),
+  );
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
@@ -898,9 +923,11 @@ export function createSandboxedReadTool(
 export function createSandboxedWriteTool(
   params: SandboxToolParams & { createTool?: typeof createWriteTool },
 ) {
-  const base = (params.createTool ?? createWriteTool)(params.root, {
-    operations: createSandboxWriteOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseSessionFileTool(
+    (params.createTool ?? createWriteTool)(params.root, {
+      operations: createSandboxWriteOperations(params),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -908,9 +935,11 @@ export function createSandboxedWriteTool(
 export function createSandboxedEditTool(
   params: SandboxToolParams & { createTool?: typeof createEditTool },
 ) {
-  const base = (params.createTool ?? createEditTool)(params.root, {
-    operations: createSandboxEditOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseSessionFileTool(
+    (params.createTool ?? createEditTool)(params.root, {
+      operations: createSandboxEditOperations(params),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -923,9 +952,11 @@ export function createHostWorkspaceWriteTool(
     createTool?: typeof createWriteTool;
   },
 ) {
-  const base = (options?.createTool ?? createWriteTool)(root, {
-    operations: createHostWriteOperations(root, options),
-  }) as unknown as AnyAgentTool;
+  const base = eraseSessionFileTool(
+    (options?.createTool ?? createWriteTool)(root, {
+      operations: createHostWriteOperations(root, options),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -938,9 +969,11 @@ export function createHostWorkspaceEditTool(
     createTool?: typeof createEditTool;
   },
 ) {
-  const base = (options?.createTool ?? createEditTool)(root, {
-    operations: createHostEditOperations(root, options),
-  }) as unknown as AnyAgentTool;
+  const base = eraseSessionFileTool(
+    (options?.createTool ?? createEditTool)(root, {
+      operations: createHostEditOperations(root, options),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -1003,13 +1036,15 @@ export function wrapReadToolWithSkillContent(
     }
     return content;
   };
-  const virtualBase = createReadTool("/", {
-    operations: {
-      resolvePath: (filePath) => filePath,
-      access: async (filePath) => void readContent(filePath),
-      readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
-    },
-  }) as unknown as AnyAgentTool;
+  const virtualBase = eraseSessionFileTool(
+    createReadTool("/", {
+      operations: {
+        resolvePath: (filePath) => filePath,
+        access: async (filePath) => void readContent(filePath),
+        readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
+      },
+    }),
+  );
   const virtualRead = createOpenClawReadTool(virtualBase, options);
   return {
     ...tool,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-support.ts
@@ -52,6 +52,13 @@ type PromptBuildToolPolicyBaseline = {
   catalogEntries: readonly ToolSearchCatalogEntry[];
 };
 
+function readNamedToolPluginMeta(tool: NamedTool): { pluginId: string } | undefined {
+  if (!("execute" in tool) || typeof tool.execute !== "function") {
+    return undefined;
+  }
+  return getPluginToolMeta(tool as AnyAgentTool);
+}
+
 export function applyResolvedToolPromptFinalizer(params: {
   prompt: string;
   activeToolNames: readonly string[];
@@ -71,8 +78,7 @@ export function applyResolvedToolPromptFinalizer(params: {
 function filterTools<T extends NamedTool>(
   tools: readonly T[],
   toolsAllow: string[],
-  toolMeta: (tool: T) => { pluginId: string } | undefined = (tool) =>
-    getPluginToolMeta(tool as unknown as AnyAgentTool),
+  toolMeta: (tool: T) => { pluginId: string } | undefined = readNamedToolPluginMeta,
 ): T[] {
   return applyEmbeddedAttemptToolsAllow([...tools], toolsAllow, {
     toolMeta,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test.ts
@@ -40,6 +40,37 @@ async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unkn
 const requireRecord = createRequireRecord("object", "expected-label");
 
 describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
+  it("supports writable non-configurable stream iterators", async () => {
+    const resultMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "plain response" }],
+      stopReason: "stop",
+    };
+    const baseStream = createFakeStream({
+      events: [{ type: "done", reason: "stop", message: resultMessage }],
+      resultMessage,
+    });
+    const iterator = baseStream[Symbol.asyncIterator];
+    Object.defineProperty(baseStream, Symbol.asyncIterator, {
+      configurable: false,
+      value: iterator,
+      writable: true,
+    });
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(
+      (() => baseStream) as never,
+      new Set(["exec"]),
+    );
+
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    await expect(collectStreamEvents(stream)).resolves.toEqual([
+      { type: "done", reason: "stop", message: resultMessage },
+    ]);
+    await expect(stream.result()).resolves.toEqual(resultMessage);
+  });
+
   it("preserves a fenced allowed-tool example in live and terminal output", async () => {
     const parts = ["`", "``json\n", "[re", 'ad]\n{"path":"example.txt"}\n[/read]\n', "```"];
     const rawText = parts.join("");

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
@@ -112,19 +112,21 @@ function wrapStreamPromoteStandaloneTextToolCalls(
   };
 
   const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
-  (stream as unknown as { [Symbol.asyncIterator]: () => AsyncIterator<unknown> })[
-    Symbol.asyncIterator
-  ] = async function* () {
-    const source = {
-      [Symbol.asyncIterator]: originalAsyncIterator,
-    } as AsyncIterable<unknown>;
-    yield* normalizePlainTextToolCallStreamEvents(source, {
-      createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
-      matcher,
-      normalizeTerminalMessage,
-      resolveProtectedRanges: findCodeRegions,
-    });
-  };
+  Object.defineProperty(stream, Symbol.asyncIterator, {
+    configurable: true,
+    async *value() {
+      const source = {
+        [Symbol.asyncIterator]: originalAsyncIterator,
+      } as AsyncIterable<unknown>;
+      yield* normalizePlainTextToolCallStreamEvents(source, {
+        createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
+        matcher,
+        normalizeTerminalMessage,
+        resolveProtectedRanges: findCodeRegions,
+      });
+    },
+    writable: true,
+  });
 
   return stream;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
@@ -112,21 +112,20 @@ function wrapStreamPromoteStandaloneTextToolCalls(
   };
 
   const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
-  Object.defineProperty(stream, Symbol.asyncIterator, {
-    configurable: true,
-    async *value() {
-      const source = {
-        [Symbol.asyncIterator]: originalAsyncIterator,
-      } as AsyncIterable<unknown>;
-      yield* normalizePlainTextToolCallStreamEvents(source, {
-        createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
-        matcher,
-        normalizeTerminalMessage,
-        resolveProtectedRanges: findCodeRegions,
-      });
-    },
-    writable: true,
-  });
+  const wrappedAsyncIterator = async function* () {
+    const source = {
+      [Symbol.asyncIterator]: originalAsyncIterator,
+    } as AsyncIterable<unknown>;
+    yield* normalizePlainTextToolCallStreamEvents(source, {
+      createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
+      matcher,
+      normalizeTerminalMessage,
+      resolveProtectedRanges: findCodeRegions,
+    });
+  };
+  if (!Reflect.set(stream, Symbol.asyncIterator, wrappedAsyncIterator)) {
+    throw new TypeError("Cannot replace stream async iterator");
+  }
 
   return stream;
 }

--- a/src/agents/failover/provider-patterns.ts
+++ b/src/agents/failover/provider-patterns.ts
@@ -1,7 +1,8 @@
 import { matchesContextOverflowMessage } from "@openclaw/ai/internal/runtime";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveNodeRequireFromMeta } from "../../logging/node-require.js";
 import { isRateLimitErrorMessage } from "./message-patterns.js";
-import type { FailoverReason } from "./signal.js";
+import { FAILOVER_REASONS, type FailoverReason } from "./signal.js";
 type ProviderErrorPattern = {
   /** Regex to match against the raw error message. */
   test: RegExp;
@@ -43,6 +44,10 @@ const PROVIDER_CONTEXT_OVERFLOW_SIGNAL_RE =
 const PROVIDER_CONTEXT_OVERFLOW_ACTION_RE =
   /\b(?:too\s+(?:large|long|many)|exceed(?:s|ed|ing)?|overflow|limit|maximum|max)\b/i;
 
+function isFailoverReason(value: unknown): value is FailoverReason {
+  return typeof value === "string" && FAILOVER_REASONS.some((reason) => reason === value);
+}
+
 function resolveProviderRuntimeHooks(): ProviderRuntimeHooks | null {
   if (cachedProviderRuntimeHooks !== undefined) {
     return cachedProviderRuntimeHooks;
@@ -52,9 +57,20 @@ function resolveProviderRuntimeHooks(): ProviderRuntimeHooks | null {
     return cachedProviderRuntimeHooks;
   }
   try {
-    cachedProviderRuntimeHooks = requireProviderRuntime(
-      "../../plugins/provider-runtime.js",
-    ) as unknown as ProviderRuntimeHooks;
+    const runtime: unknown = requireProviderRuntime("../../plugins/provider-runtime.js");
+    const classify = isRecord(runtime) ? runtime.classifyProviderFailoverSignalWithPlugin : null;
+    if (typeof classify !== "function") {
+      cachedProviderRuntimeHooks = null;
+      return cachedProviderRuntimeHooks;
+    }
+    cachedProviderRuntimeHooks = {
+      classifyProviderFailoverSignalWithPlugin: (params) => {
+        const result: unknown = Reflect.apply(classify, runtime, [params]);
+        return result === null || result === undefined || isFailoverReason(result)
+          ? result
+          : undefined;
+      },
+    };
   } catch {
     cachedProviderRuntimeHooks = null;
   }

--- a/src/agents/failover/provider-patterns.ts
+++ b/src/agents/failover/provider-patterns.ts
@@ -65,7 +65,7 @@ function resolveProviderRuntimeHooks(): ProviderRuntimeHooks | null {
     }
     cachedProviderRuntimeHooks = {
       classifyProviderFailoverSignalWithPlugin: (params) => {
-        const result: unknown = Reflect.apply(classify, runtime, [params]);
+        const result: unknown = classify(params);
         return result === null || result === undefined || isFailoverReason(result)
           ? result
           : undefined;

--- a/src/agents/mcp-pagination.ts
+++ b/src/agents/mcp-pagination.ts
@@ -19,7 +19,7 @@ type McpPaginationRequest = {
   signal: AbortSignal;
 };
 
-type CollectMcpPaginatedItemsParams<TInput, TOutput = TInput> = {
+type CollectMcpPaginatedItemsBaseParams<TInput> = {
   label: string;
   itemLabel: string;
   timeoutMs: number;
@@ -28,8 +28,13 @@ type CollectMcpPaginatedItemsParams<TInput, TOutput = TInput> = {
   maxBytes: number;
   signal?: AbortSignal;
   loadPage: (request: McpPaginationRequest) => Promise<McpPaginationPage<TInput>>;
-  mapItem?: (item: TInput) => TOutput | undefined;
 };
+
+type CollectMcpPaginatedItemsParams<TInput, TOutput> =
+  | (CollectMcpPaginatedItemsBaseParams<TInput> & {
+      mapItem: (item: TInput) => TOutput | undefined;
+    })
+  | (CollectMcpPaginatedItemsBaseParams<TInput> & { mapItem?: undefined });
 
 function positiveInteger(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value <= 0) {
@@ -43,9 +48,17 @@ function abortError(signal: AbortSignal, label: string): Error {
 }
 
 /** Collects one complete MCP list under a single bounded lifecycle. */
-export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
+export function collectMcpPaginatedItems<TInput>(
+  params: CollectMcpPaginatedItemsBaseParams<TInput> & { mapItem?: undefined },
+): Promise<TInput[]>;
+export function collectMcpPaginatedItems<TInput, TOutput>(
+  params: CollectMcpPaginatedItemsBaseParams<TInput> & {
+    mapItem: (item: TInput) => TOutput | undefined;
+  },
+): Promise<TOutput[]>;
+export async function collectMcpPaginatedItems<TInput, TOutput>(
   params: CollectMcpPaginatedItemsParams<TInput, TOutput>,
-): Promise<TOutput[]> {
+): Promise<Array<TInput | TOutput>> {
   const timeoutMs = clampPositiveTimerTimeoutMs(params.timeoutMs);
   if (timeoutMs === undefined) {
     throw new Error(`${params.label} requires a positive timeout`);
@@ -81,7 +94,7 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
     signal.addEventListener("abort", onAbort, { once: true });
   });
 
-  const items: TOutput[] = [];
+  const items: Array<TInput | TOutput> = [];
   const seenCursors = new Set<string>();
   let collectedBytes = 0;
   let cursor: string | undefined;
@@ -104,7 +117,7 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
       collectedBytes += measured.bytes;
 
       for (const item of page.items) {
-        const mapped = params.mapItem ? params.mapItem(item) : (item as unknown as TOutput);
+        const mapped = params.mapItem ? params.mapItem(item) : item;
         if (mapped === undefined) {
           continue;
         }

--- a/src/agents/sessions/session-manager-codec.ts
+++ b/src/agents/sessions/session-manager-codec.ts
@@ -406,7 +406,7 @@ export function partitionSessionFileEntries(entries: readonly FileEntry[]): {
   for (const [originalIndex, rawEntry] of entries.entries()) {
     const entry = normalizePersistedLegacyHookMessage(rawEntry) as FileEntry;
     if (!hasHeader && isRecord(entry) && entry.type === "session" && typeof entry.id === "string") {
-      fileEntries.push(entry as unknown as SessionHeader);
+      fileEntries.push(entry);
       fileEntriesByOriginalIndex[originalIndex] = entry;
       hasHeader = true;
       continue;


### PR DESCRIPTION
## What Problem This Solves

The chained-type-assertion boundary rule could not enforce `src/agents` or `src/meeting-bot` because both directories were excluded wholesale, leaving 34 production findings hidden behind two scope-level ledger entries.

## Why This Change Was Made

This removes both scope exclusions, repairs 11 assertions at their owning type boundaries, and converts the 23 load-bearing remainder into 14 explicit file-level entries with one-line reasons. The main owner repair is a single schema-checked erasure adapter for all six session file-tool factories; the other repairs use a discriminated pagination API, parsed dynamic-module hooks, guarded plugin metadata lookup, assignment-compatible stream iterator replacement, and existing session-entry narrowing.

The file-level remainder records the actual contracts that need broader redesign: synthetic messages without provider metadata, provider-only media blocks, DOM/Undici type namespaces, config-only hashing, generic session and meeting projections, SDK header sentinels, and global symbol/Proxy state.

## User Impact

No user-visible behavior changes. New chained assertions are now enforced throughout both assigned directories except for the named, reviewable file-level seams.

## Evidence

- Accounting: 34 findings total; 11 fixed, 23 ledgered across 14 files with inline reasons.
- Assigned scopes: `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src/agents src/meeting-bot`
- Full lane: `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions packages ui/src`
- Focused Vitest: 775 assertions passed across unit-fast, agents-core, embedded-runner, and agents-support shards. The final promotion suite passed 31/31.
- ClawSweeper regression: the writable non-configurable iterator fixture failed before the repair with `Cannot redefine property: Symbol(Symbol.asyncIterator)` and passes with the assignment-compatible `Reflect.set` implementation.
- Changed gate: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs` passed after the remote `ci-fast` backend was unavailable and the wrapper fell back locally.
- Autoreview: `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings on the refreshed head.
- Production LOC: +110/-39 (net +71); tests: +31/-0; tooling ledger: +14/-2. Growth is the typed schema-validation adapter, discriminated boundary contracts, and the focused descriptor regression fixture replacing erased casts.
- Known unrelated anomaly: the existing macOS Unicode-equivalent sandbox-read test reproducibly sees NFC and NFD paths as two matches for one APFS file. It was excluded from the final focused aggregate rather than mixing a filesystem behavior repair into this type-only PR.
