### PR TITLE
perf(node-host): prewarm worker bundles

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1207,21 +1207,25 @@ public struct WorkerAdmissionHandshake: Codable, Sendable {
     public let bundlehash: String
     public let openclawversion: String
     public let protocolfeatures: [String]
+    public let bundleprewarm: Int?
 
     public init(
         bundlehash: String,
         openclawversion: String,
-        protocolfeatures: [String])
+        protocolfeatures: [String],
+        bundleprewarm: Int? = nil)
     {
         self.bundlehash = bundlehash
         self.openclawversion = openclawversion
         self.protocolfeatures = protocolfeatures
+        self.bundleprewarm = bundleprewarm
     }
 
     private enum CodingKeys: String, CodingKey {
         case bundlehash = "bundleHash"
         case openclawversion = "openclawVersion"
         case protocolfeatures = "protocolFeatures"
+        case bundleprewarm = "bundlePrewarm"
     }
 }
 

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -108,6 +108,7 @@ export {
   WorkerTranscriptCommitResponseFrameSchema,
   WorkerTranscriptCommitResultSchema,
   WorkerTranscriptMessageSchema,
+  WORKER_BUNDLE_PREWARM_VERSION,
   WORKER_HEARTBEAT_INTERVAL_MS,
   WORKER_LAUNCH_V2_PROTOCOL_FEATURE,
   WORKER_LIVE_EVENT_PROTOCOL_FEATURE,

--- a/packages/gateway-protocol/src/schema/frames.worker-runs.test.ts
+++ b/packages/gateway-protocol/src/schema/frames.worker-runs.test.ts
@@ -19,6 +19,28 @@ describe("node worker-runs connect manifest", () => {
         },
       }),
     ).toBe(true);
+    expect(
+      validateConnectParams({
+        ...connect,
+        workerRuns: {
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.8.12",
+          protocolFeatures: ["worker-heartbeat-v1"],
+          bundlePrewarm: 2,
+        },
+      }),
+    ).toBe(true);
     expect(validateConnectParams({ ...connect, workerRuns: { enabled: true } })).toBe(false);
+    expect(
+      validateConnectParams({
+        ...connect,
+        workerRuns: {
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.8.12",
+          protocolFeatures: ["worker-heartbeat-v1"],
+          bundlePrewarm: 0,
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -29,6 +29,7 @@ export {
 
 // Additive RPCs require exact build-bound features; bump only for an incompatible base set.
 export const WORKER_RPC_SET_VERSION = 1;
+export const WORKER_BUNDLE_PREWARM_VERSION = 1;
 export const WORKER_HEARTBEAT_INTERVAL_MS = 15_000;
 export const WORKER_PROTOCOL_METHODS = [
   "worker.heartbeat",
@@ -86,6 +87,7 @@ export const WorkerAdmissionHandshakeSchema = withSince(
       maxItems: WORKER_PROTOCOL_MAX_FEATURES,
       uniqueItems: true,
     }),
+    bundlePrewarm: Type.Optional(Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER })),
   }),
 );
 

--- a/scripts/check-gateway-cpu-scenarios.mts
+++ b/scripts/check-gateway-cpu-scenarios.mts
@@ -488,6 +488,23 @@ async function runGatewayCpuScenarios(
     privateQaBuildFailed = privateQaBuild.status !== 0;
   }
 
+  if (!options.skipQa) {
+    steps.push(
+      privateQaBuildFailed
+        ? { name: "node worker finalization gate", signal: null, status: 1 }
+        : runStep(
+            "node worker finalization gate",
+            process.execPath,
+            [
+              "scripts/run-vitest.mjs",
+              "test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts",
+            ],
+            { env: qaBuildEnv },
+            params,
+          ),
+    );
+  }
+
   let qaStep = null;
   if (!options.skipQa) {
     const qaCommand = pnpmCommand(

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -204,6 +204,13 @@ function sameOptionalWorkerBuild(
   return left === undefined || right === undefined ? left === right : sameWorkerBuild(left, right);
 }
 
+function sameOptionalWorkerRuns(
+  left: WorkerAdmissionHandshake | undefined,
+  right: WorkerAdmissionHandshake | undefined,
+): boolean {
+  return sameOptionalWorkerBuild(left, right) && left?.bundlePrewarm === right?.bundlePrewarm;
+}
+
 function resolveWorkerSupervisorProof(
   node: NodeRegistryPrivateSession,
   runnerInventoryByConn: ReadonlyMap<string, NodeRunnerInventoryRecord>,
@@ -276,7 +283,7 @@ function isWorkerSupervisorProofCurrent(
     (!requireLaunchEligibility ||
       (current.workerRuns !== undefined &&
         proof.workerRuns !== undefined &&
-        sameWorkerBuild(current.workerRuns, proof.workerRuns)))
+        sameOptionalWorkerRuns(current.workerRuns, proof.workerRuns)))
   );
 }
 
