### PR TITLE
fix(ci): target sidebar reconnect roster response

### DIFF
--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -564,7 +564,7 @@ suite.define(() => {
         .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
         .toBe(socketsBefore + 1);
       await gateway.deferNext("sessions.subscribe");
-      await gateway.deferNext("sessions.list");
+      await gateway.deferNext("sessions.list", { includeLastMessage: true });
       await gateway.setOnline(true);
       await waitForControlUiGatewayReady(page);
       await expect
@@ -583,8 +583,56 @@ suite.define(() => {
 
       await gateway.resolveDeferred("sessions.subscribe", { subscribed: true });
       await expect
-        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 15_000 })
-        .toBeGreaterThan(initialListCount);
+        .poll(
+          async () =>
+            (await gateway.getRequests("sessions.list"))
+              .slice(initialListCount)
+              .filter((request) => requireRecord(request.params).includeLastMessage === true)
+              .length,
+        )
+        .toBe(1);
+      const reconnectListRequests = (await gateway.getRequests("sessions.list")).slice(
+        initialListCount,
+      );
+      const reconnectListParams = reconnectListRequests.map((request) =>
+        requireRecord(request.params),
+      );
+      const canonicalListIndex = reconnectListParams.findIndex(
+        (params) => params.includeLastMessage === true,
+      );
+      expect(canonicalListIndex).toBe(reconnectListParams.length - 1);
+      expect(reconnectListParams[canonicalListIndex]).toEqual({
+        agentId: "main",
+        configuredAgentsOnly: true,
+        includeDerivedTitles: true,
+        includeGlobal: true,
+        includeLastMessage: true,
+        includeUnknown: true,
+        limit: 50,
+      });
+      const routeListParams = reconnectListParams.slice(0, canonicalListIndex);
+      const routeSearches = routeListParams.map((params) => String(params.search));
+      const routeSearchOrder = [firstKey, selectedKey];
+      expect(routeSearches).toEqual(
+        routeSearches.toSorted((a, b) => routeSearchOrder.indexOf(a) - routeSearchOrder.indexOf(b)),
+      );
+      expect(new Set(routeSearches).size).toBe(routeSearches.length);
+      for (const [index, params] of routeListParams.entries()) {
+        expect(routeSearchOrder).toContain(routeSearches[index]);
+        expect(params).toEqual({
+          agentId: "main",
+          archived: "all",
+          configuredAgentsOnly: true,
+          includeDerivedTitles: true,
+          includeGlobal: true,
+          includeUnknown: true,
+          limit: 20,
+          search: routeSearches[index],
+        });
+      }
+      expect(new Set(reconnectListRequests.map((request) => request.id)).size).toBe(
+        reconnectListRequests.length,
+      );
       await gateway.resolveDeferred(
         "sessions.list",
         sessionsListResponse([

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -583,36 +583,12 @@ suite.define(() => {
 
       await gateway.resolveDeferred("sessions.subscribe", { subscribed: true });
       await expect
-        .poll(
-          async () =>
-            (await gateway.getRequests("sessions.list"))
-              .slice(initialListCount)
-              .filter((request) => requireRecord(request.params).includeLastMessage === true)
-              .length,
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list"))
+            .slice(initialListCount)
+            .some((request) => requireRecord(request.params).includeLastMessage === true),
         )
-        .toBe(1);
-      const reconnectListRequests = (await gateway.getRequests("sessions.list")).slice(
-        initialListCount,
-      );
-      const canonicalListRequest = reconnectListRequests.find(
-        (request) => requireRecord(request.params).includeLastMessage === true,
-      );
-      expect(canonicalListRequest).toEqual({
-        id: expect.any(String),
-        method: "sessions.list",
-        params: {
-          agentId: "main",
-          configuredAgentsOnly: true,
-          includeDerivedTitles: true,
-          includeGlobal: true,
-          includeLastMessage: true,
-          includeUnknown: true,
-          limit: 50,
-        },
-      });
-      expect(new Set(reconnectListRequests.map((request) => request.id)).size).toBe(
-        reconnectListRequests.length,
-      );
+        .toBe(true);
       await gateway.resolveDeferred(
         "sessions.list",
         sessionsListResponse([

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -594,42 +594,22 @@ suite.define(() => {
       const reconnectListRequests = (await gateway.getRequests("sessions.list")).slice(
         initialListCount,
       );
-      const reconnectListParams = reconnectListRequests.map((request) =>
-        requireRecord(request.params),
+      const canonicalListRequest = reconnectListRequests.find(
+        (request) => requireRecord(request.params).includeLastMessage === true,
       );
-      const canonicalListIndex = reconnectListParams.findIndex(
-        (params) => params.includeLastMessage === true,
-      );
-      expect(canonicalListIndex).toBe(reconnectListParams.length - 1);
-      expect(reconnectListParams[canonicalListIndex]).toEqual({
-        agentId: "main",
-        configuredAgentsOnly: true,
-        includeDerivedTitles: true,
-        includeGlobal: true,
-        includeLastMessage: true,
-        includeUnknown: true,
-        limit: 50,
-      });
-      const routeListParams = reconnectListParams.slice(0, canonicalListIndex);
-      const routeSearches = routeListParams.map((params) => String(params.search));
-      const routeSearchOrder = [firstKey, selectedKey];
-      expect(routeSearches).toEqual(
-        routeSearches.toSorted((a, b) => routeSearchOrder.indexOf(a) - routeSearchOrder.indexOf(b)),
-      );
-      expect(new Set(routeSearches).size).toBe(routeSearches.length);
-      for (const [index, params] of routeListParams.entries()) {
-        expect(routeSearchOrder).toContain(routeSearches[index]);
-        expect(params).toEqual({
+      expect(canonicalListRequest).toEqual({
+        id: expect.any(String),
+        method: "sessions.list",
+        params: {
           agentId: "main",
-          archived: "all",
           configuredAgentsOnly: true,
           includeDerivedTitles: true,
           includeGlobal: true,
+          includeLastMessage: true,
           includeUnknown: true,
-          limit: 20,
-          search: routeSearches[index],
-        });
-      }
+          limit: 50,
+        },
+      });
       expect(new Set(reconnectListRequests.map((request) => request.id)).size).toBe(
         reconnectListRequests.length,
       );


### PR DESCRIPTION
Related: #124371
Related: #121609

## What Problem This Solves

Resolves a problem where the Control UI sidebar reconnect E2E could fail on current `main` while waiting for a recovered selected-session label. The failure blocks otherwise verified PRs, including #124371, even though production correctly retains the selected session and one observer across reconnect and route changes.

## Why This Change Was Made

The mock Gateway's generic one-shot `sessions.list` deferral could be consumed by an archived route-resolution lookup instead of the canonical reconnect roster hydration. The recovered payload would then belong to an obsolete route request while the sidebar legitimately received the fixture's original label.

The test now matches the canonical request through `includeLastMessage: true`, waits until that qualifying request is observed, and then judges the visible recovered label, active-row count, selected route, and single observer. It does not couple the sidebar outcome to route-cache scheduling, complete request payloads, or request IDs.

The production session capability, observer lifecycle, roster reconcile, and sidebar renderer were inspected and need no change. Production LOC: +0/-0. Tests: +7/-3. AI-assisted; I reviewed and understand the change.

## User Impact

No user-visible behavior changes. Maintainers regain deterministic broken-main coverage for the selected-session reconnect path, allowing blocked verified PRs to resume once `main` is green.

## Evidence

- Pre-fix exact-head CI failure: https://github.com/openclaw/openclaw/actions/runs/31927051953/job/95116197594 (`Selected session` remained after resolving `Selected session recovered`).
- Linux Node 24 Blacksmith Testbox: final focused run `tbx_01m04jd4mzj83255s3w4mzcb8a`, hydration run https://github.com/openclaw/openclaw/actions/runs/31930277748.
- Rebased session-management E2E family: 12 files, 53/53 tests passed.
- Final sidebar E2E file: 11/11 tests passed; repaired target stress: 10/10 serial repetitions passed.
- `pnpm check:changed`: passed.
- `pnpm build`: passed.
- `pnpm ui:i18n:verify`: passed.
- Targeted `oxfmt --check` and `oxlint`: passed.
- `pnpm lint:ui:styles`: passed.
- `pnpm tsgo:test:ui`: passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `git diff --check`: passed.
- Codex autoreview: clean, no accepted/actionable findings.
- ClawSweeper findings addressed: removed route ordering, full request-object, and request-ID coupling while retaining the parameter-scoped canonical request handoff and visible sidebar outcome proof.
- No screenshot or video: this is a test-fixture synchronization repair with no product or visual change.
