### PR TITLE
refactor(gateway): remove dead worker-env surface, dedupe node issue projection

### DIFF
--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -637,7 +637,7 @@ export function isNodeRunnerSessionHost(params: {
   );
 }
 
-export function getNodeRunnerInventoryIssue(params: {
+function getNodeRunnerInventoryIssue(params: {
   registry: object;
   nodeId: string;
   connId: string;
@@ -647,6 +647,23 @@ export function getNodeRunnerInventoryIssue(params: {
   return state && node?.connId === params.connId
     ? resolveNodeRunnerIssue(node, state.runnerInventoryByConn)
     : undefined;
+}
+
+/** Shared node/environments read-projection shape: nodeId -> runner issues. */
+export function collectNodeRunnerIssuesByNodeId(
+  registry: object,
+  connectedNodes: ReadonlyArray<{ nodeId: string; connId: string }>,
+): Map<string, NodeRunnerInventoryIssue[]> {
+  return new Map(
+    connectedNodes.flatMap((node) => {
+      const issue = getNodeRunnerInventoryIssue({
+        registry,
+        nodeId: node.nodeId,
+        connId: node.connId,
+      });
+      return issue ? [[node.nodeId, [issue]] as const] : [];
+    }),
+  );
 }
 
 export function isNodeRegistryPendingInvokeConnectionActive(params: {

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -7,7 +7,10 @@ import { listNodePairing } from "../../infra/device-pairing-node.js";
 import { listDevicePairing } from "../../infra/device-pairing.js";
 import { NODE_RUNNER_UPDATE_REQUIRED_ISSUE } from "../../infra/node-runner-inventory.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../../shared/node-desktop-stream.js";
-import { getNodeRunnerInventoryIssue, isNodeRunnerSessionHost } from "../node-registry-private.js";
+import {
+  collectNodeRunnerIssuesByNodeId,
+  isNodeRunnerSessionHost,
+} from "../node-registry-private.js";
 import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentRecord } from "../worker-environments/store.js";
 import { environmentsHandlers, summarizeWorkerEnvironment } from "./environments.js";
@@ -22,7 +25,7 @@ vi.mock("../../infra/device-pairing-node.js", () => ({
 }));
 
 vi.mock("../node-registry-private.js", () => ({
-  getNodeRunnerInventoryIssue: vi.fn(() => undefined),
+  collectNodeRunnerIssuesByNodeId: vi.fn(() => new Map()),
   isNodeRunnerSessionHost: vi.fn(() => false),
 }));
 
@@ -203,7 +206,7 @@ class FakeWorkerServiceError extends Error {
 beforeEach(() => {
   vi.spyOn(Date, "now").mockReturnValue(NOW);
   vi.mocked(isNodeRunnerSessionHost).mockReturnValue(false);
-  vi.mocked(getNodeRunnerInventoryIssue).mockReturnValue(undefined);
+  vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(new Map());
   vi.mocked(listDevicePairing).mockResolvedValue({ paired: [] } as never);
   vi.mocked(listNodePairing).mockResolvedValue({
     paired: [
@@ -311,8 +314,8 @@ describe("environment gateway methods", () => {
   });
 
   it("projects the same current-node update issue through list and status", async () => {
-    vi.mocked(getNodeRunnerInventoryIssue).mockImplementation(({ nodeId }) =>
-      nodeId === "node-live" ? NODE_RUNNER_UPDATE_REQUIRED_ISSUE : undefined,
+    vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(
+      new Map([["node-live", [NODE_RUNNER_UPDATE_REQUIRED_ISSUE]]]),
     );
 
     const [, listPayload] = await callEnvironmentMethod("environments.list", {});

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -21,7 +21,10 @@ import { isDesktopCredentialsRequiredError } from "../desktop/host-source-errors
 import { getNodeDesktopService } from "../desktop/node-source-context.js";
 import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
-import { getNodeRunnerInventoryIssue, isNodeRunnerSessionHost } from "../node-registry-private.js";
+import {
+  collectNodeRunnerIssuesByNodeId,
+  isNodeRunnerSessionHost,
+} from "../node-registry-private.js";
 import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentState } from "../worker-environments/state.js";
 import { formatForLog } from "../ws-log.js";
@@ -156,16 +159,7 @@ async function listEnvironments(context: GatewayRequestContext): Promise<Environ
         : [],
     ),
   );
-  const issuesByNodeId = new Map(
-    connectedNodes.flatMap((node) => {
-      const issue = getNodeRunnerInventoryIssue({
-        registry: context.nodeRegistry,
-        nodeId: node.nodeId,
-        connId: node.connId,
-      });
-      return issue ? [[node.nodeId, [issue]] as const] : [];
-    }),
-  );
+  const issuesByNodeId = collectNodeRunnerIssuesByNodeId(context.nodeRegistry, connectedNodes);
   const catalog = createKnownNodeCatalog({
     pairedDevices: devices.paired,
     pairedNodes: nodes.paired,

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -23,7 +23,7 @@ import { replaceRemoteNodeSkills } from "../../skills/runtime/remote-skills.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../skills/runtime/remote.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
-  getNodeRunnerInventoryIssue,
+  collectNodeRunnerIssuesByNodeId,
   isNodeRunnerSessionHost,
   updateNodeRunnerInventory,
 } from "../node-registry-private.js";
@@ -98,15 +98,9 @@ async function listNodesForClient(params: {
     connectedNodes: params.connectedNodes,
     nodeRegistry: params.context.nodeRegistry,
   });
-  const issuesByNodeId = new Map(
-    params.connectedNodes.flatMap((node) => {
-      const issue = getNodeRunnerInventoryIssue({
-        registry: params.context.nodeRegistry,
-        nodeId: node.nodeId,
-        connId: node.connId,
-      });
-      return issue ? [[node.nodeId, [issue]] as const] : [];
-    }),
+  const issuesByNodeId = collectNodeRunnerIssuesByNodeId(
+    params.context.nodeRegistry,
+    params.connectedNodes,
   );
   const catalog = createKnownNodeCatalog({
     pairedDevices: params.pairedDevices,

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -120,7 +120,6 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
       ...(unavailableReason ? { unavailableReason } : {}),
     };
   };
-  const isAvailable = async (deviceId: string) => (await resolveAvailability(deviceId)).available;
   const provider: WorkerProvider = {
     id: DEVICE_WORKER_PROVIDER_ID,
     provisionBeforeInstallation: true,
@@ -166,7 +165,6 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
 
   return {
     provider,
-    isAvailable,
     resolveAvailability,
     launchNodeWorker: launchAdapter.launch,
     getNodeTransport: () => nodeTransport,

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { formatNodeRunnerUpdateRequired } from "../../infra/node-runner-inventory.js";
 import { supportsWorkerExecutionContextLaunch } from "./admission.js";
-import { DEVICE_WORKER_PROVIDER_ID, resolveDeviceWorkerAvailability } from "./device-provider.js";
+import { resolveDeviceWorkerAvailability } from "./device-provider.js";
 import {
   createPlacementFailureActions,
   isUnavailableEnvironment,
@@ -82,31 +82,13 @@ type WorkerPlacementDispatchOptions = {
 function requireProvisionedEnvironment(
   environment: Awaited<ReturnType<WorkerEnvironmentService["create"]>>,
   expectedEnvironmentId: string,
-):
-  | { transport: "node"; environmentId: string; ownerEpoch: number; bundleHash: string }
-  | { transport: "ssh"; environmentId: string; ownerEpoch: number; bundleHash: string } {
+): { environmentId: string; ownerEpoch: number; bundleHash: string } {
+  // Node vs SSH transport is decided later from the environment itself; both
+  // arms of the old discriminated return carried identical fields, so this
+  // only validates dispatchability and hands back the prepared facts.
   if (
     (environment.state !== "ready" && environment.state !== "idle") ||
-    environment.environmentId !== expectedEnvironmentId
-  ) {
-    throw new Error(
-      `Worker environment is not dispatchable with the current execution-context contract: ${environment.state}`,
-    );
-  }
-  if (
-    environment.providerId === DEVICE_WORKER_PROVIDER_ID &&
-    !environment.sshEndpoint &&
-    environment.bootstrapReceipt?.installKind === "bundle" &&
-    supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt)
-  ) {
-    return {
-      transport: "node",
-      environmentId: environment.environmentId,
-      ownerEpoch: environment.ownerEpoch,
-      bundleHash: environment.bootstrapReceipt.bundleHash,
-    };
-  }
-  if (
+    environment.environmentId !== expectedEnvironmentId ||
     !environment.bootstrapReceipt ||
     !supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt)
   ) {
@@ -115,7 +97,6 @@ function requireProvisionedEnvironment(
     );
   }
   return {
-    transport: "ssh",
     environmentId: environment.environmentId,
     ownerEpoch: environment.ownerEpoch,
     bundleHash: environment.bootstrapReceipt.bundleHash,


### PR DESCRIPTION
## What Problem This Solves

Three mechanical residues from the workers/device-bundles cutover (#124037), found by the round-6 worker-environments audit:

1. `deviceRuntime.isAvailable` had zero consumers anywhere — the availability seam moved to `resolveAvailability` (bound at startup via `bindDeviceWorkerAvailability`, consumed through `resolveDeviceWorkerAvailability`), and `provision` calls it directly.
2. `requireProvisionedEnvironment` returned a `transport: "node" | "ssh"` discriminated union whose sole consumer read only `environmentId`/`ownerEpoch`/`bundleHash` — the transport decision happens later from the environment itself. The write-only discriminant made the function look like it owned routing when it only validates dispatchability.
3. `environments.list` and `nodes.read` built byte-identical ten-line `issuesByNodeId` maps over `getNodeRunnerInventoryIssue` — duplicate projection policy that a third read surface would copy again.

## Why This Change Was Made

Dead members and write-only discriminants on the worker-authority surface are worse than ordinary dead code: they suggest routing/authority decisions live where they don't. The dedupe gives the node/environments read projection one owner (`collectNodeRunnerIssuesByNodeId`, next to the issue resolver, whose direct export drops — no external readers remain).

## User Impact

None at runtime — behavior-neutral deletions and consolidation. Receipt/launch-support validation in `requireProvisionedEnvironment` is unchanged.

## Evidence

- `node scripts/run-vitest.mjs run src/gateway/worker-environments src/gateway/server-methods/environments.test.ts src/gateway/server-methods/nodes.read.test.ts` — green (environments.test mock factory updated to the new helper per explicit-vi.mock policy).
- tsgo core + core-test shards clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +33 −49 (net −16); tests +8 −5.
