### PR TITLE
fix(system-agent): leave reasoning room in local model setup probes

### DIFF
--- a/docs/start/onboarding-redesign.md
+++ b/docs/start/onboarding-redesign.md
@@ -124,7 +124,7 @@ Remote-gateway onboarding keeps its legacy conversational handoff
   source). Once-semantics (offer only until accepted, stored scan) also lands
   with the phase 5 store; today a rerun re-offers.
 - Also fixed: custom `completeSetupInference` prompts no longer inherit the
-  32-token verification-probe output cap (`SETUP_INFERENCE_TEST_MAX_TOKENS`
+  bounded verification-probe output cap (`SETUP_INFERENCE_TEST_MAX_TOKENS`
   applies to the "reply OK" probe only).
 
 ### Phase 2 — CLI custodian spine (PR #109841)

--- a/src/system-agent/setup-inference-persist.ts
+++ b/src/system-agent/setup-inference-persist.ts
@@ -588,10 +588,9 @@ export async function runSetupInferenceTest(params: {
         reasoningLevel: "off",
         verboseLevel: "off",
         disableTrajectory: true,
-        // The 32-token probe cap is sized for the "reply OK" verification
-        // prompt only. Custom completions pass no explicit cap: the stream
-        // layer then applies the resolved model's own required maxTokens
-        // budget, which both bounds output and never exceeds provider limits.
+        // Keep the "reply OK" probe bounded while leaving room for reasoning.
+        // Custom completions pass no explicit cap: the stream layer applies the
+        // resolved model's own maxTokens budget without exceeding its limits.
         ...(params.prompt === undefined
           ? resolveSetupInferenceProbeStreamParams(plan.agentHarnessRuntimeOverride)
           : {}),

--- a/src/system-agent/setup-inference-probe.ts
+++ b/src/system-agent/setup-inference-probe.ts
@@ -1,4 +1,4 @@
-const SETUP_INFERENCE_TEST_MAX_TOKENS = 32;
+const SETUP_INFERENCE_TEST_MAX_TOKENS = 128;
 
 /** Plugin and auto-selected harnesses may not support OpenClaw's request-scoped token cap. */
 export function resolveSetupInferenceProbeStreamParams(agentHarnessId?: string): {

--- a/src/system-agent/setup-inference-probe.ts
+++ b/src/system-agent/setup-inference-probe.ts
@@ -1,4 +1,5 @@
-const SETUP_INFERENCE_TEST_MAX_TOKENS = 128;
+// Reasoning models need room to think before they can emit the requested "OK".
+const SETUP_INFERENCE_TEST_MAX_TOKENS = 256;
 
 /** Plugin and auto-selected harnesses may not support OpenClaw's request-scoped token cap. */
 export function resolveSetupInferenceProbeStreamParams(agentHarnessId?: string): {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1364,7 +1364,7 @@ describe("activateSetupInference", () => {
   it("omits the token cap when harness selection is automatic", () => {
     expect(resolveSetupInferenceProbeStreamParams("auto")).toEqual({});
     expect(resolveSetupInferenceProbeStreamParams("openclaw")).toEqual({
-      streamParams: { maxTokens: 32 },
+      streamParams: { maxTokens: 128 },
     });
   });
 

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1364,7 +1364,7 @@ describe("activateSetupInference", () => {
   it("omits the token cap when harness selection is automatic", () => {
     expect(resolveSetupInferenceProbeStreamParams("auto")).toEqual({});
     expect(resolveSetupInferenceProbeStreamParams("openclaw")).toEqual({
-      streamParams: { maxTokens: 128 },
+      streamParams: { maxTokens: 256 },
     });
   });
 
@@ -1915,6 +1915,7 @@ describe("activateSetupInference", () => {
     };
     const configHarness = createConfigTransformHarness(initialConfig);
     const updateAuthStore = vi.fn();
+    const runEmbeddedAgent = vi.fn(successfulRunner("lmstudio", "qwen-local"));
 
     const result = await activateSetupInference({
       kind: "provider-auto:lmstudio",
@@ -1930,7 +1931,7 @@ describe("activateSetupInference", () => {
           appGuidedDiscovery: true,
         }),
         resolvePluginProviders: () => [provider],
-        runEmbeddedAgent: vi.fn(successfulRunner("lmstudio", "qwen-local")) as never,
+        runEmbeddedAgent: runEmbeddedAgent as never,
         transformConfigWithPendingPluginInstalls: configHarness.transform as never,
         updateAuthProfileStoreWithLock: updateAuthStore as never,
       },
@@ -1948,6 +1949,13 @@ describe("activateSetupInference", () => {
           ]
         : []),
     ]);
+    expect(runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "lmstudio",
+        model: "qwen-local",
+        streamParams: { maxTokens: 256 },
+      }),
+    );
     expect(detect).not.toHaveBeenCalled();
     expect(prepare).toHaveBeenCalledOnce();
     expect(updateAuthStore).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Guided model setup rejects healthy local reasoning models when its inference-verification probe spends the entire 32-token response budget on reasoning before producing the requested visible `OK`. This affects the actual app-guided LM Studio activation path as well as Ollama and other models using OpenClaw's embedded harness.

The original 128-token proposal fixes the default LM Studio example, but the reporter demonstrated that it still intermittently fails for a supported Ollama model configured with high thinking.

Fixes #124345.

## Why This Change Was Made

Raise the shared setup-probe budget to 256 tokens, leaving room for reasoning before the visible reply without making setup output unbounded. Keep the existing harness boundary: plugin/automatically selected harnesses receive no unsupported explicit cap, and custom completion prompts still use the resolved model's own output budget.

Extend the existing LM Studio app-guided activation test to assert that the real embedded-agent call receives the 256-token budget. Update the existing helper expectation and remove stale hard-coded 32-token wording from the owner comment and onboarding documentation.

## User Impact

Healthy local reasoning models can complete guided setup instead of being incorrectly rejected with an empty-response inference failure. Existing custom completion and non-OpenClaw harness behavior remains unchanged.

## Evidence

### Real LM Studio streaming behavior

Tested a running LM Studio server with `nvidia/nemotron-3-nano-4b`, the exact production setup prompt (`Reply with the single word OK. Do not use tools.`), OpenAI-compatible streaming, and usage reporting. Default, `high`, and `xhigh` reasoning each produced the same before/after result:

| Setup budget | HTTP | Stream completion | Visible content | Completion tokens | Reasoning tokens |
| --- | --- | --- | --- | --- | --- |
| 32 tokens, current main | 200 | `length` | empty | 32 | 32 |
| 256 tokens, repaired PR | 200 | `stop` | `OK` | 43 | 39 |

The failing 32-token stream emitted 34 SSE events followed by `[DONE]`; the successful 256-token stream emitted 42 SSE events followed by `[DONE]`.

### Why 128 is insufficient

The original reporter tested the actual OpenClaw gateway with `ollama/gpt-oss:20b` and configured `params.think: "high"`:

- 128 tokens: 3 of 5 setup probes failed.
- 256 tokens: 5 of 5 default-thinking probes passed, and 5 of 5 high-thinking probes passed.

Source evidence: https://github.com/openclaw/openclaw/pull/124405#issuecomment-5306333461 and https://github.com/openclaw/openclaw/pull/124405#issuecomment-5306389323.

### Regression coverage

The existing setup-inference suite now checks both the OpenClaw harness's 256-token limit and the actual `provider-auto:lmstudio` activation boundary. Automatic harness selection remains uncapped. Production-line delta is net zero; focused hosted validation runs on the updated PR head.

Thanks to @synthalorian for the original fix and @eggc-tech for identifying the configured-reasoning boundary and supplying the live 128-versus-256 comparison.
