### PR TITLE
fix(gateway): avoid silent unserializable WebSocket responses

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -421,15 +421,46 @@ describe("attachGatewayWsConnectionHandler", () => {
     const socket = createGatewayWsTestSocket();
     const { passed } = await connectTestWs({ socket });
     const handlerParams = passed as {
-      send: (frame: unknown) => void;
+      send: (frame: unknown) => { kind: string };
     };
     socket.send.mockClear();
     socket.bufferedAmount = MAX_BUFFERED_BYTES + 1;
 
-    handlerParams.send({ type: "res", id: "req-slow", ok: true, payload: { ok: true } });
+    expect(
+      handlerParams.send({ type: "res", id: "req-slow", ok: true, payload: { ok: true } }),
+    ).toEqual({ kind: "unavailable" });
 
     expect(socket.send).not.toHaveBeenCalled();
     expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+  });
+
+  it("distinguishes serialization failure from unavailable transports", async () => {
+    const socket = createGatewayWsTestSocket();
+    const { passed } = await connectTestWs({ socket });
+    const handlerParams = passed as {
+      send: (frame: unknown) => { kind: string; error?: unknown };
+    };
+    socket.send.mockClear();
+
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    expect(handlerParams.send(cyclic)).toMatchObject({
+      kind: "serialization",
+      error: expect.any(TypeError),
+    });
+    expect(socket.send).not.toHaveBeenCalled();
+
+    socket.send.mockImplementationOnce(() => {
+      throw new Error("socket unavailable");
+    });
+    expect(handlerParams.send({ type: "event", event: "tick" })).toEqual({
+      kind: "unavailable",
+    });
+
+    socket.emit("close", 1000, Buffer.from("done"));
+    expect(handlerParams.send({ type: "event", event: "tick" })).toEqual({
+      kind: "unavailable",
+    });
   });
 
   it("keeps handshake phase advancement monotonic", async () => {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -351,7 +351,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const send = (obj: unknown) => {
       if (closed) {
-        return;
+        return { kind: "unavailable" } as const;
       }
       if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {
         logRejectedLargePayload({
@@ -365,12 +365,19 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           limitBytes: MAX_BUFFERED_BYTES,
         });
         close(1008, connectionKind === "worker" ? "slow-consumer" : "slow consumer");
-        return;
+        return { kind: "unavailable" } as const;
+      }
+      let encoded: string;
+      try {
+        encoded = JSON.stringify(obj);
+      } catch (error) {
+        return { kind: "serialization", error } as const;
       }
       try {
-        socket.send(JSON.stringify(obj));
+        socket.send(encoded);
+        return { kind: "sent" } as const;
       } catch {
-        /* ignore */
+        return { kind: "unavailable" } as const;
       }
     };
 

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
@@ -93,7 +93,7 @@ function createDispatcher(
       connId: client.connId,
       extraHandlers: {},
       buildRequestContext: () => ({}) as never,
-      send: vi.fn(),
+      send: vi.fn((_frame: unknown) => ({ kind: "sent" }) as const),
       close: vi.fn(),
       isClosed: () => false,
       setCloseCause: vi.fn(),

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
@@ -33,7 +33,7 @@ describe("authenticated request dispatcher load failures", () => {
     }));
     const { createGatewayAuthenticatedRequestDispatcher } =
       await import("./authenticated-request-dispatch.js");
-    const send = vi.fn();
+    const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
     const dispatcher = createGatewayAuthenticatedRequestDispatcher({
       handler: {
         connId: "stale-install-dispatch",

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
@@ -72,7 +72,7 @@ function createDispatcher(
   handler: NonNullable<GatewayWsMessageHandlerParams["extraHandlers"][string]>,
   context: Record<string, unknown> = {},
 ) {
-  const send = vi.fn();
+  const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
   const close = vi.fn();
   const setCloseCause = vi.fn();
   const logGateway = {
@@ -272,6 +272,7 @@ describe("authenticated WebSocket request trace dispatch", () => {
     });
     send.mockImplementation(() => {
       responseContext = getActiveDiagnosticTraceContext();
+      return { kind: "sent" } as const;
     });
 
     await dispatchInFreshMessageScope(dispatcher, createClient(), "failure", TRACEPARENTS.first);
@@ -446,10 +447,25 @@ describe("authenticated WebSocket request trace dispatch", () => {
   });
 
   it("returns a typed error when a handler response cannot be serialized", async () => {
-    let returnInvalidPayload = true;
+    let invalidSerializationAttempts = 0;
+    const healthySerializationAttempts = new Map<string, number>();
     const registry = createEmptyPluginRegistry();
-    registry.gatewayHandlers["test.serialize"] = ({ respond }) => {
-      respond(true, returnInvalidPayload ? { value: 1n } : { value: 1 });
+    registry.gatewayHandlers["test.serialize"] = ({ req, respond }) => {
+      const invalid = req.id === "invalid-payload";
+      respond(true, {
+        toJSON: () => {
+          if (invalid) {
+            invalidSerializationAttempts += 1;
+            return { value: 1n };
+          }
+          const attempts = (healthySerializationAttempts.get(req.id) ?? 0) + 1;
+          healthySerializationAttempts.set(req.id, attempts);
+          if (attempts > 1) {
+            throw new Error("healthy response serialized more than once");
+          }
+          return { value: 1 };
+        },
+      });
     };
     setTestPluginRegistry(registry);
 
@@ -482,10 +498,13 @@ describe("authenticated WebSocket request trace dispatch", () => {
 
       await expect(response).resolves.toMatchObject({
         ok: false,
-        error: { code: "UNAVAILABLE", message: "gateway response serialization failed" },
+        error: { code: "UNAVAILABLE", message: "response serialization failed" },
       });
+      expect(invalidSerializationAttempts).toBe(1);
+      await expect(
+        onceMessage(ws, (value) => value.type === "res" && value.id === "invalid-payload", 100),
+      ).rejects.toThrow("timeout");
 
-      returnInvalidPayload = false;
       const healthyResponse = onceMessage<{ type: "res"; id: string; ok: boolean }>(
         ws,
         (value) => value.type === "res" && value.id === "healthy-after-error",
@@ -499,6 +518,7 @@ describe("authenticated WebSocket request trace dispatch", () => {
         }),
       );
       await expect(healthyResponse).resolves.toMatchObject({ ok: true });
+      expect(healthySerializationAttempts.get("healthy-after-error")).toBe(1);
 
       ws.terminate();
       ws = await openAuthenticatedTraceSocket({
@@ -519,6 +539,7 @@ describe("authenticated WebSocket request trace dispatch", () => {
         }),
       );
       await expect(reconnectResponse).resolves.toMatchObject({ ok: true });
+      expect(healthySerializationAttempts.get("healthy-after-reconnect")).toBe(1);
     } finally {
       ws?.terminate();
       await server.close();

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
@@ -444,4 +444,85 @@ describe("authenticated WebSocket request trace dispatch", () => {
       resetTestPluginRegistry();
     }
   });
+
+  it("returns a typed error when a handler response cannot be serialized", async () => {
+    let returnInvalidPayload = true;
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["test.serialize"] = ({ respond }) => {
+      respond(true, returnInvalidPayload ? { value: 1n } : { value: 1 });
+    };
+    setTestPluginRegistry(registry);
+
+    const token = "gateway-response-serialization-test-token";
+    const port = await getGatewayTestPort();
+    const server = await startTestGatewayServer(port, {
+      auth: { mode: "token", token },
+      bind: "loopback",
+      controlUiEnabled: false,
+    });
+    let ws: WebSocket | undefined;
+    try {
+      ws = await openAuthenticatedTraceSocket({
+        port,
+        token,
+        connectTraceparent: TRACEPARENTS.first,
+      });
+      const response = onceMessage<{ type: "res"; id: string; ok: boolean; error?: unknown }>(
+        ws,
+        (value) => value.type === "res" && value.id === "invalid-payload",
+      );
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "invalid-payload",
+          method: "test.serialize",
+          params: {},
+        }),
+      );
+
+      await expect(response).resolves.toMatchObject({
+        ok: false,
+        error: { code: "UNAVAILABLE", message: "gateway response serialization failed" },
+      });
+
+      returnInvalidPayload = false;
+      const healthyResponse = onceMessage<{ type: "res"; id: string; ok: boolean }>(
+        ws,
+        (value) => value.type === "res" && value.id === "healthy-after-error",
+      );
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "healthy-after-error",
+          method: "test.serialize",
+          params: {},
+        }),
+      );
+      await expect(healthyResponse).resolves.toMatchObject({ ok: true });
+
+      ws.terminate();
+      ws = await openAuthenticatedTraceSocket({
+        port,
+        token,
+        connectTraceparent: TRACEPARENTS.second,
+      });
+      const reconnectResponse = onceMessage<{ type: "res"; id: string; ok: boolean }>(
+        ws,
+        (value) => value.type === "res" && value.id === "healthy-after-reconnect",
+      );
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "healthy-after-reconnect",
+          method: "test.serialize",
+          params: {},
+        }),
+      );
+      await expect(reconnectResponse).resolves.toMatchObject({ ok: true });
+    } finally {
+      ws?.terminate();
+      await server.close();
+      resetTestPluginRegistry();
+    }
+  });
 });

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -113,14 +113,17 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       error?: ErrorShape,
       meta?: Record<string, unknown>,
     ) => {
+      let responseOk = ok;
+      let responseError = error;
       const sendResult = send({ type: "res", id: req.id, ok, payload, error });
       if (sendResult.kind === "serialization") {
         const detail = formatForLog(sendResult.error);
         logGateway.error(`response serialization failed method=${req.method}: ${detail}`);
-        const fallback = errorShape(ErrorCodes.UNAVAILABLE, "response serialization failed");
-        return respond(false, undefined, fallback, meta);
+        responseOk = false;
+        responseError = errorShape(ErrorCodes.UNAVAILABLE, "response serialization failed");
+        send({ type: "res", id: req.id, ok: responseOk, error: responseError });
       }
-      const unauthorizedRoleError = isUnauthorizedRoleError(error);
+      const unauthorizedRoleError = isUnauthorizedRoleError(responseError);
       let logMeta = meta;
       if (unauthorizedRoleError) {
         const unauthorizedDecision = unauthorizedFloodGuard.registerUnauthorized();
@@ -150,10 +153,10 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       logWs("out", "res", {
         connId,
         id: req.id,
-        ok,
+        ok: responseOk,
         method: req.method,
-        errorCode: error?.code,
-        errorMessage: error?.message,
+        errorCode: responseError?.code,
+        errorMessage: responseError?.message,
         ...logMeta,
       });
     };

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -113,8 +113,23 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       error?: ErrorShape,
       meta?: Record<string, unknown>,
     ) => {
-      send({ type: "res", id: req.id, ok, payload, error });
-      const unauthorizedRoleError = isUnauthorizedRoleError(error);
+      let response = { ok, payload, error };
+      let frame = { type: "res", id: req.id, ...response };
+      try {
+        JSON.stringify(frame);
+      } catch (serializationError) {
+        logGateway.error(
+          `response serialization failed method=${req.method}: ${formatForLog(serializationError)}`,
+        );
+        response = {
+          ok: false,
+          payload: undefined,
+          error: errorShape(ErrorCodes.UNAVAILABLE, "gateway response serialization failed"),
+        };
+        frame = { type: "res", id: req.id, ...response };
+      }
+      send(frame);
+      const unauthorizedRoleError = isUnauthorizedRoleError(response.error);
       let logMeta = meta;
       if (unauthorizedRoleError) {
         const unauthorizedDecision = unauthorizedFloodGuard.registerUnauthorized();
@@ -144,10 +159,10 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       logWs("out", "res", {
         connId,
         id: req.id,
-        ok,
+        ok: response.ok,
         method: req.method,
-        errorCode: error?.code,
-        errorMessage: error?.message,
+        errorCode: response.error?.code,
+        errorMessage: response.error?.message,
         ...logMeta,
       });
     };

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -113,23 +113,14 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       error?: ErrorShape,
       meta?: Record<string, unknown>,
     ) => {
-      let response = { ok, payload, error };
-      let frame = { type: "res", id: req.id, ...response };
-      try {
-        JSON.stringify(frame);
-      } catch (serializationError) {
-        logGateway.error(
-          `response serialization failed method=${req.method}: ${formatForLog(serializationError)}`,
-        );
-        response = {
-          ok: false,
-          payload: undefined,
-          error: errorShape(ErrorCodes.UNAVAILABLE, "gateway response serialization failed"),
-        };
-        frame = { type: "res", id: req.id, ...response };
+      const sendResult = send({ type: "res", id: req.id, ok, payload, error });
+      if (sendResult.kind === "serialization") {
+        const detail = formatForLog(sendResult.error);
+        logGateway.error(`response serialization failed method=${req.method}: ${detail}`);
+        const fallback = errorShape(ErrorCodes.UNAVAILABLE, "response serialization failed");
+        return respond(false, undefined, fallback, meta);
       }
-      send(frame);
-      const unauthorizedRoleError = isUnauthorizedRoleError(response.error);
+      const unauthorizedRoleError = isUnauthorizedRoleError(error);
       let logMeta = meta;
       if (unauthorizedRoleError) {
         const unauthorizedDecision = unauthorizedFloodGuard.registerUnauthorized();
@@ -159,10 +150,10 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       logWs("out", "res", {
         connId,
         id: req.id,
-        ok: response.ok,
+        ok,
         method: req.method,
-        errorCode: response.error?.code,
-        errorMessage: response.error?.message,
+        errorCode: error?.code,
+        errorMessage: error?.message,
         ...logMeta,
       });
     };

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -30,6 +30,8 @@ export type WsOriginCheckMetrics = {
   hostHeaderFallbackAccepted: number;
 };
 
+type WsSendResult = { kind: "sent" | "unavailable" } | { kind: "serialization"; error: unknown };
+
 export type GatewayWsMessageHandlerParams = {
   socket: WebSocket;
   upgradeReq: IncomingMessage;
@@ -63,7 +65,7 @@ export type GatewayWsMessageHandlerParams = {
   buildRequestContext: () => GatewayRequestContext;
   nodeLifecycleDispatch: GatewayNodeLifecycleDispatchTracker;
   refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
-  send: (obj: unknown) => void;
+  send: (obj: unknown) => WsSendResult;
   close: (code?: number, reason?: string) => void;
   isClosed: () => boolean;
   clearHandshakeTimer: () => void;

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -133,7 +133,10 @@ describe("Control UI build admission over WebSocket", () => {
     let closeRequested = false;
 
     wss.on("connection", (socket, request) => {
-      const send = (value: unknown) => socket.send(JSON.stringify(value));
+      const send = (value: unknown) => {
+        socket.send(JSON.stringify(value));
+        return { kind: "sent" } as const;
+      };
       attachGatewayWsMessageHandler({
         socket,
         upgradeReq: request as IncomingMessage,

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -269,7 +269,7 @@ function attachGatewayHarness(options: {
       return socket;
     }),
   } as unknown as WebSocket;
-  const send = vi.fn();
+  const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
   let client: unknown = options.client ?? null;
   const requestHost = options.requestHost ?? "127.0.0.1:19001";
   const remoteAddr = options.remoteAddr ?? "127.0.0.1";

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -79,7 +79,7 @@ function attachHarness(params: { deferSocketSend?: boolean } = {}) {
     }),
   } as unknown as WebSocket;
   const close = vi.fn();
-  const send = vi.fn();
+  const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
   const setCloseCause = vi.fn();
   const setClient = vi.fn((next: unknown) => {
     client = next;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an authenticated Gateway RPC handler returning a non-JSON-serializable payload would leave the client waiting forever: response serialization failed inside the low-level WebSocket send path, the exception was swallowed, and request logging still described the original successful result.

## Why This Change Was Made

The connection-owned send function now returns a private closed result (`sent`, `unavailable`, or `serialization`) after serializing each frame exactly once. Only a serialization failure makes authenticated dispatch send one correlated `UNAVAILABLE` response; closed, slow, and socket-failure outcomes are not replayed, and the fallback result is never retried recursively. Final response logging and unauthorized accounting use that same fallback outcome.

The Gateway protocol package, protocol version, and frame schema are unchanged. Production LOC is `+28/-10` (net `+18`); tests are `+144/-8` (net `+136`).

## User Impact

Clients now receive one correlated typed error instead of hanging when a handler result cannot be encoded. A serialization-only failure does not poison the socket: a healthy request on the same connection and a healthy request after reconnect both continue to work.

## Evidence

- Rebased the exact three-commit stack onto `2585edba2efda9ff50e6bed0a6de8cfaef8254fc`; range-diff is unchanged and the affected owner files had no drift.
- `108/108` focused owner and sibling tests passed across nine Gateway WebSocket files.
- Source-blind real WebSocket proof used an actual token-authenticated loopback Gateway and `ws` client: an invalid payload produced one correlated `UNAVAILABLE`, no duplicate followed, a healthy same-socket request serialized once, reconnect remained healthy, and socket/server/plugin-registry cleanup completed.
- The real WebSocket regression does not mock or spy on transport send behavior; the separate low-level test covers serialization, thrown send, slow consumer, and closed transport classification.
- Fallback-send-unavailable probe: exactly two attempts, correlated fallback ID preserved, final code `UNAVAILABLE`, one serialization log, and no recursive retry.
- Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31922861289 passed exact-tree full lint, all test types, architecture/cycles, database/Kysely guards, and diff check.
- Full exact-tree build passed in https://github.com/openclaw/openclaw/actions/runs/31923480994. The candidate-scoped changed gate passed during targeted sync in https://github.com/openclaw/openclaw/actions/runs/31922015305; merge-ref CI is authoritative for two newer-main max-lines ratchet shrinks because this branch was deliberately pinned to the approved frozen base.
- Exact-head merge-ref CI passed at `233fc578b4a49194cbe630c78b4a89853a657b00`: https://github.com/openclaw/openclaw/actions/runs/31923718463
- Fresh Codex autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence `0.98`).
- Live and archive duplicate searches found no equivalent Gateway response-serialization issue or PR.
- No `CHANGELOG.md` edit: normal PRs leave release changelog generation to the release workflow.

AI-assisted; the change and evidence were reviewed and understood.
