### PR TITLE
fix(deps): add mdast-util-from-markdown to root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2035,6 +2035,7 @@
     "jszip": "3.10.1",
     "kysely": "0.29.4",
     "linkedom": "0.18.13",
+    "mdast-util-from-markdown": "2.0.3",
     "minimatch": "10.2.5",
     "ms": "2.1.3",
     "node-edge-tts": "1.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       linkedom:
         specifier: 0.18.13
         version: 0.18.13
+      mdast-util-from-markdown:
+        specifier: 2.0.3
+        version: 2.0.3(supports-color@10.2.2)
       minimatch:
         specifier: 10.2.5
         version: 10.2.5


### PR DESCRIPTION
## What Problem This Solves

The official npm packages for OpenClaw stable `2026.7.1-2` and beta `2026.8.1-beta.1` bundle `dist/extensions/memory-wiki/package.json` declaring `mdast-util-from-markdown: 2.0.3`, but the published OpenClaw package neither declares that dependency at the root nor contains it under the bundled plugin. A clean npm install therefore leaves Memory Wiki's required dependency unresolved.

## Root Cause

The `memory-wiki` extension declares `mdast-util-from-markdown` as a dependency, but it's not included in the root `package.json` dependencies, so it's not included in the published npm package.

## Fix

Add `mdast-util-from-markdown` to the root `package.json` dependencies so it's included in the published package.

## Evidence

- **Issue:** #122357
- **Runtime:** The fix ensures the dependency is included in the published npm package

Fixes #122357