### PR TITLE
fix(ui): complete stale header outcome ownership

### DIFF
--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -1,4 +1,7 @@
-import { expect, it } from "vitest";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { beforeAll, expect, it } from "vitest";
 import {
   chatSessionListResponse,
   controlUiSessionPath,
@@ -7,14 +10,56 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "header-outcomes-followup",
+);
+
+async function capture(page: Page, name: string): Promise<void> {
+  if (captureProof) {
+    await page.screenshot({ path: path.join(proofDir, name) });
+  }
+}
+
+async function navigateAwayAndBack(page: Page, sessionA: string, sessionB: string): Promise<void> {
+  for (const sessionKey of [sessionB, sessionA]) {
+    await page
+      .locator(
+        `.sidebar-recent-session[data-session-key="${sessionKey}"] a.sidebar-recent-session__link`,
+      )
+      .click();
+    await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionKey));
+    await expect
+      .poll(() =>
+        page
+          .locator(".chat-pane-cache__pane--visible")
+          .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
+      )
+      .toBe(sessionKey);
+  }
+}
+
+function proofContextOptions() {
+  return {
+    locale: "en-US",
+    serviceWorkers: "block" as const,
+    viewport: { height: 900, width: 1280 },
+    ...(captureProof ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } } : {}),
+  };
+}
 
 suite.define(() => {
+  beforeAll(async () => {
+    if (captureProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+  });
+
   it("does not resurrect a reveal failure after navigating away", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(proofContextOptions());
     const page = await context.newPage();
     const sessionA = "agent:main:session-a";
     const sessionB = "agent:main:session-b";
@@ -49,32 +94,7 @@ suite.define(() => {
       await page.getByRole("menuitem", { name: "Open in file manager" }).click();
       await gateway.waitForRequest("sessions.files.reveal");
 
-      await page
-        .locator(
-          `.sidebar-recent-session[data-session-key="${sessionB}"] a.sidebar-recent-session__link`,
-        )
-        .click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionB));
-      await expect
-        .poll(() =>
-          page
-            .locator(".chat-pane-cache__pane--visible")
-            .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
-        )
-        .toBe(sessionB);
-      await page
-        .locator(
-          `.sidebar-recent-session[data-session-key="${sessionA}"] a.sidebar-recent-session__link`,
-        )
-        .click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionA));
-      await expect
-        .poll(() =>
-          page
-            .locator(".chat-pane-cache__pane--visible")
-            .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
-        )
-        .toBe(sessionA);
+      await navigateAwayAndBack(page, sessionA, sessionB);
       await gateway.resolveDeferred("sessions.files.reveal", {
         ok: false,
         error: "Stale reveal failure must stay retired.",
@@ -96,6 +116,124 @@ suite.define(() => {
           }),
         )
         .not.toBe("Stale reveal failure must stay retired.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("does not resurrect a placement reclaim failure after navigating away", async () => {
+    const context = await suite.newBrowserContext(proofContextOptions());
+    const page = await context.newPage();
+    const sessionA = "agent:main:placement-a";
+    const sessionB = "agent:main:placement-b";
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.startup", "sessions.reclaim"],
+      historyMessages: [{ role: "assistant", content: "Placement outcome proof." }],
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            key: sessionA,
+            kind: "direct",
+            label: "Session A",
+            updatedAt: 2,
+            placement: {
+              state: "active",
+              generation: 1,
+              createdAtMs: 1,
+              updatedAtMs: 1,
+              stateChangedAtMs: 1,
+              environmentId: "worker:one",
+              activeOwnerEpoch: 1,
+              workerBundleHash: "a".repeat(64),
+              workspaceBaseManifestRef: "base-manifest",
+              remoteWorkspaceDir: "/workspace/session-a",
+            },
+          },
+          { key: sessionB, kind: "direct", label: "Session B", updatedAt: 1 },
+        ]),
+      },
+      sessionKey: sessionA,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.deferNext("sessions.reclaim");
+      await page.getByRole("button", { name: "Runs on Cloud" }).click();
+      await page.getByText("Stop cloud worker…", { exact: true }).click();
+      await page.getByRole("button", { name: "Stop worker" }).click();
+      await gateway.waitForRequest("sessions.reclaim");
+      await capture(page, "01-placement-pending.png");
+
+      await navigateAwayAndBack(page, sessionA, sessionB);
+      const message = "Stale placement failure must stay retired.";
+      await gateway.rejectDeferred("sessions.reclaim", { code: "INVALID_REQUEST", message });
+      await expect.poll(() => page.getByText(message).count()).toBe(0);
+      await expect
+        .poll(() =>
+          page.locator(".chat-pane-cache__pane--visible").evaluate((pane) => {
+            return (pane as HTMLElement & { state?: { chatError?: string | null } }).state
+              ?.chatError;
+          }),
+        )
+        .not.toBe(message);
+      await capture(page, "02-placement-returned.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("does not resurrect a sharing failure after navigating away", async () => {
+    const context = await suite.newBrowserContext(proofContextOptions());
+    const page = await context.newPage();
+    const sessionA = "agent:main:sharing-a";
+    const sessionB = "agent:main:sharing-b";
+    const gateway = await installMockGateway(page, {
+      allowedSessionVisibilities: ["shared", "draft"],
+      featureMethods: ["chat.startup", "session.visibility.set"],
+      historyMessages: [{ role: "assistant", content: "Sharing outcome proof." }],
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            key: sessionA,
+            kind: "direct",
+            label: "Session A",
+            sessionId: "sharing-session-a",
+            sharingRole: "owner",
+            visibility: "draft",
+            updatedAt: 2,
+          },
+          {
+            key: sessionB,
+            kind: "direct",
+            label: "Session B",
+            sessionId: "sharing-session-b",
+            sharingRole: "owner",
+            visibility: "shared",
+            updatedAt: 1,
+          },
+        ]),
+      },
+      sessionKey: sessionA,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.deferNext("session.visibility.set");
+      await page.getByRole("button", { name: "Session sharing" }).click();
+      await page.getByText("Publish draft", { exact: true }).click();
+      await gateway.waitForRequest("session.visibility.set");
+      await capture(page, "03-sharing-pending.png");
+
+      await navigateAwayAndBack(page, sessionA, sessionB);
+      const message = "Stale sharing failure must stay retired.";
+      await gateway.rejectDeferred("session.visibility.set", {
+        code: "INVALID_REQUEST",
+        message,
+      });
+      await expect.poll(() => page.getByText(message).count()).toBe(0);
+      await page.getByRole("button", { name: "Session sharing" }).click();
+      await expect.poll(() => page.locator(".chat-pane__sharing-status--error").count()).toBe(0);
+      await capture(page, "04-sharing-returned.png");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -51,6 +51,49 @@ function proofContextOptions() {
   };
 }
 
