### PR TITLE
fix: reconcile cloud workspaces with over 25k files

### DIFF
--- a/src/gateway/worker-environments/workspace-accepted-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-accepted-sync.test.ts
@@ -96,6 +96,7 @@ function createAcceptedWorkspacePublisherFactory(
             contentHashCount: 0,
             contentHashDurationMs: 0,
             memoHitCount: 0,
+            memoTruncatedCount: 0,
             totalDurationMs: 0,
           },
         })}\n`,

--- a/src/gateway/worker-environments/workspace-hash-memo.test.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.test.ts
@@ -145,17 +145,20 @@ describe("workspace hash memo", () => {
       contentHashCount: 7,
       contentHashDurationMs: 11,
       memoHitCount: 13,
+      memoTruncatedCount: 17,
       totalDurationMs: 17,
     });
     recordRemoteWorkspaceHashMetrics(aggregate, {
       contentHashCount: 19,
       contentHashDurationMs: 23,
       memoHitCount: 29,
+      memoTruncatedCount: 31,
       totalDurationMs: 31,
     });
     expect(aggregate).toMatchObject({
       remoteContentHashCount: 26,
       remoteMemoHitCount: 42,
+      remoteMemoTruncatedCount: 48,
       remoteHashDurationMs: 34,
       remoteManifestDurationMs: 48,
     });
@@ -179,6 +182,7 @@ describe("workspace hash memo", () => {
           contentHashCount: MAX_RECONCILIATION_ENTRIES,
           contentHashDurationMs: Number.MAX_SAFE_INTEGER,
           memoHitCount: MAX_RECONCILIATION_ENTRIES,
+          memoTruncatedCount: MAX_RECONCILIATION_ENTRIES,
           totalDurationMs: Number.MAX_SAFE_INTEGER,
         },
       })}\n`,
@@ -232,5 +236,59 @@ describe("workspace hash memo", () => {
     const nextReconcile = await capture([]);
     expect(nextReconcile.manifestRef).toBe(replaced.manifestRef);
     expect(nextReconcile.metrics).toMatchObject({ contentHashCount: 1, memoHitCount: 0 });
+  });
+
+  it("bounds the remote memo to the largest files and reports truncation", async () => {
+    const root = tempDirs.make("openclaw-remote-manifest-memo-cap-");
+    const home = path.join(root, "home");
+    const workspace = path.join(root, "workspace");
+    await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
+    await Promise.all([
+      fs.writeFile(path.join(workspace, "small.txt"), "1"),
+      fs.writeFile(path.join(workspace, "medium.txt"), "22"),
+      fs.writeFile(path.join(workspace, "large.txt"), "333"),
+    ]);
+    const limitDeclaration = `const MAX_RECONCILIATION_ENTRIES = ${MAX_RECONCILIATION_ENTRIES};`;
+    const limitedScript = REMOTE_WORKSPACE_MANIFEST_JS.replace(
+      limitDeclaration,
+      "const MAX_RECONCILIATION_ENTRIES = 2;",
+    );
+    expect(limitedScript).not.toBe(REMOTE_WORKSPACE_MANIFEST_JS);
+    const env = { ...process.env, HOME: home };
+    type MemoResponse = {
+      manifestRef: string;
+      memo: [string, string][];
+      metrics: { contentHashCount: number; memoHitCount: number; memoTruncatedCount: number };
+    };
+    const capture = async (memo: [string, string][]): Promise<MemoResponse> => {
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", limitedScript, workspace, "", "memo-v1"],
+        { timeoutMs: 10_000, baseEnv: env, input: JSON.stringify(memo) },
+      );
+      expect(result).toMatchObject({ code: 0, stderr: "" });
+      return JSON.parse(result.stdout) as MemoResponse;
+    };
+
+    const first = await capture([]);
+    expect(first.memo).toHaveLength(2);
+    expect(
+      first.memo
+        .map(([identity]) => Number(identity.split(":")[3]))
+        .toSorted((left, right) => left - right),
+    ).toEqual([2, 3]);
+    expect(first.metrics).toMatchObject({
+      contentHashCount: 3,
+      memoHitCount: 0,
+      memoTruncatedCount: 1,
+    });
+
+    const unchanged = await capture(first.memo);
+    expect(unchanged.manifestRef).toBe(first.manifestRef);
+    expect(unchanged.memo).toEqual(first.memo);
+    expect(unchanged.metrics).toMatchObject({
+      contentHashCount: 1,
+      memoHitCount: 2,
+      memoTruncatedCount: 1,
+    });
   });
 });

