### PR TITLE
fix(gateway): avoid stale session failure during model fallback

### DIFF
--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -454,6 +454,7 @@ type AgentRunLifecycleTerminalData = Omit<AgentRunTerminalWaitInput, "status"> &
   fallbackExhaustedFailure?: unknown;
   status?: unknown;
 };
+type AgentRunLifecycleInput = { phase?: unknown; data?: AgentRunLifecycleTerminalData };
 
 /** Shared grace window for terminal observations that may still be followed by a retry. */
 export const AGENT_RUN_TERMINAL_RETRY_GRACE_MS = 15_000;
@@ -621,8 +622,7 @@ export function buildAgentRunTerminalOutcomeFromLifecycleEvent(input: {
 }
 
 /** True for lifecycle events that cannot be followed by a same-run retry. */
-export function isDefinitiveRunLifecycle(input: { phase?: unknown; data?: unknown }) {
-  const data = input.data as AgentRunLifecycleTerminalData | undefined;
+export function isDefinitiveRunLifecycle(input: AgentRunLifecycleInput) {
   if (input.phase === "end") {
     return true;
   }
@@ -631,10 +631,10 @@ export function isDefinitiveRunLifecycle(input: { phase?: unknown; data?: unknow
   }
   const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
     phase: "error",
-    data,
+    data: input.data,
   });
   return (
-    data?.fallbackExhaustedFailure === true ||
+    input.data?.fallbackExhaustedFailure === true ||
     classifyAgentRunTerminalOutcome(outcome) !== "failure"
   );
 }

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -454,7 +454,7 @@ type AgentRunLifecycleTerminalData = Omit<AgentRunTerminalWaitInput, "status"> &
   fallbackExhaustedFailure?: unknown;
   status?: unknown;
 };
-type AgentRunLifecycleInput = { phase?: unknown; data?: AgentRunLifecycleTerminalData };
+type AgentRunLifecycleInput = { phase?: unknown; data?: Record<string, unknown> };
 
 /** Shared grace window for terminal observations that may still be followed by a retry. */
 export const AGENT_RUN_TERMINAL_RETRY_GRACE_MS = 15_000;

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -451,6 +451,7 @@ type AgentRunTerminalWaitInput = Omit<AgentRunTerminalInput, "status"> & {
 
 type AgentRunLifecycleTerminalData = Omit<AgentRunTerminalWaitInput, "status"> & {
   aborted?: unknown;
+  fallbackExhaustedFailure?: unknown;
   status?: unknown;
 };
 
@@ -617,6 +618,25 @@ export function buildAgentRunTerminalOutcomeFromLifecycleEvent(input: {
     endedAt: input.endedAt ?? data?.endedAt,
   });
   return stopReason && outcome.stopReason !== stopReason ? { ...outcome, stopReason } : outcome;
+}
+
+/** True for lifecycle events that cannot be followed by a same-run retry. */
+export function isDefinitiveRunLifecycle(input: { phase?: unknown; data?: unknown }) {
+  const data = input.data as AgentRunLifecycleTerminalData | undefined;
+  if (input.phase === "end") {
+    return true;
+  }
+  if (input.phase !== "error") {
+    return false;
+  }
+  const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
+    phase: "error",
+    data,
+  });
+  return (
+    data?.fallbackExhaustedFailure === true ||
+    classifyAgentRunTerminalOutcome(outcome) !== "failure"
+  );
 }
 
 function hasNestedAbortReason(value: unknown, matches: (candidate: unknown) => boolean): boolean {

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -297,12 +297,6 @@ export async function defaultPersistDigest(params: {
   return missingEntry ? null : false;
 }
 
-export function isTerminalLifecycleEvent(event: AgentEventPayload): boolean {
-  return (
-    event.stream === "lifecycle" && (event.data.phase === "end" || event.data.phase === "error")
-  );
-}
-
 export async function synthesizeSessionObserverTerminalDigest(params: {
   source: { event?: AgentEventPayload; state?: SessionObserverState };
   dormant?: DormantSessionObserverRun;

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -225,6 +225,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
         startedAt: 0,
         endedAt: 30_000,
         error: "test failure",
+        ...(phase === "error" ? { fallbackExhaustedFailure: true } : {}),
       });
 
       expect(harness.completeModel).not.toHaveBeenCalled();
@@ -289,6 +290,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
       startedAt: 0,
       endedAt: 36_000,
       error: "run failed",
+      fallbackExhaustedFailure: true,
     });
 
     expect(completeModel).toHaveBeenCalledTimes(3);
