### PR TITLE
fix(imessage): stop self-chat dedupe from tripping the echo loop limiter

### DIFF
--- a/extensions/imessage/src/monitor.self-chat-loop-limiter.test.ts
+++ b/extensions/imessage/src/monitor.self-chat-loop-limiter.test.ts
@@ -1,0 +1,222 @@
+// Imessage tests cover monitor self-chat loop rate limiter plugin behavior.
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
+import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-runtime";
+import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { createIMessageRpcClient } from "./client.js";
+import { monitorIMessageProvider } from "./monitor.js";
+import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+
+const waitForTransportReadyMock = vi.hoisted(() =>
+  vi.fn<typeof waitForTransportReady>(async () => {}),
+);
+const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
+const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
+const dispatchReplyWithBufferedBlockDispatcherMock = vi.hoisted(() =>
+  vi.fn<typeof dispatchReplyWithBufferedBlockDispatcher>(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+);
+
+vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
+  waitForTransportReady: waitForTransportReadyMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: readChannelAllowFromStoreMock,
+    recordInboundSession: vi.fn(),
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    createChannelInboundDebouncer: vi.fn((opts) => ({
+      debouncer: {
+        enqueue: async (entry: unknown) =>
+          await opts.onFlush([entry], createTestInboundDebounceFlush).completion,
+        flushKey: async () => {},
+        cancelKey: () => false,
+        drain: async () => {},
+      },
+    })),
+    shouldDebounceTextInbound: vi.fn(() => false),
+  };
+});
+
+vi.mock("./client.js", () => ({
+  createIMessageRpcClient: createIMessageRpcClientMock,
+}));
+
+vi.mock("./monitor/abort-handler.js", () => ({
+  attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
+}));
+
+type RunChannelInboundEventParams = Parameters<typeof channelInbound.runChannelInboundEvent>[0];
+
+async function runChannelInboundEventForSelfChatTest(params: RunChannelInboundEventParams) {
+  const input = await params.adapter.ingest(params.raw);
+  if (!input) {
+    return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
+  }
+  const eventClass = (await params.adapter.classify?.(input)) ?? {
+    kind: "message" as const,
+    canStartAgentTurn: true,
+  };
+  if (!eventClass.canStartAgentTurn) {
+    return {
+      admission: { kind: "handled" as const, reason: `event:${eventClass.kind}` },
+      dispatched: false,
+    };
+  }
+  const rawPreflight = await params.adapter.preflight?.(input, eventClass);
+  const preflight =
+    rawPreflight && "kind" in rawPreflight ? { admission: rawPreflight } : rawPreflight;
+  const preflightFacts = preflight ?? {};
+  const preflightAdmission = preflightFacts.admission;
+  if (
+    preflightAdmission &&
+    preflightAdmission.kind !== "dispatch" &&
+    preflightAdmission.kind !== "observeOnly"
+  ) {
+    return { admission: preflightAdmission, dispatched: false };
+  }
+  const turn = await params.adapter.resolveTurn(input, eventClass, preflightFacts);
+  if (!("route" in turn) || !("delivery" in turn)) {
+    throw new Error("expected assembled iMessage channel turn plan");
+  }
+  const admission = turn.admission ?? preflightAdmission ?? { kind: "dispatch" as const };
+  const result = {
+    admission,
+    dispatched: true as const,
+    ctxPayload: turn.ctxPayload,
+    routeSessionKey: turn.route.sessionKey,
+    dispatchResult: await dispatchReplyWithBufferedBlockDispatcherMock({
+      ctx: turn.ctxPayload,
+      cfg: turn.cfg,
+      dispatcherOptions: {
+        ...turn.dispatcherOptions,
+        deliver: turn.delivery.deliver,
+        onError: turn.delivery.onError,
+      },
+      toolsAllow: turn.toolsAllow,
+      replyOptions: turn.replyOptions,
+      replyResolver: turn.replyResolver,
+    }),
+  };
+  await params.adapter.onFinalize?.(result);
+  return result;
+}
+
+const SELF_HANDLE = "+15551234567";
+const USER_MESSAGE_COUNT = 8;
+
+describe("monitorIMessageProvider self-chat loop rate limiter", () => {
+  beforeEach(() => {
+    vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation(
+      runChannelInboundEventForSelfChatTest as typeof channelInbound.runChannelInboundEvent,
+    );
+    installIMessageStateRuntimeForTest();
+    createIMessageRpcClientMock.mockReset();
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps delivering self-chat messages past the loop limit", async () => {
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+    let onNotification:
+      | ((message: { method: string; params: unknown }) => void | Promise<void>)
+      | undefined;
+
+    const selfChatRow = (params: {
+      id: number;
+      guid: string;
+      text: string;
+      createdAt: string;
+      fromMe: boolean;
+    }) => ({
+      id: params.id,
+      guid: params.guid,
+      chat_id: 42,
+      sender: SELF_HANDLE,
+      chat_identifier: SELF_HANDLE,
+      destination_caller_id: SELF_HANDLE,
+      is_from_me: params.fromMe,
+      is_group: false,
+      text: params.text,
+      created_at: params.createdAt,
+      attachments: [],
+    });
+
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {
+        for (let index = 1; index <= USER_MESSAGE_COUNT; index += 1) {
+          const text = `user message ${index}`;
+          const createdAt = new Date(Date.now() + index).toISOString();
+          for (const fromMe of [true, false]) {
+            await onNotification?.({
+              method: "message",
+              params: {
+                message: selfChatRow({
+                  id: index * 2 + (fromMe ? 0 : 1),
+                  guid: `${fromMe ? "sent" : "recv"}-${index}`,
+                  text,
+                  createdAt,
+                  fromMe,
+                }),
+              },
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+          }
+        }
+      }),
+      stop: vi.fn(async () => {}),
+    };
+
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime,
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_500);
+    });
+
+    const delivered = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+      (call) => (call[0].ctx as { BodyForAgent?: string }).BodyForAgent,
+    );
+    expect(delivered).toEqual(
+      Array.from({ length: USER_MESSAGE_COUNT }, (_, index) => `user message ${index + 1}`),
+    );
+    const logs = runtime.log.mock.calls.map(([message]) => String(message));
+    expect(logs.filter((message) => message.includes("rate limiter tripped"))).toEqual([]);
+  });
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -795,15 +795,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
 
     if (decision.kind === "drop") {
       // Record echo/reflection drops so the rate limiter can detect sustained loops.
-      // Only loop-related drop reasons feed the counter; policy/mention/empty drops
-      // are normal and should not escalate. "from me" is excluded: every own-send
-      // (agent replies, multi-chunk sends, operator phone traffic) produces a
-      // from-me row, so counting it lets a normal outbound burst trip the limiter
-      // and silently suppress the next legitimate inbound message.
+      // Only reasons that mean agent-produced content came back feed the counter;
+      // policy/mention/empty drops are normal and should not escalate. Per-row
+      // dedupes are excluded: "from me" fires on every own-send, and "self-chat
+      // echo" fires on the duplicate row macOS writes for each self-chat message,
+      // so counting either lets ordinary traffic trip the limiter and silently
+      // suppress the next legitimate inbound message.
       const isLoopDrop =
-        decision.reason === "echo" ||
-        decision.reason === "self-chat echo" ||
-        decision.reason === "reflected assistant content";
+        decision.reason === "echo" || decision.reason === "reflected assistant content";
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
       }


