### PR TITLE
fix: restore release-validation fixture coverage

### DIFF
--- a/extensions/telegram/src/bot.media.e2e.test-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e.test-harness.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { finalizeInboundContext, resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { afterEach, beforeEach, vi, type Mock } from "vitest";
@@ -135,36 +138,14 @@ const defaultRuntimeConfig = (() =>
     channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
   }) as OpenClawConfig) as TelegramBotDeps["getRuntimeConfig"];
 
-type TopicNameEntry = {
-  name: string;
-  iconColor?: number;
-  iconCustomEmojiId?: string;
-  closed?: boolean;
-  updatedAt: number;
-};
-
-const topicNameStoresForTest = new Map<string, Map<string, TopicNameEntry>>();
-
 function installTopicNameRuntimeForTest(): void {
   setTelegramRuntime({
     state: {
-      openKeyedStore: (({ namespace }: { namespace: string }) => {
-        let store = topicNameStoresForTest.get(namespace);
-        if (!store) {
-          store = new Map();
-          topicNameStoresForTest.set(namespace, store);
-        }
-        return {
-          register: async (key: string, value: TopicNameEntry) => {
-            store.set(key, value);
-          },
-          entries: async () => [...store.entries()].map(([key, value]) => ({ key, value })),
-          delete: async (key: string) => store.delete(key),
-          clear: async () => {
-            store.clear();
-          },
-        };
-      }) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
     },
     channel: {},
   } as TelegramRuntime);
@@ -285,7 +266,6 @@ beforeEach(() => {
   process.env.OPENCLAW_STATE_DIR = ensureMediaHarnessStoreRoot();
   telegramBotDepsForTest.getRuntimeConfig = defaultRuntimeConfig;
   resetInboundDedupe();
-  topicNameStoresForTest.clear();
   resetTelegramTopicNameCacheForTest();
   installTopicNameRuntimeForTest();
   resetSaveMediaBufferMock();

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
+import { resolveEmbeddedAuthCooldownProbePolicy as resolveEmbeddedAuthCooldownProbePolicyActual } from "./embedded-agent-runner/run/auth-controller.js";
 import {
   buildEmbeddedRunnerAssistant,
   cleanupEmbeddedAgentRunnerTestWorkspace,
@@ -158,6 +159,7 @@ const installRunEmbeddedMocks = () => {
       }),
       stopRuntimeAuthRefreshTimer: vi.fn(),
     }),
+    resolveEmbeddedAuthCooldownProbePolicy: resolveEmbeddedAuthCooldownProbePolicyActual,
   }));
   vi.doMock("./models-config.js", async () => {
     const mod = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
@@ -185,10 +187,19 @@ let sessionStorePath: string;
 let sessionCounter = 0;
 let runCounter = 0;
 
-const createEmbeddedAgentRunnerOpenAiConfig = (modelIds: string[]) => ({
-  ...createBaseEmbeddedAgentRunnerOpenAiConfig(modelIds),
-  session: { store: sessionStorePath },
-});
+const createEmbeddedAgentRunnerOpenAiConfig = (modelIds: string[]) => {
+  const config = createBaseEmbeddedAgentRunnerOpenAiConfig(modelIds);
+  return {
+    ...config,
+    agents: {
+      ...config.agents,
+      list: config.agents?.list?.map((entry) =>
+        entry.id === "main" ? { ...entry, default: true } : entry,
+      ),
+    },
+    session: { store: sessionStorePath },
+  };
+};
 
 beforeAll(async () => {
   vi.useRealTimers();

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -189,16 +189,11 @@ let runCounter = 0;
 
 const createEmbeddedAgentRunnerOpenAiConfig = (modelIds: string[]) => {
   const config = createBaseEmbeddedAgentRunnerOpenAiConfig(modelIds);
-  return {
-    ...config,
-    agents: {
-      ...config.agents,
-      list: config.agents?.list?.map((entry) =>
-        entry.id === "main" ? { ...entry, default: true } : entry,
-      ),
-    },
-    session: { store: sessionStorePath },
-  };
+  const mainAgent = config.agents?.list?.find((entry) => entry.id === "main");
+  if (mainAgent) {
+    mainAgent.default = true;
+  }
+  return { ...config, session: { store: sessionStorePath } };
 };
 
 beforeAll(async () => {

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { wrapRunWithTestAdmission } from "./admitted-run-context.test-support.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./auth-profiles/store.js";
 import {
   classifyEmbeddedAgentRunResultForModelFallback,
@@ -64,7 +65,11 @@ vi.mock("./models-config.js", async () => {
   return { ...actual, ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })) };
 });
 
-let runEmbeddedAgent: typeof import("./embedded-agent-runner/run.js").runEmbeddedAgent;
+type ProductionRunEmbeddedAgent = typeof import("./embedded-agent-runner/run.js").runEmbeddedAgent;
+type TestRunEmbeddedAgent = (
+  params: Omit<Parameters<ProductionRunEmbeddedAgent>[0], "admittedRunContext">,
+) => ReturnType<ProductionRunEmbeddedAgent>;
+let runEmbeddedAgent: TestRunEmbeddedAgent;
 let runWithModelFallback: typeof import("./model-fallback-runner.js").runWithModelFallback;
 
 beforeAll(async () => {
@@ -82,7 +87,9 @@ beforeAll(async () => {
       createResolvedEmbeddedRunnerModel(provider, modelId),
   }));
 
-  ({ runEmbeddedAgent } = await import("./embedded-agent-runner/run.js"));
+  runEmbeddedAgent = wrapRunWithTestAdmission(
+    (await import("./embedded-agent-runner/run.js")).runEmbeddedAgent,
+  );
   ({ runWithModelFallback } = await import("./model-fallback-runner.js"));
 });
 

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -208,16 +208,6 @@ async function readUsageStats(agentDir: string) {
   return ensureAuthProfileStore(agentDir, { syncExternalCli: false }).usageStats ?? {};
 }
 
-function expectFailureCount(
-  usageStats: Record<string, Record<string, unknown> | undefined>,
-  profileId: string,
-  reason: AuthProfileFailureReason,
-  expected: number,
-) {
-  const failureCounts = usageStats[profileId]?.failureCounts as Record<string, unknown> | undefined;
-  expect(failureCounts?.[reason]).toBe(expected);
-}
-
 async function writeMultiProfileAuthStore(
   agentDir: string,
   options?: { openAiProfileCount?: 2 | 3 },

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -550,7 +550,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
     });
   });
 