@@ -420,11 +422,53 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
       startedAt: 0,
       endedAt: 30_000,
       error: "test failure",
+      ...(phase === "error" ? { fallbackExhaustedFailure: true } : {}),
     });
 
     expect(harness.broadcastToConnIds).toHaveBeenCalledOnce();
     const digest = broadcastDigest(harness);
     expect(digest?.health).toBe(expected);
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+  });
+
+  it("does not finalize a retryable attempt error before same-run fallback succeeds", async () => {
+    useFakeTime();
+    const harness = createHarness();
+    harness.observer.handleEvent(lifecycleEvent({ phase: "start", startedAt: 0 }));
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    harness.observer.handleEvent(
+      lifecycleEvent({ phase: "error", endedAt: 30_000, error: "retryable provider failure" }),
+    );
+    await flushObserver();
+    expect(vi.getTimerCount()).toBe(1);
+    harness.observer.handleEvent(lifecycleEvent({ phase: "start", startedAt: 30_000 }));
+    expect(vi.getTimerCount()).toBe(0);
+    vi.setSystemTime(60_000);
+    await handleLifecycle(harness, { phase: "end", endedAt: 60_000 });
+
+    expect(observerBroadcasts(harness).map((call) => call[1])).toEqual([
+      expect.objectContaining({ health: "done" }),
+    ]);
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+  });
+
+  it("finalizes an unrecovered attempt error after the retry grace", async () => {
+    useFakeTime();
+    const harness = createHarness();
+    harness.observer.handleEvent(lifecycleEvent({ phase: "start", startedAt: 0 }));
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    harness.observer.handleEvent(
+      lifecycleEvent({ phase: "error", endedAt: 30_000, error: "provider failed" }),
+    );
+    await flushObserver();
+    expect(observerBroadcasts(harness)).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await advanceAndFlush(15_000);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(broadcastDigest(harness)).toMatchObject({ health: "failed" });
     expect(harness.persistDigest).toHaveBeenCalledOnce();
   });
 
@@ -610,7 +654,12 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     const guard = persistGuard(harness);
     expect(guard?.()).toBe(true);
 
+    harness.observer.handleEvent(
+      lifecycleEvent({ phase: "error", error: "retryable provider failure" }),
+    );
+    expect(vi.getTimerCount()).toBe(1);
     harness.observer.handleEvent(lifecycleEvent({ phase: "start" }, { runId: "run-2" }));
+    expect(vi.getTimerCount()).toBe(0);
     expect(guard?.()).toBe(false);
   });
 
@@ -702,8 +751,13 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     await advanceAndFlush(12_000);
     const guard = persistGuard(harness);
     expect(guard?.()).toBe(true);
+    harness.observer.handleEvent(
+      lifecycleEvent({ phase: "error", error: "retryable provider failure" }),
+    );
+    expect(vi.getTimerCount()).toBe(1);
     harness.observer.dispose();
     activeHarnesses.delete(harness);
+    expect(vi.getTimerCount()).toBe(0);
     expect(guard?.()).toBe(false);
   });
 

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -644,7 +644,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     expect(terminalBroadcasts).toHaveLength(0);
   });
 
