### PR TITLE
fix(media-understanding): omit implicit English audio prompt on language autodetect

### DIFF
--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -508,18 +508,39 @@ describe("runCapability auto audio entries", () => {
         models: [{ provider: "openai", model: "whisper-1" }],
       });
     }
-    await runCase({
-      enabled: true,
-      models: [{ provider: "openai", model: "whisper-1" }],
-    });
 
     expect(seenPrompts).toEqual([
       "Transcribe in Russian.",
       "Transcribe the audio.",
       "Transcribe the audio.",
       "Transcribe the audio.",
-      "Transcribe the audio.",
     ]);
+  });
+
+  it("omits the implicit English audio prompt when no language is configured (autodetect)", async () => {
+    let seenPrompt: string | undefined;
+    let seenLanguage: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenPrompt = req.prompt;
+        seenLanguage = req.language;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            models: [{ provider: "openai", model: "whisper-1", capabilities: ["audio"] }],
+            audio: {
+              enabled: true,
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenLanguage).toBeUndefined();
+    expect(seenPrompt).toBeUndefined();
   });
 
   it("uses mistral when only mistral key is configured", async () => {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -452,20 +452,23 @@ function resolveAudioProviderPrompt(params: {
   hasConfiguredPrompt: boolean;
   language?: string;
 }): string | undefined {
+  if (params.hasConfiguredPrompt) {
+    return params.prompt;
+  }
   const language = params.language?.trim().toLowerCase();
-  const isEnglish =
-    !language ||
+  const isExplicitEnglish =
     language === "en" ||
     language === "eng" ||
     language === "english" ||
-    language.startsWith("en-") ||
-    language.startsWith("en_");
-  if (params.hasConfiguredPrompt || isEnglish) {
+    language?.startsWith("en-") === true ||
+    language?.startsWith("en_") === true;
+  if (isExplicitEnglish) {
     return params.prompt;
   }
   // OpenAI-compatible transcription prompts guide style/context and should
-  // match the audio language; omit OpenClaw's English default for non-English
-  // language hints unless the user supplied an explicit prompt.
+  // match the audio language; omit OpenClaw's English default when no
+  // language is configured (autodetect) or a non-English language hint is
+  // set, unless the user supplied an explicit prompt.
   return undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves

When `tools.media.audio.language` is omitted (autodetect) and no custom prompt is configured, the default English prompt `Transcribe the audio.` was forwarded to the transcription provider. Groq Whisper can echo that prompt verbatim into the transcript, contaminating the user message and causing the downstream agent to misinterpret the suffix as a user instruction.

## Root Cause

`resolveAudioProviderPrompt()` treated `!language` (no language configured) as English via the `isEnglish` check, so the autodetect path forwarded the implicit English default prompt to the provider.

## Fix

Distinguish "no language configured" (autodetect) from "explicit English language hint". The implicit English default prompt is now only forwarded when:
- An explicit prompt is configured (`hasConfiguredPrompt`), OR
- An explicit English language hint is set (`en`, `eng`, `english`, `en-*`, `en_*`)

On the autodetect path (no language configured), the prompt is omitted, preserving real provider language autodetection without injecting an instruction-style English prompt.

## Evidence

### Before (current main)

```ts
const isEnglish =
  !language ||          // ← autodetect treated as English
  language === "en" ||
  language === "eng" ||
  language === "english" ||
  language.startsWith("en-") ||
  language.startsWith("en_");
if (params.hasConfiguredPrompt || isEnglish) {
  return params.prompt;  // ← "Transcribe the audio." sent to provider
}
```

With `language = undefined` (autodetect): `isEnglish = true` → default prompt forwarded.

### After (this PR)

```ts
if (params.hasConfiguredPrompt) {
  return params.prompt;  // explicit prompt always preserved
}
const isExplicitEnglish =
  language === "en" ||
  language === "eng" ||
  language === "english" ||
  language?.startsWith("en-") === true ||
  language?.startsWith("en_") === true;
if (isExplicitEnglish) {
  return params.prompt;  // explicit English hint preserved
}
return undefined;  // autodetect: NO prompt sent
```

With `language = undefined` (autodetect): `isExplicitEnglish = false` → `undefined` returned → prompt field omitted from provider request.

### Request construction proof

The `audioPrompt` value flows into `buildRequest()` at runner.entries.ts:869, which passes `prompt: audioPrompt` to `transcribeAudio()`. When `audioPrompt` is `undefined`, the prompt field is `undefined` and not serialized into the provider HTTP request.

### Test coverage

- `omits the implicit English audio prompt when no language is configured (autodetect)` — verifies both `prompt` and `language` are `undefined` on the autodetect path ✓
- `omits the implicit English audio prompt when a non-English language is configured` — verifies non-English hints omit the default ✓
- `keeps explicit and English-compatible audio prompts` — verifies explicit prompts and explicit English hints are preserved ✓
- All 13 auto-audio tests pass ✓

Fixes #123305