### PR TITLE
fix(ui): keep Logs tails bound to their source file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1787,6 +1787,13 @@ jobs:
           --configLoader runner
           ui/src/e2e/control-ui-auth-transports.e2e.test.ts
 
+      - name: Test Control UI Logs lifecycle with a real Gateway
+        run: >-
+          node scripts/run-vitest.mjs run
+          --config test/vitest/vitest.ui-e2e.config.ts
+          --configLoader runner
+          ui/src/e2e/logs-lifecycle.e2e.test.ts
+
   control-ui-i18n:
     permissions:
       contents: read

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6607,6 +6607,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(realGatewayRuns).toEqual([
       "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts",
       "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
+      "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/logs-lifecycle.e2e.test.ts",
     ]);
     const realGatewayRunContract = realGatewayRuns.join("\n");
     expect(realGatewayRunContract).not.toContain("--retry");

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -7,6 +7,7 @@ import { UiE2eSequencer } from "./vitest.ui-e2e.sequencer.ts";
 const uiE2eIncludePatterns = ["ui/src/**/*.e2e.test.ts"];
 const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
+  "ui/src/e2e/logs-lifecycle.e2e.test.ts",
   "ui/src/e2e/mcp-app-conformance.e2e.test.ts",
 ];
 

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -17,7 +17,10 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/logs-lifecycle");
+const proofDir = path.resolve(
+  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
+  "logs-lifecycle",
+);
 const viewport = { height: 900, width: 1_440 };
 
 function logLine(message: string, level: "error" | "info" | "warn", second: number) {
@@ -71,7 +74,12 @@ suite.define(() => {
     const lineBPrefix = logLine(messageBPrefix, "info", 2);
     const lineBTail = logLine("source B tail", "error", 3);
     const lineBAppended = logLine("source B appended", "warn", 4);
-    const lineBAfterReconnect = logLine("source B after reconnect", "info", 5);
+    const messageBRestartPrefix = `source B restart prefix ${"y".repeat(
+      Buffer.byteLength(`${lineBPrefix}\n${lineBTail}\n${lineBAppended}\n`),
+    )}`;
+    const lineBRestartPrefix = logLine(messageBRestartPrefix, "info", 5);
+    const lineBRestartTail = logLine("source B restart tail", "error", 6);
+    const lineBAfterReconnect = logLine("source B after reconnect", "warn", 7);
     await Promise.all([
       writeFile(sourceA, `${lineA}\n`, "utf8"),
       writeFile(sourceB, `${lineBPrefix}\n${lineBTail}\n`, "utf8"),
@@ -173,6 +181,7 @@ suite.define(() => {
             .poll(() => page.locator(".sidebar-footer-bar__status").textContent())
             .toContain("Reconnecting…");
           await expect.poll(() => visibleMessages(page)).toHaveLength(3);
+          await writeFile(sourceB, `${lineBRestartPrefix}\n${lineBRestartTail}\n`, "utf8");
           gateway = await startGatewayServer(port, {
             auth: { mode: "none" },
             bind: "loopback",
@@ -180,15 +189,13 @@ suite.define(() => {
             sidecarStartup: "defer",
           });
           await waitForControlUiGatewayReady(page);
+          await expect
+            .poll(() => visibleMessages(page))
+            .toEqual([messageBRestartPrefix, "source B restart tail"]);
           await appendFile(sourceB, `${lineBAfterReconnect}\n`, "utf8");
           await expect
             .poll(() => visibleMessages(page))
-            .toEqual([
-              messageBPrefix,
-              "source B tail",
-              "source B appended",
-              "source B after reconnect",
-            ]);
+            .toEqual([messageBRestartPrefix, "source B restart tail", "source B after reconnect"]);
           await capture(page, "03-reconnected-tail-complete.png");
           expect(pageErrors).toEqual([]);
         },

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -80,32 +80,33 @@ suite.define(() => {
     const lineBRestartPrefix = logLine(messageBRestartPrefix, "info", 5);
     const lineBRestartTail = logLine("source B restart tail", "error", 6);
     const lineBAfterReconnect = logLine("source B after reconnect", "warn", 7);
-    await Promise.all([
-      writeFile(sourceA, `${lineA}\n`, "utf8"),
-      writeFile(sourceB, `${lineBPrefix}\n${lineBTail}\n`, "utf8"),
-      mkdir(readFailure),
-    ]);
-    await state.writeConfig({
-      gateway: {
-        auth: { mode: "none" },
-        controlUi: {
-          allowedOrigins: [new URL(suite.server.baseUrl).origin],
-          enabled: false,
-        },
-        port,
-      },
-    });
-    state.applyEnv();
-    setLoggerOverride({ consoleLevel: "silent", file: sourceA, level: "silent" });
     const { startGatewayServer } = await import("../../../src/gateway/server.js");
-    let gateway = await startGatewayServer(port, {
-      auth: { mode: "none" },
-      bind: "loopback",
-      controlUiEnabled: false,
-      sidecarStartup: "defer",
-    });
+    let gateway: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
 
     try {
+      await Promise.all([
+        writeFile(sourceA, `${lineA}\n`, "utf8"),
+        writeFile(sourceB, `${lineBPrefix}\n${lineBTail}\n`, "utf8"),
+        mkdir(readFailure),
+      ]);
+      await state.writeConfig({
+        gateway: {
+          auth: { mode: "none" },
+          controlUi: {
+            allowedOrigins: [new URL(suite.server.baseUrl).origin],
+            enabled: false,
+          },
+          port,
+        },
+      });
+      setLoggerOverride({ consoleLevel: "silent", file: sourceA, level: "silent" });
+      gateway = await startGatewayServer(port, {
+        auth: { mode: "none" },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      });
+
       await suite.withPage(
         {
           locale: "en-US",
@@ -168,7 +169,8 @@ suite.define(() => {
           await expect.poll(() => error.count()).toBe(0);
           await expect.poll(() => visibleMessages(page)).toHaveLength(3);
 
-          await gateway.close({ reason: "logs lifecycle reconnect proof" });
+          await gateway?.close({ reason: "logs lifecycle reconnect proof" });
+          gateway = null;
           await page.waitForFunction(() => {
             const app = document.querySelector("openclaw-app") as
               | (HTMLElement & {
@@ -201,7 +203,7 @@ suite.define(() => {
         },
       );
     } finally {
-      await gateway.close({ reason: "logs lifecycle e2e cleanup" });
+      await gateway?.close({ reason: "logs lifecycle e2e cleanup" });
       resetLogger();
       await state.cleanup();
     }

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -1,0 +1,202 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
+import { createOpenClawTestState } from "../../../src/test-utils/openclaw-test-state.ts";
+import { getFreePort } from "../../../src/test-utils/ports.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI logs lifecycle",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/logs-lifecycle");
+const viewport = { height: 900, width: 1_440 };
+
+function logLine(message: string, level: "error" | "info" | "warn", second: number) {
+  return JSON.stringify({
+    "0": JSON.stringify({ subsystem: "logs-lifecycle-proof" }),
+    "1": message,
+    message,
+    time: new Date(Date.UTC(2026, 7, 15, 12, 0, second)).toISOString(),
+    _meta: { logLevelName: level },
+  });
+}
+
+async function capture(page: Page, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, name),
+  });
+}
+
+async function visibleMessages(page: Page) {
+  return page.locator(".log-message").allTextContents();
+}
+
+suite.define(() => {
+  it("replaces a changed log source and preserves visible recovery through reconnect", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "control-ui-logs-lifecycle",
+      layout: "home",
+      env: {
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const sourceA = state.path("source-a.log");
+    const sourceB = state.path("source-b.log");
+    const readFailure = state.path("read-failure");
+    const lineA = logLine("source A only", "info", 1);
+    const messageBPrefix = `source B prefix ${"x".repeat(Buffer.byteLength(lineA))}`;
+    const lineBPrefix = logLine(messageBPrefix, "info", 2);
+    const lineBTail = logLine("source B tail", "error", 3);
+    const lineBAppended = logLine("source B appended", "warn", 4);
+    const lineBAfterReconnect = logLine("source B after reconnect", "info", 5);
+    await Promise.all([
+      writeFile(sourceA, `${lineA}\n`, "utf8"),
+      writeFile(sourceB, `${lineBPrefix}\n${lineBTail}\n`, "utf8"),
+      mkdir(readFailure),
+    ]);
+    await state.writeConfig({
+      gateway: {
+        auth: { mode: "none" },
+        controlUi: {
+          allowedOrigins: [new URL(suite.server.baseUrl).origin],
+          enabled: false,
+        },
+        port,
+      },
+    });
+    state.applyEnv();
+    setLoggerOverride({ consoleLevel: "silent", file: sourceA, level: "silent" });
+    const { startGatewayServer } = await import("../../../src/gateway/server.js");
+    let gateway = await startGatewayServer(port, {
+      auth: { mode: "none" },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+
+    try {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport,
+          ...(captureUiProof ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+        },
+        async ({ page }) => {
+          const pageErrors: string[] = [];
+          page.on("pageerror", (error) => pageErrors.push(String(error)));
+          const url = new URL("logs", suite.server.baseUrl);
+          url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
+          await page.goto(url.toString());
+          const confirmation = page.locator("openclaw-gateway-url-confirmation");
+          await confirmation.waitFor();
+          await confirmation.getByRole("button", { name: "Confirm", exact: true }).click();
+          await waitForControlUiGatewayReady(page);
+          await expect.poll(() => visibleMessages(page)).toEqual(["source A only"]);
+
+          setLoggerOverride({ consoleLevel: "silent", file: sourceB, level: "silent" });
+          await expect
+            .poll(() => page.locator(".logs-card .settings-row").first().textContent())
+            .toContain(sourceB);
+          await expect.poll(() => visibleMessages(page)).toEqual([messageBPrefix, "source B tail"]);
+          await capture(page, "01-source-b-complete.png");
+
+          const filter = page.getByRole("textbox", { name: "Filter" });
+          await filter.fill("source B tail");
+          await expect.poll(() => visibleMessages(page)).toEqual(["source B tail"]);
+          const downloadPromise = page.waitForEvent("download");
+          await page.getByRole("button", { name: "Export filtered" }).click();
+          const download = await downloadPromise;
+          expect(download.suggestedFilename()).toMatch(/^openclaw-logs-filtered-.*\.log$/);
+          const downloadStream = await download.createReadStream();
+          if (!downloadStream) {
+            throw new Error("filtered log export did not provide a readable download");
+          }
+          expect(await text(downloadStream)).toBe(`${lineBTail}\n`);
+
+          await filter.fill("");
+          await page.locator("label.log-chip.info input").uncheck();
+          await expect.poll(() => visibleMessages(page)).toEqual(["source B tail"]);
+          await page.locator("label.log-chip.info input").check();
+          await appendFile(sourceB, `${lineBAppended}\n`, "utf8");
+          await expect
+            .poll(() => visibleMessages(page))
+            .toEqual([messageBPrefix, "source B tail", "source B appended"]);
+
+          setLoggerOverride({ consoleLevel: "silent", file: readFailure, level: "silent" });
+          const error = page.locator(".logs-refresh-status[role=alert]");
+          await expect.poll(() => error.isVisible()).toBe(true);
+          await expect.poll(() => error.textContent()).toContain("log read failed");
+          await expect.poll(() => error.textContent()).toContain("Showing stale data");
+          await expect
+            .poll(() => visibleMessages(page))
+            .toEqual([messageBPrefix, "source B tail", "source B appended"]);
+          await capture(page, "02-read-error-stale-lines-visible.png");
+
+          setLoggerOverride({ consoleLevel: "silent", file: sourceB, level: "silent" });
+          await expect.poll(() => error.count()).toBe(0);
+          await expect.poll(() => visibleMessages(page)).toHaveLength(3);
+
+          await gateway.close({ reason: "logs lifecycle reconnect proof" });
+          await page.waitForFunction(() => {
+            const app = document.querySelector("openclaw-app") as
+              | (HTMLElement & {
+                  runtime?: { context?: { gateway?: { snapshot?: { phase?: string } } } };
+                })
+              | null;
+            return app?.runtime?.context?.gateway?.snapshot?.phase === "reconnecting";
+          });
+          await expect
+            .poll(() => page.locator(".sidebar-footer-bar__status").textContent())
+            .toContain("Reconnecting…");
+          await expect.poll(() => visibleMessages(page)).toHaveLength(3);
+          gateway = await startGatewayServer(port, {
+            auth: { mode: "none" },
+            bind: "loopback",
+            controlUiEnabled: false,
+            sidecarStartup: "defer",
+          });
+          await waitForControlUiGatewayReady(page);
+          await appendFile(sourceB, `${lineBAfterReconnect}\n`, "utf8");
+          await expect
+            .poll(() => visibleMessages(page))
+            .toEqual([
+              messageBPrefix,
+              "source B tail",
+              "source B appended",
+              "source B after reconnect",
+            ]);
+          await capture(page, "03-reconnected-tail-complete.png");
+          expect(pageErrors).toEqual([]);
+        },
+      );
+    } finally {
+      await gateway.close({ reason: "logs lifecycle e2e cleanup" });
+      resetLogger();
+      await state.cleanup();
+    }
+  });
+});

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -221,7 +221,7 @@ describe("LogsPage lifecycle", () => {
         cursor: 18,
         file: "/tmp/source-b.log",
         lines: ["B-tail"],
-        reset: true,
+        reset: false,
       })
       .mockResolvedValueOnce({
         cursor: 18,

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -217,7 +217,12 @@ describe("LogsPage lifecycle", () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({ cursor: 6, file: "/tmp/source-a.log", lines: ["A-one"] })
-      .mockResolvedValueOnce({ cursor: 18, file: "/tmp/source-b.log", lines: ["B-tail"] })
+      .mockResolvedValueOnce({
+        cursor: 18,
+        file: "/tmp/source-b.log",
+        lines: ["B-tail"],
+        reset: true,
+      })
       .mockResolvedValueOnce({
         cursor: 18,
         file: "/tmp/source-b.log",

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -8,7 +8,8 @@ import "./logs-page.ts";
 type TestLogsPage = HTMLElement & {
   context: ApplicationContext;
   logsAutoFollow: boolean;
-  logsEntries: unknown[];
+  logsEntries: Array<{ raw: string }>;
+  logsFile: string | null;
   logsStatus: { error: string | null; hasLoaded: boolean; stale: boolean };
   streamFollow: {
     atBottom: boolean;
@@ -210,6 +211,34 @@ describe("LogsPage lifecycle", () => {
     pending.resolve({ cursor: 2, lines: ["fresh"], reset: true });
     expect(await first).toBe(true);
     expect(page.logsEntries).toHaveLength(1);
+  });
+
+  it("reloads from the beginning when the gateway log file changes", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ cursor: 6, file: "/tmp/source-a.log", lines: ["A-one"] })
+      .mockResolvedValueOnce({ cursor: 18, file: "/tmp/source-b.log", lines: ["B-tail"] })
+      .mockResolvedValueOnce({
+        cursor: 18,
+        file: "/tmp/source-b.log",
+        lines: ["B-one", "B-tail"],
+      });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+    page.context = contextWithClient(client, true);
+    page.logsEntries = [{ raw: "seed" }];
+    document.body.append(page);
+    await page.updateComplete;
+    page.logsEntries = [];
+
+    await page.loadLogs({ reset: true });
+    await page.loadLogs();
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ cursor: 6 });
+    expect(request.mock.calls[2]?.[1]).toMatchObject({ cursor: undefined });
+    expect(page.logsFile).toBe("/tmp/source-b.log");
+    expect(page.logsEntries.map((entry) => entry.raw)).toEqual(["B-one", "B-tail"]);
   });
 
   it("retains loaded logs as stale after failure and clears the marker on retry success", async () => {

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -90,11 +90,7 @@ class LogsPage extends OpenClawLightDomElement {
           );
         let payload = await requestTail(reset ? undefined : (cursor ?? undefined));
         const sourceChanged =
-          !reset &&
-          !payload.reset &&
-          file !== null &&
-          typeof payload.file === "string" &&
-          payload.file !== file;
+          !reset && file !== null && payload.file !== undefined && payload.file !== file;
         if (sourceChanged) {
           payload = await requestTail();
         }
@@ -145,8 +141,12 @@ class LogsPage extends OpenClawLightDomElement {
       this.logsTaskQuiet = false;
       void this.logsTask.run([null, null, null, null, false, false]);
     },
-    onSnapshot: () => {
+    onSnapshot: (change) => {
       this.syncPolling();
+      if (change.becameConnected && this.logsFile !== null) {
+        void this.loadLogs({ reset: true, quiet: true });
+        return;
+      }
       this.ensureInitialLogs();
     },
   });

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -61,35 +61,44 @@ class LogsPage extends OpenClawLightDomElement {
       this.gateway.connected ? this.gateway.gateway : null,
       this.gateway.connected ? this.gateway.client : null,
       opts?.reset ? null : this.logsCursor,
+      this.logsFile,
       opts?.reset === true,
       opts?.quiet === true,
     ] as const;
   }
   private readonly logsTask = new Task(this, {
     autoRun: false,
-    // The cursor and reset flag make each tail page an explicit immutable read.
+    // A cursor belongs to one file; recover source changes inside this task so
+    // no mixed-source page can publish between the incremental and reset reads.
     args: () => this.logsTaskArgs(),
-    task: async ([gateway, client, cursor, reset, quiet], { signal }) => {
+    task: async ([gateway, client, cursor, file, reset, quiet], { signal }) => {
       if (!gateway || !client) {
         return initialState;
       }
       try {
-        const payload = await client.request<{
-          file?: string;
-          cursor?: number;
-          lines?: unknown;
-          truncated?: boolean;
-          reset?: boolean;
-        }>(
-          "logs.tail",
-          {
-            cursor: reset ? undefined : (cursor ?? undefined),
-            limit: this.logsLimit,
-            maxBytes: this.logsMaxBytes,
-          },
-          { signal },
-        );
-        return { ok: true as const, payload, cursor, reset, quiet };
+        const requestTail = (nextCursor?: number) =>
+          client.request<{
+            file?: string;
+            cursor?: number;
+            lines?: unknown;
+            truncated?: boolean;
+            reset?: boolean;
+          }>(
+            "logs.tail",
+            { cursor: nextCursor, limit: this.logsLimit, maxBytes: this.logsMaxBytes },
+            { signal },
+          );
+        let payload = await requestTail(reset ? undefined : (cursor ?? undefined));
+        const sourceChanged =
+          !reset &&
+          !payload.reset &&
+          file !== null &&
+          typeof payload.file === "string" &&
+          payload.file !== file;
+        if (sourceChanged) {
+          payload = await requestTail();
+        }
+        return { ok: true as const, payload, cursor, reset: reset || sourceChanged, quiet };
       } catch (error) {
         return { ok: false as const, error, quiet };
       }
@@ -134,7 +143,7 @@ class LogsPage extends OpenClawLightDomElement {
     },
     invalidateRequests: () => {
       this.logsTaskQuiet = false;
-      void this.logsTask.run([null, null, null, false, false]);
+      void this.logsTask.run([null, null, null, null, false, false]);
     },
     onSnapshot: () => {
       this.syncPolling();
@@ -179,7 +188,7 @@ class LogsPage extends OpenClawLightDomElement {
 
   override disconnectedCallback() {
     this.logsTaskQuiet = false;
-    void this.logsTask.run([null, null, null, false, false]);
+    void this.logsTask.run([null, null, null, null, false, false]);
     if (this.contentScrollFrame !== null) {
       cancelAnimationFrame(this.contentScrollFrame);
       this.contentScrollFrame = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI Logs page could show an incomplete or mixed tail after the Gateway switched to a different log file, or continue from a stale byte cursor after a same-client Gateway restart.

## Why This Change Was Made

`logs.tail` cursors are byte offsets that belong to one exact file. The page now carries the file path with the cursor, performs a cursorless reread inside the same cancellable task when the returned source changes, and publishes only the complete replacement result. A same-path Gateway reconnect also restarts the tail from the beginning. Ordinary read failures continue showing the previously loaded lines as stale and clear that marker after recovery.

The RPC shape, server-side redaction and retention limits, storage, filtering, export order, and incremental tail order are unchanged. Production delta: `+30/-21` (net `+9`).

## User Impact

Operators can keep the Logs page open through log rollover, temporary read failures, and Gateway restarts without losing the beginning of the current bounded tail, mixing files, or hiding the last readable data.

AI-assisted: yes. The implementation and proof were inspected and validated by the maintainer agent.

## Evidence

- `node scripts/run-vitest.mjs run ui/src/pages/logs/data.test.ts ui/src/pages/logs/logs-page.test.ts ui/src/pages/logs/view.test.ts ui/src/pages/gateway-source-replacement.test.ts --reporter=verbose` — 37 tests passed.
- Blacksmith Testbox `tbx_01m0465afkgv34f893ba4d4end` ([run](https://github.com/openclaw/openclaw/actions/runs/31921825061)) — 3 Chromium scenarios passed: real isolated Gateway source rollover/error/recovery/restart/reconnect/cleanup, incremental auto-follow, and compact Logs layout.
- The real Gateway scenario also verified filtered export contents, level filtering, ordered append, stale-data visibility, and recovery.
- The new lifecycle scenario is registered in `checks-ui-e2e-real-gateway` and excluded from ordinary mocked shards; 121 workflow/sharding guard tests passed.
- `pnpm check:changed --base ca849506...` — green, including exact formatting, Control UI i18n, production/test typing, targeted lint/style checks, dead exports, and boundary guards.
- `pnpm lint:ui:styles && pnpm check:import-cycles` — green; 0 runtime value cycles.
- `node --import tsx scripts/check-workflows.mts` — workflow syntax, interpolation guard, and Zizmor passed.
- `git diff --check` — clean.
- Fresh autoreview of the complete branch — no accepted/actionable findings.

### Source rollover rereads the complete new file

![Complete source B tail after rollover](https://github.com/user-attachments/assets/d94061a5-a5f0-4fc8-b3c7-59ddf518fcc8)

### Read errors retain visible stale data

![Read error with stale lines preserved](https://github.com/user-attachments/assets/610c476c-8e8d-42b9-9aac-3aba4fd0dae9)

### Gateway restart resets and resumes ordered tailing

![Complete restarted tail after reconnect](https://github.com/user-attachments/assets/be8c6cee-52a4-4fe4-8425-096e9be47555)

https://github.com/user-attachments/assets/4c3c009e-8b72-4bae-ace8-b40f18c0b2c9
