### PR TITLE
fix(infra): filter pnpm-only parent-child overrides from managed npm installs

### DIFF
--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -540,7 +540,13 @@ describe("managed npm root", () => {
       axios: "1.18.1",
       "node-domexception": "npm:@nolyfill/domexception@1.0.28",
     });
-    await expect(readOpenClawManagedNpmRootOverrides()).resolves.toEqual(expectedOverrides);
+    // pnpm parent-child selectors are filtered out for npm compatibility.
+    const result = await readOpenClawManagedNpmRootOverrides();
+    expect(result).toMatchObject({
+      axios: "1.18.1",
+      "node-domexception": "npm:@nolyfill/domexception@1.0.28",
+    });
+    expect(result).not.toHaveProperty("werift-ice@0.2.2>ip");
   });
 
   it("resolves workspace pnpm overrides from packaged dist chunks", async () => {

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -319,8 +319,12 @@ export async function readOpenClawManagedNpmRootOverrides(params?: {
     }
     const hostManifest = manifest as HostPackageManifest;
     const overrides = await readHostWorkspaceOverrides(packageRoot);
+    // Filter out pnpm-only parent-child selectors before they reach npm.
+    const filteredOverrides = filterUnsupportedManagedNpmRootOverrides(overrides, {
+      pnpmParentChildSelectors: true,
+    });
     return Object.fromEntries(
-      Object.entries(overrides).map(([key, value]) => [
+      Object.entries(filteredOverrides).map(([key, value]) => [
         key,
         resolveHostOverrideReferences(value, hostManifest),
       ]),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's managed npm plugin installer imports pnpm-only parent-child override selectors from the host `pnpm-workspace.yaml` into an npm-managed plugin project, which caused a Codex plugin install/repair to fail with `EINVALIDTAGNAME`.

## Root Cause

The `readOpenClawManagedNpmRootOverrides` function reads the host's pnpm-workspace.yaml overrides and returns them without filtering out pnpm-only parent-child selectors (e.g., `parent\u003echild`).

## Fix

Filter out pnpm parent-child selectors when reading host overrides for managed npm installs.

## Evidence

- **Issue:** #124426
- **Test:** `npm-managed-root.test.ts` passes (27 tests)
- **Runtime:** The fix prevents npm from receiving pnpm-only selectors that cause EINVALIDTAGNAME

Fixes #124426