-  it("falls back across providers after overloaded primary failure and persists transient cooldown", async () => {
+  it("falls back after overloaded primary failure without poisoning profile health", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
       mockPrimaryOverloadedThenFallbackSuccess();
@@ -568,8 +568,8 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
 
       const usageStats = await readUsageStats(agentDir);
-      expect(typeof usageStats["openai:p1"]?.cooldownUntil).toBe("number");
-      expectFailureCount(usageStats, "openai:p1", "overloaded", 1);
+      expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
+      expect(usageStats["openai:p1"]?.failureCounts?.overloaded).toBeUndefined();
       expect(typeof usageStats["groq:p1"]?.lastUsed).toBe("number");
 
       expectOpenAiThenGroqAttemptOrder();
@@ -756,7 +756,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
     });
   });
 
-  it("persists overloaded cooldown across turns while still allowing one probe and fallback", async () => {
+  it("keeps overloaded failures provider-scoped across turns while continuing fallback", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
       mockPrimaryOverloadedThenFallbackSuccess();
@@ -787,14 +787,14 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expectOpenAiThenGroqAttemptOrder({ expectOpenAiAuthProfileId: "openai:p1" });
 
       const usageStats = await readUsageStats(agentDir);
-      expect(typeof usageStats["openai:p1"]?.cooldownUntil).toBe("number");
-      expectFailureCount(usageStats, "openai:p1", "overloaded", 2);
+      expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
+      expect(usageStats["openai:p1"]?.failureCounts?.overloaded).toBeUndefined();
       expect(computeBackoffMock).not.toHaveBeenCalled();
       expect(sleepWithAbortMock).not.toHaveBeenCalled();
     });
   });
 
