### PR TITLE
fix(usage): keep healthy provider usage after auth failures

### DIFF
--- a/src/infra/provider-usage-plugin-runtime.test-mocks.ts
+++ b/src/infra/provider-usage-plugin-runtime.test-mocks.ts
@@ -6,6 +6,11 @@ const resolveProviderUsageSnapshotWithPluginMock = vi.hoisted(() =>
     async () => null,
   ),
 );
+const resolveProviderUsageAuthWithPluginMock = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/provider-runtime.js").resolveProviderUsageAuthWithPlugin>(
+    async () => undefined,
+  ),
+);
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => ({}),
@@ -17,16 +22,23 @@ vi.mock("../plugins/provider-runtime.js", async () => {
   );
   return {
     ...actual,
+    resolveProviderUsageAuthWithPlugin: resolveProviderUsageAuthWithPluginMock,
     resolveProviderUsageSnapshotWithPlugin: resolveProviderUsageSnapshotWithPluginMock,
   };
 });
 
 /** Resets the plugin-backed provider usage mock to the default no-snapshot behavior. */
 export function resetProviderUsageSnapshotWithPluginMock() {
+  resolveProviderUsageAuthWithPluginMock.mockReset();
+  resolveProviderUsageAuthWithPluginMock.mockResolvedValue(undefined);
   resolveProviderUsageSnapshotWithPluginMock.mockReset();
   resolveProviderUsageSnapshotWithPluginMock.mockResolvedValue(null);
 }
 
 export function getProviderUsageSnapshotWithPluginMock() {
   return resolveProviderUsageSnapshotWithPluginMock;
+}
+
+export function getProviderUsageAuthWithPluginMock() {
+  return resolveProviderUsageAuthWithPluginMock;
 }

--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -152,6 +152,17 @@ describe("resolveProviderAuths plugin boundary", () => {
     expect(ensureAuthProfileStoreMock).not.toHaveBeenCalled();
   });
 
