### PR TITLE
fix(gateway): avoid repeated session root scans in configured lists

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -2,8 +2,10 @@
 // Gateway callers need canonical per-agent keys even when stores are split by `{agentId}`.
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../../agents/agent-scope.js";
 import {
+  resolveSessionStoreAgentId,
   resolveSessionStoreKey,
   resolveStoredSessionKeyForAgentStore,
 } from "../../gateway/session-store-key.js";
@@ -12,7 +14,10 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { listOpenIncognitoAgentDatabases } from "../../state/openclaw-agent-db.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  listOpenIncognitoAgentDatabases,
+} from "../../state/openclaw-agent-db.js";
 import { resolveSessionStoreCompatibilityAgentId } from "../legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionStorePathCore } from "./paths.js";
@@ -173,6 +178,33 @@ function mergeOpenIncognitoStores(params: {
   return storePaths;
 }
 
+function filterCombinedStoreToConfiguredAgents(params: {
+  cfg: OpenClawConfig;
+  configuredAgentIds: ReadonlySet<string>;
+  store: Record<string, SessionEntry>;
+}): void {
+  const isConfiguredSessionKey = (key: string | undefined) => {
+    const normalizedKey = normalizeOptionalString(key);
+    if (!normalizedKey) {
+      return false;
+    }
+    const canonicalKey = resolveSessionStoreKey({ cfg: params.cfg, sessionKey: normalizedKey });
+    const agentId = resolveSessionStoreAgentId(params.cfg, canonicalKey);
+    return params.configuredAgentIds.has(normalizeAgentId(agentId));
+  };
+  for (const [key, entry] of Object.entries(params.store)) {
+    const keep =
+      key === "global" ||
+      key === "unknown" ||
+      isConfiguredSessionKey(key) ||
+      isConfiguredSessionKey(entry.spawnedBy) ||
+      isConfiguredSessionKey(entry.parentSessionKey);
+    if (!keep) {
+      delete params.store[key];
+    }
+  }
+}
+
 function resolveGatewaySessionStoreTargets(
   cfg: OpenClawConfig,
   opts: GatewaySessionStoreOptions,
@@ -188,15 +220,44 @@ function resolveGatewaySessionStoreTargets(
     opts.configuredAgentsOnly === true && !requestedAgentId
       ? new Set(listConfiguredSessionStoreAgentIds(cfg))
       : undefined;
-  const allowedIncognitoAgentIds = requestedAgentId
-    ? new Set([requestedAgentId])
-    : configuredAgentIds;
   const incognitoTargets =
     opts.includeIncognito === false
       ? []
       : listOpenIncognitoAgentDatabases().filter(
-          (target) => !allowedIncognitoAgentIds || allowedIncognitoAgentIds.has(target.agentId),
+          (target) => !requestedAgentId || target.agentId === requestedAgentId,
         );
+
+  if (configuredAgentIds) {
+    const incognitoTargetKeys = new Set(
+      incognitoTargets.map((target) => `${target.agentId}\0${target.storePath}`),
+    );
+    const candidates = dedupeSessionStoreTargetsBySqliteTarget(
+      [
+        ...listOpenClawRegisteredAgentDatabases().map(({ agentId, path }) => ({
+          agentId,
+          storePath: path,
+        })),
+        ...resolveSessionStoreTargets(cfg, { allAgents: true }),
+        ...incognitoTargets,
+      ],
+      {
+        defaultAgentId,
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
+      },
+    );
+    return {
+      configuredAgentIds,
+      defaultAgentId,
+      diagnostics,
+      durableTargets: candidates.filter(
+        (target) => !incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`),
+      ),
+      incognitoTargets: candidates.filter((target) =>
+        incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`),
+      ),
+      storeConfig,
+    };
+  }
 
   if (storeConfig && !isStorePathTemplate(storeConfig)) {
     const ownerIds = [
@@ -230,9 +291,7 @@ function resolveGatewaySessionStoreTargets(
 
   const durableTargets = requestedAgentId
     ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)
-    : opts.configuredAgentsOnly === true
-      ? resolveSessionStoreTargets(cfg, { allAgents: true })
-      : resolveAllAgentSessionStoreTargetsSync(cfg);
+    : resolveAllAgentSessionStoreTargetsSync(cfg);
   return {
     configuredAgentIds,
     defaultAgentId,
@@ -273,6 +332,7 @@ export function loadCombinedSessionStoreForGatewayCore(
 ): {
   diagnostics?: string[];
   durableStorePath?: string;
+  durableTargets: Array<{ agentId: string; storePath: string }>;
   storePath: string;
   store: Record<string, SessionEntry>;
 } {
@@ -288,53 +348,6 @@ export function loadCombinedSessionStoreForGatewayCore(
     requestedAgentId,
     storeConfig,
   } = resolveGatewaySessionStoreTargets(cfg, opts);
-  if (storeConfig && !isStorePathTemplate(storeConfig)) {
-    const combined: Record<string, SessionEntry> = {};
-    for (const { agentId, storePath } of durableTargets) {
-      const store = loadGatewayStoreEntries({ agentId, projection, storePath });
-      for (const { sessionKey: key, entry } of store) {
-        const canonicalKey = resolveStoredSessionKeyForAgentStore({
-          cfg,
-          agentId,
-          sessionKey: key,
-        });
-        if (key !== canonicalKey) {
-          throw canonicalSessionKeyMigrationRequiredError(
-            `non-canonical persisted row resolves to session key ${canonicalKey}`,
-          );
-        }
-        const canonicalAgentId = normalizeAgentId(
-          parseAgentSessionKey(canonicalKey)?.agentId ?? agentId,
-        );
-        if (configuredAgentIds && !configuredAgentIds.has(canonicalAgentId)) {
-          continue;
-        }
-        if (requestedAgentId && canonicalAgentId !== requestedAgentId) {
-          continue;
-        }
-        mergeSessionEntryIntoCombined({
-          cfg,
-          combined,
-          entry,
-          agentId: canonicalAgentId,
-          canonicalKey,
-        });
-      }
-    }
-    const durableStorePath = resolveCombinedDatabasePath(durableTargets, defaultAgentId);
-    const incognitoStorePaths = mergeOpenIncognitoStores({
-      cfg,
-      combined,
-      projection,
-      targets: incognitoTargets,
-    });
-    return {
-      diagnostics,
-      durableStorePath,
-      storePath: incognitoStorePaths.length > 0 ? "(multiple)" : durableStorePath,
-      store: combined,
-    };
-  }
   const combined: Record<string, SessionEntry> = {};
   for (const target of durableTargets) {
     const agentId = target.agentId;
@@ -354,9 +367,6 @@ export function loadCombinedSessionStoreForGatewayCore(
       const canonicalAgentId = normalizeAgentId(
         parseAgentSessionKey(canonicalKey)?.agentId ?? agentId,
       );
-      if (configuredAgentIds && !configuredAgentIds.has(canonicalAgentId)) {
-        continue;
-      }
       if (requestedAgentId && canonicalAgentId !== requestedAgentId) {
         continue;
       }
@@ -376,12 +386,24 @@ export function loadCombinedSessionStoreForGatewayCore(
     projection,
     targets: incognitoTargets,
   });
+  if (configuredAgentIds) {
+    filterCombinedStoreToConfiguredAgents({ cfg, configuredAgentIds, store: combined });
+  }
 
   const durableStorePaths = durableTargets.map((target) => target.storePath);
   const durableStorePath = resolveCombinedDatabasePath(durableTargets, defaultAgentId);
+  if (storeConfig && !isStorePathTemplate(storeConfig)) {
+    return {
+      diagnostics,
+      durableStorePath,
+      durableTargets,
+      storePath: incognitoStorePaths.length > 0 ? "(multiple)" : durableStorePath,
+      store: combined,
+    };
+  }
   const storePath = resolveCombinedStorePath(
     [...durableStorePaths, ...incognitoStorePaths],
     storeConfig,
   );
-  return { diagnostics, durableStorePath, storePath, store: combined };
+  return { diagnostics, durableStorePath, durableTargets, storePath, store: combined };
 }

--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as sessionDirs from "../../agents/session-dirs.js";
+import { EMPTY_LEGACY_SESSION_SURFACES } from "../../plugins/legacy-session-surfaces.types.js";
+import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { loadCombinedSessionStoreForGatewayCore } from "./combined-store-gateway.js";
+import { replaceSessionEntry } from "./session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { runSessionStartupMigration } from "./startup-migration.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it("re-registers durable lineage children before configured-only runtime reads", async () => {
+  const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-registry-recovery-"));
+  const stateDir = path.join(root, "state");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const env = { ...process.env };
+    const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: { entries: { ops: { default: true } } },
+      session: { store: storeTemplate },
+    };
+    const mainKey = "agent:ops:main";
+    const childKey = "agent:codex:subagent:upgrade-child";
+    const storePathFor = (agentId: string) => storeTemplate.replace("{agentId}", agentId);
+
+    await replaceSessionEntry(
+      { agentId: "ops", env, sessionKey: mainKey, storePath: storePathFor("ops") },
+      { sessionId: "session-ops", updatedAt: 20 },
+    );
+    await replaceSessionEntry(
+      { agentId: "codex", env, sessionKey: childKey, storePath: storePathFor("codex") },
+      { sessionId: "session-codex", spawnedBy: mainKey, updatedAt: 30 },
+    );
+    await replaceSessionEntry(
+      {
+        agentId: "local",
+        env,
+        sessionKey: "agent:local:main",
+        storePath: storePathFor("local"),
+      },
+      { sessionId: "session-local", updatedAt: 10 },
+    );
+
+    const childDatabasePath = resolveSqliteTargetFromSessionStorePath(storePathFor("codex"), {
+      agentId: "codex",
+      env,
+    }).path;
+    closeOpenClawAgentDatabasesForTest();
+    unregisterOpenClawAgentDatabase({ agentId: "codex", env, path: childDatabasePath });
+
+    expect(fs.existsSync(childDatabasePath)).toBe(true);
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).some(
+        (entry) => entry.agentId === "codex" && entry.path === childDatabasePath,
+      ),
+    ).toBe(false);
+
+    await runSessionStartupMigration({
+      cfg,
+      env,
+      log: { info: vi.fn(), warn: vi.fn() },
+      deps: {
+        migrateLegacyMainSessionKeys: vi.fn(async () => ({
+          armed: false,
+          changes: [],
+          complete: false,
+          ledgerComplete: false,
+          legacyAgentId: "main",
+          mainKey: "main",
+          outcomes: [{ kind: "not-armed" as const }],
+          warnings: [],
+        })),
+        migrateOrphanedSessionKeys: vi.fn(async () => ({ changes: [], warnings: [] })),
+        prepareLegacySessionSurfaces: () => EMPTY_LEGACY_SESSION_SURFACES,
+        sweepOrphanSessionStoreTemps: vi.fn(async () => 0),
+      },
+    });
+
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toContainEqual(
+      expect.objectContaining({ agentId: "codex", path: childDatabasePath }),
+    );
+
+    const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
+    try {
+      const store = loadCombinedSessionStoreForGatewayCore(cfg, {
+        configuredAgentsOnly: true,
+      }).store;
+      expect(store[mainKey]?.sessionId).toBe("session-ops");
+      expect(store[childKey]?.sessionId).toBe("session-codex");
+      expect(store["agent:local:main"]).toBeUndefined();
+      expect(enumerateAgentDirs).not.toHaveBeenCalled();
+    } finally {
+      enumerateAgentDirs.mockRestore();
+    }
+  });
+});

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -76,11 +76,7 @@ import {
 import { emitSessionsChanged } from "./session-change-event.js";
 import { respondWithCachedSessionList } from "./sessions-list-cache.js";
 import { resolveSessionSearchScope } from "./sessions-search-scope.js";
-import {
-  filterSessionStoreToConfiguredAgents,
-  loadSessionEntriesForTarget,
-  requireSessionKey,
-} from "./sessions-shared.js";
+import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -224,11 +220,8 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           options: {
             allowFullReload?: boolean;
             excludedKeys?: ReadonlySet<string>;
-            loaded?: {
-              durableStorePath?: string;
-              listStore: Record<string, SessionEntry>;
+            loaded?: ReturnType<typeof loadCombinedSessionStoreForGatewayCore> & {
               modelCatalog: Awaited<ReturnType<typeof readPreparedServerMethodModelCatalog>>;
-              storePath: string;
             };
             rowRepairAttempted?: boolean;
           } = {},
@@ -247,11 +240,12 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 phase: "sessions.list",
               },
             );
-            const { durableStorePath, storePath, store } = measureDiagnosticsTimelineSpanSync(
+            const loadedStore = measureDiagnosticsTimelineSpanSync(
               "gateway.sessions.list.store_load",
               () =>
                 loadCombinedSessionStoreForGatewayCore(cfg, {
                   agentId: p.agentId,
+                  configuredAgentsOnly,
                   projection: "list",
                 }),
               {
@@ -263,19 +257,12 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 },
               },
             );
-            loaded = {
-              durableStorePath,
-              listStore: configuredAgentsOnly
-                ? filterSessionStoreToConfiguredAgents(cfg, store)
-                : store,
-              modelCatalog,
-              storePath,
-            };
+            loaded = { ...loadedStore, modelCatalog };
           }
           if (!loaded) {
             throw new Error("sessions.list store input was not loaded");
           }
