### PR TITLE
perf(test): make Workshop contention deterministic

### DIFF
--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
-import { withSkillCollectionLock } from "../../skills/workshop/target-lock.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -10,10 +9,36 @@ import {
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
 
+const commitLockState = vi.hoisted(() => ({ active: false, calls: 0 }));
+
+vi.mock("../../skills/workshop/target-lock.js", () => ({
+  withSkillCollectionLock: async (_workspaceDir: string, fn: () => Promise<unknown>) => await fn(),
+  withSkillProposalTargetLock: async (_record: unknown, fn: () => Promise<unknown>) => await fn(),
+  withSkillProposalCommitLock: async (
+    _workspaceDir: string,
+    _record: unknown,
+    fn: () => Promise<unknown>,
+  ) => {
+    if (commitLockState.active) {
+      throw new Error("skill proposal reconciliations overlapped");
+    }
+    commitLockState.active = true;
+    commitLockState.calls += 1;
+    await Promise.resolve();
+    try {
+      return await fn();
+    } finally {
+      commitLockState.active = false;
+    }
+  },
+}));
+
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 
 beforeEach(async () => {
+  commitLockState.active = false;
+  commitLockState.calls = 0;
   testState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-skill-workshop-list-state-",
@@ -69,51 +94,26 @@ describe("skill_workshop list", () => {
       })),
     );
 
-    let releaseLock: (() => void) | undefined;
-    let markAcquired: (() => void) | undefined;
-    const acquired = new Promise<void>((resolve) => {
-      markAcquired = resolve;
-    });
-    const heldLock = withSkillCollectionLock(
-      workspaceDir,
-      async () => {
-        markAcquired?.();
-        await new Promise<void>((resolve) => {
-          releaseLock = resolve;
-        });
-      },
-      { env: testState.env },
-    );
-    await acquired;
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-    const releaseTimer = setTimeout(() => releaseLock?.(), 4_600);
-
-    try {
-      for (const [limit, expectedCount] of [
-        [49, 49],
-        [50, 50],
-        [51, 50],
-      ] as const) {
-        const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
-        const proposals = (result.details as { proposals: Array<{ status: string }> }).proposals;
-        expect(proposals).toHaveLength(expectedCount);
-        expect(proposals.every((proposal) => proposal.status === "stale")).toBe(true);
-      }
-
-      await expect(
-        tool.execute("call-list-last", {
-          action: "list",
-          query: "Limit Proposal 50",
-          limit: 1,
-        }),
-      ).resolves.toMatchObject({
-        details: { proposals: [expect.objectContaining({ status: "stale" })] },
-      });
-    } finally {
-      clearTimeout(releaseTimer);
-      releaseLock?.();
-      await heldLock;
-      randomSpy.mockRestore();
+    for (const [limit, expectedCount] of [
+      [49, 49],
+      [50, 50],
+      [51, 50],
+    ] as const) {
+      const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
+      const proposals = (result.details as { proposals: Array<{ status: string }> }).proposals;
+      expect(proposals).toHaveLength(expectedCount);
+      expect(proposals.every((proposal) => proposal.status === "stale")).toBe(true);
     }
-  }, 15_000);
+
+    await expect(
+      tool.execute("call-list-last", {
+        action: "list",
+        query: "Limit Proposal 50",
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({
+      details: { proposals: [expect.objectContaining({ status: "stale" })] },
+    });
+    expect(commitLockState.calls).toBe(51);
+  });
 });

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -842,6 +842,13 @@ describe("skill collection reconciliation", () => {
       { env: testState.env },
     );
     await acquired;
+    const startedAt = performance.now();
+    const clockSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(startedAt)
+      .mockReturnValueOnce(startedAt + 5_001)
+      .mockReturnValueOnce(startedAt)
+      .mockReturnValue(startedAt + 5_001);
 
     try {
       await Promise.all([
@@ -858,6 +865,7 @@ describe("skill collection reconciliation", () => {
         }),
       ]);
     } finally {
+      clockSpy.mockRestore();
       releaseLock?.();
       await heldLock;
     }


### PR DESCRIPTION
## What Problem This Solves

Two Skill Workshop contention regressions spend almost ten seconds near production lease deadlines: the list-tool test holds a collection lock for 4.6 seconds to detect accidental parallel reconciliation, and the real lease-timeout test waits the full five-second acquisition budget.

## Why This Change Was Made

Split the invariants at their actual owners:

- The list-tool test now wraps the existing Workshop lock module with an exact test factory that rejects overlapping commit-lock entries. It still creates and reconciles all 51 real proposals, preserves pagination and stale-status assertions, and deterministically proves that `listSkillProposals` processes reconciliations serially.
- The collection test still holds the real SQLite collection lease and invokes both real proposal read paths. It advances only the monotonic acquisition clock past the five-second deadline so both callers return the real typed `OPENCLAW_STATE_LEASE_TIMEOUT` without sleeping.

Real lock blocking, rollback serialization, and cross-process lease behavior remain covered by the collection and plugin lifecycle suites. Production code and lease policy are unchanged.

## User Impact

Maintainer Skill Workshop test feedback is substantially faster and the serialization regression now fails immediately rather than indirectly near a deadline.

## Evidence

Controlled same-Testbox A/B on `tbx_01m04g95378a8095c9gtat86j4`, one excluded warmup plus two retained samples per state, the same two-file command, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 27.22s | 17.44s | -9.79s (-35.9%) |
| Summed Vitest | 21.78s | 11.90s | -45.4% |
| Test body | 13.23s | 3.42s | -74.2% |
| Imports | 7.34s | 7.26s | effectively flat |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 32/32 Workshop list, collection reconciliation, and plugin lifecycle lease tests.
- Full core changed gate on the retained Testbox, including assertion-safety, core-test typecheck, and targeted lint.
- Fresh post-rebase Codex autoreview: no accepted/actionable findings.
- Mutation: restoring `Promise.all` in `listSkillProposals` fails immediately with `skill proposal reconciliations overlapped`.
- Real SQLite timeout assertions still return `OPENCLAW_STATE_LEASE_TIMEOUT` for both list and inspect callers.
- Production LOC: `+0/-0`; test LOC: `+55/-47`.

Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/31928815959