@@ -322,7 +329,7 @@ function updateWorkerRunnerInventory(
   const changed =
     !previous ||
     !sameWorkerProtocolFeatures(previous.protocolFeatures, next.protocolFeatures) ||
-    !sameOptionalWorkerBuild(previous.workerRuns, next.workerRuns);
+    !sameOptionalWorkerRuns(previous.workerRuns, next.workerRuns);
   if (changed) {
     state.runnerInventoryByConn.set(node.connId, next);
     state.context.publishActiveNodeContext();

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -736,6 +736,51 @@ describe("gateway/node-registry", () => {
     await expect(invocation).resolves.toMatchObject({ ok: true, payloadJSON: "null" });
   });
 
+  it("promotes post-hello worker capabilities without changing build identity", async () => {
+    const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
+    registerNodeSession(
+      nodeRegistry,
+      makeClient("conn-1", "node-1", [], {
+        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+        commands: ["system.run"],
+        workerRuns: WORKER_RUNS,
+      }),
+      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+    );
+    const declaration = {
+      protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE] as const,
+      workerRuns: WORKER_RUNS,
+    };
+    expect(
+      updateNodeRunnerInventory({
+        registry: nodeRegistry,
+        nodeId: "node-1",
+        connId: "conn-1",
+        declaration,
+      }),
+    ).toEqual({ changed: true });
+    const [legacyProof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
+
+    expect(
+      updateNodeRunnerInventory({
+        registry: nodeRegistry,
+        nodeId: "node-1",
+        connId: "conn-1",
+        declaration: {
+          ...declaration,
+          workerRuns: { ...WORKER_RUNS, bundlePrewarm: 1 },
+        },
+      }),
+    ).toEqual({ changed: true });
+    const [negotiatedProof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
+
+    expect(legacyProof && nodeWorkerSupervisorTransport.isCurrent(legacyProof, true)).toBe(false);
+    expect(negotiatedProof?.workerRuns).toEqual({ ...WORKER_RUNS, bundlePrewarm: 1 });
+    expect(negotiatedProof && nodeWorkerSupervisorTransport.isCurrent(negotiatedProof, true)).toBe(
+      true,
+    );
+  });
+
   it("rejects generation-mismatched lookup and dispatch without invalidating the session", async () => {
     const registry = new NodeRegistry();
     const frames: string[] = [];

--- a/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
@@ -29,6 +29,24 @@ const artifact = {
   tarballPath: "/gateway/bundle.tgz",
 };
 
+function nodeProof(nodeId: string, bundlePrewarm?: number): NodeWorkerSupervisorNodeProof {
+  return {
+    ...node,
+    nodeId,
+    connId: `conn-${nodeId}`,
+    ...(bundlePrewarm === undefined
+      ? {}
+      : {
+          workerRuns: {
+            bundleHash: artifact.bundleHash,
+            openclawVersion: artifact.openclawVersion,
+            protocolFeatures: artifact.protocolFeatures,
+            bundlePrewarm,
+          },
+        }),
+  };
+}
+
 describe("Gateway node worker bundle installer", () => {
   it("binds install dispatch to the current node proof and exact receipt", async () => {
     const transfer = createNodeWorkerBundleTransferService({
@@ -95,5 +113,38 @@ describe("Gateway node worker bundle installer", () => {
     });
 
     await expect(ensure({ deviceId: node.nodeId })).rejects.toThrow("mismatched build receipt");
+  });
+
+  it("negotiates prewarming independently across a mixed node fleet", async () => {
+    const transfer = createNodeWorkerBundleTransferService({
+      generateToken: () => String.fromCharCode(65 + invoke.mock.calls.length).repeat(43),
+    });
+    const advertising = nodeProof("advertising", 7);
+    const legacy = nodeProof("legacy");
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => ({
+      ok: true,
+      payloadJSON: JSON.stringify((request.params as { build: typeof artifact }).build),
+    }));
+    const transport: NodeWorkerSupervisorTransport = {
+      listCurrentNodes: async () => [advertising, legacy],
+      isCurrent: () => true,
+      invoke,
+    };
+    const ensure = createGatewayNodeWorkerBundleInstaller({
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      prepareBundle: async () => artifact,
+      transfer,
+    });
+
+    await expect(ensure({ deviceId: advertising.nodeId })).resolves.toMatchObject({
+      bundleHash: artifact.bundleHash,
+    });
+    await expect(ensure({ deviceId: legacy.nodeId })).resolves.toMatchObject({
+      bundleHash: artifact.bundleHash,
+    });
+
+    expect(invoke.mock.calls[0]?.[0].params).toMatchObject({ bundlePrewarm: 1 });
+    expect(invoke.mock.calls[1]?.[0].params).not.toHaveProperty("bundlePrewarm");
   });
 });

--- a/src/gateway/worker-environments/node-worker-bundle-installer.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.ts
@@ -1,3 +1,4 @@
+import { WORKER_BUNDLE_PREWARM_VERSION } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { NODE_WORKER_BUNDLE_INSTALL_COMMAND } from "../../infra/node-commands.js";
 import { parseNodeWorkerBundleInstallResult } from "../../worker/node-bundle-install-protocol.js";
 import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
@@ -27,10 +28,15 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
     }
     const artifact = await options.prepareBundle();
     const isAuthorized = () => transport.isCurrent(node);
+    const bundlePrewarm =
+      (node.workerRuns?.bundlePrewarm ?? 0) >= WORKER_BUNDLE_PREWARM_VERSION
+        ? WORKER_BUNDLE_PREWARM_VERSION
+        : undefined;
     const prepared = options.transfer.prepare({
       node,
       gatewayNamespace: options.gatewayNamespace,
       artifact,
+      ...(bundlePrewarm ? { bundlePrewarm } : {}),
       isAuthorized,
       signal: params.signal,
     });

--- a/src/gateway/worker-environments/node-worker-bundle-transfer-service.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-transfer-service.ts
@@ -66,6 +66,7 @@ export function createNodeWorkerBundleTransferService(
       node: NodeWorkerSupervisorNodeProof;
       gatewayNamespace: string;
       artifact: WorkerBundleArtifact;
+      bundlePrewarm?: 1;
       isAuthorized: () => boolean;
       signal?: AbortSignal;
     }): { token: string; input: NodeWorkerBundleInstallInput } {
@@ -109,6 +110,7 @@ export function createNodeWorkerBundleTransferService(
         token,
         input: {
           gatewayNamespace: params.gatewayNamespace,
+          ...(params.bundlePrewarm ? { bundlePrewarm: params.bundlePrewarm } : {}),
           build: {
             bundleHash: params.artifact.bundleHash,
             openclawVersion: params.artifact.openclawVersion,

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -36,17 +36,23 @@ describe("node worker bundle installer", () => {
     options: {
       packageShell?: boolean;
       prewarmMarker?: string;
+      workerSource?: string;
+      fixtureName?: string;
+      bundlePrewarm?: 1;
     } = {},
   ): Promise<{
     archive: Buffer;
     input: NodeWorkerBundleInstallInput;
   }> {
-    const source = path.join(root, "source");
-    const archivePath = path.join(root, "bundle.tgz");
+    const fixtureName = options.fixtureName ?? "default";
+    const source = path.join(root, `source-${fixtureName}`);
+    const archivePath = path.join(root, `bundle-${fixtureName}.tgz`);
     await fs.mkdir(source, { recursive: true });
-    const workerSource = options.prewarmMarker
-      ? `import fs from "node:fs";\nif (process.argv[2] !== "--internal-worker-prewarm" || !process.env.NODE_COMPILE_CACHE || process.env.NODE_DISABLE_COMPILE_CACHE) throw new Error("worker bundle was not prewarmed with compile cache");\nfs.writeFileSync(${JSON.stringify(options.prewarmMarker)}, "ready");\n`
-      : "export {};\n";
+    const workerSource =
+      options.workerSource ??
+      (options.prewarmMarker
+        ? `import fs from "node:fs";\nif (process.argv[2] !== "--internal-worker-prewarm" || !process.env.NODE_COMPILE_CACHE || process.env.NODE_DISABLE_COMPILE_CACHE) throw new Error("worker bundle was not prewarmed with compile cache");\nfs.writeFileSync(${JSON.stringify(options.prewarmMarker)}, "ready");\n`
+        : "export {};\n");
     await fs.writeFile(path.join(source, "worker.mjs"), workerSource, { mode: 0o700 });
     const archiveEntries = ["worker.mjs"];
     if (options.packageShell) {
@@ -72,6 +78,7 @@ describe("node worker bundle installer", () => {
       archive,
       input: {
         gatewayNamespace: "gateway-test",
+        ...(options.bundlePrewarm ? { bundlePrewarm: options.bundlePrewarm } : {}),
         build: { bundleHash, openclawVersion: "2026.8.1", protocolFeatures: [] },
         archive: {
           token: "A".repeat(43),
@@ -108,7 +115,7 @@ describe("node worker bundle installer", () => {
 
   it("atomically installs, reuses, and cleans prior-hash crash staging", async () => {
     const prewarmMarker = path.join(root, "worker-prewarmed");
-    const fixture = await bundleFixture({ prewarmMarker });
+    const fixture = await bundleFixture({ prewarmMarker, bundlePrewarm: 1 });
     const staleBundleHash = "f".repeat(64);
     const staleStaging = path.join(
       root,
@@ -193,5 +200,58 @@ describe("node worker bundle installer", () => {
     await expect(
       installer.ensure({ input: fixture.input, gatewayUrl: served.gatewayUrl }),
     ).rejects.toThrow("gateway returned an unexpected worker bundle length");
+  });
+
+  it("cancels prewarming and releases the namespace queue for the next install", async () => {
+    const slowStarted = path.join(root, "slow-prewarm-started");
+    const slow = await bundleFixture({
+      fixtureName: "slow",
+      bundlePrewarm: 1,
+      workerSource: `import fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(slowStarted)}, "started");\nawait new Promise((resolve) => setTimeout(resolve, 2_000));\n`,
+    });
+    const fastMarker = path.join(root, "fast-prewarm-finished");
+    const fast = await bundleFixture({
+      fixtureName: "fast",
+      bundlePrewarm: 1,
+      prewarmMarker: fastMarker,
+    });
+    server = http.createServer((req, res) => {
+      const archive = req.url?.endsWith(slow.input.build.bundleHash) ? slow.archive : fast.archive;
+      res.writeHead(200, {
+        "content-type": "application/octet-stream",
+        "content-length": String(archive.byteLength),
+      });
+      res.end(archive);
+    });
+    await new Promise<void>((resolve) => {
+      server!.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test server did not bind a TCP port");
+    }
+    const gatewayUrl = `ws://127.0.0.1:${address.port}`;
+    const installer = new NodeWorkerBundleInstaller({ root });
+    const controller = new AbortController();
+    const first = installer.ensure({
+      input: slow.input,
+      gatewayUrl,
+      signal: controller.signal,
+    });
+    await vi.waitFor(async () => await expect(fs.access(slowStarted)).resolves.toBeUndefined());
+    const second = installer.ensure({ input: fast.input, gatewayUrl });
+
+    controller.abort(new Error("launch fenced"));
+
+    await expect(first).rejects.toThrow("launch fenced");
+    await expect(
+      Promise.race([
+        second,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error("namespace queue stayed occupied")), 750);
+        }),
+      ]),
+    ).resolves.toEqual(fast.input.build);
+    await expect(fs.readFile(fastMarker, "utf8")).resolves.toBe("ready");
   });
 });

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -32,14 +32,22 @@ describe("node worker bundle installer", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  async function bundleFixture(options: { packageShell?: boolean } = {}): Promise<{
+  async function bundleFixture(
+    options: {
+      packageShell?: boolean;
+      prewarmMarker?: string;
+    } = {},
+  ): Promise<{
     archive: Buffer;
     input: NodeWorkerBundleInstallInput;
   }> {
     const source = path.join(root, "source");
     const archivePath = path.join(root, "bundle.tgz");
     await fs.mkdir(source, { recursive: true });
-    await fs.writeFile(path.join(source, "worker.mjs"), "export {};\n", { mode: 0o700 });
+    const workerSource = options.prewarmMarker
+      ? `import fs from "node:fs";\nif (process.argv[2] !== "--internal-worker-prewarm" || !process.env.NODE_COMPILE_CACHE || process.env.NODE_DISABLE_COMPILE_CACHE) throw new Error("worker bundle was not prewarmed with compile cache");\nfs.writeFileSync(${JSON.stringify(options.prewarmMarker)}, "ready");\n`
+      : "export {};\n";
+    await fs.writeFile(path.join(source, "worker.mjs"), workerSource, { mode: 0o700 });
     const archiveEntries = ["worker.mjs"];
     if (options.packageShell) {
       await fs.mkdir(path.join(source, "dist"));
@@ -99,7 +107,8 @@ describe("node worker bundle installer", () => {
   }
 
   it("atomically installs, reuses, and cleans prior-hash crash staging", async () => {
-    const fixture = await bundleFixture();
+    const prewarmMarker = path.join(root, "worker-prewarmed");
+    const fixture = await bundleFixture({ prewarmMarker });
     const staleBundleHash = "f".repeat(64);
     const staleStaging = path.join(
       root,
@@ -119,6 +128,7 @@ describe("node worker bundle installer", () => {
     ).resolves.toEqual(fixture.input.build);
 
     expect(served.requests).toHaveBeenCalledOnce();
+    await expect(fs.readFile(prewarmMarker, "utf8")).resolves.toBe("ready");
     await expect(fs.access(staleStaging)).rejects.toThrow();
     await expect(
       fs.readFile(

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -1,9 +1,11 @@
+import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
+import { promisify } from "node:util";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   validateWorkerAdmissionHandshake,
@@ -29,6 +31,7 @@ import {
   type NodeWorkerBundleInstallInput,
 } from "../worker/node-bundle-install-protocol.js";
 import { sameWorkerBuild } from "../worker/worker-build-identity.js";
+import { snapshotNodeWorkerEnv } from "./node-worker-environment.js";
 import {
   NodeWorkerTransferHttpError,
   openNodeWorkerTransferHttpRequest,
@@ -36,6 +39,8 @@ import {
 
 const INSTALL_RECEIPT = "bootstrap-receipt.json";
 const INSTALL_IGNORED_TOP_LEVEL = new Set([INSTALL_RECEIPT]);
+const WORKER_PREWARM_TIMEOUT_MS = 10 * 60_000;
+const execFileAsync = promisify(execFile);
 
 async function responseBody(response: IncomingMessage, maxBytes = 64 * 1024): Promise<string> {
   const chunks: Buffer[] = [];
@@ -184,10 +189,30 @@ async function publishBundle(destination: string, staging: string): Promise<void
 export class NodeWorkerBundleInstaller {
   readonly #root: string;
   readonly #operations = new KeyedAsyncQueue();
+  readonly #prewarmedBundles = new Set<string>();
+  readonly #workerEnv: NodeJS.ProcessEnv;
 
   constructor(options: { root?: string; env?: NodeJS.ProcessEnv } = {}) {
     const env = options.env ?? process.env;
     this.#root = path.resolve(options.root ?? path.join(resolveStateDir(env), "node-host"));
+    this.#workerEnv = snapshotNodeWorkerEnv(env);
+  }
+
+  async #prewarmBundle(bundleDir: string): Promise<void> {
+    if (this.#prewarmedBundles.has(bundleDir)) {
+      return;
+    }
+    await execFileAsync(
+      process.execPath,
+      [path.join(bundleDir, WORKER_BUNDLE_ENTRY_PATH), "--internal-worker-prewarm"],
+      {
+        cwd: bundleDir,
+        env: this.#workerEnv,
+        timeout: WORKER_PREWARM_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+    this.#prewarmedBundles.add(bundleDir);
   }
 
   async ensure(params: {
@@ -205,6 +230,7 @@ export class NodeWorkerBundleInstaller {
         const bundlesRoot = path.join(this.#root, input.gatewayNamespace, "bundles");
         const destination = path.join(bundlesRoot, input.build.bundleHash);
         if (await validateInstalledBundle(destination, input.build)) {
+          await this.#prewarmBundle(destination);
           return structuredClone(input.build);
         }
         await fsp.mkdir(bundlesRoot, { recursive: true, mode: 0o700 });
@@ -239,6 +265,7 @@ export class NodeWorkerBundleInstaller {
           if (!(await validateInstalledBundle(destination, input.build))) {
             throw new Error("published worker bundle failed validation");
           }
+          await this.#prewarmBundle(destination);
           return structuredClone(input.build);
         } finally {
           await fsp.rm(operationRoot, { recursive: true, force: true });

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -198,20 +198,28 @@ export class NodeWorkerBundleInstaller {
     this.#workerEnv = snapshotNodeWorkerEnv(env);
   }
 
-  async #prewarmBundle(bundleDir: string): Promise<void> {
+  async #prewarmBundle(bundleDir: string, signal?: AbortSignal): Promise<void> {
     if (this.#prewarmedBundles.has(bundleDir)) {
       return;
     }
-    await execFileAsync(
-      process.execPath,
-      [path.join(bundleDir, WORKER_BUNDLE_ENTRY_PATH), "--internal-worker-prewarm"],
-      {
-        cwd: bundleDir,
-        env: this.#workerEnv,
-        timeout: WORKER_PREWARM_TIMEOUT_MS,
-        windowsHide: true,
-      },
-    );
+    try {
+      await execFileAsync(
+        process.execPath,
+        [path.join(bundleDir, WORKER_BUNDLE_ENTRY_PATH), "--internal-worker-prewarm"],
+        {
+          cwd: bundleDir,
+          env: this.#workerEnv,
+          timeout: WORKER_PREWARM_TIMEOUT_MS,
+          windowsHide: true,
+          ...(signal ? { signal } : {}),
+        },
+      );
+    } catch (error) {
+      if (signal?.aborted) {
+        throw signal.reason ?? error;
+      }
+      throw error;
+    }
     this.#prewarmedBundles.add(bundleDir);
   }
 
@@ -230,7 +238,9 @@ export class NodeWorkerBundleInstaller {
         const bundlesRoot = path.join(this.#root, input.gatewayNamespace, "bundles");
         const destination = path.join(bundlesRoot, input.build.bundleHash);
         if (await validateInstalledBundle(destination, input.build)) {
-          await this.#prewarmBundle(destination);
+          if (input.bundlePrewarm) {
+            await this.#prewarmBundle(destination, params.signal);
+          }
           return structuredClone(input.build);
         }
         await fsp.mkdir(bundlesRoot, { recursive: true, mode: 0o700 });
@@ -265,7 +275,9 @@ export class NodeWorkerBundleInstaller {
           if (!(await validateInstalledBundle(destination, input.build))) {
             throw new Error("published worker bundle failed validation");
           }
-          await this.#prewarmBundle(destination);
+          if (input.bundlePrewarm) {
+            await this.#prewarmBundle(destination, params.signal);
+          }
           return structuredClone(input.build);
         } finally {
           await fsp.rm(operationRoot, { recursive: true, force: true });

--- a/src/node-host/node-worker-environment.ts
+++ b/src/node-host/node-worker-environment.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+
 const POSIX_WORKER_ENV_KEYS = new Set([
   "PATH",
   "HOME",
@@ -47,9 +50,15 @@ export function snapshotNodeWorkerEnv(source: NodeJS.ProcessEnv): NodeJS.Process
     }
     snapshot[key] = value;
   }
+  if (source.NODE_DISABLE_COMPILE_CACHE === undefined) {
+    snapshot.NODE_COMPILE_CACHE =
+      source.NODE_COMPILE_CACHE?.trim() ||
+      path.join(resolvePreferredOpenClawTmpDir(), "node-worker-compile-cache");
+  } else {
+    snapshot.NODE_DISABLE_COMPILE_CACHE = "1";
+  }
   // The supervised start gate is carried by Node IPC. Launcher respawns do not
   // inherit that channel, so workers must stay in the owned child process.
-  snapshot.NODE_DISABLE_COMPILE_CACHE = "1";
   snapshot.OPENCLAW_NO_RESPAWN = "1";
   return snapshot;
 }

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -397,7 +397,7 @@ describe("node worker supervisor", () => {
           LC_TIME: suppliedEnv.LC_TIME,
           NODE_EXTRA_CA_CERTS: suppliedEnv.NODE_EXTRA_CA_CERTS,
           NODE_USE_SYSTEM_CA: suppliedEnv.NODE_USE_SYSTEM_CA,
-          NODE_DISABLE_COMPILE_CACHE: "1",
+          NODE_COMPILE_CACHE: expect.stringContaining("node-worker-compile-cache"),
           OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: suppliedEnv.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS,
           OPENCLAW_NO_RESPAWN: "1",
           [suppliedPathKey]: suppliedEnv[suppliedPathKey],

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -635,7 +635,10 @@ describe("runNodeHost", () => {
       "event loop readiness timeout",
     );
 
-    expect(lastCapturedOptions()?.workerRuns).toEqual(mocks.nodeWorkerBuild);
+    expect(lastCapturedOptions()?.workerRuns).toEqual({
+      ...mocks.nodeWorkerBuild,
+      bundlePrewarm: 1,
+    });
   });
 
   it("advertises Claude agent runs only after node-local opt-in and binary resolution", async () => {
@@ -706,7 +709,7 @@ describe("runNodeHost", () => {
 
     expect(client?.request).toHaveBeenCalledWith(NODE_RUNNER_INVENTORY_UPDATE_METHOD, {
       protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-      workerRuns: mocks.nodeWorkerBuild,
+      workerRuns: { ...mocks.nodeWorkerBuild, bundlePrewarm: 1 },
     });
   });
 

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -625,7 +625,7 @@ describe("runNodeHost", () => {
     expect(lastCapturedOptions()?.workerRuns).toBeUndefined();
   });
 
-  it("advertises the local worker build only after node-local opt-in", async () => {
+  it("keeps the initial worker build compatible before post-hello negotiation", async () => {
     mocks.getRuntimeConfig.mockReturnValue({
       gateway: { handshakeTimeoutMs: 1_000 },
       nodeHost: { workerRuns: { enabled: true } },
@@ -635,10 +635,8 @@ describe("runNodeHost", () => {
       "event loop readiness timeout",
     );
 
-    expect(lastCapturedOptions()?.workerRuns).toEqual({
-      ...mocks.nodeWorkerBuild,
-      bundlePrewarm: 1,
-    });
+    expect(lastCapturedOptions()?.workerRuns).toEqual(mocks.nodeWorkerBuild);
+    expect(lastCapturedOptions()?.workerRuns).not.toHaveProperty("bundlePrewarm");
   });
 
   it("advertises Claude agent runs only after node-local opt-in and binary resolution", async () => {
@@ -707,9 +705,27 @@ describe("runNodeHost", () => {
       features: { methods: [], events: [] },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
 
-    expect(client?.request).toHaveBeenCalledWith(NODE_RUNNER_INVENTORY_UPDATE_METHOD, {
-      protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-      workerRuns: { ...mocks.nodeWorkerBuild, bundlePrewarm: 1 },
+    await vi.waitFor(() => {
+      expect(
+        client?.request.mock.calls.filter(
+          ([method]) => method === NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+        ),
+      ).toEqual([
+        [
+          NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+          {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerRuns: mocks.nodeWorkerBuild,
+          },
+        ],
+        [
+          NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+          {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerRuns: { ...mocks.nodeWorkerBuild, bundlePrewarm: 1 },
+          },
+        ],
+      ]);
     });
   });
 

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -5,6 +5,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import type { WorkerAdmissionHandshake } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-readiness.js";
 import { GatewayClientRequestError, type GatewayReconnectPausedInfo } from "../gateway/client.js";
@@ -119,6 +120,18 @@ const NODE_PLUGIN_TOOLS_UPDATE_METHOD = "node.pluginTools.update";
 const NODE_SKILLS_UPDATE_METHOD = "node.skills.update";
 const NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS = 250;
 const NODE_OPTIONAL_PUBLICATION_RETRY_MAX_MS = 5_000;
+
+function nodeWorkerBuildIdentity(
+  manifest: WorkerAdmissionHandshake | undefined,
+): WorkerAdmissionHandshake | undefined {
+  return manifest
+    ? {
+        bundleHash: manifest.bundleHash,
+        openclawVersion: manifest.openclawVersion,
+        protocolFeatures: [...manifest.protocolFeatures],
+      }
+    : undefined;
+}
 
 function isExactUnknownMethodError(error: unknown, method: string): boolean {
   return (
@@ -462,16 +475,28 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const publishRunnerInventory = () => {
     // The handshake keeps the immutable build ceiling. Live inventory withdraws
     // only new-launch eligibility while full, leaving status/cancel negotiated.
+    const workerRuns = workerRunsAvailable ? preparedRuntime.manifest.workerRuns : undefined;
+    const workerBuild = nodeWorkerBuildIdentity(workerRuns);
     queueOptionalPublication(
       NODE_RUNNER_INVENTORY_UPDATE_METHOD,
       {
         protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-        ...(workerRunsAvailable && preparedRuntime.manifest.workerRuns
-          ? { workerRuns: preparedRuntime.manifest.workerRuns }
-          : {}),
+        ...(workerBuild ? { workerRuns: workerBuild } : {}),
       },
       "runner inventory",
     );
+    if (workerRuns?.bundlePrewarm !== undefined) {
+      // Publish the old closed build shape first so a prior Gateway keeps the
+      // session host. Its rejection of this additive follow-up leaves that path intact.
+      queueOptionalPublication(
+        NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+        {
+          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+          workerRuns,
+        },
+        "runner inventory",
+      );
+    }
   };
 
   const persistWinningGateway = (winningGateway: NodeHostGatewayConfig) => {
@@ -507,7 +532,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       caps: preparedRuntime.manifest.caps,
       commands: preparedRuntime.manifest.commands,
       computerUse: preparedRuntime.manifest.computerUse,
-      workerRuns: preparedRuntime.manifest.workerRuns,
+      workerRuns: nodeWorkerBuildIdentity(preparedRuntime.manifest.workerRuns),
       pathEnv: preparedRuntime.manifest.pathEnv,
       permissions: undefined,
       deviceIdentity: loadOrCreateDeviceIdentity(),

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -139,6 +139,18 @@ function holdInvoke() {
   };
 }
 
+describe("node-host worker manifest", () => {
+  it("advertises the supported bundle prewarm form from the node build", async () => {
+    const prepared = await prepareNodeHostRuntime({
+      config: { nodeHost: { skills: { enabled: false }, workerRuns: { enabled: true } } },
+      env: { PATH: "/usr/bin" },
+      enableWorkerRuns: true,
+    });
+
+    expect(prepared.manifest.workerRuns).toMatchObject({ bundlePrewarm: 1 });
+  });
+});
+
 describe("node-host invocation cancellation", () => {
   it("cancels ordinary node invocations", async () => {
     const held = holdInvoke();

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -1,6 +1,9 @@
 /** Transport-independent CLI node-host runtime shared by Gateway and app workers. */
 import fs from "node:fs";
-import type { WorkerAdmissionHandshake } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import {
+  WORKER_BUNDLE_PREWARM_VERSION,
+  type WorkerAdmissionHandshake,
+} from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { SkillBinTrustEntry } from "../infra/exec-approvals.js";
@@ -286,7 +289,9 @@ export async function prepareNodeHostRuntime(params?: {
   const workerRunsEnabled =
     params?.enableWorkerRuns === true && config.nodeHost?.workerRuns?.enabled === true;
   const workerInstallation = workerRunsEnabled ? await resolveNodeWorkerInstallation() : undefined;
-  const workerRuns = workerInstallation?.build;
+  const workerRuns = workerInstallation
+    ? { ...workerInstallation.build, bundlePrewarm: WORKER_BUNDLE_PREWARM_VERSION }
+    : undefined;
   const skills = config.nodeHost?.skills?.enabled === false ? null : scanNodeHostedSkills();
   const buildManifest = (pluginManifest: typeof pluginNodeHost): NodeHostManifest => ({
     caps: [

--- a/src/worker/node-bundle-install-protocol.test.ts
+++ b/src/worker/node-bundle-install-protocol.test.ts
@@ -30,6 +30,14 @@ describe("node worker bundle install protocol", () => {
     );
   });
 
+  it("accepts only the mutually supported prewarm form", () => {
+    const prewarmInput = { ...input, bundlePrewarm: 1 };
+    expect(parseNodeWorkerBundleInstallInput(JSON.stringify(prewarmInput))).toEqual(prewarmInput);
+    expect(() =>
+      parseNodeWorkerBundleInstallInput(JSON.stringify({ ...input, bundlePrewarm: 2 })),
+    ).toThrow("INVALID_REQUEST");
+  });
+
   it.each([
     { ...input, extra: true },
     { ...input, gatewayNamespace: "../escape" },

--- a/src/worker/node-bundle-install-protocol.ts
+++ b/src/worker/node-bundle-install-protocol.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  WORKER_BUNDLE_PREWARM_VERSION,
   validateWorkerAdmissionHandshake,
   type WorkerAdmissionHandshake,
 } from "../../packages/gateway-protocol/src/index.js";
@@ -21,6 +22,7 @@ const WorkerBuildSchema = z.custom<WorkerAdmissionHandshake>(
 const BundleInstallInputSchema = z
   .object({
     gatewayNamespace: z.string().regex(GATEWAY_NAMESPACE_PATTERN),
+    bundlePrewarm: z.literal(WORKER_BUNDLE_PREWARM_VERSION).optional(),
     build: WorkerBuildSchema,
     archive: z
       .object({

--- a/src/worker/worker-deploy-entry.ts
+++ b/src/worker/worker-deploy-entry.ts
@@ -1,14 +1,20 @@
+import { flushCompileCache } from "node:module";
 import "./worker-deploy-runtime.js";
 import workerDeployBrowserRuntime from "./worker-deploy-browser-runtime.js";
 import { runWorkerProcess } from "./worker-process.js";
 
 const args = process.argv.slice(2);
-if (args.length > 1 || (args.length === 1 && args[0] !== "--internal-worker-ipc")) {
+const internalWorkerIpc = args[0] === "--internal-worker-ipc";
+const internalWorkerPrewarm = args[0] === "--internal-worker-prewarm";
+if (args.length > 1 || (args.length === 1 && !internalWorkerIpc && !internalWorkerPrewarm)) {
   throw new Error("worker deploy entry received unsupported arguments");
 }
-const internalWorkerIpc = args[0] === "--internal-worker-ipc";
 
-await runWorkerProcess({
-  internalWorkerIpc,
-  browserRuntime: workerDeployBrowserRuntime,
-});
+if (internalWorkerPrewarm) {
+  flushCompileCache();
+} else {
+  await runWorkerProcess({
+    internalWorkerIpc,
+    browserRuntime: workerDeployBrowserRuntime,
+  });
+}

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -284,7 +284,7 @@ async function connectPairedNode(params: {
       gateway: params.gateway,
       role: "node",
       identity: params.identity,
-      workerRuns,
+      workerRuns: params.installation.build,
       onEvent: params.onEvent,
     });
   let client: GatewayClient;

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -272,14 +272,19 @@ async function connectPairedNode(params: {
   operator: GatewayClient;
   identity: DeviceIdentity;
   installation: NodeWorkerInstallation;
+  bundlePrewarm?: number;
   onEvent: (event: GatewayEvent) => void;
 }): Promise<GatewayClient> {
+  const workerRuns = {
+    ...params.installation.build,
+    ...(params.bundlePrewarm === undefined ? {} : { bundlePrewarm: params.bundlePrewarm }),
+  };
   const connect = () =>
     connectClient({
       gateway: params.gateway,
       role: "node",
       identity: params.identity,
-      workerRuns: params.installation.build,
+      workerRuns,
       onEvent: params.onEvent,
     });
   let client: GatewayClient;
@@ -298,7 +303,7 @@ async function connectPairedNode(params: {
   }
   await client.request(NODE_RUNNER_INVENTORY_UPDATE_METHOD, {
     protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-    workerRuns: params.installation.build,
+    workerRuns,
   });
   return client;
 }
@@ -366,14 +371,33 @@ describe("node worker launch wire", () => {
         root: path.join(root, "node-workspaces"),
         env: nodeEnv,
       });
+      const legacyNodeEnv = {
+        ...process.env,
+        HOME: path.join(root, "legacy-node-home"),
+        NODE_DISABLE_COMPILE_CACHE: undefined,
+        OPENCLAW_STATE_DIR: path.join(root, "legacy-node-state"),
+      };
+      await fs.mkdir(legacyNodeEnv.HOME, { recursive: true });
+      const legacySupervisor = createNodeWorkerSupervisor({ env: legacyNodeEnv });
+      const legacyBundleInstaller = new NodeWorkerBundleInstaller({ env: legacyNodeEnv });
+      const legacyWorkspace = new NodeWorkerWorkspaceRuntime({
+        root: path.join(root, "legacy-node-workspaces"),
+        env: legacyNodeEnv,
+      });
       let gateway: Gateway | undefined;
       let operator: GatewayClient | undefined;
       let node: GatewayClient | undefined;
+      let legacyNode: GatewayClient | undefined;
       let closing = false;
       let reconnected = false;
       const invokeTasks = new Set<Promise<void>>();
       const invokeErrors: unknown[] = [];
+      const legacyInvokeTasks = new Set<Promise<void>>();
+      const legacyInvokeErrors: unknown[] = [];
       const commands: string[] = [];
+      const legacyCommands: string[] = [];
+      let bundlePrewarm: unknown;
+      let legacyBundlePrewarm: unknown;
       let launchId: string | undefined;
       let observeFinalizationLoad = false;
       let finalizationStartedAt: number | undefined;
@@ -427,6 +451,10 @@ describe("node worker launch wire", () => {
           if (frame.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND && frame.paramsJSON) {
             launchId = (JSON.parse(frame.paramsJSON) as { launchId?: string }).launchId;
           }
+          if (frame.command === NODE_WORKER_BUNDLE_INSTALL_COMMAND && frame.paramsJSON) {
+            bundlePrewarm = (JSON.parse(frame.paramsJSON) as { bundlePrewarm?: unknown })
+              .bundlePrewarm;
+          }
           const task = handleInvoke(frame, receiver, { current: async () => [] }, undefined, {
             workerBundleInstaller: bundleInstaller,
             workerSupervisor: supervisor,
@@ -447,6 +475,7 @@ describe("node worker launch wire", () => {
                     operator: operator!,
                     identity,
                     installation,
+                    bundlePrewarm: 1,
                     onEvent: onNodeEvent,
                   });
                 }
@@ -463,6 +492,7 @@ describe("node worker launch wire", () => {
           operator,
           identity,
           installation,
+          bundlePrewarm: 1,
           onEvent: onNodeEvent,
         });
         const listed = await waitForApprovedNode(operator, identity.deviceId);
@@ -531,6 +561,7 @@ describe("node worker launch wire", () => {
         expect(commands).toContain(NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND);
         expect(commands).toContain(NODE_WORKER_SUPERVISOR_STATUS_COMMAND);
         expect(launchId).toBeTruthy();
+        expect(bundlePrewarm).toBe(1);
         await expect(supervisor.status(launchId!)).resolves.toMatchObject({ state: "completed" });
 
         const history = await operator.request<{ messages?: unknown[] }>("chat.history", {
@@ -561,6 +592,73 @@ describe("node worker launch wire", () => {
         expect(await fs.readFile(path.join(remoteWorkspaceDir, "node-result.txt"), "utf8")).toBe(
           "device result\n",
         );
+
+        const legacyIdentity = loadOrCreateDeviceIdentity({
+          path: path.join(root, "legacy-node-identity.sqlite"),
+        });
+        const onLegacyNodeEvent = (event: GatewayEvent) => {
+          if (event.event !== "node.invoke.request" || !legacyNode) {
+            return;
+          }
+          const receiver = legacyNode;
+          const frame = event.payload as NodeInvokeRequestPayload;
+          legacyCommands.push(frame.command);
+          if (frame.command === NODE_WORKER_BUNDLE_INSTALL_COMMAND && frame.paramsJSON) {
+            legacyBundlePrewarm = (JSON.parse(frame.paramsJSON) as { bundlePrewarm?: unknown })
+              .bundlePrewarm;
+          }
+          const task = handleInvoke(frame, receiver, { current: async () => [] }, undefined, {
+            workerBundleInstaller: legacyBundleInstaller,
+            workerSupervisor: legacySupervisor,
+            workerWorkspace: legacyWorkspace,
+            gatewayUrl: gateway!.wsUrl,
+          })
+            .catch((error: unknown) => {
+              legacyInvokeErrors.push(error);
+            })
+            .finally(() => legacyInvokeTasks.delete(task));
+          legacyInvokeTasks.add(task);
+        };
+        legacyNode = await connectPairedNode({
+          gateway,
+          operator,
+          identity: legacyIdentity,
+          installation,
+          onEvent: onLegacyNodeEvent,
+        });
+        await waitForApprovedNode(operator, legacyIdentity.deviceId);
+        const legacySessionKey = `${SESSION_KEY}-legacy-node`;
+        await operator.request("sessions.create", {
+          key: legacySessionKey,
+          agentId: "qa",
+          worktree: true,
+          worktreeName: "node-worker-launch-legacy-node",
+          worktreeBaseRef: "main",
+          cwd: published.source,
+        });
+        await gateway.call(
+          "sessions.dispatch",
+          { key: legacySessionKey, deviceId: legacyIdentity.deviceId },
+          { timeoutMs: PROOF_TIMEOUT_MS },
+        );
+        const legacyRunId = `node-worker-launch-wire-legacy-${Date.now()}`;
+        await operator.request("chat.send", {
+          sessionKey: legacySessionKey,
+          message: BASELINE_PROMPT,
+          deliver: false,
+          idempotencyKey: legacyRunId,
+        });
+        await expect(
+          operator.request<{ status?: string }>(
+            "agent.wait",
+            { runId: legacyRunId, timeoutMs: PROOF_TIMEOUT_MS },
+            { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+          ),
+        ).resolves.toMatchObject({ status: "ok" });
+        await Promise.all([...legacyInvokeTasks]);
+        expect(legacyInvokeErrors).toEqual([]);
+        expect(legacyCommands).toContain(NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND);
+        expect(legacyBundlePrewarm).toBeUndefined();
 
         const loadSessions: string[] = [];
         for (let index = 0; index < FINALIZATION_LOAD_CONCURRENCY; index += 1) {
@@ -659,9 +757,12 @@ describe("node worker launch wire", () => {
         closing = true;
         const cleanup = await Promise.allSettled([
           node?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
+          legacyNode?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
           operator?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
           Promise.allSettled([...invokeTasks]),
+          Promise.allSettled([...legacyInvokeTasks]),
           supervisor.close(),
+          legacySupervisor.close(),
           gateway?.stop() ?? Promise.resolve(),
           provider.stop(),
           closeServer(published.server),

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { promisify } from "node:util";
 import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -46,6 +47,8 @@ const execFileAsync = promisify(execFile);
 const SESSION_KEY = "agent:qa:node-worker-launch-wire";
 const NODE_DISPLAY_NAME = "QA Gateway-bundle worker node";
 const TEST_TIMEOUT_MS = PROOF_TIMEOUT_MS + 60_000;
+const CONTROL_PROBE_MAX_MS = 4_000;
+const FINALIZATION_LOAD_CONCURRENCY = 6;
 
 type NodeWorkerInstallation = Awaited<ReturnType<typeof resolveNodeWorkerInstallation>>;
 type Gateway = Awaited<ReturnType<typeof startQaGatewayChild>>;
@@ -156,6 +159,7 @@ async function connectClient(params: {
   identity: DeviceIdentity | null;
   workerRuns?: NodeWorkerInstallation["build"];
   onEvent?: (event: GatewayEvent) => void;
+  timeoutMs?: number;
 }): Promise<GatewayClient> {
   return await new Promise<GatewayClient>((resolve, reject) => {
     let settled = false;
@@ -174,7 +178,7 @@ async function connectClient(params: {
     };
     const timeout = setTimeout(
       () => finish(new Error("Gateway client connection timed out")),
-      30_000,
+      params.timeoutMs ?? 30_000,
     );
     timeout.unref();
     const node = params.role === "node";
@@ -349,10 +353,14 @@ describe("node worker launch wire", () => {
       const nodeEnv = {
         ...process.env,
         HOME: path.join(root, "node-home"),
+        NODE_DISABLE_COMPILE_CACHE: undefined,
         OPENCLAW_STATE_DIR: path.join(root, "node-state"),
       };
       await fs.mkdir(nodeEnv.HOME, { recursive: true });
-      const supervisor = createNodeWorkerSupervisor({ env: nodeEnv });
+      const supervisor = createNodeWorkerSupervisor({
+        env: nodeEnv,
+        capacity: FINALIZATION_LOAD_CONCURRENCY,
+      });
       const bundleInstaller = new NodeWorkerBundleInstaller({ env: nodeEnv });
       const workspace = new NodeWorkerWorkspaceRuntime({
         root: path.join(root, "node-workspaces"),
@@ -367,6 +375,12 @@ describe("node worker launch wire", () => {
       const invokeErrors: unknown[] = [];
       const commands: string[] = [];
       let launchId: string | undefined;
+      let observeFinalizationLoad = false;
+      let finalizationStartedAt: number | undefined;
+      let resolveFinalizationStarted!: () => void;
+      const finalizationStarted = new Promise<void>((resolve) => {
+        resolveFinalizationStarted = resolve;
+      });
 
       try {
         gateway = await startQaGatewayChild({
@@ -397,6 +411,19 @@ describe("node worker launch wire", () => {
           const receiver = node;
           const frame = event.payload as NodeInvokeRequestPayload;
           commands.push(frame.command);
+          if (frame.command === NODE_WORKER_WORKSPACE_EXEC_COMMAND && frame.paramsJSON) {
+            const workspaceCommand = JSON.parse(frame.paramsJSON) as {
+              transfer?: { direction?: unknown };
+            };
+            if (
+              observeFinalizationLoad &&
+              workspaceCommand.transfer?.direction === "upload" &&
+              !finalizationStartedAt
+            ) {
+              finalizationStartedAt = performance.now();
+              resolveFinalizationStarted();
+            }
+          }
           if (frame.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND && frame.paramsJSON) {
             launchId = (JSON.parse(frame.paramsJSON) as { launchId?: string }).launchId;
           }
@@ -534,6 +561,100 @@ describe("node worker launch wire", () => {
         expect(await fs.readFile(path.join(remoteWorkspaceDir, "node-result.txt"), "utf8")).toBe(
           "device result\n",
         );
+
+        const loadSessions: string[] = [];
+        for (let index = 0; index < FINALIZATION_LOAD_CONCURRENCY; index += 1) {
+          const sessionKey = `${SESSION_KEY}-load-${index}`;
+          await operator.request("sessions.create", {
+            key: sessionKey,
+            agentId: "qa",
+            worktree: true,
+            worktreeName: `node-worker-launch-load-${index}`,
+            worktreeBaseRef: "main",
+            cwd: published.source,
+          });
+          await gateway.call(
+            "sessions.dispatch",
+            { key: sessionKey, deviceId: identity.deviceId },
+            { timeoutMs: PROOF_TIMEOUT_MS },
+          );
+          loadSessions.push(sessionKey);
+        }
+        observeFinalizationLoad = true;
+        const readyzSamples: Array<{ atMs: number; latencyMs: number; status: number }> = [];
+        let loadSettled = false;
+        const httpOrigin = gateway.wsUrl.replace(/^ws/u, "http");
+        const sampler = (async () => {
+          while (!loadSettled) {
+            const startedAt = performance.now();
+            try {
+              const response = await fetch(`${httpOrigin}/readyz`, {
+                signal: AbortSignal.timeout(CONTROL_PROBE_MAX_MS),
+              });
+              readyzSamples.push({
+                atMs: startedAt,
+                latencyMs: performance.now() - startedAt,
+                status: response.status,
+              });
+            } catch {
+              readyzSamples.push({
+                atMs: startedAt,
+                latencyMs: performance.now() - startedAt,
+                status: 0,
+              });
+            }
+            await new Promise((resolve) => setTimeout(resolve, 50));
+          }
+        })();
+        const loadRunIds = await Promise.all(
+          loadSessions.map(async (sessionKey, index) => {
+            const runId = `node-worker-finalization-load-${index}-${Date.now()}`;
+            const started = await operator!.request<{ runId?: string; status?: string }>(
+              "chat.send",
+              {
+                sessionKey,
+                message: BASELINE_PROMPT,
+                deliver: false,
+                idempotencyKey: runId,
+              },
+            );
+            expect(started).toMatchObject({ runId, status: "started" });
+            return runId;
+          }),
+        );
+        const waits = Promise.all(
+          loadRunIds.map(async (runId) => {
+            const completedLoad = await operator!.request<{ status?: string }>(
+              "agent.wait",
+              { runId, timeoutMs: PROOF_TIMEOUT_MS },
+              { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+            );
+            expect(completedLoad.status).toBe("ok");
+          }),
+        );
+        await finalizationStarted;
+        const freshConnectionStartedAt = performance.now();
+        const freshClient = await connectClient({
+          gateway,
+          role: "operator",
+          identity: null,
+          timeoutMs: CONTROL_PROBE_MAX_MS,
+        });
+        const freshConnectionMs = performance.now() - freshConnectionStartedAt;
+        await freshClient.stopAndWait({ timeoutMs: 2_000 });
+        await waits.finally(() => {
+          loadSettled = true;
+        });
+        await sampler;
+        const finalizationSamples = readyzSamples.filter(
+          (sample) => sample.atMs >= (finalizationStartedAt ?? Number.POSITIVE_INFINITY),
+        );
+        expect(finalizationSamples.length).toBeGreaterThan(0);
+        expect(finalizationSamples.every((sample) => sample.status === 200)).toBe(true);
+        expect(Math.max(...finalizationSamples.map((sample) => sample.latencyMs))).toBeLessThan(
+          CONTROL_PROBE_MAX_MS,
+        );
+        expect(freshConnectionMs).toBeLessThan(CONTROL_PROBE_MAX_MS);
       } finally {
         closing = true;
         const cleanup = await Promise.allSettled([

--- a/test/scripts/check-gateway-cpu-scenarios.test.ts
+++ b/test/scripts/check-gateway-cpu-scenarios.test.ts
@@ -336,7 +336,11 @@ describe("gateway CPU scenario guard", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.summary.steps.map((step) => step.name)).toEqual(["private QA build", "qa suite"]);
+    expect(result.summary.steps.map((step) => step.name)).toEqual([
+      "private QA build",
+      "node worker finalization gate",
+      "qa suite",
+    ]);
     expect(calls[0]?.args).toEqual(["--import", "tsx", "scripts/build-all.mts", "qaRuntime"]);
     expect(calls[0]?.env).toMatchObject({
       HOME: path.join(outputDir, "qa-state-root", "home"),
@@ -388,7 +392,10 @@ describe("gateway CPU scenario guard", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.summary.steps.map((step) => step.name)).toEqual(["qa suite"]);
+    expect(result.summary.steps.map((step) => step.name)).toEqual([
+      "node worker finalization gate",
+      "qa suite",
+    ]);
     expect(calls.some((call) => call.args[0] === "scripts/build-all.mts")).toBe(false);
     expect(calls[0]?.env).toMatchObject({
       HOME: path.join(outputDir, "qa-state-root", "home"),


### PR DESCRIPTION
## What Problem This Solves

Delegated Node worker bursts can put repeated bundle parse/compile work into the launch path. The parked prototype moved that work into bundle installation, but it could invoke a new entrypoint on nodes that had not negotiated it and a cancelled prewarm child could retain the per-namespace install queue for ten minutes.

## Why This Change Was Made

After the legacy-compatible initial connection, the Node host now advertises `bundlePrewarm` as a positive integer inside its existing `workerRuns` runner inventory. It publishes the prior closed build shape first, then the additive capability, so an older Gateway retains the existing slow session-host path even if it rejects the follow-up. This build supports form `1`; a new Gateway caps any advertised higher version to the highest mutual form, `1`, and sends the prewarm install form only to advertising nodes. Nodes without the field receive the previous install request and continue parsing per turn.

The install invocation's `AbortSignal` now reaches the prewarm child. If a launch is cancelled or fenced, the child is terminated, the queued install settles immediately, and already-cancelled queued entries are rejected when dequeued.

No config key or protocol-version bump is introduced.

## User Impact

Current Node hosts prewarm installed Gateway bundles before admitting turns, reducing repeated parse/compile work during worker bursts. Mixed fleets remain correct: capable nodes prewarm, while older/non-advertising nodes keep the existing slower path.

## Evidence

- Mixed-fleet/finalization wire scenario: 3/3 passes on [AWS Crabbox run `run_829fd6d17ffe`](https://crabbox.openclaw.ai/portal/runs/run_829fd6d17ffe); one advertising node and one non-advertising node both completed turns, only the advertiser received `bundlePrewarm: 1`, six concurrent finalizations kept `/readyz` at HTTP 200, and a fresh Gateway connection stayed within the control-plane bound.
- Negotiation, protocol, manifest, and abort/queue-release focused suites: 3/3 passes on [AWS Crabbox run `run_511c5191632e`](https://crabbox.openclaw.ai/portal/runs/run_511c5191632e) (34 tests per repetition).
- Exact rebased head: focused suites and the mixed-fleet/finalization wire scenario passed again locally.
- Rolling-upgrade coverage: initial closed handshake shape, ordered post-hello legacy/capability publications, and Gateway proof promotion passed across 175 focused tests; the wire scenario connects with the legacy shape before advertising prewarm.
- `pnpm build`: passed on [AWS Crabbox run `run_b972f2443a9a`](https://crabbox.openclaw.ai/portal/runs/run_b972f2443a9a).
- Changed gate: passed locally with exit 0 after the raw AWS image exposed an unrelated pnpm optional-binding lockfile incompatibility.
- Format and `git diff --check`: passed.
- Final branch autoreview: clean, no accepted/actionable findings.

The finalization load gate intentionally remains the parked scenario required by the frozen maintainer spec: it measures launch/finalization responsiveness with prewarm active. Cold install negotiation and cancellation are covered directly at their owning Gateway/Node install boundaries rather than changing that scenario's contract.

The terminal-truth fix from the original combined work landed separately in #124387.
