### PR TITLE
perf(test): synchronize MCP lifecycle tests

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -448,6 +448,22 @@ async function waitForPredicate(
   throw new Error(`Timed out waiting for ${description}`);
 }
 
+async function waitForFileTextCount(
+  filePath: string,
+  expectedText: string,
+  expectedCount: number,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForPredicate(
+    async () => {
+      const text = await fs.readFile(filePath, "utf8").catch(() => "");
+      return text.split(expectedText).length - 1 >= expectedCount;
+    },
+    `${expectedCount} occurrences of ${expectedText} in ${filePath}`,
+    timeoutMs,
+  );
+}
+
 /** Waits for a replacement child to register a pid different from the one that died. */
 async function waitForChangedPid(
   pidPath: string,
@@ -1169,6 +1185,7 @@ describe("session MCP runtime", () => {
     const tempDir = tempDirTracker.make("bundle-mcp-catalog-retry-");
     const retryServerPath = path.join(tempDir, "retry-list-tools.mjs");
     const retryLogPath = path.join(tempDir, "retry-server.log");
+    const retryReleasePath = path.join(tempDir, "retry.release");
     const healthyServerPath = path.join(tempDir, "healthy-list-tools.mjs");
     const healthyLogPath = path.join(tempDir, "healthy-server.log");
     let nowMs = 10_000;
@@ -1237,7 +1254,7 @@ describe("session MCP runtime", () => {
       await writeListToolsMcpServer({
         filePath: retryServerPath,
         logPath: retryLogPath,
-        initializeDelayMs: 500,
+        listToolsReleasePath: retryReleasePath,
       });
       await expect(runtime.getCatalog()).resolves.toBe(failedCatalog);
 
@@ -1250,9 +1267,16 @@ describe("session MCP runtime", () => {
       );
       expect(staleCatalog).toBe(failedCatalog);
       expect(staleCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
+      await waitForFileTextCount(
+        retryLogPath,
+        "recv tools/list",
+        2,
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
       await expect(runtime.callTool("healthyServer", "healthy_tool", {})).resolves.toMatchObject({
         isError: false,
       });
+      await fs.writeFile(retryReleasePath, "release", "utf8");
 
       await waitForPredicate(
         () => staticRuntime.peekCatalog()?.servers.retryServer !== undefined,
@@ -1678,13 +1702,15 @@ process.on("SIGINT", shutdown);`,
     const serverPath = path.join(tempDir, "server.mjs");
     const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
+    const listToolsReleasePath = path.join(tempDir, "list-tools.release");
     const healthyServerPath = path.join(tempDir, "healthy.mjs");
     const healthyLogPath = path.join(tempDir, "healthy.log");
+    await fs.writeFile(listToolsReleasePath, "release", "utf8");
     await writeListToolsMcpServer({
       filePath: serverPath,
       logPath,
       pidPath,
-      initializeDelayMs: 750,
+      listToolsReleasePath,
     });
     await writeListToolsMcpServer({ filePath: healthyServerPath, logPath: healthyLogPath });
 
@@ -1708,6 +1734,7 @@ process.on("SIGINT", shutdown);`,
       });
       await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+      await fs.rm(listToolsReleasePath, { force: true });
       // SIGKILL rather than the default SIGTERM: this test is about what happens once the
       // child is actually gone, so the kill must not race the assertions below.
       process.kill(pid, "SIGKILL");
@@ -1719,6 +1746,8 @@ process.on("SIGINT", shutdown);`,
         "closed transport to schedule a catalog retry",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
+      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow("is not connected");
+      await waitForFileTextCount(logPath, "recv tools/list", 2, LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       await expect(
         withTestTimeout(
           runtime.callTool("healthy", "slow_tool", {}),
@@ -1726,6 +1755,7 @@ process.on("SIGINT", shutdown);`,
           "healthy sibling stalled during reconnect",
         ),
       ).resolves.toMatchObject({ isError: false });
+      await fs.writeFile(listToolsReleasePath, "release", "utf8");
       await waitForPredicate(
         async () => {
           try {


### PR DESCRIPTION
## What Problem This Solves

Two MCP runtime lifecycle regressions spend about two seconds waiting on fixed child-process initialization delays. The sleeps make a focused 91-test owner suite materially slower while still relying on elapsed time rather than observing the lifecycle state each case needs.

## Why This Change Was Made

Replace the 500 ms catalog-retry delay and the 750 ms-per-process reconnect delay with filesystem release gates already supported by the real stdio test server. Each test now waits until the replacement server has received its second `tools/list`, proves the healthy sibling remains callable while recovery is blocked, then releases the exact operation under test.

The suite still exercises the real MCP SDK, child processes, stdio transport, stale-while-revalidate catalog path, SIGKILL close handling, fail-closed disconnected calls, sibling routing, and replacement PID. No production code changes.

## User Impact

Maintainer test feedback is faster and less timing-dependent. Runtime behavior is unchanged.

## Evidence

Controlled same-Testbox A/B on `tbx_01m049k24ea63j530ermpf157x`, one excluded warmup plus two retained samples per state, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 8.69s | 6.66s | -2.03s (-23.4%) |
| Vitest | 5.78s | 3.92s | -32.2% |
| Test body | 4.01s | 2.09s | -48.0% |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 91/91 MCP runtime owner tests.
- 99/99 combined runtime, real Agent Plugins stdio integration, and runtime-config tests.
- Full `check:changed` core-test gate on the retained Testbox, including core test typecheck and targeted lint.
- Fresh Codex autoreview after rebasing onto current `origin/main`: no accepted/actionable findings.
- Mutation: making stale catalog retry synchronous fails with `catalog retry blocked the triggering turn` while the release gate is closed.
- Mutation: removing transport-close retry scheduling fails waiting for the closed transport to schedule catalog recovery.

Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/31924169948
