### PR TITLE
fix(gateway): distinguish queued chats from completed empty replies

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -19341,6 +19341,7 @@ public struct ChatFinalEvent: Codable, Sendable {
     public let usage: AnyCodable?
     public let stopreason: String?
     public let yielded: Bool?
+    public let queued: Bool?
 
     public init(
         runid: String,
@@ -19352,7 +19353,8 @@ public struct ChatFinalEvent: Codable, Sendable {
         message: AnyCodable? = nil,
         usage: AnyCodable? = nil,
         stopreason: String? = nil,
-        yielded: Bool? = nil)
+        yielded: Bool? = nil,
+        queued: Bool? = nil)
     {
         self.runid = runid
         self.sessionkey = sessionkey
@@ -19364,6 +19366,7 @@ public struct ChatFinalEvent: Codable, Sendable {
         self.usage = usage
         self.stopreason = stopreason
         self.yielded = yielded
+        self.queued = queued
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -19377,6 +19380,7 @@ public struct ChatFinalEvent: Codable, Sendable {
         case usage
         case stopreason = "stopReason"
         case yielded
+        case queued
     }
 }
 

--- a/packages/gateway-protocol/src/schema/logs-chat.test.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.test.ts
@@ -3,6 +3,7 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
   ChatEventSchema,
+  ChatFinalEventSchema,
   ChatHistoryParamsSchema,
   ChatSendParamsSchema,
   ChatStatusEventSchema,
@@ -14,6 +15,14 @@ const statusEvent = {
   seq: 1,
   state: "status",
   phase: "preparing_context",
+} as const;
+
+const queuedFinalEvent = {
+  runId: "run-queued",
+  sessionKey: "agent:main:main",
+  seq: 1,
+  state: "final",
+  queued: true,
 } as const;
 
 describe("ChatHistoryParamsSchema", () => {
@@ -34,6 +43,17 @@ describe("ChatStatusEventSchema", () => {
   it("rejects unknown phases and extra fields", () => {
     expect(Value.Check(ChatStatusEventSchema, { ...statusEvent, phase: "thinking" })).toBe(false);
     expect(Value.Check(ChatStatusEventSchema, { ...statusEvent, detail: "Loading" })).toBe(false);
+  });
+});
+
+describe("ChatFinalEventSchema", () => {
+  it("accepts an explicit queued terminal outcome", () => {
+    expect(Value.Check(ChatFinalEventSchema, queuedFinalEvent)).toBe(true);
+    expect(Value.Check(ChatEventSchema, queuedFinalEvent)).toBe(true);
+  });
+
+  it("keeps the queued marker closed to literal true", () => {
+    expect(Value.Check(ChatFinalEventSchema, { ...queuedFinalEvent, queued: false })).toBe(false);
   });
 });
 

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -207,7 +207,7 @@ export const ChatDeltaEventSchema = closedObject({
   usage: Type.Optional(Type.Unknown()),
 });
 
-/** Successful terminal event for a completed chat run. */
+/** Successful terminal event for a completed or explicitly queued chat run. */
 export const ChatFinalEventSchema = closedObject({
   ...ChatEventBaseSchema,
   state: Type.Literal("final"),
@@ -215,6 +215,8 @@ export const ChatFinalEventSchema = closedObject({
   usage: Type.Optional(Type.Unknown()),
   stopReason: Type.Optional(Type.String()),
   yielded: Type.Optional(Type.Literal(true)),
+  /** This client run ended after its prompt was accepted for a later queue drain. */
+  queued: Type.Optional(Type.Literal(true)),
 });
 
 /** Terminal event for user-initiated or coordinator-initiated cancellation. */

--- a/src/gateway/server-methods/chat-broadcast.test.ts
+++ b/src/gateway/server-methods/chat-broadcast.test.ts
@@ -68,6 +68,28 @@ describe("chat terminal broadcasts", () => {
     expect(context.agentRunSeq.has("run-1")).toBe(false);
   });
 
+  it("marks queue-admission finals without changing terminal delivery", () => {
+    const { context } = createContext();
+
+    broadcastChatFinal({
+      context,
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      queued: true,
+    });
+
+    const payload = context.broadcast.mock.calls[0]?.[1];
+    expect(payload).toEqual({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      seq: 1,
+      state: "final",
+      message: undefined,
+      queued: true,
+    });
+    expect(context.nodeSendToSession).toHaveBeenCalledWith("agent:main:main", "chat", payload);
+  });
+
   it("emits canonical error payloads without message or agentId", () => {
     const { context } = createContext(2);
 

--- a/src/gateway/server-methods/chat-broadcast.ts
+++ b/src/gateway/server-methods/chat-broadcast.ts
@@ -93,7 +93,7 @@ type ChatBroadcastParams = {
 };
 
 type ChatTerminal =
-  | { state: "final"; message?: Record<string, unknown> }
+  | { state: "final"; message?: Record<string, unknown>; queued?: true }
   | { state: "error"; errorMessage?: string };
 
 function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void {
@@ -101,7 +101,11 @@ function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void
   const payloadAgentId = parseAgentSessionKey(params.sessionKey) ? undefined : params.agentId;
   const terminal =
     params.state === "final"
-      ? { state: params.state, message: projectChatDisplayMessage(params.message) }
+      ? {
+          state: params.state,
+          message: projectChatDisplayMessage(params.message),
+          ...(params.queued ? { queued: true as const } : {}),
+        }
       : { state: params.state, errorMessage: params.errorMessage };
   const payload = {
     runId: params.runId,
@@ -128,7 +132,7 @@ function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void
 }
 
 export function broadcastChatFinal(
-  params: ChatBroadcastParams & { message?: Record<string, unknown> },
+  params: ChatBroadcastParams & { message?: Record<string, unknown>; queued?: true },
 ): void {
   broadcastChatTerminal({ ...params, state: "final" });
 }

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -503,6 +503,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
           runId: clientRunId,
           sessionKey,
           agentId,
+          queued: true,
         });
       }
     })

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -135,6 +135,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
           runId: clientRunId,
           sessionKey,
           agentId,
+          queued: true,
         });
       }
       return;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4336,6 +4336,7 @@ describe("gateway server chat", () => {
             runId: "idem-queued-followup",
             sessionKey: "agent:main:main",
             state: "final",
+            queued: true,
           }),
           { sessionKeys: ["agent:main:main"] },
         );
