### PR TITLE
fix(agents): defer auth republication to a superseding config publication

### DIFF
--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
+  loadPublishedGatewayReplyDispatchRuntime,
   markPreparedModelRuntimeSnapshotsStale,
   prepareModelRuntimeSnapshot,
   publishPreparedModelRuntimeSnapshot,
@@ -821,6 +822,66 @@ describe("prepared model runtime snapshots", () => {
     finishAuthRefresh?.();
     await publication;
     expect(settled).toBe(true);
+  });
+
+  it("defers an in-flight auth refresh to a superseding config publication", async () => {
+    mocks.configuredAgentIds = ["default"];
+    await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
+    let finishAuthRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+        }),
+    );
+
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+    const reload = refreshPreparedModelRuntimeSnapshots(
+      { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      { gatewayLifecycle: true },
+    );
+    finishAuthRefresh?.();
+    await reload;
+    unregister();
+
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ agentId: "default" });
+  });
+
+  it("does not announce an auth republication while a config replacement gate is pending", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const replacementConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    const publishedSnapshots: Array<ReturnType<typeof getPreparedModelRuntimeSnapshot>> = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        publishedSnapshots.push(
+          getPreparedModelRuntimeSnapshot({
+            agentId: "default",
+            agentDir: "/tmp/unused-agent",
+            inheritedAuthDir: "/tmp/unused-agent",
+            config: replacementConfig,
+          }),
+        );
+      }
+    });
+
+    // The mutation queues an auth task; the synchronous stale edge of the config
+    // refresh opens the replacement gate before that task runs.
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
+    unregister();
+
+    expect(publishedSnapshots).toHaveLength(1);
+    expect(publishedSnapshots[0]).toMatchObject({ config: replacementConfig });
   });
 
   it("invalidates and refreshes the affected owner at auth publication", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -631,7 +631,17 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });
   pendingAuthMutations.push(normalizedEvent);
   void enqueuePreparedModelRuntimePublication(async () => {
+    // A pending replacement gate means a queued config publication owns the next generation:
+    // it drains queued auth mutations against the new config and rebuilds/announces the
+    // dispatch publication. Rebuilding here would revive stale owners with the old config or
+    // throw on them, emitting a spurious failed/published event that wedges chat metadata.
+    if (pendingModelRuntimeReplacement) {
+      return;
+    }
     await drainPendingAuthMutations();
+    if (pendingModelRuntimeReplacement) {
+      return;
+    }
     replyDispatchPublication.rebuild(owners.values());
     notifyPreparedModelRuntimePublication({ phase: "published" });
   }).catch((error: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

Every config hot reload (e.g. `openclaw config set ...` against a running gateway) raced the auth-mutation refresh task on the prepared model runtime publication tail. When the reload superseded a queued auth refresh, the task still ran against invalidated owners, producing two user-visible failures on the default fresh-install OpenAI path:

1. `auth-triggered model runtime refresh failed: prepared reply dispatch runtime owner was not published for main` logged on every config hot reload (spurious `phase: 'failed'` publication event).
2. A permanent `chat.metadata` UNAVAILABLE wedge: a spurious `phase: 'published'` event fired while the replacement gate was still pending, the chat metadata lifecycle refreshed, `captureGenerationFacts` saw an undefined snapshot, `ChatMetadataSnapshotUnavailableError` latched with `preparedModelRuntimeAvailable=false`, and Control UI web chat stayed wedged until gateway restart (CLI turns kept working, masking it).

## Why This Change Was Made

Root cause: `invalidateForAuthMutation` in `src/agents/prepared-model-runtime.ts` queued a publication task that unconditionally drained pending auth mutations and rebuilt/announced the reply dispatch publication, even when `markPreparedModelRuntimeSnapshotsStale` had already marked every owner stale and opened a replacement gate (`pendingModelRuntimeReplacement`). The superseding config publication already owns that work: `refreshPreparedModelRuntimeSnapshots` drains the queued auth mutations against the new config before its own rebuild and announcement. The auth task now fails closed against a pending replacement gate — checked both before and after its own drain (the drain awaits, so the gate can open mid-task) — so deferring loses nothing and no stale owner is ever revived or announced.

## User Impact

Operators on the default path no longer see a runtime error logged on every config hot reload, and web chat metadata can no longer permanently wedge (UNAVAILABLE until restart) after a reload races an auth refresh. No config, API, or behavior surface changes beyond removing the erroneous events.

## Evidence

- Two regression tests in `src/agents/prepared-model-runtime.lifecycle.test.ts` reproduce both failure shapes (spurious failed event; spurious published event while gate pending) and fail on pre-fix code.
- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts` — 44/44 passed (rerun after rebase onto latest `origin/main`).
- Full prepared-model-runtime suites green pre-rebase: 44/44, 67/67, 30/30.
- Production LOC delta: +10 (two fail-closed gate checks plus the invariant comment); tests +61.
- Autoreview clean (0.96, no actionable findings).
