### PR TITLE
fix(computer-use): converge provider ref lifecycles on the contract

### DIFF
--- a/apps/macos/Sources/OpenClaw/ComputerActionService.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionService.swift
@@ -486,7 +486,7 @@ final class ComputerActionService {
             case .eventCreationFailed:
                 "Failed to synthesize input event"
             case .lifecycleChanged:
-                "Computer control lifecycle changed while the action was pending"
+                "COMPUTER_STALE_OBSERVATION: provider generation changed; take a fresh observation and retry"
             case let .invalidV2Request(message):
                 "COMPUTER_INVALID_REQUEST: \(message)"
             case .staleObservation:

--- a/apps/macos/Sources/OpenClaw/ComputerActionServiceV2.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionServiceV2.swift
@@ -42,6 +42,97 @@ struct ComputerActionExecutionAuthority {
     }
 }
 
+struct ComputerOpaqueReferenceStore<WindowTarget, ElementTarget> {
+    struct Observation {
+        let id: String
+        let windowRef: String
+        let snapshotId: String
+        let elements: [String: ElementTarget]
+    }
+
+    private(set) var lifecycleGeneration: UInt64?
+    private var windowRefs: [String: WindowTarget] = [:]
+    private(set) var observation: Observation?
+
+    mutating func adoptLifecycleGeneration(_ generation: UInt64) {
+        guard self.lifecycleGeneration != generation else { return }
+        self.lifecycleGeneration = generation
+        self.windowRefs.removeAll()
+        self.observation = nil
+    }
+
+    mutating func projectWindows(
+        _ targets: [WindowTarget],
+        matches: (WindowTarget, WindowTarget) -> Bool,
+        issueRef: (String) -> String) -> [(ref: String, target: WindowTarget)]
+    {
+        // Discovery may omit windows transiently; only generation rotation owns
+        // ref invalidation, while matching live identities keep stable refs.
+        targets.map { target in
+            let ref = self.issueWindowRef(target, matches: matches, issueRef: issueRef)
+            return (ref, target)
+        }
+    }
+
+    func resolveWindow(_ ref: String) throws -> WindowTarget {
+        guard let target = self.windowRefs[ref] else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return target
+    }
+
+    mutating func replaceWindow(_ target: WindowTarget, for ref: String) {
+        guard self.windowRefs[ref] != nil else { return }
+        self.windowRefs[ref] = target
+    }
+
+    mutating func replaceObservation(
+        windowRef: String,
+        snapshotId: String,
+        elements: [ElementTarget],
+        issueRef: (String) -> String) -> (id: String, elementRefs: [String])
+    {
+        let id = issueRef("observation")
+        let elementRefs = elements.map { _ in issueRef("element") }
+        self.observation = Observation(
+            id: id,
+            windowRef: windowRef,
+            snapshotId: snapshotId,
+            elements: Dictionary(uniqueKeysWithValues: zip(elementRefs, elements)))
+        return (id, elementRefs)
+    }
+
+    func resolveObservation(_ id: String?, windowRef: String) throws -> Observation {
+        guard let observation = self.observation,
+              observation.id == id,
+              observation.windowRef == windowRef
+        else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return observation
+    }
+
+    func resolveElement(_ ref: String, observation: Observation) throws -> ElementTarget {
+        guard let element = observation.elements[ref] else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return element
+    }
+
+    private mutating func issueWindowRef(
+        _ target: WindowTarget,
+        matches: (WindowTarget, WindowTarget) -> Bool,
+        issueRef: (String) -> String) -> String
+    {
+        if let existing = self.windowRefs.first(where: { matches($0.value, target) })?.key {
+            return existing
+        }
+        let ref = issueRef("window")
+        self.windowRefs[ref] = target
+        return ref
+    }
+}
+
 /// Implements the additive computer.act v2 surface without changing the v1
 /// coordinate path. All authority-bearing references are process-local,
 /// execution-local, and invalidated when the native lifecycle generation moves.
@@ -57,13 +148,6 @@ final class ComputerActionServiceV2 {
         let bounds: CGRect
     }
 
-    private struct ObservationState {
-        let id: String
-        let windowRef: String
-        let snapshotId: String
-        let elements: [String: ElementTarget]
-    }
-
     private let executionID = UUID().uuidString.lowercased()
     private let automation: UIAutomationService
     private let applications: ApplicationService