+  it("preserves exact plugin auth failures for direct callers", async () => {
+    const authError = new Error("plugin auth failed");
+    resolveProviderUsageAuthWithPluginMock.mockRejectedValueOnce(authError);
+
+    await expect(
+      resolveProviderAuthsForTest({
+        providers: ["anthropic"],
+      }),
+    ).rejects.toBe(authError);
+  });
+
   it("resolves SecretRef-backed profiles before provider credential classification", async () => {
     const store = {
       profiles: {

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -481,6 +481,7 @@ export async function resolveProviderAuths(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   skipPluginAuthWithoutCredentialSource?: boolean;
+  onError?: (provider: UsageProviderId, error: unknown) => void;
 }): Promise<ProviderAuth[]> {
   if (params.auth) {
     return params.auth;
@@ -501,80 +502,84 @@ export async function resolveProviderAuths(params: {
   const auths: ProviderAuth[] = [];
 
   for (const provider of params.providers) {
-    if (!params.skipPluginAuthWithoutCredentialSource) {
-      const pluginAuth = await resolveProviderUsageAuthViaPlugin({
-        state: authProfileSourceState,
+    try {
+      if (!params.skipPluginAuthWithoutCredentialSource) {
+        const pluginAuth = await resolveProviderUsageAuthViaPlugin({
+          state: authProfileSourceState,
+          provider,
+        });
+        if (pluginAuth.auth) {
+          auths.push(pluginAuth.auth);
+          continue;
+        }
+        if (pluginAuth.handled) {
+          continue;
+        }
+        const fallbackAuth = await resolveProviderUsageAuthFallback({
+          state: authProfileSourceState,
+          provider,
+        });
+        if (fallbackAuth) {
+          auths.push(fallbackAuth);
+        }
+        continue;
+      }
+
+      const directCredentialState = { ...stateBase, allowAuthProfileStore: false };
+      const credentialProviderIds = resolveUsageCredentialProviderIds({
+        state: directCredentialState,
         provider,
       });
-      if (pluginAuth.auth) {
-        auths.push(pluginAuth.auth);
-        continue;
-      }
-      if (pluginAuth.handled) {
-        continue;
+      const hasDirectCredentialSource =
+        Boolean(
+          resolveProviderApiKeyFromConfig({
+            state: directCredentialState,
+            providerIds: credentialProviderIds,
+          }),
+        ) ||
+        hasProviderAuthEnvCredentialSource({
+          state: directCredentialState,
+          providerIds: credentialProviderIds,
+        }) ||
+        hasProviderUsageAuthEnvCredentialSource({
+          state: directCredentialState,
+          providerIds: credentialProviderIds,
+        });
+      const allowAuthProfileStore =
+        hasDirectCredentialSource ||
+        (hasAuthProfileStoreSource &&
+          hasAuthProfileCredentialSource({
+            state: authProfileSourceState,
+            providerIds: credentialProviderIds,
+          }));
+      const state: UsageAuthState = {
+        ...stateBase,
+        allowAuthProfileStore,
+      };
+      const hasPluginCredentialSource = hasDirectCredentialSource || allowAuthProfileStore;
+
+      if (hasPluginCredentialSource) {
+        const pluginAuth = await resolveProviderUsageAuthViaPlugin({
+          state,
+          provider,
+        });
+        if (pluginAuth.auth) {
+          auths.push(pluginAuth.auth);
+          continue;
+        }
+        if (pluginAuth.handled) {
+          continue;
+        }
       }
       const fallbackAuth = await resolveProviderUsageAuthFallback({
-        state: authProfileSourceState,
+        state,
         provider,
       });
       if (fallbackAuth) {
         auths.push(fallbackAuth);
       }
-      continue;
-    }
-
-    const directCredentialState = { ...stateBase, allowAuthProfileStore: false };
-    const credentialProviderIds = resolveUsageCredentialProviderIds({
-      state: directCredentialState,
-      provider,
-    });
-    const hasDirectCredentialSource =
-      Boolean(
-        resolveProviderApiKeyFromConfig({
-          state: directCredentialState,
-          providerIds: credentialProviderIds,
-        }),
-      ) ||
-      hasProviderAuthEnvCredentialSource({
-        state: directCredentialState,
-        providerIds: credentialProviderIds,
-      }) ||
-      hasProviderUsageAuthEnvCredentialSource({
-        state: directCredentialState,
-        providerIds: credentialProviderIds,
-      });
-    const allowAuthProfileStore =
-      hasDirectCredentialSource ||
-      (hasAuthProfileStoreSource &&
-        hasAuthProfileCredentialSource({
-          state: authProfileSourceState,
-          providerIds: credentialProviderIds,
-        }));
-    const state: UsageAuthState = {
-      ...stateBase,
-      allowAuthProfileStore,
-    };
-    const hasPluginCredentialSource = hasDirectCredentialSource || allowAuthProfileStore;
-
-    if (hasPluginCredentialSource) {
-      const pluginAuth = await resolveProviderUsageAuthViaPlugin({
-        state,
-        provider,
-      });
-      if (pluginAuth.auth) {
-        auths.push(pluginAuth.auth);
-        continue;
-      }
-      if (pluginAuth.handled) {
-        continue;
-      }
-    }
-    const fallbackAuth = await resolveProviderUsageAuthFallback({
-      state,
-      provider,
-    });
-    if (fallbackAuth) {
-      auths.push(fallbackAuth);
+    } catch (error) {
+      params.onError?.(provider, error);
     }
   }
 

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -579,7 +579,10 @@ export async function resolveProviderAuths(params: {
         auths.push(fallbackAuth);
       }
     } catch (error) {
-      params.onError?.(provider, error);
+      if (!params.onError) {
+        throw error;
+      }
+      params.onError(provider, error);
     }
   }
 

--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createProviderUsageFetch, makeResponse } from "../test-utils/provider-usage-fetch.js";
 import {
+  getProviderUsageAuthWithPluginMock,
   getProviderUsageSnapshotWithPluginMock,
   resetProviderUsageSnapshotWithPluginMock,
 } from "./provider-usage-plugin-runtime.test-mocks.js";
@@ -16,6 +17,7 @@ import type { ProviderUsageSnapshot } from "./provider-usage.types.js";
 
 type ProviderAuth = ProviderUsageAuth<typeof loadProviderUsageSummary>;
 const googleGeminiCliProvider = "google-gemini-cli" as unknown as ProviderAuth["provider"];
+const resolveProviderUsageAuthWithPluginMock = getProviderUsageAuthWithPluginMock();
 const resolveProviderUsageSnapshotWithPluginMock = getProviderUsageSnapshotWithPluginMock();
 
 describe("provider-usage.load", () => {
@@ -210,6 +212,35 @@ describe("provider-usage.load", () => {
         provider: "openai",
         displayName: "Codex",
         windows: [{ label: "3h", usedPercent: 12 }],
+      },
+    ]);
+  });
+
+  it("keeps successful provider usage when a sibling auth hook rejects", async () => {
+    resolveProviderUsageAuthWithPluginMock.mockImplementation(async ({ provider }) => {
+      if (provider === "anthropic") {
+        throw new Error("auth failed");
+      }
+      return { token: `${provider}-token` };
+    });
+    resolveProviderUsageSnapshotWithPluginMock.mockImplementation(async ({ provider }) => ({
+      provider,
+      displayName: provider,
+      windows: [{ label: "5h", usedPercent: 12 }],
+    }));
+
+    const summary = await loadProviderUsageSummary({
+      providers: ["anthropic", "openai"],
+      config: {},
+      env: {},
+    });
+
+    expect(summary.providers).toEqual([
+      { provider: "anthropic", displayName: "Claude", windows: [], error: "auth failed" },
+      {
+        provider: "openai",
+        displayName: "openai",
+        windows: [{ label: "5h", usedPercent: 12 }],
       },
     ]);
   });

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -122,6 +122,14 @@ export async function loadProviderUsageSummary(
   const displayNames = new Map(
     descriptors.map((descriptor) => [descriptor.provider, descriptor.displayName]),
   );
+  const providerOrder = new Map(descriptors.map(({ provider }, index) => [provider, index]));
+  const failureSnapshot = (provider: UsageProviderId, error: string): ProviderUsageSnapshot => ({
+    provider,
+    displayName: displayNames.get(provider) ?? providerUsageLabel(provider) ?? provider,
+    windows: [],
+    error,
+  });
+  const authFailures: ProviderUsageSnapshot[] = [];
   const auths = await resolveProviderAuths({
     providers: descriptors.map((descriptor) => descriptor.provider),
     auth: opts.auth,
@@ -129,19 +137,16 @@ export async function loadProviderUsageSummary(
     config,
     env,
     skipPluginAuthWithoutCredentialSource: opts.skipPluginAuthWithoutCredentialSource,
+    onError: (provider, error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      authFailures.push(failureSnapshot(provider, message.trim() || "Auth failed"));
+    },
   });
-  if (auths.length === 0) {
+  if (auths.length === 0 && authFailures.length === 0) {
     return { updatedAt: now, providers: [] };
   }
 
   const tasks = auths.map((auth) => {
-    const failureSnapshot = (error: string): ProviderUsageSnapshot => ({
-      provider: auth.provider,
-      displayName:
-        displayNames.get(auth.provider) ?? providerUsageLabel(auth.provider) ?? auth.provider,
-      windows: [],
-      error,
-    });
     return raceUsageTimeout(
       fetchProviderUsageSnapshot({
         auth,
@@ -162,11 +167,15 @@ export async function loadProviderUsageSummary(
       },
     ).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      return failureSnapshot(message.trim() || "Fetch failed");
+      return failureSnapshot(auth.provider, message.trim() || "Fetch failed");
     });
   });
 
-  const snapshots = await Promise.all(tasks);
+  const snapshots = [...(await Promise.all(tasks)), ...authFailures].toSorted(
+    (left, right) =>
+      (providerOrder.get(left.provider) ?? Number.MAX_SAFE_INTEGER) -
+      (providerOrder.get(right.provider) ?? Number.MAX_SAFE_INTEGER),
+  );
   const providers = snapshots.filter((entry) => {
     if (entry.windows.length > 0) {
       return true;

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -158,13 +158,7 @@ export async function loadProviderUsageSummary(
         fetchFn,
       }),
       timeoutMs + 1000,
-      {
-        provider: auth.provider,
-        displayName:
-          displayNames.get(auth.provider) ?? providerUsageLabel(auth.provider) ?? auth.provider,
-        windows: [],
-        error: "Timeout",
-      },
+      failureSnapshot(auth.provider, "Timeout"),
     ).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
       return failureSnapshot(auth.provider, message.trim() || "Fetch failed");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where one provider usage auth hook rejecting could make the entire provider-usage request fail, hiding otherwise healthy provider quota snapshots.

## Why This Change Was Made

Provider auth is still resolved in the existing deterministic descriptor order, but `resolveProviderAuths` now lets the summary owner receive a provider-scoped error. `loadProviderUsageSummary` converts only those opted-in errors into the same snapshot shape already used for fetch failures and timeouts, then restores descriptor order across healthy and failed results. Direct `resolveProviderAuths` callers that do not supply the error owner still receive the exact original rejection object.

This leaves the #124131 cache boundary intact: the exact `OpenClawConfig` object remains the cache/dedupe identity and is passed unchanged into `loadProviderUsageSummary`. There is no provider auth, routing, config, default, billing, protocol, or schema contract change.

## User Impact

Usage/status surfaces now keep healthy providers visible when a sibling provider's auth resolver fails. The failed provider appears with its existing error snapshot instead of blocking the whole response.

No changelog entry: this is a narrow internal reliability repair with no new user-facing surface.

## Evidence

- Rebased without patch drift onto the approved immutable base `2585edba2efda9ff50e6bed0a6de8cfaef8254fc`; production `+89/-78`, net **+11**. Tests/test support `+54/-0`.
- The requested provider-usage sweep now enumerates **208 tests** in the rebased source (79 fast + 129 infra); all passed with the exact candidate files over hosted main on Blacksmith Testbox `tbx_01m045cxt2tcf1cb9qmmw5at87`, run [31921321514](https://github.com/openclaw/openclaw/actions/runs/31921321514).
- Full build passed on the same candidate-file Testbox overlay, including runtime postbuild, all 145 public Plugin SDK subpaths, Control UI build, and build stamps. Exact-head hosted CI remains the merge authority.
- Built Gateway + built CLI loopback passed with ordered providers `success → HTTP 503 → timeout → auth failure`, exact endpoint requests `1/1/1/0`, a live late timeout socket at result time, and verified Gateway listener plus isolated-state cleanup.
- Core production types, all core test-type shards, changed-file oxfmt/oxlint, coercion-helper guard, and import-cycle check passed; `git diff --check` is clean.
- The exact local changed gate honored sibling locks for ten minutes and exited without running. No lock was recovered. Exact-head hosted CI and native Testbox prepare remain authoritative.
- Fresh autoreview against the immutable base: no findings; patch correct (0.99 confidence).

Codex contract inspection at `openai/codex@57f42a81131ccf5933e7ec5dc659c381eeb5d72b`:

- [rate-limit snapshots are recorded and emitted through `TokenCount`](https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/src/session/mod.rs#L3878-L3918)
- [app-server projects token usage and rate-limit notifications](https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server/src/bespoke_event_handling.rs#L1577-L1602)
- [restored token usage replay is connection-scoped and does not repersist a model event](https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server/src/request_processors/token_usage_replay.rs#L28-L55)

Related sequencing:

- #113920 is broader profile fan-out work and overlaps `provider-usage.load.ts`; it should rebase after this repair and preserve provider-level auth-failure isolation.
- #120309 is complementary UI request-failure visibility and has no source overlap.
- #121799 is complementary Gateway cache/latency work and has no overlap with these five files.
