### PR TITLE
fix(ui): refresh config before saving after reconnect

### DIFF
--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -33,6 +33,44 @@ function configResponse(config: Record<string, unknown>, hash: string, appliedCo
   };
 }
 
+function configSchemaResponse() {
+  return {
+    generatedAt: "2026-08-03T00:00:00.000Z",
+    schema: {
+      type: "object",
+      properties: {
+        laboratory: {
+          type: "object",
+          title: "Safe writes",
+          properties: {
+            endpoint: {
+              type: "string",
+              title: "Endpoint",
+              description: "Endpoint selected by the operator.",
+            },
+            retryBudget: {
+              type: "integer",
+              title: "Retry budget",
+              minimum: 0,
+              maximum: 10,
+            },
+          },
+        },
+        tools: {
+          type: "object",
+          title: "Tools",
+          additionalProperties: true,
+        },
+      },
+    },
+    uiHints: {
+      "laboratory.endpoint": { advanced: false },
+      "laboratory.retryBudget": { advanced: false },
+    },
+    version: "e2e",
+  };
+}
+
 function mutationParams(request: MockGatewayRequest): {
   baseHash?: string;
   note?: string;
@@ -75,6 +113,9 @@ suite.define(() => {
       {
         colorScheme: "dark",
         locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: uiProofArtifactDir, size: { height: 1000, width: 1440 } }
+          : undefined,
         serviceWorkers: "block",
         viewport: { height: 1000, width: 1440 },
       },
@@ -90,41 +131,7 @@ suite.define(() => {
         const gateway = await installMockGateway(page, {
           methodResponses: {
             "config.get": configResponse(initialConfig, "snapshot-1"),
-            "config.schema": {
-              generatedAt: "2026-08-03T00:00:00.000Z",
-              schema: {
-                type: "object",
-                properties: {
-                  laboratory: {
-                    type: "object",
-                    title: "Safe writes",
-                    properties: {
-                      endpoint: {
-                        type: "string",
-                        title: "Endpoint",
-                        description: "Endpoint selected by the operator.",
-                      },
-                      retryBudget: {
-                        type: "integer",
-                        title: "Retry budget",
-                        minimum: 0,
-                        maximum: 10,
-                      },
-                    },
-                  },
-                  tools: {
-                    type: "object",
-                    title: "Tools",
-                    additionalProperties: true,
-                  },
-                },
-              },
-              uiHints: {
-                "laboratory.endpoint": { advanced: false },
-                "laboratory.retryBudget": { advanced: false },
-              },
-              version: "e2e",
-            },
+            "config.schema": configSchemaResponse(),
           },
         });
 
@@ -267,6 +274,102 @@ suite.define(() => {
           .toBe(0);
         await expect.poll(() => rawEditor.inputValue()).toBe(rawDraft);
         await capture(page, "04-apply-complete.png");
+      },
+    );
+  });
+
+  it("refreshes config after reconnect and client replacement before the next save", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: uiProofArtifactDir, size: { height: 1000, width: 1440 } }
+          : undefined,
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const initialConfig = {
+          laboratory: { endpoint: "initial-api", retryBudget: 2 },
+          tools: {},
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialConfig, "snapshot-initial"),
+            "config.schema": configSchemaResponse(),
+          },
+        });
+
+        expect(
+          (
+            await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`)
+          )?.status(),
+        ).toBe(200);
+        const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
+        await expect.poll(() => endpoint.inputValue()).toBe("initial-api");
+        const initialConfigGets = (await gateway.getRequests("config.get")).length;
+
+        await page.locator('.settings-sidebar__item[href="/settings/connection"]').click();
+        await page.waitForURL(/\/settings\/connection$/u);
+        const reconnectedConfig = {
+          laboratory: { endpoint: "reconnected-api", retryBudget: 4 },
+          tools: {},
+        };
+        await gateway.setMethodResponse(
+          "config.get",
+          configResponse(reconnectedConfig, "snapshot-reconnected"),
+        );
+        await gateway.setOnline(false);
+        await gateway.setOnline(true);
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBe(initialConfigGets + 1);
+
+        await page.locator('.settings-sidebar__item[href="/settings/advanced"]').click();
+        await page.waitForURL(/\/settings\/advanced/u);
+        await expect.poll(() => endpoint.inputValue()).toBe("reconnected-api");
+        await capture(page, "05-reconnected-config.png");
+
+        await page.locator('.settings-sidebar__item[href="/settings/connection"]').click();
+        await page.waitForURL(/\/settings\/connection$/u);
+        const replacementConfig = {
+          laboratory: { endpoint: "replacement-api", retryBudget: 6 },
+          tools: {},
+        };
+        await gateway.setMethodResponse(
+          "config.get",
+          configResponse(replacementConfig, "snapshot-replacement"),
+        );
+        const configGetsBeforeReplacement = (await gateway.getRequests("config.get")).length;
+        const connectsBeforeReplacement = (await gateway.getRequests("connect")).length;
+        await page.getByRole("textbox", { name: "WebSocket URL" }).fill("ws://127.0.0.1:19999");
+        await page.getByRole("button", { name: "Connect", exact: true }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("connect")).length)
+          .toBe(connectsBeforeReplacement + 1);
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBe(configGetsBeforeReplacement + 1);
+
+        await page.locator('.settings-sidebar__item[href="/settings/advanced"]').click();
+        await page.waitForURL(/\/settings\/advanced/u);
+        await expect.poll(() => endpoint.inputValue()).toBe("replacement-api");
+        await gateway.deferNext("config.set");
+        const setsBeforeEdit = (await gateway.getRequests("config.set")).length;
+        await endpoint.fill("saved-on-replacement");
+        const save = mutationParams(await gateway.waitForRequest("config.set"));
+        expect(save.baseHash).toBe("snapshot-replacement");
+        expect(JSON.parse(String(save.raw))).toEqual({
+          laboratory: { endpoint: "saved-on-replacement", retryBudget: 6 },
+          tools: {},
+        });
+        expect(await gateway.getRequests("config.set")).toHaveLength(setsBeforeEdit + 1);
+        await gateway.resolveDeferred("config.set", { hash: "snapshot-saved" });
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saved");
+        await capture(page, "06-replacement-save.png");
       },
     );
   });

--- a/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
+++ b/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
@@ -159,11 +159,12 @@ suite.define(() => {
 
       const patch = await gateway.waitForRequest("config.patch");
       expect(patchPrefs(patch)).toEqual({ theme: "knot" });
-      expect(await gateway.getRequests("config.get")).toHaveLength(configGetsBeforeEdit);
+      // Reconnect owns one authoritative read even while the pending LWW preference shadows it.
+      await waitForRequestCount(gateway, "config.get", configGetsBeforeEdit + 1);
 
       await gateway.setMethodResponse("config.get", committed);
       await gateway.resolveDeferred("config.patch", committed);
-      await waitForRequestCount(gateway, "config.get", configGetsBeforeEdit + 1);
+      await waitForRequestCount(gateway, "config.get", configGetsBeforeEdit + 2);
       await expectThemeActive(page, "knot");
     } finally {
       await context.close();

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -87,7 +87,12 @@ export type RuntimeConfigDispatchOptions = {
   canDispatch?: () => boolean;
 };
 
-export type ConfigMethod = "config.set" | "config.apply" | "config.patch" | "config.openFile";
+export type ConfigMethod =
+  | "config.set"
+  | "config.apply"
+  | "config.patch"
+  | "config.openFile"
+  | "config.schema";
 
 export type ConfigWriteCoordinator = {
   prepareDiscard: () => Promise<void>;

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -48,6 +48,7 @@ type ConfigWriteCoordinatorContext = {
   trackLoad: (key: "config" | "schema", promise: Promise<unknown>) => Promise<void>;
   resetLoads: () => void;
   resetConfigLoad: () => void;
+  refreshConnectionState: () => Promise<boolean>;
   canCallConfigMethod: (
     method: ConfigMethod,
     options?: { requireAdvertisement?: boolean },
@@ -67,6 +68,7 @@ export function createConfigWriteCoordinator({
   trackLoad,
   resetLoads,
   resetConfigLoad,
+  refreshConnectionState,
   canCallConfigMethod,
   cancelAppliedRefresh,
   reconcileAppliedRefresh,
@@ -452,8 +454,7 @@ export function createConfigWriteCoordinator({
               ? cloneConfigObject(state.configForm)
               : null;
           const draftRawBefore = draftFormBefore ? serializeConfigForm(draftFormBefore) : null;
-          const reconcile = run(() => loadConfig(state));
-          void trackLoad("config", reconcile);
+          const reconcile = refreshConnectionState();
           void reconcile.then((loaded) => {
             if (isDisposed()) {
               return;
@@ -509,7 +510,7 @@ export function createConfigWriteCoordinator({
             reconcileAppliedRefresh();
           });
         } else {
-          reconcileAppliedRefresh();
+          void refreshConnectionState().then(() => reconcileAppliedRefresh());
         }
       }
     }

--- a/ui/src/lib/config/runtime-config-capability.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.test.ts
@@ -107,6 +107,70 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
+  it.each([
+    {
+      label: "same-client scope downgrade",
+      replaceClient: false,
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.read"] },
+        features: { methods: ["config.get", "config.schema"] },
+      } as GatewayHelloOk,
+    },
+    {
+      label: "replacement without config.schema",
+      replaceClient: true,
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
+        features: { methods: ["config.get"] },
+      } as GatewayHelloOk,
+    },
+  ])("refreshes config but skips schema after a $label", async ({ replaceClient, hello }) => {
+    let current = false;
+    const createRequest = () =>
+      vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          return {
+            config: { endpoint: current ? "current" : "initial" },
+            hash: current ? "hash-current" : "hash-initial",
+            valid: true,
+            issues: [],
+          };
+        }
+        return method === "config.schema"
+          ? { schema: {}, uiHints: {}, version: "schema-initial", generatedAt: "" }
+          : {};
+      });
+    const requestA = createRequest();
+    const requestB = createRequest();
+    const clientA = { request: requestA } as unknown as GatewayBrowserClient;
+    const clientB = { request: requestB } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(clientA);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+    await runtimeConfig.ensureLoaded();
+    await runtimeConfig.ensureSchemaLoaded();
+
+    current = true;
+    publish(false, clientA);
+    publish(true, replaceClient ? clientB : clientA, hello);
+
+    await vi.waitFor(() => expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-current"));
+    expect(runtimeConfig.state.configForm).toEqual({ endpoint: "current" });
+    expect(runtimeConfig.state.configSchemaVersion).toBe("schema-initial");
+    expect(runtimeConfig.state.lastError).toBeNull();
+    const activeRequest = replaceClient ? requestB : requestA;
+    expect(activeRequest.mock.calls.filter(([method]) => method === "config.get")).toHaveLength(
+      replaceClient ? 1 : 2,
+    );
+    expect(activeRequest.mock.calls.filter(([method]) => method === "config.schema")).toHaveLength(
+      replaceClient ? 0 : 1,
+    );
+    runtimeConfig.dispose();
+  });
+
   it("ignores a save completion from an earlier connection epoch", async () => {
     const save = deferred<unknown>();
     let getCount = 0;

--- a/ui/src/lib/config/runtime-config-capability.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.test.ts
@@ -52,6 +52,61 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
+  it.each([
+    { label: "same-client reconnect", replaceClient: false },
+    { label: "client replacement", replaceClient: true },
+  ])("refreshes config and schema after a $label", async ({ replaceClient }) => {
+    let snapshot = {
+      config: { endpoint: "initial" },
+      hash: "hash-initial",
+      valid: true,
+      issues: [],
+    };
+    let schema = {
+      schema: { type: "object" },
+      uiHints: {},
+      version: "schema-initial",
+      generatedAt: "2026-08-15T00:00:00.000Z",
+    };
+    const requestA = vi.fn(async (method: string) =>
+      method === "config.get" ? snapshot : method === "config.schema" ? schema : {},
+    );
+    const requestB = vi.fn(async (method: string) =>
+      method === "config.get" ? snapshot : method === "config.schema" ? schema : {},
+    );
+    const clientA = { request: requestA } as unknown as GatewayBrowserClient;
+    const clientB = { request: requestB } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(clientA);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+    await runtimeConfig.ensureLoaded();
+    await runtimeConfig.ensureSchemaLoaded();
+
+    snapshot = {
+      config: { endpoint: "current" },
+      hash: "hash-current",
+      valid: true,
+      issues: [],
+    };
+    schema = { ...schema, version: "schema-current" };
+    publish(false, clientA);
+    publish(true, replaceClient ? clientB : clientA);
+
+    await vi.waitFor(() => expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-current"));
+    expect(runtimeConfig.state.configForm).toEqual({ endpoint: "current" });
+    expect(runtimeConfig.state.configSchemaVersion).toBe("schema-current");
+    expect(runtimeConfig.state.configFormDirty).toBe(false);
+    expect(requestB).not.toHaveBeenCalledWith("config.set", expect.anything());
+    if (replaceClient) {
+      expect(requestA.mock.calls.filter(([method]) => method === "config.get")).toHaveLength(1);
+      expect(requestB).toHaveBeenCalledWith("config.get", {});
+      expect(requestB).toHaveBeenCalledWith("config.schema", {});
+    } else {
+      expect(requestA.mock.calls.filter(([method]) => method === "config.get")).toHaveLength(2);
+      expect(requestA).toHaveBeenCalledWith("config.schema", {});
+    }
+    runtimeConfig.dispose();
+  });
+
   it("ignores a save completion from an earlier connection epoch", async () => {
     const save = deferred<unknown>();
     let getCount = 0;
@@ -467,7 +522,7 @@ describe("runtime config capability", () => {
       }
       return { ok: true };
     });
-    const requestB = vi.fn(async () => ({ ok: true }));
+    const requestB = vi.fn(async (_method: string) => ({ ok: true }));
     const clientA = { request: requestA } as unknown as GatewayBrowserClient;
     const clientB = { request: requestB } as unknown as GatewayBrowserClient;
     const { gateway, publish } = createGatewayHarness(clientA);
@@ -490,7 +545,8 @@ describe("runtime config capability", () => {
       error: "Connection changed before the configuration update started.",
     });
     expect(requestA).not.toHaveBeenCalled();
-    expect(requestB).not.toHaveBeenCalled();
+    expect(requestB.mock.calls.map(([method]) => method)).toEqual(["config.get"]);
+    expect(requestB).not.toHaveBeenCalledWith("config.patch", expect.anything());
     runtimeConfig.dispose();
   });
 

--- a/ui/src/lib/config/runtime-config-capability.ts
+++ b/ui/src/lib/config/runtime-config-capability.ts
@@ -143,6 +143,17 @@ export function createRuntimeConfigCapability(
       state.configSnapshot?.appliedConfigHash !== undefined,
     refresh: (isCurrent) => loadOnce("config", () => loadConfig(state, {}, isCurrent)),
   });
+  const refreshConnectionState = () => {
+    const config = run(() => loadConfig(state));
+    void trackLoad("config", config);
+    if (state.configSchemaVersion !== null) {
+      void trackLoad(
+        "schema",
+        run(() => loadConfigSchema(state)),
+      );
+    }
+    return config;
+  };
 
   const writes: ConfigWriteCoordinator = createConfigWriteCoordinator({
     state,
@@ -158,6 +169,7 @@ export function createRuntimeConfigCapability(
     resetConfigLoad: () => {
       configLoad = null;
     },
+    refreshConnectionState,
     canCallConfigMethod,
     cancelAppliedRefresh: appliedRefresh.cancel,
     reconcileAppliedRefresh: appliedRefresh.reconcile,

--- a/ui/src/lib/config/runtime-config-capability.ts
+++ b/ui/src/lib/config/runtime-config-capability.ts
@@ -146,7 +146,7 @@ export function createRuntimeConfigCapability(
   const refreshConnectionState = () => {
     const config = run(() => loadConfig(state));
     void trackLoad("config", config);
-    if (state.configSchemaVersion !== null) {
+    if (state.configSchemaVersion !== null && canCallConfigMethod("config.schema")) {
       void trackLoad(
         "schema",
         run(() => loadConfigSchema(state)),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI config editor could keep showing and saving against an old config snapshot after the Gateway reconnected or the operator selected a replacement Gateway. A later edit could therefore use the previous connection generation's CAS hash instead of first loading the active Gateway's config.

## Why This Change Was Made

The runtime config capability retained its already-loaded snapshot across connection generations, while the shell's `ensureLoaded()` path correctly avoided reloading a non-null snapshot. The write coordinator fenced stale requests by connection epoch, but the clean reconnect path did not start a new authoritative config read.

The connection owner now refreshes `config.get` for every successful connection generation, refreshes `config.schema` only when the schema was previously loaded, and reuses that same path for interrupted-write reconciliation. Existing draft ownership stays intact: clean editors adopt the active snapshot/hash, dirty drafts remain preserved on their original CAS base, and retired-generation responses remain fenced.

No config key, schema, default, migration, Gateway protocol, security, persistence, or fallback behavior changes. Production LOC is +22/-4 (net +18); tests are +263/-39.

## User Impact

After a reconnect or Gateway replacement, Settings shows the active Gateway's current values before accepting a new save. A subsequent edit is sent once with the refreshed `baseHash`, while an explicit draft remains visible until the operator saves, applies, reloads, or discards it.

## Evidence

- `157/157` focused config lifecycle, app-host ownership, and save-indicator tests passed. The added downgrade rows prove same-client `operator.read` and replacement-without-`config.schema` connections still refresh config, skip schema, and record no error.
- `2/2` Chromium mocked-Gateway E2E tests passed, including one authoritative `config.get` per reconnect/replacement and one exact replacement `config.set` with `baseHash=snapshot-replacement`.
- `9/9` Chromium scalar integrity tests passed, including the focused in-flight edit assertion.
- `5/5` server-preference reconnect E2E tests passed; the reconnect-generation read and post-LWW-patch refresh are asserted separately.
- Exact-path changed gate passed on Blacksmith Testbox run [31921477812](https://github.com/openclaw/openclaw/actions/runs/31921477812): i18n, formatting, lint, stylelint, UI/core-test types, and changed-file guards.
- The prior red-main blocker was resolved by canonical PR #124370; fresh scheduled exact-head CI run [31925782490](https://github.com/openclaw/openclaw/actions/runs/31925782490) is green for `8bb03098a71cf2cbb54336ceeb2733fa01a2476a`.
- `config:schema:check`, import-cycle check, and `git diff --check` passed.
- Source-blind behavior validation passed all reconnect, replacement, draft, stale-response, CAS, and media clauses.
- Fresh structured autoreview reported no accepted/actionable findings.
- The unrelated config-doc count/hash anomaly reproduces unchanged on an untouched archive of exact base `2585edba2efda9ff50e6bed0a6de8cfaef8254fc`; no baseline file is changed here.

Reconnected authoritative config:

![Control UI showing the reconnected Gateway config](https://github.com/user-attachments/assets/a5d944d1-3dc6-48af-b088-0b00dacd8f34)

Replacement-generation save:

![Control UI showing the saved replacement Gateway config](https://github.com/user-attachments/assets/ac1ff4b8-2325-4e15-b9a7-84a9013b85db)

Short reconnect/replacement recording:

https://github.com/user-attachments/assets/47f44f0a-76e7-4fbc-b8a2-452440e07c1d
