### PR TITLE
fix: cloud worker reconcile failures no longer block reclaim

### DIFF
--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -1,6 +1,11 @@
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
-import { required, type WorkerSessionPlacementRecord } from "./placement-record.js";
+import {
+  isCurrentPlacementTurnClaim,
+  required,
+  type WorkerSessionPlacementRecord,
+  type WorkerSessionTurnClaim,
+} from "./placement-record.js";
 import { getRequired, query, transitionValues } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
 import {
@@ -23,13 +28,32 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
       const outcome = write((db) => {
         const current = getRequired(db, sessionId);
         const persisted = current.turnClaim;
+        const releasedClaim: WorkerSessionTurnClaim | null = persisted
+          ? {
+              sessionId,
+              claimId: persisted.claimId,
+              runId: persisted.runId,
+              placementGeneration: persisted.generation,
+              owner:
+                persisted.owner === "worker"
+                  ? {
+                      kind: "worker",
+                      environmentId: pending.environmentId,
+                      ownerEpoch: persisted.ownerEpoch,
+                    }
+                  : {
+                      kind: "local",
+                      environmentId: pending.environmentId,
+                      ownerEpoch: pending.ownerEpoch,
+                    },
+            }
+          : null;
         const exactClaim =
-          persisted === null ||
-          (persisted.owner === "worker" &&
-            persisted.claimId === pending.claimId &&
-            persisted.runId === pending.runId &&
-            persisted.generation === pending.placementGeneration &&
-            persisted.ownerEpoch === pending.ownerEpoch);
+          releasedClaim === null ||
+          (releasedClaim.claimId === pending.claimId &&
+            releasedClaim.runId === pending.runId &&
+            releasedClaim.placementGeneration === pending.placementGeneration &&
+            isCurrentPlacementTurnClaim(current, releasedClaim));
         if (
           (current.state !== "active" && current.state !== "draining") ||
           current.environmentId !== pending.environmentId ||
@@ -143,20 +167,7 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
         }
         return {
           record: getRequired(db, sessionId),
-          releasedClaim:
-            persisted?.owner === "worker"
-              ? {
-                  sessionId,
-                  owner: {
-                    kind: "worker" as const,
-                    environmentId: pending.environmentId,
-                    ownerEpoch: pending.ownerEpoch,
-                  },
-                  claimId: pending.claimId,
-                  runId: pending.runId,
-                  placementGeneration: pending.placementGeneration,
-                }
-              : null,
+          releasedClaim,
         };
       });
       if (outcome.releasedClaim) {

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -338,6 +338,66 @@ describe("worker turn launcher local placement", () => {
     expect([placement?.state, placement?.turnClaim]).toEqual(["active", null]);
   });
 
+  it("records a remote-exec reconciliation failure and releases its local claim", async () => {
+    seedActivePlacement("remote-exec");
+    const reconciliationError = new Error("workspace manifest memo exceeds its entry limit");
+    const tunnel: WorkerTunnelHandle = {
+      environmentId: ENVIRONMENT_ID,
+      ownerEpoch: OWNER_EPOCH,
+      launchTurn: vi.fn(),
+      runWorkspaceCommand: vi.fn(),
+      quiesceWorkspace: vi.fn(async () => ({
+        assertActive: vi.fn(async () => {}),
+        resume: vi.fn(async () => {}),
+      })),
+      syncWorkspace: vi.fn(),
+      reconcileWorkspace: vi.fn(async () => {
+        throw reconciliationError;
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const environments: WorkerTurnEnvironmentService = {
+      ...unusedEnvironments(),
+      get: vi.fn(() => attachedEnvironment()),
+      startTunnel: vi.fn(async () => tunnel),
+    };
+    const recoverPendingWorkspaceResult = vi.fn(async () => {
+      const placement = placements.get(SESSION_ID);
+      if (placement?.state !== "failed" || placement.turnClaim !== null) {
+        throw new Error("expected terminal placement before teardown recovery");
+      }
+      expect(placements.listPendingWorkspaceResults()).toEqual([]);
+    });
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments,
+      placements,
+      recoverPendingWorkspaceResult,
+    });
+
+    await expect(
+      provider.executeTurn(
+        {
+          sessionId: SESSION_ID,
+          sessionKey: SESSION_KEY,
+          agentId: "main",
+          runId: "run-remote-exec-reconcile-failure",
+        },
+        turn("run-remote-exec-reconcile-failure"),
+        async () => ({ payloads: [{ text: "remote work completed" }], meta: { durationMs: 1 } }),
+      ),
+    ).rejects.toThrow(
+      "Cloud worker finished, but its workspace result could not be reconciled: workspace manifest memo exceeds its entry limit",
+    );
+
+    expect(recoverPendingWorkspaceResult).toHaveBeenCalledWith(ENVIRONMENT_ID);
+    expect(placements.get(SESSION_ID)).toMatchObject({
+      state: "failed",
+      turnClaim: null,
+      terminalReason: expect.stringContaining("workspace manifest memo exceeds its entry limit"),
+    });
+    expect(placements.listPendingWorkspaceResults()).toEqual([]);
+  });
+
   it("rejects a reused worker bundle without execution context before launch", async () => {
     seedActivePlacement();
     const oldEnvironment = attachedEnvironment();

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -511,16 +511,22 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       } catch (error) {
         const pendingWorkspaceResult = options.placements
           .listPendingWorkspaceResults()
-          .some(
+          .find(
             (pending) =>
               pending.sessionId === turnClaim.sessionId &&
               pending.claimId === turnClaim.claimId &&
               pending.runId === turnClaim.runId,
           );
         if (pendingWorkspaceResult) {
-          // A recovery sweep owns the still-live worker claim. Teardown here
-          // could discard the terminal event's durably fenced file results.
-          options.placements.handoffWorkspaceResultRecovery(turnClaim);
+          if (turnClaim.owner.kind === "local") {
+            // The Gateway-owned run is already terminal. Atomically record the
+            // reconciliation failure before teardown so reclaim cannot see live work.
+            options.placements.failWorkspaceResultAndReleaseTurn(pendingWorkspaceResult, error);
+          } else {
+            // A recovery sweep owns the still-live worker claim. Teardown here
+            // could discard the terminal event's durably fenced file results.
+            options.placements.handoffWorkspaceResultRecovery(turnClaim);
+          }
           await options.recoverPendingWorkspaceResult(placement.environmentId);
           throw error;
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a remote-exec cloud worker turn that finished successfully but failed during post-turn workspace reconciliation could retain its local turn claim forever. The live incident occurred on 2026-08-15 after the worker transcript had streamed back; every later `sessions.reclaim` was rejected as active work even though the turn had already terminated.

## Why This Change Was Made

Remote-exec turns use an environment-bound local claim, while the pending-result terminalizer previously accepted only worker-owned claims. The launcher now atomically records a terminal reconciliation failure for the exact local claim before teardown recovery, and the terminalizer validates and closes either exact claim owner through the canonical placement-claim invariant. Worker-owned results keep their existing recover-and-retry path, and the reclaim guard for genuinely running work is unchanged.

Gateway restart recovery already clears local claims before pending-result recovery; this change repairs the same-process path so operators no longer need a restart to escape the dead end.

Production LOC: +42/-25 (net +17) | Tests: +60/-0. The production growth is the explicit owner-boundary handling needed to preserve the original terminal error, atomically clear the pending fence and local claim, and notify claim-closure observers without weakening reclaim authorization.

## User Impact

Operators can stop or recover a cloud worker after a terminal post-turn workspace reconciliation failure. The placement records the actual reconciliation error, recovery tears down the failed environment, and `sessions.reclaim` is no longer permanently blocked by stale active-work state.

## Evidence

- Live reproduction: a real Hetzner remote-exec turn completed, then a manifest memo schema failure left `turn_claim_owner=local` and `turn_claim_run_id=r3fixproof1` on an active placement; repeated reclaim calls returned `UNAVAILABLE`.
- Regression before the fix: `worker-turn-launcher.test.ts` failed with `workspace result owner changed before failure` instead of recording the original reconciliation failure.
- Focused proof after the fix: `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-launcher.test.ts src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts src/gateway/worker-environments/placement-store-terminal.test.ts` — 3 files, 25 tests passed.
- Changed gate: `node scripts/check-changed.mjs` — conservative all-lanes Testbox run passed, including all TypeScript projects, lint, import cycles, dead-code, database-first, dependency, formatting, and plugin-boundary guards. Run: https://github.com/openclaw/openclaw/actions/runs/31921873274
- Autoreview: `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.

AI-assisted: yes. The implementation and failure-path evidence were manually inspected and verified against the owner, caller, recovery, restart, and reclaim boundaries.
