### PR TITLE
feat(openrouter): discovery-driven per-model image generation controls

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1039,6 +1039,13 @@ catalog, API-key auth, and dynamic model resolution.
         invoking provider code. Request-time capability lookup and enforcement
         still belong in `resolveModelCapabilities` and `generateVideo`; reuse
         the same capability constant for both paths when possible.
+
+        Image providers accept the same optional `resolveModelCapabilities`
+        hook: the runtime overlays its result onto the static `capabilities`
+        for the selected model before override sanitization, so unsupported
+        values surface as ignored overrides instead of being dropped silently.
+        A hook failure falls back to the static capabilities and never fails
+        the generation.
       </Tab>
       <Tab title="Web fetch and search">
         ```typescript

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -116,11 +116,17 @@ under `agents.defaults.mediaModels.image`:
 ```
 
 OpenClaw sends canonical OpenRouter image requests to the dedicated image API
-(`POST /api/v1/images`). Gemini image models additionally receive
-`aspect_ratio` and `resolution` hints, and image edits pass source images as
-`input_references`. Generated images come back as base64 (`b64_json`) with an
-optional `media_type`; when `media_type` is absent, OpenClaw sniffs the image
-format from the bytes.
+(`POST /api/v1/images`). Per-model controls are discovered live from
+`GET /api/v1/images/models` (`supported_parameters`): `aspect_ratio`,
+`resolution`, `quality`, and `background` are forwarded when the selected
+model advertises them, values the model does not support are dropped and
+reported back as ignored overrides, and newly launched OpenRouter image models
+pick up the right controls without an OpenClaw update. Discovery results are
+cached briefly; if the lookup fails, OpenClaw falls back to its static
+capability defaults and the generation proceeds. Image edits pass source
+images as `input_references`. Generated images come back as base64
+(`b64_json`) with an optional `media_type`; when `media_type` is absent,
+OpenClaw sniffs the image format from the bytes.
 
 Configured custom OpenRouter `baseUrl` destinations retain the existing
 chat-completions image route for compatibility with proxies that do not expose

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -83,6 +83,9 @@ describe("openrouter image generation provider", () => {
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.edit.enabled).toBe(true);
     expect(provider.capabilities.edit.maxInputImages).toBe(5);
+    // Live per-model discovery hook; the runtime overlays its result onto the
+    // static capabilities above for the selected model.
+    expect(provider.resolveModelCapabilities).toBeTypeOf("function");
   });
 
   it("preserves chat-completion image requests for configured custom bases", async () => {
@@ -347,6 +350,121 @@ describe("openrouter image generation provider", () => {
     const image = requireGeneratedImage(result, 0);
     expect(image.buffer.toString()).toBe("webp-one");
     expect(image.mimeType).toBe("image/webp");
+  });
+
+  // Regression guard: the dedicated /images body must not be gated by model
+  // family — pre-discovery code silently dropped these axes for non-Gemini models.
+  it("forwards aspect_ratio for non-Gemini models on the dedicated endpoint", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: Response.json({
+        data: [{ b64_json: Buffer.from("png-wide").toString("base64") }],
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    await buildOpenRouterImageGenerationProvider().generateImage({
+      provider: "openrouter",
+      model: "openai/gpt-5.4-image-2",
+      prompt: "draw a wide banner",
+      aspectRatio: "16:9",
+      cfg: {},
+    });
+
+    const request = requireOpenRouterPostRequest();
+    expect(request.url).toBe("https://openrouter.ai/api/v1/images");
+    expect(request.body).toEqual({
+      model: "openai/gpt-5.4-image-2",
+      prompt: "draw a wide banner",
+      n: 1,
+      aspect_ratio: "16:9",
+    });
+  });
+
+  it("forwards sanitized quality and background on the dedicated endpoint", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: Response.json({
+        data: [{ b64_json: Buffer.from("png-hq").toString("base64") }],
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    await buildOpenRouterImageGenerationProvider().generateImage({
+      provider: "openrouter",
+      model: "openai/gpt-5.4-image-2",
+      prompt: "draw a logo",
+      quality: "high",
+      background: "opaque",
+      cfg: {},
+    });
+
+    expect(requireOpenRouterPostRequest().body).toEqual({
+      model: "openai/gpt-5.4-image-2",
+      prompt: "draw a logo",
+      n: 1,
+      quality: "high",
+      background: "opaque",
+    });
+  });
+
+  it("forwards aspect_ratio and resolution for Gemini models on the dedicated endpoint", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: Response.json({
+        data: [{ b64_json: Buffer.from("png-gem").toString("base64") }],
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    await buildOpenRouterImageGenerationProvider().generateImage({
+      provider: "openrouter",
+      model: "google/gemini-3.1-flash-image-preview",
+      prompt: "draw a wide banner",
+      aspectRatio: "16:9",
+      resolution: "2K",
+      cfg: {},
+    });
+
+    expect(requireOpenRouterPostRequest().body).toEqual({
+      model: "google/gemini-3.1-flash-image-preview",
+      prompt: "draw a wide banner",
+      n: 1,
+      aspect_ratio: "16:9",
+      resolution: "2K",
+    });
+  });
+
+  // Pin: the legacy custom-base path keeps its Google-specific image_config and
+  // Gemini gate — discovery does not apply off the canonical base (see §3.4).
+  it("keeps custom-base chat completions Gemini-gated with no geometry for other models", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: Response.json({
+        choices: [
+          {
+            message: {
+              images: [{ image_url: { url: "data:image/png;base64,cG5n" } }],
+            },
+          },
+        ],
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    await buildOpenRouterImageGenerationProvider().generateImage({
+      provider: "openrouter",
+      model: "openai/gpt-5.4-image-2",
+      prompt: "draw a wide banner",
+      aspectRatio: "16:9",
+      quality: "high",
+      cfg: customOpenRouterConfig(),
+    });
+
+    const request = requireOpenRouterPostRequest();
+    expect(request.url).toBe("https://custom.openrouter.test/api/v1/chat/completions");
+    expect(request.body).toEqual({
+      model: "openai/gpt-5.4-image-2",
+      messages: [{ role: "user", content: "draw a wide banner" }],
+      modalities: ["image", "text"],
+      n: 1,
+    });
   });
 
   it.each(["google/gemini-3.1-flash-image-preview", "openai/gpt-5.4-image-2"])(

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -23,6 +23,7 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveOpenRouterImageModelCapabilities } from "./image-model-catalog.js";
 import { normalizeOpenRouterBaseUrl, OPENROUTER_BASE_URL } from "./provider-catalog.js";
 
 const DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview";
@@ -197,15 +198,28 @@ function buildDedicatedImageBody(
     prompt: req.prompt,
     n: count,
   };
-  if (isGeminiImageModel(model)) {
-    const aspectRatio = normalizeOptionalString(req.aspectRatio);
-    if (aspectRatio) {
-      body.aspect_ratio = aspectRatio;
-    }
-    const resolution = normalizeOptionalString(req.resolution);
-    if (resolution) {
-      body.resolution = resolution;
-    }
+  // On the dedicated /images endpoint these are normalized cross-provider axes.
+  // Capability gating happens upstream: the runtime overlays live-discovered
+  // per-model caps (image-model-catalog.ts) and strips unsupported values into
+  // ignoredOverrides, so anything still present here is forwarded as-is.
+  // quality/background only survive that sanitization when discovery declared
+  // them (static caps have no output block), so on the static-caps fallback
+  // path they are always reported ignored rather than sent.
+  const aspectRatio = normalizeOptionalString(req.aspectRatio);
+  if (aspectRatio) {
+    body.aspect_ratio = aspectRatio;
+  }
+  const resolution = normalizeOptionalString(req.resolution);
+  if (resolution) {
+    body.resolution = resolution;
+  }
+  const quality = normalizeOptionalString(req.quality);
+  if (quality) {
+    body.quality = quality;
+  }
+  const background = normalizeOptionalString(req.background);
+  if (background) {
+    body.background = background;
   }
   const inputReferences = buildInputReferences(req);
   if (inputReferences.length > 0) {
@@ -248,6 +262,10 @@ function buildMessageContent(
 }
 
 function buildImageConfig(req: ImageGenerationRequest, model: string): Record<string, string> {
+  // Legacy /chat/completions path for custom (non-canonical) bases only. The
+  // `image_config` body shape is Google-specific, and capability discovery is
+  // unavailable off the canonical base, so the Gemini predicate stays here even
+  // though the dedicated /images path above no longer gates by model family.
   if (!isGeminiImageModel(model)) {
     return {};
   }
@@ -270,6 +288,10 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
     defaultModel: DEFAULT_MODEL,
     models: [...SUPPORTED_MODELS],
     isConfigured: (ctx) => isProviderApiKeyConfigured({ provider: "openrouter", ...ctx }),
+    resolveModelCapabilities: resolveOpenRouterImageModelCapabilities,
+    // Static caps below are the fallback when discovery is unavailable (custom
+    // base, outage, model missing from the catalog); discovered caps otherwise
+    // overlay them per model at request time.
     capabilities: {
       generate: {
         maxCount: MAX_IMAGE_RESULTS,

--- a/extensions/openrouter/image-model-catalog.test.ts
+++ b/extensions/openrouter/image-model-catalog.test.ts
@@ -1,0 +1,317 @@
+// Openrouter tests cover image model capability discovery.
+import type { ImageGenerationModelCapabilitiesContext } from "openclaw/plugin-sdk/image-generation";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOpenRouterImageModelCapabilities } from "./image-model-catalog.js";
+
+const { fetchWithTimeoutGuardedMock, resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  fetchWithTimeoutGuardedMock: vi.fn(),
+  resolveApiKeyForProviderMock: vi.fn(
+    async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: "openrouter-key" }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-http")>(
+    "openclaw/plugin-sdk/provider-http",
+  );
+  return {
+    ...actual,
+    fetchWithTimeoutGuarded: fetchWithTimeoutGuardedMock,
+  };
+});
+
+// Trimmed from the live `GET /api/v1/images/models` payload (captured 2026-08-15).
+const CATALOG_PAYLOAD = {
+  data: [
+    {
+      id: "google/gemini-3.1-flash-image-preview",
+      name: "Google: Gemini 3.1 Flash Image Preview",
+      supported_parameters: {
+        aspect_ratio: {
+          type: "enum",
+          values: ["1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9"],
+        },
+        resolution: { type: "enum", values: ["512", "1K", "2K", "4K"] },
+        n: { type: "range", min: 1, max: 1 },
+        input_references: { type: "range", min: 0, max: 14 },
+      },
+    },
+    {
+      // Synthetic: every advertised resolution falls outside OpenClaw's union,
+      // and no input_references descriptor (generate-only model).
+      id: "test/low-res-only",
+      supported_parameters: {
+        aspect_ratio: { type: "enum", values: ["1:1"] },
+        resolution: { type: "enum", values: ["512"] },
+      },
+    },
+    {
+      // Synthetic: malformed descriptors that must each drop only themselves.
+      id: "test/malformed-descriptors",
+      supported_parameters: {
+        aspect_ratio: { type: "enum", values: [1, 2, "16:9"] },
+        input_references: { type: "range", min: 0, max: -1 },
+        n: { type: "range", min: 1, max: 0.5 },
+      },
+    },
+    {
+      id: "openai/gpt-5.4-image-2",
+      name: "OpenAI: GPT-5.4 Image 2",
+      supported_parameters: {
+        aspect_ratio: {
+          type: "enum",
+          values: ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+        },
+        quality: { type: "enum", values: ["auto", "low", "medium", "high"] },
+        background: { type: "enum", values: ["auto", "opaque"] },
+        n: { type: "range", min: 1, max: 10 },
+        input_references: { type: "range", min: 0, max: 16 },
+        output_compression: { type: "range", min: 0, max: 100 },
+        seed: { type: "boolean" },
+        future_knob: { type: "enum_number", values: [1, 2] },
+      },
+    },
+  ],
+};
+
+function releasedJson(value: unknown) {
+  return {
+    response: new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    release: vi.fn(async () => {}),
+  };
+}
+
+function buildContext(
+  model: string,
+  cfg: Record<string, unknown> = {},
+): ImageGenerationModelCapabilitiesContext {
+  return {
+    provider: "openrouter",
+    model,
+    cfg,
+  } as ImageGenerationModelCapabilitiesContext;
+}
+
+function requireFetchRequest(index = 0): { url: string; headers: Headers } {
+  const call = fetchWithTimeoutGuardedMock.mock.calls[index];
+  if (!call) {
+    throw new Error(`expected image catalog fetch at index ${index}`);
+  }
+  const [url, init] = call as [string, { headers: Headers }];
+  return { url, headers: init.headers };
+}
+
+describe("openrouter image model catalog", () => {
+  beforeEach(() => {
+    clearLiveCatalogCacheForTests();
+    fetchWithTimeoutGuardedMock.mockReset();
+    resolveApiKeyForProviderMock.mockReset();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "openrouter-key" });
+  });
+
+  it("parses Gemini descriptors into aspect-ratio and resolution capabilities", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("google/gemini-3.1-flash-image-preview"),
+    );
+
+    expect(capabilities).toEqual({
+      generate: { supportsAspectRatio: true, supportsResolution: true },
+      edit: {
+        supportsAspectRatio: true,
+        supportsResolution: true,
+        enabled: true,
+        maxInputImages: 14,
+      },
+      geometry: {
+        aspectRatios: ["1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9"],
+        // "512" is advertised upstream but outside OpenClaw's resolution union.
+        resolutions: ["1K", "2K", "4K"],
+      },
+    });
+    // `n: {min:1,max:1}` must never surface as maxCount: the provider fans out
+    // `count` single-image requests, so per-request batch size is irrelevant.
+    expect(capabilities?.generate).not.toHaveProperty("maxCount");
+    expect(requireFetchRequest().url).toBe("https://openrouter.ai/api/v1/images/models");
+  });
+
+  it("parses OpenAI descriptors and drops unrecognized ones per parameter", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("openai/gpt-5.4-image-2"),
+    );
+
+    expect(capabilities).toEqual({
+      generate: { supportsAspectRatio: true, supportsResolution: false },
+      edit: {
+        supportsAspectRatio: true,
+        supportsResolution: false,
+        enabled: true,
+        maxInputImages: 16,
+      },
+      geometry: {
+        aspectRatios: ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+      },
+      // The boolean `seed` and unknown `future_knob` descriptors drop only
+      // themselves; sibling enums still parse.
+      output: {
+        qualities: ["auto", "low", "medium", "high"],
+        backgrounds: ["auto", "opaque"],
+      },
+    });
+  });
+
+  it("treats a resolution set entirely outside the union as unsupported", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("test/low-res-only"),
+    );
+
+    // supportsResolution: true with an empty geometry list would skip enum
+    // snapping and forward raw values unsanitized; unsupported reports instead.
+    expect(capabilities?.generate).toEqual({
+      supportsAspectRatio: true,
+      supportsResolution: false,
+    });
+    expect(capabilities?.geometry).toEqual({ aspectRatios: ["1:1"] });
+    // No input_references descriptor → edits unsupported, so reference images
+    // skip visibly instead of riding the static limit into a model that never
+    // advertised them.
+    expect(capabilities?.edit).toEqual({
+      supportsAspectRatio: true,
+      supportsResolution: false,
+      enabled: false,
+      maxInputImages: 0,
+    });
+  });
+
+  it("drops malformed descriptors per parameter without disabling the model", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("test/malformed-descriptors"),
+    );
+
+    // Numeric enum entries are dropped; the remaining string still parses.
+    expect(capabilities?.geometry).toEqual({ aspectRatios: ["16:9"] });
+    expect(capabilities?.generate).toEqual({
+      supportsAspectRatio: true,
+      supportsResolution: false,
+    });
+    // A negative range max (an "unlimited" sentinel or bad data) drops only
+    // input_references — it must never become a limit that blocks generation.
+    expect(capabilities?.edit).toEqual({
+      supportsAspectRatio: true,
+      supportsResolution: false,
+      enabled: false,
+      maxInputImages: 0,
+    });
+  });
+
+  it("returns undefined for models absent from the catalog", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    await expect(
+      resolveOpenRouterImageModelCapabilities(buildContext("someone/new-model")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips discovery entirely for non-canonical base URLs", async () => {
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("google/gemini-3.1-flash-image-preview", {
+        models: {
+          providers: {
+            openrouter: { baseUrl: "https://custom.openrouter.test/api/v1" },
+          },
+        },
+      }),
+    );
+
+    expect(capabilities).toBeUndefined();
+    expect(fetchWithTimeoutGuardedMock).not.toHaveBeenCalled();
+  });
+
+  it("serves repeated lookups from one cached catalog fetch", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const first = await resolveOpenRouterImageModelCapabilities(
+      buildContext("google/gemini-3.1-flash-image-preview"),
+    );
+    const second = await resolveOpenRouterImageModelCapabilities(
+      buildContext("openai/gpt-5.4-image-2"),
+    );
+
+    expect(first?.generate.supportsResolution).toBe(true);
+    expect(second?.generate.supportsResolution).toBe(false);
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches the public catalog without an API key when none resolves", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    const capabilities = await resolveOpenRouterImageModelCapabilities(
+      buildContext("google/gemini-3.1-flash-image-preview"),
+    );
+
+    expect(capabilities?.generate.supportsAspectRatio).toBe(true);
+    expect(requireFetchRequest().headers.get("Authorization")).toBeNull();
+  });
+
+  it("sends the API key when one resolves", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(CATALOG_PAYLOAD));
+
+    await resolveOpenRouterImageModelCapabilities(
+      buildContext("google/gemini-3.1-flash-image-preview"),
+    );
+
+    expect(requireFetchRequest().headers.get("Authorization")).toBe("Bearer openrouter-key");
+  });
+
+  it("propagates fetch failures for the runtime overlay to degrade to static caps", async () => {
+    fetchWithTimeoutGuardedMock.mockRejectedValueOnce(new Error("catalog offline"));
+    await expect(
+      resolveOpenRouterImageModelCapabilities(
+        buildContext("google/gemini-3.1-flash-image-preview"),
+      ),
+    ).rejects.toThrow("catalog offline");
+  });
+
+  it("propagates non-200 catalog responses", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+      response: new Response("upstream unavailable", { status: 503 }),
+      release: vi.fn(async () => {}),
+    });
+    await expect(
+      resolveOpenRouterImageModelCapabilities(
+        buildContext("google/gemini-3.1-flash-image-preview"),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("propagates malformed catalog JSON", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+      response: new Response("not-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+    await expect(
+      resolveOpenRouterImageModelCapabilities(
+        buildContext("google/gemini-3.1-flash-image-preview"),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/extensions/openrouter/image-model-catalog.ts
+++ b/extensions/openrouter/image-model-catalog.ts
@@ -1,0 +1,268 @@
+// Openrouter plugin module implements image model capability discovery.
+import type {
+  ImageGenerationBackground,
+  ImageGenerationModelCapabilitiesContext,
+  ImageGenerationProviderCapabilities,
+  ImageGenerationQuality,
+  ImageGenerationResolution,
+} from "openclaw/plugin-sdk/image-generation";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeoutGuarded,
+  readProviderJsonResponse,
+  resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
+} from "openclaw/plugin-sdk/provider-http";
+import {
+  isRecord,
+  normalizeOptionalString,
+  normalizeTrimmedStringList,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOpenRouterBaseUrl, OPENROUTER_BASE_URL } from "./provider-catalog.js";
+
+// Discovery sits on the image request path; keep its budget far below the
+// generation timeout so a slow catalog degrades to static caps, never a stall.
+const DISCOVERY_TIMEOUT_MS = 10_000;
+
+type OpenRouterImageDispatcherPolicy = NonNullable<
+  Parameters<typeof fetchWithTimeoutGuarded>[4]
+>["dispatcherPolicy"];
+
+type OpenRouterImageRequestPolicyCacheKey = ReturnType<
+  typeof sanitizeConfiguredModelProviderRequest
+>;
+
+type OpenRouterImageRequestConfig = Parameters<typeof sanitizeConfiguredModelProviderRequest>[0];
+
+const IMAGE_RESOLUTION_VALUES: readonly ImageGenerationResolution[] = ["1K", "2K", "4K"];
+const IMAGE_QUALITY_VALUES: readonly ImageGenerationQuality[] = ["auto", "low", "medium", "high"];
+const IMAGE_BACKGROUND_VALUES: readonly ImageGenerationBackground[] = [
+  "auto",
+  "opaque",
+  "transparent",
+];
+
+function isImageResolution(value: string): value is ImageGenerationResolution {
+  return (IMAGE_RESOLUTION_VALUES as readonly string[]).includes(value);
+}
+
+function isImageQuality(value: string): value is ImageGenerationQuality {
+  return (IMAGE_QUALITY_VALUES as readonly string[]).includes(value);
+}
+
+function isImageBackground(value: string): value is ImageGenerationBackground {
+  return (IMAGE_BACKGROUND_VALUES as readonly string[]).includes(value);
+}
+
+// `supported_parameters` values are typed descriptors ({type: "enum"|"range"|"boolean", ...}).
+// Each reader validates one descriptor in isolation: an unrecognized or malformed
+// descriptor drops only its own parameter, never the model or the catalog.
+function readEnumValues(descriptor: unknown): string[] | undefined {
+  if (!isRecord(descriptor) || descriptor.type !== "enum") {
+    return undefined;
+  }
+  const values = normalizeTrimmedStringList(descriptor.values);
+  return values.length > 0 ? values : undefined;
+}
+
+function readRangeMax(descriptor: unknown): number | undefined {
+  if (!isRecord(descriptor) || descriptor.type !== "range") {
+    return undefined;
+  }
+  // Negative sentinels ("unlimited") or fractional maxima must drop the
+  // parameter, not flow into count gates as nonsense limits.
+  return typeof descriptor.max === "number" &&
+    Number.isInteger(descriptor.max) &&
+    descriptor.max >= 0
+    ? descriptor.max
+    : undefined;
+}
+
+function buildOpenRouterImageModelCapabilities(
+  supportedParameters: Record<string, unknown>,
+): ImageGenerationProviderCapabilities {
+  const aspectRatios = readEnumValues(supportedParameters.aspect_ratio);
+  // The API also advertises values outside OpenClaw's resolution union (e.g. "512");
+  // drop those rather than widening the union here. A model whose entire set falls
+  // outside the union counts as unsupported: an empty geometry list would skip enum
+  // snapping and pass raw values through unsanitized instead of reporting them ignored.
+  const resolutions = readEnumValues(supportedParameters.resolution)?.filter(isImageResolution);
+  const supportsResolution = (resolutions?.length ?? 0) > 0;
+  const qualities = readEnumValues(supportedParameters.quality)?.filter(isImageQuality);
+  const backgrounds = readEnumValues(supportedParameters.background)?.filter(isImageBackground);
+  const maxInputImages = readRangeMax(supportedParameters.input_references);
+
+  // `n` is deliberately NOT mapped to maxCount: `n` is the upstream per-request
+  // batch size, while the provider fans out `count` parallel requests with n=1,
+  // so a model with n:{min:1,max:1} still serves multi-image generations.
+  const modeCapabilities = {
+    supportsAspectRatio: aspectRatios !== undefined,
+    supportsResolution,
+  };
+  return {
+    generate: modeCapabilities,
+    // Absence means unsupported, same client-side policy as the axes above:
+    // an edit request against a model that never advertised input_references
+    // must skip visibly, not silently drop the user's reference images. Every
+    // current catalog model advertises the parameter, so this only fires for
+    // malformed or future generate-only entries.
+    edit: {
+      ...modeCapabilities,
+      enabled: maxInputImages !== undefined && maxInputImages > 0,
+      maxInputImages: maxInputImages ?? 0,
+    },
+    geometry: {
+      ...(aspectRatios ? { aspectRatios } : {}),
+      ...(supportsResolution ? { resolutions } : {}),
+    },
+    ...(qualities?.length || backgrounds?.length
+      ? {
+          output: {
+            ...(qualities?.length ? { qualities } : {}),
+            ...(backgrounds?.length ? { backgrounds } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function findModelSupportedParameters(
+  payload: unknown,
+  model: string,
+): Record<string, unknown> | undefined {
+  const entries = isRecord(payload) && Array.isArray(payload.data) ? payload.data : [];
+  for (const entry of entries) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    if (normalizeOptionalString(entry.id) !== model) {
+      continue;
+    }
+    return isRecord(entry.supported_parameters) ? entry.supported_parameters : undefined;
+  }
+  return undefined;
+}
+
+// Canonical key ordering keeps equivalent request policies on one cache entry.
+function stableCacheKeyValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableCacheKeyValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, stableCacheKeyValue(entry)]),
+  );
+}
+
+function buildRequestPolicyCacheKey(request: OpenRouterImageRequestPolicyCacheKey): unknown {
+  return stableCacheKeyValue(request ?? null);
+}
+
+function resolveOpenRouterImageCatalogRequest(params: {
+  apiKey: string | undefined;
+  baseUrl: string | undefined;
+  request: OpenRouterImageRequestConfig;
+}) {
+  const request = sanitizeConfiguredModelProviderRequest(params.request);
+  return {
+    ...resolveProviderHttpRequestConfig({
+      provider: "openrouter",
+      capability: "image",
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: OPENROUTER_BASE_URL,
+      defaultHeaders: {
+        // `GET /images/models` is public; send the key when one resolves (rate
+        // limits, consistency) but never require it for discovery.
+        ...(params.apiKey ? { Authorization: `Bearer ${params.apiKey}` } : {}),
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+      },
+      request,
+    }),
+    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
+  };
+}
+
+async function fetchOpenRouterImageModels(params: {
+  baseUrl: string;
+  headers: Headers;
+  requestPolicyCacheKey: unknown;
+  timeoutMs: number;
+  allowPrivateNetwork: boolean;
+  dispatcherPolicy: OpenRouterImageDispatcherPolicy;
+}): Promise<unknown> {
+  return await getCachedLiveCatalogValue({
+    // The route is public and its payload identical for every caller, so the
+    // API key stays out of the cache identity (unlike the auth-gated video catalog).
+    keyParts: ["openrouter", "image-models", params.baseUrl, params.requestPolicyCacheKey],
+    load: async () => {
+      const url = new URL("images/models", `${params.baseUrl}/`).href;
+      const headers = new Headers(params.headers);
+      headers.delete("content-type");
+      const { response, release } = await fetchWithTimeoutGuarded(
+        url,
+        { method: "GET", headers },
+        params.timeoutMs,
+        fetch,
+        {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          auditContext: "openrouter-image-models",
+        },
+      );
+      try {
+        await assertOkOrThrowHttpError(response, "OpenRouter image models request failed");
+        return await readProviderJsonResponse<unknown>(
+          response,
+          "OpenRouter image models request failed",
+        );
+      } finally {
+        await release();
+      }
+    },
+  });
+}
+
+export async function resolveOpenRouterImageModelCapabilities(
+  ctx: ImageGenerationModelCapabilitiesContext,
+): Promise<ImageGenerationProviderCapabilities | undefined> {
+  const auth = await resolveApiKeyForProvider({
+    provider: "openrouter",
+    cfg: ctx.cfg,
+    agentDir: ctx.agentDir,
+    store: ctx.authStore,
+  });
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy, requestPolicyCacheKey } =
+    resolveOpenRouterImageCatalogRequest({
+      apiKey: auth.apiKey,
+      baseUrl: ctx.cfg?.models?.providers?.openrouter?.baseUrl,
+      request: ctx.cfg?.models?.providers?.openrouter?.request,
+    });
+  // Discovery is defined only for the canonical OpenRouter API. Custom bases use
+  // the legacy /chat/completions image path and are not guaranteed to serve this route.
+  const canonicalBaseUrl = normalizeOpenRouterBaseUrl(baseUrl);
+  if (!canonicalBaseUrl) {
+    return undefined;
+  }
+  const payload = await fetchOpenRouterImageModels({
+    baseUrl: canonicalBaseUrl,
+    headers,
+    requestPolicyCacheKey,
+    timeoutMs: ctx.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+    allowPrivateNetwork,
+    dispatcherPolicy,
+  });
+  const supportedParameters = findModelSupportedParameters(payload, ctx.model);
+  if (!supportedParameters) {
+    // Model absent from the catalog: no overlay — static caps apply and the
+    // API stays the authority on whether forwarded knobs are accepted.
+    return undefined;
+  }
+  return buildOpenRouterImageModelCapabilities(supportedParameters);
+}

--- a/src/image-generation/capability-overlays.test.ts
+++ b/src/image-generation/capability-overlays.test.ts
@@ -1,0 +1,144 @@
+/** Tests image capability overlay merging and request-local provider resolution. */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  mergeImageGenerationProviderCapabilities,
+  resolveProviderWithModelCapabilities,
+} from "./capability-overlays.js";
+import type { ImageGenerationProvider, ImageGenerationProviderCapabilities } from "./types.js";
+
+const cfg = {} as OpenClawConfig;
+
+function buildProvider(overrides: Partial<ImageGenerationProvider> = {}): ImageGenerationProvider {
+  return {
+    id: "openrouter",
+    capabilities: {
+      generate: { maxCount: 4, supportsAspectRatio: true, supportsResolution: true },
+      edit: { enabled: true, maxInputImages: 5, supportsAspectRatio: true },
+      geometry: { aspectRatios: ["1:1", "16:9"], resolutions: ["1K", "2K", "4K"] },
+    },
+    generateImage: async () => ({
+      images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+    }),
+    ...overrides,
+  };
+}
+
+describe("mergeImageGenerationProviderCapabilities", () => {
+  it("lets overlay values win per mode while keeping unset base values", () => {
+    const merged = mergeImageGenerationProviderCapabilities(buildProvider().capabilities, {
+      generate: { supportsResolution: false },
+      edit: { enabled: true, maxInputImages: 14 },
+      geometry: { aspectRatios: ["1:1", "21:9"] },
+      output: { qualities: ["high"] },
+    });
+
+    expect(merged.generate).toEqual({
+      maxCount: 4,
+      supportsAspectRatio: true,
+      supportsResolution: false,
+    });
+    expect(merged.edit).toEqual({ enabled: true, maxInputImages: 14, supportsAspectRatio: true });
+    expect(merged.geometry).toEqual({
+      aspectRatios: ["1:1", "21:9"],
+      resolutions: ["1K", "2K", "4K"],
+    });
+    expect(merged.output).toEqual({ qualities: ["high"] });
+  });
+
+  it("keeps base geometry and output when the overlay declares neither", () => {
+    const base: ImageGenerationProviderCapabilities = {
+      generate: {},
+      edit: { enabled: false },
+      output: { backgrounds: ["opaque"] },
+    };
+    const merged = mergeImageGenerationProviderCapabilities(base, {
+      generate: {},
+      edit: { enabled: false },
+    });
+    expect(merged.geometry).toBeUndefined();
+    expect(merged.output).toEqual({ backgrounds: ["opaque"] });
+  });
+});
+
+describe("resolveProviderWithModelCapabilities", () => {
+  const baseParams = {
+    providerId: "openrouter",
+    model: "some/model",
+    cfg,
+    log: { debug: () => {} },
+  };
+
+  it("returns the provider unchanged when it declares no capability hook", async () => {
+    const provider = buildProvider();
+    const resolved = await resolveProviderWithModelCapabilities({ ...baseParams, provider });
+    expect(resolved).toBe(provider);
+  });
+
+  it("returns the provider unchanged when the hook resolves undefined", async () => {
+    const provider = buildProvider({ resolveModelCapabilities: async () => undefined });
+    const resolved = await resolveProviderWithModelCapabilities({ ...baseParams, provider });
+    expect(resolved).toBe(provider);
+  });
+
+  it("returns a request-local copy so model caps never leak across requests", async () => {
+    const provider = buildProvider({
+      resolveModelCapabilities: async () => ({
+        generate: { supportsResolution: false },
+        edit: { enabled: true },
+      }),
+    });
+    const resolved = await resolveProviderWithModelCapabilities({ ...baseParams, provider });
+
+    expect(resolved).not.toBe(provider);
+    expect(resolved.capabilities.generate.supportsResolution).toBe(false);
+    // The registered provider's static capabilities stay untouched.
+    expect(provider.capabilities.generate.supportsResolution).toBe(true);
+  });
+
+  it("passes the request context through to the capability hook", async () => {
+    let seenContext: unknown;
+    const provider = buildProvider({
+      resolveModelCapabilities: async (ctx) => {
+        seenContext = ctx;
+        return undefined;
+      },
+    });
+    await resolveProviderWithModelCapabilities({
+      ...baseParams,
+      provider,
+      agentDir: "/tmp/agent",
+      timeoutMs: 1234,
+    });
+    expect(seenContext).toEqual({
+      provider: "openrouter",
+      model: "some/model",
+      cfg,
+      agentDir: "/tmp/agent",
+      authStore: undefined,
+      timeoutMs: 1234,
+    });
+  });
+
+  it("treats a hook failure as no overlay and logs at debug", async () => {
+    const debugMessages: string[] = [];
+    const provider = buildProvider({
+      resolveModelCapabilities: async () => {
+        throw new Error("discovery down");
+      },
+    });
+    const resolved = await resolveProviderWithModelCapabilities({
+      ...baseParams,
+      provider,
+      log: {
+        debug: (message: string) => {
+          debugMessages.push(message);
+        },
+      },
+    });
+    expect(resolved).toBe(provider);
+    expect(debugMessages).toHaveLength(1);
+    expect(debugMessages[0]).toContain("discovery down");
+    expect(debugMessages[0]).toContain("openrouter/some/model");
+  });
+});

--- a/src/image-generation/capability-overlays.ts
+++ b/src/image-generation/capability-overlays.ts
@@ -1,0 +1,62 @@
+// Image capability overlays merge per-model discovered capabilities into provider capabilities.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GenerateImageParams } from "./runtime-types.js";
+import type { ImageGenerationProvider, ImageGenerationProviderCapabilities } from "./types.js";
+
+// Runtime/model capability overlays let a provider refine static manifest caps
+// for the selected model without rebuilding the registry.
+export function mergeImageGenerationProviderCapabilities(
+  base: ImageGenerationProviderCapabilities,
+  overlay: ImageGenerationProviderCapabilities,
+): ImageGenerationProviderCapabilities {
+  return {
+    generate: { ...base.generate, ...overlay.generate },
+    edit: { ...base.edit, ...overlay.edit },
+    ...(base.geometry || overlay.geometry
+      ? { geometry: { ...base.geometry, ...overlay.geometry } }
+      : {}),
+    ...(base.output || overlay.output ? { output: { ...base.output, ...overlay.output } } : {}),
+  };
+}
+
+export async function resolveProviderWithModelCapabilities(params: {
+  provider: ImageGenerationProvider;
+  providerId: string;
+  model: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  authStore?: GenerateImageParams["authStore"];
+  timeoutMs?: number;
+  log: Pick<Console, "debug">;
+}): Promise<ImageGenerationProvider> {
+  if (!params.provider.resolveModelCapabilities) {
+    return params.provider;
+  }
+  try {
+    const modelCapabilities = await params.provider.resolveModelCapabilities({
+      provider: params.providerId,
+      model: params.model,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      authStore: params.authStore,
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    });
+    if (!modelCapabilities) {
+      return params.provider;
+    }
+    // Return a request-local provider copy so dynamic model caps cannot leak
+    // across later requests or different model candidates.
+    return {
+      ...params.provider,
+      capabilities: mergeImageGenerationProviderCapabilities(
+        params.provider.capabilities,
+        modelCapabilities,
+      ),
+    };
+  } catch (err) {
+    params.log.debug(
+      `image-generation model capability lookup failed for ${params.providerId}/${params.model}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return params.provider;
+  }
+}

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -14,6 +14,7 @@ let providers: ImageGenerationProvider[] = [];
 let listedConfigs: Array<OpenClawConfig | undefined> = [];
 let providerEnvVars: Record<string, string[]> = {};
 let warnings: string[] = [];
+let debugs: string[] = [];
 
 const runtimeDeps: ImageGenerationRuntimeDeps = {
   getProvider: (providerId) => providers.find((provider) => provider.id === providerId),
@@ -25,6 +26,9 @@ const runtimeDeps: ImageGenerationRuntimeDeps = {
   log: {
     warn: (message) => {
       warnings.push(message);
+    },
+    debug: (message) => {
+      debugs.push(message);
     },
   },
 };
@@ -67,6 +71,7 @@ describe("image-generation runtime", () => {
     listedConfigs = [];
     providerEnvVars = {};
     warnings = [];
+    debugs = [];
   });
 
   it("generates images through the active image-generation provider", async () => {
@@ -1049,5 +1054,190 @@ describe("image-generation runtime", () => {
     ).rejects.toThrow(
       'No image-generation model configured. Set agents.defaults.mediaModels.image.primary to a provider/model like "vision-one/paint-v1". If you want a specific provider, also configure that provider\'s auth/API key first (vision-one: VISION_ONE_API_KEY; vision-two: VISION_TWO_API_KEY).',
     );
+  });
+
+  it("applies discovered per-model capabilities before override sanitization", async () => {
+    let seenRequest:
+      | {
+          aspectRatio?: string;
+          resolution?: string;
+          quality?: string;
+          background?: string;
+        }
+      | undefined;
+    providers = [
+      {
+        id: "openrouter",
+        capabilities: {
+          generate: { supportsAspectRatio: true, supportsResolution: true },
+          edit: { enabled: true, supportsAspectRatio: true, supportsResolution: true },
+          geometry: { aspectRatios: ["1:1", "16:9"], resolutions: ["1K", "2K", "4K"] },
+        },
+        resolveModelCapabilities: async () => ({
+          generate: { supportsAspectRatio: true, supportsResolution: false },
+          edit: { enabled: true, supportsAspectRatio: true, supportsResolution: false },
+          geometry: { aspectRatios: ["1:1", "16:9", "21:9"] },
+          output: { qualities: ["high"], backgrounds: ["opaque"] },
+        }),
+        async generateImage(req) {
+          seenRequest = {
+            aspectRatio: req.aspectRatio,
+            resolution: req.resolution,
+            quality: req.quality,
+            background: req.background,
+          };
+          return { images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }] };
+        },
+      },
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: { primary: "openrouter/openai/gpt-5.4-image-2" },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+      aspectRatio: "16:9",
+      resolution: "2K",
+      quality: "high",
+      background: "transparent",
+    });
+
+    expect(seenRequest).toEqual({
+      aspectRatio: "16:9",
+      resolution: undefined,
+      quality: "high",
+      background: undefined,
+    });
+    expect(result.ignoredOverrides).toEqual([
+      { key: "resolution", value: "2K" },
+      { key: "background", value: "transparent" },
+    ]);
+  });
+
+  it("keeps discovered capabilities request-local across fallback candidates", async () => {
+    const seen: Array<{ model: string; resolution?: string }> = [];
+    const staticCapabilities = {
+      generate: { supportsAspectRatio: true, supportsResolution: true },
+      edit: { enabled: true },
+      geometry: { resolutions: ["1K", "2K", "4K"] as Array<"1K" | "2K" | "4K"> },
+    };
+    providers = [
+      {
+        id: "openrouter",
+        capabilities: staticCapabilities,
+        resolveModelCapabilities: async (ctx) =>
+          ctx.model === "limited/model"
+            ? {
+                generate: { supportsResolution: false },
+                edit: { enabled: true, supportsResolution: false },
+              }
+            : undefined,
+        async generateImage(req) {
+          seen.push({ model: req.model, resolution: req.resolution });
+          if (req.model === "limited/model") {
+            throw new Error("limited model unavailable");
+          }
+          return { images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }] };
+        },
+      },
+    ];
+
+    // One request, two candidates on the same provider: the second candidate
+    // must not inherit the first candidate's discovered caps.
+    const result = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "openrouter/limited/model",
+              fallbacks: ["openrouter/other/model"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+      resolution: "2K",
+    });
+
+    expect(seen).toEqual([
+      { model: "limited/model", resolution: undefined },
+      { model: "other/model", resolution: "2K" },
+    ]);
+    expect(result.model).toBe("other/model");
+    expect(result.ignoredOverrides).toEqual([]);
+    // The overlay must never mutate the registered provider's static capabilities.
+    expect(staticCapabilities.generate.supportsResolution).toBe(true);
+  });
+
+  it("falls back to static capabilities when capability discovery fails", async () => {
+    let seenResolution: string | undefined;
+    providers = [
+      {
+        id: "openrouter",
+        capabilities: {
+          generate: { supportsAspectRatio: true, supportsResolution: true },
+          edit: { enabled: true },
+          geometry: { resolutions: ["1K", "2K", "4K"] },
+        },
+        resolveModelCapabilities: async () => {
+          throw new Error("catalog offline");
+        },
+        async generateImage(req) {
+          seenResolution = req.resolution;
+          return { images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }] };
+        },
+      },
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: { defaults: { imageGenerationModel: { primary: "openrouter/some/model" } } },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+      resolution: "2K",
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(seenResolution).toBe("2K");
+    expect(debugs.some((message) => message.includes("catalog offline"))).toBe(true);
+  });
+
+  it("applies discovered reference-image limits before the input gate", async () => {
+    let seenInputImages: number | undefined;
+    providers = [
+      {
+        id: "openrouter",
+        capabilities: {
+          generate: {},
+          edit: { enabled: true, maxInputImages: 1 },
+        },
+        resolveModelCapabilities: async () => ({
+          generate: {},
+          edit: { enabled: true, maxInputImages: 3 },
+        }),
+        async generateImage(req) {
+          seenInputImages = req.inputImages?.length;
+          return { images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }] };
+        },
+      },
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: { defaults: { imageGenerationModel: { primary: "openrouter/some/model" } } },
+      } as OpenClawConfig,
+      prompt: "combine these",
+      inputImages: [
+        { buffer: Buffer.from("one"), mimeType: "image/png" },
+        { buffer: Buffer.from("two"), mimeType: "image/png" },
+      ],
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(seenInputImages).toBe(2);
   });
 });

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -17,11 +17,16 @@ import {
 } from "../media-generation/runtime-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveImageGenerationMaxInputImages } from "./capabilities.js";
+import { resolveProviderWithModelCapabilities } from "./capability-overlays.js";
 import { resolveImageGenerationOverrides } from "./normalization.js";
 import type { GenerateImageParams, GenerateImageRuntimeResult } from "./runtime-types.js";
 import type { ImageGenerationResult } from "./types.js";
 
 const log = createSubsystemLogger("image-generation");
+
+// Discovery hooks run on the request path; bound them well below generation timeouts
+// so a slow catalog lookup degrades to static caps instead of stalling the request.
+const MODEL_CAPABILITY_LOOKUP_TIMEOUT_MS = 10_000;
 
 // Runtime dependency seam for tests and plugin-host callers. Production uses
 // the plugin registry and provider-env helpers by default.
@@ -30,7 +35,7 @@ type ImageGenerationRuntimeDeps = {
   getProvider?: typeof getImageGenerationProvider;
   listProviders?: typeof listImageGenerationProviders;
   getProviderEnvVars?: typeof getProviderEnvVars;
-  log?: Pick<typeof log, "warn">;
+  log?: Pick<typeof log, "debug" | "warn">;
 };
 
 export type { GenerateImageParams, GenerateImageRuntimeResult } from "./runtime-types.js";
@@ -100,9 +105,22 @@ export async function generateImage(
       continue;
     }
 
+    // Overlay discovered per-model caps before ANY capability gate — the
+    // maxInputImages check below and the geometry sanitizer both must see them.
+    const activeProvider = await resolveProviderWithModelCapabilities({
+      provider,
+      providerId: candidate.provider,
+      model: candidate.model,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      authStore: params.authStore,
+      timeoutMs: MODEL_CAPABILITY_LOOKUP_TIMEOUT_MS,
+      log: logger,
+    });
+
     const inputImageCount = params.inputImages?.length ?? 0;
     const maxInputImages = resolveImageGenerationMaxInputImages({
-      provider,
+      provider: activeProvider,
       model: candidate.model,
     });
     if (maxInputImages !== undefined && inputImageCount > maxInputImages) {
@@ -120,19 +138,19 @@ export async function generateImage(
     try {
       const timeoutMs = resolveMediaProviderRequestTimeoutMs({
         timeoutMs: requestedTimeoutMs,
-        providerDefaultTimeoutMs: provider.defaultTimeoutMs,
+        providerDefaultTimeoutMs: activeProvider.defaultTimeoutMs,
       });
       const modelResolutions =
-        provider.capabilities.geometry?.resolutionsByModel?.[candidate.model];
+        activeProvider.capabilities.geometry?.resolutionsByModel?.[candidate.model];
       const modeCapabilities = params.inputImages?.length
-        ? provider.capabilities.edit
-        : provider.capabilities.generate;
+        ? activeProvider.capabilities.edit
+        : activeProvider.capabilities.generate;
       const inferredResolution =
         modeCapabilities.supportsResolution === false || modelResolutions?.length === 0
           ? undefined
           : params.inferredResolution;
       const sanitized = resolveImageGenerationOverrides({
-        provider,
+        provider: activeProvider,
         model: candidate.model,
         size: params.size,
         aspectRatio: params.aspectRatio,
@@ -144,7 +162,7 @@ export async function generateImage(
       });
       // Providers receive only supported overrides. Ignored/normalized values
       // are returned to callers so user-facing replies can explain adjustments.
-      const result: ImageGenerationResult = await provider.generateImage({
+      const result: ImageGenerationResult = await activeProvider.generateImage({
         provider: candidate.provider,
         model: candidate.model,
         prompt: params.prompt,

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -61,6 +61,15 @@ export type ImageGenerationProviderConfiguredContext = {
   agentDir?: string;
 };
 
+export type ImageGenerationModelCapabilitiesContext = {
+  provider: string;
+  model: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  authStore?: AuthProfileStore;
+  timeoutMs?: number;
+};
+
 /** Runtime request passed to an image-generation provider implementation. */
 export type ImageGenerationRequest = {
   provider: string;
@@ -140,5 +149,11 @@ export type ImageGenerationProvider = {
   models?: string[];
   capabilities: ImageGenerationProviderCapabilities;
   isConfigured?: (ctx: ImageGenerationProviderConfiguredContext) => boolean;
+  resolveModelCapabilities?: (
+    ctx: ImageGenerationModelCapabilitiesContext,
+  ) =>
+    | ImageGenerationProviderCapabilities
+    | undefined
+    | Promise<ImageGenerationProviderCapabilities | undefined>;
   generateImage: (req: ImageGenerationRequest) => Promise<ImageGenerationResult>;
 };

--- a/src/plugin-sdk/image-generation.ts
+++ b/src/plugin-sdk/image-generation.ts
@@ -27,11 +27,13 @@ export {
 export type {
   GeneratedImageAsset,
   ImageGenerationBackground,
+  ImageGenerationModelCapabilitiesContext,
   ImageGenerationOpenAIBackground,
   ImageGenerationOpenAIModeration,
   ImageGenerationOpenAIOptions,
   ImageGenerationOutputFormat,
   ImageGenerationProvider,
+  ImageGenerationProviderCapabilities,
   ImageGenerationProviderConfiguredContext,
   ImageGenerationProviderOptions,
   ImageGenerationQuality,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #101367. On the dedicated `POST /api/v1/images` path, `buildDedicatedImageBody()` only forwards `aspect_ratio` / `resolution` when the model id starts with `google/gemini-`. That predicate is a carryover from the older `/chat/completions` + `image_config` shape, not a capability decision: on the dedicated endpoint both fields are normalized cross-provider axes.

Two user-visible defects:

1. **Wrong for non-Gemini models.** `openai/gpt-5.4-image-2` honors `aspect_ratio` (measured: `16:9` → 1536x864 PNG, exact 16:9), but OpenClaw silently drops it today.
2. **It fails silently.** The provider advertises `supportsAspectRatio`/`supportsResolution: true` unconditionally, so the override sanitizer passes the value through as supported and the provider then discards it — no error, no `ignoredOverrides` entry. This is on the default path (`google/gemini-3.1-flash-image-preview` is the default model, and most users never pick one explicitly).

A static per-model table would rot — the OpenRouter image model list changes continuously. So per-model support is **discovered live** from `GET /api/v1/images/models` (`supported_parameters`), the same way this extension already discovers video capabilities from `videos/models`.

## Why This Change Was Made

**Core seam (mirrors the existing video one):**
- `src/image-generation/types.ts`: `ImageGenerationModelCapabilitiesContext` + optional `resolveModelCapabilities` hook on `ImageGenerationProvider` — the image twin of `VideoGenerationProvider.resolveModelCapabilities`.
- New `src/image-generation/capability-overlays.ts`: merge + `resolveProviderWithModelCapabilities()`, modeled on `src/video-generation/capability-overlays.ts`. Same invariants: request-local provider copy (per-model caps never leak across candidates), and any hook failure degrades to static caps with a `log.debug` — discovery can never fail a generation.
- `src/image-generation/runtime.ts`: the overlay is applied right after the candidate's provider resolves and **before** the `maxInputImages` gate, so both the reference-image check and the geometry sanitizer see discovered caps. Everything downstream is unchanged; `ignoredOverrides` now reports axes the selected model does not support.
- Re-exported from `src/plugin-sdk/image-generation.ts`; SDK docs updated.

**Extension:**
- New `extensions/openrouter/image-model-catalog.ts`: fetches `${canonicalBaseUrl}/images/models` (canonical bases only — custom proxies keep the legacy path and skip discovery), cached via `getCachedLiveCatalogValue` with a 10s discovery timeout. Descriptors are parsed **per parameter**: `enum`/`range` are read, while `boolean`, unknown future types, and malformed values (non-string enum entries, negative or fractional range maxima) drop only their own parameter — never the model, never the catalog. Mapping: `aspect_ratio` → `geometry.aspectRatios`, `resolution` → `geometry.resolutions` (filtered to `1K|2K|4K`; a set entirely outside the union counts as unsupported so raw values can't bypass sanitization), `quality` → `output.qualities`, `background` → `output.backgrounds`, `input_references.max` → `edit.maxInputImages` (absence means edits unsupported — reference images then skip visibly instead of being sent to a model that never advertised them; every current catalog model advertises the parameter). `n` is deliberately **not** mapped to `maxCount`: `n` is the per-request batch size and this provider fans out `count` parallel requests with `n: 1`, so Gemini's `n: {min:1,max:1}` must not declare it a one-image model.
- `buildDedicatedImageBody()` no longer gates by model family and now also forwards `quality`/`background` (previously dropped by the provider even when requested; the runtime already reported them ignored because the static caps declare no `output` block — mapping the enums without forwarding the fields would have turned a reported drop into a silent one).
- The legacy custom-base `/chat/completions` path is byte-identical to before: Google-shaped `image_config` with the Gemini predicate, no discovery request — pinned by test.
- Static caps stay as the documented fallback: discovery outage, custom base, or a model missing from the catalog degrades to today's behavior — `aspect_ratio`/`resolution` forwarded (API remains the authority), `quality`/`background` reported ignored as they are today (the static caps declare no `output` block, so those two only flow when discovery vouches for them).

## User Impact

- Aspect ratio now works on `openai/gpt-5.4-image-2` (and any non-Gemini model that advertises it) instead of being silently dropped.
- Unsupported axes are reported back as `ignoredOverrides` instead of vanishing — e.g. `resolution=2K` on `gpt-5.4-image-2` now tells the user it was ignored.
- `quality` and `background` now reach models that advertise them (previously never sent).
- Gemini gains the aspect ratios the static list was missing (`1:4`, `1:8`, `4:1`, `8:1`), and edit-mode reference-image limits rise from the static 5 to the advertised 14 (Gemini) / 16 (gpt-5.4-image-2) on the runtime path.
- A newly launched OpenRouter image model gets correct controls with no OpenClaw code change.
- Custom-base proxy users see no change.

Known follow-ups (out of scope here):
- The `image_generate` tool pre-validates reference-image count against static registry caps before the runtime overlay runs, so the discovered 14/16 limits are not yet reachable through that tool (the static 5 still applies there, as today). Discovery-aware tool pre-validation is a separate change.
- `resolveProviderWithModelCapabilities` intentionally mirrors its video sibling near-verbatim (the spec for this change was "core seam minimal and symmetric with video"); folding both into one generic helper is a natural sibling-dedup refactor once a third media type needs the hook.

## Evidence

- Focused suites: `pnpm vitest run extensions/openrouter/image-generation-provider.test.ts extensions/openrouter/image-model-catalog.test.ts src/image-generation/` → 15 files, **151 tests passing** (baseline before this change: 12 + 94). `pnpm tsgo:extensions:test`, `pnpm tsgo:test:src`, `pnpm plugin-sdk:surface:check`, `pnpm format:docs:check`, `pnpm docs:check-mdx` all green.
- **Regression test proven against pre-fix code**: "forwards aspect_ratio for non-Gemini models on the dedicated endpoint" fails on the pre-change provider (body arrives without `aspect_ratio`) and passes after.
- Catalog fixtures are trimmed from the live payload (captured 2026-08-15) and cover: `512` filtered from resolutions, `boolean`/unknown descriptor types dropping only their own parameter, no `maxCount` derived from `n`, request-local overlay isolation across models, exactly one catalog fetch across repeated lookups (cache), no discovery on custom bases, discovery failure degrading to static caps without failing the generation.
- **Live matrix** (raw `POST /api/v1/images`, one axis at a time, 2026-08-15; status / media type / decoded pixels):

| model | aspect_ratio=16:9 only | resolution=2K only | neither |
|---|---|---|---|
| `google/gemini-3.1-flash-image-preview` | 200 · jpeg · 1376x768 (honored) | 200 · jpeg · 2816x1536 (honored) | 200 · jpeg · 1408x768 |
| `google/gemini-3-pro-image-preview` | 200 · jpeg · 1376x768 (honored) | 200 · jpeg · 2816x1536 (honored) | 200 · jpeg · 1408x768 |
| `openai/gpt-5.4-image-2` | 200 · png · 1536x864 (honored, exact 16:9) | 200 · png · 1122x1402 (ignored upstream — matches metadata: no `resolution` advertised) | 200 · png · 1122x1402 |

  Discovered metadata agrees with measured behavior on every cell; no disagreements to report. (`supported_parameters` for the OpenAI wrapper slugs was corrected upstream on 2026-08-15 — all 43 catalog models now advertise `aspect_ratio`.)
- **Live end-to-end through the runtime** (real API, requests recorded at the provider-http seam): Gemini → one `GET /api/v1/images/models` discovery hit, `POST https://openrouter.ai/api/v1/images` body carries `aspect_ratio: "16:9"` + `resolution: "2K"`, empty `ignoredOverrides`, image returned. `openai/gpt-5.4-image-2` → body carries `aspect_ratio: "16:9"` + `quality: "high"` and omits `resolution`, `ignoredOverrides` = `[{key: "resolution", value: "2K"}]`, returned PNG is 16:9.
- Production LOC: +404/−17 (extension catalog 271; core seam 105 across types/overlays/runtime/SDK re-export, symmetric with the video seam; provider body builder +31/−9). Tests +769, docs +18/−5. The growth is the discovery capability itself; no per-model literals anywhere in the diff.
