### PR TITLE
refactor(heartbeat): delete unreachable prompt-null skip and dead lanes-busy surface

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -756,7 +756,7 @@ Look for:
 
 - Cron enabled and next wake present.
 - Job run history status (`ok`, `skipped`, `error`).
-- Heartbeat skip reasons (`quiet-hours`, `requests-in-flight`, `cron-in-progress`, `lanes-busy`, `alerts-disabled`, `empty-heartbeat-file`).
+- Heartbeat skip reasons (`quiet-hours`, `requests-in-flight`, `cron-in-progress`, `alerts-disabled`, `empty-heartbeat-file`).
 
 <AccordionGroup>
   <Accordion title="Common signatures">

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -13,7 +13,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import {
   HEARTBEAT_IDLE_RETRY_GRACE_MS,
-  HEARTBEAT_SKIP_LANES_BUSY,
+  HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   HEARTBEAT_SKIP_PREEMPTED,
   type HeartbeatRunResult,
 } from "../../infra/heartbeat-wake.js";
@@ -1410,7 +1410,7 @@ describe("cron service timer regressions", () => {
       );
 
       now = scheduledAt + 2_000;
-      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY });
+      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
       await vi.advanceTimersByTimeAsync(0);
       await timerPromise;
 
@@ -1593,7 +1593,7 @@ describe("cron service timer regressions", () => {
       expect(isCronJobActive(cronJob.id)).toBe(true);
 
       now = scheduledAt + 2_000;
-      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY });
+      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
       await vi.advanceTimersByTimeAsync(0);
       await timerPromise;
 
@@ -1784,7 +1784,7 @@ describe("cron service timer regressions", () => {
     };
     const runHeartbeatOnce = vi
       .fn<() => Promise<HeartbeatRunResult>>()
-      .mockResolvedValueOnce({ status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY })
+      .mockResolvedValueOnce({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT })
       .mockResolvedValueOnce({ status: "ran", durationMs: 12 });
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeat = vi.fn();

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -45,7 +45,6 @@ import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import {
   getQueueSize,
   isCommandLaneTaskMarkerCurrent,
-  type CommandLaneSnapshot,
   type CommandLaneTaskMarker,
 } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -96,7 +95,6 @@ import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
-import { consumeSelectedSystemEventEntries } from "./system-events.js";
 
 const log = heartbeatLog;
 
@@ -105,7 +103,6 @@ export type HeartbeatDeps = OutboundSendDeps &
     getReplyFromConfig?: typeof import("./heartbeat-runner.runtime.js").getReplyFromConfig;
     runtime?: RuntimeEnv;
     getQueueSize?: (lane?: string) => number;
-    getCommandLaneSnapshots?: () => readonly CommandLaneSnapshot[];
     isReplyRunActive?: (sessionKey: string) => boolean;
     listActiveReplyRunSessionKeys?: () => readonly string[];
     listActiveEmbeddedRunSessionKeys?: () => readonly string[];
@@ -479,21 +476,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
   });
 
-  if (heartbeatRunPrompt.prompt === null) {
-    // Wake-triggered events should stay queued when the run short-circuits:
-    // no reply turn ran, so there is nothing that actually consumed that wake payload.
-    const shouldConsumeInspectedEvents =
-      !preflight.isWakePayload && preflight.shouldInspectPendingEvents;
-    const inspectedSystemEventsToConsume = selectSystemEventsConsumedByHeartbeat({
-      preflight,
-      hasExecCompletion: heartbeatRunPrompt.hasExecCompletion,
-      hasCronEvents: heartbeatRunPrompt.hasCronEvents,
-    });
-    if (shouldConsumeInspectedEvents && inspectedSystemEventsToConsume.length > 0) {
-      consumeSelectedSystemEventEntries(sessionKey, inspectedSystemEventsToConsume);
-    }
-    return { kind: "skipped", reason: "not-due" } as const;
-  }
   let runSessionKey = sessionKey;
   let runSessionEntry = entry;
   let outboundPolicySessionKey: string | undefined;
@@ -602,10 +584,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     }
   }
   const { hasExecCompletion, hasCronEvents } = heartbeatRunPrompt;