### PR DESCRIPTION
## What Problem This Solves

In an iMessage self-chat (the "Note to Self" thread that is the standard single-number OpenClaw iMessage setup), the sixth and every later user message inside a 60 second window is silently discarded. Nothing reaches the agent, nothing is retried, nothing is dead-lettered, and the only signal is a warning claiming an echo loop was detected when no loop occurred. After roughly 60 seconds of silence the thread starts working again on its own.

macOS writes two rows for one self-chat message: the `is_from_me` row and the looped-back received copy. The received copy is correctly recognized as a duplicate and dropped with reason `"self-chat echo"`. That benign per-row dedupe is what charges the echo-loop rate limiter, so every ordinary user message counts as one loop hit. The limiter allows 5 hits per 60 seconds, so message 6 onward is suppressed. Suppression happens after the durable ingress claim has been completed and tombstoned, so the message is permanently lost rather than retried.

## Root cause

`extensions/imessage/src/monitor/monitor-provider.ts:803` treats a per-row dedupe as loop evidence.

before:

```ts
const isLoopDrop =
  decision.reason === "echo" ||
  decision.reason === "self-chat echo" ||
  decision.reason === "reflected assistant content";
if (isLoopDrop) {
  loopRateLimiter.record(rateLimitKey);
}
```

The chain, at the current base:

