### PR TITLE
fix(agents): pass agent workspaceDir to localRoots for image hydration

### DIFF
--- a/src/agents/embedded-agent-runner/run/images.media-refs.ts
+++ b/src/agents/embedded-agent-runner/run/images.media-refs.ts
@@ -13,6 +13,7 @@ export type MediaFileRef = {
   raw: string;
   type: "path" | "media-uri";
   resolved: string;
+  workspaceDir?: string;
 };
 
 export type MediaImageRef = MediaFileRef & {
@@ -20,7 +21,6 @@ export type MediaImageRef = MediaFileRef & {
   detect?: boolean;
   factIndex: number;
   hydrate: boolean;
-  workspaceDir?: string;
 };
 
 export function isOpenClawCliImageCachePath(filePath: string): boolean {

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -257,8 +257,12 @@ async function loadMediaFromRef(
         })
       : await loadWebMedia(
           targetPath,
-          options?.workspaceOnly || options?.localRoots
-            ? { maxBytes: options.maxBytes, localRoots: options.localRoots ?? [workspaceDir] }
+          options?.workspaceOnly || options?.localRoots || ref.workspaceDir
+            ? {
+                maxBytes: options.maxBytes,
+                localRoots:
+                  options.localRoots ?? (ref.workspaceDir ? [ref.workspaceDir] : [workspaceDir]),
+              }
             : options?.maxBytes,
         );
 


### PR DESCRIPTION
## Summary

When loading staged image attachments for named (non-default) agents, `loadMediaFromRef` was not passing the agent's `workspaceDir` to `loadWebMedia`'s `localRoots` option. This caused `loadWebMedia` to fall back to default roots which only include the default workspace, rejecting images staged in named agent workspaces.

## Root Cause

In `src/agents/embedded-agent-runner/run/images.ts`, the `loadMediaFromRef` function had this logic:

```ts
options?.workspaceOnly || options?.localRoots
  ? { maxBytes: options.maxBytes, localRoots: options.localRoots ?? [workspaceDir] }
  : options?.maxBytes
```

When `workspaceOnly` is false and no explicit `localRoots` are provided, the code passed only `maxBytes` as a number to `loadWebMedia`, which then used `getDefaultLocalRootsCore()` — containing only the default workspace, not named agent workspaces.

## Fix

- Added `workspaceDir` to `MediaFileRef` type (moved from `MediaImageRef` since it's applicable to all media refs)
- In `loadMediaFromRef`, include `ref.workspaceDir` in `localRoots` when `workspaceOnly` is false and no explicit `localRoots` are provided

## Testing

- All existing tests pass: `npx vitest run src/agents/embedded-agent-runner/run/images.test.ts src/agents/embedded-agent-runner/run/images.media-refs.test.ts`

Fixes #123273