-  const prompt = heartbeatRunPrompt.prompt;
-  if (prompt === null) {
-    return { kind: "skipped", reason: "not-due" } as const;
-  }
   return {
     kind: "ready",
     ...preflight.session,
@@ -617,7 +595,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     runSessionKey,
     outboundPolicySessionKey,
     ...heartbeatRunPrompt,
-    prompt,
     inspectedSystemEventsToConsume: selectSystemEventsConsumedByHeartbeat({
       preflight,
       hasExecCompletion,

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -202,7 +202,7 @@ export async function resolveHeartbeatPreflight(params: {
 }
 
 type HeartbeatPromptResolution = {
-  prompt: string | null;
+  prompt: string;
   hasExecCompletion: boolean;
   hasRelayableExecCompletion: boolean;
   hasCronEvents: boolean;

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -9,7 +9,6 @@ import {
   createEmbeddedRunHandle,
   testing as embeddedRunTesting,
 } from "../agents/embedded-agent-runner/runs.test-support.js";
-import { resolveNestedAgentLaneForSession } from "../agents/lanes.js";
 import { recordReplyOperationAgentTurn } from "../auto-reply/reply/reply-operation-agent-turn-state.js";
 import { resolveReplyOperationRunState } from "../auto-reply/reply/reply-operation-run-state.js";
 import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
@@ -17,7 +16,6 @@ import { testing as replyRunRegistryTesting } from "../auto-reply/reply/reply-ru
 import type { OpenClawConfig } from "../config/config.js";
 import { markCronJobActive, resetCronActiveJobs } from "../cron/active-jobs.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
-import type { CommandLaneSnapshot } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { getAgentEventLifecycleGeneration } from "./agent-events.js";
@@ -111,17 +109,6 @@ function runHeartbeat(
       ...deps,
     } as HeartbeatDeps,
   });
-}
-
-function createBusyLaneSnapshot(lane: string): CommandLaneSnapshot {
-  return {
-    lane,
-    activeCount: 1,
-    queuedCount: 0,
-    maxConcurrent: 1,
-    draining: false,
-    generation: 0,
-  };
 }
 
 describe("heartbeat runner skips when target session lane is busy", () => {
@@ -304,11 +291,10 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
-  it("does not return lanes-busy for global subagent-lane work alone", async () => {
+  it("does not skip for global subagent-lane work alone", async () => {
     // The global Subagent lane has no agent identity in its name — a stalled
     // subagent on any one agent must not silently disable every other
-    // agent's heartbeat. Per-agent attribution comes from the session-keyed
-    // lane variants exercised below.
+    // agent's heartbeat.
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig(storePath);
       cfg.agents!.defaults!.heartbeat = { every: "30m", target: "last" };
@@ -320,50 +306,6 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         {},
         {
           getQueueSize: vi.fn((lane?: string) => (lane === CommandLane.Subagent ? 1 : 0)),
-          getCommandLaneSnapshots: vi.fn(() => []),
-        },
-      );
-
-      expect(result.status).not.toBe("skipped");
-    });
-  });
-
-  it("runs despite work in this agent's nested session lane", async () => {
-    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
-      const cfg = createHeartbeatTelegramConfig(storePath);
-      cfg.agents!.defaults!.heartbeat = { every: "30m", target: "last" };
-      await seedHeartbeatTelegramSession(storePath, cfg);
-      const nestedSessionLane = resolveNestedAgentLaneForSession("agent:main:telegram:123");
-
-      const result = await runHeartbeat(
-        cfg,
-        replySpy,
-        {},
-        {
-          getCommandLaneSnapshots: vi.fn(() => [createBusyLaneSnapshot(nestedSessionLane)]),
-        },
-      );
-
-      expect(result.status).toBe("ran");
-      expect(replySpy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does not return lanes-busy for another agent's session-scoped nested lane", async () => {
-    // Per-agent scoping: a zombie subagent or nested run belonging to a
-    // different agent must not block this agent's heartbeat.
-    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
-      const cfg = createHeartbeatTelegramConfig(storePath);
-      cfg.agents!.defaults!.heartbeat = { every: "30m", target: "last" };
-      await seedHeartbeatTelegramSession(storePath, cfg);
-      const nestedSessionLane = resolveNestedAgentLaneForSession("agent:other:telegram:123");
-
-      const result = await runHeartbeat(
-        cfg,
-        replySpy,
-        {},
-        {
-          getCommandLaneSnapshots: vi.fn(() => [createBusyLaneSnapshot(nestedSessionLane)]),
         },
       );
 

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../process/gateway-work-admission.js";
 import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
-  HEARTBEAT_SKIP_LANES_BUSY,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   requestHeartbeat,
   setHeartbeatWakeHandler as setRuntimeHeartbeatWakeHandler,
@@ -639,7 +638,7 @@ describe("heartbeat-wake", () => {
     });
   });
 
-  it.each([HEARTBEAT_SKIP_CRON_IN_PROGRESS, HEARTBEAT_SKIP_LANES_BUSY])(
+  it.each([HEARTBEAT_SKIP_CRON_IN_PROGRESS])(
     "retries %s after the default retry delay",
     async (reason) => {
       vi.useFakeTimers();

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -35,13 +35,11 @@ export type {
 
 export const HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT = "requests-in-flight";
 export const HEARTBEAT_SKIP_CRON_IN_PROGRESS = "cron-in-progress";
-export const HEARTBEAT_SKIP_LANES_BUSY = "lanes-busy";
 export const HEARTBEAT_SKIP_NO_PENDING_EVENT = "no-pending-event";
 export const HEARTBEAT_SKIP_PREEMPTED = "preempted";
 const RETRYABLE_HEARTBEAT_SKIP_REASONS = new Set([
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
-  HEARTBEAT_SKIP_LANES_BUSY,
   HEARTBEAT_SKIP_PREEMPTED,
 ]);
 const RETRYABLE_GUARD_SKIP_REASONS = new Set(["not-due", "min-spacing", "flood"]);


### PR DESCRIPTION
## What Problem This Solves

Two dead surfaces in the heartbeat runner that read as live policy and mislead both maintainers and the model of the code:

1. `resolveHeartbeatRunPrompt` was typed `prompt: string | null`, and `heartbeat-runner-execution.ts` carried two `prompt === null` → `skipped/not-due` short-circuits (one with wake-payload event-consumption bookkeeping). But every prompt producer returns a non-empty string — the only `prompt: null` producer (inferred commitments follow-ups) was deleted in 4b0151682ef. Both branches were unreachable.
2. `HEARTBEAT_SKIP_LANES_BUSY` had no producer anywhere, and `HeartbeatDeps.getCommandLaneSnapshots` had no production reader — the per-lane busy check was consolidated into requests-in-flight admission. Tests still injected the dep and simulated the reason, proving only the mocks.

## Why This Change Was Made

Dead branches in lifecycle code are worse than dead helpers: the not-due short-circuit implied a heartbeat could still silently skip after prompt resolution, and the phantom skip reason kept a retryable code path in `RETRYABLE_HEARTBEAT_SKIP_REASONS` that nothing can emit. Narrowing `HeartbeatPromptResolution.prompt` to `string` makes the invariant (a resolved heartbeat run always has a prompt) structural.

## User Impact

None at runtime — all removed paths were unreachable. Troubleshooting docs no longer list a `lanes-busy` skip reason that can never appear in logs.

## Evidence

- All heartbeat infra suites green: `node scripts/run-vitest.mjs run src/infra/heartbeat-runner*.test.ts src/infra/heartbeat-wake*.test.ts src/infra/heartbeat-events.test.ts` (3 shards) plus `src/cron/service/timer.regression.test.ts` and scheduler/targeted-wake suites.
- Retry-simulation tests retargeted at live retryable reasons (`requests-in-flight`); the two tests that only exercised the deleted dep are removed with the seam, per test-audit policy on obsolete-internals tests.
- tsgo core + test shards clean; oxfmt/oxlint clean; grep proves zero residual refs to `lanes-busy`/`getCommandLaneSnapshots`.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +2 −27 (net −25); tests +7 −66.