- `extensions/imessage/src/monitor/inbound-processing.ts:501` and `:504` remember every self-chat `is_from_me` row in `selfChatCache`; `:700` looks the row up again and `:709` returns `{ kind: "drop", reason: "self-chat echo" }` for the looped-back copy. This fires once per self-chat message, for user messages and agent replies alike, and it fires precisely because the dedupe worked. It is not evidence of amplification.
- `extensions/imessage/src/monitor/loop-rate-limiter.ts:6-7` sets the budget at 5 hits per 60 seconds, and `monitor-provider.ts:374` constructs the limiter with those defaults.
- `monitor-provider.ts:840-853` then returns early for any `dispatch` decision once the limiter is tripped, logging `echo loop detected (rate limiter tripped)`.
- That return is inside `handleMessageNowInner`, reached from `handleMessageNow` at `:689`. The caller at `:573`/`:591` runs `await handleMessageNow(...)` and then `await settle()` unconditionally, so the durable ingress claim is completed and tombstoned for a message that was never delivered. There is no retry path and no dead letter.

This is the same defect class that #120260 already fixed for `"from me"`. That PR removed `"from me"` from this counter because "every own-send produces a from-me row, so counting it lets a normal outbound burst trip the limiter and silently suppress the next legitimate inbound message". `"self-chat echo"` has the same shape and was left in.

## Fix

after:

```ts
const isLoopDrop =
  decision.reason === "echo" || decision.reason === "reflected assistant content";
```

The counter now holds only the two reasons that mean agent-produced content came back: `"echo"` (inbound matched a recent outbound send) and `"reflected assistant content"`. Both are produced by the echo cache, which matches against what OpenClaw actually sent, so they fire only when the agent's own output re-enters the pipeline. A genuine self-chat amplification loop still trips the limiter through those reasons, so the safety net is scoped rather than deleted.

## Why this is the right boundary

The limiter's contract is "sustained agent-content reflection", and this is the single place that decides which drops count as evidence for it. Filtering downstream (per chat, behind a config flag, or by disabling the limiter for self-chats) would leave the wrong signal being recorded and would reopen the loop the limiter defends against.

There is no sibling surface to fix: `createLoopRateLimiter` has exactly one production caller, `monitorIMessageProvider`. No other channel consumes iMessage inbound drop reasons.

Existing behavior is preserved. The genuine echo-loop case still trips the limiter and still logs the redacted default-level warning; that path is covered by the assertion added in #120260 at `extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`, which is untouched here.

Related but distinct: issue #122794 also reports self-chat messages being dropped, but through id-less pending markers in the persisted echo cache dropping a distinct-GUID message as `"echo"`. That is a matching bug in the echo cache. This one is a counting bug in the loop limiter, and it discards messages that the dedupe layer had already handled correctly.

## Verification

Please treat CI as the authoritative signal for this branch head. Exactly what was and was not run locally:

- Not re-run at this head. After the local runs below, this session was instructed to stop running test, lint, and typecheck lanes, so nothing was executed against the rebased head commit.
- The mechanism was confirmed by reading the code at the current base: the drop reason at `inbound-processing.ts:709`, its membership in the `isLoopDrop` set at `monitor-provider.ts:803-809`, the 5/60s budget at `loop-rate-limiter.ts:6-7`, the suppression return at `monitor-provider.ts:840-853`, and the unconditional `await settle()` after `await handleMessageNow(...)` at `:573-577` and `:591-592`.
- Earlier in the session, against pristine upstream main `c3488150c55` and the same patch, the runtime scenario in the proof below was executed, and the new colocated suite `extensions/imessage/src/monitor.self-chat-loop-limiter.test.ts` failed before the fix with `expected [ 'user message 1', ...(4) ] to deeply equal [ 'user message 1', ...(7) ]` and passed after it, alongside `monitor.watch-subscribe-retry.test.ts`. `extensions/imessage` is byte-identical between `c3488150c55` and this branch's base, so those runs describe this diff, but they predate the rebase and were not repeated.
- `oxfmt --check` was clean on both changed files. A typecheck of `tsconfig.extensions.json` reported only pre-existing errors in `extensions/cua-computer` from a stale local dependency, and none in `extensions/imessage`; the extension test-types lane was stopped before completing.
- Production delta is net negative: 7 added, 8 removed in `monitor-provider.ts`, of which the behavior change is one removed condition line. The remaining lines are the adjacent comment restated to name why per-row dedupes are excluded. Every other added line is the regression suite.

## Real behavior proof

Behavior addressed: in an iMessage self-chat, the sixth and later user messages within 60 seconds never reach the agent and are permanently discarded, behind a warning that claims an echo loop.
Real environment tested: the real `monitorIMessageProvider` monitor loop, driven through its real RPC notification handler, on pristine upstream main `c3488150c55` and on the patched tree; `extensions/imessage` is unchanged between that commit and this branch's base. The self-chat detection, `selfChatCache` dedupe, inbound decision resolver, durable ingress admission and settle, loop rate limiter, and conversation routing were all the shipped code. The only substituted seam is the imsg RPC transport that would otherwise read the macOS `chat.db`; it emits the exact two-row shape macOS writes for one self-chat message.
Exact steps or command run after this patch: start the iMessage monitor against that transport, deliver 8 consecutive self-chat messages from the operator handle, each as its `is_from_me` row followed by the looped-back received copy, and record for each message whether an agent turn started.
Evidence after fix:
```
# BEFORE (pristine upstream main c3488150c55)
Note to Self  >>  typed: "user message 1"
agent turn    <<  started for: "user message 1"
Note to Self  >>  typed: "user message 2"
agent turn    <<  started for: "user message 2"
Note to Self  >>  typed: "user message 3"
agent turn    <<  started for: "user message 3"
Note to Self  >>  typed: "user message 4"
agent turn    <<  started for: "user message 4"
Note to Self  >>  typed: "user message 5"
agent turn    <<  started for: "user message 5"
Note to Self  >>  typed: "user message 6"
agent turn    <<  NONE (message never reached the agent)
monitor log   --  [imessage:default] Suppressing inbound from group:sha256:c9042efcbc90: echo loop detected (rate limiter tripped)
Note to Self  >>  typed: "user message 7"
agent turn    <<  NONE (message never reached the agent)
Note to Self  >>  typed: "user message 8"
agent turn    <<  NONE (message never reached the agent)

# AFTER (this patch, identical inputs)
Note to Self  >>  typed: "user message 1"
agent turn    <<  started for: "user message 1"
Note to Self  >>  typed: "user message 2"
agent turn    <<  started for: "user message 2"
Note to Self  >>  typed: "user message 3"
agent turn    <<  started for: "user message 3"
Note to Self  >>  typed: "user message 4"
agent turn    <<  started for: "user message 4"
Note to Self  >>  typed: "user message 5"
agent turn    <<  started for: "user message 5"
Note to Self  >>  typed: "user message 6"
agent turn    <<  started for: "user message 6"
Note to Self  >>  typed: "user message 7"
agent turn    <<  started for: "user message 7"
Note to Self  >>  typed: "user message 8"
agent turn    <<  started for: "user message 8"
```
Observed result after fix: on the same 8 self-chat messages the base tree starts an agent turn for only the first 5 and silently discards the last 3 behind a false echo-loop warning, while the patched monitor starts a turn for all 8 and emits no suppression warning.
What was not tested: no live macOS `chat.db` or real imsg process was driven, so the row shape came from the substituted transport rather than a real Messages database; a genuine amplification loop was exercised only through the existing echo-cache path, not against a live device; nothing was re-executed against this branch head after the rebase, and no build was run.
