### PR TITLE
fix(setup): preserve configured channel when status refresh fails

### DIFF
--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -971,6 +971,61 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
   });
 
+  it("keeps completed setup when the follow-up status refresh fails", async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        channel: "external-chat",
+        configured: false,
+        statusLines: [],
+      })
+      .mockRejectedValueOnce(new Error("controlled status failure"));
+    const externalChatPlugin = makeSetupPlugin({
+      id: "external-chat",
+      label: "External Chat",
+      setupWizard: {
+        channel: "external-chat",
+        getStatus,
+        configure: vi.fn(async ({ cfg }) => ({
+          cfg: {
+            ...cfg,
+            channels: { ...cfg.channels, "external-chat": { token: "configured" } },
+          },
+          accountId: "external-account",
+        })),
+      } as ChannelSetupPlugin["setupWizard"],
+    });
+    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
+    listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
+    const note = vi.fn(async () => undefined);
+
+    const result = await setupChannels(
+      {} as OpenClawConfig,
+      {} as never,
+      {
+        confirm: vi.fn(async () => true),
+        note,
+        select: vi.fn(async () => "__done__"),
+      } as never,
+      {
+        initialSelection: ["external-chat"],
+        finishAfterInitialSelection: true,
+        deferStatusUntilSelection: true,
+        skipDmPolicyPrompt: true,
+      },
+    );
+
+    expect(result).toMatchObject({
+      channels: { "external-chat": { token: "configured" } },
+    });
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(note).toHaveBeenCalledWith(
+      "Status unavailable (controlled status failure).\n" +
+        "Retry: openclaw channels status --channel external-chat",
+      "Channel status",
+    );
+  });
+
   it("returns targeted channel setup Back navigation to the channel picker", async () => {
     const promptOrder: string[] = [];
     const configureInteractive = vi.fn(async ({ prompter }) => {

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -1,4 +1,5 @@
 // Channel setup flow configures channels, auth, and workspace bindings.
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listActiveChannelSetupPlugins } from "../channels/plugins/setup-registry.js";
@@ -369,8 +370,22 @@ export async function setupChannels(
     if (!adapter) {
       return;
     }
-    const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
-    statusByChannel.set(channel, status);
+    try {
+      const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
+      statusByChannel.set(channel, status);
+    } catch (error) {
+      const detail = sanitizeTerminalText(formatErrorMessage(error));
+      statusByChannel.set(channel, {
+        channel,
+        configured: isChannelConfigured(next, channel),
+        statusLines: [],
+        selectionHint: "status unavailable",
+      });
+      await prompter.note(
+        `Status unavailable (${detail}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${channel}`)}`,
+        t("wizard.channels.statusTitle"),
+      );
+    }
   };
 
   const enableBundledPluginForSetup = async (channel: ChannelChoice): Promise<boolean> => {

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -370,22 +370,8 @@ export async function setupChannels(
     if (!adapter) {
       return;
     }
-    try {
-      const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
-      statusByChannel.set(channel, status);
-    } catch (error) {
-      const detail = sanitizeTerminalText(formatErrorMessage(error));
-      statusByChannel.set(channel, {
-        channel,
-        configured: isChannelConfigured(next, channel),
-        statusLines: [],
-        selectionHint: "status unavailable",
-      });
-      await prompter.note(
-        `Status unavailable (${detail}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${channel}`)}`,
-        t("wizard.channels.statusTitle"),
-      );
-    }
+    const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
+    statusByChannel.set(channel, status);
   };
 
   const enableBundledPluginForSetup = async (channel: ChannelChoice): Promise<boolean> => {
@@ -473,7 +459,21 @@ export async function setupChannels(
     if (channel === targetedChannel) {
       finishSetupRequested = true;
     }
-    await refreshStatus(channel);
+    try {
+      await refreshStatus(channel);
+    } catch (error) {
+      const detail = sanitizeTerminalText(formatErrorMessage(error));
+      statusByChannel.set(channel, {
+        channel,
+        configured: isChannelConfigured(next, channel),
+        statusLines: [],
+        selectionHint: "status unavailable",
+      });
+      await prompter.note(
+        `Status unavailable (${detail}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${channel}`)}`,
+        t("wizard.channels.statusTitle"),
+      );
+    }
   };
 
   const applyCustomSetupResult = async (


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could complete channel configuration successfully but have the wizard report failure and skip persisting the configured state when the plugin's immediate follow-up status refresh failed.

## Why This Change Was Made

The channel setup flow now treats only the observation after a completed configuration as fail-soft. It preserves the configured result, records status as unavailable, and shows sanitized diagnostic detail plus the exact `openclaw channels status --channel <id>` retry. The actual configure operation and cancellation path remain outside that recovery boundary and still fail normally.

This does not change config shape, defaults, provider or channel policy, the public CLI contract, plugin APIs, or security behavior. Invalid or empty `--channel` wizard handling is separate and intentionally excluded.

## User Impact

Operators keep successfully configured channel state even when an optional status read is temporarily unavailable. They receive a visible, redacted explanation and a precise status retry command instead of a false setup failure.

## Evidence

- Pre-fix regression proof: the new focused case failed with `controlled status failure` at the unguarded post-configure status refresh.
- Focused matrix: 94/94 tests passed across channel setup, setup prompts, channel add/configure, and built-CLI onboarding E2E.
- Source-blind built CLI: normal success persisted; post-configure status failure exited zero, persisted config, redacted an injected credential, and printed the exact retry; the retry succeeded in a fresh process; configure failure and Ctrl-C cancellation remained nonzero and did not persist configuration.
- Full build passed, including built plugin control-plane loads and Plugin SDK export checks.
- Production types and test types passed.
- `check:changed`, full lint, focused format check, runtime import-cycle check, and `git diff --check` passed.
- Structured autoreview completed cleanly with no accepted/actionable findings.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/31922677756
- Production LOC: +17/-2 (net +15). Tests: +55/-0.
- No changelog entry: normal PR changelog updates are release-generated.
