### PR TITLE
fix(gateway): close ask-fallback replay to cancelled approvals

### DIFF
--- a/src/gateway/exec-approval-manager.expiry.test.ts
+++ b/src/gateway/exec-approval-manager.expiry.test.ts
@@ -81,4 +81,28 @@ describe("ExecApprovalManager timeout expiry publication", () => {
       { recordId: record.id, status: "expired", requestCommand: "echo expired" },
     ]);
   });
+
+  it("rejects ask-fallback replay of a run-aborted cancellation", async () => {
+    installTimerMocks();
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-cancelled");
+    const decisionPromise = manager.register(record, 60_000);
+
+    // Dispatch fencing / run abort ends decision-less like a timeout, but its
+    // authority closed deliberately — replay must not re-admit through it.
+    const denied = manager.forceDenyDetailed(
+      "approval-cancelled",
+      "run-aborted",
+      { kind: "system", id: "worker-dispatch" },
+      "cancelled",
+    );
+    expect(denied.outcome).toBe("denied");
+    await expect(decisionPromise).resolves.toBeNull();
+
+    expect(manager.getSnapshot("approval-cancelled")).toMatchObject({
+      status: "cancelled",
+      terminalReason: "run-aborted",
+    });
+    expect(manager.consumeAskFallback("approval-cancelled")).toBe(false);
+  });
 });

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -160,7 +160,6 @@ type ExecApprovalDurableLookup =
 type PendingEntry<TPayload = ExecApprovalRequestPayload> = {
   record: ExecApprovalRecord<TPayload>;
   resolve: (decision: ExecApprovalDecision | null) => void;
-  reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout> | null;
   cleanupTimer: ReturnType<typeof setTimeout> | null;
   handoffRetainCount: number;
@@ -357,16 +356,13 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     }
 
     let resolvePromise: (decision: ExecApprovalDecision | null) => void;
-    let rejectPromise: (err: Error) => void;
-    const promise = new Promise<ExecApprovalDecision | null>((resolve, reject) => {
+    const promise = new Promise<ExecApprovalDecision | null>((resolve) => {
       resolvePromise = resolve;
-      rejectPromise = reject;
     });
     // Create entry first so we can capture it in the closure (not re-fetch from map)
     const entry: PendingEntry<TPayload> = {
       record,
       resolve: resolvePromise!,
-      reject: rejectPromise!,
       timer: null,
       cleanupTimer: null,
       handoffRetainCount: 0,
@@ -1020,7 +1016,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       record.resolvedAtMs === undefined ||
       record.decision !== undefined ||
       record.consumedDecision !== undefined ||
-      record.askFallbackConsumed === true
+      record.askFallbackConsumed === true ||
+      // Only unanswered approvals (timeout or no delivery route) are
+      // re-admissible. Cancelled/fenced records also end decision-less, but
+      // their authority closed deliberately — never replay through them.
+      (record.status !== "expired" && record.terminalReason !== "no-route")
     ) {
       return false;
     }
@@ -1255,10 +1255,6 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       return { kind: "ambiguous", ids: matches };
     }
     return { kind: "none" };
-  }
-
-  lookupPendingId(input: string): ExecApprovalIdLookupResult {
-    return this.lookupApprovalId(input);
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -372,14 +372,16 @@ export async function startGatewayCoreRuntime(input: {
     for (const sessionKey of keys) {
       revokeAttachGrantsForSession(sessionKey);
     }
-    for (const record of execApprovalManager.listPendingRecords()) {
-      if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
-        execApprovalManager.expire(record.id, "worker-dispatch");
-      }
-    }
-    for (const record of pluginApprovalManager.listPendingRecords()) {
-      if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
-        pluginApprovalManager.expire(record.id, "worker-dispatch");
+    // Dispatch fencing closes approval authority deliberately: record it as a
+    // run-aborted cancellation, not a timeout, so ask-fallback replay cannot
+    // re-admit through the fenced record (consumeAskFallback admits only
+    // expired/no-route terminals).
+    const fenceResolver = { kind: "system", id: "worker-dispatch" } as const;
+    for (const manager of [execApprovalManager, pluginApprovalManager]) {
+      for (const record of manager.listPendingRecords()) {
+        if (approvalRequestTargetsSession(record.request, keys, sessionId)) {
+          manager.forceDenyDetailed(record.id, "run-aborted", fenceResolver, "cancelled");
+        }
       }
     }
   };

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3567,8 +3567,8 @@ describe("exec approval handlers", () => {
     const pendingRecord = manager.create({ command: "echo new", host: "gateway" }, 2_000, "abcdef");
     void manager.register(pendingRecord, 2_000);
 
-    expect(manager.lookupPendingId("abc")).toEqual({ kind: "none" });
-    expect(manager.lookupPendingId("abcdef")).toEqual({ kind: "exact", id: "abcdef" });
+    expect(manager.lookupApprovalId("abc")).toEqual({ kind: "none" });
+    expect(manager.lookupApprovalId("abcdef")).toEqual({ kind: "exact", id: "abcdef" });
   });
 
   it("stores versioned system.run binding and sorted env keys on approval request", async () => {


### PR DESCRIPTION
## What Problem This Solves

`consumeAskFallback` re-admits a timed-out `system.run` approval exactly once (the documented ask-fallback bridge until the strict exec-timeout cutover). Its gate only checked "resolved and decision-less" — but run-aborted cancellations and worker-dispatch fencing revocations *also* end decision-less, so a deliberately closed approval could satisfy the timed-out predicate and be replayed as ask-fallback. That violates the closure-bound-authority invariant: terminal state and fencing must fail closed.

A second dishonesty compounded it: worker-dispatch fencing revoked approvals via `expire()`, which persists a durable `timeout` terminal — the audit trail claimed the operator never answered when in fact the gateway deliberately fenced the run.

## Why This Change Was Made

- `consumeAskFallback` now requires the record's terminal to be genuinely unanswered: `status === "expired"` (timeout) or `terminalReason === "no-route"`. Cancelled/fenced records fail closed.
- `workerDispatchAuthority.revoke` routes through `forceDenyDetailed(id, "run-aborted", {kind:"system", id:"worker-dispatch"}, "cancelled")` so the durable row records what actually happened. Both managers share one loop.
- Rider cleanup: `PendingEntry.reject`/`rejectPromise` were write-only (no caller ever rejects the decision promise) and `lookupPendingId` was a pure alias of `lookupApprovalId` with a single test caller — both deleted.

## User Impact

An operator who fences a worker dispatch or aborts a run can no longer have that run's exec approval replayed through the ask-fallback path, and `approvals list`/audit surfaces show `cancelled/run-aborted` instead of a false `timeout` for fenced approvals.

## Evidence

- New regression `rejects ask-fallback replay of a run-aborted cancellation` (exec-approval-manager.expiry.test.ts) fails pre-fix via stash proof, passes post-fix.
- `node scripts/run-vitest.mjs run src/gateway/exec-approval-manager.test.ts src/gateway/exec-approval-manager.expiry.test.ts src/gateway/node-invoke-system-run-approval.test.ts` — 110/110.
- `node scripts/run-vitest.mjs run src/gateway/server-methods/server-methods.test.ts` — green.
- tsgo core + test shards clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.98.
- Prod LOC: +16 −18 (net −2); tests +26 −2.