+async function installPlacementGateway(page: Page, sessionA: string, sessionB: string) {
+  return installMockGateway(page, {
+    featureMethods: ["chat.startup", "sessions.reclaim"],
+    historyMessages: [{ role: "assistant", content: "Placement outcome proof." }],
+    methodResponses: {
+      "sessions.list": chatSessionListResponse([
+        {
+          key: sessionA,
+          kind: "direct",
+          label: "Session A",
+          updatedAt: 2,
+          placement: {
+            state: "active",
+            generation: 1,
+            createdAtMs: 1,
+            updatedAtMs: 1,
+            stateChangedAtMs: 1,
+            environmentId: "worker:one",
+            activeOwnerEpoch: 1,
+            workerBundleHash: "a".repeat(64),
+            workspaceBaseManifestRef: "base-manifest",
+            remoteWorkspaceDir: "/workspace/session-a",
+          },
+        },
+        { key: sessionB, kind: "direct", label: "Session B", updatedAt: 1 },
+      ]),
+    },
+    sessionKey: sessionA,
+  });
+}
+
+async function startPlacementReclaim(
+  page: Page,
+  gateway: Awaited<ReturnType<typeof installMockGateway>>,
+): Promise<void> {
+  await page.goto(`${suite.server.baseUrl}chat`);
+  await gateway.deferNext("sessions.reclaim");
+  await page.getByRole("button", { name: "Runs on Cloud" }).click();
+  await page.getByText("Stop cloud worker…", { exact: true }).click();
+  await page.getByRole("button", { name: "Stop worker" }).click();
+  await gateway.waitForRequest("sessions.reclaim");
+}
+
 suite.define(() => {
   beforeAll(async () => {
     if (captureProof) {
@@ -126,42 +169,10 @@ suite.define(() => {
     const page = await context.newPage();
     const sessionA = "agent:main:placement-a";
     const sessionB = "agent:main:placement-b";
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.startup", "sessions.reclaim"],
-      historyMessages: [{ role: "assistant", content: "Placement outcome proof." }],
-      methodResponses: {
-        "sessions.list": chatSessionListResponse([
-          {
-            key: sessionA,
-            kind: "direct",
-            label: "Session A",
-            updatedAt: 2,
-            placement: {
-              state: "active",
-              generation: 1,
-              createdAtMs: 1,
-              updatedAtMs: 1,
-              stateChangedAtMs: 1,
-              environmentId: "worker:one",
-              activeOwnerEpoch: 1,
-              workerBundleHash: "a".repeat(64),
-              workspaceBaseManifestRef: "base-manifest",
-              remoteWorkspaceDir: "/workspace/session-a",
-            },
-          },
-          { key: sessionB, kind: "direct", label: "Session B", updatedAt: 1 },
-        ]),
-      },
-      sessionKey: sessionA,
-    });
+    const gateway = await installPlacementGateway(page, sessionA, sessionB);
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
-      await gateway.deferNext("sessions.reclaim");
-      await page.getByRole("button", { name: "Runs on Cloud" }).click();
-      await page.getByText("Stop cloud worker…", { exact: true }).click();
-      await page.getByRole("button", { name: "Stop worker" }).click();
-      await gateway.waitForRequest("sessions.reclaim");
+      await startPlacementReclaim(page, gateway);
       await capture(page, "01-placement-pending.png");
 
       await navigateAwayAndBack(page, sessionA, sessionB);
@@ -177,6 +188,36 @@ suite.define(() => {
         )
         .not.toBe(message);
       await capture(page, "02-placement-returned.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps a current placement reclaim failure visible and retryable", async () => {
+    const context = await suite.newBrowserContext(proofContextOptions());
+    const page = await context.newPage();
+    const sessionA = "agent:main:placement-current";
+    const sessionB = "agent:main:placement-other";
+    const gateway = await installPlacementGateway(page, sessionA, sessionB);
+
+    try {
+      await startPlacementReclaim(page, gateway);
+      const message = "Current placement failure stays actionable.";
+      await gateway.rejectDeferred("sessions.reclaim", { code: "INVALID_REQUEST", message });
+
+      const visiblePane = page.locator(".chat-pane-cache__pane--visible");
+      await expect
+        .poll(() =>
+          visiblePane.evaluate(
+            (pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey,
+          ),
+        )
+        .toBe(sessionA);
+      await visiblePane.getByText(message, { exact: true }).waitFor();
+
+      await page.getByRole("button", { name: "Runs on Cloud" }).click();
+      await page.getByText("Stop cloud worker…", { exact: true }).waitFor();
+      await capture(page, "00-placement-current-failure.png");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -78,6 +78,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // before route data resolves).
   @property({ attribute: false }) sessionKey = "";
   private activeValue = false;
+  private headerPresentationGeneration = 0;
   private presentedValue = true;
   get presented(): boolean {
     return this.presentedValue;
@@ -87,11 +88,18 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     if (value === previous) {
       return;
     }
+    this.headerPresentationGeneration += 1;
     this.presentedValue = value;
     this.requestUpdate("presented", previous);
     this.presentedChanged(value);
   }
   protected presentedChanged(_presented: boolean): void {}
+  protected get headerOutcomeOwner(): string {
+    return `${this.connectionGeneration}:${this.headerPresentationGeneration}`;
+  }
+  protected ownsHeaderOutcome(owner: string): boolean {
+    return this.presented && owner === this.headerOutcomeOwner;
+  }
   get active(): boolean {
     return this.activeValue;
   }
@@ -416,7 +424,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected abstract reconcileWaitingApprovalSnapshot(
     approvalQueue?: ChatPageContext["overlays"]["snapshot"]["approvalQueue"],
   ): boolean;
-  protected abstract publishHeaderError(error: unknown): void;
+  protected abstract publishHeaderError(error: unknown, owner?: string): void;
   protected abstract probeSessionDiscussion(sessionKey: string): Promise<void>;
   protected abstract loadHeaderPlatform(
     client: GatewayBrowserClient,

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
@@ -26,6 +27,8 @@ type TestChatPane = HTMLElement & {
   state: ChatPageHost;
   createSession: () => Promise<boolean>;
   paneId: string;
+  presented: boolean;
+  presentedChanged: (presented: boolean) => void;
   sessionKey: string;
   resetConfirmationOpen: boolean;
   routeFace: "chat" | "dashboard";
@@ -318,6 +321,24 @@ describe("chat pane board shell", () => {
     });
   });
 
+  it("does not publish a board dock failure after leaving and returning", async () => {
+    const pane = createTestPane();
+    const provider = mockBoardProvider("agent:main:stale-board-outcome");
+    const applied = createDeferred<never>();
+    const applyOps = vi.spyOn(provider, "applyOps").mockReturnValue(applied.promise);
+    pane.boardProvider = provider;
+    pane.presentedChanged = () => undefined;
+
+    pane.handleBoardDockChange("left");
+    pane.presented = false;
+    pane.presented = true;
+    applied.reject(new Error("stale board dock failed"));
+    await applied.promise.catch(() => undefined);
+    await vi.waitFor(() => expect(applyOps).toHaveBeenCalledOnce());
+
+    expect(pane.state.lastError).toBeNull();
+    expect(pane.state.chatError).toBeNull();
+  });
   it("activates an existing tabbed chat panel when reopening a side dock", () => {
     const pane = createTestPane();
     const withChat = openSlot(openSlot({ columns: [] }, "chat"), "discussion");

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -437,9 +437,10 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     const reopenDock = dock === "hidden" ? board.reopenDock : dock;
     this.lastVisibleBoardDock.set(`${sessionKey}:${board.activeTabId}`, reopenDock);
     this.persistBoardReopenDock(board, reopenDock);
+    const owner = this.headerOutcomeOwner;
     void board.provider
       .applyOps([{ kind: "tab_update", tabId: board.activeTabId, chatDock: dock }])
-      .catch((error: unknown) => this.publishHeaderError(error));
+      .catch((error: unknown) => this.publishHeaderError(error, owner));
   }
 
   protected renderBoardDivider(dock: BoardVisibleChatDock) {

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -58,6 +58,10 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
   }
 
   protected async reclaimHeaderPlacement(row: GatewaySessionRow): Promise<void> {
+    const scope = this.captureConnectionScope();
+    if (!scope) {
+      return;
+    }
     const onReclaimingChange = (reclaimingKey: string | null) => {
       // A later reclaim may take ownership before this request settles. Only
       // the request that still owns the row may clear the pane's progress key.
@@ -66,16 +70,15 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       }
     };
     await reclaimChatPanePlacement({
-      client: this.connectedClient,
-      connectionGeneration: this.connectionGeneration,
-      gatewaySnapshot: this.context.gateway.snapshot,
+      client: scope.client,
+      connectionGeneration: scope.generation,
+      gatewaySnapshot: scope.context.gateway.snapshot,
       reclaimingKey: this.headerPlacementReclaimingKey,
       row,
-      isCurrent: (client, generation) =>
-        this.connectedClient === client && this.connectionGeneration === generation,
+      isCurrent: () => this.ownsHeaderOutcomeScope(scope),
       onReclaimingChange,
-      publishError: (error) => this.publishHeaderError(error),
-      refreshReplacement: (agentId) => this.context.sessions.refreshReplacement(agentId),
+      publishError: (error) => this.publishHeaderError(error, scope.headerOutcomeOwner),
+      refreshReplacement: (agentId) => scope.sessions.refreshReplacement(agentId),
       requestUpdate: () => this.requestUpdate(),
     });
   }

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
@@ -157,7 +158,57 @@ describe("chat pane placement", () => {
     await reclaim;
 
     expect(request).not.toHaveBeenCalled();
-    expect(state.chatError).toBe(t("sessionsView.actionUnavailable"));
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+  });
+
+  it("publishes a reclaim failure for the current presentation", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("reclaim failed");
+    });
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: ["sessions.reclaim"] },
+      auth: { role: "operator", scopes: ["operator.admin"] },
+    } as never;
+    const session = activePlacementSession();
+
+    const reclaim = pane.reclaimHeaderPlacement(session);
+    const actions = await waitForConfirmDialogActions();
+    answerConfirmDialog(actions, "confirm");
+    await reclaim;
+
+    expect(state.lastError).toBe("reclaim failed");
+    expect(state.chatError).toBe(state.lastError);
+  });
+
+  it("does not publish a reclaim failure after leaving and returning", async () => {
+    const response = createDeferred<never>();
+    const request = vi.fn(() => response.promise);
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: ["sessions.reclaim"] },
+      auth: { role: "operator", scopes: ["operator.admin"] },
+    } as never;
+    const session = activePlacementSession();
+
+    const reclaim = pane.reclaimHeaderPlacement(session);
+    const actions = await waitForConfirmDialogActions();
+    answerConfirmDialog(actions, "confirm");
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    pane.presented = false;
+    pane.presented = true;
+    response.reject(new Error("stale reclaim failed"));
+    await reclaim;
+
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
   });
 
   it("keeps reclaim progress with its session when the pane switches rows", async () => {

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -28,14 +28,6 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
   private headerSessionOperationsLoad: Promise<
     typeof import("../../components/session-organizer-operations.runtime.ts")
   > | null = null;
-  private headerPresentationGeneration = 0;
-  protected override presentedChanged(presented: boolean): void {
-    this.headerPresentationGeneration += 1;
-    super.presentedChanged(presented);
-  }
-  private get headerOutcomeOwner() {
-    return `${this.connectionGeneration}:${this.headerPresentationGeneration}`;
-  }
   protected async loadHeaderPlatform(
     client: GatewayBrowserClient,
     generation: number,
@@ -232,7 +224,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
 
   private isHeaderSessionActionCurrent(scope: SidebarSessionMutationScope, owner: string): boolean {
     return (
-      owner === this.headerOutcomeOwner &&
+      this.ownsHeaderOutcome(owner) &&
       this.isConnected &&
       this.context === scope.context &&
       this.context.gateway === scope.gateway &&
@@ -399,7 +391,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     if (copiedValue) {
       const owner = this.headerOutcomeOwner;
       void copy(copiedValue).then((copied) => {
-        if (!this.presented || owner !== this.headerOutcomeOwner) {
+        if (!this.ownsHeaderOutcome(owner)) {
           return;
         }
         if (copied) {
@@ -416,7 +408,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
   }
 
   protected publishHeaderError(error: unknown, owner = this.headerOutcomeOwner): void {
-    if (!this.state || !this.presented || owner !== this.headerOutcomeOwner) {
+    if (!this.state || !this.ownsHeaderOutcome(owner)) {
       return;
     }
     this.state.chatError = this.state.lastError =

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -227,6 +227,7 @@ export type ChatPaneConnectionScope = {
   state: ChatPageHost;
   client: GatewayBrowserClient;
   generation: number;
+  headerOutcomeOwner: string;
   sessions: ChatPageContext["sessions"];
 };
 export const CHAT_OPEN_DETAILS_SELECTOR =

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -333,6 +333,25 @@ describe("chat pane sharing authorization", () => {
       result: sharingResult(replacement),
     });
   });
+
+  it("drops a sharing load failure after leaving and returning", async () => {
+    const row = sessionRow();
+    const listed = createDeferred<SessionMembersListResult>();
+    const request = vi.fn(() => listed.promise);
+    const { pane: testPane } = createSharingTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const pane = testPane as SharingPane;
+    const pending = pane.loadSessionSharing(row);
+    pane.presented = false;
+    pane.presented = true;
+
+    listed.reject(new Error("stale sharing load failed"));
+    await pending;
+
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))).toBeUndefined();
+  });
 });
 
 describe.each(mutations)("chat pane $name mutation connection ownership", (mutation) => {
@@ -464,6 +483,36 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       loading: false,
       error: `Error: ${mutation.name} failed after session switch`,
     });
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(sessions.refreshReplacement).not.toHaveBeenCalled();
+  });
+
+  it("drops a failure after leaving and returning to the retained pane", async () => {
+    const response = createDeferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method !== mutation.method) {
+        throw new Error(`unexpected request: ${method}`);
+      }
+      return response.promise;
+    });
+    const sessions = {
+      refreshReplacement: vi.fn(),
+    } as unknown as SessionCapability;
+    const { pane: testPane, state } = createSharingTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    const pane = testPane as SharingPane;
+    const row = sessionRow();
+    const pending = mutation.invoke(pane, row);
+    pane.presented = false;
+    pane.presented = true;
+
+    response.reject(new Error(`stale ${mutation.name} failed`));
+    await pending;
+
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))).toBeUndefined();
     expect(state.lastError).toBeNull();
     expect(state.chatError).toBeNull();
     expect(sessions.refreshReplacement).not.toHaveBeenCalled();

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -35,6 +35,8 @@ import {
   type ChatSessionSharingState,
 } from "./components/chat-session-sharing.ts";
 
+type HeaderScope = ChatPaneConnectionScope;
+
 export abstract class ChatPaneSharing extends ChatPaneBase {
   protected readonly clearSessionCompanion = async () => {
     const scope = this.captureConnectionScope();
@@ -132,7 +134,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
           : {}),
       });
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow) ||
         !ownsLoadingState()
       ) {
@@ -144,7 +146,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       this.setSessionSharingState(cacheKey, { loading: false, result });
     } catch (error) {
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow) ||
         !ownsLoadingState()
       ) {
@@ -157,15 +159,18 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     }
   }
 
