### PR TITLE
fix(ui): keep task recovery actions across refresh

### DIFF
--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -131,6 +131,21 @@ class TasksPage extends OpenClawLightDomElement {
     }
     this.requestUpdate();
   });
+
+  private bufferTaskRefreshEvent(event: TaskRefreshEvent | null) {
+    const buffer = this.taskRefreshEvents;
+    if (
+      event &&
+      event.action !== "restored" &&
+      buffer &&
+      buffer.gateway === this.gateway.gateway &&
+      buffer.client === this.gateway.client &&
+      buffer.scopeId === this.context.agentSelection.state.scopeId
+    ) {
+      buffer.events.push(event);
+    }
+  }
+
   private readonly listTask = new Task(this, {
     autoRun: false,
     // Gateway identity retires reconnect/source replacements even when they reuse a client.
@@ -199,18 +214,12 @@ class TasksPage extends OpenClawLightDomElement {
           }
           const scopeId = this.context.agentSelection.state.scopeId;
           const normalizedEvent = normalizeTaskEventPayload(event.payload);
-          const buffer = this.taskRefreshEvents;
           if (
-            normalizedEvent &&
-            normalizedEvent.action !== "restored" &&
-            buffer &&
-            buffer.gateway === gateway &&
-            buffer.client === this.gateway.client &&
-            buffer.scopeId === scopeId &&
-            (normalizedEvent.action === "deleted" ||
+            normalizedEvent?.action === "deleted" ||
+            (normalizedEvent?.action === "upserted" &&
               taskMatchesAgentScope(normalizedEvent.task, scopeId))
           ) {
-            buffer.events.push(normalizedEvent);
+            this.bufferTaskRefreshEvent(normalizedEvent);
           }
           this.tasks = result.tasks.filter((task) => taskMatchesAgentScope(task, scopeId));
         });
@@ -271,18 +280,9 @@ class TasksPage extends OpenClawLightDomElement {
       const result = normalizeTasksCancelResult(payload);
       if (result?.task) {
         const event = normalizeTaskEventPayload({ action: "upserted", task: result.task });
-        const buffer = this.taskRefreshEvents;
-        if (
-          event &&
-          buffer &&
-          buffer.gateway === gateway &&
-          buffer.client === scope.client &&
-          buffer.scopeId === this.context.agentSelection.state.scopeId
-        ) {
-          // Cancellation replies are authoritative even if the best-effort
-          // registry event is dropped while the matching pages are in flight.
-          buffer.events.push(event);
-        }
+        // Mutation replies are authoritative even if the best-effort registry
+        // event is dropped while the matching pages are in flight.
+        this.bufferTaskRefreshEvent(event);
         this.tasks = applyTaskEvent(this.tasks, { action: "upserted", task: result.task }).tasks;
       }
       // Refusals (already terminal, stale id, no cancellation handle) are
@@ -330,10 +330,12 @@ class TasksPage extends OpenClawLightDomElement {
         return;
       }
       if (result.task) {
-        this.tasks = applyTaskEvent(this.tasks, {
+        const event = normalizeTaskEventPayload({
           action: "upserted",
           task: result.task,
-        }).tasks;
+        });
+        this.bufferTaskRefreshEvent(event);
+        this.tasks = applyTaskEvent(this.tasks, event).tasks;
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -82,6 +82,23 @@ const readOnlyRetainedTask = {
 
 const readOnlyRetainedResult = "Synthetic retained result copied by a read-only operator.";
 
+const retryBlockedTask = {
+  ...readOnlyRetainedTask,
+  id: "task-retry-blocked",
+  taskId: "task-retry-blocked",
+  title: "Automation report delivery",
+  deliveryStatus: "failed",
+  terminalSummary: "Automation completed; result delivery is blocked.",
+};
+
+const dismissBlockedTask = {
+  ...retryBlockedTask,
+  id: "task-dismiss-blocked",
+  taskId: "task-dismiss-blocked",
+  title: "Automation cleanup delivery",
+  updatedAt: baseTime - 51_000,
+};
+
 const pageTwoSentinel = {
   id: "task-page-two-sentinel",
   taskId: "task-page-two-sentinel",
@@ -113,6 +130,162 @@ const activePageOneTasks = [
 ];
 
 suite.define(() => {
+  it("keeps retry and dismiss outcomes authoritative across a stale refresh and reconnect", async () => {
+    const actionArtifactDir = path.resolve(
+      process.cwd(),
+      ".artifacts/control-ui-e2e/task-action-outcomes",
+    );
+    const rawVideoDir = path.join(actionArtifactDir, "raw-video");
+    await rm(actionArtifactDir, { force: true, recursive: true });
+    await mkdir(rawVideoDir, { recursive: true });
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: rawVideoDir, size: { width: 1440, height: 900 } },
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    const listResponses = {
+      cases: [
+        {
+          match: { agentId: "main", limit: 500, status: ["queued", "running"] },
+          response: { tasks: [] },
+        },
+        {
+          match: { agentId: "main", limit: 200 },
+          response: { tasks: [retryBlockedTask, dismissBlockedTask] },
+        },
+      ],
+    };
+    const retriedTask = {
+      ...retryBlockedTask,
+      deliveryStatus: "session_queued",
+      terminalOutcome: "succeeded",
+      updatedAt: baseTime + 1_000,
+    };
+    const dismissedTask = {
+      ...dismissBlockedTask,
+      deliveryStatus: "dismissed",
+      updatedAt: baseTime + 2_000,
+    };
+    try {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "tasks.list": listResponses,
+          "tasks.retry": {
+            results: [{ taskId: retryBlockedTask.taskId, ok: true, task: retriedTask }],
+          },
+          "tasks.dismiss": {
+            results: [{ taskId: dismissBlockedTask.taskId, ok: true, task: dismissedTask }],
+          },
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}tasks`);
+      expect(response?.status()).toBe(200);
+      const retryRow = page.locator(`[data-task-id="${retryBlockedTask.id}"]`);
+      const dismissRow = page.locator(`[data-task-id="${dismissBlockedTask.id}"]`);
+      await retryRow.waitFor({ state: "visible" });
+      await dismissRow.waitFor({ state: "visible" });
+      await page.screenshot({ path: path.join(actionArtifactDir, "01-blocked.png") });
+
+      await gateway.deferNext("tasks.retry", { taskIds: [retryBlockedTask.taskId] });
+      const retryButton = retryRow.getByRole("button", { name: "Retry delivery" });
+      await retryButton.evaluate((element) => {
+        (element as HTMLButtonElement).click();
+        (element as HTMLButtonElement).click();
+      });
+      await expect.poll(async () => gateway.getRequests("tasks.retry")).toHaveLength(1);
+      await expect.poll(() => retryButton.isDisabled()).toBe(true);
+      await gateway.rejectDeferred("tasks.retry", { message: "Synthetic delivery retry failed" });
+      await expect
+        .poll(() => page.locator(".callout.danger").textContent())
+        .toContain("Synthetic delivery retry failed");
+      await expect.poll(() => retryButton.isEnabled()).toBe(true);
+      await page.screenshot({ path: path.join(actionArtifactDir, "02-retry-failed.png") });
+
+      await gateway.deferNext("tasks.list", {
+        agentId: "main",
+        limit: 500,
+        status: ["queued", "running"],
+      });
+      await gateway.deferNext("tasks.list", { agentId: "main", limit: 200 });
+      await page.getByRole("button", { name: "Refresh" }).click();
+      await expect.poll(async () => gateway.getRequests("tasks.list")).toHaveLength(4);
+
+      await gateway.deferNext("tasks.retry", { taskIds: [retryBlockedTask.taskId] });
+      await gateway.deferNext("tasks.dismiss", { taskIds: [dismissBlockedTask.taskId] });
+      await retryButton.click();
+      await dismissRow.getByRole("button", { name: "Dismiss delivery" }).click();
+      await expect.poll(async () => gateway.getRequests("tasks.retry")).toHaveLength(2);
+      await expect.poll(async () => gateway.getRequests("tasks.dismiss")).toHaveLength(1);
+      await gateway.resolveDeferred("tasks.dismiss", {
+        results: [{ taskId: dismissBlockedTask.taskId, ok: true, task: dismissedTask }],
+      });
+      await gateway.resolveDeferred("tasks.retry", {
+        results: [{ taskId: retryBlockedTask.taskId, ok: true, task: retriedTask }],
+      });
+      await expect
+        .poll(() => retryRow.getByRole("button", { name: "Retry delivery" }).count())
+        .toBe(0);
+      await expect
+        .poll(() => dismissRow.getByRole("button", { name: "Dismiss delivery" }).count())
+        .toBe(0);
+      await page.screenshot({ path: path.join(actionArtifactDir, "03-actions-succeeded.png") });
+
+      await gateway.emitGatewayEvent("task", {
+        action: "deleted",
+        taskId: dismissBlockedTask.taskId,
+      });
+      await dismissRow.waitFor({ state: "detached" });
+      await gateway.resolveDeferred("tasks.list", { tasks: [] });
+      await gateway.resolveDeferred("tasks.list", {
+        tasks: [retryBlockedTask, dismissBlockedTask],
+      });
+
+      await expect
+        .poll(() => retryRow.getByRole("button", { name: "Retry delivery" }).count())
+        .toBe(0);
+      await expect.poll(() => retryRow.locator(".callout.warn").count()).toBe(0);
+      await dismissRow.waitFor({ state: "detached" });
+      expect(await gateway.getRequests("tasks.retry")).toHaveLength(2);
+      expect((await gateway.getRequests("tasks.retry")).map((request) => request.params)).toEqual([
+        { taskIds: [retryBlockedTask.taskId] },
+        { taskIds: [retryBlockedTask.taskId] },
+      ]);
+      expect((await gateway.getRequests("tasks.dismiss"))[0]?.params).toEqual({
+        taskIds: [dismissBlockedTask.taskId],
+      });
+      await page.screenshot({
+        path: path.join(actionArtifactDir, "04-stale-refresh-suppressed.png"),
+      });
+
+      const socketCount = await gateway.getSocketCount();
+      await gateway.closeLatest(1012, "Replace the task action client");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await retryRow.waitFor({ state: "visible" });
+      await expect
+        .poll(() => retryRow.getByRole("button", { name: "Retry delivery" }).count())
+        .toBe(1);
+      await retryRow.getByRole("button", { name: "Retry delivery" }).click();
+      await expect.poll(async () => gateway.getRequests("tasks.retry")).toHaveLength(3);
+      await expect
+        .poll(() => retryRow.getByRole("button", { name: "Retry delivery" }).count())
+        .toBe(0);
+      await page.screenshot({ path: path.join(actionArtifactDir, "05-reconnect-retry.png") });
+    } finally {
+      await context.close();
+      if (video) {
+        await copyFile(
+          await video.path(),
+          path.join(actionArtifactDir, "task-action-outcomes.webm"),
+        );
+      }
+      await rm(rawVideoDir, { force: true, recursive: true });
+    }
+  });
+
   it("renders every active page, applies pushed completion, and cancels a page-two task", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using Retry or Dismiss on a blocked task delivery could briefly see the successful action, then have an older in-flight Tasks refresh restore the stale blocked state or the wrong row.

## Why This Change Was Made

The Tasks page already replayed pushed task events and cancellation responses through a refresh-local buffer, but Retry and Dismiss responses updated only the visible list. This routes pushed events, cancellation responses, Retry responses, and Dismiss responses through the same gateway/client/agent-scoped buffer, so an older `tasks.list` snapshot cannot overwrite a newer authoritative mutation.

This is UI-only concurrency custody. Scheduler actions, task persistence, Gateway RPC schemas, delivery semantics, and protocol behavior are unchanged. Production delta: **+25/-23, net +2 LOC**. Test delta: **+173/-0**. No changelog change; changelog generation is release-only.

AI-assisted: Codex implementation/review with an explicit Claude land decision.

## User Impact

Retry and Dismiss now remain visibly authoritative while a manual refresh is in flight. Pushed deletion, cancellation, and reconnect behavior continue to share the same ordering boundary, so stale snapshots cannot resurrect removed rows or blocked controls.

## Evidence

- Post-rebase Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31922293408
  - 53/53 focused Control UI tests
  - 14/14 automation/task E2E tests
  - 19/19 Gateway task contracts
  - 3/3 Chromium Tasks scenarios
  - scoped changed gate, Control UI i18n, format, oxlint, stylelint, UI production/test types, import cycles (0), and `git diff --check`
- Retained exact-candidate real Gateway action scenario and Chromium evidence: https://github.com/openclaw/openclaw/actions/runs/31920926626
- Fresh Codex autoreview: no accepted/actionable findings (`patch is correct`, confidence 0.97).
- Stable patch identity across rebase: `71fb47cf6f9a7c3701001410abfb0e8e54947d36`.

### Visual proof

Blocked deliveries before action:

![Blocked task deliveries](https://github.com/user-attachments/assets/c2c8b1a5-cc1f-4ff8-ba98-42d0262223ef)

Rejected Retry remains visible and actionable:

![Retry failure surfaced](https://github.com/user-attachments/assets/3827effe-e751-4936-9540-715c92aba058)

Successful Retry and Dismiss projections:

![Successful task recovery actions](https://github.com/user-attachments/assets/4c5d98fe-cf63-4d1f-b88b-17f2e1df322b)

Older refresh cannot restore the dismissed row or blocked Retry state:

![Stale refresh suppressed](https://github.com/user-attachments/assets/1df51131-1dad-4198-8275-a9992137fee0)

Reconnect establishes a replacement projection and permits one new Retry:

![Reconnect retry](https://github.com/user-attachments/assets/0544868d-12b0-4727-ab65-6765bb008e8d)

https://github.com/user-attachments/assets/f8148993-9e6c-4a6e-98c7-309586fdae18

### Disclosed unrelated follow-up

The real `gateway-rpc-automation` scenario still has its separately owned heartbeat fixture defect: the fixture asserts `target-none` while omitting `target: "none"`, so current `main` deterministically reports `no-route`. The existing task will align that fixture with its asserted contract. This PR does not bundle, bypass, retry around, or weaken that assertion.
