### PR TITLE
[AI-assisted] fix(gateway): gate workspace retain dispatch on workerBuild claim

### DIFF
--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -171,11 +171,7 @@ describe("node workspace retain coordinator", () => {
   });
 
   it("skips nodes that are not worker hosts", async () => {
-    const { coordinator, invoke } = createHarness({
-      results: [{ applied: true, deleted: 0, hasMore: false }],
-    });
-
-    // Replace the transport with a node that is not a worker host (no workerBuild)
+    // Create a coordinator with a node that is not a worker host (no workerBuild)
     const invokeFiltered = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => ({
       ok: true,
       payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -14,7 +14,12 @@ const node = {
   clientId: "node-host",
   clientMode: "node",
   protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-  commands: [NODE_WORKER_WORKSPACE_RETAIN_COMMAND],
+  commands: ["system.run"],
+  workerBuild: {
+    bundleHash: "a".repeat(64),
+    openclawVersion: "1.0.0",
+    protocolFeatures: [],
+  },
 } as const;
 
 function environment(overrides: Record<string, unknown> = {}) {
@@ -165,12 +170,12 @@ describe("node workspace retain coordinator", () => {
     await coordinator.stop();
   });
 
-  it("skips nodes that do not advertise the workspace retain command", async () => {
+  it("skips nodes that are not worker hosts", async () => {
     const { coordinator, invoke } = createHarness({
       results: [{ applied: true, deleted: 0, hasMore: false }],
     });
 
-    // Replace the transport with a node that omits the retain command.
+    // Replace the transport with a node that is not a worker host (no workerBuild)
     const invokeFiltered = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => ({
       ok: true,
       payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),
@@ -179,7 +184,7 @@ describe("node workspace retain coordinator", () => {
       listCurrentNodes: async () => [
         {
           ...node,
-          commands: ["system.run", "system.which"],
+          workerBuild: undefined,
         },
       ],
       isCurrent: () => true,

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -14,7 +14,7 @@ const node = {
   clientId: "node-host",
   clientMode: "node",
   protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-  commands: [],
+  commands: [NODE_WORKER_WORKSPACE_RETAIN_COMMAND],
 } as const;
 
 function environment(overrides: Record<string, unknown> = {}) {
@@ -163,6 +163,44 @@ describe("node workspace retain coordinator", () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(invoke.mock.calls[1]?.[0].params).toEqual(invoke.mock.calls[0]?.[0].params);
     await coordinator.stop();
+  });
+
+  it("skips nodes that do not advertise the workspace retain command", async () => {
+    const { coordinator, invoke } = createHarness({
+      results: [{ applied: true, deleted: 0, hasMore: false }],
+    });
+
+    // Replace the transport with a node that omits the retain command.
+    const invokeFiltered = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => ({
+      ok: true,
+      payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),
+    }));
+    const transportFiltered: NodeWorkerSupervisorTransport = {
+      listCurrentNodes: async () => [
+        {
+          ...node,
+          commands: ["system.run", "system.which"],
+        },
+      ],
+      isCurrent: () => true,
+      invoke: invokeFiltered,
+    };
+
+    const coordinatorFiltered = createNodeWorkspaceRetainCoordinator({
+      gatewayNamespace: "gateway-test",
+      environments: {
+        list: () => [environment()] as never,
+      } as Pick<WorkerEnvironmentService, "list">,
+      placements: {
+        list: () => [placement()] as never,
+      } as Pick<WorkerSessionPlacementStore, "list">,
+      warn: vi.fn(),
+    });
+    coordinatorFiltered.bindTransport(transportFiltered);
+
+    await coordinatorFiltered.start();
+    expect(invokeFiltered).not.toHaveBeenCalled();
+    await coordinatorFiltered.stop();
   });
 
   it("republishes an identical full snapshot for reconnect-scoped inventory", async () => {

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { NODE_WORKER_WORKSPACE_RETAIN_COMMAND } from "../../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
-import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
+import type { NodeWorkerSupervisorNodeProof, NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import { createNodeWorkspaceRetainCoordinator } from "./node-workspace-retain-coordinator.js";
 import type { WorkerSessionPlacementStore } from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";
@@ -20,7 +20,7 @@ const node = {
     openclawVersion: "1.0.0",
     protocolFeatures: [],
   },
-} as const;
+} satisfies NodeWorkerSupervisorNodeProof;
 
 function environment(overrides: Record<string, unknown> = {}) {
   return {

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { NODE_WORKER_WORKSPACE_RETAIN_COMMAND } from "../../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
-import type { NodeWorkerSupervisorNodeProof, NodeWorkerSupervisorTransport } from "../node-registry-private.js";
+import type {
+  NodeWorkerSupervisorNodeProof,
+  NodeWorkerSupervisorTransport,
+} from "../node-registry-private.js";
 import { createNodeWorkspaceRetainCoordinator } from "./node-workspace-retain-coordinator.js";
 import type { WorkerSessionPlacementStore } from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -163,7 +163,7 @@ export function createNodeWorkspaceRetainCoordinator(
         : currentNodes.filter((node) => requestedNodes.has(node.nodeId));
       await Promise.all(
         targets
-          .filter((node) => node.commands.includes(NODE_WORKER_WORKSPACE_RETAIN_COMMAND))
+          .filter((node) => node.workerBuild != null)
           .map(async (node) => {
             try {
               await publishSnapshot(currentTransport, node);

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -162,15 +162,17 @@ export function createNodeWorkspaceRetainCoordinator(
         ? currentNodes
         : currentNodes.filter((node) => requestedNodes.has(node.nodeId));
       await Promise.all(
-        targets.map(async (node) => {
-          try {
-            await publishSnapshot(currentTransport, node);
-          } catch (error) {
-            options.warn(
-              `Node workspace retain publication failed (${node.nodeId}): ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
-        }),
+        targets
+          .filter((node) => node.commands.includes(NODE_WORKER_WORKSPACE_RETAIN_COMMAND))
+          .map(async (node) => {
+            try {
+              await publishSnapshot(currentTransport, node);
+            } catch (error) {
+              options.warn(
+                `Node workspace retain publication failed (${node.nodeId}): ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+          }),
       );
     }
   };


### PR DESCRIPTION
## What Problem This Solves

Closes #124346

The node workspace retain coordinator dispatches `worker.workspace.retain.v1` to every connected node without checking whether that node is a worker host. Nodes running without the worker runtime (e.g. system-only nodes that come up with `caps: ["system", …]` and no worker bundle) reject the private invocation and produce a `WARN` log roughly once per minute, forever:

```
Node workspace retain publication failed (node-id): workspace retain command failed (unknown)
```

## Fix

Gate retention dispatch on the `workerBuild` connection-level claim on `NodeWorkerSupervisorNodeProof` (see `src/gateway/node-registry-private.ts:78`). Nodes without a `workerBuild` claim are not worker hosts and are silently skipped — they have no worker workspaces to retain.

The prior version checked `node.commands.includes(NODE_WORKER_WORKSPACE_RETAIN_COMMAND)`, which would never match a real worker host because the retain command is a **private** node control (`NODE_WORKER_PRIVATE_COMMANDS`) that is never advertised in the public `commands` array (filtered by `filterPublicNodeCommands` in `src/infra/node-commands.ts`).

## Evidence

**Bug still on upstream:** Verified `upstream/main` — `drain()` iterates `targets.map(node => publishSnapshot(...))` with no worker-host check.

**Fix verified by code reading:**
- Private command contract: `src/infra/node-commands.ts:29-38` — `NODE_WORKER_WORKSPACE_RETAIN_COMMAND` is in `NODE_WORKER_PRIVATE_COMMANDS`, whose docstring says "Private node controls are never part of advertised or operator-invocable command surfaces."
- Worker-host claim: `src/gateway/node-registry-private.ts:78` — `workerBuild?: WorkerAdmissionHandshake` is the connection-level worker-host proof separate from public commands.
- Existing sibling test: `src/gateway/worker-environments/node-worker-tunnel.test.ts:119` models a valid worker host with `commands: ["system.run"]` and `workerBuild`.

**No existing PR on #124346:** `gh pr list --state all --search "124346"` returns empty.

**Test:** `node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts` — all tests pass. The new test directly verifies that a node without `workerBuild` is skipped (invoke not called).

**CI note:** The `checks-node-compact-large-9` shard failure (`workspace-sync.test.ts` — expected 776 to be 777, off-by-one timing assertion) is a pre-existing flaky test in a file not touched by this PR. Main-branch CI passes with zero failures; the failure is a scheduling artifact of the random shard assignment.