### PR TITLE
perf(test): shorten Slack startup auth regression

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -77,7 +77,6 @@ type SlackTestState = {
   >;
   socketModeLogger?: { error: (...args: unknown[]) => void };
   createSlackStartupAuthClientMock: Mock<SlackStartupAuthClientFactory>;
-  createSlackStartupAuthClientActual?: SlackStartupAuthClientFactory;
 };
 
 // globalThis-backed singleton: with isolate=false, a vi.resetModules() in any
@@ -110,12 +109,8 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
 
 export const getSlackTestState = (): SlackTestState => slackTestState;
 
-export function useRealSlackStartupAuthClientOnce(): void {
-  const actual = slackTestState.createSlackStartupAuthClientActual;
-  if (!actual) {
-    throw new Error("real Slack WebClient factory is unavailable");
-  }
-  slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(actual);
+export function useSlackStartupAuthClientOnce(factory: SlackStartupAuthClientFactory): void {
+  slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(factory);
 }
 
 type SlackClient = {
@@ -426,7 +421,6 @@ vi.mock("./resolve-users.js", () => ({
 
 vi.mock("./client.js", async () => {
   const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
-  slackTestState.createSlackStartupAuthClientActual = actual.createSlackStartupAuthClient;
   return {
     ...actual,
     createSlackStartupAuthClient: (...args: Parameters<SlackStartupAuthClientFactory>) =>

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover auth.test token handling during provider boot.
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { WebClient } from "@slack/web-api";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -17,7 +18,7 @@ import {
   resetSlackTestState,
   startSlackMonitor as startSlackMonitorUntracked,
   stopSlackMonitor,
-  useRealSlackStartupAuthClientOnce,
+  useSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
 import { getSlackRuntime } from "../runtime.js";
 
@@ -60,6 +61,26 @@ const PROXY_ENV_KEYS = [
   "NO_PROXY",
   "no_proxy",
 ] as const;
+const SLACK_TEST_STARTUP_AUTH_TIMEOUT_MS = 100;
+
+function useShortSlackStartupAuthClientOnce(): void {
+  useSlackStartupAuthClientOnce(
+    (token, options) =>
+      new WebClient(token, {
+        ...options,
+        // Production timeout and retry policy are pinned in client owner tests. This provider
+        // regression keeps the real SDK/transport while shortening only its test-owned clock.
+        retryConfig: {
+          retries: 2,
+          factor: 1,
+          minTimeout: 1,
+          maxTimeout: 1,
+          randomize: false,
+        },
+        timeout: SLACK_TEST_STARTUP_AUTH_TIMEOUT_MS,
+      }),
+  );
+}
 
 async function startStalledSlackApiServer(events: string[]) {
   let requestCount = 0;
@@ -266,7 +287,7 @@ describe("auth.test boot call", () => {
     }
     const server = await startStalledSlackApiServer(events);
     vi.stubEnv("SLACK_API_URL", server.apiUrl);
-    useRealSlackStartupAuthClientOnce();
+    useShortSlackStartupAuthClientOnce();
 
     const runtimeLog = vi.fn((...args: unknown[]) => {
       const message = args[0];
@@ -282,7 +303,7 @@ describe("auth.test boot call", () => {
       runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
     });
     try {
-      await vi.waitFor(() => expect(appStartMock).toHaveBeenCalledTimes(1), { timeout: 35_000 });
+      await vi.waitFor(() => expect(appStartMock).toHaveBeenCalledTimes(1), { timeout: 2_000 });
       await vi.waitFor(() => expect(events).toContain("socket-closed"), { timeout: 1_000 });
 
       expect(server.requestCount).toBe(3);
@@ -297,7 +318,7 @@ describe("auth.test boot call", () => {
       await monitor.run;
       await server.close();
     }
-  }, 40_000);
+  }, 5_000);
 
   it("preserves workspace startup when auth.test omits app_id", async () => {
     getSlackClient().auth.test.mockResolvedValueOnce({


### PR DESCRIPTION
## What Problem This Solves

One Slack provider regression spends more than 31 seconds waiting for three production-length startup-auth timeouts. The test needs to prove provider ordering, retry count, real socket cleanup, and degraded startup—not make the entire suite pay the production 10-second deadline three times.

## Why This Change Was Made

Inject a real Slack `WebClient` with a short test-owned timeout and deterministic retry delays through the existing mocked startup-auth factory. The provider test still sends three real HTTP requests to a stalled loopback server, observes socket closure, requires auth settlement before app startup, and verifies the degraded warning.

Production timeout and retry contracts remain owned by `client.test.ts`, while real stalled-header abortion remains owned by `client.web-api.test.ts`. The old one-shot helper retained the production factory only for this test; replacing it with a typed one-shot factory keeps the integration boundary while removing the fixed wait.

## User Impact

Maintainer Slack test feedback is substantially faster. Production Slack behavior is unchanged.

## Evidence

Controlled same-Testbox A/B on `tbx_01m04bez84mgdgsnjndgzb40bj`, one excluded warmup plus two retained samples per state, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 48.96s | 17.03s | -31.93s (-65.2%) |
| Vitest | 46.19s | 14.27s | -69.1% |
| Test body | 34.92s | 3.03s | -91.3% |
| Import | 11.08s | 11.05s | flat |

CPU changed only slightly and peak RSS was noisy, so this PR makes no resource-usage claim.

Validation:

- 71/71 Slack provider, client policy, and real Web API owner tests.
- Full extension changed gate on the retained Testbox, including extension-test typecheck and targeted lint.
- Fresh post-rebase Codex autoreview: no accepted/actionable findings.
- Mutation: starting the app without awaiting startup auth fails the provider regression before all three requests complete.
- Mutation: removing the production startup-auth timeout fails the client owner contract expecting `timeout: 10_000`.
- Production LOC: `+0/-0`; test and test-support LOC: `+27/-12`.

Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/31925464449
