### PR TITLE
fix(subagents): bound settle-wake deferrals to prevent indefinite parking

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -2869,6 +2869,71 @@ describe("subagent announce formatting", () => {
     });
   });
 
+  it("terminates an accepted descendant wake after completion delivery closes", async () => {
+    sessionStore = {
+      "agent:main:subagent:parent": {
+        sessionId: "session-parent",
+      },
+    };
+    subagentRegistryMock.listSubagentRunsForRequester.mockReturnValue([
+      {
+        runId: "run-child",
+        childSessionKey: "agent:main:subagent:parent:subagent:child",
+        requesterSessionKey: "agent:main:subagent:parent",
+        requesterDisplayKey: "parent",
+        task: "child task",
+        cleanup: "keep",
+        createdAt: 10,
+        execution: { endedAt: 20, outcome: { status: "ok" } },
+        cleanupCompletedAt: 21,
+        completion: { required: true, resultText: "child result" },
+      },
+    ]);
+    let releaseWake: (() => void) | undefined;
+    agentSpy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseWake = () => resolve(visibleAgentResponse("run-parent-phase-2"));
+        }),
+    );
+    callGatewaySpy.mockImplementation(async (req: unknown) => {
+      const typed = req as { method?: string; params?: { runId?: string } };
+      if (typed.method === "agent") {
+        return await agentSpy(typed);
+      }
+      if (typed.method === "chat.abort") {
+        return { aborted: true, runIds: [typed.params?.runId] };
+      }
+      return {};
+    });
+    let completionDeliveryAllowed = true;
+
+    const announce = runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:parent",
+      childRunId: "run-parent-phase-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      wakeOnDescendantSettle: true,
+      roundOneReply: "waiting for child",
+      isCompletionDeliveryAllowed: () => completionDeliveryAllowed,
+    });
+    await vi.waitFor(() => expect(agentSpy).toHaveBeenCalledOnce());
+
+    completionDeliveryAllowed = false;
+    releaseWake?.();
+
+    await expect(announce).resolves.toBe("intentional_non_delivery");
+    expect(subagentRegistryMock.replaceSubagentRunAfterSteer).not.toHaveBeenCalled();
+    expect(callGatewaySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "chat.abort",
+        params: expect.objectContaining({ runId: "run-parent-phase-2" }),
+      }),
+    );
+  });
+
   it("does not re-wake an already woken run id", async () => {
     sessionStore = {
       "agent:main:subagent:parent": {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -967,6 +967,44 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       }
     });
 
+    it("terminalizes a repeatedly deferred batch once and rejects a stale wake", async () => {
+      const child = makeSettledChild({
+        runId: "run-a",
+        delivery: { status: "pending" },
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-a"],
+          requesterYieldBatch: true,
+          rearmGeneration: 1,
+          deferralCount: 9,
+        },
+      });
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(true);
+
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(false);
+
+      expect(transitionBatchSpy).not.toHaveBeenCalled();
+      expect(deliverSpy).not.toHaveBeenCalled();
+      expect(completeBatchSpy).toHaveBeenCalledOnce();
+      expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1, {
+        delivered: false,
+        path: "none",
+        error: "requester settle wake deferred too many times",
+      });
+      expect(child.requesterSettleWake).toBeUndefined();
+
+      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(false);
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(false);
+      expect(completeBatchSpy).toHaveBeenCalledOnce();
+      expect(deliverSpy).not.toHaveBeenCalled();
+    });
+
     it("coalesces concurrent row restores for one persisted batch", async () => {
       const state = {
         status: "dispatching" as const,

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -929,45 +929,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-a,run-b"));
     });
 
-    it("defers a frozen batch replay until a newer descendant settles", async () => {
-      const state = {
-        status: "dispatching" as const,
-        attemptCount: 1,
-        batchRunIds: ["run-a", "run-b"],
-      };
-      const firstChild = makeSettledChild({
-        runId: "run-a",
-        requesterSettleWake: { ...state },
-      });
-      const children = [
-        firstChild,
-        makeSettledChild({ runId: "run-b", requesterSettleWake: { ...state } }),
-        makeSettledChild({
-          runId: "run-new",
-          endedAt: undefined,
-          requesterSettleWake: undefined,
-        }),
-      ];
-      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(true);
-
-      vi.useFakeTimers();
-      vi.setSystemTime(0);
-      try {
-        expect(
-          await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: firstChild })),
-        ).toBe(false);
-        expect(deliverSpy).not.toHaveBeenCalled();
-        expect(firstChild.requesterSettleWake).toMatchObject({
-          ...state,
-          nextAttemptAt: 30_000,
-        });
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("terminalizes a repeatedly deferred batch once and rejects a stale wake", async () => {
+    it("defers a frozen batch before terminalizing its capped stale wake", async () => {
       const child = makeSettledChild({
         runId: "run-a",
         delivery: { status: "pending" },
@@ -977,32 +939,42 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
           batchRunIds: ["run-a"],
           requesterYieldBatch: true,
           rearmGeneration: 1,
-          deferralCount: 9,
+          deferralCount: 8,
         },
       });
       registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
       registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(true);
 
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(false);
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      try {
+        await expect(
+          maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+        ).resolves.toBe(false);
+        expect(child.requesterSettleWake).toMatchObject({
+          deferralCount: 9,
+          nextAttemptAt: 30_000,
+        });
 
-      expect(transitionBatchSpy).not.toHaveBeenCalled();
-      expect(deliverSpy).not.toHaveBeenCalled();
-      expect(completeBatchSpy).toHaveBeenCalledOnce();
-      expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1, {
-        delivered: false,
-        path: "none",
-        error: "requester settle wake deferred too many times",
-      });
-      expect(child.requesterSettleWake).toBeUndefined();
+        vi.setSystemTime(30_000);
+        await expect(
+          maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+        ).resolves.toBe(false);
+        expect(transitionBatchSpy).toHaveBeenCalledOnce();
+        expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1, {
+          delivered: false,
+          path: "none",
+          error: "requester settle wake deferred too many times",
+        });
+        expect(child.requesterSettleWake).toBeUndefined();
 
-      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(false);
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(false);
-      expect(completeBatchSpy).toHaveBeenCalledOnce();
-      expect(deliverSpy).not.toHaveBeenCalled();
+        registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(false);
+        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child }));
+        expect(completeBatchSpy).toHaveBeenCalledOnce();
+        expect(deliverSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("coalesces concurrent row restores for one persisted batch", async () => {
@@ -1036,18 +1008,6 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expect(deliverSpy).toHaveBeenCalledOnce();
       releaseDelivery?.();
       await expect(firstWake).resolves.toBe(true);
-    });
-
-    it("does not replay after the durable success transition retired the rows", async () => {
-      const children = [makeSettledChild({ runId: "run-a" }), makeSettledChild({ runId: "run-b" })];
-      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-      await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: children[1] }));
-      deliverSpy.mockClear();
-
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: children[1] })),
-      ).toBe(false);
-      expect(deliverSpy).not.toHaveBeenCalled();
     });
 
     it("honors a persisted retry deadline and budget", async () => {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -152,23 +152,23 @@ function deferRequesterSettleWakeBatch(params: {
   batchRunIds: readonly string[];
   state: RequesterSettleWakeBatchState;
   transitionBatch: (runIds: readonly string[], state: RequesterSettleWakeBatchState) => void;
+  completeBatch(
+    runIds: readonly string[],
+    rearmGeneration?: number,
+    delivery?: SubagentAnnounceDeliveryResult,
+  ): void;
 }): void {
   const deferralCount = (params.state.deferralCount ?? 0) + 1;
   if (deferralCount >= REQUESTER_SETTLE_WAKE_MAX_DEFERRALS) {
-    // Max deferrals reached; complete the batch with a recorded reason.
-    params.transitionBatch(params.batchRunIds, {
-      status: "pending",
-      attemptCount: params.state.attemptCount,
-      ...(params.state.replayCount !== undefined ? { replayCount: params.state.replayCount } : {}),
-      nextAttemptAt: Date.now(),
-      batchRunIds: [...params.batchRunIds],
-      ...(params.state.requesterYieldBatch === true ? { requesterYieldBatch: true } : {}),
-      ...(params.state.afterRequesterYield === true ? { afterRequesterYield: true } : {}),
-      ...(params.state.rearmGeneration !== undefined
-        ? { rearmGeneration: params.state.rearmGeneration }
-        : {}),
-      lastError: "requester settle wake deferred too many times",
-      deferralCount,
+    completeRequesterSettleWakeBatch({
+      runIds: params.batchRunIds,
+      state: params.state,
+      completeBatch: params.completeBatch,
+      delivery: {
+        delivered: false,
+        path: "none",
+        error: "requester settle wake deferred too many times",
+      },
     });
     return;
   }
@@ -323,6 +323,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         batchRunIds,
         state: selectedState,
         transitionBatch: params.transitionBatch,
+        completeBatch,
       });
     }
     return false;
@@ -416,6 +417,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         batchRunIds,
         state,
         transitionBatch: params.transitionBatch,
+        completeBatch,
       });
       return false;
     }

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -163,7 +163,8 @@ function deferRequesterSettleWakeBatch(params: {
     completeRequesterSettleWakeBatch({
       runIds: params.batchRunIds,
       state: params.state,
-      completeBatch: params.completeBatch,
+      completeBatch: (runIds, rearmGeneration, delivery) =>
+        params.completeBatch(runIds, rearmGeneration, delivery),
       delivery: {
         delivered: false,
         path: "none",

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -144,6 +144,7 @@ function readSharedBatchState(batch: readonly SubagentRunRecord[]): RequesterSet
       : {}),
     ...(source?.rearmGeneration !== undefined ? { rearmGeneration: source.rearmGeneration } : {}),
     ...(source?.lastError !== undefined ? { lastError: source.lastError } : {}),
+    deferralCount: Math.max(0, ...states.map((state) => state.deferralCount ?? 0)),
   };
 }
 

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -44,6 +44,7 @@ export type RequesterSettleWakeBatchState = Omit<RequesterSettleWakeState, "reti
 
 const REQUESTER_SETTLE_WAKE_MAX_ATTEMPTS = 3;
 const REQUESTER_SETTLE_WAKE_MAX_AMBIGUOUS_REPLAYS = 3;
+const REQUESTER_SETTLE_WAKE_MAX_DEFERRALS = 10;
 const REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS = [30_000, 120_000] as const;
 const activeRequesterSettleWakeBatches = new Set<string>();
 
@@ -151,6 +152,25 @@ function deferRequesterSettleWakeBatch(params: {
   state: RequesterSettleWakeBatchState;
   transitionBatch: (runIds: readonly string[], state: RequesterSettleWakeBatchState) => void;
 }): void {
+  const deferralCount = (params.state.deferralCount ?? 0) + 1;
+  if (deferralCount >= REQUESTER_SETTLE_WAKE_MAX_DEFERRALS) {
+    // Max deferrals reached; complete the batch with a recorded reason.
+    params.transitionBatch(params.batchRunIds, {
+      status: "pending",
+      attemptCount: params.state.attemptCount,
+      ...(params.state.replayCount !== undefined ? { replayCount: params.state.replayCount } : {}),
+      nextAttemptAt: Date.now(),
+      batchRunIds: [...params.batchRunIds],
+      ...(params.state.requesterYieldBatch === true ? { requesterYieldBatch: true } : {}),
+      ...(params.state.afterRequesterYield === true ? { afterRequesterYield: true } : {}),
+      ...(params.state.rearmGeneration !== undefined
+        ? { rearmGeneration: params.state.rearmGeneration }
+        : {}),
+      lastError: "requester settle wake deferred too many times",
+      deferralCount,
+    });
+    return;
+  }
   params.transitionBatch(params.batchRunIds, {
     status: params.state.status,
     attemptCount: params.state.attemptCount,
@@ -166,6 +186,7 @@ function deferRequesterSettleWakeBatch(params: {
       ? { rearmGeneration: params.state.rearmGeneration }
       : {}),
     ...(params.state.lastError !== undefined ? { lastError: params.state.lastError } : {}),
+    deferralCount,
   });
 }
 

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -321,7 +321,8 @@ export async function runSubagentAnnounceFlow(params: {
         taskLabel: params.label || params.task || "task",
         findings: childCompletionFindings,
         announceId,
-        isChildSessionEffectsAllowed: childSessionEffectsAllowed,
+        isChildSessionEffectsAllowed: () =>
+          childSessionEffectsAllowed() && completionDeliveryAllowed(),
         hasUsableSessionEntry,
         deps: {
           callGateway: subagentAnnounceDeps.callGateway,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -202,9 +202,11 @@ const finalizeSubagentCleanup = async (
     await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
     return;
   }
-  if (entry.expectsCompletionMessage === false || options?.skipRequesterDelivery) {
+  const skipRequesterDelivery =
+    options?.skipRequesterDelivery === true || entry.suppressCompletionDelivery === true;
+  if (entry.expectsCompletionMessage === false || skipRequesterDelivery) {
     clearSubagentPendingDelivery(entry);
-    if (options?.skipRequesterDelivery) {
+    if (skipRequesterDelivery) {
       ensureDeliveryState(entry).status = "not_required";
       entry.suppressCompletionDelivery = undefined;
     }
@@ -222,6 +224,7 @@ const finalizeSubagentCleanup = async (
       entry,
       cleanup,
       completedAt: Date.now(),
+      skipRequesterSettleWake: skipRequesterDelivery,
     });
     if (!shouldSuppressSubagentRecoverySessionEffects(entry)) {
       await emitCompletionEndedHookIfNeeded(
@@ -391,6 +394,19 @@ export const startSubagentAnnounceCleanupFlow = (
     return false;
   }
   const cleanup = entry.cleanup;
+  const skipRequesterDelivery = entry.suppressCompletionDelivery === true;
+  // A terminal delivery failure closes upward delivery, not live descendants.
+  // Their completion callback re-enters this same cleanup path without a timer.
+  if (
+    skipRequesterDelivery &&
+    entry.wakeOnDescendantSettle === true &&
+    params.countPendingDescendantRuns(entry.childSessionKey) > 0
+  ) {
+    entry.cleanupHandled = false;
+    params.resumedRuns.delete(runId);
+    params.persist(runId);
+    return true;
+  }
   let suppressSessionEffects = shouldSuppressSubagentRecoverySessionEffects(entry);
   if (typeof entry.delivery?.announcedAt === "number" || entry.delivery?.status === "delivered") {
     const cleanupGeneration = beginSubagentCleanup(context, runId);
@@ -448,7 +464,6 @@ export const startSubagentAnnounceCleanupFlow = (
       !suppressSessionEffects && context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)
     );
   };
-  const skipRequesterDelivery = entry.suppressCompletionDelivery === true;
   if (entry.expectsCompletionMessage === false || skipRequesterDelivery) {
     runDetachedCleanupAttempt(context, {
       runId,
@@ -558,6 +573,7 @@ export const startSubagentAnnounceCleanupFlow = (
     suppressChildSessionEffects: suppressSessionEffects,
     isChildSessionEffectsAllowed: childSessionEffectsAllowed,
     isCompletionDeliveryAllowed: () =>
+      entry.suppressCompletionDelivery !== true &&
       context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration),
     isCompletionOwnedByRequesterYield: () =>
       entry.requesterTurnYielded === true ||

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -82,6 +82,7 @@ const completeRequesterSettleWakeBatch = (
     delivery: structuredClone(entry.delivery),
     requesterSettleWake: structuredClone(entry.requesterSettleWake),
     retireAfterRequesterTurn: entry.retireAfterRequesterTurn,
+    suppressCompletionDelivery: entry.suppressCompletionDelivery,
   }));
   const settledDeliveries: SubagentRunRecord[] = [];
   for (const [runId, entry] of entries) {
@@ -105,6 +106,7 @@ const completeRequesterSettleWakeBatch = (
         delivery.lastError = outcome.error ?? outcome.reason ?? "requester settle wake failed";
         delivery.deliveredAt = undefined;
         delivery.announcedAt = undefined;
+        entry.suppressCompletionDelivery = true;
       }
       settledDeliveries.push(entry);
     }
@@ -130,6 +132,7 @@ const completeRequesterSettleWakeBatch = (
       entry.delivery = previous?.delivery;
       entry.requesterSettleWake = previous?.requesterSettleWake;
       entry.retireAfterRequesterTurn = previous?.retireAfterRequesterTurn;
+      entry.suppressCompletionDelivery = previous?.suppressCompletionDelivery;
     });
     throw error;
   }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -4606,7 +4606,7 @@ describe("requester settle wake trigger", () => {
     entry.cleanupCompletedAt = undefined;
     entry.cleanupHandled = false;
     entry.wakeOnDescendantSettle = true;
-    runSubagentAnnounceFlow.mockClear();
+    vi.mocked(runSubagentAnnounceFlow).mockClear();
     taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockClear();
 
     pendingDescendantRuns = 1;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -4566,10 +4566,12 @@ describe("requester settle wake trigger", () => {
         return "intentional_non_delivery" as const;
       },
     );
+    let pendingDescendantRuns = 0;
     const controller = createLifecycleController({
       entry,
       maybeWakeRequesterAfterAllChildrenSettled,
       runSubagentAnnounceFlow,
+      countPendingDescendantRuns: () => pendingDescendantRuns,
     });
 
     await completeRun(controller, entry, {
@@ -4599,6 +4601,30 @@ describe("requester settle wake trigger", () => {
     expect(taskExecutorMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
       expect.objectContaining({ terminalOutcome: "blocked" }),
     );
+    expect(entry.suppressCompletionDelivery).toBe(true);
+
+    entry.cleanupCompletedAt = undefined;
+    entry.cleanupHandled = false;
+    entry.wakeOnDescendantSettle = true;
+    runSubagentAnnounceFlow.mockClear();
+    taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockClear();
+
+    pendingDescendantRuns = 1;
+    expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+    expect(entry.suppressCompletionDelivery).toBe(true);
+    expect(entry.wakeOnDescendantSettle).toBe(true);
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    pendingDescendantRuns = 0;
+    expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+    await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toEqual(expect.any(Number)));
+
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    expect(entry.suppressCompletionDelivery).toBeUndefined();
+    expect(entry.wakeOnDescendantSettle).toBeUndefined();
+    expect(entry.requesterSettleWake).toBeUndefined();
+    expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
   });
 
   it("retains a delete-mode child after no-wake until its requester turn settles", async () => {

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -261,7 +261,7 @@ export type SubagentRunRecord = {
   killReconciliation?: SubagentKillReconciliationState;
   /** Durable operator cancellation ownership before runtime side effects complete. */
   killIntent?: SubagentKillIntent;
-  /** Durable requester-stop policy until silent completion cleanup finishes. */
+  /** Durable requester-delivery closure until silent completion cleanup finishes. */
   suppressCompletionDelivery?: boolean;
   expectsCompletionMessage?: boolean;
   endedReason?: SubagentLifecycleEndedReason;

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -193,6 +193,8 @@ export type RequesterSettleWakeState = {
   afterRequesterYield?: true;
   /** Monotonic process generation protecting a newer yield from stale completion. */
   rearmGeneration?: number;
+  /** Number of times this batch has been deferred due to unsettled descendants. */
+  deferralCount?: number;
   lastError?: string | null;
   /** Cleanup wanted to retire this row; defer deletion until the outbox resolves. */
   retireAfterSettle?: boolean;


### PR DESCRIPTION
## What Problem This Solves

A requester can yield after spawning a subagent. If that subagent finishes while one of its descendants stays active, the requester settle wake can defer forever. The user gets no final result and the task records no terminal delivery reason.

## Root Cause

The durable requester settle-wake batch had no deferral bound. The submitted cap wrote another pending state instead of using the lifecycle completion owner. A late descendant wake could also replace the already blocked parent run and overwrite its delivery result.

## Fix

- Persist a bounded deferral count on the existing settle-wake batch.
- Route the cap through the existing completion owner with one failed delivery reason.
- Close later descendant delivery while descendants drain, then finish cleanup without a new requester wake.
- Abort an accepted descendant wake if delivery ownership closes before replacement.

## User Impact

The requester now gets a bounded, visible blocked task result instead of waiting forever. Late descendant completion cannot overwrite or duplicate that result.

## Evidence

### Live red on current main

On `5090935817e3`, a real Telegram requester spawned a subagent and yielded. The subagent finished while its non-announcing descendant stayed active. After ten settle intervals, `/tasks` still showed pending delivery with no error or terminal outcome. The durable settle wake remained pending with another future deadline. Releasing the descendant later proved the held work was real.

### Live green on final head

Hosted CI built merge candidate `5593dc27a9b2` from current main `608e365ce485` with exact PR head `0b5be69dc866` as its second parent. The same Telegram flow showed this result after ten settle intervals:

```text
Tasks
Current session: 0 active · 1 total

1. settle-wake-parent-child
Subagent · blocked
requester settle wake deferred too many times
```

The durable task recorded failed delivery, terminal outcome `blocked`, and one error reason. Requester settle-wake state was absent. After the descendant was released, the task stayed failed and blocked, cleanup completed, and no replacement wake or duplicate requester result appeared.

### Regression tests

```text
node scripts/run-vitest.mjs src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/subagents/registry/subagent-registry-requester-yield.test.ts src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
Test Files 4 passed
Tests 222 passed

OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
Test Files 1 passed
Tests 85 passed
```

Fixes #124343