@@ -71,10 +155,8 @@ final class ComputerActionServiceV2 {
     private let menu: MenuService
     private let observationService: DesktopObservationService
     private let snapshotManager: InMemorySnapshotManager
-    private var lifecycleGeneration: UInt64?
     private var appRefs: [String: ServiceApplicationInfo] = [:]
-    private var windowRefs: [String: WindowTarget] = [:]
-    private var observation: ObservationState?
+    private var references = ComputerOpaqueReferenceStore<WindowTarget, ElementTarget>()
     private var executionAuthority: ComputerActionExecutionAuthority?
 
     init() {
@@ -190,8 +272,7 @@ final class ComputerActionServiceV2 {
         let appOutput = try await self.withExecutionAuthority {
             try await self.applications.listApplications()
         }
-        self.windowRefs.removeAll(keepingCapacity: true)
-        var rows: [[String: Any]] = []
+        var targets: [WindowTarget] = []
         var warnings = appOutput.metadata.warnings
         outer: for app in appOutput.data.applications
             where app.windowCount > 0 || app.windowIDs?.isEmpty == false
@@ -204,20 +285,25 @@ final class ComputerActionServiceV2 {
                 }
                 warnings.append(contentsOf: output.metadata.warnings)
                 for window in output.data.windows where window.layer == 0 {
-                    let ref = self.issueWindowRef(app: app, window: window)
-                    rows.append([
-                        "windowRef": ref,
-                        "appName": app.name,
-                        "title": window.title,
-                        "bounds": Self.boundsDictionary(window.bounds),
-                        "isOnScreen": window.isOnScreen,
-                        "minimized": window.isMinimized,
-                    ])
-                    if rows.count == 500 { break outer }
+                    targets.append(WindowTarget(app: app, window: window))
+                    if targets.count == 500 { break outer }
                 }
             } catch {
                 warnings.append("\(app.name): \(error.localizedDescription)")
             }
+        }
+        let rows = self.references.projectWindows(
+            targets,
+            matches: Self.sameWindow,
+            issueRef: self.makeRef).map { entry in
+            [
+                "windowRef": entry.ref,
+                "appName": entry.target.app.name,
+                "title": entry.target.window.title,
+                "bounds": Self.boundsDictionary(entry.target.window.bounds),
+                "isOnScreen": entry.target.window.isOnScreen,
+                "minimized": entry.target.window.isMinimized,
+            ] as [String: Any]
         }
         var details: [String: AnyCodable] = ["windows": AnyCodable(rows)]
         if !warnings.isEmpty {
@@ -294,32 +380,30 @@ final class ComputerActionServiceV2 {
         guard observedWindow.windowID == target.window.windowID else {
             throw ComputerActionService.ComputerActionError.staleObservation
         }
-        self.windowRefs[windowRef] = WindowTarget(app: target.app, window: observedWindow)
+        self.references.replaceWindow(
+            WindowTarget(app: target.app, window: observedWindow),
+            for: windowRef)
         let detected = result.elements?.elements.all ?? []
         let filtered = Self.filterElements(detected, query: params.query)
         let bounded = Array(filtered.prefix(limits.maxElements))
-        let observationID = self.issueRef("observation")
-        var elementTargets: [String: ElementTarget] = [:]
-        let elements = bounded.map { element in
-            let ref = self.issueRef("element")
-            elementTargets[ref] = ElementTarget(id: element.id, bounds: element.bounds)
-            return OpenClawComputerObservationElement(
+        let snapshotID = result.elements?.snapshotId ?? ""
+        guard !snapshotID.isEmpty else {
+            throw ComputerActionService.ComputerActionError.refused(
+                "Peekaboo observation returned no snapshot receipt")
+        }
+        let issuedObservation = self.references.replaceObservation(
+            windowRef: windowRef,
+            snapshotId: snapshotID,
+            elements: bounded.map { ElementTarget(id: $0.id, bounds: $0.bounds) },
+            issueRef: self.makeRef)
+        let elements = zip(bounded, issuedObservation.elementRefs).map { element, ref in
+            OpenClawComputerObservationElement(
                 elementRef: ref,
                 role: element.type.rawValue,
                 label: element.label,
                 value: element.value,
                 bounds: Self.bounds(element.bounds))
         }
-        let snapshotID = result.elements?.snapshotId ?? ""
-        guard !snapshotID.isEmpty else {
-            throw ComputerActionService.ComputerActionError.refused(
-                "Peekaboo observation returned no snapshot receipt")
-        }
-        self.observation = ObservationState(
-            id: observationID,
-            windowRef: windowRef,
-            snapshotId: snapshotID,
-            elements: elementTargets)
         var details: [String: AnyCodable] = [
             "totalElementCount": AnyCodable(detected.count),
             "coordinateSpace": AnyCodable("global-logical-points"),
@@ -343,7 +427,7 @@ final class ComputerActionServiceV2 {
                 format: "png",
                 width: Int(size.width),
                 height: Int(size.height),
-                observationId: observationID,
+                observationId: issuedObservation.id,
                 elements: elements.isEmpty ? nil : elements),
             details: details)
     }
@@ -479,7 +563,7 @@ final class ComputerActionServiceV2 {
                     try await self.automation.typeActionsWithOutcome(
                         [.text(text)],
                         cadence: .fixed(milliseconds: 0),
-                        snapshotId: params.elementRef == nil ? nil : self.observation?.snapshotId,
+                        snapshotId: params.elementRef == nil ? nil : self.references.observation?.snapshotId,
                         expectedWindowIdentity: identity,
                         expectedWindowBounds: target.window.bounds)
                 }
@@ -540,7 +624,7 @@ final class ComputerActionServiceV2 {
                 try await self.automation.setValueWithOutcome(
                     target: element.id,
                     value: .string(value),
-                    snapshotId: self.observation?.snapshotId)
+                    snapshotId: self.references.observation?.snapshotId)
             }
             return Self.result(from: result.outcome, background: true)
         } catch let failure as DesktopActionFailure {
@@ -595,7 +679,7 @@ final class ComputerActionServiceV2 {
                 direction: Self.scrollDirection(direction),
                 amount: min(100, max(1, params.scrollAmount ?? 3)),
                 target: element?.id,
-                snapshotId: element == nil ? nil : self.observation?.snapshotId,
+                snapshotId: element == nil ? nil : self.references.observation?.snapshotId,
                 foreground: mode == .foreground))
         }
         return Self.result(from: result.outcome, background: mode == .background)
@@ -604,36 +688,29 @@ final class ComputerActionServiceV2 {
     // MARK: - Reference and target helpers
 
     private func adoptLifecycleGeneration(_ generation: UInt64) {
-        guard self.lifecycleGeneration != generation else { return }
-        self.lifecycleGeneration = generation
+        let previousGeneration = self.references.lifecycleGeneration
+        self.references.adoptLifecycleGeneration(generation)
+        guard previousGeneration != generation else { return }
         self.appRefs.removeAll()
-        self.windowRefs.removeAll()
-        self.observation = nil
     }
 
     private func issueRef(_ kind: String) -> String {
-        "peekaboo:v2:\(kind):\(self.executionID):\(self.lifecycleGeneration ?? 0):" +
+        "peekaboo:v2:\(kind):\(self.executionID):\(self.references.lifecycleGeneration ?? 0):" +
             UUID().uuidString.lowercased()
     }
 
-    private func issueWindowRef(app: ServiceApplicationInfo, window: ServiceWindowInfo) -> String {
-        if let existing = self.windowRefs.first(where: {
-            $0.value.app.processIdentifier == app.processIdentifier &&
-                $0.value.window.windowID == window.windowID &&
-                $0.value.window.mutationIdentity == window.mutationIdentity
-        })?.key {
-            return existing
-        }
-        let ref = self.issueRef("window")
-        self.windowRefs[ref] = WindowTarget(app: app, window: window)
-        return ref
+    private func makeRef(_ kind: String) -> String {
+        self.issueRef(kind)
+    }
+
+    private static func sameWindow(_ lhs: WindowTarget, _ rhs: WindowTarget) -> Bool {
+        lhs.app.processIdentifier == rhs.app.processIdentifier &&
+            lhs.window.windowID == rhs.window.windowID &&
+            lhs.window.mutationIdentity == rhs.window.mutationIdentity
     }
 
     private func resolveWindow(_ ref: String) throws -> WindowTarget {
-        guard let target = self.windowRefs[ref] else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return target
+        try self.references.resolveWindow(ref)
     }
 
     private func requiredWindow(_ params: OpenClawComputerActParams) throws -> WindowTarget {
@@ -641,15 +718,9 @@ final class ComputerActionServiceV2 {
     }
 
     private func requiredObservation(_ params: OpenClawComputerActParams, windowRef: String) throws
-        -> ObservationState
+        -> ComputerOpaqueReferenceStore<WindowTarget, ElementTarget>.Observation
     {
-        guard let observation = self.observation,
-              observation.id == params.observationId,
-              observation.windowRef == windowRef
-        else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return observation
+        try self.references.resolveObservation(params.observationId, windowRef: windowRef)
     }
 
     private func requiredElement(
@@ -658,10 +729,7 @@ final class ComputerActionServiceV2 {
     {
         let elementRef = try Self.require(params.elementRef, field: "elementRef")
         let observation = try self.requiredObservation(params, windowRef: windowRef)
-        guard let element = observation.elements[elementRef] else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return element
+        return try self.references.resolveElement(elementRef, observation: observation)
     }
 
     private func clickTarget(

--- a/apps/macos/Sources/OpenClaw/ComputerActionServiceV2.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionServiceV2.swift
@@ -42,110 +42,26 @@ struct ComputerActionExecutionAuthority {
     }
 }
 
-struct ComputerOpaqueReferenceStore<WindowTarget, ElementTarget> {
-    struct Observation {
-        let id: String
-        let windowRef: String
-        let snapshotId: String
-        let elements: [String: ElementTarget]
-    }
-
-    private(set) var lifecycleGeneration: UInt64?
-    private var windowRefs: [String: WindowTarget] = [:]
-    private(set) var observation: Observation?
-
-    mutating func adoptLifecycleGeneration(_ generation: UInt64) {
-        guard self.lifecycleGeneration != generation else { return }
-        self.lifecycleGeneration = generation
-        self.windowRefs.removeAll()
-        self.observation = nil
-    }
-
-    mutating func projectWindows(
-        _ targets: [WindowTarget],
-        matches: (WindowTarget, WindowTarget) -> Bool,
-        issueRef: (String) -> String) -> [(ref: String, target: WindowTarget)]
-    {
-        // Discovery may omit windows transiently; only generation rotation owns
-        // ref invalidation, while matching live identities keep stable refs.
-        targets.map { target in
-            let ref = self.issueWindowRef(target, matches: matches, issueRef: issueRef)
-            return (ref, target)
-        }
-    }
-
-    func resolveWindow(_ ref: String) throws -> WindowTarget {
-        guard let target = self.windowRefs[ref] else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return target
-    }
-
-    mutating func replaceWindow(_ target: WindowTarget, for ref: String) {
-        guard self.windowRefs[ref] != nil else { return }
-        self.windowRefs[ref] = target
-    }
-
-    mutating func replaceObservation(
-        windowRef: String,
-        snapshotId: String,
-        elements: [ElementTarget],
-        issueRef: (String) -> String) -> (id: String, elementRefs: [String])
-    {
-        let id = issueRef("observation")
-        let elementRefs = elements.map { _ in issueRef("element") }
-        self.observation = Observation(
-            id: id,
-            windowRef: windowRef,
-            snapshotId: snapshotId,
-            elements: Dictionary(uniqueKeysWithValues: zip(elementRefs, elements)))
-        return (id, elementRefs)
-    }
-
-    func resolveObservation(_ id: String?, windowRef: String) throws -> Observation {
-        guard let observation = self.observation,
-              observation.id == id,
-              observation.windowRef == windowRef
-        else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return observation
-    }
-
-    func resolveElement(_ ref: String, observation: Observation) throws -> ElementTarget {
-        guard let element = observation.elements[ref] else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
-        return element
-    }
-
-    private mutating func issueWindowRef(
-        _ target: WindowTarget,
-        matches: (WindowTarget, WindowTarget) -> Bool,
-        issueRef: (String) -> String) -> String
-    {
-        if let existing = self.windowRefs.first(where: { matches($0.value, target) })?.key {
-            return existing
-        }
-        let ref = issueRef("window")
-        self.windowRefs[ref] = target
-        return ref
-    }
-}
-
 /// Implements the additive computer.act v2 surface without changing the v1
 /// coordinate path. All authority-bearing references are process-local,
 /// execution-local, and invalidated when the native lifecycle generation moves.
 @MainActor
 final class ComputerActionServiceV2 {
-    private struct WindowTarget {
+    struct WindowTarget {
         let app: ServiceApplicationInfo
         let window: ServiceWindowInfo
     }
 
-    private struct ElementTarget {
+    struct ElementTarget {
         let id: String
         let bounds: CGRect
+    }
+
+    struct ObservationState {
+        let id: String
+        let windowRef: String
+        let snapshotId: String
+        let elements: [String: ElementTarget]
     }
 
     private let executionID = UUID().uuidString.lowercased()
@@ -155,8 +71,10 @@ final class ComputerActionServiceV2 {
     private let menu: MenuService
     private let observationService: DesktopObservationService
     private let snapshotManager: InMemorySnapshotManager
+    private var lifecycleGeneration: UInt64?
     private var appRefs: [String: ServiceApplicationInfo] = [:]
-    private var references = ComputerOpaqueReferenceStore<WindowTarget, ElementTarget>()
+    private var windowRefs: [String: WindowTarget] = [:]
+    private var observation: ObservationState?
     private var executionAuthority: ComputerActionExecutionAuthority?
 
     init() {
@@ -272,7 +190,7 @@ final class ComputerActionServiceV2 {
         let appOutput = try await self.withExecutionAuthority {
             try await self.applications.listApplications()
         }
-        var targets: [WindowTarget] = []
+        var rows: [[String: Any]] = []
         var warnings = appOutput.metadata.warnings
         outer: for app in appOutput.data.applications
             where app.windowCount > 0 || app.windowIDs?.isEmpty == false
@@ -285,25 +203,19 @@ final class ComputerActionServiceV2 {
                 }
                 warnings.append(contentsOf: output.metadata.warnings)
                 for window in output.data.windows where window.layer == 0 {
-                    targets.append(WindowTarget(app: app, window: window))
-                    if targets.count == 500 { break outer }
+                    rows.append([
+                        "windowRef": self.issueWindowRef(app: app, window: window),
+                        "appName": app.name,
+                        "title": window.title,
+                        "bounds": Self.boundsDictionary(window.bounds),
+                        "isOnScreen": window.isOnScreen,
+                        "minimized": window.isMinimized,
+                    ])
+                    if rows.count == 500 { break outer }
                 }
             } catch {
                 warnings.append("\(app.name): \(error.localizedDescription)")
             }
-        }
-        let rows = self.references.projectWindows(
-            targets,
-            matches: Self.sameWindow,
-            issueRef: self.makeRef).map { entry in
-            [
-                "windowRef": entry.ref,
-                "appName": entry.target.app.name,
-                "title": entry.target.window.title,
-                "bounds": Self.boundsDictionary(entry.target.window.bounds),
-                "isOnScreen": entry.target.window.isOnScreen,
-                "minimized": entry.target.window.isMinimized,
-            ] as [String: Any]
         }
         var details: [String: AnyCodable] = ["windows": AnyCodable(rows)]
         if !warnings.isEmpty {
@@ -380,9 +292,7 @@ final class ComputerActionServiceV2 {
         guard observedWindow.windowID == target.window.windowID else {
             throw ComputerActionService.ComputerActionError.staleObservation
         }
-        self.references.replaceWindow(
-            WindowTarget(app: target.app, window: observedWindow),
-            for: windowRef)
+        self.windowRefs[windowRef] = WindowTarget(app: target.app, window: observedWindow)
         let detected = result.elements?.elements.all ?? []
         let filtered = Self.filterElements(detected, query: params.query)
         let bounded = Array(filtered.prefix(limits.maxElements))
@@ -391,12 +301,11 @@ final class ComputerActionServiceV2 {
             throw ComputerActionService.ComputerActionError.refused(
                 "Peekaboo observation returned no snapshot receipt")
         }
-        let issuedObservation = self.references.replaceObservation(
+        let issued = self.issueObservation(
             windowRef: windowRef,
             snapshotId: snapshotID,
-            elements: bounded.map { ElementTarget(id: $0.id, bounds: $0.bounds) },
-            issueRef: self.makeRef)
-        let elements = zip(bounded, issuedObservation.elementRefs).map { element, ref in
+            elements: bounded.map { ElementTarget(id: $0.id, bounds: $0.bounds) })
+        let elements = zip(bounded, issued.elementRefs).map { element, ref in
             OpenClawComputerObservationElement(
                 elementRef: ref,
                 role: element.type.rawValue,
@@ -427,7 +336,7 @@ final class ComputerActionServiceV2 {
                 format: "png",
                 width: Int(size.width),
                 height: Int(size.height),
-                observationId: issuedObservation.id,
+                observationId: issued.id,
                 elements: elements.isEmpty ? nil : elements),
             details: details)
     }
@@ -563,7 +472,7 @@ final class ComputerActionServiceV2 {
                     try await self.automation.typeActionsWithOutcome(
                         [.text(text)],
                         cadence: .fixed(milliseconds: 0),
-                        snapshotId: params.elementRef == nil ? nil : self.references.observation?.snapshotId,
+                        snapshotId: params.elementRef == nil ? nil : self.observation?.snapshotId,
                         expectedWindowIdentity: identity,
                         expectedWindowBounds: target.window.bounds)
                 }
@@ -624,7 +533,7 @@ final class ComputerActionServiceV2 {
                 try await self.automation.setValueWithOutcome(
                     target: element.id,
                     value: .string(value),
-                    snapshotId: self.references.observation?.snapshotId)
+                    snapshotId: self.observation?.snapshotId)
             }
             return Self.result(from: result.outcome, background: true)
         } catch let failure as DesktopActionFailure {
@@ -679,7 +588,7 @@ final class ComputerActionServiceV2 {
                 direction: Self.scrollDirection(direction),
                 amount: min(100, max(1, params.scrollAmount ?? 3)),
                 target: element?.id,
-                snapshotId: element == nil ? nil : self.references.observation?.snapshotId,
+                snapshotId: element == nil ? nil : self.observation?.snapshotId,
                 foreground: mode == .foreground))
         }
         return Self.result(from: result.outcome, background: mode == .background)
@@ -687,40 +596,80 @@ final class ComputerActionServiceV2 {
 
     // MARK: - Reference and target helpers
 
-    private func adoptLifecycleGeneration(_ generation: UInt64) {
-        let previousGeneration = self.references.lifecycleGeneration
-        self.references.adoptLifecycleGeneration(generation)
-        guard previousGeneration != generation else { return }
+    func adoptLifecycleGeneration(_ generation: UInt64) {
+        guard self.lifecycleGeneration != generation else { return }
+        self.lifecycleGeneration = generation
         self.appRefs.removeAll()
+        self.windowRefs.removeAll()
+        self.observation = nil
+    }
+
+    /// A window ref names one live window for the whole lifecycle generation and
+    /// keys on stable identity only: WindowServer id plus the owner process
+    /// generation that guards pid reuse. Bounds and minimized state stay out —
+    /// they belong to the per-action expected-identity check — so a window that
+    /// moves, resizes, or minimizes keeps its ref and has its stored target
+    /// refreshed here, and later checks compare against the live window.
+    func issueWindowRef(app: ServiceApplicationInfo, window: ServiceWindowInfo) -> String {
+        let ref = self.windowRefs.first { Self.sameWindow($0.value.window, window) }?.key
+            ?? self.issueRef("window")
+        self.windowRefs[ref] = WindowTarget(app: app, window: window)
+        return ref
+    }
+
+    func resolveWindow(_ ref: String) throws -> WindowTarget {
+        guard let target = self.windowRefs[ref] else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return target
+    }
+
+    /// Only the newest observation may authorize element work, so issuing one
+    /// supersedes every element ref handed out by the previous observation.
+    func issueObservation(
+        windowRef: String,
+        snapshotId: String,
+        elements: [ElementTarget]) -> (id: String, elementRefs: [String])
+    {
+        let id = self.issueRef("observation")
+        let elementRefs = elements.map { _ in self.issueRef("element") }
+        self.observation = ObservationState(
+            id: id,
+            windowRef: windowRef,
+            snapshotId: snapshotId,
+            elements: Dictionary(uniqueKeysWithValues: zip(elementRefs, elements)))
+        return (id, elementRefs)
+    }
+
+    func resolveObservation(_ id: String?, windowRef: String) throws -> ObservationState {
+        guard let observation = self.observation,
+              observation.id == id,
+              observation.windowRef == windowRef
+        else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return observation
+    }
+
+    func resolveElement(_ ref: String, observation: ObservationState) throws -> ElementTarget {
+        guard let element = observation.elements[ref] else {
+            throw ComputerActionService.ComputerActionError.staleObservation
+        }
+        return element
     }
 
     private func issueRef(_ kind: String) -> String {
-        "peekaboo:v2:\(kind):\(self.executionID):\(self.references.lifecycleGeneration ?? 0):" +
+        "peekaboo:v2:\(kind):\(self.executionID):\(self.lifecycleGeneration ?? 0):" +
             UUID().uuidString.lowercased()
     }
 
-    private func makeRef(_ kind: String) -> String {
-        self.issueRef(kind)
-    }
-
-    private static func sameWindow(_ lhs: WindowTarget, _ rhs: WindowTarget) -> Bool {
-        lhs.app.processIdentifier == rhs.app.processIdentifier &&
-            lhs.window.windowID == rhs.window.windowID &&
-            lhs.window.mutationIdentity == rhs.window.mutationIdentity
-    }
-
-    private func resolveWindow(_ ref: String) throws -> WindowTarget {
-        try self.references.resolveWindow(ref)
+    private static func sameWindow(_ lhs: ServiceWindowInfo, _ rhs: ServiceWindowInfo) -> Bool {
+        guard let left = lhs.mutationIdentity, let right = rhs.mutationIdentity else { return false }
+        return left.windowID == right.windowID && left.processIdentity == right.processIdentity
     }
 
     private func requiredWindow(_ params: OpenClawComputerActParams) throws -> WindowTarget {
         try self.resolveWindow(Self.require(params.windowRef, field: "windowRef"))
-    }
-
-    private func requiredObservation(_ params: OpenClawComputerActParams, windowRef: String) throws
-        -> ComputerOpaqueReferenceStore<WindowTarget, ElementTarget>.Observation
-    {
-        try self.references.resolveObservation(params.observationId, windowRef: windowRef)
     }
 
     private func requiredElement(
@@ -728,15 +677,15 @@ final class ComputerActionServiceV2 {
         windowRef: String) throws -> ElementTarget
     {
         let elementRef = try Self.require(params.elementRef, field: "elementRef")
-        let observation = try self.requiredObservation(params, windowRef: windowRef)
-        return try self.references.resolveElement(elementRef, observation: observation)
+        let observation = try self.resolveObservation(params.observationId, windowRef: windowRef)
+        return try self.resolveElement(elementRef, observation: observation)
     }
 
     private func clickTarget(
         _ params: OpenClawComputerActParams,
         windowRef: String) throws -> (target: ClickTarget, point: CGPoint, snapshotId: String)
     {
-        let observation = try self.requiredObservation(params, windowRef: windowRef)
+        let observation = try self.resolveObservation(params.observationId, windowRef: windowRef)
         if params.elementRef != nil {
             let element = try self.requiredElement(params, windowRef: windowRef)
             return (.elementId(element.id), element.bounds.centerPoint, observation.snapshotId)
@@ -769,7 +718,7 @@ final class ComputerActionServiceV2 {
             throw ComputerActionService.ComputerActionError.invalidV2Request(
                 "coordinates must be nonnegative")
         }
-        _ = try self.requiredObservation(params, windowRef: windowRef)
+        _ = try self.resolveObservation(params.observationId, windowRef: windowRef)
         return CGPoint(x: x, y: y)
     }
 
@@ -780,10 +729,8 @@ final class ComputerActionServiceV2 {
         foreground: Bool) async throws -> OpenClawComputerActResult
     {
         let windowRef = try Self.require(params.windowRef, field: "windowRef")
-        let observation = try self.requiredObservation(params, windowRef: windowRef)
-        guard let element = observation.elements[elementRef] else {
-            throw ComputerActionService.ComputerActionError.staleObservation
-        }
+        let observation = try self.resolveObservation(params.observationId, windowRef: windowRef)
+        let element = try self.resolveElement(elementRef, observation: observation)
         if foreground {
             try await self.focus(target)
             try Self.postForegroundClick(at: element.bounds.centerPoint, action: .leftClick, modifiers: nil)

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct ComputerRefLifecycleContractTests {
+    private struct Contract: Decodable {
+        let staleErrorCode: String
+        let cases: [Case]
+    }
+
+    private struct Case: Decodable {
+        let id: String
+        let scenario: Scenario
+        let expected: Expected
+    }
+
+    private enum Scenario: String, Decodable {
+        case freshWindow = "fresh_window"
+        case freshElement = "fresh_element"
+        case generationRotation = "generation_rotation"
+        case inFlightGenerationChange = "in_flight_generation_change"
+        case supersededObservation = "superseded_observation"
+        case unrelatedDiscovery = "unrelated_discovery"
+        case unknownRef = "unknown_ref"
+    }
+
+    private enum Expected: String, Decodable {
+        case valid
+        case stale
+    }
+
+    @Test func `Peekaboo satisfies the shared ref lifecycle cases`() throws {
+        let contract = try Self.loadContract()
+
+        for testCase in contract.cases {
+            let error = self.run(testCase)
+            switch testCase.expected {
+            case .valid:
+                #expect(error == nil, "\(testCase.id) unexpectedly failed: \(String(describing: error))")
+            case .stale:
+                #expect(
+                    error?.localizedDescription.hasPrefix("\(contract.staleErrorCode):") == true,
+                    "\(testCase.id) returned \(String(describing: error))")
+            }
+        }
+    }
+
+    private func run(_ testCase: Case) -> Error? {
+        var store = ComputerOpaqueReferenceStore<String, String>()
+        store.adoptLifecycleGeneration(1)
+        var nextRef = 0
+        let issueRef: (String) -> String = { kind in
+            nextRef += 1
+            return "peekaboo:v2:\(kind):\(nextRef)"
+        }
+        let windowRef = store.projectWindows(
+            ["primary"],
+            matches: ==,
+            issueRef: issueRef)[0].ref
+        let observation = store.replaceObservation(
+            windowRef: windowRef,
+            snapshotId: "snapshot-1",
+            elements: ["button"],
+            issueRef: issueRef)
+
+        do {
+            switch testCase.scenario {
+            case .freshWindow:
+                _ = try store.resolveWindow(windowRef)
+            case .freshElement:
+                let current = try store.resolveObservation(observation.id, windowRef: windowRef)
+                _ = try store.resolveElement(observation.elementRefs[0], observation: current)
+            case .generationRotation:
+                store.adoptLifecycleGeneration(2)
+                _ = try store.resolveWindow(windowRef)
+            case .inFlightGenerationChange:
+                throw ComputerActionService.ComputerActionError.lifecycleChanged
+            case .supersededObservation:
+                _ = store.replaceObservation(
+                    windowRef: windowRef,
+                    snapshotId: "snapshot-2",
+                    elements: ["button"],
+                    issueRef: issueRef)
+                _ = try store.resolveObservation(observation.id, windowRef: windowRef)
+            case .unrelatedDiscovery:
+                _ = store.projectWindows(["secondary"], matches: ==, issueRef: issueRef)
+                _ = try store.resolveWindow(windowRef)
+            case .unknownRef:
+                _ = try store.resolveWindow("peekaboo:v2:window:unknown")
+            }
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private static func loadContract() throws -> Contract {
+        var cursor = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<8 {
+            let candidate = cursor
+                .appendingPathComponent("test")
+                .appendingPathComponent("fixtures")
+                .appendingPathComponent("computer-ref-lifecycle-contract.json")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return try JSONDecoder().decode(Contract.self, from: Data(contentsOf: candidate))
+            }
+            cursor.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "ComputerRefLifecycleContractTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "missing shared computer ref lifecycle fixture"])
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
@@ -1,7 +1,13 @@
+import CoreGraphics
 import Foundation
+import OpenClawKit
+import PeekabooAutomationKit
 import Testing
 @testable import OpenClaw
 
+/// Drives the real `ComputerActionServiceV2` reference lifecycle through the same
+/// case table the CUA provider runs in `ref-lifecycle.contract.test.ts`, so the two
+/// providers cannot drift apart on what an opaque ref means.
 @MainActor
 struct ComputerRefLifecycleContractTests {
     private struct Contract: Decodable {
@@ -18,6 +24,7 @@ struct ComputerRefLifecycleContractTests {
     private enum Scenario: String, Decodable {
         case freshWindow = "fresh_window"
         case freshElement = "fresh_element"
+        case windowMoved = "window_moved"
         case generationRotation = "generation_rotation"
         case inFlightGenerationChange = "in_flight_generation_change"
         case supersededObservation = "superseded_observation"
@@ -30,11 +37,21 @@ struct ComputerRefLifecycleContractTests {
         case stale
     }
 
-    @Test func `Peekaboo satisfies the shared ref lifecycle cases`() throws {
+    private static let app = ServiceApplicationInfo(
+        processIdentifier: 4321,
+        processStartIdentity: 90210,
+        bundleIdentifier: "com.example.contract",
+        name: "Contract",
+        windowCount: 1)
+
+    private static let originalBounds = CGRect(x: 0, y: 0, width: 400, height: 300)
+    private static let movedBounds = CGRect(x: 120, y: 80, width: 640, height: 480)
+
+    @Test func `Peekaboo satisfies the shared ref lifecycle cases`() async throws {
         let contract = try Self.loadContract()
 
         for testCase in contract.cases {
-            let error = self.run(testCase)
+            let error = await self.run(testCase)
             switch testCase.expected {
             case .valid:
                 #expect(error == nil, "\(testCase.id) unexpectedly failed: \(String(describing: error))")
@@ -46,53 +63,81 @@ struct ComputerRefLifecycleContractTests {
         }
     }
 
-    private func run(_ testCase: Case) -> Error? {
-        var store = ComputerOpaqueReferenceStore<String, String>()
-        store.adoptLifecycleGeneration(1)
-        var nextRef = 0
-        let issueRef: (String) -> String = { kind in
-            nextRef += 1
-            return "peekaboo:v2:\(kind):\(nextRef)"
-        }
-        let windowRef = store.projectWindows(
-            ["primary"],
-            matches: ==,
-            issueRef: issueRef)[0].ref
-        let observation = store.replaceObservation(
+    private func run(_ testCase: Case) async -> Error? {
+        let service = ComputerActionServiceV2()
+        service.adoptLifecycleGeneration(1)
+        let windowRef = service.issueWindowRef(
+            app: Self.app,
+            window: Self.window(windowID: 77, bounds: Self.originalBounds))
+        let observation = service.issueObservation(
             windowRef: windowRef,
             snapshotId: "snapshot-1",
-            elements: ["button"],
-            issueRef: issueRef)
+            elements: [ComputerActionServiceV2.ElementTarget(id: "button", bounds: .zero)])
 
         do {
             switch testCase.scenario {
             case .freshWindow:
-                _ = try store.resolveWindow(windowRef)
+                _ = try service.resolveWindow(windowRef)
             case .freshElement:
-                let current = try store.resolveObservation(observation.id, windowRef: windowRef)
-                _ = try store.resolveElement(observation.elementRefs[0], observation: current)
+                let current = try service.resolveObservation(observation.id, windowRef: windowRef)
+                _ = try service.resolveElement(observation.elementRefs[0], observation: current)
+            case .windowMoved:
+                let moved = Self.window(windowID: 77, bounds: Self.movedBounds)
+                #expect(service.issueWindowRef(app: Self.app, window: moved) == windowRef)
+                let refreshed = try service.resolveWindow(windowRef).window
+                #expect(refreshed.bounds == Self.movedBounds)
+                #expect(refreshed.mutationIdentity == moved.mutationIdentity)
             case .generationRotation:
-                store.adoptLifecycleGeneration(2)
-                _ = try store.resolveWindow(windowRef)
+                service.adoptLifecycleGeneration(2)
+                _ = try service.resolveWindow(windowRef)
             case .inFlightGenerationChange:
-                throw ComputerActionService.ComputerActionError.lifecycleChanged
+                try await Self.performWithRevokedLifecycle(service)
             case .supersededObservation:
-                _ = store.replaceObservation(
+                _ = service.issueObservation(
                     windowRef: windowRef,
                     snapshotId: "snapshot-2",
-                    elements: ["button"],
-                    issueRef: issueRef)
-                _ = try store.resolveObservation(observation.id, windowRef: windowRef)
+                    elements: [ComputerActionServiceV2.ElementTarget(id: "button", bounds: .zero)])
+                _ = try service.resolveObservation(observation.id, windowRef: windowRef)
             case .unrelatedDiscovery:
-                _ = store.projectWindows(["secondary"], matches: ==, issueRef: issueRef)
-                _ = try store.resolveWindow(windowRef)
+                _ = service.issueWindowRef(
+                    app: Self.app,
+                    window: Self.window(windowID: 88, bounds: Self.movedBounds))
+                _ = try service.resolveWindow(windowRef)
             case .unknownRef:
-                _ = try store.resolveWindow("peekaboo:v2:window:unknown")
+                _ = try service.resolveWindow("peekaboo:v2:window:unknown")
             }
             return nil
         } catch {
             return error
         }
+    }
+
+    /// Runs a real action whose lifecycle generation is revoked after the work
+    /// completed but before the result is released, which is the only way the
+    /// in-flight change reaches a caller.
+    private static func performWithRevokedLifecycle(_ service: ComputerActionServiceV2) async throws {
+        var checks = 0
+        _ = try await service.perform(
+            OpenClawComputerActParams(action: .getCursorPosition),
+            lifecycleGeneration: 1,
+            checkExecutionAllowed: {
+                checks += 1
+                if checks > 1 {
+                    throw ComputerActionService.ComputerActionError.lifecycleChanged
+                }
+            })
+    }
+
+    private static func window(windowID: Int, bounds: CGRect) -> ServiceWindowInfo {
+        ServiceWindowInfo(
+            windowID: windowID,
+            title: "Contract Window",
+            bounds: bounds,
+            mutationIdentity: WindowMutationIdentity(
+                windowID: windowID,
+                ownerProcessIdentifier: self.app.processIdentifier,
+                ownerProcessStartIdentity: 90210,
+                capturedBounds: bounds))
     }
 
     private static func loadContract() throws -> Contract {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -830,7 +830,7 @@ struct MacNodeRuntimeTests {
 
         #expect(!response.ok)
         #expect(response.error?.code == .unavailable)
-        #expect(response.error?.message.contains("lifecycle changed") == true)
+        #expect(response.error?.message.contains("COMPUTER_STALE_OBSERVATION") == true)
         #expect(generations.perform == [0])
         #expect(generations.release == [1])
     }

--- a/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
+++ b/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  adoptGeneration,
+  issueElementRef,
+  issueObservation,
+  issueWindowRef,
+  resolveElementRef,
+  resolveObservation,
+  resolveWindowRef,
+  verifyGeneration,
+  type CuaFrameState,
+} from "./frame.js";
+
+type RefLifecycleCase = {
+  id: string;
+  scenario:
+    | "fresh_window"
+    | "fresh_element"
+    | "generation_rotation"
+    | "in_flight_generation_change"
+    | "superseded_observation"
+    | "unrelated_discovery"
+    | "unknown_ref";
+  expected: "valid" | "stale";
+};
+
+type RefLifecycleContract = {
+  staleErrorCode: string;
+  cases: RefLifecycleCase[];
+};
+
+const contract = JSON.parse(
+  readFileSync(
+    new URL("../../../test/fixtures/computer-ref-lifecycle-contract.json", import.meta.url),
+    "utf8",
+  ),
+) as RefLifecycleContract;
+
+function runCase(testCase: RefLifecycleCase): void {
+  const state: CuaFrameState = { generation: "generation-1" };
+  const windowRef = issueWindowRef(state, { pid: 100, windowId: 10 });
+  const observation = issueObservation(state, windowRef);
+  const elementRef = issueElementRef(observation, { elementIndex: 0 });
+
+  switch (testCase.scenario) {
+    case "fresh_window":
+      resolveWindowRef(state, windowRef);
+      return;
+    case "fresh_element":
+      resolveElementRef(resolveObservation(state, observation.id, windowRef), elementRef);
+      return;
+    case "generation_rotation":
+      adoptGeneration(state, "generation-2");
+      resolveWindowRef(state, windowRef);
+      return;
+    case "in_flight_generation_change":
+      verifyGeneration(state, "generation-2");
+      return;
+    case "superseded_observation":
+      issueObservation(state, windowRef);
+      resolveObservation(state, observation.id, windowRef);
+      return;
+    case "unrelated_discovery":
+      issueWindowRef(state, { pid: 200, windowId: 20 });
+      resolveWindowRef(state, windowRef);
+      return;
+    case "unknown_ref":
+      resolveWindowRef(state, "cua:v2:window:unknown");
+  }
+}
+
+describe("Computer Use ref lifecycle contract", () => {
+  for (const testCase of contract.cases) {
+    it(testCase.id, () => {
+      if (testCase.expected === "valid") {
+        expect(() => runCase(testCase)).not.toThrow();
+      } else {
+        expect(() => runCase(testCase)).toThrow(new RegExp(`^${contract.staleErrorCode}:`, "u"));
+      }
+    });
+  }
+});

--- a/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
+++ b/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { driver, result } from "./commands.test-helpers.js";
+import { callWindowTool } from "./driver-result.js";
 import {
   adoptGeneration,
   issueElementRef,
@@ -8,7 +10,6 @@ import {
   resolveElementRef,
   resolveObservation,
   resolveWindowRef,
-  verifyGeneration,
   type CuaFrameState,
 } from "./frame.js";
 
@@ -38,7 +39,7 @@ const contract = JSON.parse(
   ),
 ) as RefLifecycleContract;
 
-function runCase(testCase: RefLifecycleCase): void {
+async function runCase(testCase: RefLifecycleCase): Promise<void> {
   const state: CuaFrameState = { generation: "generation-1" };
   const windowRef = issueWindowRef(state, { pid: 100, windowId: 10 });
   const observation = issueObservation(state, windowRef);
@@ -64,9 +65,23 @@ function runCase(testCase: RefLifecycleCase): void {
       adoptGeneration(state, "generation-2");
       resolveWindowRef(state, windowRef);
       return;
-    case "in_flight_generation_change":
-      verifyGeneration(state, "generation-2");
+    case "in_flight_generation_change": {
+      // The production path is callWindowTool: it snapshots the driver
+      // generation, awaits the driver call, then detects rotation. Asserting a
+      // pre-call guard instead would leave that post-await check unprotected.
+      const session = driver();
+      session.callTool.mockImplementationOnce(async () => {
+        session.setGeneration("execution-2");
+        return result({});
+      });
+      await callWindowTool(
+        session.session,
+        { generation: session.session.generation },
+        "get_window_state",
+        {},
+      );
       return;
+    }
     case "superseded_observation":
       issueObservation(state, windowRef);
       resolveObservation(state, observation.id, windowRef);
@@ -82,11 +97,13 @@ function runCase(testCase: RefLifecycleCase): void {
 
 describe("Computer Use ref lifecycle contract", () => {
   for (const testCase of contract.cases) {
-    it(testCase.id, () => {
+    it(testCase.id, async () => {
       if (testCase.expected === "valid") {
-        expect(() => runCase(testCase)).not.toThrow();
+        await expect(runCase(testCase)).resolves.toBeUndefined();
       } else {
-        expect(() => runCase(testCase)).toThrow(new RegExp(`^${contract.staleErrorCode}:`, "u"));
+        await expect(runCase(testCase)).rejects.toThrow(
+          new RegExp(`^${contract.staleErrorCode}:`, "u"),
+        );
       }
     });
   }

--- a/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
+++ b/extensions/cua-computer/src/ref-lifecycle.contract.test.ts
@@ -17,6 +17,7 @@ type RefLifecycleCase = {
   scenario:
     | "fresh_window"
     | "fresh_element"
+    | "window_moved"
     | "generation_rotation"
     | "in_flight_generation_change"
     | "superseded_observation"
@@ -50,6 +51,15 @@ function runCase(testCase: RefLifecycleCase): void {
     case "fresh_element":
       resolveElementRef(resolveObservation(state, observation.id, windowRef), elementRef);
       return;
+    case "window_moved": {
+      // A moved window is rediscovered under the same stable identity, so the
+      // ref survives and still resolves to the live window. CUA stores only that
+      // identity, so the refreshed target is the identity itself.
+      const moved = { pid: 100, windowId: 10 };
+      expect(issueWindowRef(state, moved)).toBe(windowRef);
+      expect(resolveWindowRef(state, windowRef)).toEqual(moved);
+      return;
+    }
     case "generation_rotation":
       adoptGeneration(state, "generation-2");
       resolveWindowRef(state, windowRef);

--- a/src/plugins/computer-use-contract.test.ts
+++ b/src/plugins/computer-use-contract.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
+  COMPUTER_STALE_OBSERVATION,
   COMPUTER_USE_V2_ACTION_NAMES,
   parseComputerActParamsJSON,
   parseComputerActResult,
@@ -11,6 +13,17 @@ import {
 import type { OpenClawPluginNodeHostCommand } from "./types.js";
 
 describe("Computer Use wire contract", () => {
+  it("owns the shared provider ref-lifecycle error code", () => {
+    const contract = JSON.parse(
+      readFileSync(
+        new URL("../../test/fixtures/computer-ref-lifecycle-contract.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { staleErrorCode: string };
+
+    expect(contract.staleErrorCode).toBe(COMPUTER_STALE_OBSERVATION);
+  });
+
   it("validates the canonical computer.act payload", () => {
     expect(
       parseComputerActParamsJSON(

--- a/test/fixtures/computer-ref-lifecycle-contract.json
+++ b/test/fixtures/computer-ref-lifecycle-contract.json
@@ -1,0 +1,40 @@
+{
+  "staleErrorCode": "COMPUTER_STALE_OBSERVATION",
+  "cases": [
+    {
+      "id": "fresh-window-ref-valid",
+      "scenario": "fresh_window",
+      "expected": "valid"
+    },
+    {
+      "id": "fresh-element-ref-valid",
+      "scenario": "fresh_element",
+      "expected": "valid"
+    },
+    {
+      "id": "generation-rotation-invalidates-refs",
+      "scenario": "generation_rotation",
+      "expected": "stale"
+    },
+    {
+      "id": "in-flight-generation-change-uses-contract-code",
+      "scenario": "in_flight_generation_change",
+      "expected": "stale"
+    },
+    {
+      "id": "superseded-observation-invalidates-elements",
+      "scenario": "superseded_observation",
+      "expected": "stale"
+    },
+    {
+      "id": "unrelated-discovery-preserves-window-ref",
+      "scenario": "unrelated_discovery",
+      "expected": "valid"
+    },
+    {
+      "id": "unknown-ref-uses-contract-code",
+      "scenario": "unknown_ref",
+      "expected": "stale"
+    }
+  ]
+}

--- a/test/fixtures/computer-ref-lifecycle-contract.json
+++ b/test/fixtures/computer-ref-lifecycle-contract.json
@@ -12,6 +12,11 @@
       "expected": "valid"
     },
     {
+      "id": "window-moved-keeps-ref-and-refreshes-target",
+      "scenario": "window_moved",
+      "expected": "valid"
+    },
+    {
       "id": "generation-rotation-invalidates-refs",
       "scenario": "generation_rotation",
       "expected": "stale"


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

Related: #124355

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

A model following the documented observe-then-act flow could reuse a window reference after `list_windows` with CUA, but the identical flow failed on native Peekaboo. Two separate defects caused that:

1. Every discovery call cleared `windowRefs`, so any earlier window ref went stale.
2. Ref identity included the whole `WindowMutationIdentity`, which embeds `capturedBounds` and `isMinimized`. Any move, resize, or minimize made the same live window look like a different one, so it got a **new** ref, the old ref was never evicted, and that old ref kept resolving to a stale `ServiceWindowInfo`. Its `mutationIdentity` and `bounds` were then passed as `expectedWindowIdentity` / `expectedWindowBounds`, so the operator got a downstream mismatch failure instead of the contract's `COMPUTER_STALE_OBSERVATION`.

A provider generation change during an action also surfaced different error vocabulary across the two providers.

## Why This Change Was Made

The shared Computer Use contract is the authority: opaque refs belong to a provider generation, element refs additionally belong to the current observation, and stale refs report `COMPUTER_STALE_OBSERVATION`.

Native window refs now key on **stable identity only** — WindowServer id plus the owner process generation that guards pid reuse — and the stored `WindowTarget` is refreshed in place on every discovery. One live window keeps one ref for the whole lifecycle generation, the ref map is bounded by distinct windows rather than by movement, and the per-action identity and bounds checks always compare against current data. `mutationIdentity` keeps doing what it is for: the per-action expected-identity check, not ref identity. The in-flight lifecycle-change condition maps to the contract code. CUA production behavior is unchanged because it already matched those rules.

A single JSON case table drives both the Swift and TypeScript provider tests, and both run against real production code. The Swift side drives the real `ComputerActionServiceV2` with real `ServiceApplicationInfo` / `ServiceWindowInfo` / `WindowMutationIdentity` values; its in-flight case runs a real `perform()` whose lifecycle is revoked mid-action rather than asserting an error it threw itself.

Shared cases: `fresh_window`, `fresh_element`, `window_moved`, `generation_rotation`, `in_flight_generation_change`, `superseded_observation`, `unrelated_discovery`, `unknown_ref`.

## User Impact

Models can consistently call `list_windows` or `get_window_state`, then act on the returned refs across both providers, including after the user moves, resizes, or minimizes the window. When a ref really is stale, both providers return the same closed code and the model can take a fresh observation and retry.

## Evidence

- Regression proof: with the pre-fix matcher restored, the new `window_moved` case fails on all three of its assertions (ref changed, bounds not refreshed, `mutationIdentity` not refreshed); it passes on the fix.
- Pre-fix shared Swift case `unrelated-discovery-preserves-window-ref` failed with `staleObservation`; the same CUA table passed.
- `swift test --parallel --package-path apps/macos` (exit 0, zero failures)
- `swift test --filter Computer` (31 tests in 3 suites passed)
- `node scripts/run-vitest.mjs extensions/cua-computer src/plugins/computer-use-contract.test.ts src/agents/tools` (96 files, 2,066 tests passed, one file/test skipped)
- `pnpm tsgo`, `pnpm check:test-types`
- `swiftformat --config config/swiftformat --lint` and `swiftlint lint --config config/swiftlint.yml` on both changed Swift files (clean)
- `node scripts/run-oxlint.mjs` on the changed TS tests, `oxfmt --check` (clean)
- `node --import tsx scripts/check-madge-import-cycles.ts` (0 cycles), `pnpm deadcode:full`, `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)

Production LOC: **+71/-56 (net +15)**, of which 9 lines are two invariant doc comments. Tests and shared fixture: +312/-1. The one-instantiation generic `ComputerOpaqueReferenceStore` from the earlier revision is gone; the lifecycle is plain concrete state plus small helpers on its only owner, with no injected matcher or ref-minting closures.
