### PR TITLE
fix(gateway): audit aborted unconfirmed steer as skipped, not completed

### DIFF
--- a/src/gateway/server-methods/chat-send-message-injection.test.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.test.ts
@@ -1,0 +1,109 @@
+/** Covers steer finalize audit honesty: aborted unconfirmed commits must not audit as completed. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitInboundMessageAuditTerminal } from "../../auto-reply/reply/dispatch-from-config.audit.js";
+import {
+  abortReplyMessageInjectionTarget,
+  recordAcceptedReplyMessageInjectionTarget,
+  type ReplyMessageInjectionOutcome,
+  type ReplyMessageInjectionTarget,
+} from "../../auto-reply/reply/reply-run-registry.js";
+import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import { logMessageProcessed } from "../../logging/diagnostic.js";
+import { finalizeAcceptedChatSendMessageInjection } from "./chat-send-message-injection.js";
+import type { GatewayRequestContext } from "./types.js";
+
+vi.mock("../../auto-reply/reply/dispatch-from-config.audit.js", () => ({
+  emitInboundMessageAuditTerminal: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/reply-run-registry.js", () => ({
+  abortReplyMessageInjectionTarget: vi.fn(() => true),
+  beginReplyMessageInjectionTarget: vi.fn(),
+  recordAcceptedReplyMessageInjectionTarget: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/message-received-hooks.js", () => ({
+  emitMessageReceivedHooks: vi.fn(),
+}));
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  updateSessionEntry: vi.fn(async () => undefined),
+}));
+vi.mock("../../logging/diagnostic.js", () => ({
+  logMessageProcessed: vi.fn(),
+  logMessageReceived: vi.fn(),
+}));
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => undefined),
+}));
+vi.mock("./chat-broadcast.js", () => ({
+  broadcastChatFinal: vi.fn(),
+}));
+vi.mock("../agent-turn/agent-job.js", () => ({
+  setGatewayDedupeEntry: vi.fn(),
+}));
+
+function makeParams(outcome: Extract<ReplyMessageInjectionOutcome, { status: "accepted" }>) {
+  const context = {
+    logGateway: { warn: vi.fn() },
+    chatRunState: { hasAbortMarker: () => true },
+    dedupe: new Map(),
+  } as unknown as GatewayRequestContext;
+  return {
+    context,
+    ctx: { Provider: "dashboard", From: "user", To: "user", Body: "steer" },
+    outcome,
+    persistUserTurnTranscriptBestEffort: vi.fn(async () => undefined),
+    session: {
+      agentId: "main",
+      cfg: {},
+      clientRunId: "run-1",
+      entry: undefined,
+      sessionKey: "agent:main:dashboard:s",
+      storePath: "/tmp/nowhere.json",
+    },
+    startedAt: Date.now(),
+    target: {} as ReplyMessageInjectionTarget,
+    targetRunId: "run-1",
+  } as unknown as Parameters<typeof finalizeAcceptedChatSendMessageInjection>[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("finalizeAcceptedChatSendMessageInjection", () => {
+  it("audits a confirmed steer as completed active_run_injected", async () => {
+    await finalizeAcceptedChatSendMessageInjection(
+      makeParams({ status: "accepted", result: undefined } as never),
+    );
+
+    expect(abortReplyMessageInjectionTarget).not.toHaveBeenCalled();
+    expect(recordAcceptedReplyMessageInjectionTarget).toHaveBeenCalledOnce();
+    expect(logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "completed", reason: "active_run_injected" }),
+    );
+    expect(emitInboundMessageAuditTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminal: { outcome: "completed", options: { reason: "active_run_injected" } },
+      }),
+    );
+    expect(updateSessionEntry).toHaveBeenCalledOnce();
+  });
+
+  it("audits an unconfirmed-transcript steer abort as skipped, not completed", async () => {
+    await finalizeAcceptedChatSendMessageInjection(
+      makeParams({
+        status: "accepted",
+        result: { transcriptCommit: "unconfirmed", errorMessage: "commit timeout" },
+      } as never),
+    );
+
+    expect(abortReplyMessageInjectionTarget).toHaveBeenCalledOnce();
+    expect(logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "skipped", reason: "reply_operation_aborted" }),
+    );
+    expect(emitInboundMessageAuditTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminal: { outcome: "skipped", options: { reason: "reply_operation_aborted" } },
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -186,7 +186,11 @@ export async function finalizeAcceptedChatSendMessageInjection(params: {
   recordAcceptedReplyMessageInjectionTarget(target, {
     inboundAudio: hasInboundAudio(finalizedCtx),
   });
-  if (outcome.result?.transcriptCommit === "unconfirmed") {
+  // An unconfirmed transcript commit aborts the exact target without replay:
+  // the steer did not take effect, so diagnostics and audit must record the
+  // abort, not a completed injection.
+  const steerAborted = outcome.result?.transcriptCommit === "unconfirmed";
+  if (steerAborted) {
     abortReplyMessageInjectionTarget(target);
     context.logGateway.warn(
       `active run ${params.targetRunId ?? "unknown"} accepted chat steering without transcript confirmation; aborted exact target without replay`,
@@ -208,8 +212,8 @@ export async function finalizeAcceptedChatSendMessageInjection(params: {
       sessionId: entry?.sessionId,
       sessionKey,
       durationMs: Math.max(0, Date.now() - params.startedAt),
-      outcome: "completed",
-      reason: "active_run_injected",
+      outcome: steerAborted ? "skipped" : "completed",
+      reason: steerAborted ? "reply_operation_aborted" : "active_run_injected",
     });
   }
   emitMessageReceivedHooks({
@@ -227,7 +231,9 @@ export async function finalizeAcceptedChatSendMessageInjection(params: {
     ctx: finalizedCtx,
     observedRunId: clientRunId,
     startedAt: params.startedAt,
-    terminal: { outcome: "completed", options: { reason: "active_run_injected" } },
+    terminal: steerAborted
+      ? { outcome: "skipped", options: { reason: "reply_operation_aborted" } }
+      : { outcome: "completed", options: { reason: "active_run_injected" } },
   });
   const updatedAt = Date.now();
   if (entry) {


### PR DESCRIPTION
## What Problem This Solves

When an active run accepts chat steering but the transcript commit comes back `unconfirmed`, `finalizeAcceptedChatSendMessageInjection` aborts the exact target without replay — the steer never took effect. But diagnostics (`logMessageProcessed`) and the inbound-message audit terminal still recorded `completed`/`active_run_injected`, claiming a successful injection that did not happen. That is a doctrine-class finding: a recorded fact (the audit trail) contradicting shipped behavior.

## Why This Change Was Made

The abort path now records `skipped`/`reply_operation_aborted` — the existing audit reason for exactly this class (steering aborted before taking effect) — in both diagnostics and the audit terminal. Confirmed steers keep the `completed`/`active_run_injected` record unchanged. One `steerAborted` fact drives all three sites (abort, diagnostics, audit), so they cannot drift again.

## User Impact

Operators reading the inbound-message audit or diagnostics after a failed steer (transcript-commit timeout) see the truthful skipped/aborted terminal instead of a phantom successful injection.

## Evidence

- New regression `audits an unconfirmed-transcript steer abort as skipped, not completed` fails pre-fix (stash proof); companion test pins the unchanged confirmed path.
- `node scripts/run-vitest.mjs run src/gateway/server-methods/chat-send-message-injection.test.ts` — 2/2; neighbor suite `server.chat.gateway-server-chat.test.ts` green.
- tsgo core + core-test shards clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +10 −4 (net +6: the recorded fact and its two honest consumers); tests +109.
