### PR TITLE
fix(ui): release losing fallback payloads on composer adoption

### DIFF
--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -87,6 +87,20 @@ export function releaseChatAttachmentPayloads(attachments: readonly ChatAttachme
   }
 }
 
+/**
+ * Releases displaced attachments except ids still referenced by a retained
+ * owner (live composer, surviving fallbacks). Attachments are backups of
+ * composer state, so shared ids across owners are the norm — dropping one
+ * owner must never revoke another owner's payload.
+ */
+export function releaseDisplacedChatAttachmentPayloads(
+  displaced: readonly ChatAttachment[],
+  retained: ReadonlyArray<readonly ChatAttachment[]>,
+): void {
+  const retainedIds = new Set(retained.flat().map((attachment) => attachment.id));
+  releaseChatAttachmentPayloads(displaced.filter((attachment) => !retainedIds.has(attachment.id)));
+}
+
 export function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }

--- a/ui/src/pages/chat/chat-composer-memory-fallback.test.ts
+++ b/ui/src/pages/chat/chat-composer-memory-fallback.test.ts
@@ -1,0 +1,105 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+} from "./attachment-payload-store.ts";
+import { retainChatComposerMemoryFallback } from "./chat-composer-memory-fallback.ts";
+import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
+import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
+
+function storedAttachment(id: string, mimeType = "image/png"): ChatAttachment {
+  return registerChatAttachmentPayload({
+    attachment: { id, mimeType },
+    dataUrl: `data:${mimeType};base64,${id}`,
+    file: new File([id], id, { type: mimeType }),
+  });
+}
+
+function globalHost(
+  fallbacks: Record<string, ChatComposerMemoryFallback>,
+  attachments: ChatAttachment[] = [],
+): ChatPageHost {
+  return {
+    agentsList: { defaultId: "main", mainKey: "main" },
+    assistantAgentId: "main",
+    chatAttachments: attachments,
+    chatComposerFallbackByScope: fallbacks,
+    hello: null,
+    sessionKey: "global",
+    settings: { gatewayUrl: "ws://example.test" },
+  } as unknown as ChatPageHost;
+}
+
+describe("chat composer memory fallback adoption", () => {
+  it("releases losing sibling fallback payloads when adoption drops them", () => {
+    const losing = storedAttachment("losing-sibling-attachment");
+    const winning = storedAttachment("winning-attachment");
+    const scope = { sessionKey: "global", agentId: "main" } as const;
+    const scopeKey = storedChatOutboxScopeKey(scope);
+    const bareGlobalKey = storedChatOutboxScopeKey({ sessionKey: "global" });
+    const host = globalHost({
+      [bareGlobalKey]: {
+        message: "older sibling draft",
+        attachments: [losing],
+        storageFailed: true,
+        sequence: 1,
+      },
+      [scopeKey]: {
+        message: "newest draft",
+        attachments: [winning],
+        storageFailed: true,
+        sequence: 2,
+      },
+    });
+
+    const ownership = retainChatComposerMemoryFallback(host, scope, {
+      message: "newest draft",
+      attachments: [winning],
+    });
+
+    expect(ownership).toEqual({ sequence: 2 });
+    expect(Object.keys(host.chatComposerFallbackByScope)).toEqual([scopeKey]);
+    // The losing sibling was dropped for good: its payload-store entry must be
+    // released with it, while the adopted fallback's payload stays available.
+    expect(getChatAttachmentDataUrl({ id: losing.id, mimeType: losing.mimeType })).toBeNull();
+    expect(getChatAttachmentDataUrl({ id: winning.id, mimeType: winning.mimeType })).toBe(
+      "data:image/png;base64,winning-attachment",
+    );
+  });
+
+  it("keeps payloads shared with the live composer when a sibling is dropped", () => {
+    const shared = storedAttachment("shared-with-composer");
+    const scope = { sessionKey: "global", agentId: "main" } as const;
+    const scopeKey = storedChatOutboxScopeKey(scope);
+    const bareGlobalKey = storedChatOutboxScopeKey({ sessionKey: "global" });
+    const host = globalHost(
+      {
+        [bareGlobalKey]: {
+          message: "older sibling draft",
+          attachments: [shared],
+          storageFailed: true,
+          sequence: 1,
+        },
+        [scopeKey]: {
+          message: "newest draft",
+          attachments: [],
+          storageFailed: true,
+          sequence: 2,
+        },
+      },
+      [shared],
+    );
+
+    retainChatComposerMemoryFallback(host, scope, {
+      message: "newest draft",
+      attachments: [],
+    });
+
+    expect(getChatAttachmentDataUrl({ id: shared.id, mimeType: shared.mimeType })).toBe(
+      "data:image/png;base64,shared-with-composer",
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-composer-memory-fallback.ts
+++ b/ui/src/pages/chat/chat-composer-memory-fallback.ts
@@ -6,6 +6,7 @@ import {
   resolveUiDefaultAgentId,
   resolveUiKnownSelectedGlobalAgentId,
 } from "../../lib/sessions/session-key.ts";
+import { releaseDisplacedChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
 import {
   loadChatComposerCommittedDraftRevision,
@@ -106,6 +107,13 @@ function resolveChatComposerMemoryFallback(
     delete nextFallbacks[candidate.scopeKey];
   }
   nextFallbacks[scopeKey] = adoptedFallback;
+  // Losing sibling fallbacks are dropped for good here; release their
+  // payload-store entries (like the pane-handoff owner does) or the data URLs
+  // leak for the pane's lifetime.
+  releaseDisplacedChatAttachmentPayloads(
+    candidates.flatMap((candidate) => candidate.fallback.attachments),
+    [state.chatAttachments, ...Object.values(nextFallbacks).map((f) => f.attachments)],
+  );
   state.chatComposerFallbackByScope = nextFallbacks;
   return { fallback: adoptedFallback, scopeKey };
 }

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -1,6 +1,9 @@
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
-import { releaseChatAttachmentPayload } from "./attachment-payload-store.ts";
+import {
+  releaseChatAttachmentPayload,
+  releaseDisplacedChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
 import { panesOf, type ChatSplitLayout, visiblePanesOf } from "./split-layout.ts";
@@ -51,13 +54,10 @@ export function restorePaneStagedAttachments(
     ...restored.fallbacks,
     ...state.chatComposerFallbackByScope,
   };
-  const retainedIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
-  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-    for (const attachment of fallback.attachments) {
-      retainedIds.add(attachment.id);
-    }
-  }
-  releaseAttachments(displaced, retainedIds);
+  releaseDisplacedChatAttachmentPayloads(displaced, [
+    state.chatAttachments,
+    ...Object.values(state.chatComposerFallbackByScope).map((fallback) => fallback.attachments),
+  ]);
 }
 
 export function preparePaneStagedAttachments(


### PR DESCRIPTION
## What Problem This Solves

Global-scope composer fallback adoption (`resolveChatComposerMemoryFallback`) coalesces sibling candidates — bare-global, default-main alias, qualified-main — into one winner and deletes the losers from `chatComposerFallbackByScope`. Unlike every `clearChatComposerMemoryFallback` caller, it never released the losers' attachment payload-store entries, so their data URLs and object URLs (up to 5 MiB each) leaked for the pane's lifetime.

## Why This Change Was Made

The payload store is ref-by-id with explicit release; every other drop point (clear, pane handoff, queue drain, editor replace) releases what it drops. Adoption was the one owner that didn't. The fix releases dropped candidates' payloads at the adoption site with the same retention rule the pane-handoff owner already uses (ids still referenced by the live composer or any surviving fallback stay retained) — and that shared rule is now one helper, `releaseDisplacedChatAttachmentPayloads`, used by both owners instead of two hand-rolled retained-id set builders.

## User Impact

Long-lived Control UI panes that flip between global agent targets with attachment drafts no longer accumulate leaked attachment payloads and un-revoked object URLs.

## Evidence

- New regression `releases losing sibling fallback payloads when adoption drops them` fails pre-fix (stash proof) and passes post-fix; companion test proves ids shared with the live composer survive a sibling drop.
- `node scripts/run-vitest.mjs run ui/src/pages/chat/chat-composer-memory-fallback.test.ts ui/src/pages/chat/chat-pane-attachment-handoff.test.ts ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-pane-retained-presentation.test.ts` — all green.
- `tsgo:ui` clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.98.
- Prod LOC: +30 −8 (net +22: the release call, the shared helper, and the handoff-site consolidation); tests +105.
