### PR TITLE
perf(test): fast-forward Slack probe retry window

### DIFF
--- a/extensions/slack/src/probe.transport.test.ts
+++ b/extensions/slack/src/probe.transport.test.ts
@@ -1,7 +1,7 @@
 // Prove Slack probe deadlines against the real SDK and loopback HTTP transport.
 import { createServer, type RequestListener } from "node:http";
 import type { Socket } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { probeSlack } from "./probe.js";
 
 const TEST_ENV_KEYS = [
@@ -111,24 +111,49 @@ describe("probeSlack real network deadlines", () => {
   it("does not retry a dropped request after the probe has already returned", async () => {
     clearSlackTransportEnv();
     let requests = 0;
+    let notifyRequest: () => void = () => undefined;
+    let notifyRetry: () => void = () => undefined;
+    const requestArrived = new Promise<void>((resolve) => {
+      notifyRequest = resolve;
+    });
+    const retryArrived = new Promise<void>((resolve) => {
+      notifyRetry = resolve;
+    });
     const server = await startSlackTransportServer((request, response) => {
       requests += 1;
+      notifyRequest();
+      if (requests === 2) {
+        notifyRetry();
+      }
       request.resume();
       response.destroy();
     });
     try {
       process.env.SLACK_API_URL = server.apiUrl;
+      const nativeSetTimeout = globalThis.setTimeout;
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        const probe = probeSlack("probe-fixture", 100);
+        await requestArrived;
+        await vi.advanceTimersByTimeAsync(100);
+        await expect(probe).resolves.toMatchObject({ ok: false });
 
-      await expect(probeSlack("probe-fixture", 100)).resolves.toMatchObject({ ok: false });
-
-      // The default Slack read retry is randomized between 500 and 1,000 ms.
-      // Keep the endpoint alive long enough to catch work after the probe ends.
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 1_200);
-      });
-      expect(requests).toBe(1);
+        // The default Slack read retry is randomized between 500 and 1,000 ms.
+        await vi.advanceTimersByTimeAsync(1_200);
+        const retried = await Promise.race([
+          retryArrived.then(() => true),
+          new Promise<boolean>((resolve) => {
+            nativeSetTimeout(() => resolve(false), 100);
+          }),
+        ]);
+        expect(retried).toBe(false);
+        expect(requests).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
       await expect.poll(() => server.sockets.size, { timeout: 400 }).toBe(0);
     } finally {
+      vi.useRealTimers();
       await server.close();
     }
   });


### PR DESCRIPTION
## What Problem This Solves

The real Slack probe transport regression waits 1.2 seconds after a dropped request solely to observe the SDK's randomized default retry window. The test needs to prove that a completed health probe cannot leave retry work behind, but it does not need to spend that retry window in wall-clock time.

## Why This Change Was Made

Keep the real Slack SDK, loopback HTTP server, dropped response, socket cleanup, and absolute probe deadline. Synchronize on the first real request, advance the probe deadline and retry window with fake timers, then allow a short native-timer I/O settlement window for a forbidden second request to reach the server.

This is stronger than the old sleep: removing `retryConfig: { retries: 0 }` now makes the real server observe the second request and fails the test. Production code and retry policy remain unchanged.

## User Impact

Maintainer Slack test feedback is faster and the post-return retry proof is deterministic. Runtime behavior is unchanged.

## Evidence

Controlled same-Testbox A/B on `tbx_01m04ekr07ekaw19h1cv6c6tcv`, one excluded warmup plus two retained samples per state, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 7.58s | 6.37s | -1.21s (-16.0%) |
| Vitest | 4.87s | 3.68s | -24.5% |
| Test body | 1.52s | 0.42s | -72.3% |
| Import | 3.14s | 3.06s | effectively flat |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 47/47 Slack probe transport, probe owner, and client-policy tests.
- Full extension changed gate on the retained Testbox, including extension-test typecheck and targeted lint. The initial run found narrow notifier return-type inference; explicit `() => void` annotations fixed it and the complete gate reran green.
- Fresh post-rebase Codex autoreview: no accepted/actionable findings.
- Mutation: removing probe retry suppression makes the real loopback server observe a second request after the virtual retry window.
- Production LOC: `+0/-0`; test LOC: `+35/-10`.

Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/31927656538
