### PR TITLE
fix(ui): restore browser routing E2E after panel move

### DIFF
--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -327,17 +327,13 @@ suite.define(() => {
           }
 
           await page.goto(`${suite.server.baseUrl}chat`);
-          await expect
-            .poll(() =>
-              page.evaluate(async () => {
-                await customElements.whenDefined("openclaw-browser-panel");
-                const panel = document.querySelector<HTMLElement & { available?: boolean }>(
-                  "openclaw-browser-panel",
-                );
-                return { available: panel?.available === true };
-              }),
-            )
-            .toEqual({ available: true });
+          await page.locator(".agent-chat__composer-combobox textarea").waitFor();
+          if (captureUiProofEnabled && host === "browser") {
+            await page.screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "03-link-routing-before.png"),
+            });
+          }
           await page.evaluate(() => {
             const link = document.createElement("a");
             link.href = "https://example.com/application-handled";
@@ -390,7 +386,13 @@ suite.define(() => {
             method: "POST",
             path: "/tabs/open",
           });
-          const browserPanel = page.locator("openclaw-browser-panel");
+          const browserPanel = page.locator("openclaw-browser-panel[embedded]");
+          await browserPanel.waitFor();
+          expect(
+            await browserPanel.evaluate(
+              (element: HTMLElement & { available?: boolean }) => element.available === true,
+            ),
+          ).toBe(true);
           await browserPanel.getByText("Example", { exact: true }).first().waitFor();
           await expect
             .poll(
@@ -398,6 +400,12 @@ suite.define(() => {
             )
             .toBe(false);
           expect(await browserPanel.textContent()).not.toContain("Browser request failed");
+          if (captureUiProofEnabled && host === "browser") {
+            await page.screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "04-browser-panel-after.png"),
+            });
+          }
 
           if (host === "app") {
             expect(


### PR DESCRIPTION
Related: #124371

## What Problem This Solves

Fixes the Control UI browser-routing E2E failure that broke main CI after chat browser panels moved from the application shell into the on-demand tabbed side panel. The stale pre-action assertion waited for a shell-owned browser panel that session routes intentionally no longer render, so both browser-hosted and app-hosted cases timed out before exercising link routing.

## Why This Change Was Made

The E2E now follows the current ownership boundary: it waits for the chat surface, proves application-cancelled links remain untouched, clicks an eligible external link, and then asserts that the resulting embedded browser panel is available and renders the mocked page. This keeps the meaningful request/result coverage while removing an obsolete DOM precondition; production behavior is unchanged.

## User Impact

No user-visible runtime behavior changes. Main CI can validate the intended browser-link flow again, allowing unrelated PRs blocked by the broken test to resume.

## Evidence

- Pre-fix Linux Node 24 Testbox (`tbx_01m049jbemc6stb23dpqcycdss`, [run 31924156341](https://github.com/openclaw/openclaw/actions/runs/31924156341)): both host variants failed at `config-controls-visual.e2e.test.ts:340` with `expected { available: false } to deeply equal { available: true }`.
- Post-fix exact file: 4/4 passed on the same Testbox lease and frozen base `92b6c17bb82b5ae27ffb0c83863267557d8c3400`.
- Sibling Chromium proof: `chat-rail-columns`, `browser-screenshot-body-cancel`, and `native-link-routing` passed 8/8.
- Green Testbox gates: format, Control UI i18n, stylelint, UI and test types, import cycles, full build, full lint, changed gate, and `git diff --check`.
- Fresh Codex autoreview: no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +20/-12 (net +8).

### Visual proof

Before: settled chat with no browser panel before the eligible link action.

![Settled chat before opening the browser panel](https://github.com/user-attachments/assets/fdf98cf7-9b29-45cd-9828-2e1ffb42900e)

After: the same action opens the Browser tab in the embedded chat side panel and renders the mocked page.

![Browser link opened in the embedded chat side panel](https://github.com/user-attachments/assets/8e30a468-a13b-4010-9411-9485e2840cec)