@@ -4436,7 +4437,7 @@ describe("gateway server chat", () => {
           (payload as { runId?: string }).runId === "idem-queued-followup-post-error",
       );
       expect(acceptedErrorEvents).toHaveLength(1);
-      expect(acceptedErrorEvents[0]?.[1]).toMatchObject({ state: "final" });
+      expect(acceptedErrorEvents[0]?.[1]).toMatchObject({ state: "final", queued: true });
       expect(context.dedupe.get("chat:idem-queued-followup-post-error")).toMatchObject({
         ok: true,
         payload: { status: "ok" },

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -36,6 +36,7 @@ type GatewayFixture = {
   events: AgentEvent[];
   chatErrors: Array<{ errorMessage?: string; runId?: string; state: "error" }>;
   chatFinalRunIds: string[];
+  queuedChatFinalRunIds: string[];
   sessionKey: string;
   steeringTools?: SteeringToolsFixture;
 };
@@ -531,6 +532,7 @@ async function createGatewayFixture(
   const events: AgentEvent[] = [];
   const chatErrors: Array<{ errorMessage?: string; runId?: string; state: "error" }> = [];
   const chatFinalRunIds: string[] = [];
+  const queuedChatFinalRunIds: string[] = [];
   const client = new GatewayChatClient({
     url: instance.url,
     token: "steer-fifo-token",
@@ -542,7 +544,12 @@ async function createGatewayFixture(
       events.push(agentEvent);
     }
     if (event === "chat" && payload && typeof payload === "object") {
-      const chat = payload as { errorMessage?: unknown; runId?: unknown; state?: unknown };
+      const chat = payload as {
+        errorMessage?: unknown;
+        queued?: unknown;
+        runId?: unknown;
+        state?: unknown;
+      };
       if (chat.state === "error") {
         chatErrors.push({
           state: "error",
@@ -553,6 +560,9 @@ async function createGatewayFixture(
         });
       } else if (chat.state === "final" && typeof chat.runId === "string") {
         chatFinalRunIds.push(chat.runId);
+        if (chat.queued === true) {
+          queuedChatFinalRunIds.push(chat.runId);
+        }
       }
     }
   };
@@ -568,6 +578,7 @@ async function createGatewayFixture(
     events,
     chatErrors,
     chatFinalRunIds,
+    queuedChatFinalRunIds,
     sessionKey: `agent:main:${name}`,
     ...(steeringTools ? { steeringTools } : {}),
   };
@@ -732,6 +743,7 @@ async function queueOrdinaryFollowup(
   expect(result).toMatchObject({ runId, status: "started" });
   await vi.waitFor(() => {
     expect(fixture.chatFinalRunIds).toContain(runId);
+    expect(fixture.queuedChatFinalRunIds).toContain(runId);
     expect(fixture.modelServer.requests).toHaveLength(1);
   }, WAIT_OPTS);
 }


### PR DESCRIPTION
Closes #124447

Related: #50298, #116649, #31346, #33016

## What Problem This Solves

Fixes an issue where Gateway clients submitting a chat turn while a session is busy under `collect` would receive an empty successful `final` indistinguishable from an ordinary completed empty reply, even though the prompt had instead been accepted for a later queue drain.

This is the independently fixable classification part of #50298. It does not claim to correlate the initiating run with a later aggregate run.

## Why This Change Was Made

Queued client runs keep their existing terminal `final`, preventing older request clients from waiting forever, but now carry the backward-compatible literal `queued: true`. The marker is emitted only after successful queue admission, including the post-admission dispatch-error path; ordinary successful finals retain their exact existing payload.

The change adds no queue owner, worker, retry, or lifecycle behavior. It extends the shared protocol schema and regenerated Swift model, then marks the two existing queue-admission terminal producers.

## User Impact

Gateway clients can now distinguish “your requested run completed” from “your prompt was retained for later processing.” Existing clients can continue treating the event as a terminal final, while clients that understand the optional marker can avoid reporting the queued turn as a completed empty reply.

Clients still need a future resolution of #50298 if they must correlate the initiating run with the later aggregate response.

## Evidence

- Red before the production change: the focused direct Gateway regression expected `queued: true` on the accepted follow-up final and failed on the unchanged payload; the other 101 tests in that file passed.
- Protocol schema tests: 6 passed, including acceptance of literal `true`, rejection of `false`, and unchanged ordinary finals.
- Direct Gateway server chat tests: 102 passed, covering normal queue admission and the post-admission dispatch-error path.
- Chat terminal broadcast tests: 6 passed, including exact ordinary-final payload compatibility.
- Real authenticated Gateway WebSocket regression over loopback with an isolated session store and mock OpenAI Responses SSE: 1 selected collect/FIFO test passed (4 skipped); it observed `queued: true` before the retained prompt drained in FIFO order.
- `tsgo:core`, changed core-test/root-test TypeScript checks, targeted Oxlint/Oxfmt, and `git diff --check`: passed.
- Protocol registry, JSON generation, Swift generation check, Kotlin generation, protocol-since guard, and generated-file cleanliness: passed.
- Tested under the repository-supported Node.js 22.23.1 toolchain. The optional `$crabbox` wrapper was not available in this environment, so these were repository-native local lanes; GitHub CI remains the independent containerized check.
- Exact-head GitHub CI on `ca61005f2bff82a647d39e75ac9b1736c53bc1d1` passed the protocol, Gateway boundary, security, lint/type, Node matrix, iOS debug/release build, and focused iOS lifecycle lanes. One unrelated shard is red: [`checks-node-compact-large-9`](https://github.com/openclaw/openclaw/actions/runs/31930838182/job/95125328789) observed `776` instead of an exact `777` ms in `workspace-sync.test.ts`; this PR does not touch worker workspaces or timeout budgeting. That test passed once in its full 7-test file and 10/10 additional focused repetitions locally. Contributor permissions cannot rerun the upstream job.

AI-assisted: Codex helped investigate prior art, implement the focused patch, and run the validation above. I reviewed the diff and evidence. Maintainer edits are enabled.