-  protected publishSharingFailure(cacheKey: string, sessionKey: string, error: unknown): void {
-    this.setSessionSharingState(cacheKey, {
-      ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
+  protected failSharing(scope: HeaderScope, key: string, session: string, error: unknown): void {
+    if (!this.ownsHeaderOutcomeScope(scope)) {
+      return;
+    }
+    this.setSessionSharingState(key, {
+      ...(this.sessionSharingStates.get(key) ?? { loading: false }),
       loading: false,
       error: String(error),
     });
     // Sharing errors stay with their session; the visible slot belongs only to the selected session.
-    if (areUiSessionKeysEquivalent(this.state?.sessionKey, sessionKey)) {
-      this.publishHeaderError(error);
+    if (areUiSessionKeysEquivalent(this.state?.sessionKey, session)) {
+      this.publishHeaderError(error, scope.headerOutcomeOwner);
     }
   }
 
@@ -196,25 +201,25 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     try {
       await scope.client.request("session.visibility.set", params);
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow)
       ) {
         return;
       }
       await scope.sessions.refreshReplacement(agentId);
       const refreshedRow = this.currentSessionSharingRow(scope, currentRow);
-      if (!this.isConnectionScopeCurrent(scope) || !refreshedRow) {
+      if (!this.ownsHeaderOutcomeScope(scope) || !refreshedRow) {
         return;
       }
       await this.loadSessionSharing(refreshedRow, true);
     } catch (error) {
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow)
       ) {
         return;
       }
-      this.publishSharingFailure(cacheKey, currentRow.key, error);
+      this.failSharing(scope, cacheKey, currentRow.key, error);
     }
   }
 
