### PR TITLE
perf(test): fast-forward cron receipt handoff

### DIFF
--- a/src/cron/service/owner-hardening.test.ts
+++ b/src/cron/service/owner-hardening.test.ts
@@ -25,8 +25,10 @@ import {
   releaseLocalCronRunReceiptOwnership,
 } from "../store/run-receipt-store.js";
 import type { CronJob } from "../types.js";
+import { listForeignReceipts } from "./foreign-receipt-monitor.js";
 import type { CronServiceState } from "./state.js";
 import { findCronTaskRunRecoveryInDatabase } from "./task-runs.js";
+import { stopTimer } from "./timer.js";
 
 const { makeStorePath } = createCronStoreHarness({ prefix: "cron-owner-hardening-" });
 const children = new Set<ChildProcess>();
@@ -201,6 +203,22 @@ async function waitForExit(child: ChildProcess): Promise<void> {
     child.once("exit", () => resolve());
     child.once("error", reject);
   });
+}
+
+async function waitForImmediate(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
 }
 
 function makeParentService(storePath: string, runCommandJob = vi.fn()) {
@@ -510,6 +528,7 @@ describe("cron durable run ownership", () => {
     let second: ChildProcess | undefined;
     try {
       await replacement.start();
+      const replacementState = (replacement as unknown as { state: CronServiceState }).state;
       replacement.pauseScheduling();
       first.kill("SIGKILL");
       await waitForExit(first);
@@ -521,22 +540,31 @@ describe("cron durable run ownership", () => {
         outputPath: path.join(scriptRoot, `second-output-${now}`),
       });
       await waitForLine(second, "started");
+      const secondReceiptId = receipts(storePath, job.id)[0]?.receiptId;
+      expect(secondReceiptId).toBeDefined();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       replacement.resumeScheduling();
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 2_500);
-      });
+      // Isolate the lifecycle-owned foreign receipt monitor from the ordinary job timer.
+      stopTimer(replacementState);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await waitForImmediate(
+        () => listForeignReceipts(replacementState)[0]?.receiptId === secondReceiptId,
+        "replacement foreign receipt enrollment",
+      );
       second.kill("SIGKILL");
       await waitForExit(second);
+      await vi.advanceTimersByTimeAsync(2_000);
 
       await vi.waitFor(
         async () => {
           expect(receipts(storePath, job.id)[0]).toMatchObject({ status: "interrupted" });
           expect((await loadCronStore(storePath)).jobs[0]?.state.runningAtMs).toBeUndefined();
         },
-        { timeout: 6_000, interval: 50 },
+        { timeout: 1_000, interval: 10 },
       );
     } finally {
       replacement.stop();
+      vi.useRealTimers();
       for (const child of [first, second]) {
         if (child && child.exitCode === null && child.signalCode === null) {
           child.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

The cron durable-ownership handoff regression waits on real two-second monitor intervals while coordinating two external owner processes. The test must prove that the replacement receipt becomes the monitored authority and that its later death is recovered, but it does not need to spend four seconds of wall clock observing those parent-owned timers.

## Why This Change Was Made

Keep both real child processes, the shared SQLite state, durable receipt replacement, process death, and final interrupted recovery. After the replacement process has claimed ownership, switch only the parent process to fake timers, isolate the foreign-receipt monitor from the ordinary cron job timer, advance each two-second monitor interval explicitly, and observe the exact replacement receipt in the monitor before killing its owner.

The immediate-yield poll does not advance fake timers, so it can distinguish asynchronous receipt enrollment from another elapsed monitor cycle. Production code and monitor timing remain unchanged.

## User Impact

Maintainer cron test feedback is faster and the handoff proof is more deterministic. Runtime behavior is unchanged.

## Evidence

Controlled same-Testbox A/B on `tbx_01m04cmmjg6s60dwa9n79qxcn8`, one excluded warmup plus two retained samples per state, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 29.13s | 25.36s | -3.77s (-12.9%) |
| Vitest | 26.21s | 22.42s | -14.5% |
| Test body | 22.54s | 18.82s | -16.5% |
| Handoff case | 6.98s | 3.03s | -56.6% |
| Import | 3.05s | 2.97s | effectively flat |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 13/13 cron durable-ownership tests.
- Full core changed gate on the retained Testbox, including core-test typecheck and targeted lint.
- Fresh post-rebase Codex autoreview: no accepted/actionable findings.
- Mutation: removing `enrollForeignReceipt(state, result.receipt)` from superseded-receipt recovery fails waiting for the exact replacement receipt to enter the monitor.
- Production LOC: `+0/-0`; test LOC: `+32/-4`.

Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/31926297673
