### PR TITLE
fix(agents): apply_patch silently deletes lines when a chunk is marked End of File

### DIFF
--- a/src/agents/apply-patch-eof-hunks.test.ts
+++ b/src/agents/apply-patch-eof-hunks.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { applyPatch } from "./apply-patch.test-support.js";
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-eof-")));
+  try {
+    return await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("applyPatch end-of-file hunks", () => {
+  it("rejects an end-of-file hunk that reclaims lines an earlier hunk consumed", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "source.txt");
+      await fs.writeFile(filePath, "a\nb\nc\n", "utf8");
+      const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-a
+-b
++X
+@@
+-b
+-c
++Y
+*** End of File
+*** End Patch`;
+
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Failed to find expected lines/,
+      );
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("a\nb\nc\n");
+    });
+  });
+
+  it("applies an end-of-file hunk that follows an earlier disjoint hunk", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "source.txt");
+      await fs.writeFile(filePath, "a\nb\nc\nd\n", "utf8");
+      const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-a
++X
+@@
+-c
+-d
++Y
+*** End of File
+*** End Patch`;
+
+      await applyPatch(patch, { cwd: dir });
+
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("X\nb\nY\n");
+    });
+  });
+});

--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -187,7 +187,7 @@ function seekSequence(
   }
 
   const maxStart = lines.length - pattern.length;
-  const searchStart = eof && lines.length >= pattern.length ? maxStart : start;
+  const searchStart = eof ? Math.max(start, maxStart) : start;
   if (searchStart > maxStart) {
     return { kind: "missing" };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent editing a file with `apply_patch` could destroy lines it never asked to change, and be told the edit succeeded. It triggers when a patch has more than one update chunk for the same file and the last chunk carries the standard `*** End of File` marker while restating a line an earlier chunk already consumed. A three line file loses two of its lines, the requested replacement is never written, and the tool result reads `Success. Updated the following files`.

This is on the default path for every model: `apply_patch` is bound unless `tools.exec.applyPatch.enabled` is explicitly false (`src/agents/agent-tools.ts:545`), and `isApplyPatchAllowedForModel` allows every model when `allowModels` is empty (`src/agents/apply-patch-model-policy.ts:11`). The agent has no signal that anything went wrong, so the destroyed content survives only in git.

## Why This Change Was Made

`seekSequence` locates each chunk's old lines starting from the cursor the previous chunk left behind. For an end-of-file chunk it discarded that cursor entirely and searched only from the last possible offset:

```ts
// before, src/agents/apply-patch-update.ts:174
const maxStart = lines.length - pattern.length;
const searchStart = eof && lines.length >= pattern.length ? maxStart : start;
if (searchStart > maxStart) {
  return null;
}
```

In that branch `searchStart` is always exactly `maxStart`, so the guard below it can never fire, and the match can land behind the cursor, inside a region an earlier chunk already claimed. `computeReplacements` then records two overlapping windows and `applyReplacements` splices both, deleting the same lines twice.

```ts
// after
const searchStart = eof ? Math.max(start, maxStart) : start;
```

The end-of-file preference is kept, but it can no longer reach behind the cursor. When the only end-of-file position would overlap an earlier chunk, the existing `searchStart > maxStart` guard finally fires, the match fails, and `apply_patch` raises `Failed to find expected lines in <path>` with the offending lines instead of writing a corrupted file. The `lines.length >= pattern.length` term was redundant with the `pattern.length > lines.length` early return above it.

This lands at the same ownership boundary the sibling `edit` tool already enforces: `src/agents/sessions/tools/edit-diff.ts:539` rejects edits whose matched ranges overlap. `apply_patch` was the surface missing that invariant. Production delta is one changed line, net zero; the regression coverage is a new colocated file because `src/agents/apply-patch.test.ts` is at its `max-lines` ceiling.

Scope is limited to the overlap defect. Other `apply_patch` matching issues (patch indentation on added lines, uniqueness of the tolerant `trim()` match, BOM and end of line handling) are separate defects and are not touched here.

## User Impact

Agents can no longer silently lose file content through a multi chunk `apply_patch` whose final chunk is marked `*** End of File`. A patch that would have produced overlapping edits is now refused with a message naming the file and the lines that could not be placed, so the model can retry with disjoint chunks. Patches whose end-of-file chunk sits after the previous chunk keep applying exactly as before.

## Evidence

Both scenarios below were driven through the real `apply_patch` tool built by `createApplyPatchTool` against real files on disk, first with the tree pinned to `main` at `92b6c17bb82`, then with this patch applied and the same inputs. Nothing was stubbed: the real parser, the real matcher, the real workspace guard and the real filesystem writes. The disjoint scenario is included to show the fix changes only the overlapping case.

Maintainer validation on exact head `1c899f949eac67fd9d276a62e656d97be132201a` used sanitized direct AWS Crabbox run [`run_89b0c56dbaee`](https://crabbox.openclaw.ai/portal/runs/run_89b0c56dbaee): all six `src/agents/apply-patch*.test.ts` files passed (95 tests), targeted format checks passed, and targeted oxlint completed with 0 warnings and 0 errors. Local autoreview was clean, and exact-head hosted CI completed without a failure.

## Real behavior proof
Behavior addressed: a multi chunk apply_patch whose final chunk is marked `*** End of File` and restates a line the previous chunk consumed deletes lines it was never asked to touch and still reports success.
Real environment tested: the real `apply_patch` tool from `createApplyPatchTool({ cwd })` driven against real files in a temporary workspace, on pristine `main` `92b6c17bb82` and on the patched tree; the parser, matcher, workspace guard and filesystem writes all stayed real, and nothing was stubbed or faked.
Exact steps or command run after this patch: write `a\nb\nc\n` to `notes.txt` and `a\nb\nc\nd\n` to `other.txt`, then call the tool with `*** Begin Patch / *** Update File / @@ -a -b +X / @@ -b -c +Y / *** End of File / *** End Patch` for `notes.txt` and with the disjoint `@@ -a +X / @@ -c -d +Y / *** End of File` for `other.txt`, then read both files back from disk.
Evidence after fix:
```
# BEFORE (pristine main 92b6c17bb82)
[overlapping end-of-file hunk]
  file before  : "a\nb\nc\n"
  tool reported : Success. Updated the following files: | M notes.txt
  file on disk : "X\n"
[disjoint end-of-file hunk]
  file before  : "a\nb\nc\nd\n"
  tool reported : Success. Updated the following files: | M other.txt
  file on disk : "X\nb\nY\n"

# AFTER (this patch, identical inputs)
[overlapping end-of-file hunk]
  file before  : "a\nb\nc\n"
  tool reported : Failed to find expected lines in <tmp>/notes.txt: | b | c
  file on disk : "a\nb\nc\n"
[disjoint end-of-file hunk]
  file before  : "a\nb\nc\nd\n"
  tool reported : Success. Updated the following files: | M other.txt
  file on disk : "X\nb\nY\n"
```
Observed result after fix: on the base tree the three line file collapsed to `X\n` while the tool announced success, and after the patch the same input leaves the file byte identical and the tool reports the failure, while the disjoint patch still applies to `X\nb\nY\n`.
What was not tested: very large files, CRLF sources, sandbox-backed hosts, and a live-model end-to-end flow were not exercised by this maintainer proof.

Punchcard-Session: frost-orchard-willow-p3