-  it("keeps bare service-unavailable failures in the timeout lane without persisting cooldown", async () => {
+  it("classifies bare service-unavailable failures as overloaded without cooling the profile", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
       mockPrimaryErrorThenFallbackSuccess("LLM error: service unavailable");
@@ -807,7 +807,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       });
 
       expect(result.provider).toBe("groq");
-      expect(result.attempts[0]?.reason).toBe("timeout");
+      expect(result.attempts[0]?.reason).toBe("overloaded");
 
       const usageStats = await readUsageStats(agentDir);
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();

--- a/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
@@ -99,10 +99,16 @@ vi.mock("./reply/agent-runner.runtime.js", () => ({
   },
 }));
 
-vi.mock("./reply/commands-compact.runtime.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./reply/commands-compact.runtime.js")>()),
-  isEmbeddedAgentRunAbortableForCompaction: () => false,
-}));
+vi.mock("./reply/commands-compact.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./reply/commands-compact.runtime.js")>();
+  return {
+    ...actual,
+    incrementCompactionCount: (params: Parameters<typeof actual.incrementCompactionCount>[0]) =>
+      actual.incrementCompactionCount({ ...params, expectedSession: undefined }),
+    isCurrentSessionEntry: () => true,
+    isEmbeddedAgentRunAbortableForCompaction: () => false,
+  };
+});
 
 let capturedGetReplyFromConfig: GetReplyFromConfig | undefined;
 installTriggerHandlingReplyHarness((impl) => {

--- a/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
@@ -99,16 +99,10 @@ vi.mock("./reply/agent-runner.runtime.js", () => ({
   },
 }));
 
-vi.mock("./reply/commands-compact.runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./reply/commands-compact.runtime.js")>();
-  return {
-    ...actual,
-    incrementCompactionCount: (params: Parameters<typeof actual.incrementCompactionCount>[0]) =>
-      actual.incrementCompactionCount({ ...params, expectedSession: undefined }),
-    isCurrentSessionEntry: () => true,
-    isEmbeddedAgentRunAbortableForCompaction: () => false,
-  };
-});
+vi.mock("./reply/commands-compact.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./reply/commands-compact.runtime.js")>()),
+  isEmbeddedAgentRunAbortableForCompaction: () => false,
+}));
 
 let capturedGetReplyFromConfig: GetReplyFromConfig | undefined;
 installTriggerHandlingReplyHarness((impl) => {
@@ -551,13 +545,17 @@ describe("trigger handling", () => {
       const storePath = join(home, "compact-main.sessions.json");
       const cfg = makeCfg(home);
       cfg.session = { ...cfg.session, store: storePath };
-      mockSuccessfulCompaction();
-
       const request = {
         Body: "/compact focus on decisions",
         From: "+1003",
         To: "+2000",
       };
+      const sessionKey = resolveSessionKey("per-sender", request, undefined, "main");
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        { sessionId: "compact-main-session", updatedAt: Date.now() },
+      );
+      mockSuccessfulCompaction();
 
       const res = await getReplyFromConfig(
         {
@@ -570,7 +568,6 @@ describe("trigger handling", () => {
       const text = maybeReplyText(res);
       expect(text).toMatch(/^⚙️ Compacted/u);
       expect(getCompactEmbeddedAgentSessionMock()).toHaveBeenCalledOnce();
-      const sessionKey = resolveSessionKey("per-sender", request, undefined, "main");
       expect(loadSessionEntry({ storePath, sessionKey })?.compactionCount).toBe(1);
     });
   });
@@ -580,13 +577,19 @@ describe("trigger handling", () => {
       getCompactEmbeddedAgentSessionMock().mockReset();
       mockSuccessfulCompaction();
       const cfg = makeCfg(home);
-      cfg.session = { ...cfg.session, store: join(home, "compact-worker.sessions.json") };
+      const storePath = join(home, "compact-worker.sessions.json");
+      const sessionKey = "agent:worker1:telegram:12345";
+      cfg.session = { ...cfg.session, store: storePath };
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        { sessionId: "compact-worker-session", updatedAt: Date.now() },
+      );
       const res = await getReplyFromConfig(
         {
           Body: "/compact",
           From: "+1004",
           To: "+2000",
-          SessionKey: "agent:worker1:telegram:12345",
+          SessionKey: sessionKey,
           CommandAuthorized: true,
         },
         {},

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -154,7 +154,7 @@ describe("claws lifecycle cli e2e", () => {
     const config = JSON.parse(await readFile(join(result.stateDir, "openclaw.json"), "utf8"));
     const canonicalStateDir = await realpath(result.stateDir);
     expect(config.agents.entries).toEqual({
-      main: { default: true },
+      main: { workspace: join(canonicalStateDir, "workspace") },
       "internal-triage": expect.objectContaining({
         name: "Internal Triage",
         tools: { deny: ["exec", "browser"] },
@@ -275,7 +275,14 @@ describe("claws lifecycle cli e2e", () => {
       agentRemoved: true,
     });
     const config = JSON.parse(await readFile(join(added.stateDir, "openclaw.json"), "utf8"));
-    expect(config.agents).toEqual({ entries: { main: { default: true } } });
+    const canonicalStateDir = await realpath(added.stateDir);
+    expect(config.agents).toEqual({
+      defaults: {
+        heartbeat: { agentId: "main" },
+        systemAgent: { agentId: "main" },
+      },
+      entries: { main: { workspace: join(canonicalStateDir, "workspace") } },
+    });
   });
 
   it("exports an installed agent as a self-contained grouped package", async () => {

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -157,10 +157,6 @@ const autoMigrateLegacyTaskStateSidecars = vi.fn().mockResolvedValue({
   changes: [],
   warnings: [],
 }) as unknown as MockFn;
-const migrateLegacyConfigMachineState = vi.fn(() => ({
-  changes: [],
-  warnings: [],
-})) as unknown as MockFn;
 const runChannelPluginStartupMaintenance = vi
   .fn()
   .mockResolvedValue(undefined) as unknown as MockFn;
@@ -613,21 +609,15 @@ vi.mock("./onboard-helpers.js", () => ({
   randomToken: vi.fn(() => "test-gateway-token"),
 }));
 
-vi.mock("./doctor-state-migrations.js", async () => {
-  const actual = await vi.importActual<typeof import("./doctor-state-migrations.js")>(
-    "./doctor-state-migrations.js",
-  );
-  return {
-    ...actual,
-    autoMigrateLegacyPluginDoctorState,
-    autoMigrateLegacyState,
-    autoMigrateLegacyStateDir,
-    autoMigrateLegacyTaskStateSidecars,
-    detectLegacyStateMigrations,
-    migrateLegacyConfigMachineState,
-    runLegacyStateMigrations,
-  };
-});
+vi.mock("./doctor-state-migrations.js", () => ({
+  autoMigrateLegacyPluginDoctorState,
+  autoMigrateLegacyState,
+  autoMigrateLegacyStateDir,
+  autoMigrateLegacyTaskStateSidecars,
+  detectLegacyStateMigrations,
+  migrateLegacyConfigMachineState: vi.fn(() => ({ changes: [], warnings: [] })),
+  runLegacyStateMigrations,
+}));
 
 vi.mock("../channels/plugins/lifecycle-startup.js", () => ({
   runChannelPluginStartupMaintenance,
@@ -744,7 +734,6 @@ beforeEach(() => {
   });
   autoMigrateLegacyState.mockReset().mockResolvedValue({ changes: [], warnings: [] });
   autoMigrateLegacyTaskStateSidecars.mockReset().mockResolvedValue({ changes: [], warnings: [] });
-  migrateLegacyConfigMachineState.mockReset().mockReturnValue({ changes: [], warnings: [] });
   runChannelPluginStartupMaintenance.mockReset().mockResolvedValue(undefined);
 
   originalIsTTY = process.stdin.isTTY;

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -157,6 +157,10 @@ const autoMigrateLegacyTaskStateSidecars = vi.fn().mockResolvedValue({
   changes: [],
   warnings: [],
 }) as unknown as MockFn;
+const migrateLegacyConfigMachineState = vi.fn(() => ({
+  changes: [],
+  warnings: [],
+})) as unknown as MockFn;
 const runChannelPluginStartupMaintenance = vi
   .fn()
   .mockResolvedValue(undefined) as unknown as MockFn;
@@ -609,14 +613,21 @@ vi.mock("./onboard-helpers.js", () => ({
   randomToken: vi.fn(() => "test-gateway-token"),
 }));
 
-vi.mock("./doctor-state-migrations.js", () => ({
-  autoMigrateLegacyPluginDoctorState,
-  autoMigrateLegacyState,
-  autoMigrateLegacyStateDir,
-  autoMigrateLegacyTaskStateSidecars,
-  detectLegacyStateMigrations,
-  runLegacyStateMigrations,
-}));
+vi.mock("./doctor-state-migrations.js", async () => {
+  const actual = await vi.importActual<typeof import("./doctor-state-migrations.js")>(
+    "./doctor-state-migrations.js",
+  );
+  return {
+    ...actual,
+    autoMigrateLegacyPluginDoctorState,
+    autoMigrateLegacyState,
+    autoMigrateLegacyStateDir,
+    autoMigrateLegacyTaskStateSidecars,
+    detectLegacyStateMigrations,
+    migrateLegacyConfigMachineState,
+    runLegacyStateMigrations,
+  };
+});
 
 vi.mock("../channels/plugins/lifecycle-startup.js", () => ({
   runChannelPluginStartupMaintenance,
@@ -733,6 +744,7 @@ beforeEach(() => {
   });
   autoMigrateLegacyState.mockReset().mockResolvedValue({ changes: [], warnings: [] });
   autoMigrateLegacyTaskStateSidecars.mockReset().mockResolvedValue({ changes: [], warnings: [] });
+  migrateLegacyConfigMachineState.mockReset().mockReturnValue({ changes: [], warnings: [] });
   runChannelPluginStartupMaintenance.mockReset().mockResolvedValue(undefined);
 
   originalIsTTY = process.stdin.isTTY;

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -750,7 +750,8 @@ describe("installPluginFromNpmSpec e2e", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain("blocked by install policy: blocked installed package tree");
+      expect(result.error).toContain("Install blocked by policy");
+      expect(result.error).toContain("Reason: blocked installed package tree");
     }
     const projectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
     try {
@@ -839,7 +840,8 @@ describe("installPluginFromNpmSpec e2e", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain("blocked by install policy: blocked installed package tree");
+      expect(result.error).toContain("Install blocked by policy");
+      expect(result.error).toContain("Reason: blocked installed package tree");
     }
     const rootManifest = await readJson<{
       dependencies?: Record<string, string>;

--- a/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
@@ -398,28 +398,41 @@ describe("Gateway task and automation RPCs", () => {
         await expect
           .poll(() => providerRequests.length, { timeout: 15_000, interval: 50 })
           .toBeGreaterThan(requestsBeforeWake);
-        await expect
-          .poll(
-            async () => {
-              const lastHeartbeat = await client.request<{
-                ts: number;
-                status: string;
-                reason?: string;
-                message?: string;
-                preview?: string;
-              }>("last-heartbeat", {});
-              return (
-                lastHeartbeat.ts >= wakeRequestedAt &&
-                lastHeartbeat.status === "skipped" &&
-                lastHeartbeat.reason === "target-none" &&
-                lastHeartbeat.message ===
-                  "Heartbeat delivery is disabled by configuration (target: none)." &&
-                lastHeartbeat.preview === `Heartbeat handled: ${wakeText}`
-              );
-            },
-            { timeout: 15_000, interval: 50 },
-          )
-          .toBe(true);
+        let observedHeartbeat: {
+          ts: number;
+          status: string;
+          reason?: string;
+          message?: string;
+          preview?: string;
+        } | null = null;
+        try {
+          await expect
+            .poll(
+              async () => {
+                observedHeartbeat = await client.request<{
+                  ts: number;
+                  status: string;
+                  reason?: string;
+                  message?: string;
+                  preview?: string;
+                }>("last-heartbeat", {});
+                return (
+                  observedHeartbeat.ts >= wakeRequestedAt &&
+                  observedHeartbeat.status === "skipped" &&
+                  observedHeartbeat.reason === "no-route" &&
+                  observedHeartbeat.message ===
+                    "Heartbeat has no delivery route yet. Message your bot once, or set agents.defaults.heartbeat.target." &&
+                  observedHeartbeat.preview === `Heartbeat handled: ${wakeText}`
+                );
+              },
+              { timeout: 15_000, interval: 50 },
+            )
+            .toBe(true);
+        } catch (error) {
+          throw new Error(`Unexpected last-heartbeat state: ${JSON.stringify(observedHeartbeat)}`, {
+            cause: error,
+          });
+        }
       } finally {
         if (gateway) {
           await disconnectGatewayClient(gateway.client);

--- a/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
@@ -419,9 +419,9 @@ describe("Gateway task and automation RPCs", () => {
                 return (
                   observedHeartbeat.ts >= wakeRequestedAt &&
                   observedHeartbeat.status === "skipped" &&
-                  observedHeartbeat.reason === "no-route" &&
+                  observedHeartbeat.reason === "target-none" &&
                   observedHeartbeat.message ===
-                    "Heartbeat has no delivery route yet. Message your bot once, or set agents.defaults.heartbeat.target." &&
+                    "Heartbeat delivery is disabled by configuration (target: none)." &&
                   observedHeartbeat.preview === `Heartbeat handled: ${wakeText}`
                 );
               },

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -486,7 +486,12 @@ async function connectDiagnosticsClient(instance: OpenClawTestInstance): Promise
     mode: GATEWAY_CLIENT_MODES.UI,
     role: "operator",
     scopes: ["operator.admin", "operator.read", "operator.write"],
-    caps: [GATEWAY_CLIENT_CAPS.TASK_SUGGESTIONS],
+    caps: [
+      GATEWAY_CLIENT_CAPS.AGENT_KIND,
+      GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS,
+      GATEWAY_CLIENT_CAPS.TASK_SUGGESTIONS,
+      GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
+    ],
     platform: process.platform,
     requestTimeoutMs: 30_000,
     onHelloOk: resolveHello,

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -38,6 +38,7 @@ export function createE2EVitestConfig(env: Record<string, string | undefined> = 
     test: {
       ...baseTest,
       maxWorkers: e2eWorkers,
+      reporters: ["verbose"],
       silent: !verboseE2E,
       globalSetup: [resolveRepoRootPath("test/vitest/vitest.e2e.global-setup.ts")],
       setupFiles: [


### PR DESCRIPTION
## What Problem This Solves

Resolves release-validation failures caused by test fixtures drifting behind the current owner contracts after #124282 and #124215 landed. The stale fixtures could fail before exercising the intended behavior, and long E2E shards could appear silent long enough to trip the 300-second false-stall watchdog.

## Why This Change Was Made

The fixtures now use the state, admitted-run, migration, session, capability, and delivery outcomes owned by their production boundaries instead of maintaining local approximations. The E2E Vitest config uses the verbose reporter so long-running validation continuously emits per-test progress without weakening timeouts or changing runtime behavior.

This is test, test-support, and test-config work only: production runtime LOC is unchanged. The immutable v2026.8.1-beta.2 release, its tag, package, and artifacts are not modified.

## User Impact

There is no user-visible runtime behavior change. Maintainers get release-validation coverage that reaches the intended assertions, matches the repaired owner contracts, and remains observable during long E2E runs.

## Evidence

- Combined non-isolated fixture run: 9 files, 110 tests passed.
- Exact gateway steer regression: 1/1 passed.
- Trigger-handling suite: 21/21 passed in 479.65s.
- Claws lifecycle suite: 8/8 passed in 344.66s.
- Post-rebase E2E config contract: 3/3 passed with `node scripts/run-vitest.mjs src/infra/vitest-e2e-config.test.ts`.
- Targeted formatting completed on all 11 files; `git diff --check` is clean.
- Two fresh full-diff Codex autoreviews, plus the final pre-commit rerun, reviewed the same 21,316-byte bundle and reported no accepted/actionable findings at 0.99 confidence.
- Diff classification: 11 test/test-support/config files, +126/-82, zero production runtime LOC.
