### PR TITLE
fix(gateway): report worker errors returned before launch

### DIFF
--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -395,19 +395,19 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
       await measureDiagnosticsTimelineSpan(
         "gateway.chat_send.post_dispatch",
         async () => {
-          const returnedAgentErrorPayloads = agentRunStarted
-            ? replyDispatch.deliveredReplies
-                .map((entryInner) => entryInner.payload)
-                .filter((payload) => payload.isError)
-            : [];
+          const returnedAgentErrorPayloads = replyDispatch.deliveredReplies
+            .map((entryInner) => entryInner.payload)
+            .filter((payload) => payload.isError);
+          const hasReturnedAgentError =
+            returnedAgentErrorPayloads.length > 0 &&
+            (agentRunStarted || !isInternalTextSlashCommandTurn);
           const returnedAgentErrorMessage =
             returnedAgentErrorPayloads
               .map((payload) => payload.text?.trim())
               .filter((text): text is string => Boolean(text))
               .join(" | ") || undefined;
           if (
-            agentRunStarted &&
-            returnedAgentErrorPayloads.length > 0 &&
+            hasReturnedAgentError &&
             !userTurnRecorder.hasPersisted() &&
             !userTurnRecorder.isBlocked()
           ) {
@@ -426,7 +426,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
           // Agent runs persist model-visible turns through SessionManager; this dispatcher owns
           // live delivery. Mirroring agent finals would duplicate normal assistant turns. The
           // non-agent branch has no runtime-owned turn, so it appends one before broadcasting.
-          if (!agentRunStarted && !queuedFollowup.isEnqueued()) {
+          if (!agentRunStarted && !queuedFollowup.isEnqueued() && !hasReturnedAgentError) {
             await finalizeChatSendNonAgentReplies({
               accountId,
               context,
@@ -443,12 +443,11 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
               context,
               deliveredReplies: replyDispatch.deliveredReplies,
               emitFirstAssistantServerTiming,
-              hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
+              hasReturnedAgentErrorPayloads: hasReturnedAgentError,
               session,
             });
           }
-          const shouldBroadcastAgentError =
-            returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+          const shouldBroadcastAgentError = hasReturnedAgentError && !broadcastedSourceReplyFinal;
           if (shouldBroadcastAgentError) {
             broadcastChatError({
               context,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4521,10 +4521,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(finalBroadcasts).toStrictEqual([]);
   });
 
-  it("broadcasts returned agent-run error payloads after an agent starts", async () => {
+  it.each([
+    ["after start", true],
+    ["before launch", false],
+  ] as const)("broadcasts returned agent-run error payloads $0", async (_name, agentStarted) => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-agent-returned-error-");
-    const errorMessage = "LLM idle timeout (120s): no response from model";
-    mockState.triggerAgentRunStart = true;
+    const errorMessage = agentStarted
+      ? "LLM idle timeout (120s): no response from model"
+      : "Worker must bootstrap the current build before continuing";
+    mockState.triggerAgentRunStart = agentStarted;
     mockState.dispatchedReplies = [
       {
         kind: "final",
@@ -4535,23 +4540,24 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     const { context, send } = createChatRequestFixture();
+    const runId = agentStarted ? "idem-agent-returned-error" : "idem-agent-rejected-before-launch";
 
     const broadcast = await send({
-      idempotencyKey: "idem-agent-returned-error",
+      idempotencyKey: runId,
       message: "please keep working",
     });
 
     expect(broadcast).toMatchObject({
-      runId: "idem-agent-returned-error",
+      runId,
       sessionKey: "agent:main:main",
       state: "error",
       errorMessage,
     });
     expect(broadcast).not.toHaveProperty("message");
-    const dedupe = context.dedupe.get("chat:idem-agent-returned-error");
+    const dedupe = context.dedupe.get(`chat:${runId}`);
     expect(dedupe?.ok).toBe(false);
     expect(dedupe?.payload).toMatchObject({
-      runId: "idem-agent-returned-error",
+      runId,
       status: "error",
       summary: errorMessage,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a delegated worker rejection returned before the agent-run-start boundary could be delivered internally but recorded as a successful or missing terminal outcome, leaving wait and dedupe clients without the actual error.

## Why This Change Was Made

Chat dispatch now treats returned error payloads as authoritative for normal turns whether the worker failed before launch or after the agent run started. Internal text slash commands retain their existing non-agent reply behavior.

## User Impact

Waiting clients receive and retain the real worker error when launch is rejected, instead of an ambiguous success or a missing completion.

## Evidence

- Focused Gateway suite: `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts` — 199 passed on the rebased two-file head.
- Behavior contract: both post-start and pre-launch worker-error variants broadcast an error state and persist the matching dedupe error; both named variants passed.
- Production LOC: +10/-11 (net -1); tests: +13/-7 (net +6).
- Autoreview: clean, no accepted/actionable findings.

## Split From The Original PR

The Node bundle prewarm work was removed from this PR. It is parked on `steipete/bundle-prewarm-negotiated` for a separate draft that requires mixed-version capability negotiation and abort propagation before it can be considered for merge.