--- a/src/gateway/worker-environments/workspace-hash-memo.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.ts
@@ -13,13 +13,17 @@ export type WorkspaceReconcileMetrics = {
   remoteManifestCalls: number;
   remoteContentHashCount: number;
   remoteMemoHitCount: number;
+  remoteMemoTruncatedCount: number;
   remoteHashDurationMs: number;
   remoteManifestDurationMs: number;
   remoteManifestWallDurationMs: number;
   localReconciliationDurationMs: number;
 };
 
-type RemoteWorkspaceHashMetrics = WorkspaceHashMetrics & { totalDurationMs: number };
+type RemoteWorkspaceHashMetrics = WorkspaceHashMetrics & {
+  memoTruncatedCount: number;
+  totalDurationMs: number;
+};
 
 export const MAX_WORKSPACE_HASH_MEMO_BYTES = 8 * 1024 * 1024;
 
@@ -40,6 +44,7 @@ export function createWorkspaceReconcileMetrics(): WorkspaceReconcileMetrics {
     remoteManifestCalls: 0,
     remoteContentHashCount: 0,
     remoteMemoHitCount: 0,
+    remoteMemoTruncatedCount: 0,
     remoteHashDurationMs: 0,
     remoteManifestDurationMs: 0,
     remoteManifestWallDurationMs: 0,
@@ -87,6 +92,7 @@ export function recordRemoteWorkspaceHashMetrics(
 ): void {
   aggregate.remoteContentHashCount += metrics.contentHashCount;
   aggregate.remoteMemoHitCount += metrics.memoHitCount;
+  aggregate.remoteMemoTruncatedCount += metrics.memoTruncatedCount;
   aggregate.remoteHashDurationMs += metrics.contentHashDurationMs;
   aggregate.remoteManifestDurationMs += metrics.totalDurationMs;
 }

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -40,6 +40,7 @@ const remoteWorkspaceManifestEnvelopeSchema = z
         contentHashCount: z.number().finite().nonnegative(),
         contentHashDurationMs: z.number().finite().nonnegative(),
         memoHitCount: z.number().finite().nonnegative(),
+        memoTruncatedCount: z.number().finite().nonnegative(),
         totalDurationMs: z.number().finite().nonnegative(),
       })
       .strict(),

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -98,10 +98,18 @@ const entriesByPath = new Map();
 let inventoryPathBytes = 0;
 let eligibleBytes = 0;
 const usedHashMemo = new Map();
