### PR TITLE
fix(talk): round fractional timestamps for STRICT session_nodes.updated_at

### DIFF
--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -459,7 +459,8 @@ function appendVoiceTranscript(params: {
         throw new Error(`agent session not found (${normalized.sessionKey})`);
       }
       const observedAt = Date.now();
-      const timestamp = normalized.timestamp ?? observedAt;
+      // STRICT session_nodes.updated_at requires INTEGER; round fractional timestamps.
+      const timestamp = Math.round(normalized.timestamp ?? observedAt);
       // Reserve before the fallible append. A crash can leave a conservative
       // retry requirement, but can never let close skip an accepted entry.
       runOpenClawAgentWriteTransaction(


### PR DESCRIPTION
## What Problem This Solves

Every `talk.client.transcript` request fails with `INVALID_REQUEST: Error: cannot store REAL value in INTEGER column session_nodes.updated_at`. The Talk realtime writer supplies a fractional (REAL) epoch timestamp, but the agent session store migrated to STRICT tables where the column is declared `updated_at INTEGER NOT NULL`, so SQLite rejects the write.

## Root Cause

The Talk realtime transcript writer passes fractional timestamps directly to the database without rounding.

## Fix

Round the timestamp to an integer using `Math.round()` before persisting.

## Evidence

- **Issue:** #119079
- **Test:** `client-voice-session.test.ts` passes (22 tests)
- **Runtime:** The fix rounds fractional timestamps to integers, allowing STRICT table writes to succeed

Fixes #119079