### PR TITLE
fix(plugin-sdk): re-export privateFileStore from security-runtime

### DIFF
--- a/src/plugin-sdk/security-runtime.ts
+++ b/src/plugin-sdk/security-runtime.ts
@@ -67,7 +67,7 @@ export {
   resolveAbsolutePathForWrite,
 } from "../infra/fs-safe.js";
 export { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
-export { privateFileStoreSync } from "../infra/private-file-store.js";
+export { privateFileStore, privateFileStoreSync } from "../infra/private-file-store.js";
 export { movePathWithCopyFallback, replaceFileAtomic } from "../infra/replace-file.js";
 
 export { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "../infra/fs-safe-advanced.js";


### PR DESCRIPTION
## Summary

The public `plugin-sdk/security-runtime` facade was exporting `privateFileStoreSync` but not its async counterpart `privateFileStore`. This caused the official `@openclaw/discord` plugin (latest tag) to fail registration on core 2026.8 with:

```
SyntaxError: The requested module 'openclaw/plugin-sdk/security-runtime'
does not provide an export named 'privateFileStore'
```

## Root Cause

In `src/plugin-sdk/security-runtime.ts`, only `privateFileStoreSync` was re-exported:

```ts
export { privateFileStoreSync } from "../infra/private-file-store.js";
```

The underlying `privateFileStore` function still exists in the core (`src/infra/private-file-store.ts` exports both), so this was an accidental gap in the facade.

## Fix

Added `privateFileStore` to the re-export:

```ts
export { privateFileStore, privateFileStoreSync } from "../infra/private-file-store.js";
```

## Testing

- Plugin compat tests pass: `npx vitest run src/plugins/compat/registry.test.ts`

Fixes #122655