### PR TITLE
refactor(types): drain chained-assertion ledger — extensions

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-result.ts
+++ b/extensions/browser/src/browser/chrome-mcp-result.ts
@@ -21,7 +21,6 @@ import {
   redactChromeMcpProfileLabelForDiagnostic,
 } from "./chrome-mcp-diagnostics.js";
 import type { ChromeMcpSnapshotNode } from "./chrome-mcp.snapshot.js";
-import { ROLE_SNAPSHOT_MAX_DEPTH } from "./snapshot-depth-limit.js";
 
 function asPages(value: unknown): ChromeMcpStructuredPage[] {
   if (!Array.isArray(value)) {
@@ -79,18 +78,8 @@ export function extractStructuredPages(result: ChromeMcpToolResult): ChromeMcpSt
   return structured.length > 0 ? structured : extractTextPages(result);
 }
 
-function normalizeSnapshotNode(value: unknown, depth = 0): ChromeMcpSnapshotNode | null {
-  const record = asNullableRecord(value);
-  if (!record || depth > ROLE_SNAPSHOT_MAX_DEPTH) {
-    return null;
-  }
+function normalizeSnapshotFields(record: Record<string, unknown>): ChromeMcpSnapshotNode {
   const snapshotValue = record.value;
-  const children = Array.isArray(record.children)
-    ? record.children.flatMap((child) => {
-        const normalized = normalizeSnapshotNode(child, depth + 1);
-        return normalized ? [normalized] : [];
-      })
-    : undefined;
   return {
     id: readStringValue(record.id),
     role: readStringValue(record.role),
@@ -101,8 +90,34 @@ function normalizeSnapshotNode(value: unknown, depth = 0): ChromeMcpSnapshotNode
       ? { value: snapshotValue }
       : {}),
     description: readStringValue(record.description),
-    ...(children ? { children } : {}),
   };
+}
+
+function normalizeSnapshotNode(value: unknown): ChromeMcpSnapshotNode | null {
+  const rootRecord = asNullableRecord(value);
+  if (!rootRecord) {
+    return null;
+  }
+  const root = normalizeSnapshotFields(rootRecord);
+  const pending = [{ record: rootRecord, node: root }];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || !Array.isArray(current.record.children)) {
+      continue;
+    }
+    const children: ChromeMcpSnapshotNode[] = [];
+    for (const child of current.record.children) {
+      const record = asNullableRecord(child);
+      if (!record) {
+        continue;
+      }
+      const node = normalizeSnapshotFields(record);
+      children.push(node);
+      pending.push({ record, node });
+    }
+    current.node.children = children;
+  }
+  return root;
 }
 
 export function extractSnapshot(result: ChromeMcpToolResult): ChromeMcpSnapshotNode {

--- a/extensions/browser/src/browser/chrome-mcp-result.ts
+++ b/extensions/browser/src/browser/chrome-mcp-result.ts
@@ -21,6 +21,7 @@ import {
   redactChromeMcpProfileLabelForDiagnostic,
 } from "./chrome-mcp-diagnostics.js";
 import type { ChromeMcpSnapshotNode } from "./chrome-mcp.snapshot.js";
+import { ROLE_SNAPSHOT_MAX_DEPTH } from "./snapshot-depth-limit.js";
 
 function asPages(value: unknown): ChromeMcpStructuredPage[] {
   if (!Array.isArray(value)) {
@@ -78,13 +79,39 @@ export function extractStructuredPages(result: ChromeMcpToolResult): ChromeMcpSt
   return structured.length > 0 ? structured : extractTextPages(result);
 }
 
+function normalizeSnapshotNode(value: unknown, depth = 0): ChromeMcpSnapshotNode | null {
+  const record = asNullableRecord(value);
+  if (!record || depth > ROLE_SNAPSHOT_MAX_DEPTH) {
+    return null;
+  }
+  const snapshotValue = record.value;
+  const children = Array.isArray(record.children)
+    ? record.children.flatMap((child) => {
+        const normalized = normalizeSnapshotNode(child, depth + 1);
+        return normalized ? [normalized] : [];
+      })
+    : undefined;
+  return {
+    id: readStringValue(record.id),
+    role: readStringValue(record.role),
+    name: readStringValue(record.name),
+    ...(typeof snapshotValue === "string" ||
+    typeof snapshotValue === "number" ||
+    typeof snapshotValue === "boolean"
+      ? { value: snapshotValue }
+      : {}),
+    description: readStringValue(record.description),
+    ...(children ? { children } : {}),
+  };
+}
+
 export function extractSnapshot(result: ChromeMcpToolResult): ChromeMcpSnapshotNode {
   const structured = extractStructuredContent(result);
-  const snapshot = asNullableRecord(structured.snapshot);
+  const snapshot = normalizeSnapshotNode(structured.snapshot);
   if (!snapshot) {
     throw new Error("Chrome MCP snapshot response was missing structured snapshot data.");
   }
-  return snapshot as unknown as ChromeMcpSnapshotNode;
+  return snapshot;
 }
 
 function extractJsonBlock(text: string): unknown {

--- a/extensions/deepinfra/doctor-contract-api.ts
+++ b/extensions/deepinfra/doctor-contract-api.ts
@@ -47,21 +47,26 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
   config: OpenClawConfig;
   changes: string[];
 } {
-  const models = asObjectRecord(cfg.models);
-  const providers = asObjectRecord(models?.providers);
-  const provider = asObjectRecord(providers?.deepinfra);
+  const models = cfg.models;
+  const providers = models?.providers;
+  const provider = providers?.deepinfra;
   if (!provider) {
     return { config: cfg, changes: [] };
   }
 
   const changes: string[] = [];
-  const next: Record<string, unknown> = { ...provider };
+  const providerRecord = asObjectRecord(provider) ?? {};
+  const { nativeBaseUrl, ...providerWithoutLegacyNativeBaseUrl } = providerRecord;
+  const next = {
+    ...providerWithoutLegacyNativeBaseUrl,
+    baseUrl: provider.baseUrl,
+    models: provider.models,
+  };
 
   // Change messages never echo configured URL values: a legacy URL may carry
   // userinfo or query tokens, and doctor output lands in terminals/CI logs.
-  if (Object.hasOwn(next, "nativeBaseUrl")) {
-    const legacyNative = normalizeBaseUrlValue(next.nativeBaseUrl);
-    delete next.nativeBaseUrl;
+  if (Object.hasOwn(providerRecord, "nativeBaseUrl")) {
+    const legacyNative = normalizeBaseUrlValue(nativeBaseUrl);
     if (normalizeBaseUrlValue(next.baseUrl)) {
       changes.push(`${PROVIDER_PATH}.nativeBaseUrl: removed (baseUrl is already configured)`);
     } else if (legacyNative && !isDeepInfraApiHost(legacyNative)) {
@@ -101,7 +106,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
       models: {
         ...models,
         providers: { ...providers, deepinfra: next },
-      } as unknown as OpenClawConfig["models"],
+      },
     },
     changes,
   };

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -386,7 +386,7 @@ function toPersistedBindingRecord(record: ThreadBindingRecord): PersistedThreadB
   if (!serialized) {
     return { ...record };
   }
-  return JSON.parse(serialized) as unknown as PersistedThreadBindingRecord;
+  return normalizePersistedBinding(record.threadId, JSON.parse(serialized)) ?? { ...record };
 }
 
 export function saveBindingsToDisk(params: { force?: boolean; minIntervalMs?: number } = {}) {

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -261,8 +261,8 @@ function validateGoogleChatServiceAccountCredentials(
     throw new Error(`Google Chat credentials must use service_account auth, got "${type}" instead`);
   }
 
-  readRequiredTrimmedString(credentials, "client_email");
-  readRequiredTrimmedString(credentials, "private_key");
+  const clientEmail = readRequiredTrimmedString(credentials, "client_email");
+  const privateKey = readRequiredTrimmedString(credentials, "private_key");
 
   const universeDomain = readOptionalTrimmedString(credentials, "universe_domain");
   if (universeDomain && universeDomain !== GOOGLE_AUTH_UNIVERSE_DOMAIN) {
@@ -276,7 +276,11 @@ function validateGoogleChatServiceAccountCredentials(
   assertExactUrlField(credentials, "token_uri", GOOGLE_AUTH_TOKEN_URI);
   assertUrlPrefixField(credentials, "client_x509_cert_url", GOOGLE_CLIENT_CERTS_URL_PREFIX);
 
-  return credentials as unknown as GoogleChatServiceAccountCredentials;
+  return {
+    ...credentials,
+    client_email: clientEmail,
+    private_key: privateKey,
+  };
 }
 
 async function readCredentialsFile(filePath: string): Promise<Record<string, unknown>> {

--- a/extensions/longcat/doctor-contract-api.ts
+++ b/extensions/longcat/doctor-contract-api.ts
@@ -85,7 +85,9 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     if (!isLegacyStockLongCatModel(model)) {
       return model;
     }
-    return { ...model, cost: { ...model.cost, cacheWrite: 0 } };
+    return Object.assign({}, model, {
+      cost: Object.assign({}, model.cost, { cacheWrite: 0 }),
+    });
   });
 
   return {

--- a/extensions/longcat/doctor-contract-api.ts
+++ b/extensions/longcat/doctor-contract-api.ts
@@ -69,11 +69,15 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
   config: OpenClawConfig;
   changes: string[];
 } {
-  const models = asObjectRecord(cfg.models);
-  const providers = asObjectRecord(models?.providers);
-  const provider = asObjectRecord(providers?.longcat);
+  const models = cfg.models;
+  const providers = models?.providers;
+  const provider = providers?.longcat;
   const configuredModels = provider?.models;
-  if (!hasLegacyStockLongCatModel(configuredModels) || !Array.isArray(configuredModels)) {
+  if (
+    !provider ||
+    !hasLegacyStockLongCatModel(configuredModels) ||
+    !Array.isArray(configuredModels)
+  ) {
     return { config: cfg, changes: [] };
   }
 
@@ -81,11 +85,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     if (!isLegacyStockLongCatModel(model)) {
       return model;
     }
-    const row = asObjectRecord(model) ?? {};
-    const cost = asObjectRecord(row.cost) ?? {};
-    return Object.assign({}, row, {
-      cost: Object.assign({}, cost, { cacheWrite: 0 }),
-    });
+    return { ...model, cost: { ...model.cost, cacheWrite: 0 } };
   });
 
   return {
@@ -97,7 +97,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
           ...providers,
           longcat: { ...provider, models: nextModels },
         },
-      } as unknown as OpenClawConfig["models"],
+      },
     },
     changes: ["Updated the historical stock LongCat-2.0 cache-write price from $0.75 to $0."],
   };

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements summary behavior.
+import { asNullableObjectRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isMatrixNotFoundError } from "../errors.js";
 import { resolveMatrixMessageAttachment, resolveMatrixMessageBody } from "../media-text.js";
 import { fetchMatrixPollMessageSummary } from "../poll-summary.js";