-const metrics = { contentHashCount: 0, contentHashDurationMs: 0, memoHitCount: 0 };
+const metrics = {
+  contentHashCount: 0,
+  contentHashDurationMs: 0,
+  memoHitCount: 0,
+  memoTruncatedCount: 0,
+};
 const startedAt = performance.now();
 function fail(message) {
   throw new Error(message);
+}
+function compareHashMemoIdentity(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 function readHashMemo() {
   if (!memoMode) return new Map();
@@ -373,7 +381,7 @@ async function hashFiles(entries) {
       entry.mode = Number(after.mode & 0o777n);
       entry.size = Number(after.size);
       entry.sha256 = sha256;
-      usedHashMemo.set(identity, sha256);
+      usedHashMemo.set(identity, { sha256, size: Number(after.size) });
     } finally {
       await handle.close();
     }
@@ -440,14 +448,23 @@ async function main() {
   const manifest = serializeManifest(baseCommit, entries);
   const digest = publishManifest(manifestRoot, manifest);
   const manifestRef = "sha256:" + digest;
-  const measured = { ...metrics, totalDurationMs: performance.now() - startedAt };
   if (memoMode) {
+    // Largest files preserve the most expensive hashes. Identity tie-breaking and
+    // final ordering keep the bounded cache deterministic across captures.
+    const memo = [...usedHashMemo]
+      .sort(
+        (left, right) =>
+          right[1].size - left[1].size || compareHashMemoIdentity(left[0], right[0]),
+      )
+      .slice(0, MAX_RECONCILIATION_ENTRIES)
+      .map(([identity, value]) => [identity, value.sha256])
+      .sort((left, right) => compareHashMemoIdentity(left[0], right[0]));
+    metrics.memoTruncatedCount = usedHashMemo.size - memo.length;
+    const measured = { ...metrics, totalDurationMs: performance.now() - startedAt };
     process.stdout.write(JSON.stringify({
       version: 1,
       manifestRef,
-      memo: [...usedHashMemo].sort((left, right) =>
-        left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0,
-      ),
+      memo,
       metrics: measured,
     }) + "\n");
   } else {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cloud-worker sessions using repositories with more than 25,000 hashed files would dispatch and run successfully, then fail every post-turn workspace reconciliation because the performance memo exceeded its hard response-schema limit. The live 2026-08-15 reproduction used an OpenClaw managed worktree with 32,383 tracked files.

## Why This Change Was Made

The remote manifest producer now bounds the memo before serialization instead of weakening the gateway protocol cap. It deterministically retains the 25,000 largest-file hashes, with identity tie-breaking and identity-sorted output, preserving the most expensive hashing work. Missing memo entries are simply re-hashed on the next capture and do not affect the canonical workspace manifest.

The response metrics now report `memoTruncatedCount`, aggregated as `remoteMemoTruncatedCount` in the existing reconcile diagnostic, so operators can observe the performance tradeoff. The strict 25,000-entry schema remains the hard trust-boundary limit.

Provenance: PR #121365 introduced the memo optimization and emitted every hashed file while retaining the existing 25,000-entry schema cap.

Production LOC: +31/-7 (net +24) | Tests: +59/-0. The production growth implements deterministic producer-side selection plus the requested end-to-end truncation metric; it does not add a compatibility path or raise any trust-boundary limit.

## User Impact

Cloud-worker turns can reconcile normal changes in repositories larger than 25,000 files. Large repositories keep most memoized hashing savings, and operators can see exactly how many cache entries were omitted.

The other 25,000-entry checks remain intentional delta/structural-replacement safeguards. Full workspace inventory is separately capped at 250,000 entries, and existing coverage proves a one-file change plus an unchanged result on a 31,274-entry Git baseline.

## Evidence

- Live reproduction: initial sync and agent execution succeeded on a 32,383-file managed worktree; post-turn capture failed with `memo` array `too_big`, maximum 25,000.
- Regression before the fix: the generated-script test injected a cap of 2 and received 3 memo entries.
- Producer proof after the fix: the same real generated script emits the 2- and 3-byte file hashes, reports one truncation, reuses those two hashes on the next capture, and produces the same manifest reference.
- Focused proof: `node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-hash-memo.test.ts src/gateway/worker-environments/workspace-sync.test.ts src/gateway/worker-environments/workspace-sync-scripts.test.ts src/gateway/worker-environments/workspace-accepted-sync.test.ts src/gateway/worker-environments/workspace-large-inventory.test.ts` — 5 files, 45 tests passed.
- Changed gate: `node scripts/check-changed.mjs` — core/coreTests Testbox plan passed, including core and test typechecks, changed-file lint, 6 selected Vitest shards (317 passed, 39 skipped), import cycles, dead-code, database-first, dependency, formatting, and plugin-boundary guards. Run: https://github.com/openclaw/openclaw/actions/runs/31922863691
- Autoreview: `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.

AI-assisted: yes. The implementation and evidence were manually inspected against initial sync, post-turn capture, schema, metrics aggregation, changed-delta staging, structural replacement traversal, and large-baseline behavior.
