### PR TITLE
fix(sessions): always take file lock before reading settings

### DIFF
--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -157,21 +157,15 @@ export class FileSettingsStorage implements SettingsStorage {
 
     let release: (() => void) | undefined;
     try {
-      // Only create directory and lock if file exists or we need to write
-      const fileExists = existsSync(path);
-      if (fileExists) {
-        release = acquireFileLockSyncWithRetry(path);
+      // Always take the lock before reading to prevent concurrent first-write races.
+      // Create directory first so the lock file can be created.
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
       }
-      const current = fileExists ? readFileSync(path, "utf-8") : undefined;
+      release = acquireFileLockSyncWithRetry(path);
+      const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
-        // Only create directory when we actually need to write
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
-        }
-        if (!release) {
-          release = acquireFileLockSyncWithRetry(path);
-        }
         writeFileSync(path, next, "utf-8");
       }
     } finally {


### PR DESCRIPTION
## What Problem This Solves

`FileSettingsStorage.withLock` only took the file lock when the settings file already existed, and it took it after the initial read. Two OpenClaw processes that persisted a setting before `settings.json` existed could both read "no file", both compute their own merge from an empty base, and the second write would replace the first.

## Root Cause

The lock was only taken when the file existed, and it was taken after the read, creating a race window for concurrent first writes.

## Fix

Always take the lock before reading to prevent concurrent first-write races.

## Evidence

- **Issue:** #124394
- **Test:** `settings-manager.test.ts` passes (5 tests)
- **Runtime:** The fix prevents silent setting loss on concurrent first writes

Fixes #124394