@@ -247,14 +252,14 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     try {
       await scope.client.request(method, params);
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow)
       ) {
         return;
       }
       await this.loadSessionSharing(currentRow, true);
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow)
       ) {
         return;
@@ -262,12 +267,12 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       await scope.sessions.refreshReplacement(agentId);
     } catch (error) {
       if (
-        !this.isConnectionScopeCurrent(scope) ||
+        !this.ownsHeaderOutcomeScope(scope) ||
         !this.currentSessionSharingRow(scope, currentRow)
       ) {
         return;
       }
-      this.publishSharingFailure(cacheKey, currentRow.key, error);
+      this.failSharing(scope, cacheKey, currentRow.key, error);
     }
   }
 
@@ -281,6 +286,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       state,
       client: state.client,
       generation: this.connectionGeneration,
+      headerOutcomeOwner: this.headerOutcomeOwner,
       sessions: this.context.sessions,
     };
     return this.isConnectionScopeCurrent(scope) ? scope : null;
@@ -298,6 +304,10 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       scope.context.gateway.snapshot.client === scope.client &&
       this.connectionGeneration === scope.generation
     );
+  }
+
+  protected ownsHeaderOutcomeScope(scope: HeaderScope): boolean {
+    return this.isConnectionScopeCurrent(scope) && this.ownsHeaderOutcome(scope.headerOutcomeOwner);
   }
 
   protected suggestionMatchesCurrentSession(


### PR DESCRIPTION
Related: #123955
Follow-up to #123958

AI-assisted: yes. The repair was source-audited, browser-tested, behavior-validated, and independently autoreviewed.

## What Problem This Solves

Fixes the remaining issue where retained Control UI chat panes could publish delayed placement-reclaim, sharing, or board-dock failures after the operator navigated away and returned to the same pane, making an old outcome look current.

## Why This Change Was Made

This completes the invariant begun in #123958: every asynchronous chat-header outcome belongs to the exact connection generation and presentation generation that launched it. `chat-pane-base` remains the canonical owner; placement reclaim, sharing loads and mutations, and board dock writes carry the captured owner through settlement. Navigation, reconnect, client replacement, and A → B → A presentation cycles retire old outcomes, while failures from the current presentation remain visible and retryable.

Rename, copy path/branch, reveal workspace, and session-menu behavior from #123958 remain unchanged. The companion rail is intentionally outside this header-outcome boundary.

Production LOC against current local `origin/main`: +50/-35 (net +15). This does not double-count #123958's already-merged production delta. Tests: +333/-33 (net +300).

No public API, configuration, protocol, persistence, security, release, or changelog surface changes.

## User Impact

Operators no longer see stale placement, sharing, or board failures resurrect after returning to a retained chat pane. A current placement failure still appears in the correct pane, and the action remains available for retry.

## Evidence

Exact head: `61102d7148f34f66edc5fc54fd22008897ef613d`

- Focused owner-boundary unit bundle: 93/93 passed across the chat pane, placement, sharing, and board suites.
- Focused Chromium mocked-Gateway E2E: 4/4 passed, covering stale reveal, stale placement, current placement visibility/retry, and stale sharing.
- Source-blind behavior contract: 5/5 passed with fixture-only screenshots and four fresh recordings.
- Real Gateway reconnect lifecycle: 1/1 passed on Blacksmith Testbox `tbx_01m04g4a7fjg7vkpb6222yj2dq`, run https://github.com/openclaw/openclaw/actions/runs/31928716318.
- Changed gate, Control UI i18n, targeted format, full lint, stylelint, UI production/test types, import cycles, and diff hygiene: passed on Blacksmith Testbox `tbx_01m04g7xm9dq1cp4zrf09c5m64`, run https://github.com/openclaw/openclaw/actions/runs/31928789790.
- Fresh Codex autoreview: clean, no accepted/actionable findings (0.99 confidence).
- A broad local UI E2E run hit an unrelated informational-steer timeout and then the harness watchdog; the exact failed scenario passed immediately on rerun. Exact-head CI remains the authoritative broad lane.

Current placement failure remains visible and retryable:

![Current placement failure remains visible beside the retry action](https://github.com/user-attachments/assets/1e18ffa5-d570-4a85-a1c1-56450d4ac8ab)

Placement request pending in Session A:

![Placement reclaim pending in Session A](https://github.com/user-attachments/assets/74477709-67a1-4aa9-91bf-edfd98aa6ad3)

Returned Session A rejects the stale placement outcome:

![Session A after return with no stale placement error](https://github.com/user-attachments/assets/74ee2f9f-ab9c-4d28-a5d4-d5a6e1e9f839)

Sharing mutation pending in Session A:

![Sharing visibility mutation pending in Session A](https://github.com/user-attachments/assets/30a55a1a-20c2-4553-8e61-fe041511df9e)

Returned Session A rejects the stale sharing outcome:

![Session A sharing menu after return with no stale error](https://github.com/user-attachments/assets/16a17ef2-2e4e-4ed7-90d1-d0ab2d031abb)

A → B → A retained-pane recording:

https://github.com/user-attachments/assets/6c56fdf2-5630-4410-bc97-1d369afecaba
