### PR TITLE
fix(workboard): guard execution slot consumption with done-card check

### DIFF
--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -262,7 +262,7 @@ function selectStartableCards(
       !isWorkboardClaimReclaimable(claim, now) &&
       (card.status === "running" ||
         (card.status !== "done" && cardHasActiveClaim(card, now)) ||
-        card.execution?.status === "running");
+        (card.status !== "done" && card.execution?.status === "running"));
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }


### PR DESCRIPTION
## Summary

A dead worker run's execution record (status: "running") was permanently starving its agent's dispatch lane because `selectStartableCards` counted it toward owner concurrency even after the card was completed. The claim arm had a `card.status !== "done"` guard, but the execution arm did not.

## Root Cause

In `extensions/workboard/src/dispatcher.ts` L258-L272:

```ts
const consumesOwnerSlot =
  !isWorkboardClaimReclaimable(claim, now) &&
  (card.status === "running" ||
    (card.status !== "done" && cardHasActiveClaim(card, now)) ||
    card.execution?.status === "running");   // <-- no done-card guard
```

`runningByOwner` is built from **all** cards ("Owner capacity is global"), so one zombie anywhere starves the owner everywhere. The later skip is a bare `continue` — the starved card appears in neither `started` nor `startFailures`.

## Fix

Added the same done-card guard to the execution arm:

```ts
(card.status !== "done" && card.execution?.status === "running")
```

A done card's execution cannot be doing work, so it should not consume the owner's dispatch slot.

## Testing

- All existing tests pass: `npx vitest run extensions/workboard/src/dispatcher.test.ts extensions/workboard/src/dispatcher.races.test.ts extensions/workboard/src/dispatcher-ownership.test.ts`

Fixes #122911