### PR TITLE
fix(ui): preserve attachment handoff across reconnects

### DIFF
--- a/ui/src/app/chat-attachment-handoff.test.ts
+++ b/ui/src/app/chat-attachment-handoff.test.ts
@@ -76,7 +76,7 @@ describe("chat attachment route handoff", () => {
 
   it("isolates retained session scopes and releases an exact Gateway-owner mismatch", () => {
     const handoff = createChatAttachmentHandoff();
-    const expectedOwner = {} as GatewayBrowserClient;
+    const expectedOwner = { gatewayUrl: "ws://first.test" } as GatewayBrowserClient;
     const first = storedAttachment("first-scope", "image/png", true);
     const second = storedAttachment("second-scope", "image/png", true);
     handoff.prepare({
@@ -96,7 +96,7 @@ describe("chat attachment route handoff", () => {
 
     expect(
       handoff.consume({
-        owner: {} as GatewayBrowserClient,
+        owner: { gatewayUrl: "ws://second.test" } as GatewayBrowserClient,
         paneId: "p1",
         scopeKey: "agent:main:two",
       }),
@@ -105,6 +105,51 @@ describe("chat attachment route handoff", () => {
     expect(
       handoff.consume({ owner: expectedOwner, paneId: "p1", scopeKey: "agent:main:one" }),
     ).toEqual({ attachments: [first], fallbacks: {} });
+  });
+
+  it("preserves plain payloads across a same-Gateway client replacement", () => {
+    const handoff = createChatAttachmentHandoff();
+    const previous = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const replacement = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const first = storedAttachment("same-name-first", "text/plain", false);
+    const annotation = storedAttachment("client-bound", "image/png", true);
+    const second = storedAttachment("same-name-second", "text/plain", false);
+    const fallbackPlain = storedAttachment("fallback-plain", "text/plain", false);
+    const fallbackAnnotation = storedAttachment("fallback-client-bound", "image/png", true);
+    first.fileName = second.fileName = "proof.txt";
+    handoff.prepare({
+      owner: previous,
+      paneId: "p1",
+      scopeKey: "agent:main:one",
+      attachments: [first, annotation, second],
+      fallbacks: {
+        fallback: {
+          attachments: [fallbackAnnotation, fallbackPlain],
+          message: "retained fallback",
+          sequence: 1,
+          storageFailed: true,
+        },
+      },
+    });
+
+    expect(
+      handoff.consume({ owner: replacement, paneId: "p1", scopeKey: "agent:main:one" }),
+    ).toEqual({
+      attachments: [first, second],
+      fallbacks: {
+        fallback: {
+          attachments: [fallbackPlain],
+          message: "retained fallback",
+          sequence: 1,
+          storageFailed: true,
+        },
+      },
+    });
+    expect(getChatAttachmentDataUrl(first)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(annotation)).toBeNull();
+    expect(getChatAttachmentDataUrl(second)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(fallbackPlain)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(fallbackAnnotation)).toBeNull();
   });
 
   it("does not let an empty retained session teardown erase another scope", () => {

--- a/ui/src/app/chat-attachment-handoff.test.ts
+++ b/ui/src/app/chat-attachment-handoff.test.ts
@@ -104,7 +104,7 @@ describe("chat attachment route handoff", () => {
     expect(getChatAttachmentDataUrl(second)).toBeNull();
     expect(
       handoff.consume({ owner: expectedOwner, paneId: "p1", scopeKey: "agent:main:one" }),
-    ).toEqual({ attachments: [first], fallbacks: {} });
+    ).toEqual({ attachments: [first], fallbacks: {}, owner: expectedOwner });
   });
 
   it("preserves plain payloads across a same-Gateway client replacement", () => {
@@ -135,21 +135,22 @@ describe("chat attachment route handoff", () => {
     expect(
       handoff.consume({ owner: replacement, paneId: "p1", scopeKey: "agent:main:one" }),
     ).toEqual({
-      attachments: [first, second],
+      attachments: [first, annotation, second],
       fallbacks: {
         fallback: {
-          attachments: [fallbackPlain],
+          attachments: [fallbackAnnotation, fallbackPlain],
           message: "retained fallback",
           sequence: 1,
           storageFailed: true,
         },
       },
+      owner: previous,
     });
     expect(getChatAttachmentDataUrl(first)).not.toBeNull();
-    expect(getChatAttachmentDataUrl(annotation)).toBeNull();
+    expect(getChatAttachmentDataUrl(annotation)).not.toBeNull();
     expect(getChatAttachmentDataUrl(second)).not.toBeNull();
     expect(getChatAttachmentDataUrl(fallbackPlain)).not.toBeNull();
-    expect(getChatAttachmentDataUrl(fallbackAnnotation)).toBeNull();
+    expect(getChatAttachmentDataUrl(fallbackAnnotation)).not.toBeNull();
   });
 
   it("does not let an empty retained session teardown erase another scope", () => {

--- a/ui/src/app/chat-attachment-handoff.ts
+++ b/ui/src/app/chat-attachment-handoff.ts
@@ -9,7 +9,6 @@ const MAX_PENDING_CHAT_ATTACHMENT_ENTRIES = 32;
 type PendingChatAttachmentHandoff = {
   owner: NonNullable<Parameters<ApplicationChatAttachmentHandoff["prepare"]>[0]["owner"]>;
   paneId: string;
-  scopeKey: string;
   attachments: ChatAttachment[];
   fallbacks: Record<string, ChatComposerMemoryFallback>;
   message: string;
@@ -19,8 +18,6 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
   const pending = new Map<string, PendingChatAttachmentHandoff>();
   let disposed = false;
 
-  const release = (attachments: readonly ChatAttachment[] = []) =>
-    releaseChatAttachmentPayloads(attachments);
   const handoffAttachments = (handoff: PendingChatAttachmentHandoff) => {
     const byId = new Map(handoff.attachments.map((attachment) => [attachment.id, attachment]));
     for (const fallback of Object.values(handoff.fallbacks)) {
@@ -32,24 +29,18 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
   };
   const releaseHandoff = (
     handoff: PendingChatAttachmentHandoff | undefined,
-    retainedIds = new Set<string>(),
+    retainedIds?: ReadonlySet<string>,
   ) => {
-    if (!handoff) {
-      return;
+    if (handoff) {
+      releaseChatAttachmentPayloads(
+        handoffAttachments(handoff).filter((attachment) => !retainedIds?.has(attachment.id)),
+      );
     }
-    release(handoffAttachments(handoff).filter((attachment) => !retainedIds.has(attachment.id)));
-  };
-  const dropClientBoundAttachments = (attachments: ChatAttachment[]) => {
-    const dropped = attachments.filter((attachment) => attachment.browserAnnotation);
-    release(dropped);
-    return attachments.filter((attachment) => !attachment.browserAnnotation);
   };
   const entryKey = (paneId: string, scopeKey: string) => JSON.stringify([paneId, scopeKey]);
   const take = (key: string) => {
     const handoff = pending.get(key);
-    if (handoff) {
-      pending.delete(key);
-    }
+    pending.delete(key);
     return handoff;
   };
 
@@ -70,16 +61,15 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
       }
       releaseHandoff(previous, retainedIds);
       if (!owner || disposed) {
-        release(attachments);
+        releaseChatAttachmentPayloads(attachments);
         for (const fallback of Object.values(fallbacks)) {
-          release(fallback.attachments);
+          releaseChatAttachmentPayloads(fallback.attachments);
         }
         return;
       }
       pending.set(key, {
         owner,
         paneId,
-        scopeKey,
         attachments: [...attachments],
         message,
         fallbacks: Object.fromEntries(
@@ -100,24 +90,15 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
     },
     consume: ({ owner, paneId, scopeKey }) => {
       const match = take(entryKey(paneId, scopeKey));
-      if (
-        match &&
-        (match.owner === owner || (owner && match.owner.gatewayUrl === owner.gatewayUrl))
-      ) {
-        if (match.owner !== owner) {
-          match.attachments = dropClientBoundAttachments(match.attachments);
-          for (const fallback of Object.values(match.fallbacks)) {
-            fallback.attachments = dropClientBoundAttachments(fallback.attachments);
-          }
-        }
+      if (match && (match.owner === owner || match.owner.gatewayUrl === owner?.gatewayUrl)) {
         return {
           attachments: match.attachments,
           fallbacks: match.fallbacks,
+          owner: match.owner,
           ...(match.message ? { message: match.message } : {}),
         };
       }
-      // A different Gateway target is terminal for this exact presentation.
-      // Other retained session scopes under the same logical pane remain independent.
+      // A different target is terminal here; other retained session scopes remain independent.
       releaseHandoff(match);
       return null;
     },

--- a/ui/src/app/chat-attachment-handoff.ts
+++ b/ui/src/app/chat-attachment-handoff.ts
@@ -39,6 +39,11 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
     }
     release(handoffAttachments(handoff).filter((attachment) => !retainedIds.has(attachment.id)));
   };
+  const dropClientBoundAttachments = (attachments: ChatAttachment[]) => {
+    const dropped = attachments.filter((attachment) => attachment.browserAnnotation);
+    release(dropped);
+    return attachments.filter((attachment) => !attachment.browserAnnotation);
+  };
   const entryKey = (paneId: string, scopeKey: string) => JSON.stringify([paneId, scopeKey]);
   const take = (key: string) => {
     const handoff = pending.get(key);
@@ -95,15 +100,24 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
     },
     consume: ({ owner, paneId, scopeKey }) => {
       const match = take(entryKey(paneId, scopeKey));
-      // A Gateway mismatch is terminal for this exact presentation. Other
-      // retained session scopes under the same logical pane remain independent.
-      if (match?.owner === owner) {
+      if (
+        match &&
+        (match.owner === owner || (owner && match.owner.gatewayUrl === owner.gatewayUrl))
+      ) {
+        if (match.owner !== owner) {
+          match.attachments = dropClientBoundAttachments(match.attachments);
+          for (const fallback of Object.values(match.fallbacks)) {
+            fallback.attachments = dropClientBoundAttachments(fallback.attachments);
+          }
+        }
         return {
           attachments: match.attachments,
           fallbacks: match.fallbacks,
           ...(match.message ? { message: match.message } : {}),
         };
       }
+      // A different Gateway target is terminal for this exact presentation.
+      // Other retained session scopes under the same logical pane remain independent.
       releaseHandoff(match);
       return null;
     },

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -90,6 +90,13 @@ export type ApplicationChatAttachmentHandoff = {
   consume(handoff: ChatAttachmentHandoffKey): {
     attachments: ChatAttachment[];
     fallbacks: Record<string, ChatComposerMemoryFallback>;
+    // This exact client is lifecycle identity, never authorization.
+    // Same-target replacement may retain plain local payload bytes.
+    // Consumers compare it with the current client before adoption,
+    // release browser annotations bound to the old client generation,
+    // and keep shared ids referenced by live or fallback owners.
+    // Different Gateway targets never produce a consumable result.
+    owner: ApplicationGateway["snapshot"]["client"];
     message?: string;
   } | null;
   clearPane(paneId: string): void;

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -2,12 +2,14 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
   navigateToControlUiSession,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { navigateInApp, replaceGatewayClient } from "./new-session-page.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI chat attachment read lifecycle",
@@ -56,6 +58,105 @@ async function pastePng(composer: Locator): Promise<void> {
 }
 
 suite.define(() => {
+  it("keeps exact staged files across a same-Gateway client replacement", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(artifactDir ? { recordVideo: { dir: artifactDir } } : {}),
+      },
+      async ({ page }) => {
+        const sessionKey = "agent:main:attachment-owner-rotation";
+        const gateway = await installMockGateway(page, { sessionKey });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        const files = [
+          { name: "proof.txt", mimeType: "text/plain", buffer: Buffer.from("first-proof") },
+          { name: "proof.txt", mimeType: "text/plain", buffer: Buffer.from("second-proof") },
+        ];
+        await composer.fill("Keep both exact files");
+        await page.locator(".agent-chat__file-input").setInputFiles(files);
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({ path: path.join(artifactDir, "01-staged-files.png") });
+        }
+
+        await navigateInApp(page, "new-session");
+        await page.locator(".new-session-page__message").waitFor();
+        const socketsBefore = await gateway.getSocketCount();
+        await replaceGatewayClient(page);
+        await expect.poll(() => gateway.getSocketCount()).toBe(socketsBefore + 1);
+        await waitForControlUiGatewayReady(page);
+        await navigateInApp(page, "chat");
+        await composer.waitFor();
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "02-restored-files.png") });
+        }
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+        await expect.poll(() => composer.inputValue()).toBe("Keep both exact files");
+
+        await gateway.deferNext("chat.send");
+        await composer.press("Enter");
+        const rejectedRequest = await gateway.waitForRequest("chat.send");
+        expect(rejectedRequest.params).toMatchObject({
+          sessionKey,
+          message: "Keep both exact files",
+          attachments: [
+            { content: Buffer.from("first-proof").toString("base64"), fileName: "proof.txt" },
+            { content: Buffer.from("second-proof").toString("base64"), fileName: "proof.txt" },
+          ],
+        });
+        await gateway.rejectDeferred("chat.send", { message: "Rejected for attachment proof" });
+        await page
+          .getByRole("alert")
+          .filter({ hasText: "Rejected for attachment proof" })
+          .waitFor();
+        await expect.poll(() => composer.inputValue()).toBe("Keep both exact files");
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "03-rejected-restored.png") });
+        }
+
+        await composer.press("Enter");
+        await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(2);
+        const acceptedRequest = (await gateway.getRequests("chat.send"))[1]!;
+        expect(acceptedRequest.params).toMatchObject({
+          sessionKey,
+          message: "Keep both exact files",
+          attachments: [
+            { content: Buffer.from("first-proof").toString("base64"), fileName: "proof.txt" },
+            { content: Buffer.from("second-proof").toString("base64"), fileName: "proof.txt" },
+          ],
+        });
+        const acceptedRunId = (acceptedRequest.params as { idempotencyKey?: unknown })
+          .idempotencyKey;
+        expect(typeof acceptedRunId).toBe("string");
+        await gateway.emitChatFinal({
+          runId: String(acceptedRunId),
+          sessionKey,
+          text: "Done.",
+        });
+        await page.getByText("Done.", { exact: true }).last().waitFor();
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
+        await expect.poll(() => composer.inputValue()).toBe("");
+        await page.getByRole("button", { name: "Remove queued message" }).click();
+        await expect.poll(() => page.locator(".chat-queue__item").count()).toBe(0);
+        await navigateInApp(page, "new-session");
+        await page.locator(".new-session-page__message").waitFor();
+        await navigateInApp(page, "chat");
+        await composer.waitFor();
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
+        expect(await gateway.getRequests("chat.send")).toHaveLength(2);
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "04-final-clean.png") });
+        }
+      },
+    );
+  });
+
   it("rejects a combined attachment frame before the Gateway connection is lost", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -213,8 +213,12 @@ describe("staged chat attachment pane handoff", () => {
   });
 
   it("drops every staged attachment when the Gateway target changes", () => {
-    const previousOwner = { gatewayUrl: "ws://first.test" } as GatewayBrowserClient;
-    const nextOwner = { gatewayUrl: "ws://second.test" } as GatewayBrowserClient;
+    const previousOwner = {
+      gatewayUrl: "ws://same.test/control?tenant=one",
+    } as GatewayBrowserClient;
+    const nextOwner = {
+      gatewayUrl: "ws://same.test/control?tenant=two",
+    } as GatewayBrowserClient;
     const handoff = createChatAttachmentHandoff();
     const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
     const attachment = storedAttachment("different-gateway-file", "application/pdf");

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -182,8 +182,8 @@ describe("staged chat attachment pane handoff", () => {
   });
 
   it("keeps plain staged attachments across a gateway client rotation", () => {
-    const previousOwner = {} as GatewayBrowserClient;
-    const nextOwner = {} as GatewayBrowserClient;
+    const previousOwner = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const nextOwner = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
     const handoff = createChatAttachmentHandoff();
     const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
     const plainImage = storedAttachment("rotation-image");
@@ -212,9 +212,34 @@ describe("staged chat attachment pane handoff", () => {
     discardStateStagedAttachments(current);
   });
 
+  it("drops every staged attachment when the Gateway target changes", () => {
+    const previousOwner = { gatewayUrl: "ws://first.test" } as GatewayBrowserClient;
+    const nextOwner = { gatewayUrl: "ws://second.test" } as GatewayBrowserClient;
+    const handoff = createChatAttachmentHandoff();
+    const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
+    const attachment = storedAttachment("different-gateway-file", "application/pdf");
+    const fallback = storedAttachment("different-gateway-fallback", "text/plain");
+    const current = state([attachment]);
+    current.chatComposerFallbackByScope = {
+      fallback: {
+        attachments: [fallback],
+        message: "must not cross gateways",
+        sequence: 1,
+        storageFailed: true,
+      },
+    };
+
+    replacePaneStagedAttachmentGatewayOwner(context, "p1", current, previousOwner, nextOwner);
+
+    expect(current.chatAttachments).toEqual([]);
+    expect(current.chatComposerFallbackByScope.fallback?.attachments).toEqual([]);
+    expect(getChatAttachmentDataUrl(attachment)).toBeNull();
+    expect(getChatAttachmentDataUrl(fallback)).toBeNull();
+  });
+
   it("restores a mixed package only to the exact mounted owner", () => {
-    const owner = {} as GatewayBrowserClient;
-    const otherOwner = {} as GatewayBrowserClient;
+    const owner = { gatewayUrl: "ws://first.test" } as GatewayBrowserClient;
+    const otherOwner = { gatewayUrl: "ws://second.test" } as GatewayBrowserClient;
     const handoff = createChatAttachmentHandoff();
     const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
     const image = storedAttachment("image");

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -42,6 +42,17 @@ export function restorePaneStagedAttachments(
   if (!restored) {
     return;
   }
+  if (restored.owner !== owner) {
+    const retainPlain = (attachments: readonly ChatAttachment[]) => {
+      const retained = attachments.filter((attachment) => !attachment.browserAnnotation);
+      releaseDisplacedChatAttachmentPayloads(attachments, [retained]);
+      return retained;
+    };
+    restored.attachments = retainPlain(restored.attachments);
+    for (const fallback of Object.values(restored.fallbacks)) {
+      fallback.attachments = retainPlain(fallback.attachments);
+    }
+  }
   const currentIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
   state.chatAttachments = [
     ...state.chatAttachments,
@@ -102,15 +113,16 @@ export function replacePaneStagedAttachmentGatewayOwner(
   // reconnect or plugin-install rotation must not silently discard them.
   if (state) {
     const preservePlain = !previousOwner || previousOwner.gatewayUrl === nextOwner.gatewayUrl;
-    const dropAnnotations = (attachments: readonly ChatAttachment[]) => {
-      const shouldRetain = (attachment: ChatAttachment) =>
-        preservePlain && !attachment.browserAnnotation;
-      releaseAttachments(attachments.filter((attachment) => !shouldRetain(attachment)));
-      return attachments.filter(shouldRetain);
+    const retainPlain = (attachments: readonly ChatAttachment[]) => {
+      const retained = preservePlain
+        ? attachments.filter((attachment) => !attachment.browserAnnotation)
+        : [];
+      releaseDisplacedChatAttachmentPayloads(attachments, [retained]);
+      return retained;
     };
-    state.chatAttachments = dropAnnotations(state.chatAttachments);
+    state.chatAttachments = retainPlain(state.chatAttachments);
     for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-      fallback.attachments = dropAnnotations(fallback.attachments);
+      fallback.attachments = retainPlain(fallback.attachments);
     }
     state.requestUpdate?.();
   }

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -101,9 +101,12 @@ export function replacePaneStagedAttachmentGatewayOwner(
   // client, but plain file/image payloads are client-local data URLs — a gap
   // reconnect or plugin-install rotation must not silently discard them.
   if (state) {
+    const preservePlain = !previousOwner || previousOwner.gatewayUrl === nextOwner.gatewayUrl;
     const dropAnnotations = (attachments: readonly ChatAttachment[]) => {
-      releaseAttachments(attachments.filter((attachment) => attachment.browserAnnotation));
-      return attachments.filter((attachment) => !attachment.browserAnnotation);
+      const shouldRetain = (attachment: ChatAttachment) =>
+        preservePlain && !attachment.browserAnnotation;
+      releaseAttachments(attachments.filter((attachment) => !shouldRetain(attachment)));
+      return attachments.filter(shouldRetain);
     };
     state.chatAttachments = dropAnnotations(state.chatAttachments);
     for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
@@ -111,7 +114,9 @@ export function replacePaneStagedAttachmentGatewayOwner(
     }
     state.requestUpdate?.();
   }
-  context.chatAttachmentHandoff.clearPane(paneId);
+  if (previousOwner && previousOwner.gatewayUrl !== nextOwner.gatewayUrl) {
+    context.chatAttachmentHandoff.clearPane(paneId);
+  }
   return nextOwner;
 }
 

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -326,8 +326,8 @@ describe("staged attachment composer adoption", () => {
   });
 
   it("rejects a new pane after client replacement instead of relabeling staged annotations", () => {
-    const owner = {} as GatewayBrowserClient;
-    const replacement = {} as GatewayBrowserClient;
+    const owner = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const replacement = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
     const context = createSessionContext(owner, {} as SessionCapability);
     const pane = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:replaced-client");
     pane.active = true;
@@ -349,8 +349,8 @@ describe("staged attachment composer adoption", () => {
   });
 
   it("preserves the package on same-client reconnect and clears it on replacement", () => {
-    const owner = {} as GatewayBrowserClient;
-    const replacement = {} as GatewayBrowserClient;
+    const owner = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const replacement = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({
       client: owner,
       sessions: {} as SessionCapability,
@@ -441,8 +441,8 @@ describe("staged attachment composer adoption", () => {
   });
 
   it("invalidates annotation Undo when the logical Gateway client is replaced", async () => {
-    const owner = {} as GatewayBrowserClient;
-    const replacement = {} as GatewayBrowserClient;
+    const owner = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
+    const replacement = { gatewayUrl: "ws://same.test" } as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({
       client: owner,
       sessions: {} as SessionCapability,


### PR DESCRIPTION
> [!CAUTION]
> Landing stopped after security review. A same-URL `gateway.connect({ token: ... })` replacement can change the authenticated principal, so `gatewayUrl` alone cannot safely authorize reuse of staged attachment bytes. This draft requires an owner-issued authenticated identity or credential generation plus same-URL token-replacement proof before it can become ready.

## What Problem This Solves

Fixes an issue where Control UI users could stage files, trigger a same-Gateway client replacement during navigation or reconnect, and return to a composer that had silently lost the handoff package. The mounted composer already retained plain local payloads across client rotation (#123628), but the route-level handoff still required the exact old `GatewayBrowserClient` object and discarded the same bytes after that ephemeral client generation changed.

Related work is distinct: #123628 fixed mounted-composer rotation, #124139 fixed oversized request rejection/draft restoration, and #124048 fixed Gateway-managed reply-media finalization.

## Why This Change Was Made

The candidate treats the Gateway URL as the target boundary and the client object as an ephemeral connection generation. It correctly separates ordinary same-target reconnects from different URL/query targets, but security review proved that URL equality cannot distinguish a token replacement that changes authenticated principal. The implementation remains draft-only pending an owner-issued identity/generation fact.

The eager route handoff now records the original client and only decides whether the Gateway target matches. The lazy chat consumer compares that original owner with the current client and prunes browser annotations before adoption, keeping startup cost out of the application bootstrap. Rejected sends restore the exact draft and bytes; the accepted retry sends them once; final navigation does not restore or resend them.

Production LOC: +41/-22 (net +19). Tests: +189/-13 (net +176). No protocol, config, security-policy, persistence, or changelog change.

## User Impact

Two same-name files with different contents survive a normal same-Gateway reconnect in their original order. A rejected send remains retryable with the exact bytes, and an accepted retry clears the composer without a later navigation resend. Switching to a different Gateway target drops the entire staged package.

## Evidence

- Reviewed head: `47b78c631c8fa636f02a202882ff0cc4708394ae`.
- Blacksmith Testbox `tbx_01m04kw1gff1zza0e56s37j1ws`: https://github.com/openclaw/openclaw/actions/runs/31931331911
- 30 focused UI owner/lifecycle cases passed on the exact head.
- 4 Chromium cases passed on the exact head, including exact two-same-name payload order, rejected restoration, accepted retry, reconnect, cross-session isolation, and final cleanup/no resend.
- Source-blind behavior contract passed against a fresh Chromium recording and four state screenshots.
- Explicit-path changed gate passed: UI/core-test types, oxfmt, oxlint, stylelint, UI i18n, assertion/max-lines ratchets, deps/patches, dead exports, and diff checks.
- Full build passed; startup JS was 335,446 bytes (one byte under the ratchet). Runtime import cycles: 0; madge cycles: 0.
- Fresh branch-mode autoreview on the exact head: no accepted/actionable findings.
- Native artifacts and exact-head CI will be added before landing.
- ClawSweeper security review blocks landing: https://github.com/openclaw/openclaw/pull/124444#issuecomment-5306021390

### Codex contract inspection

Personally checked sibling Codex at `57f42a81131ccf5933e7ec5dc659c381eeb5d72b`:

- App-server input keeps image URLs as ordered `UserInput` values and maps them directly to core input: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L292-L340
- Turn start preserves input order while mapping the vector: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server/src/request_processors/turn_processor.rs#L512-L517
- Response preparation iterates in order and forwards each pre-encoded image URL unchanged: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/protocol/src/models.rs#L1713-L1740
- Local images are snapshotted into portable validated data URLs before request serialization: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/protocol/src/local_media.rs#L18-L34

### Media

Staged before replacement:

![Two same-name staged files](https://github.com/user-attachments/assets/1df4312b-4002-4d0c-8c23-2432ff8e482c)

Restored after same-Gateway replacement:

![Two same-name files restored](https://github.com/user-attachments/assets/b07caaf5-3d99-47e6-a860-0878d70d5fc5)

Rejected send restored for retry:

![Rejected send with draft and files restored](https://github.com/user-attachments/assets/08faaaa1-afea-41b1-8182-8efa7c70602a)

Accepted retry followed by navigation cleanup:

![Final clean composer](https://github.com/user-attachments/assets/374a38d9-7732-451d-9f4a-641c2c4e5944)

Browser recording:

https://github.com/user-attachments/assets/e95b701b-ddc4-466a-8c33-11fb5479e6c9

AI-assisted: yes.