@@ -10,6 +11,42 @@ import {
   type RoomMessageEventContent,
   type RoomPinnedEventsEventContent,
 } from "./types.js";
+
+function parseMatrixRawEvent(value: unknown): MatrixRawEvent | null {
+  const event = asNullableObjectRecord(value);
+  const content = asNullableObjectRecord(event?.content);
+  if (
+    !event ||
+    typeof event.event_id !== "string" ||
+    typeof event.sender !== "string" ||
+    typeof event.type !== "string" ||
+    typeof event.origin_server_ts !== "number" ||
+    !content
+  ) {
+    return null;
+  }
+  const unsigned = asNullableObjectRecord(event.unsigned);
+  const relations = asNullableObjectRecord(unsigned?.["m.relations"]);
+  return {
+    event_id: event.event_id,
+    sender: event.sender,
+    type: event.type,
+    origin_server_ts: event.origin_server_ts,
+    content,
+    ...(unsigned
+      ? {
+          unsigned: {
+            ...(typeof unsigned.age === "number" ? { age: unsigned.age } : {}),
+            ...(relations ? { "m.relations": relations } : {}),
+            ...(unsigned.redacted_because !== undefined
+              ? { redacted_because: unsigned.redacted_because }
+              : {}),
+          },
+        }
+      : {}),
+    ...(typeof event.state_key === "string" ? { state_key: event.state_key } : {}),
+  };
+}
 
 function resolveBundledMatrixReplacementContent(
   event: MatrixRawEvent,
@@ -106,7 +143,10 @@ export async function fetchEventSummary(
   eventId: string,
 ): Promise<MatrixMessageSummary | null> {
   try {
-    const raw = await client.getEvent(roomId, eventId);
+    const raw = parseMatrixRawEvent(await client.getEvent(roomId, eventId));
+    if (!raw) {
+      return null;
+    }
     if (raw.unsigned?.redacted_because) {
       return null;
     }

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -106,7 +106,7 @@ export async function fetchEventSummary(
   eventId: string,
 ): Promise<MatrixMessageSummary | null> {
   try {
-    const raw = (await client.getEvent(roomId, eventId)) as unknown as MatrixRawEvent;
+    const raw = await client.getEvent(roomId, eventId);
     if (raw.unsigned?.redacted_because) {
       return null;
     }

--- a/extensions/matrix/src/matrix/sdk/client-core.ts
+++ b/extensions/matrix/src/matrix/sdk/client-core.ts
@@ -429,10 +429,10 @@ export abstract class MatrixClientCore extends MatrixClientBase {
     return uploaded.content_uri;
   }
 
-  async getEvent(roomId: string, eventId: string): Promise<MatrixRawEvent> {
-    const rawEvent = await this.client.fetchRoomEvent(roomId, eventId);
+  async getEvent(roomId: string, eventId: string): Promise<Record<string, unknown>> {
+    const rawEvent = (await this.client.fetchRoomEvent(roomId, eventId)) as Record<string, unknown>;
     if (rawEvent.type !== "m.room.encrypted") {
-      return rawEvent as MatrixRawEvent;
+      return rawEvent;
     }
 
     const mapper = this.client.getEventMapper();

--- a/extensions/matrix/src/matrix/sdk/client-core.ts
+++ b/extensions/matrix/src/matrix/sdk/client-core.ts
@@ -429,10 +429,10 @@ export abstract class MatrixClientCore extends MatrixClientBase {
     return uploaded.content_uri;
   }
 
-  async getEvent(roomId: string, eventId: string): Promise<Record<string, unknown>> {
-    const rawEvent = (await this.client.fetchRoomEvent(roomId, eventId)) as Record<string, unknown>;
+  async getEvent(roomId: string, eventId: string): Promise<MatrixRawEvent> {
+    const rawEvent = await this.client.fetchRoomEvent(roomId, eventId);
     if (rawEvent.type !== "m.room.encrypted") {
-      return rawEvent;
+      return rawEvent as MatrixRawEvent;
     }
 
     const mapper = this.client.getEventMapper();

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -743,7 +743,7 @@ export function buildFoundryAuthResult(params: {
               api: params.api,
               deployments: params.deployments,
             },
-          ) as unknown as ModelProviderConfig,
+          ),
         },
       },
       ...buildPluginsAllowPatch(params.currentPluginsAllow),

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -6,6 +6,7 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-ingress";
+import { z } from "zod";
 import { normalizeAccountId, resolveQaBusPollStartCursor } from "./bus-queries.js";
 import type { QaBusState } from "./bus-state.js";
 import type {
@@ -28,6 +29,141 @@ const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
 const QA_MALFORMED_JSON_BODY_MESSAGE = "Malformed JSON body";
+
+const qaBusConversationSchema = z
+  .object({
+    id: z.string(),
+    kind: z.enum(["direct", "channel", "group"]),
+    title: z.string().optional(),
+  })
+  .passthrough();
+const qaBusAttachmentSchema = z
+  .object({
+    id: z.string(),
+    kind: z.enum(["image", "video", "audio", "file"]),
+    mimeType: z.string(),
+    mediaFactCarrier: z.enum(["path", "media-store-url"]).optional(),
+    fileName: z.string().optional(),
+    inline: z.boolean().optional(),
+    url: z.string().optional(),
+    contentBase64: z.string().optional(),
+    width: z.number().optional(),
+    height: z.number().optional(),
+    durationMs: z.number().optional(),
+    altText: z.string().optional(),
+    transcript: z.string().optional(),
+  })
+  .passthrough();
+const qaBusToolCallSchema = z
+  .object({
+    name: z.string(),
+    arguments: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+const qaBusMessageOptionalFields = {
+  accountId: z.string().optional(),
+  senderName: z.string().optional(),
+  timestamp: z.number().optional(),
+  threadId: z.string().optional(),
+  replyToId: z.string().optional(),
+  attachments: z.array(qaBusAttachmentSchema).optional(),
+  toolCalls: z.array(qaBusToolCallSchema).optional(),
+};
+
+const qaBusRequestBodySchemas = {
+  "/v1/inbound/message": z
+    .object({
+      ...qaBusMessageOptionalFields,
+      conversation: qaBusConversationSchema,
+      senderId: z.string(),
+      text: z.string(),
+      threadTitle: z.string().optional(),
+      nativeCommand: z.object({ name: z.string() }).passthrough().optional(),
+    })
+    .passthrough(),
+  "/v1/outbound/message": z
+    .object({
+      ...qaBusMessageOptionalFields,
+      to: z.string(),
+      senderId: z.string().optional(),
+      text: z.string(),
+      isError: z.boolean().optional(),
+    })
+    .passthrough(),
+  "/v1/actions/thread-create": z
+    .object({
+      accountId: z.string().optional(),
+      conversationId: z.string(),
+      title: z.string(),
+      createdBy: z.string().optional(),
+      timestamp: z.number().optional(),
+    })
+    .passthrough(),
+  "/v1/actions/react": z
+    .object({
+      accountId: z.string().optional(),
+      messageId: z.string(),
+      emoji: z.string(),
+      senderId: z.string().optional(),
+      timestamp: z.number().optional(),
+    })
+    .passthrough(),
+  "/v1/actions/edit": z
+    .object({
+      accountId: z.string().optional(),
+      messageId: z.string(),
+      text: z.string(),
+      timestamp: z.number().optional(),
+    })
+    .passthrough(),
+  "/v1/actions/delete": z
+    .object({
+      accountId: z.string().optional(),
+      messageId: z.string(),
+      timestamp: z.number().optional(),
+    })
+    .passthrough(),
+  "/v1/actions/read": z
+    .object({
+      accountId: z.string().optional(),
+      messageId: z.string(),
+    })
+    .passthrough(),
+  "/v1/wait": z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("event-kind"),
+      eventKind: z.enum([
+        "inbound-message",
+        "outbound-message",
+        "thread-created",
+        "message-edited",
+        "message-deleted",
+        "reaction-added",
+      ]),
+      timeoutMs: z.number().optional(),
+    }),
+    z.object({
+      kind: z.literal("message-text"),
+      textIncludes: z.string(),
+      direction: z.enum(["inbound", "outbound"]).optional(),
+      timeoutMs: z.number().optional(),
+    }),
+    z.object({
+      kind: z.literal("thread-id"),
+      threadId: z.string(),
+      timeoutMs: z.number().optional(),
+    }),
+  ]),
+} satisfies {
+  "/v1/inbound/message": z.ZodType<QaBusInboundMessageInput>;
+  "/v1/outbound/message": z.ZodType<QaBusOutboundMessageInput>;
+  "/v1/actions/thread-create": z.ZodType<QaBusCreateThreadInput>;
+  "/v1/actions/react": z.ZodType<QaBusReactToMessageInput>;
+  "/v1/actions/edit": z.ZodType<QaBusEditMessageInput>;
+  "/v1/actions/delete": z.ZodType<QaBusDeleteMessageInput>;
+  "/v1/actions/read": z.ZodType<QaBusReadMessageInput>;
+  "/v1/wait": z.ZodType<QaBusWaitForInput>;
+};
 
 class QaMalformedJsonBodyError extends Error {
   constructor() {
@@ -210,37 +346,51 @@ export async function handleQaBusRequest(params: {
         return true;
       case "/v1/inbound/message":
         writeJson(params.res, 200, {
-          message: params.state.addInboundMessage(body as unknown as QaBusInboundMessageInput),
+          message: params.state.addInboundMessage(
+            qaBusRequestBodySchemas["/v1/inbound/message"].parse(body),
+          ),
         });
         return true;
       case "/v1/outbound/message":
         writeJson(params.res, 200, {
-          message: params.state.addOutboundMessage(body as unknown as QaBusOutboundMessageInput),
+          message: params.state.addOutboundMessage(
+            qaBusRequestBodySchemas["/v1/outbound/message"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/thread-create":
         writeJson(params.res, 200, {
-          thread: params.state.createThread(body as unknown as QaBusCreateThreadInput),
+          thread: params.state.createThread(
+            qaBusRequestBodySchemas["/v1/actions/thread-create"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/react":
         writeJson(params.res, 200, {
-          message: params.state.reactToMessage(body as unknown as QaBusReactToMessageInput),
+          message: params.state.reactToMessage(
+            qaBusRequestBodySchemas["/v1/actions/react"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/edit":
         writeJson(params.res, 200, {
-          message: params.state.editMessage(body as unknown as QaBusEditMessageInput),
+          message: params.state.editMessage(
+            qaBusRequestBodySchemas["/v1/actions/edit"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/delete":
         writeJson(params.res, 200, {
-          message: params.state.deleteMessage(body as unknown as QaBusDeleteMessageInput),
+          message: params.state.deleteMessage(
+            qaBusRequestBodySchemas["/v1/actions/delete"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/read":
         writeJson(params.res, 200, {
-          message: params.state.readMessage(body as unknown as QaBusReadMessageInput),
+          message: params.state.readMessage(
+            qaBusRequestBodySchemas["/v1/actions/read"].parse(body),
+          ),
         });
         return true;
       case "/v1/actions/search":
@@ -279,7 +429,7 @@ export async function handleQaBusRequest(params: {
       }
       case "/v1/wait":
         writeJson(params.res, 200, {
-          match: await params.state.waitFor(body as unknown as QaBusWaitForInput),
+          match: await params.state.waitFor(qaBusRequestBodySchemas["/v1/wait"].parse(body)),
         });
         return true;
       default:

--- a/extensions/reef/protocol/guard.ts
+++ b/extensions/reef/protocol/guard.ts
@@ -123,7 +123,13 @@ export function parseVerdict(value: unknown): Verdict {
   ) {
     throw new Error("invalid guard verdict fields");
   }
-  return record as unknown as Verdict;
+  return {
+    decision: record.decision,
+    category: record.category,
+    reason: record.reason,
+    model: record.model,
+    policyVersion: record.policyVersion,
+  };
 }
 
 function guardFailure(model: string, policyVersion: string): Verdict {

--- a/extensions/reef/src/doctor-durable-state.ts
+++ b/extensions/reef/src/doctor-durable-state.ts
@@ -9,6 +9,7 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 // Import from defining modules, not the protocol barrel: index.js re-exports
 // guard-adapters, whose provider-http graph doctor enumeration must not cold-load.
 import { verifyChain, verifyChainSegment, type AuditEntry } from "../protocol/audit.js";
+import { parseVerdict } from "../protocol/guard.js";
 import type { ReviewRequest } from "../protocol/pipeline.js";
 import type { SignedReceipt } from "../protocol/receipts.js";
 import {
@@ -121,6 +122,43 @@ function requireLegacyReplayString(record: Record<string, unknown>, field: strin
   return value;
 }
 
+function parseLegacySignedReceipt(value: Record<string, unknown>): SignedReceipt {
+  const id = requireLegacyReplayString(value, "id");
+  const bodyHash = requireLegacyReplayString(value, "bodyHash");
+  const auditHead = requireLegacyReplayString(value, "auditHead");
+  const signature = requireLegacyReplayString(value, "signature");
+  if (value.status !== "accepted" && value.status !== "rejected") {
+    throw new Error("invalid Reef replay receipt status");
+  }
+  if (value.category !== undefined && typeof value.category !== "string") {
+    throw new Error("invalid Reef replay receipt category");
+  }
+  return {
+    id,
+    bodyHash,
+    auditHead,
+    status: value.status,
+    signature,
+    ...(value.category !== undefined ? { category: value.category } : {}),
+  };
+}
+
+function parseLegacyReviewRequest(value: Record<string, unknown>): ReviewRequest {
+  const direction = value.direction;
+  if (direction !== "inbound" && direction !== "outbound") {
+    throw new Error("invalid Reef review direction");
+  }
+  return {
+    id: requireLegacyReplayString(value, "id"),
+    from: requireLegacyReplayString(value, "from"),
+    to: requireLegacyReplayString(value, "to"),
+    direction,
+    bodyHash: requireLegacyReplayString(value, "bodyHash"),
+    approvalDigest: requireLegacyReplayString(value, "approvalDigest"),
+    verdict: parseVerdict(value.verdict),
+  };
+}
+
 function parseLegacyReefReplayLine(value: unknown): LegacyReefReplayLogRecord {
   if (!isRecord(value)) {
     throw new Error("invalid Reef replay record");
@@ -141,7 +179,7 @@ function parseLegacyReefReplayLine(value: unknown): LegacyReefReplayLogRecord {
   if (value.op !== "complete" || !isRecord(value.receipt)) {
     throw new Error("invalid Reef replay operation");
   }
-  const receipt = value.receipt as unknown as SignedReceipt;
+  const receipt = parseLegacySignedReceipt(value.receipt);
   if (receipt.id !== id || !["accepted", "rejected"].includes(receipt.status)) {
     throw new Error("invalid Reef replay receipt");
   }
@@ -227,7 +265,7 @@ async function readLegacyReefReviews(filePath: string): Promise<Map<string, Reef
     if (!isRecord(raw) || !isRecord(raw.review)) {
       throw new Error(`invalid Reef review ${digest}`);
     }
-    const review = raw.review as unknown as ReviewRequest;
+    const review = parseLegacyReviewRequest(raw.review);
     if (
       review.approvalDigest !== digest ||
       (raw.approved !== undefined && typeof raw.approved !== "boolean")

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -9,6 +9,7 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 // Inline content types
 type StoryInline =
   | string
+  | { __image: { src: string; alt: string } }
   | { bold: StoryInline[] }
   | { italics: StoryInline[] }
   | { strike: StoryInline[] }
@@ -121,7 +122,7 @@ function parseInlineMarkdown(text: string): StoryInline[] {
           src: expectDefined(imageMatch[2], "image URL capture"),
           alt: expectDefined(imageMatch[1], "image alt capture"),
         },
-      } as unknown as StoryInline);
+      });
       remaining = remaining.slice(imageMatch[0].length);
       continue;
     }
@@ -231,7 +232,7 @@ function processInlinesForImages(inlines: StoryInline[]): {
 
   for (const inline of inlines) {
     if (typeof inline === "object" && "__image" in inline) {
-      const img = (inline as unknown as { __image: { src: string; alt: string } })["__image"];
+      const img = inline.__image;
       imageBlocks.push(createImageBlock(img.src, img.alt));
     } else {
       cleanInlines.push(inline);

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -9,7 +9,7 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 // Inline content types
 type StoryInline =
   | string
-  | { __image: { src: string; alt: string } }
+  | { imageBlock: { src: string; alt: string } }
   | { bold: StoryInline[] }
   | { italics: StoryInline[] }
   | { strike: StoryInline[] }
@@ -118,7 +118,7 @@ function parseInlineMarkdown(text: string): StoryInline[] {
     if (imageMatch) {
       // Return a special marker that will be hoisted to a block
       result.push({
-        __image: {
+        imageBlock: {
           src: expectDefined(imageMatch[2], "image URL capture"),
           alt: expectDefined(imageMatch[1], "image alt capture"),
         },
@@ -231,8 +231,8 @@ function processInlinesForImages(inlines: StoryInline[]): {
   const imageBlocks: StoryVerse[] = [];
 
   for (const inline of inlines) {
-    if (typeof inline === "object" && "__image" in inline) {
-      const img = inline.__image;
+    if (typeof inline === "object" && "imageBlock" in inline) {
+      const img = inline.imageBlock;
       imageBlocks.push(createImageBlock(img.src, img.alt));
     } else {
       cleanInlines.push(inline);

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -97,8 +97,13 @@ function parseClaimedUpdate(payload: ZaloWebhookSpoolPayload, claimedId: string)
   const message = facts.update.message as Record<string, unknown>;
   const from = isRecord(message.from) ? message.from : null;
   const chat = isRecord(message.chat) ? message.chat : null;
-  if (!nonEmptyString(from?.id)) {
+  const fromId = nonEmptyString(from?.id);
+  if (!from || !fromId) {
     throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.from.id.");
+  }
+  const chatId = nonEmptyString(chat?.id);
+  if (!chatId) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
   }
   if (chat?.chat_type !== "PRIVATE" && chat?.chat_type !== "GROUP") {
     throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid chat type.");
@@ -109,7 +114,29 @@ function parseClaimedUpdate(payload: ZaloWebhookSpoolPayload, claimedId: string)
   if (eventName === "message.text.received" && typeof message.text !== "string") {
     throw new ZaloWebhookPayloadError("Zalo text event is missing message.text.");
   }
-  return facts.update as unknown as ZaloUpdate;
+  return {
+    event_name: eventName,
+    message: {
+      message_id: claimedId,
+      from: {
+        id: fromId,
+        ...(typeof from.name === "string" ? { name: from.name } : {}),
+        ...(typeof from.display_name === "string" ? { display_name: from.display_name } : {}),
+        ...(typeof from.avatar === "string" ? { avatar: from.avatar } : {}),
+        ...(typeof from.is_bot === "boolean" ? { is_bot: from.is_bot } : {}),
+      },
+      chat: {
+        id: chatId,
+        chat_type: chat.chat_type,
+      },
+      date: message.date,
+      ...(typeof message.text === "string" ? { text: message.text } : {}),
+      ...(typeof message.photo_url === "string" ? { photo_url: message.photo_url } : {}),
+      ...(typeof message.caption === "string" ? { caption: message.caption } : {}),
+      ...(typeof message.sticker === "string" ? { sticker: message.sticker } : {}),
+      ...(typeof message.message_type === "string" ? { message_type: message.message_type } : {}),
+    },
+  };
 }
 
 function isZaloAuthenticationFailure(error: unknown): boolean {

--- a/scripts/oxlint-boundary-guards.mjs
+++ b/scripts/oxlint-boundary-guards.mjs
@@ -631,38 +631,76 @@ export default {
       roots: ["src", "extensions", "packages", "ui/src", BOUNDARY_GUARD_FIXTURE_ROOT],
       // Burn-down ledger — shrink only; see PR #124060/#124073/#124079/#124082.
       excludedRoots: [
-        "extensions/amazon-bedrock-mantle",
-        "extensions/anthropic-vertex",
-        "extensions/browser",
-        "extensions/codex",
-        "extensions/copilot",
-        "extensions/deepinfra",
-        "extensions/diagnostics-otel",
-        "extensions/diagnostics-prometheus",
-        "extensions/discord",
-        "extensions/github-copilot",
-        "extensions/google",
-        "extensions/googlechat",
-        "extensions/imessage",
-        "extensions/line",
-        "extensions/llm-task",
-        "extensions/longcat",
-        "extensions/matrix",
-        "extensions/microsoft-foundry",
-        "extensions/msteams",
-        "extensions/qa-lab",
-        "extensions/reef",
-        "extensions/signal",
-        "extensions/slack",
-        "extensions/sms",
-        "extensions/synology-chat",
-        "extensions/telegram",
-        "extensions/tlon",
-        "extensions/voice-call",
-        "extensions/whatsapp",
-        "extensions/workboard",
-        "extensions/zalo",
-        "extensions/zalouser",
+        "extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts", // duplicate SDK installs make the Anthropic client class nominal
+        "extensions/anthropic-vertex/stream-runtime.ts", // Undici and DOM fetch return types use distinct body namespaces
+        "extensions/browser/src/browser/bridge-server.ts", // Express app crosses the browser route registrar SDK seam
+        "extensions/browser/src/browser/pw-session-actions.ts", // Playwright role overloads cannot express runtime-selected roles
+        "extensions/browser/src/browser/pw-session.page-cdp.ts", // Playwright CDP typings require a closed method-name map
+        "extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts", // navigation observation uses a narrowed Playwright page capability
+        "extensions/browser/src/browser/pw-tools-core.state.ts", // Playwright CDP typings require a closed method-name map
+        "extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts", // test support
+        "extensions/browser/src/browser/system-chrome-cookies.ts", // SQLite row results cross the browser cookie schema boundary
+        "extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts", // batch budgeting intentionally sees permissive actions before route validation
+        "extensions/browser/src/server.ts", // Express app crosses the browser route registrar SDK seam
+        "extensions/codex/src/app-server/event-projector-tool-transcript.ts", // Codex transcript synthesis extends the public AgentMessage union
+        "extensions/codex/src/app-server/run-attempt-resources.ts", // staged attempt resources initialize required lifecycle fields later
+        "extensions/codex/src/app-server/run-attempt-runtime.ts", // supervised Codex models bridge the agent-harness model generic
+        "extensions/copilot/harness.ts", // test support
+        "extensions/copilot/src/attempt-execution.ts", // Copilot SDK session implementations expose incompatible private shapes
+        "extensions/copilot/src/attempt-transcript-journal.ts", // OpenClaw transcript metadata extends the public AgentMessage union
+        "extensions/copilot/src/byok-proxy.ts", // DOM and Node readable streams use distinct type namespaces
+        "extensions/copilot/src/isolated-completion.ts", // Copilot SDK isolated sessions expose a narrower private shape
+        "extensions/copilot/src/runtime.ts", // staged Copilot client state initializes after async acquisition
+        "extensions/copilot/src/tool-bridge.ts", // plugin tool metadata crosses duplicate SDK package types
+        "extensions/diagnostics-otel/src/service.ts", // optional diagnostics capabilities are private runtime extensions
+        "extensions/diagnostics-prometheus/src/service.ts", // exporter health reporting is a private diagnostics bridge
+        "extensions/discord/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/discord/src/components.modal.ts", // test-only fallback preserves partially mocked Discord module graphs
+        "extensions/discord/src/monitor/gateway-plugin.ts", // Discord gateway lifecycle needs private SDK state
+        "extensions/discord/src/monitor/message-handler.hydration.ts", // hydrated Discord messages bridge SDK constructor-private fields
+        "extensions/discord/src/monitor/provider.startup-log.ts", // reconnect attempts are private Discord gateway diagnostics
+        "extensions/discord/src/monitor/threading.starter.ts", // Discord thread channels narrow a dependency union after runtime checks
+        "extensions/github-copilot/index.ts", // config merge patches are intentionally deeper than Partial<OpenClawConfig>
+        "extensions/google/realtime-voice-provider.ts", // provider tool schemas and lifecycle fields bridge Google SDK versions
+        "extensions/google/transport-stream.ts", // transport stream seam; needs API redesign
+        "extensions/googlechat/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/imessage/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/line/src/outbound.ts", // LINE batch overload requires a bounded tuple that slice cannot retain
+        "extensions/llm-task/index.ts", // tool factory bridges plugin-local and public AgentTool package types
+        "extensions/matrix/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/matrix/src/matrix/client/logging.ts", // Matrix SDK logger singleton has an undeclared loglevel capability
+        "extensions/matrix/src/test-runtime.ts", // test support
+        "extensions/msteams/src/attachments/shared.ts", // Vitest mock metadata is intentionally probed in production test support
+        "extensions/msteams/src/sdk-proactive.ts", // proactive sends require private Teams app transport internals
+        "extensions/msteams/src/sdk.ts", // Teams SDK public and deep-import types disagree across package boundaries
+        "extensions/qa-lab/src/harness-runtime.ts", // test harness runtime implements the public PluginRuntime surface
+        "extensions/qa-lab/src/suite-runtime-agent-session.ts", // symbol-keyed session metadata extends transcript entries
+        "extensions/reef/protocol/envelope.ts", // signed version fields authenticate before unsupported versions are rejected
+        "extensions/signal/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/slack/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/slack/src/monitor/events/agent.ts", // Slack app typings omit the agent event registrar
+        "extensions/slack/src/monitor/events/assistant.ts", // Slack app typings omit the assistant event registrar
+        "extensions/slack/src/monitor/events/messages.ts", // app mentions adapt into the shared Slack message pipeline
+        "extensions/slack/src/monitor/slash.ts", // Slack action and options overloads omit runtime middleware fields
+        "extensions/slack/src/progress-blocks.ts", // Slack runtime supports url_source ahead of its published types
+        "extensions/slack/src/streaming.ts", // failed-stream recovery clears a private Slack SDK buffer
+        "extensions/sms/src/channel.ts", // channel runtime crosses the public plugin adapter seam
+        "extensions/synology-chat/src/channel.ts", // plugin factory implementation carries a narrower runtime surface
+        "extensions/synology-chat/src/test-http-utils.ts", // test support
+        "extensions/telegram/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/telegram/src/client-fetch.ts", // Telegram and DOM fetch signatures use distinct body namespaces
+        "extensions/telegram/src/doctor-contract.ts", // legacy doctor migration normalizes retired untyped config shapes
+        "extensions/telegram/src/fetch.ts", // Node DNS and Undici fetch overloads bridge DOM-compatible runtime calls
+        "extensions/telegram/src/outbound-media.ts", // Telegram API operation selection crosses overloaded method signatures
+        "extensions/telegram/src/telegram-ingress-supersede-auth.ts", // Telegraf message input narrows into the ingress message contract
+        "extensions/voice-call/src/webhook.ts", // voice runtime layers a core config subset into the full config contract
+        "extensions/whatsapp/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
+        "extensions/whatsapp/src/inbound/group-metadata-cache.ts", // Baileys event overloads are stricter than its emitted payloads
+        "extensions/whatsapp/src/inbound/message-delivery.ts", // Baileys listener registration erases per-event callback parameters
+        "extensions/whatsapp/src/inbound/socket-session.ts", // Baileys emitter typings omit generic listener and detach capabilities
+        "extensions/whatsapp/src/session.ts", // Baileys WebSocket and emitter cleanup use undeclared runtime capabilities
+        "extensions/workboard/src/store-core.ts", // legacy keyed store multiplexes cards, boards, subscriptions, and attachments
+        "extensions/zalouser/src/zca-client.ts", // optional zca-js runtime is loaded through a local lazy module facade
         "packages/ai",
         "src/acp/client.ts", // Node and Web ReadableStream types live in separate namespaces.
         "src/acp/server.ts", // Node and Web ReadableStream types live in separate namespaces.


### PR DESCRIPTION
## What Problem This Solves

The no-chained-type-assertions guard still excluded every bundled plugin scope, leaving 124 findings in 82 extension files outside enforcement.

## Why This Change Was Made

This drains the extension portion of the burn-down ledger. Twenty-one fixable assertions now retain type evidence through boundary parsers, schema validation, owner return types, or typed reconstruction. The remaining 103 assertions are narrowed to 70 exact files, each with a reviewable reason describing the dependency, SDK, lifecycle, test-support, or protocol seam that still requires the assertion.

Notable owner fixes include a Zod-owned QA bus request envelope, validated Matrix/Chrome/Zalo/Reef boundary objects, typed provider doctor migrations, and reuse of Discord's canonical persisted-binding normalizer. No public Plugin SDK shape changes.

## User Impact

No user-facing feature change. Extension code now gets the chained-assertion guard by default, while malformed external inputs are parsed before entering typed runtime paths.

## Evidence

- `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json extensions` — pass
- `node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions packages ui/src` — pass
- `node scripts/run-vitest.mjs test/scripts/oxlint-boundary-guards.test.ts` — 4 tests pass
- Focused plugin tests for browser, DeepInfra, Discord, Google Chat, LongCat, Matrix, Microsoft Foundry, QA Lab, Reef, Tlon, and Zalo — pass; the exact Chrome MCP regression file has 87 passing tests and the final Matrix shard has 147
- `node scripts/check-changed.mjs` — changed production/test typechecks and extension/script lint pass; final unrelated runtime-sidecar guard cannot run in this linked worktree because local `node_modules/playwright-core` is intentionally absent (remote `ci-fast` backend was unavailable)
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- Initial inventory: 124 findings / 82 files. Result: 21 fixed / 103 ledgered in 70 exact files with reasons; zero extension scope exclusions
- LOC: production `+357/-42` (net +315, primarily runtime boundary schemas/parsers); tooling ledger `+70/-32`; tests `+0/-0`

Codex-backed seams were checked directly against upstream app-server protocol ownership in `codex-rs/app-server-protocol/src/protocol/v2/model.rs`, `protocol/v2/thread.rs`, and `protocol/event_mapping.rs`; the Codex assertions remain exact-file entries for transcript and staged lifecycle bridges.
