### PR TITLE
fix(browser): report refused Chrome MCP tab closes

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-actions.ts
+++ b/extensions/browser/src/browser/chrome-mcp-actions.ts
@@ -15,7 +15,13 @@ import {
   type ChromeMcpProfileOptions,
   type ChromeMcpTargetOperation,
 } from "./chrome-mcp-contracts.js";
-import { extractJsonMessage, extractSnapshot } from "./chrome-mcp-result.js";
+import {
+  extractJsonMessage,
+  extractSnapshot,
+  extractStructuredPages,
+  extractToolErrorMessage,
+  formatChromeMcpToolErrorMessage,
+} from "./chrome-mcp-result.js";
 import {
   callTargetTool,
   callTool,
@@ -76,7 +82,7 @@ export async function closeChromeMcpTab(
       ...options,
     },
     async (target) => {
-      await callTool(
+      const result = await callTool(
         profileName,
         target.profileOptions,
         "close_page",
@@ -84,6 +90,16 @@ export async function closeChromeMcpTab(
         options,
         target.lease,
       );
+      if (extractStructuredPages(result).some((page) => page.id === target.pageId)) {
+        throw new Error(
+          formatChromeMcpToolErrorMessage({
+            profileName,
+            options: target.profileOptions,
+            toolName: "close_page",
+            message: extractToolErrorMessage(result, "close_page"),
+          }),
+        );
+      }
       // Retire inside the same operation lock so queued work cannot dispatch
       // against a closed page id. A later list gets a new opaque handle even if
       // Chrome reuses that numeric id.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -569,6 +569,35 @@ describe("chrome MCP page parsing", () => {
     expect(calls).toEqual(["list_pages", "close_page"]);
   });
 
+  it("rejects a close result when Chrome MCP kept the target open", async () => {
+    const pages: SessionPage[] = [{ id: 1, url: "https://a.example", selected: true }];
+    const session = createPageSession({
+      pid: 131,
+      pages,
+      onTool: (call) =>
+        call.name === "close_page"
+          ? {
+              structuredContent: {
+                message: "The last open page cannot be closed. It is fine to keep it open.",
+                pages,
+              },
+            }
+          : undefined,
+    });
+    const factory = vi.fn(async () => session);
+    setChromeMcpSessionFactoryForTest(factory);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+
+    await expect(closeChromeMcpTab("chrome-live", targetId)).rejects.toThrow(
+      "The last open page cannot be closed",
+    );
+    await expect(listChromeMcpTabs("chrome-live")).resolves.toEqual([
+      expect.objectContaining({ targetId, url: "https://a.example" }),
+    ]);
+    expect(factory).toHaveBeenCalledOnce();
+    expect((session.client.close as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+
   it("retires a closed target and issues a new handle when Chrome reuses its page id", async () => {
     const pages: SessionPage[] = [
       { id: 1, url: "https://a.example" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users closing the last tab in an existing Chrome session would receive an apparent success even though Chrome kept the tab open. OpenClaw then retired the tab handle and snapshot refs, making the still-open tab look lost.

## Why This Change Was Made

Chrome DevTools MCP 1.7.0 intentionally returns a non-error `close_page` result when the last page cannot be closed. Its handler includes the refusal message and an authoritative structured `pages` list that still contains the requested numeric page ID. OpenClaw now checks that returned list before retiring local target/ref state; if the exact ID remains, it reports the existing bounded/redacted formatter message and preserves the handle. Successful closes keep the existing operation-lock retirement path.

The change is isolated to the Chrome-MCP adapter. The Playwright close path, public browser tool schema, and tab security policy are unchanged.

Production LOC: +18/-2 (net +16). Tests: +29/-0.

Upstream contract inspected at `ChromeDevTools/chrome-devtools-mcp` tag `chrome-devtools-mcp-v1.7.0` / commit `774d78f5eef5e610407a0c92fa6ec5ed74b027e8`: `src/tools/pages.ts`, `src/McpContext.ts`, `src/McpResponse.ts`, and the close-page tests.

## User Impact

Closing the only Chrome-MCP tab now reports Chrome's refusal and leaves that tab usable. Closing a real tab still retires its stale handle and gives a reused numeric Chrome page ID a fresh OpenClaw handle.

No changelog file is included; this PR body carries the release-note context under the repository's release-generated changelog policy.

## Evidence

- Published `chrome-devtools-mcp@1.7.0` against an isolated headless Chrome: `close_page` returned “The last open page cannot be closed,” retained page ID `1` in `structuredContent.pages`, and the same ID remained usable for `evaluate_script` and relisting.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts` — 88 passed.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.ownership.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts` — 29 passed.
- Blacksmith Testbox full build passed on exact head.
- Blacksmith Testbox plugin boundary report, extension production/test types, full extension lint, targeted format, import-cycle check, and diff check all passed: https://github.com/openclaw/openclaw/actions/runs/31930622166
- Fresh structured autoreview: clean, no accepted/actionable findings.
- Exact-head GitHub CI is green at `8a4f7a2a81b6a30ceb9bcd07e7059f8bace5929c`; it includes the independently landed assertion-safety repair #124445.
