### PR TITLE
refactor(types): enforce chained-assertion guard in AI and UI

### DIFF
--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1510,7 +1510,9 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
             for (const part of candidate.content.parts) {
               const hasThoughtSignature =
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
-              const hasText = typeof part.text === "string";
+              const rawText = part.text;
+              const hasText = typeof rawText === "string";
+              const partText = typeof rawText === "string" ? rawText : "";
               if (hasText || (hasThoughtSignature && !part.functionCall)) {
                 if (hasThoughtSignature && !hasText && part.thought !== true) {
                   const latestBlock = output.content[output.content.length - 1];
@@ -1553,8 +1555,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                 }
                 const activeBlock = output.content[currentBlockIndex];
                 if (activeBlock?.type === "thinking") {
-                  const delta = hasText ? part.text : "";
-                  activeBlock.thinking += delta;
+                  activeBlock.thinking += partText;
                   activeBlock.thinkingSignature = retainThoughtSignature(
                     activeBlock.thinkingSignature,
                     part.thoughtSignature,
@@ -1562,11 +1563,11 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                   stream.push({
                     type: "thinking_delta",
                     contentIndex: currentBlockIndex,
-                    delta,
+                    delta: partText,
                     partial: output as never,
                   });
                 } else if (activeBlock?.type === "text") {
-                  activeBlock.text += part.text;
+                  activeBlock.text += partText;
                   activeBlock.textSignature = retainThoughtSignature(
                     activeBlock.textSignature,
                     part.thoughtSignature,
@@ -1574,7 +1575,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                   stream.push({
                     type: "text_delta",
                     contentIndex: currentBlockIndex,
-                    delta: part.text,
+                    delta: partText,
                     partial: output as never,
                   });
                 }

--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -193,8 +193,15 @@ export function prepareClaudeNoPrefillRequestContext(model: Model, context: Cont
     : { ...context, messages: context.messages.slice(0, end) };
 }
 
+type ClaudeSamplingRequestParams = {
+  temperature?: unknown;
+  top_p?: unknown;
+  top_k?: unknown;
+  service_tier?: unknown;
+};
+
 export function applyClaudeRequestContract(
-  params: object,
+  params: ClaudeSamplingRequestParams,
   model: {
     id?: string;
     params?: Record<string, unknown>;
@@ -209,11 +216,11 @@ export function applyClaudeRequestContract(
   if (!requiresClaudeDefaultSampling(model) && !opus5 && !sonnet5) {
     return;
   }
-  Reflect.deleteProperty(params, "temperature");
-  Reflect.deleteProperty(params, "top_p");
-  Reflect.deleteProperty(params, "top_k");
+  delete params.temperature;
+  delete params.top_p;
+  delete params.top_k;
   if (opus5 || sonnet5) {
-    Reflect.deleteProperty(params, "service_tier");
+    delete params.service_tier;
   }
 }
 

--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -194,7 +194,7 @@ export function prepareClaudeNoPrefillRequestContext(model: Model, context: Cont
 }
 
 export function applyClaudeRequestContract(
-  params: Record<string, unknown>,
+  params: object,
   model: {
     id?: string;
     params?: Record<string, unknown>;
@@ -209,11 +209,11 @@ export function applyClaudeRequestContract(
   if (!requiresClaudeDefaultSampling(model) && !opus5 && !sonnet5) {
     return;
   }
-  delete params.temperature;
-  delete params.top_p;
-  delete params.top_k;
+  Reflect.deleteProperty(params, "temperature");
+  Reflect.deleteProperty(params, "top_p");
+  Reflect.deleteProperty(params, "top_k");
   if (opus5 || sonnet5) {
-    delete params.service_tier;
+    Reflect.deleteProperty(params, "service_tier");
   }
 }
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -413,7 +413,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
       if (nextParams !== undefined) {
         params = nextParams as MessageCreateParamsStreaming;
       }
-      applyClaudeRequestContract(params as unknown as Record<string, unknown>, model);
+      applyClaudeRequestContract(params, model);
       const sdkRequestOptions = {
         ...(requestOptions?.signal ? { signal: requestOptions.signal } : {}),
         ...(requestOptions?.timeoutMs !== undefined ? { timeout: requestOptions.timeoutMs } : {}),
@@ -1089,13 +1089,7 @@ async function buildParams(
         params.thinking = { type: "adaptive", display };
         const effort = options?.effort ?? (mandatoryAdaptiveThinking ? "high" : undefined);
         if (effort) {
-          // The Anthropic SDK types can lag newly supported effort values such as "xhigh".
-          params.output_config =
-            effort === "xhigh"
-              ? ({ effort } as unknown as NonNullable<
-                  MessageCreateParamsStreaming["output_config"]
-                >)
-              : { effort };
+          params.output_config = { effort };
         }
       } else {
         // Budget-based thinking for older models.

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -1,4 +1,5 @@
 import type {
+  AssistantMessageEvent,
   AssistantMessageDiagnostic,
   Context,
   ImageContent,
@@ -1171,7 +1172,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
       // Classifier refusals can invalidate partial output, so no event is safe
       // to expose until the terminal stop reason is known.
       const refusalBuffer = usesClaudeStreamingRefusalContract(model)
-        ? createDeferredEventBuffer<unknown>(stream, () =>
+        ? createDeferredEventBuffer<AssistantMessageEvent>(stream, () =>
             notifyLlmRequestActivity(options?.signal),
           )
         : undefined;
@@ -1260,6 +1261,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               partial: output as never,
             });
           }
+          if (contentIndex === undefined) {
+            return false;
+          }
           block.thinking += text;
           block.thinkingSignature = "reasoning_content";
           eventSink.push({
@@ -1297,6 +1301,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               contentIndex,
               partial: output as never,
             });
+          }
+          if (contentIndex === undefined) {
+            return false;
           }
           block.text += text;
           eventSink.push({
@@ -1553,7 +1560,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               ) {
                 const text = sanitizeTransportPayloadText(delta.content);
                 if (text.length > 0) {
-                  if (block?.type === "text") {
+                  if (block?.type === "text" && index !== undefined) {
                     block.text += text;
                     eventSink.push({
                       type: "text_delta",
@@ -1584,6 +1591,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 contentIndex: index,
                 partial: output as never,
               });
+            }
+            if (index === undefined) {
+              continue;
             }
             if (
               block?.type === "text" &&

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -34,6 +34,17 @@ import {
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
 
+type OpenAICompatibleChoice = ChatCompletionChunk["choices"][number] & {
+  // Some compatible providers attach usage per choice instead of per chunk.
+  usage?: ChatCompletionChunk["usage"];
+  // Some compatible providers stream a complete message in place of delta.
+  message?: ChatCompletionChunk["choices"][number]["delta"];
+};
+
+type OpenAICompatibleChatCompletionChunk = Omit<ChatCompletionChunk, "choices"> & {
+  choices: OpenAICompatibleChoice[];
+};
+
 function extractToolCallThoughtSignature(toolCall: unknown): string | undefined {
   const tc = toolCall as Record<string, unknown> | undefined;
   if (!tc) {
@@ -328,7 +339,7 @@ export async function processCompletionsStream(
     }
     // Hidden reasoning is still provider progress; keep the idle watchdog alive without exposing it.
     notifyLlmRequestActivity(options?.signal);
-    const chunk = rawChunk as ChatCompletionChunk;
+    const chunk = rawChunk as OpenAICompatibleChatCompletionChunk;
     output.responseId ||= chunk.id;
     let hasReasoningUsageActivity = false;
     if (chunk.usage) {
@@ -341,7 +352,7 @@ export async function processCompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
-    const choiceUsage = (choice as unknown as { usage?: ChatCompletionChunk["usage"] }).usage;
+    const choiceUsage = choice.usage;
     if (!chunk.usage && choiceUsage) {
       output.usage = parseOpenAICompletionsUsage(choiceUsage, model);
       hasReasoningUsageActivity = hasOpenAICompletionsReasoningUsageActivity(choiceUsage);
@@ -358,9 +369,7 @@ export async function processCompletionsStream(
         output.errorMessage = finishReasonResult.errorMessage;
       }
     }
-    const rawChoiceDelta =
-      choice.delta ??
-      (choice as unknown as { message?: ChatCompletionChunk["choices"][number]["delta"] }).message;
+    const rawChoiceDelta = choice.delta ?? choice.message;
     if (!rawChoiceDelta) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
       await cooperativeScheduler.afterEvent();

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -3,7 +3,6 @@ import OpenAI from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type { OpenAICompletionsOptions } from "../provider-options.js";
 import { finalizeOpenAICompletionsToolCalls } from "../providers/openai-completions-tool-calls.js";
-import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
@@ -32,9 +31,9 @@ import {
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
 import {
+  createWritableTransportEventStream,
   failTransportStream,
   finalizeTransportStream,
-  type WritableTransportStream,
   withProviderResponseHook,
 } from "./transport-stream-shared.js";
 
@@ -173,8 +172,7 @@ function buildOpenAICompletionsClientConfig(
 
 export function createOpenAICompletionsTransportStreamFn(): StreamFn {
   return (model, context, options) => {
-    const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as WritableTransportStream;
+    const { eventStream, stream } = createWritableTransportEventStream();
     void (async () => {
       const output: MutableAssistantOutput = {
         role: "assistant" as const,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -7,7 +7,6 @@ import { getAiTransportHost } from "../host.js";
 import { resolveAzureDeploymentNameFromMap } from "../providers/azure-deployment-map.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../providers/azure-openai-responses-client-compat.js";
 import { applyResponsesServiceTierPricing } from "../providers/openai-responses-shared.js";
-import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import {
   createFirstStreamEventAbortController,
@@ -74,9 +73,9 @@ import {
 import { createOpenAIResponseHook, log } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import {
+  createWritableTransportEventStream,
   mergeTransportMetadata,
   transportAbortError,
-  type WritableTransportStream,
   withProviderResponseHook,
 } from "./transport-stream-shared.js";
 import { redactIdentifier } from "./transport-utils.js";
@@ -240,8 +239,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
     const compactRequest = claimResponsesCompactRequest(responsesOptions);
-    const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as WritableTransportStream;
+    const { eventStream, stream } = createWritableTransportEventStream();
     void (async () => {
       const output = createOpenAIResponsesAssistantOutput(model, config.outputApi);
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -12,6 +12,13 @@ import { log } from "./openai-transport-shared.js";
 
 type ResponsesClientLike = ReturnType<typeof createOpenAIResponsesClient>;
 
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    ((typeof value === "object" && value !== null) || typeof value === "function") &&
+    Symbol.asyncIterator in value
+  );
+}
+
 export function isInvalidEncryptedContentError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
@@ -184,7 +191,10 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
         params.onCompactionRejected?.(checkpoint);
       }
     });
-    return { stream: data as unknown as AsyncIterable<unknown>, response, attempt };
+    if (!isAsyncIterable(data)) {
+      throw new Error("OpenAI Responses streaming request returned a non-stream response");
+    }
+    return { stream: data, response, attempt };
   };
 
   let attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams> = {

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -21,10 +21,10 @@ type TransportUsage = {
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
 };
 
-export type WritableTransportStream = {
-  push(event: unknown): void;
-  end(): void;
-};
+export type WritableTransportStream = Pick<
+  ReturnType<typeof createAssistantMessageEventStream>,
+  "push" | "end"
+>;
 
 type TransportOutputShape = Partial<Omit<ProviderErrorProjection, "stopReason">> & {
   stopReason: string;
@@ -106,7 +106,7 @@ export function createWritableTransportEventStream() {
   const eventStream = createAssistantMessageEventStream();
   return {
     eventStream,
-    stream: eventStream as unknown as WritableTransportStream,
+    stream: eventStream,
   };
 }
 

--- a/scripts/lib/type-assertion-guard-scope.mjs
+++ b/scripts/lib/type-assertion-guard-scope.mjs
@@ -104,7 +104,11 @@ export const CHAINED_ASSERTION_EXCLUDED_ROOTS = [
   "extensions/whatsapp/src/session.ts", // Baileys WebSocket and emitter cleanup use undeclared runtime capabilities
   "extensions/workboard/src/store-core.ts", // legacy keyed store multiplexes cards, boards, subscriptions, and attachments
   "extensions/zalouser/src/zca-client.ts", // optional zca-js runtime is loaded through a local lazy module facade
-  "packages/ai",
+  "packages/ai/src/providers/anthropic.ts", // Anthropic compaction blocks are absent from the SDK content union
+  "packages/ai/src/providers/openai-chatgpt-responses.ts", // raw Codex events and runtime WebSockets outpace SDK and DOM types
+  "packages/ai/src/transports/openai-completions-transport.ts", // compatible-provider payloads are a superset of the OpenAI SDK request
+  "packages/ai/src/transports/openai-responses-params-internal.ts", // response formats bridge legacy caller and current SDK shapes
+  "packages/ai/src/transports/openai-responses-websocket.ts", // dual SDK ESM declarations split one client across nominal private fields
   "src/acp/client.ts", // Node and Web ReadableStream types live in separate namespaces.
   "src/acp/server.ts", // Node and Web ReadableStream types live in separate namespaces.
   "src/agents/agent-hooks/compaction-safeguard.ts", // AgentMessage custom roles exceed the Copilot header message contract.
@@ -148,7 +152,10 @@ export const CHAINED_ASSERTION_EXCLUDED_ROOTS = [
   "src/process/exec-spawn.ts", // Rebuilt Execa options cross its result generic.
   "src/proxy-capture/store.sqlite.ts", // Implementation preserves overloaded shipped constructor contracts.
   "src/trajectory/export.ts", // Legacy migration mutates pre-canonical transcript entries.
-  "ui/src",
+  "ui/src/app/native-bridge.ts", // WebView2 hosts augment Window outside the DOM type namespace
+  "ui/src/app/native-link-routing.ts", // WebKit hosts augment Window with native message handlers
+  "ui/src/app/native-window-drag.ts", // WebKit hosts augment Window with a native drag handler
+  "ui/src/pages/chat/chat-state-page.ts", // two-phase page construction assigns required host actions after state creation
 ];
 
 export function pathMatchesTypeAssertionRoot(repoPath, root) {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -227,7 +227,7 @@ export type UiSettings = {
 };
 
 type LastActiveSessionHost = {
-  settings: UiSettings;
+  settings: Pick<UiSettings, "lastActiveSessionKey">;
   applySettings(patch: Partial<UiSettings>): void;
 };
 

--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -163,6 +163,22 @@ describe("SidebarSessionNarrationController", () => {
       "Reviewing the current implementation",
     );
 
+    const digestUpdateCount = digests.length;
+    controller.handleEvent(
+      gatewayEvent("session.observer", {
+        sessionKey: "agent:main:run",
+        runId: "run-2",
+        revision: 0,
+        updatedAt: 10_001,
+        headline: "Invalid replacement",
+        health: "on-track",
+      }),
+    );
+    expect(digests).toHaveLength(digestUpdateCount);
+    expect(digests.at(-1)?.get("agent:main:run")?.headline).toBe(
+      "Reviewing the current implementation",
+    );
+
     controller.handleEvent(
       gatewayEvent("agent", {
         sessionKey: "agent:main:run",

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -540,11 +540,11 @@ export class SidebarSessionNarrationController {
     ) {
       return;
     }
-    this.observeRun(key, runId);
     const digest = { ...record, runId };
     if (!Value.Check(SessionObserverDigestSchema, digest)) {
       return;
     }
+    this.observeRun(key, runId);
     const previous = this.observerDigests.get(key);
     if (previous && pickFreshestObserverDigest(previous, digest) === previous) {
       return;

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -1,5 +1,9 @@
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
+import { Value } from "typebox/value";
+import {
+  SessionObserverDigestSchema,
+  type SessionObserverDigest,
+} from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -537,7 +541,10 @@ export class SidebarSessionNarrationController {
       return;
     }
     this.observeRun(key, runId);
-    const digest = { ...record, runId } as unknown as SessionObserverDigest;
+    const digest = { ...record, runId };
+    if (!Value.Check(SessionObserverDigestSchema, digest)) {
+      return;
+    }
     const previous = this.observerDigests.get(key);
     if (previous && pickFreshestObserverDigest(previous, digest) === previous) {
       return;

--- a/ui/src/components/terminal/terminal-runtime.ts
+++ b/ui/src/components/terminal/terminal-runtime.ts
@@ -1,4 +1,9 @@
 import type { CreateGhosttyTerminalOptions } from "@openclaw/libterminal/browser";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+
+function isEventListener(value: unknown): value is EventListener {
+  return typeof value === "function";
+}
 
 /** Creates a terminal whose WASM memory is never reused by another tab. */
 export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTerminalOptions) {
@@ -11,11 +16,9 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
   const runtime = await loadGhosttyRuntime({ module: ghosttyModule });
   const controller = await createGhosttyTerminal({ ...options, runtime });
   const dispose = controller.dispose.bind(controller);
-  const terminal = controller.terminal as unknown as { handleMouseUp?: unknown };
-  let handleMouseUp =
-    typeof terminal.handleMouseUp === "function"
-      ? (terminal.handleMouseUp as EventListener)
-      : undefined;
+  const terminal = controller.terminal;
+  const mouseUpCandidate = asOptionalRecord(terminal)?.handleMouseUp;
+  let handleMouseUp = isEventListener(mouseUpCandidate) ? mouseUpCandidate : undefined;
   let disposed = false;
   controller.dispose = () => {
     if (disposed) {

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -641,6 +641,10 @@ suite.define(() => {
           hasText: "claude --resume claude-termi…",
         })
         .waitFor();
+      const resize = await gateway.waitForRequest("terminal.resize");
+      expect(resize.params).toEqual(
+        expect.objectContaining({ sessionId: "claude-terminal-timeout" }),
+      );
       await page.clock.fastForward(30_001);
       await page.clock.runFor(100);
 

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -30,7 +30,7 @@ import { clearChatHistory } from "./chat-history.ts";
 import { enqueuePendingRunMessage } from "./chat-queue.ts";
 import { readChatSessionActionAccess } from "./chat-session-action-access.ts";
 import { handleAbortChat } from "./run-lifecycle.ts";
-import { scheduleChatScroll } from "./scroll.ts";
+import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";
 
 let refreshSeq = 0;
 const REMOTE_SLASH_COMMAND_CACHE_TTL_MS = 60_000;
@@ -77,7 +77,8 @@ export type ChatCommandHost = Parameters<typeof handleAbortChat>[0] &
     exportCurrentChat?: () => Promise<void> | void;
     refreshCurrentSessionTools?: () => Promise<void>;
     refreshCurrentChat?: () => Promise<void>;
-  } & UiSessionDefaultsHost;
+  } & UiSessionDefaultsHost &
+  ChatScrollHost;
 
 function setChatCommandError(
   host: { lastError?: string | null; chatError?: string | null },
@@ -401,7 +402,7 @@ export async function dispatchChatSlashCommand(
       host,
       `Cannot run \`/${name}\`: Control UI is not connected to the Gateway.`,
     );
-    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], false, false, {
+    scheduleChatScroll(host, false, false, {
       contentChanged: true,
     });
     return "failed";
@@ -430,14 +431,9 @@ export async function dispatchChatSlashCommand(
     if (targetIsCurrent()) {
       setChatCommandError(host, String(err));
       injectCommandResult(host, `Command \`/${name}\` failed unexpectedly.`);
-      scheduleChatScroll(
-        host as unknown as Parameters<typeof scheduleChatScroll>[0],
-        false,
-        false,
-        {
-          contentChanged: true,
-        },
-      );
+      scheduleChatScroll(host, false, false, {
+        contentChanged: true,
+      });
     }
     return "failed";
   }
@@ -448,14 +444,9 @@ export async function dispatchChatSlashCommand(
   if (result.failed) {
     if (targetIsCurrent()) {
       setChatCommandError(host, result.content || `Command /${name} failed.`);
-      scheduleChatScroll(
-        host as unknown as Parameters<typeof scheduleChatScroll>[0],
-        false,
-        false,
-        {
-          contentChanged: Boolean(result.content),
-        },
-      );
+      scheduleChatScroll(host, false, false, {
+        contentChanged: Boolean(result.content),
+      });
     }
     return "failed";
   }
@@ -487,7 +478,7 @@ export async function dispatchChatSlashCommand(
   }
 
   if (targetIsCurrent()) {
-    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], false, false, {
+    scheduleChatScroll(host, false, false, {
       contentChanged: Boolean(result.content),
     });
   }

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -349,7 +349,7 @@ function handleChatEvent(
     outcome: "done" | "interrupted",
     sessionStatus: "done" | "failed" | "killed" | "timeout",
   ) =>
-    reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
+    reconcileChatRunLifecycle(state, {
       outcome,
       sessionStatus,
       runId: terminalRunId,
@@ -411,17 +411,14 @@ function handleChatEvent(
       state.chatMessages = materializeVisibleStream();
     }
     if (payload.yielded === true && payload.stopReason === "end_turn") {
-      reconcileChatRunLifecycle(
-        state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
-        {
-          yielded: true,
-          runId: terminalRunId,
-          sessionKey: state.sessionKey,
-          sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
-          clearLocalRun: true,
-          clearChatStream: true,
-        },
-      );
+      reconcileChatRunLifecycle(state, {
+        yielded: true,
+        runId: terminalRunId,
+        sessionKey: state.sessionKey,
+        sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
+        clearLocalRun: true,
+        clearChatStream: true,
+      });
     } else {
       reconcileTerminalRun("done", "done");
     }

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -64,7 +64,7 @@ import {
   recordControlUiPerformanceEvent,
   roundedControlUiDurationMs,
 } from "./performance.ts";
-import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
+import { reconcileChatRunLifecycle, type LocalTerminalReconcile } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import {
   cacheChatSessionSnapshot,
@@ -294,7 +294,7 @@ export type ChatState = {
   lastError: string | null;
   chatError?: string | null;
   chatRunError?: { summary: string } | null;
-  lastLocalTerminalReconcile?: { runId: string | null } | null;
+  lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
   chatReplyTarget?: unknown;
   agentsError?: string | null;
   onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => boolean;

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -5,7 +5,7 @@ import {
 } from "@openclaw/gateway-client/browser";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
-import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsListResult,
   GatewaySessionRow,
@@ -14,8 +14,6 @@ import type {
   SessionBranch,
   SessionsListResult,
 } from "../../api/types.ts";
-import type { ApplicationInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
-import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
@@ -52,7 +50,8 @@ import {
   resolveStartupRetryDelayMs,
   sleep,
 } from "./chat-history-retry.ts";
-import type { ChatRunStartupPhase, ChatRunStartupState } from "./chat-run-startup.ts";
+import type { ChatRunStartupPhase } from "./chat-run-startup.ts";
+import type { ChatState } from "./chat-state-contract.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
 import {
   getChatSessionProjection,
@@ -64,13 +63,9 @@ import {
   recordControlUiPerformanceEvent,
   roundedControlUiDurationMs,
 } from "./performance.ts";
-import { reconcileChatRunLifecycle, type LocalTerminalReconcile } from "./run-lifecycle.ts";
+import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-import {
-  cacheChatSessionSnapshot,
-  clearChatMessagesFromCache,
-  type ChatMessageCache,
-} from "./session-message-cache.ts";
+import { cacheChatSessionSnapshot, clearChatMessagesFromCache } from "./session-message-cache.ts";
 import { retirePersistedSteeredChips } from "./steer-lifecycle.ts";
 import {
   clearToolStreamSegments,
@@ -260,63 +255,7 @@ function chatPersistCommentaryEnabled(state: ChatState): boolean {
   return state.settings?.chatPersistCommentary !== false;
 }
 
-export type ChatState = {
-  client: GatewayBrowserClient | null;
-  connected: boolean;
-  initialUserMessage?: ApplicationInitialUserMessageHandoff;
-  /** Monotonic owner epoch; reconnects can reuse the same client object. */
-  connectionEpoch: number;
-  sessionKey: string;
-  currentSessionId?: string | null;
-  reconnectResumeSessionId?: string | null;
-  chatLoading: boolean;
-  chatHistoryPagination?: ChatHistoryPagination;
-  chatMessages: unknown[];
-  chatMessagesBySession?: ChatMessageCache;
-  /** Active leaf of the history snapshot currently rendered by this pane. */
-  chatDisplayedLeafEntryId?: string | null;
-  chatThinkingLevel: string | null;
-  chatVerboseLevel: string | null;
-  /** Pane-owned explicit session queue override from the latest history response. */
-  chatQueueModeOverride?: GatewaySessionRow["queueMode"];
-  /** Pane-owned effective queue mode from this session's latest history response. */
-  chatEffectiveQueueMode?: GatewaySessionRow["effectiveQueueMode"];
-  chatSending: boolean;
-  chatMessage: string;
-  chatAttachments: ChatAttachment[];
-  chatQueue: ChatQueueItem[];
-  chatRunId: string | null;
-  chatRunUsageById?: Map<string, number>;
-  chatStream: string | null;
-  chatStreamStartedAt: number | null;
-  chatRunStartup?: ChatRunStartupState | null;
-  planStatus?: PlanStatus | null;
-  lastError: string | null;
-  chatError?: string | null;
-  chatRunError?: { summary: string } | null;
-  lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
-  chatReplyTarget?: unknown;
-  agentsError?: string | null;
-  onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => boolean;
-  resetChatInputHistoryNavigation?: () => void;
-  assistantAgentId?: string | null;
-  agentsList?: ChatAgentsListSnapshot | null;
-  agentsSelectedId?: string | null;
-  hello: GatewayHelloOk | null;
-  canvasPluginSurfaceUrl?: string | null;
-  settings?: { chatPersistCommentary?: boolean; gatewayUrl?: string | null };
-  sessions?: Partial<SessionCapability>;
-  chatSessionMessageSubscriptionRequestedKey?: string | null;
-  chatSessionMessageSubscription?: SessionMessageSubscription | null;
-  chatBranches?: SessionBranch[];
-  chatBranchesSessionKey?: string | null;
-  chatBranchesConnectionEpoch?: number | null;
-  requestUpdate?: () => void;
-};
-
-type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
-  agents?: AgentsListResult["agents"];
-};
+export type { ChatState } from "./chat-state-contract.ts";
 
 type ChatSessionMessageSubscriptionState = ChatState & {
   sessions: Pick<SessionCapability, "subscribeMessages" | "unsubscribeMessages">;

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -43,7 +43,7 @@ type TestChatHost = Omit<ChatHost, "settings"> & {
   sessionsArchivedFilter?: "active" | "archived" | "all";
   password?: string;
   pendingSettingsPatches?: Record<string, Promise<boolean>>;
-  settings?: Partial<UiSettings>;
+  settings: Pick<UiSettings, "lastActiveSessionKey"> & Partial<UiSettings>;
 };
 
 function createPendingSettingsSessionCapability(
@@ -72,12 +72,15 @@ function createPendingSettingsSessionCapability(
 }
 
 type TestChatHostWithRequest = TestChatHost & { request: RequestMock };
-type MakeHostOverrides = Partial<TestChatHost> & { requestHandlers?: RequestHandlers };
+type MakeHostOverrides = Partial<Omit<TestChatHost, "settings">> & {
+  requestHandlers?: RequestHandlers;
+  settings?: Partial<UiSettings>;
+};
 
 export function makeChatHost(
   overrides: MakeHostOverrides & { requestHandlers: RequestHandlers },
 ): TestChatHostWithRequest;
-export function makeChatHost(overrides?: Partial<TestChatHost>): TestChatHost;
+export function makeChatHost(overrides?: MakeHostOverrides): TestChatHost;
 export function makeChatHost(
   overrides?: MakeHostOverrides,
 ): TestChatHost | TestChatHostWithRequest {
@@ -107,8 +110,11 @@ export function makeChatHost(
     chatStreamSegments: [],
     chatToolMessages: [],
     connected: true,
+    connectionEpoch: 0,
     chatLoading: false,
     chatMessage: "",
+    chatThinkingLevel: null,
+    chatVerboseLevel: null,
     chatLocalInputHistoryBySession: {},
     chatInputHistorySessionKey: null,
     chatInputHistoryItems: null,
@@ -119,6 +125,7 @@ export function makeChatHost(
     chatQueue: [],
     chatRunId: null,
     chatSending: false,
+    chatStreamStartedAt: null,
     lastError: null,
     sessionKey: "agent:main",
     basePath: "",

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -15,7 +15,7 @@ import {
   type ChatCommandTarget,
   type ChatCommandResetOptions,
 } from "./chat-commands.ts";
-import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
+import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
 import {
   excludeComposerAttachments,
   readQueuedMessageById,
@@ -208,7 +208,7 @@ async function readCurrentStoredChatHistory(
     }
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
     if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)) {
-      void loadChatHistory(host as unknown as ChatState);
+      void loadChatHistory(host);
     }
     return "continue";
   }

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -111,7 +111,7 @@ const resetRetryState = (
 });
 
 export const steerSendDependencies: SteerSendDependencies = {
-  loadChatHistory: (host) => void loadChatHistory(host as unknown as ChatState),
+  loadChatHistory: (host) => void loadChatHistory(host),
   resumeRestoredOutbox: (host, itemId) => {
     const restoredOutbox = findStoredOutbox(host as ChatHost, itemId);
     if (!host.chatRunId && restoredOutbox) {
@@ -123,7 +123,7 @@ export const steerSendDependencies: SteerSendDependencies = {
     }
   },
   sendChatMessage: (host, message, attachments, options) =>
-    sendChatMessageWithGeneratedRunId(host as unknown as ChatState, message, attachments, options),
+    sendChatMessageWithGeneratedRunId(host, message, attachments, options),
 };
 
 export const steerQueuedChatMessage = (host: ChatHost, id: string) =>

--- a/ui/src/pages/chat/chat-send-contract.ts
+++ b/ui/src/pages/chat/chat-send-contract.ts
@@ -1,7 +1,7 @@
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import type { CommandClientPresentationAction } from "../../app/command-client-presentation.ts";
-import type { ChatFollowUpMode } from "../../app/settings.ts";
+import type { UiSettings } from "../../app/settings.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import type { ControlUiFollowUpMode } from "../../lib/chat/follow-up-mode.ts";
 import type { SessionCapability, SessionRefreshTarget } from "../../lib/sessions/index.ts";
@@ -10,19 +10,29 @@ import type { ChatRunStartupState } from "./chat-run-startup.ts";
 import type { ChatSendTimingEntry } from "./chat-send-ack.ts";
 import type { ChatInputHistoryState } from "./input-history.ts";
 import type { QueuedMessageEdit } from "./queued-message-edit.ts";
-import type { RenderLifecycle } from "./render-lifecycle.ts";
+import type { ChatScrollHost } from "./scroll.ts";
+import type { ToolStreamHost } from "./tool-stream.ts";
 
 type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
   agents?: AgentsListResult["agents"];
 };
 
 export type ChatHost = ChatInputHistoryState &
+  ChatScrollHost &
+  ToolStreamHost &
   ChatCommandHost & {
     sessions: SessionCapability;
     client: GatewayBrowserClient | null;
-    chatStream: string | null;
     connected: boolean;
-    connectionEpoch?: number;
+    connectionEpoch: number;
+    currentSessionId?: string | null;
+    reconnectResumeSessionId?: string | null;
+    chatLoading: boolean;
+    chatMessage: string;
+    chatMessages: unknown[];
+    chatThinkingLevel: string | null;
+    chatVerboseLevel: string | null;
+    chatStreamStartedAt: number | null;
     chatAttachments: ChatAttachment[];
     chatQueue: ChatQueueItem[];
     /** Set while a queued row is held out of the queue inside the composer. */
@@ -35,10 +45,9 @@ export type ChatHost = ChatInputHistoryState &
     chatSending: boolean;
     chatSendingScopeKey?: string | null;
     chatRunError?: { summary: string } | null;
-    lastError?: string | null;
+    lastError: string | null;
     chatError?: string | null;
     hello: GatewayHelloOk | null;
-    renderLifecycle?: RenderLifecycle;
     requestUpdate?: () => void;
     refreshSessionsAfterChat: Map<string, SessionRefreshTarget>;
     chatSubmitGuards?: Map<string, Promise<void>>;
@@ -46,7 +55,8 @@ export type ChatHost = ChatInputHistoryState &
     eventLogBuffer?: unknown[];
     assistantAgentId?: string | null;
     agentsList?: ChatAgentsListSnapshot | null;
-    settings?: { chatFollowUpMode?: ChatFollowUpMode };
+    settings: Pick<UiSettings, "lastActiveSessionKey"> & Partial<UiSettings>;
+    applySettings: (patch: Partial<UiSettings>) => void;
     /** Prepared from the browser override and current Gateway effective queue mode. */
     chatFollowUpMode?: ControlUiFollowUpMode;
     /** Selected message to reply to (right-click / keyboard shortcut). */

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -7,7 +7,7 @@ import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessio
 import { generateUUID } from "../../lib/uuid.ts";
 import { discardChatAttachmentDataUrls } from "./attachment-payload-store.ts";
 import { readChatResetTargetAccess } from "./chat-commands.ts";
-import { loadChatBranches, loadChatHistory, type ChatState } from "./chat-history.ts";
+import { loadChatBranches, loadChatHistory } from "./chat-history.ts";
 import {
   flushStoredChatOutbox,
   retryableGatewayDelayMs,
@@ -282,17 +282,17 @@ async function sendQueuedChatMessage(
   if (isVisible()) {
     host.chatSendingScopeKey = storedChatOutboxScopeKey(scope);
     host.chatSending = true;
-    resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
-    resetChatScroll(host as unknown as Parameters<typeof resetChatScroll>[0]);
+    resetToolStream(host);
+    resetChatScroll(host);
     setChatError(host, null);
-    reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
+    reconcileChatRunLifecycle(host, {
       clearRunStatus: true,
     });
   }
 
   try {
     const ack = prepared.skillWorkshopRevision
-      ? await requestSkillWorkshopRevisionChatSend(host as unknown as ChatState, {
+      ? await requestSkillWorkshopRevisionChatSend(host, {
           proposalId: prepared.skillWorkshopRevision.proposalId,
           ...(prepared.skillWorkshopRevision.agentId
             ? { agentId: prepared.skillWorkshopRevision.agentId }
@@ -302,7 +302,7 @@ async function sendQueuedChatMessage(
           runId,
           sessionKey,
         })
-      : await requestChatSend(host as unknown as ChatState, {
+      : await requestChatSend(host, {
           message,
           attachments: attachments.length ? attachments : undefined,
           runId,
@@ -338,20 +338,17 @@ async function sendQueuedChatMessage(
           { type: "sendFailed", runId },
           { scope: projectionScope },
         );
-        reconcileChatRunLifecycle(
-          host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
-          {
-            outcome: "interrupted",
-            sessionStatus: ack.status === "error" ? "failed" : "killed",
-            runId: ack.runId,
-            sessionKey,
-            clearLocalRun: true,
-            clearChatStream: true,
-            clearToolStream: true,
-            publishRunStatus: false,
-            armLocalTerminalReconcile: ack.runId === runId,
-          },
-        );
+        reconcileChatRunLifecycle(host, {
+          outcome: "interrupted",
+          sessionStatus: ack.status === "error" ? "failed" : "killed",
+          runId: ack.runId,
+          sessionKey,
+          clearLocalRun: true,
+          clearChatStream: true,
+          clearToolStream: true,
+          publishRunStatus: false,
+          armLocalTerminalReconcile: ack.runId === runId,
+        });
         setChatError(host, error);
         restoreComposer(host, options ?? {});
       }
@@ -399,21 +396,18 @@ async function sendQueuedChatMessage(
         }
       }
       if (ack.status === "ok") {
-        reconcileChatRunLifecycle(
-          host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
-          {
-            outcome: "done",
-            sessionStatus: "done",
-            runId: ack.runId,
-            sessionKey,
-            clearLocalRun: true,
-            clearChatStream: true,
-            clearToolStream: true,
-            publishRunStatus: false,
-            armLocalTerminalReconcile: true,
-          },
-        );
-        void loadChatHistory(host as unknown as ChatState);
+        reconcileChatRunLifecycle(host, {
+          outcome: "done",
+          sessionStatus: "done",
+          runId: ack.runId,
+          sessionKey,
+          clearLocalRun: true,
+          clearChatStream: true,
+          clearToolStream: true,
+          publishRunStatus: false,
+          armLocalTerminalReconcile: true,
+        });
+        void loadChatHistory(host);
       } else if (isNonTerminalAgentRunStatus(ack.status)) {
         const adopted = host.chatRunId === ack.runId;
         const adoptedStream = adopted && typeof host.chatStream === "string";
@@ -423,8 +417,7 @@ async function sendQueuedChatMessage(
         }
         if (!adoptedStream) {
           host.chatStream = "";
-          (host as ChatHost & { chatStreamStartedAt?: number | null }).chatStreamStartedAt =
-            startedAt;
+          host.chatStreamStartedAt = startedAt;
         }
       }
     }
@@ -544,10 +537,7 @@ async function sendQueuedChatMessage(
       setChatError(host, error);
       restoreComposer(host, options ?? {});
       if (activeLeafChanged) {
-        void Promise.all([
-          loadChatHistory(host as unknown as ChatState),
-          loadChatBranches(host as unknown as ChatState),
-        ]);
+        void Promise.all([loadChatHistory(host), loadChatBranches(host)]);
       }
     }
     recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, { error });
@@ -657,10 +647,7 @@ export async function deliverChatQueueItem(
     result = drainResult ?? "pending";
   }
   if (result === "sent" && host.sessionKey === sessionKey) {
-    setLastActiveSessionKey(
-      host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
-      sessionKey,
-    );
+    setLastActiveSessionKey(host, sessionKey);
     resetChatInputHistoryNavigation(host);
     if (options.restoreDraft && options.previousDraft?.trim()) {
       host.chatMessage = options.previousDraft;
@@ -674,7 +661,7 @@ export async function deliverChatQueueItem(
     host.sessionKey === routingSessionKey &&
     visibleSessionMatches(host, routingSessionKey, deliveryAgentId)
   ) {
-    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);
+    scheduleChatScroll(host, true);
   }
   if (result === "sent" && host.sessionKey === sessionKey && !host.chatRunId) {
     void flushStoredChatOutbox(host, chatOutboxDrainDependencies);

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -83,7 +83,7 @@ export function enqueuePendingSendMessage(
     recordChatSendTiming(host, pending, sendState, submittedAtMs);
   }
   schedulePendingSendPaintTiming(host, pending, submittedAtMs);
-  scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true, false, {
+  scheduleChatScroll(host, true, false, {
     source: "manual",
   });
   return pending;

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -16,7 +16,7 @@ import {
   requireChatSessionAction,
   shouldQueueLocalSlashCommand,
 } from "./chat-commands.ts";
-import { loadChatHistory, type ChatState } from "./chat-history.ts";
+import { loadChatHistory } from "./chat-history.ts";
 import {
   admitQueuedMessageForSession,
   enqueueChatMessage,
@@ -161,15 +161,10 @@ async function sendDetachedCommandMessage(
     runId?: string;
   },
 ) {
-  const ack = await sendChatMessageWithGeneratedRunId(
-    host as unknown as ChatState,
-    message,
-    opts?.attachments,
-    {
-      canApplyError: () => submittedCommandScopeIsVisible(host, opts.recovery),
-      runId: opts.runId,
-    },
-  );
+  const ack = await sendChatMessageWithGeneratedRunId(host, message, opts?.attachments, {
+    canApplyError: () => submittedCommandScopeIsVisible(host, opts.recovery),
+    runId: opts.runId,
+  });
   const sendAck = ack && !("kind" in ack) ? ack : null;
   const ok =
     sendAck?.status === "ok" || sendAck?.status === "started" || sendAck?.status === "in_flight";
@@ -188,10 +183,7 @@ async function sendDetachedCommandMessage(
       clearOwnedCommandComposerFallback(host, opts.recovery);
     }
     if (submittedScopeIsVisible) {
-      setLastActiveSessionKey(
-        host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
-        host.sessionKey,
-      );
+      setLastActiveSessionKey(host, host.sessionKey);
     }
     if (!commandComposerFallbackRetainsAttachments(host, opts.recovery)) {
       releaseChatAttachmentPayloads(excludeComposerAttachments(host, opts.attachments));
@@ -208,7 +200,7 @@ export async function handleSendChat(
   const userMessage = (messageOverride ?? host.chatMessage).trim();
   const submittedAtMs = controlUiNowMs();
   const submittedSessionKey = host.sessionKey;
-  let expectedLeafEntryId = resolveDisplayedLeafEntryId(host as unknown as ChatState);
+  let expectedLeafEntryId = resolveDisplayedLeafEntryId(host);
   const attachmentsToSend =
     messageOverride == null ? snapshotChatAttachments(host.chatAttachments) : [];
   const hasAttachments = attachmentsToSend.length > 0;
@@ -462,10 +454,10 @@ export async function handleSendChat(
     if (host.chatLoading) {
       // A terminal event can render before its authoritative leaf arrives.
       // Reuse the in-flight history request before fencing the follow-up send.
-      if (!(await loadChatHistory(host as unknown as ChatState))) {
+      if (!(await loadChatHistory(host))) {
         return;
       }
-      expectedLeafEntryId = resolveDisplayedLeafEntryId(host as unknown as ChatState);
+      expectedLeafEntryId = resolveDisplayedLeafEntryId(host);
     }
     if (host.sessionKey !== submittedSessionKey) {
       return;

--- a/ui/src/pages/chat/chat-state-contract.ts
+++ b/ui/src/pages/chat/chat-state-contract.ts
@@ -1,0 +1,68 @@
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
+import type { AgentsListResult, GatewaySessionRow, SessionBranch } from "../../api/types.ts";
+import type { ApplicationInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
+import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import type { SessionCapability, SessionMessageSubscription } from "../../lib/sessions/index.ts";
+import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
+import type { ChatRunStartupState } from "./chat-run-startup.ts";
+import type { LocalTerminalReconcile } from "./run-lifecycle.ts";
+import type { ChatMessageCache } from "./session-message-cache.ts";
+import type { PlanStatus } from "./tool-stream.ts";
+
+type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
+  agents?: AgentsListResult["agents"];
+};
+
+export type ChatState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  initialUserMessage?: ApplicationInitialUserMessageHandoff;
+  /** Monotonic owner epoch; reconnects can reuse the same client object. */
+  connectionEpoch: number;
+  sessionKey: string;
+  currentSessionId?: string | null;
+  reconnectResumeSessionId?: string | null;
+  chatLoading: boolean;
+  chatHistoryPagination?: ChatHistoryPagination;
+  chatMessages: unknown[];
+  chatMessagesBySession?: ChatMessageCache;
+  /** Active leaf of the history snapshot currently rendered by this pane. */
+  chatDisplayedLeafEntryId?: string | null;
+  chatThinkingLevel: string | null;
+  chatVerboseLevel: string | null;
+  /** Pane-owned explicit session queue override from the latest history response. */
+  chatQueueModeOverride?: GatewaySessionRow["queueMode"];
+  /** Pane-owned effective queue mode from this session's latest history response. */
+  chatEffectiveQueueMode?: GatewaySessionRow["effectiveQueueMode"];
+  chatSending: boolean;
+  chatMessage: string;
+  chatAttachments: ChatAttachment[];
+  chatQueue: ChatQueueItem[];
+  chatRunId: string | null;
+  chatRunUsageById?: Map<string, number>;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  chatRunStartup?: ChatRunStartupState | null;
+  planStatus?: PlanStatus | null;
+  lastError: string | null;
+  chatError?: string | null;
+  chatRunError?: { summary: string } | null;
+  lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
+  chatReplyTarget?: unknown;
+  agentsError?: string | null;
+  onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => boolean;
+  resetChatInputHistoryNavigation?: () => void;
+  assistantAgentId?: string | null;
+  agentsList?: ChatAgentsListSnapshot | null;
+  agentsSelectedId?: string | null;
+  hello: GatewayHelloOk | null;
+  canvasPluginSurfaceUrl?: string | null;
+  settings?: { chatPersistCommentary?: boolean; gatewayUrl?: string | null };
+  sessions?: Partial<SessionCapability>;
+  chatSessionMessageSubscriptionRequestedKey?: string | null;
+  chatSessionMessageSubscription?: SessionMessageSubscription | null;
+  chatBranches?: SessionBranch[];
+  chatBranchesSessionKey?: string | null;
+  chatBranchesConnectionEpoch?: number | null;
+  requestUpdate?: () => void;
+};

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -33,7 +33,6 @@ import {
   loadChatBranches,
   loadChatHistory,
   shouldHideAssistantChatMessage,
-  type ChatState,
 } from "./chat-history.ts";
 import {
   readDeliveredQueuedChatSendForRun,
@@ -491,7 +490,7 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
       // Materialize it before the terminal assistant to preserve transcript order.
       preserveQueuedUserTurn(state, delivered);
     }
-    const result = handleChatGatewayEvent(state as unknown as ChatState, payload);
+    const result = handleChatGatewayEvent(state, payload);
     if (shouldCelebrateFirstReply && result === "final") {
       fireFirstReplyConfetti();
     }

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -41,7 +41,7 @@ export type ChatRunUiStatus = {
 
 type TerminalSessionRunStatus = Exclude<SessionRunStatus, "running">;
 
-type LocalTerminalReconcile = {
+export type LocalTerminalReconcile = {
   sessionKey: string;
   runId: string | null;
   phase: ChatRunUiStatus["phase"];
@@ -70,7 +70,7 @@ type RunLifecycleHost = Omit<
   chatRunStatus?: ChatRunUiStatus | null;
   chatRunStatusClearTimer?: TimerHandle | number | null;
   sessionsResult?: SessionsListResult | null;
-  sessions?: Pick<SessionCapability, "reconcileRunTerminal" | "setModelOverride">;
+  sessions?: Partial<Pick<SessionCapability, "reconcileRunTerminal" | "setModelOverride">>;
   lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
   requestUpdate?: () => void;
 };
@@ -410,7 +410,7 @@ function reconcileSessionRows(
   if (host.sessionsResult) {
     host.sessionsResult = reconcileSessionRunTerminal(host.sessionsResult, terminal);
   }
-  host.sessions?.reconcileRunTerminal(terminal);
+  host.sessions?.reconcileRunTerminal?.(terminal);
 }
 
 function reconcileYieldedSessionRows(
@@ -430,7 +430,7 @@ function reconcileYieldedSessionRows(
   if (host.sessionsResult) {
     host.sessionsResult = reconcileSessionRunTerminal(host.sessionsResult, terminal);
   }
-  host.sessions?.reconcileRunTerminal(terminal);
+  host.sessions?.reconcileRunTerminal?.(terminal);
 }
 
 export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: ReconcileOptions = {}) {

--- a/ui/src/pages/chat/scroll.ts
+++ b/ui/src/pages/chat/scroll.ts
@@ -86,7 +86,7 @@ export function captureChatSessionScrollPosition(target: {
   };
 }
 
-type ChatScrollHost = {
+export type ChatScrollHost = {
   renderLifecycle: RenderLifecycle;
   querySelector: (selectors: string) => Element | null;
   chatScrollCommitCleanup: (() => void) | null;

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -11,7 +11,6 @@ import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
-import type { ChatState } from "./chat-history.ts";
 import {
   clearPendingQueueItemsForRun,
   clearTransientQueuedMessageProjection,
@@ -28,6 +27,7 @@ import {
   type ChatSendAck,
   type TerminalFailureChatSendAck,
 } from "./chat-send-ack.ts";
+import type { ChatState } from "./chat-state-contract.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -11,6 +11,7 @@ import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
+import type { ChatState } from "./chat-history.ts";
 import {
   clearPendingQueueItemsForRun,
   clearTransientQueuedMessageProjection,
@@ -29,32 +30,25 @@ import {
 } from "./chat-send-ack.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
-import { scheduleChatScroll } from "./scroll.ts";
-import {
-  appendChatMessageToCache,
-  readChatMessagesFromCache,
-  type ChatMessageCache,
-} from "./session-message-cache.ts";
+import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";
+import { appendChatMessageToCache, readChatMessagesFromCache } from "./session-message-cache.ts";
 import { ackSteeredChip, buildInflightSteerChip, isAckedSteeredChip } from "./steered-chip.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
-type SteerLifecycleHost = ChatQueueScopedSessionHost & {
-  connected: boolean;
-  chatRunId: string | null;
-  chatMessages: unknown[];
-  currentSessionId?: string | null;
-  chatDisplayedLeafEntryId?: string | null;
-  chatMessagesBySession?: ChatMessageCache;
-  sessionsResult?: SessionsListResult | null;
-  lastError?: string | null;
-  chatError?: string | null;
-};
+type SteerLifecycleHost = ChatState &
+  ChatQueueScopedSessionHost & {
+    sessionsResult?: SessionsListResult | null;
+  };
+
+type SteerSendHost = SteerLifecycleHost &
+  ChatScrollHost &
+  Parameters<typeof setLastActiveSessionKey>[0];
 
 export type SteerSendDependencies = {
-  loadChatHistory: (host: SteerLifecycleHost) => void;
-  resumeRestoredOutbox: (host: SteerLifecycleHost, itemId: string) => void;
+  loadChatHistory: (host: SteerSendHost) => void;
+  resumeRestoredOutbox: (host: SteerSendHost, itemId: string) => void;
   sendChatMessage: (
-    host: SteerLifecycleHost,
+    host: SteerSendHost,
     message: string,
     attachments: ChatAttachment[] | undefined,
     options: {
@@ -320,7 +314,7 @@ function setChatError(host: SteerLifecycleHost, error: string | null): void {
 }
 
 export async function sendQueuedChatMessageWithQueueMode(
-  host: SteerLifecycleHost,
+  host: SteerSendHost,
   id: string,
   queueMode: QueueMode | undefined,
   dependencies: SteerSendDependencies,
@@ -507,16 +501,13 @@ export async function sendQueuedChatMessageWithQueueMode(
     releaseChatAttachmentPayloads(attachments);
   }
   if (itemStillVisible) {
-    setLastActiveSessionKey(
-      host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
-      itemSessionKey,
-    );
-    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
+    setLastActiveSessionKey(host, itemSessionKey);
+    scheduleChatScroll(host);
   }
 }
 
 export function steerQueuedChatMessage(
-  host: SteerLifecycleHost,
+  host: SteerSendHost,
   id: string,
   dependencies: SteerSendDependencies,
 ): Promise<void> {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -56,7 +56,7 @@ export type ToolStreamEntry = {
   message: Record<string, unknown>;
 };
 
-type ToolStreamHost = {
+export type ToolStreamHost = {
   sessionKey: string;
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null } | null;


### PR DESCRIPTION
## What Problem This Solves

Removes the broad `packages/ai` and `ui/src` exclusions from the chained-type-assertion guard, so new evidence-erasing casts can no longer accumulate across those scopes.

## Why This Change Was Made

The transport stream now exposes its real writable shape, OpenAI-compatible response variants own typed adapter shapes, and the Control UI chat-send flow carries one complete host contract through delivery, history, lifecycle, scrolling, and steering. Intentional SDK, native-host, and two-phase-construction bridges remain as file-level ledger entries with reviewer-visible reasons in the canonical ledger module.

Accounting: 40 of 52 findings fixed; 12 findings retained in 9 file-level entries. Production LOC is +263/-252 (net +11); tests/support are +30/-3 (net +27); tooling is +9/-2 (net +7). The production growth is the leaf `ChatState` contract that removes the history/steering import cycle plus the explicit optional Claude sampling-field contract that preserves strict request cleanup without a chained assertion.

## User Impact

No intended user-visible behavior changes. Developers get active chained-assertion enforcement across the AI package and Control UI instead of two broad scope exemptions.

## Evidence

- Focused guard: `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json packages/ai ui/src`
- Full guard: `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions packages ui/src`
- Full changed gate: delegated Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31921581312 (exit 0, 18m12s)
- Rebased exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31928408144, including the complete Control UI E2E matrix and `openclaw/ci-gate`
- Focused AI transport/provider tests: 16 files, 318 tests passed; post-review Claude request-contract rerun: 2 files, 219 tests passed
- Focused Control UI tests: 19 files, 754 tests passed; sidebar observer regression: 22 tests passed
- Focused native browser E2E: 2 files, 3 tests passed
- Google transport sibling: 130 tests passed on https://github.com/openclaw/openclaw/actions/runs/31921533236
- Madge runtime topology: 0 cycles on https://github.com/openclaw/openclaw/actions/runs/31923419381
- Focused Control UI browser-link E2E: 4 tests passed on https://github.com/openclaw/openclaw/actions/runs/31923730254
- Final branch autoreview after conflict resolution: clean, no accepted/actionable findings

## Review Follow-up

Both actionable ClawSweeper findings were applied. The Claude request contract declares its four optional removable fields and uses ordinary `delete`, preserving strict failure semantics. Sidebar observer payloads are now schema-validated before run mutation, with a regression proving an invalid new-run digest cannot erase the active digest. Direct inspection of the pinned Anthropic SDK confirms that `output_config.effort` already includes both `xhigh` and `max`, so the removed evidence-erasing effort cast remains correctly deleted.
