### PR TITLE
fix(agents): keep conversation history when truncating oversized tool results

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -357,4 +357,61 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
       { type: "text", text: "[runtime rewrite]" },
     ]);
   });
+
+  it("replays a keyed user turn in the rewritten suffix", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-keyed-"));
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "runtime-sqlite-keyed-suffix-rewrite";
+    const sessionKey = "agent:main:test";
+    const sessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId,
+      storePath,
+    });
+    const target = {
+      agentId: "main",
+      sessionId,
+      sessionKey,
+      storePath,
+    };
+    await replaceSessionEntry({ sessionKey, storePath }, {
+      sessionFile,
+      sessionId,
+      updatedAt: 10,
+    } as SessionEntry);
+    const sessionManager = SessionManager.open(target, dir);
+    const [, toolResultEntryId] = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "run tool", timestamp: 1 }),
+      asAppendMessage(createToolResultReplacement("exec", "before rewrite", 2)),
+      asAppendMessage({
+        role: "user",
+        content: "second question",
+        timestamp: 3,
+        idempotencyKey: "chat-send-key-2",
+      }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("second answer"),
+        timestamp: 4,
+      }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: expectDefined(toolResultEntryId, "persisted tool result entry id"),
+          message: createToolResultReplacement("exec", "[runtime rewrite]", 2),
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const activeMessages = getBranchMessages(SessionManager.open(target, dir));
+    expect(
+      activeMessages.map((message) =>
+        message.role === "user" ? String(message.content) : message.role,
+      ),
+    ).toEqual(["run tool", "toolResult", "second question", "assistant"]);
+  });
 });

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -185,7 +185,12 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
 
   // Maintenance rewrites should preserve the exact requested history without
   // re-running persistence hooks or size truncation on replayed messages.