-  it("invalidates the persist-time guard when a newer run replaces the digest's run", async () => {
+  it("invalidates the persist-time guard when a newer run replaces a dormant run", async () => {
     useFakeTime();
     const persistDigest = vi.fn(async (_params: PersistDigestParams) => undefined);
     const harness = createHarness({ persistDigest });
@@ -653,6 +653,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     expect(persistDigest).toHaveBeenCalledOnce();
     const guard = persistGuard(harness);
     expect(guard?.()).toBe(true);
+    harness.observer.setConnectionVisibility("conn-1", false);
 
     harness.observer.handleEvent(
       lifecycleEvent({ phase: "error", error: "retryable provider failure" }),

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -221,6 +221,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   };
 
   const suspendStatesWithoutAudience = () => {
+    // Map iteration tolerates suspendState deleting the current entry.
     for (const state of states.values()) {
       if (!audience.has(state.sessionKey, state.agentId)) {
         suspendState(state);
@@ -724,8 +725,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     getCompanionSnapshot,
     dispose() {
       disposed = true;
-      pendingTerminalErrors.forEach(clearTimeoutFn);
-      pendingTerminalErrors.clear();
+      pendingTerminalErrors.forEach((_timer, runId) => clearPendingTerminalError(runId));
       preamblePublisher.dispose();
       unsubscribeChanges();
       for (const state of states.values()) {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -221,7 +221,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   };
 
   const suspendStatesWithoutAudience = () => {
-    // Map iteration tolerates suspendState deleting the current entry.
     for (const state of states.values()) {
       if (!audience.has(state.sessionKey, state.agentId)) {
         suspendState(state);
@@ -636,6 +635,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         }
         for (const run of superseded) {
           markSessionObserverRunSuperseded(supersededRuns, run.runId, event.ts);
+          clearPendingTerminalError(run.runId);
           dormantRuns.delete(run.runId);
         }
       }

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -1,6 +1,10 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import {
+  AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
+  isDefinitiveRunLifecycle,
+} from "../agents/agent-run-terminal-outcome.js";
+import {
   createSessionActivityNoteState,
   flushSessionActivityAssistantNote,
   noteSessionActivityEvent,
@@ -20,7 +24,6 @@ import {
   defaultPersistDigest,
   defaultPrepareModel,
   defaultReadSession,
-  isTerminalLifecycleEvent,
   markSessionObserverRunSuperseded,
   rememberSessionObserverDisabledRun,
   rememberSessionObserverDormantRun,
@@ -64,9 +67,14 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const supersededRuns = new Map<string, number>();
   const contextlessTerminalRuns = new Map<string, number>();
   const terminalRuns = new Map<string, number>();
+  const pendingTerminalErrors = new Map<string, ReturnType<typeof setTimeout>>();
   const disabledRuns = new Set<string>();
   const visibleConnections = new Set<string>();
   let disposed = false;
+  const clearPendingTerminalError = (runId: string) => {
+    clearTimeoutFn(pendingTerminalErrors.get(runId));
+    pendingTerminalErrors.delete(runId);
+  };
   const getCompanionSnapshot = createSessionObserverCompanionSnapshotReader({
     getConfig: deps.getConfig,
     readSession,
@@ -213,8 +221,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   };
 
   const suspendStatesWithoutAudience = () => {
-    // suspendState deletes from `states`; Map iteration tolerates removal of
-    // the entry being visited.
+    // Map iteration tolerates suspendState deleting the current entry.
     for (const state of states.values()) {
       if (!audience.has(state.sessionKey, state.agentId)) {
         suspendState(state);
@@ -333,8 +340,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     state.lastRunAt = now();
     const lastSelectedSequence = selectedNotes.at(-1)?.sequence ?? state.lastDigestNoteSequence;
     const retireSelectedNotes = () => {
-      // Run rollover replaces the state object, and inFlight serializes its slots;
-      // stale work can only retire this run's own notes, monotonically.
+      // Run rollover replaces state; inFlight keeps its note retirement monotonic.
       state.lastDigestNoteSequence = Math.max(state.lastDigestNoteSequence, lastSelectedSequence);
     };
     const requestGeneration = modelSlots.beginRequest(state);
@@ -515,11 +521,22 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     return state;
   };
 
-  const handleEvent = (event: SessionObserverEvent) => {
+  const handleEvent = (event: SessionObserverEvent, settledError = false) => {
     if (disposed || getAgentRunContext(event.runId)?.isHeartbeat) {
       return;
     }
-    const terminal = isTerminalLifecycleEvent(event);
+    const lifecyclePhase = event.stream === "lifecycle" ? event.data.phase : undefined;
+    const terminal =
+      settledError || isDefinitiveRunLifecycle({ phase: lifecyclePhase, data: event.data });
+    if (lifecyclePhase === "error" && !terminal) {
+      clearPendingTerminalError(event.runId);
+      const timer = setTimeoutFn(() => handleEvent(event, true), AGENT_RUN_TERMINAL_RETRY_GRACE_MS);
+      pendingTerminalErrors.set(event.runId, timer);
+      return;
+    }
+    if (terminal || lifecyclePhase === "start") {
+      clearPendingTerminalError(event.runId);
+    }
     if (terminalRuns.has(event.runId)) {
       return;
     }
@@ -589,6 +606,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         revisionFloor = candidate;
       }
       const supersededRunId = state.runId;
+      clearPendingTerminalError(supersededRunId);
       if (isRunStart) {
         markSessionObserverRunSuperseded(supersededRuns, supersededRunId, event.ts);
       }
@@ -706,6 +724,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     getCompanionSnapshot,
     dispose() {
       disposed = true;
+      pendingTerminalErrors.forEach(clearTimeoutFn);
+      pendingTerminalErrors.clear();
       preamblePublisher.dispose();
       unsubscribeChanges();
       for (const state of states.values()) {

--- a/src/gateway/worker-environments/live-event-projection.ts
+++ b/src/gateway/worker-environments/live-event-projection.ts
@@ -1,4 +1,5 @@
 import type { WorkerLiveEventParams } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { isDefinitiveRunLifecycle } from "../../agents/agent-run-terminal-outcome.js";
 import {
   capLiveExecResult,
   sanitizeToolArgs,
@@ -40,9 +41,7 @@ export function prepareWorkerLiveEventData(
 export function isDefinitiveWorkerTerminalEvent(event: WorkerLiveEventParams["event"]): boolean {
   return (
     event.kind === "lifecycle" &&
-    (event.payload.phase === "end" ||
-      (event.payload.phase === "error" &&
-        (event.payload.aborted === true || event.payload.fallbackExhaustedFailure === true)))
+    isDefinitiveRunLifecycle({ phase: event.payload.phase, data: event.payload })
   );
 }
 


### PR DESCRIPTION
Related: #64051

## What Problem This Solves

Fixes an issue where users watching an active session could see a stale failed observer status when a retryable provider attempt emitted an error before the same run restarted and completed through model fallback.

## Why This Change Was Made

The repair keeps terminal precedence in the canonical agent-run terminal outcome owner: lifecycle end, abort/cancellation/timeout, and exhausted fallback are definitive, while an ordinary failure remains provisional for the existing 15-second retry grace. The session observer independently owns its keyed grace timers and clears them on same-run restart/completion, active or dormant supersession, and disposal; worker projection reuses the same classifier instead of maintaining duplicate policy.

The production delta is the explicitly approved coherent-owner exception: +49/-16, net +33. Those lines remove observer and worker classification duplication while preserving their separate lifecycle state ownership. There is no protocol, configuration, persistence, authentication, or SQLite change.

## User Impact

Session observer health now follows the final run outcome during model fallback instead of publishing a premature failure. Definitive failures still settle immediately, and an unrecovered ordinary failure still settles once when the existing retry grace expires.

## Evidence

- Exact head: `8a8baf274a8d8b014ad0d8728c3c65782fff5739`.
- Original-order negative control: restoring the pre-fix terminal predicate made `start -> provisional error -> same-run restart -> end` fail because no grace timer was created (`0`, expected `1`). Restoring the repair passed the same test.
- Dormant replacement negative control: before the final cleanup line, the strengthened replacement test retained one timer after supersession; the repaired path clears it and passes.
- Focused and sibling tests: 72/72 passed (`session-observer.terminal.test.ts` plus worker `live-events.test.ts`).
- Private-QA build passed on Blacksmith Testbox `tbx_01m04jtnasksma3m41ps4gvfb9`, run [31930592699](https://github.com/openclaw/openclaw/actions/runs/31930592699). One unchanged rerun was needed after the Control UI gzip ratchet fluctuated four bytes over its tolerance; the passing build measured `335434 <= 335447` bytes.
- Real ephemeral Gateway QA passed 1/1 with qa-channel + QA Lab + mock-openai: three primary requests, one fallback request, and exactly one visible `MODEL-FALLBACK-VISIBLE-OK` reply.
- Exact-path `check:changed`, production and test types, full lint, repo-wide format, import cycles, and diff hygiene passed; runtime value cycles: 0.
- Fresh Codex autoreview: clean, no accepted/actionable findings; overall correctness 0.98.
- Production LOC: +49/-16 (net +33, explicitly approved coherent-owner exception). Tests: +56/-1.

No changelog entry is included: `CHANGELOG.md` is release-only under repository policy.

AI-assisted: yes. The implementation and lifecycle ownership were inspected and verified by the maintainer workflow.