-          const { durableStorePath, listStore, modelCatalog, storePath } = loaded;
+          const { durableStorePath, durableTargets, modelCatalog, storePath } = loaded;
           const visibilityFilter = createSessionListEntryFilter({ client });
           const entryFilter =
             visibilityFilter || options.excludedKeys?.size
@@ -290,7 +277,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 durableStorePath,
                 ...(entryFilter ? { entryFilter } : {}),
                 storePath,
-                store: listStore,
+                store: loaded.store,
                 modelCatalog,
                 opts: p,
               }),
@@ -307,6 +294,14 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
               // materialized every entry of a candidate store once per row.
               const sharingStoreCache: GatewaySessionStoreCache = new Map();
               const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+              const storeConfig = cfg.session?.store;
+              for (const target of durableTargets) {
+                const agentId = target.agentId;
+                const existing = targetDiscoveryCache.get(agentId)?.existing ?? [];
+                const fallbackStorePath = resolveSessionStorePathCore(storeConfig, { agentId });
+                const fallback = { agentId, storePath: fallbackStorePath };
+                targetDiscoveryCache.set(agentId, { existing: [...existing, target], fallback });
+              }
               const resolvedSharingTargets = result.sessions.map((session) =>
                 resolveSessionSharingTarget({
                   cfg,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -19,7 +19,6 @@ import {
   runSessionsCleanup,
   serializeSessionCleanupResult,
   type SessionEntry,
-  type SessionStoreTarget,
 } from "../../config/sessions.js";
 import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
@@ -51,9 +50,9 @@ import {
   readRecentSessionMessagesWithStatsAsync,
   readSessionPreviewItemsFromTranscript,
 } from "../session-transcript-readers.js";
-import type {
-  GatewaySessionStoreCache,
-  GatewaySessionStoreDiscoveryCache,
+import {
+  createGatewaySessionStoreDiscoveryCache,
+  type GatewaySessionStoreCache,
 } from "../session-utils-store-lookup.js";
 import {
   buildGatewaySessionRow,
@@ -294,37 +293,15 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
               // One cache for the whole listing: sharing resolution otherwise
               // materialized every entry of a candidate store once per row.
               const sharingStoreCache: GatewaySessionStoreCache = new Map();
-              const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
-              const prepareTarget = (rawAgentId: string, target?: SessionStoreTarget) => {
-                const agentId = normalizeAgentId(rawAgentId);
-                const cached = targetDiscoveryCache.get(agentId);
-                if (cached) {
-                  if (target) {
-                    cached.existing.push(target);
-                  }
-                  return;
-                }
-                const fallback = {
-                  agentId,
-                  storePath: resolveSessionStorePathCore(cfg.session?.store, { agentId }),
-                };
-                const existing = target
-                  ? [target]
-                  : durableTargets.length > 0
-                    ? durableTargets
-                    : [fallback];
-                targetDiscoveryCache.set(agentId, { existing, fallback });
-              };
-              for (const target of durableTargets) {
-                prepareTarget(target.agentId, target);
-              }
-              for (const session of result.sessions) {
-                prepareTarget(
+              const targetDiscoveryCache = createGatewaySessionStoreDiscoveryCache({
+                cfg,
+                targets: durableTargets,
+                agentIds: result.sessions.map((session) =>
                   session.key === "global" && p.agentId
                     ? p.agentId
                     : resolveSessionStoreAgentId(cfg, session.key),
-                );
-              }
+                ),
+              });
               const resolvedSharingTargets = result.sessions.map((session) =>
                 resolveSessionSharingTarget({
                   cfg,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -19,6 +19,7 @@ import {
   runSessionsCleanup,
   serializeSessionCleanupResult,
   type SessionEntry,
+  type SessionStoreTarget,
 } from "../../config/sessions.js";
 import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
@@ -294,13 +295,35 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
               // materialized every entry of a candidate store once per row.
               const sharingStoreCache: GatewaySessionStoreCache = new Map();
               const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
-              const storeConfig = cfg.session?.store;
+              const prepareTarget = (rawAgentId: string, target?: SessionStoreTarget) => {
+                const agentId = normalizeAgentId(rawAgentId);
+                const cached = targetDiscoveryCache.get(agentId);
+                if (cached) {
+                  if (target) {
+                    cached.existing.push(target);
+                  }
+                  return;
+                }
+                const fallback = {
+                  agentId,
+                  storePath: resolveSessionStorePathCore(cfg.session?.store, { agentId }),
+                };
+                const existing = target
+                  ? [target]
+                  : durableTargets.length > 0
+                    ? durableTargets
+                    : [fallback];
+                targetDiscoveryCache.set(agentId, { existing, fallback });
+              };
               for (const target of durableTargets) {
-                const agentId = target.agentId;
-                const existing = targetDiscoveryCache.get(agentId)?.existing ?? [];
-                const fallbackStorePath = resolveSessionStorePathCore(storeConfig, { agentId });
-                const fallback = { agentId, storePath: fallbackStorePath };
-                targetDiscoveryCache.set(agentId, { existing: [...existing, target], fallback });
+                prepareTarget(target.agentId, target);
+              }
+              for (const session of result.sessions) {
+                prepareTarget(
+                  session.key === "global" && p.agentId
+                    ? p.agentId
+                    : resolveSessionStoreAgentId(cfg, session.key),
+                );
               }
               const resolvedSharingTargets = result.sessions.map((session) =>
                 resolveSessionSharingTarget({

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -6,17 +6,16 @@ import {
   type SessionOperationEvent,
   type SessionsPatchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { listConfiguredSessionStoreAgentIds, type SessionEntry } from "../../config/sessions.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import {
   resolvePluginSessionOwnershipError,
   type PluginSessionOwnershipAction,
 } from "../session-plugin-ownership.js";
-import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "../session-store-key.js";
 import {
   resolveCanonicalSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -82,36 +81,6 @@ export function resolveSessionWorkerPlacementPatchError(params: {
   return executionMode
     ? `Session ${params.key} cannot change cloud placement execution mode while placement is ${placement.state}.`
     : `Session ${params.key} cannot select the ${runtime} runtime while cloud worker placement is ${placement.state}.`;
-}
-
-export function filterSessionStoreToConfiguredAgents(
-  cfg: OpenClawConfig,
-  store: Record<string, SessionEntry>,
-): Record<string, SessionEntry> {
-  const configuredAgentIds = new Set(listConfiguredSessionStoreAgentIds(cfg));
-  const isConfiguredSessionKey = (key: string | undefined) => {
-    const normalizedKey = normalizeOptionalString(key);
-    if (!normalizedKey) {
-      return false;
-    }
-    const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey: normalizedKey });
-    const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
-    return configuredAgentIds.has(normalizeAgentId(agentId));
-  };
-  return Object.fromEntries(
-    Object.entries(store).filter(([key, entry]) => {
-      if (key === "global" || key === "unknown") {
-        return true;
-      }
-      if (isConfiguredSessionKey(key)) {
-        return true;
-      }
-      // Keep spawned child sessions visible when their parent belongs to a configured agent.
-      return (
-        isConfiguredSessionKey(entry?.spawnedBy) || isConfiguredSessionKey(entry?.parentSessionKey)
-      );
-    }),
-  );
 }
 
 export const loadSessionsRuntimeModule = createLazyRuntimeModule(

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -245,6 +245,7 @@ describe("sessions.abort agent scope", () => {
     listSessionsFromStoreAsyncMock.mockResolvedValue({ sessions: [] });
     loadCombinedSessionStoreForGatewayMock.mockReset();
     loadCombinedSessionStoreForGatewayMock.mockReturnValue({
+      durableTargets: [],
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
     });

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -24,7 +24,11 @@ vi.mock("../session-utils.js", async () => {
   return {
     ...actual,
     loadGatewaySessionEntryReadOnly: vi.fn(actual.loadGatewaySessionEntryReadOnly),
-    loadCombinedSessionStoreForGatewayCore: vi.fn(() => ({ storePath: "(multiple)", store: {} })),
+    loadCombinedSessionStoreForGatewayCore: vi.fn(() => ({
+      durableTargets: [],
+      storePath: "(multiple)",
+      store: {},
+    })),
   };
 });
 
@@ -512,6 +516,7 @@ describe("sessions.usage", () => {
 
   it("does not attach out-of-scope store entries to list-style usage results", async () => {
     vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+      durableTargets: [],
       storePath: "(multiple)",
       store: {
         "agent:main:s-opus": {
@@ -543,6 +548,7 @@ describe("sessions.usage", () => {
       mockStoredSession("agent:opus:main", "main");
 
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           "agent:opus:main": {
@@ -596,6 +602,7 @@ describe("sessions.usage", () => {
         updatedAt: 999,
       };
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           global: sessionEntry,
@@ -634,6 +641,7 @@ describe("sessions.usage", () => {
       const sessionFile = writeSessionFile("shared.jsonl");
 
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           "agent:main:shared": {
@@ -679,6 +687,7 @@ describe("sessions.usage", () => {
       // Swap the store mock for this test: the canonical key differs from the discovered key
       // but points at the same sessionId.
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           [storeKey]: {
@@ -713,6 +722,7 @@ describe("sessions.usage", () => {
       mockStoredSession(storeKey, "current");
 
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           [storeKey]: {
@@ -792,6 +802,7 @@ describe("sessions.usage", () => {
       mockStoredSession(preferredKey, "run-dup");
 
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+        durableTargets: [],
         storePath: "(multiple)",
         store: {
           [preferredKey]: {

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -76,7 +76,7 @@ test("sessions.list does not materialize the lookup store once per row", async (
   expect(large).toBeLessThan(small * 12);
 });
 
-test("sessions.list discovers store targets at most once per agent", async () => {
+test("sessions.list reuses prepared store targets for sharing", async () => {
   await createSessionStoreDir();
   await writeSessionStore({
     entries: Object.fromEntries(
@@ -90,7 +90,7 @@ test("sessions.list discovers store targets at most once per agent", async () =>
   try {
     const result = await directSessionReq("sessions.list", LIST_PARAMS);
     expect(result.ok).toBe(true);
-    expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(1);
+    expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(0);
   } finally {
     discoverySpy.mockRestore();
   }

--- a/src/gateway/server.sessions.store-paths.test.ts
+++ b/src/gateway/server.sessions.store-paths.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import * as sessionDirs from "../agents/session-dirs.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -49,4 +51,45 @@ test("sessions.list reports multiple physical agent stores", async () => {
   const listed = await directSessionReq<{ path: string }>("sessions.list", {});
 
   expect(listed).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+});
+
+test("configured-only parent-owned stores keep lineage children without directory discovery", async () => {
+  const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!rootStateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const stateDir = path.join(rootStateDir, "fixed-configured-list-regression");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json");
+    const storePath = storeTemplate.replace("{agentId}", "ops");
+    const mainKey = "agent:ops:main";
+    const childKey = "agent:codex:subagent:fixed-child";
+    testState.sessionConfig = { store: storeTemplate };
+    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }] };
+    testState.agentConfig = { sessionStore: { agentId: "ops" } };
+    await writeSessionStore({
+      agentId: "ops",
+      storePath,
+      entries: {
+        [childKey]: { sessionId: "session-child", updatedAt: 30, parentSessionKey: mainKey },
+        [mainKey]: { sessionId: "session-main", updatedAt: 20 },
+        "agent:local:main": { sessionId: "session-local", updatedAt: 10 },
+      },
+    });
+
+    const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
+    try {
+      const listed = await directSessionReq<{ sessions: Array<{ key: string }> }>("sessions.list", {
+        includeGlobal: false,
+        includeUnknown: false,
+        configuredAgentsOnly: true,
+      });
+
+      expect(listed.ok).toBe(true);
+      expect(listed.payload?.sessions.map((session) => session.key)).toEqual([childKey, mainKey]);
+      expect(enumerateAgentDirs).not.toHaveBeenCalled();
+    } finally {
+      enumerateAgentDirs.mockRestore();
+    }
+  });
 });

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -5,12 +5,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, test, vi } from "vitest";
+import * as sessionDirs from "../agents/session-dirs.js";
 import {
   loadSessionEntry,
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
 } from "../config/sessions/session-accessor.js";
 import type { CronJob } from "../cron/types.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { agentDiscoveryMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
@@ -668,90 +670,90 @@ test("lists and patches session store via sessions.* RPC", async () => {
 });
 
 test("sessions.list configuredAgentsOnly keeps configured-agent children and hides unrelated stores", async () => {
-  const stateDir = process.env.OPENCLAW_STATE_DIR;
-  if (!stateDir) {
-    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
-  }
-  testState.agentsConfig = { list: [{ id: "main", default: true }] };
-  const configPath = process.env.OPENCLAW_CONFIG_PATH;
-  if (!configPath) {
-    throw new Error("OPENCLAW_CONFIG_PATH is required for gateway session tests");
-  }
-  await fs.writeFile(
-    configPath,
-    JSON.stringify({ acp: { defaultAgent: "claude", allowedAgents: ["gemini"] } }, null, 2),
-    "utf-8",
-  );
-  testState.sessionConfig = {
-    store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
-  };
+  const rootStateDir = expectDefined(process.env.OPENCLAW_STATE_DIR, "OPENCLAW_STATE_DIR");
+  const stateDir = path.join(rootStateDir, "configured-list-regression");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }] };
+    testState.agentConfig = { sessionStore: { agentId: "ops" } };
+    const configPath = expectDefined(process.env.OPENCLAW_CONFIG_PATH, "OPENCLAW_CONFIG_PATH");
+    const configJson = '{"acp":{"defaultAgent":"claude","allowedAgents":["gemini"]}}';
+    await fs.writeFile(configPath, configJson, "utf-8");
+    const agentsDir = path.join(stateDir, "agents");
+    const storeTemplate = path.join(agentsDir, "{agentId}", "sessions", "sessions.json");
+    testState.sessionConfig = { store: storeTemplate };
 
-  const mainStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
-  const acpStorePath = path.join(stateDir, "agents", "claude", "sessions", "sessions.json");
-  const childStorePath = path.join(stateDir, "agents", "codex", "sessions", "sessions.json");
-  const diskOnlyStorePath = path.join(stateDir, "agents", "local", "sessions", "sessions.json");
-  await writeSessionStore({
-    storePath: mainStorePath,
-    agentId: "main",
-    entries: { main: { sessionId: "sess-main", updatedAt: 20 } },
-  });
-  await writeSessionStore({
-    storePath: acpStorePath,
-    agentId: "claude",
-    entries: {
-      "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7": {
-        sessionId: "sess-claude-acp",
-        updatedAt: 30,
-        acp: {
-          backend: "acpx",
-          agent: "claude",
-          runtimeSessionName: "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7",
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: 30,
-        },
+    const acpStorePath = path.join(agentsDir, "claude", "sessions", "sessions.json");
+    const childStorePath = path.join(agentsDir, "codex", "sessions", "sessions.json");
+    const diskOnlyStorePath = path.join(agentsDir, "local", "sessions", "sessions.json");
+    const mainKey = "agent:ops:main";
+    const acpKey = "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7";
+    const acp = {
+      backend: "acpx",
+      agent: "claude",
+      runtimeSessionName: acpKey,
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: 30,
+    } as const;
+    const spawnedChildKey = "agent:codex:subagent:app-server-child";
+    const parentChildKey = "agent:codex:subagent:parent-key-child";
+    await writeSessionStore({
+      storePath: path.join(agentsDir, "ops", "sessions", "sessions.json"),
+      agentId: "ops",
+      entries: { main: { sessionId: "sess-main", updatedAt: 20 } },
+    });
+    await writeSessionStore({
+      storePath: acpStorePath,
+      agentId: "claude",
+      entries: {
+        [acpKey]: { sessionId: "sess-claude-acp", updatedAt: 30, acp },
       },
-    },
-  });
-  await writeSessionStore({
-    storePath: childStorePath,
-    agentId: "codex",
-    entries: {
-      "agent:codex:subagent:app-server-child": {
-        sessionId: "sess-codex-child",
-        updatedAt: 25,
-        spawnedBy: "agent:main:main",
+    });
+    await writeSessionStore({
+      storePath: childStorePath,
+      agentId: "codex",
+      entries: {
+        [spawnedChildKey]: { sessionId: "sess-codex-child", updatedAt: 25, spawnedBy: mainKey },
+        [parentChildKey]: { sessionId: "child-2", updatedAt: 27, parentSessionKey: mainKey },
       },
-    },
-  });
-  await writeSessionStore({
-    storePath: diskOnlyStorePath,
-    agentId: "local",
-    entries: { main: { sessionId: "sess-local", updatedAt: 10 } },
-  });
+    });
+    await writeSessionStore({
+      storePath: diskOnlyStorePath,
+      agentId: "local",
+      entries: { main: { sessionId: "sess-local", updatedAt: 10 } },
+    });
+    const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
+    try {
+      const configuredOnly = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+        "sessions.list",
+        { includeGlobal: false, includeUnknown: false, configuredAgentsOnly: true },
+      );
+      expect(configuredOnly.ok).toBe(true);
+      expect(configuredOnly.payload?.sessions.map((session) => session.key)).toEqual([
+        acpKey,
+        parentChildKey,
+        spawnedChildKey,
+        mainKey,
+      ]);
+      expect(enumerateAgentDirs).not.toHaveBeenCalled();
 
-  const configuredOnly = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
-    "sessions.list",
-    { includeGlobal: false, includeUnknown: false, configuredAgentsOnly: true },
-  );
-  expect(configuredOnly.ok).toBe(true);
-  expect(configuredOnly.payload?.sessions.map((session) => session.key)).toEqual([
-    "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7",
-    "agent:codex:subagent:app-server-child",
-    "agent:main:main",
-  ]);
-
-  const broad = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
-    "sessions.list",
-    { includeGlobal: false, includeUnknown: false },
-  );
-  expect(broad.ok).toBe(true);
-  expect(broad.payload?.sessions.map((session) => session.key)).toEqual([
-    "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7",
-    "agent:codex:subagent:app-server-child",
-    "agent:main:main",
-    "agent:local:main",
-  ]);
+      const broad = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+        "sessions.list",
+        { includeGlobal: false, includeUnknown: false },
+      );
+      expect(broad.ok).toBe(true);
+      expect(broad.payload?.sessions.map((session) => session.key)).toEqual([
+        acpKey,
+        parentChildKey,
+        spawnedChildKey,
+        mainKey,
+        "agent:local:main",
+      ]);
+      expect(enumerateAgentDirs).toHaveBeenCalled();
+    } finally {
+      enumerateAgentDirs.mockRestore();
+    }
+  });
 });
 
 test("sessions.list hides phantom agent store placeholder rows", async () => {

--- a/src/gateway/session-child-sessions.test.ts
+++ b/src/gateway/session-child-sessions.test.ts
@@ -23,6 +23,7 @@ function entry(patch: Partial<SessionEntry>): SessionEntry {
 
 test("findDirectChildSessionsForParent matches direct lineage only", () => {
   vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+    durableTargets: [],
     storePath: "(combined)",
     store: {
       "agent:main:main": entry({

--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { filterSessionStoreToConfiguredAgents } from "./server-methods/sessions-shared.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { createSessionListEntryFilter } from "./session-sharing.js";
 
@@ -208,13 +207,6 @@ it("preserves legacy list output across visibility, scope, creator, and search f
       updatedAt: now - 5,
       visibility: "shared",
     },
-    "agent:retired:shared": {
-      createdActor: { type: "human", id: "profile-carol" },
-      sessionId: "session-retired-shared",
-      subject: "needle retired",
-      updatedAt: now - 6,
-      visibility: "shared",
-    },
     "agent:main:archived": {
       archivedAt: now - 10,
       createdActor: { type: "human", id: "profile-bob" },
@@ -247,14 +239,13 @@ it("preserves legacy list output across visibility, scope, creator, and search f
     },
   } as GatewayClient;
   const entryFilter = createSessionListEntryFilter({ client: viewer });
-  const configuredStore = filterSessionStoreToConfiguredAgents(cfg, store);
 
   const project = async (opts: Parameters<typeof listSessionsFromStore>[0]["opts"]) => {
     const result = await listSessionsFromStoreAsync({
       cfg,
       ...(entryFilter ? { entryFilter } : {}),
       opts,
-      store: configuredStore,
+      store,
       storePath: "/tmp/openclaw-session-filter-parity",
     });
     return {

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -142,6 +142,37 @@ export type GatewaySessionStoreDiscoveryCache = Map<
   { existing: SessionStoreTarget[]; fallback: SessionStoreTarget }
 >;
 
+export function createGatewaySessionStoreDiscoveryCache(params: {
+  cfg: OpenClawConfig;
+  targets: SessionStoreTarget[];
+  agentIds: Iterable<string>;
+}): GatewaySessionStoreDiscoveryCache {
+  const cache: GatewaySessionStoreDiscoveryCache = new Map();
+  const prepare = (rawAgentId: string, target?: SessionStoreTarget) => {
+    const agentId = normalizeAgentId(rawAgentId);
+    const current = cache.get(agentId);
+    if (current) {
+      if (target) {
+        current.existing.push(target);
+      }
+      return;
+    }
+    const fallback = {
+      agentId,
+      storePath: resolveSessionStorePathCore(params.cfg.session?.store, { agentId }),
+    };
+    const existing = target ? [target] : params.targets.length > 0 ? params.targets : [fallback];
+    cache.set(agentId, { existing, fallback });
+  };
+  for (const target of params.targets) {
+    prepare(target.agentId, target);
+  }
+  for (const agentId of params.agentIds) {
+    prepare(agentId);
+  }
+  return cache;
+}
+
 function loadGatewaySessionLookupStore(
   storePath: string,
   clone: boolean | undefined,

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -1499,11 +1499,16 @@ describe("loadCombinedSessionStoreForGatewayCore includes disk-only agents (#328
         { sessionId: "s-legacy-ops", spawnedBy: "agent:ops:main", updatedAt: 400 },
         "ops",
       );
-      const dynamicIncognitoKey = "dashboard:incognito-dynamic";
+      const dynamicIncognitoKey = "agent:dynamic:dashboard:incognito-child";
       await seedSessionEntry(
         resolveIncognitoOpenClawAgentSqlitePath({ agentId: "dynamic" }),
         dynamicIncognitoKey,
-        { incognito: true, sessionId: "s-incognito-dynamic", updatedAt: 500 },
+        {
+          incognito: true,
+          parentSessionKey: "agent:ops:main",
+          sessionId: "s-incognito-dynamic",
+          updatedAt: 500,
+        },
         "dynamic",
       );
       await seedSessionEntry(
@@ -1531,7 +1536,7 @@ describe("loadCombinedSessionStoreForGatewayCore includes disk-only agents (#328
       expect(configuredOnly["agent:ops:legacy"]?.sessionId).toBe("s-legacy-ops");
       expect(configuredOnly["agent:ops:legacy"]?.spawnedBy).toBe("agent:ops:main");
       expect(configuredOnly["agent:dynamic:main"]).toBeUndefined();
-      expect(configuredOnly[dynamicIncognitoKey]).toBeUndefined();
+      expect(configuredOnly[dynamicIncognitoKey]?.sessionId).toBe("s-incognito-dynamic");
 
       const opsOnly = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "ops" }).store;
       expect(opsOnly["agent:ops:main"]?.sessionId).toBe("s-ops");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI clients requesting configured-only all-agent session lists repeatedly enumerated configured, retired, and manual session roots. The repeated discovery happened on a request-time hot path after `88d6a2c8d63` stopped forwarding the configured-only scope into combined-store loading.

A simple switch to configured targets would be incorrect: it would regress the configured-parent child visibility shipped in `8483d0337530`, where an unconfigured child remains visible when its `spawnedBy` or `parentSessionKey` belongs to a configured agent.

## Why This Change Was Made

The combined Gateway store now builds configured-only candidates from configured direct targets, the startup/runtime-seeded durable database registry, and currently open incognito databases. It deduplicates physical targets with the existing ownership rules, canonicalizes and merges rows before applying the lineage-aware configured filter, and returns authoritative prepared durable targets for sharing resolution.

Sharing enrichment seeds every logical result agent from those prepared targets. This includes a child whose logical agent differs from the configured physical database owner, preventing a fallback to request-time filesystem discovery while preserving configured-parent lineage. The prepared discovery-cache constructor lives in the existing store-lookup owner because the CI max-lines rule correctly rejects further growth in `sessions-read.ts`. Broad non-configured all-agent lists retain their existing directory discovery behavior. No configuration, schema, protocol, compatibility fallback, or process cache was added.

Production LOC: +133/-116 (net +17). Tests: +263/-98 (net +165). The positive production growth is the explicit prepared-target owner boundary plus the extracted cache constructor required to preserve all child-lineage cases without request-time discovery while keeping `sessions-read.ts` below its hard line limit.

## User Impact

Operators with multiple configured agents and connected Control UI clients avoid repeated session-root scans during configured-only refreshes. Configured main and ACP sessions, configured-parent durable and incognito children, parent-owned physical-store children, and existing ownership/collision behavior remain visible as before. Retired or manual stores unrelated to configured lineage stay hidden from configured-only results and remain available in broad lists.

## Evidence

- Original pre-fix regression: 1 of 7 tests failed because one configured-only request performed four directory enumerations.
- Original post-fix Gateway RPC regression: 7 of 7 passed with zero configured-only enumeration; the broad request still enumerated and included the unrelated local store.
- Combined lineage coverage: 31 of 31 passed.
- Consolidated initial validation: 117 tests passed across 10 files and 3 Vitest shards.
- Follow-up pre-fix regression: a parent-owned physical-store child triggered one directory enumeration during sharing enrichment; the fixed request performs zero.
- Prepared-target focused validation: 77 tests passed across 5 files; targeted core oxlint passed and final autoreview was clean.
- Upgrade-boundary proof removes only an existing durable child database's registry row, leaves the DB intact, and runs the real startup migration discovery/open loop. Startup restores the exact registry row; the post-start configured-only read retains the configured-parent child with zero directory discovery and excludes an unrelated registered row.
- Startup and configured-list siblings pass across 6 files and 74 tests; the new migration contract also passes independently.
- The prior ClawSweeper P1 is addressed by explicit proof of the existing startup owner that backfills durable registry state before runtime reads.
- Full changed gate, targeted lint, formatting, diff checks, and fresh autoreview are clean.

New exact-head CI, a fresh current-head ClawSweeper review, and the post-landing live multi-client soak are pending.