-  const appendMessage = getRawSessionAppendMessage(params.sessionManager);
+  // The replayed suffix is already-admitted history, so ingress idempotency must
+  // not resolve a replayed key back to its row on the abandoned branch; that
+  // returns a foreign entry id and aborts the replay with the suffix half written.
+  const rawAppendMessage = getRawSessionAppendMessage(params.sessionManager);
+  const appendMessage: typeof rawAppendMessage = (message, options) =>
+    rawAppendMessage(message, { ...options, idempotencyLookup: "caller-checked" });
   const rewrittenEntryIds = new Map<string, string>();
   // Every re-appended message follows the rewritten prefix, so its prefix-bound checkpoint is stale.
   for (const entry of branch.slice(firstMatchedIndex)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users in an ordinary long channel conversation would silently lose most of their conversation history when the agent trimmed an oversized tool result.

Tool-result truncation rewrites the transcript by branching from the replaced entry and re-appending the rest of the conversation. If any message in that re-appended suffix carries an `idempotencyKey`, the replay aborts partway through and the transcript is left permanently cut off at the truncation point. Everything after it is gone from the active conversation, the agent's next turn continues on the amputated branch, and the operation reports `truncated: false` as though it had done nothing.

Idempotency keys are minted on ordinary channel turns (`src/agents/sessions-messaging.ts`, `src/agents/source-reply-mirror.ts`, `src/channels/deliver-transcript.ts`), so any channel conversation long enough to hit tool-result truncation qualifies. The truncation entry points are on the hot path: `src/agents/embedded-agent-runner/run/overflow-context-recovery.ts:226` and `:285`, `src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts:88`, and `src/agents/embedded-agent-runner/context-engine-maintenance.ts:272`, which runs on every post-compaction pass.

## Why This Change Was Made

The replayed suffix is already-admitted history, not new ingress. Ingress idempotency exists to collapse a duplicate submission of the same turn onto the row that was already stored; applying it to a replay resolves the replayed key back to the row on the branch that is being abandoned, hands back a foreign entry id, and aborts the loop with the suffix half written. The replay now declares itself caller-checked, which is the store's existing contract for exactly this case.

No schema change and no schema-version bump. `src/config/sessions/session-accessor.sqlite-transcript-store.ts:105-115` already anticipates caller-checked appends that carry a duplicate key in the payload and leaves the second row's indexed key unset, so the partial unique index on `(session_id, message_idempotency_key)` stays satisfied.

## User Impact

A channel conversation that crosses the tool-result size budget keeps its full history. Only the oversized tool-result bytes shrink; every user question and assistant answer after it survives, and the next turn continues on the complete conversation instead of a stump. Truncation also reports what it actually did rather than a false `truncated: false`.

## Evidence

Driven end to end through the production entry point `truncateOversizedToolResultsInActiveTarget` against a real on-disk SQLite transcript, on pristine `main` and on the patched tree with identical inputs. Verbatim output is in the Real behavior proof block below.

## Root cause

`src/agents/embedded-agent-runner/transcript-rewrite.ts:188` replays the branch suffix through a raw `appendMessage` that passes no `idempotencyLookup`:

```ts
// before
const appendMessage = getRawSessionAppendMessage(params.sessionManager);
```

For a replayed message that carries an `idempotencyKey`, `appendTranscriptMessageInTransaction` (`src/config/sessions/session-accessor.sqlite-transcript-message-append.ts:71-88`) then resolves that key to the pre-rewrite row on the abandoned branch and returns `appended: false` with the old row id. `src/agents/sessions/session-manager-persistence.ts:240` sees `result.messageId !== entry.id`, takes the ingress-adoption path, fails to match, and throws `Session transcript parent entry was not persisted: <id>`. The replay loop has no transaction around it, so the entries already re-appended are committed and the remainder of the suffix is never replayed. `truncateOversizedToolResultsInSessionManager` catches the throw, logs a warning, and returns `{ truncated: false, truncatedCount: 0 }`.

## Fix

```ts
// after
const rawAppendMessage = getRawSessionAppendMessage(params.sessionManager);
const appendMessage: typeof rawAppendMessage = (message, options) =>
  rawAppendMessage(message, { ...options, idempotencyLookup: "caller-checked" });
```

`caller-checked` tells the store the caller has already resolved admission for these messages, which is true: they were read off the branch that was just admitted. The append then inserts a fresh row under the new entry id, the id round-trips, and the replay completes.

## Why this is the right boundary

`rewriteTranscriptEntriesInSessionManager` is the sole owner of branch-and-reappend replay, and the only consumer of `getRawSessionAppendMessage` outside the guard that installs it. Every rewrite caller routes through it, so all three sibling surfaces are covered by the single change: `tool-result-truncation.ts:1294`, `context-engine-maintenance.ts:272`, and `thinking-replay-repair.ts:41`. Wrapping the append once at the top of the replay loop also covers both replay paths inside the function, the verbatim suffix entries and the explicit replacements.

Ingress call sites that legitimately want dedupe are untouched and keep their existing lookup mode (`src/agents/command/attempt-execution.ts:355`, `src/agents/main-session-recovery/main-session-restart-recovery-checkpoint.ts:450`).

A transaction around the replay loop was considered and deliberately not added. The invariant violation, not an arbitrary mid-loop failure, is what tore the branch, and the branch-and-reappend design from #115310 is append-only: the original rows stay in SQLite on the abandoned branch, so the loop is not the durability owner. Adding a transaction would be speculative scope on top of the actual defect.

Production delta is 6 added and 1 removed in one file, three of the added lines being the invariant comment the root guide requires for ownership-boundary behavior. The remaining two lines introduce no new helper, file, or exported surface. All other added lines are the new regression case.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-rewrite.test.ts` passes with the patch (6 passed); the new case fails on pristine `main` with `Error: Session transcript parent entry was not persisted: 12c6f67e` raised from `transcript-rewrite.ts:195`, which is the intended pre-fix reason.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts` passes unchanged (70 passed).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean.
- `node_modules/.bin/oxfmt --check` clean on both changed files.
- Gap, stated plainly so nothing here is assumed green: `scripts/run-oxlint.mjs` could not complete in this environment. It aborts in `prepare-extension-package-boundary-artifacts` on a shared lock directory held by a concurrent checkout, before reaching either changed file. Both changed files are core `src/agents/**` and touch no extension package boundary. CI has not run yet on this branch.
- Full build not run; nothing in this change touches dynamic imports, packaging, or published surfaces.

## Real behavior proof

Behavior addressed: truncating an oversized tool result in a channel conversation permanently drops every conversation turn after the truncation point whenever a later turn carries a delivery idempotency key, while reporting that nothing was truncated.
Real environment tested: the production entry point `truncateOversizedToolResultsInActiveTarget` driven against a real on-disk SQLite session store in an isolated `OPENCLAW_STATE_DIR`, on pristine main c3488150c557f65afada9b3667b4fc0264059d51 and then on the patched tree with byte-identical inputs. Real throughout: the SQLite transcript store, the session accessor, the branch-and-reappend rewrite, the size budget, and reloading each session fresh from disk. Nothing was substituted or stubbed; no provider or network call is involved in this path.
Exact steps or command run after this patch: seed a session through `appendTranscriptMessage` with seven entries (three user turns, two 1.55M-char tool results, two assistant turns), where the second and third user turns carry `idempotencyKey` values as channel delivery assigns them, then call `truncateOversizedToolResultsInActiveTarget({ scope, contextWindowTokens: 200000 })` and reopen the session from SQLite.
Evidence after fix:
```
# BEFORE (pristine main c3488150c55)
--- conversation before tool-result truncation: 7 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 1550000 chars>
      assistant: here is what I found
      user: SECOND USER QUESTION
      toolResult: <toolResult call_2 1550000 chars>
      assistant: THIRD ASSISTANT ANSWER
      user: THIRD USER QUESTION
[agent/embedded] [tool-result-truncation] Failed to truncate: Session transcript parent entry was not persisted: e62071a2
--- truncation reported: {"truncated":false,"truncatedCount":0,"reason":"Session transcript parent entry was not persisted: e62071a2"}
--- conversation reloaded from SQLite after truncation: 3 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 64000 chars>
      assistant: here is what I found
--- conversation turns lost: 3
      LOST user: SECOND USER QUESTION
      LOST assistant: THIRD ASSISTANT ANSWER
      LOST user: THIRD USER QUESTION
--- after the next turn lands on the surviving branch: 4 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 64000 chars>
      assistant: here is what I found
      user: FOURTH USER QUESTION (next turn)

# AFTER (this patch, identical inputs)
--- conversation before tool-result truncation: 7 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 1550000 chars>
      assistant: here is what I found
      user: SECOND USER QUESTION
      toolResult: <toolResult call_2 1550000 chars>
      assistant: THIRD ASSISTANT ANSWER
      user: THIRD USER QUESTION
[agent/embedded] [tool-result-truncation] Truncated 2 tool result(s) in session (contextWindow=200000 maxChars=64000 aggregateBudgetChars=400000 oversized=2 aggregate=0) sessionKey=agent:main:channel
--- truncation reported: {"truncated":true,"truncatedCount":2}
--- conversation reloaded from SQLite after truncation: 7 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 64000 chars>
      assistant: here is what I found
      user: SECOND USER QUESTION
      toolResult: <toolResult call_2 64000 chars>
      assistant: THIRD ASSISTANT ANSWER
      user: THIRD USER QUESTION
--- conversation turns lost: 0
--- after the next turn lands on the surviving branch: 8 transcript entries
      user: please read the big file
      toolResult: <toolResult call_1 64000 chars>
      assistant: here is what I found
      user: SECOND USER QUESTION
      toolResult: <toolResult call_2 64000 chars>
      assistant: THIRD ASSISTANT ANSWER
      user: THIRD USER QUESTION
      user: FOURTH USER QUESTION (next turn)
```
Observed result after fix: the conversation reloaded from disk keeps all seven entries instead of three, the two 1.55M-char tool results shrink to the 64000-char budget, the three lost conversation turns become zero, and the following turn extends the complete conversation rather than a stump.
What was not tested: no live provider or channel round trip; the transcript is driven directly through the session store rather than through a running gateway. Cross-process concurrent writers during a rewrite were not exercised. Full build not run.
