### PR TITLE
fix(gateway): allow new session creation when parent session doesn't exist

### DIFF
--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -516,36 +516,33 @@ export async function createGatewaySession(params: {
       agentId: parentSelectedAgentId,
     });
     if (!parent.entry?.sessionId) {
-      return {
-        ok: false,
-        error: errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `unknown parent session: ${parentSessionKey}`,
-        ),
-      };
+      // Parent session doesn't exist yet (e.g., clean gateway). Create without parent.
+      canonicalParentSessionKey = undefined;
+      parentSessionEntry = undefined;
+    } else {
+      const parentOwnershipError = resolvePluginSessionOwnershipError({
+        action: params.fork === true ? "fork" : "link",
+        entry: parent.entry,
+        key: parent.canonicalKey,
+        pluginOwnerId: params.authorizedPluginId,
+      });
+      if (parentOwnershipError) {
+        return { ok: false, error: parentOwnershipError };
+      }
+      if (isModelSelectionLocked(parent.entry)) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_PARENT_FORK_MESSAGE),
+        };
+      }
+      canonicalParentSessionKey = parent.canonicalKey;
+      parentSessionEntry = parent.entry;
+      parentSessionTarget = resolveGatewaySessionStoreTarget({
+        cfg: params.cfg,
+        key: parentSessionKey,
+        ...(parentSelectedAgentId ? { agentId: parentSelectedAgentId } : {}),
+      });
     }
-    const parentOwnershipError = resolvePluginSessionOwnershipError({
-      action: params.fork === true ? "fork" : "link",
-      entry: parent.entry,
-      key: parent.canonicalKey,
-      pluginOwnerId: params.authorizedPluginId,
-    });
-    if (parentOwnershipError) {
-      return { ok: false, error: parentOwnershipError };
-    }
-    if (isModelSelectionLocked(parent.entry)) {
-      return {
-        ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_PARENT_FORK_MESSAGE),
-      };
-    }
-    canonicalParentSessionKey = parent.canonicalKey;
-    parentSessionEntry = parent.entry;
-    parentSessionTarget = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: parentSessionKey,
-      ...(parentSelectedAgentId ? { agentId: parentSelectedAgentId } : {}),
-    });
   }
   const parentIncognito =
     parentSessionEntry?.incognito === true || isIncognitoSessionKey(canonicalParentSessionKey);


### PR DESCRIPTION
## What Problem This Solves

Control UI New session fails with `unknown parent session` on clean and normal gateways. When a parent session key is provided but doesn't exist in the store, the code returned an error.

## Root Cause

The session creation code required the parent session to exist in the store, but on a clean gateway, the parent session may not exist yet.

## Fix

Allow creating a new session without a parent when the parent doesn't exist.

## Evidence

- **Issue:** #124424
- **Test:** `session-create-fork-entry.test.ts` passes (6 tests)
- **Runtime:** The fix allows new session creation on clean gateways

Fixes #124424