### PR TITLE
fix(gateway): keep sessions.list responsive with many configured agents

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -17,6 +17,8 @@ import {
 import {
   listOpenClawRegisteredAgentDatabases,
   listOpenIncognitoAgentDatabases,
+  readOpenClawAgentDatabaseRegistryToken,
+  readOpenIncognitoAgentDatabaseGeneration,
 } from "../../state/openclaw-agent-db.js";
 import { resolveSessionStoreCompatibilityAgentId } from "../legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
@@ -36,7 +38,6 @@ import {
   listKnownSessionStoreAgentIds,
   resolveAgentSessionStoreTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
-  resolveSessionStoreTargets,
 } from "./targets.js";
 import type { SessionEntry } from "./types.js";
 
@@ -52,12 +53,25 @@ type GatewaySessionStoreOptions = {
 type ResolvedGatewaySessionStoreTargets = {
   configuredAgentIds?: ReadonlySet<string>;
   defaultAgentId: string;
-  diagnostics: string[];
-  durableTargets: Array<{ agentId: string; storePath: string }>;
-  incognitoTargets: Array<{ agentId: string; storePath: string }>;
+  diagnostics: readonly string[];
+  durableStorePath?: string;
+  durableTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
+  incognitoTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
   requestedAgentId?: string;
   storeConfig?: string;
 };
+
+type PreparedConfiguredSessionStoreTargets = {
+  cfg: OpenClawConfig;
+  includeIncognito: boolean;
+  incognitoGeneration: number;
+  registryToken: symbol;
+  resolved: ResolvedGatewaySessionStoreTargets;
+};
+
+// Gateway aliases, config, registry, and incognito topology are process-stable until
+// an explicit generation change or restart; generic CLI/Doctor dedupe stays fresh.
+let preparedConfiguredSessionStoreTargets: PreparedConfiguredSessionStoreTargets | undefined;
 
 // Template-backed stores need per-agent scans before they can be merged for Gateway views.
 function isStorePathTemplate(store?: string): boolean {
@@ -73,9 +87,13 @@ function resolveCombinedStorePath(paths: string[], storeConfig?: string): string
 }
 
 function resolveCombinedDatabasePath(
-  targets: Array<{ agentId: string; storePath: string }>,
+  targets: ReadonlyArray<{ agentId: string; storePath: string }>,
   defaultAgentId: string,
+  physicallyDeduped = false,
 ): string {
+  if (physicallyDeduped && targets.length !== 1) {
+    return "(multiple)";
+  }
   const paths = [
     ...new Set(
       targets.map(
@@ -147,7 +165,7 @@ function mergeOpenIncognitoStores(params: {
   cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
   projection: GatewaySessionEntryProjection;
-  targets: Array<{ agentId: string; storePath: string }>;
+  targets: ReadonlyArray<{ agentId: string; storePath: string }>;
 }): string[] {
   const storePaths: string[] = [];
   for (const target of params.targets) {
@@ -205,6 +223,74 @@ function filterCombinedStoreToConfiguredAgents(params: {
   }
 }
 
+function resolvePreparedConfiguredSessionStoreTargets(
+  cfg: OpenClawConfig,
+  includeIncognito: boolean,
+): ResolvedGatewaySessionStoreTargets {
+  const registryToken = readOpenClawAgentDatabaseRegistryToken();
+  const incognitoGeneration = readOpenIncognitoAgentDatabaseGeneration();
+  const cached = preparedConfiguredSessionStoreTargets;
+  if (
+    cached?.cfg === cfg &&
+    cached.registryToken === registryToken &&
+    cached.incognitoGeneration === incognitoGeneration &&
+    cached.includeIncognito === includeIncognito
+  ) {
+    return cached.resolved;
+  }
+
+  const storeConfig = cfg.session?.store;
+  const defaultAgentId = normalizeAgentId(resolveSessionStoreCompatibilityAgentId(cfg));
+  const configuredIds = listConfiguredSessionStoreAgentIds(cfg);
+  const configuredAgentIds = new Set(configuredIds);
+  const incognitoTargets = includeIncognito ? listOpenIncognitoAgentDatabases() : [];
+  const incognitoTargetKeys = new Set(
+    incognitoTargets.map((target) => `${target.agentId}\0${target.storePath}`),
+  );
+  const diagnostics: string[] = [];
+  const candidates = dedupeSessionStoreTargetsBySqliteTarget(
+    [
+      ...listOpenClawRegisteredAgentDatabases().map(({ agentId, path }) => ({
+        agentId,
+        storePath: path,
+      })),
+      ...configuredIds.map((agentId) => ({
+        agentId,
+        storePath: resolveSessionStorePathCore(storeConfig, { agentId }),
+      })),
+      ...incognitoTargets,
+    ],
+    {
+      defaultAgentId,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
+    },
+  );
+  const durableTargets = candidates.filter(
+    (target) => !incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`),
+  );
+  const resolved = Object.freeze({
+    configuredAgentIds,
+    defaultAgentId,
+    diagnostics: Object.freeze(diagnostics),
+    durableStorePath: resolveCombinedDatabasePath(durableTargets, defaultAgentId, true),
+    durableTargets: Object.freeze(durableTargets.map((target) => Object.freeze({ ...target }))),
+    incognitoTargets: Object.freeze(
+      candidates
+        .filter((target) => incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`))
+        .map((target) => Object.freeze({ ...target })),
+    ),
+    storeConfig,
+  });
+  preparedConfiguredSessionStoreTargets = {
+    cfg,
+    includeIncognito,
+    incognitoGeneration,
+    registryToken,
+    resolved,
+  };
+  return resolved;
+}
+
 function resolveGatewaySessionStoreTargets(
   cfg: OpenClawConfig,
   opts: GatewaySessionStoreOptions,
@@ -215,49 +301,16 @@ function resolveGatewaySessionStoreTargets(
     typeof opts.agentId === "string" && opts.agentId.trim()
       ? normalizeAgentId(opts.agentId)
       : undefined;
+  if (opts.configuredAgentsOnly === true && !requestedAgentId) {
+    return resolvePreparedConfiguredSessionStoreTargets(cfg, opts.includeIncognito !== false);
+  }
   const defaultAgentId = normalizeAgentId(resolveSessionStoreCompatibilityAgentId(cfg));
-  const configuredAgentIds =
-    opts.configuredAgentsOnly === true && !requestedAgentId
-      ? new Set(listConfiguredSessionStoreAgentIds(cfg))
-      : undefined;
   const incognitoTargets =
     opts.includeIncognito === false
       ? []
       : listOpenIncognitoAgentDatabases().filter(
           (target) => !requestedAgentId || target.agentId === requestedAgentId,
         );
-
-  if (configuredAgentIds) {
-    const incognitoTargetKeys = new Set(
-      incognitoTargets.map((target) => `${target.agentId}\0${target.storePath}`),
-    );
-    const candidates = dedupeSessionStoreTargetsBySqliteTarget(
-      [
-        ...listOpenClawRegisteredAgentDatabases().map(({ agentId, path }) => ({
-          agentId,
-          storePath: path,
-        })),
-        ...resolveSessionStoreTargets(cfg, { allAgents: true }),
-        ...incognitoTargets,
-      ],
-      {
-        defaultAgentId,
-        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
-      },
-    );
-    return {
-      configuredAgentIds,
-      defaultAgentId,
-      diagnostics,
-      durableTargets: candidates.filter(
-        (target) => !incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`),
-      ),
-      incognitoTargets: candidates.filter((target) =>
-        incognitoTargetKeys.has(`${target.agentId}\0${target.storePath}`),
-      ),
-      storeConfig,
-    };
-  }
 
   if (storeConfig && !isStorePathTemplate(storeConfig)) {
     const ownerIds = [
@@ -279,7 +332,6 @@ function resolveGatewaySessionStoreTargets(
       },
     );
     return {
-      configuredAgentIds,
       defaultAgentId,
       diagnostics,
       durableTargets,
@@ -290,10 +342,12 @@ function resolveGatewaySessionStoreTargets(
   }
 
   const durableTargets = requestedAgentId
-    ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)
+    ? dedupeSessionStoreTargetsBySqliteTarget(
+        resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId),
+        { defaultAgentId },
+      )
     : resolveAllAgentSessionStoreTargetsSync(cfg);
   return {
-    configuredAgentIds,
     defaultAgentId,
     diagnostics,
     durableTargets,
@@ -311,10 +365,13 @@ export function canPrewarmCombinedSessionStoresForGateway(
   let totalRows = 0;
   for (const agentId of params.agentIds) {
     const resolved = resolveGatewaySessionStoreTargets(cfg, { agentId });
-    const projectionTargets = dedupeSessionStoreTargetsBySqliteTarget(
-      [...resolved.durableTargets, ...resolved.incognitoTargets],
-      { defaultAgentId: resolved.defaultAgentId },
-    );
+    const projectionTargets =
+      resolved.incognitoTargets.length === 0
+        ? resolved.durableTargets
+        : dedupeSessionStoreTargetsBySqliteTarget(
+            [...resolved.durableTargets, ...resolved.incognitoTargets],
+            { defaultAgentId: resolved.defaultAgentId },
+          );
     for (const target of projectionTargets) {
       totalRows += countSessionEntryRowsReadOnly(target);
       if (totalRows > params.maxRows) {
@@ -330,9 +387,9 @@ export function loadCombinedSessionStoreForGatewayCore(
   cfg: OpenClawConfig,
   opts: GatewaySessionStoreOptions = {},
 ): {
-  diagnostics?: string[];
+  diagnostics?: readonly string[];
   durableStorePath?: string;
-  durableTargets: Array<{ agentId: string; storePath: string }>;
+  durableTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
   storePath: string;
   store: Record<string, SessionEntry>;
 } {
@@ -343,6 +400,7 @@ export function loadCombinedSessionStoreForGatewayCore(
     configuredAgentIds,
     defaultAgentId,
     diagnostics,
+    durableStorePath: preparedDurableStorePath,
     durableTargets,
     incognitoTargets,
     requestedAgentId,
@@ -391,7 +449,8 @@ export function loadCombinedSessionStoreForGatewayCore(
   }
 
   const durableStorePaths = durableTargets.map((target) => target.storePath);
-  const durableStorePath = resolveCombinedDatabasePath(durableTargets, defaultAgentId);
+  const durableStorePath =
+    preparedDurableStorePath ?? resolveCombinedDatabasePath(durableTargets, defaultAgentId);
   if (storeConfig && !isStorePathTemplate(storeConfig)) {
     return {
       diagnostics,

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -3,6 +3,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
 import { readSessionTranscriptUpdateVersion } from "../../sessions/transcript-events.js";
+import {
+  readOpenClawAgentDatabaseRegistryToken,
+  readOpenIncognitoAgentDatabaseGeneration,
+} from "../../state/openclaw-agent-db.js";
 import { readSessionAutomationVersion } from "../session-automation-index.js";
 import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
@@ -14,6 +18,8 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js
 
 type SessionListFence = {
   agentRunIndexVersion: number;
+  agentDatabaseRegistryToken: symbol;
+  incognitoDatabaseGeneration: number;
   lifecyclePersistenceVersion: number;
   sessionAutomationVersion: number;
   sessionIdentityMutationVersion: number;
@@ -36,6 +42,8 @@ const sessionListsByContext = new WeakMap<GatewayRequestContext, SessionListStat
 function readSessionListFence(context: GatewayRequestContext): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
+    agentDatabaseRegistryToken: readOpenClawAgentDatabaseRegistryToken(),
+    incognitoDatabaseGeneration: readOpenIncognitoAgentDatabaseGeneration(),
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
     sessionAutomationVersion: readSessionAutomationVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
@@ -51,6 +59,8 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
 function matchesSessionListFence(value: SessionListFence, fence: SessionListFence): boolean {
   return (
     value.agentRunIndexVersion === fence.agentRunIndexVersion &&
+    value.agentDatabaseRegistryToken === fence.agentDatabaseRegistryToken &&
+    value.incognitoDatabaseGeneration === fence.incognitoDatabaseGeneration &&
     value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
     value.sessionAutomationVersion === fence.sessionAutomationVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import {
@@ -11,11 +12,21 @@ import {
   replaceSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import { waitForSessionTranscriptIndexReconcile } from "../../config/sessions/session-transcript-reconcile.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
-import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  registerOpenClawAgentDatabase,
+  unregisterOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  openOpenClawAgentDatabase,
+  readOpenIncognitoAgentDatabaseGeneration,
+  resolveIncognitoOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { bumpSessionAutomationVersion } from "../session-automation-index.js";
 import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
@@ -254,6 +265,109 @@ describe("sessions.list single-flight", () => {
 
       emitSessionsChanged(context, { reason: "test", sessionKey: "agent:main:active" });
       await listSessions({ client, context, request });
+      expect(loader.calls).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("rebuilds configured targets after registry-only register and unregister", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const config = await seedSessions();
+      const extraStorePath = path.join(state.stateDir, "extra-main-sessions.json");
+      const extraDatabasePath = resolveSqliteTargetFromSessionStorePath(extraStorePath, {
+        agentId: "main",
+      }).path;
+      const extraSessionKey = "agent:main:registry-only";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: extraSessionKey, storePath: extraStorePath },
+        {
+          sessionId: "registry-only",
+          updatedAt: 500,
+          createdActor: { type: "human", id: "owner@example.com" },
+          visibility: "shared",
+        },
+      );
+      closeOpenClawAgentDatabaseByPath(extraDatabasePath);
+      unregisterOpenClawAgentDatabase({ agentId: "main", env: state.env, path: extraDatabasePath });
+
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, configuredAgentsOnly: true, limit: 100 };
+      const first = await listSessions({ client, context, request });
+      expect(first.sessions.map((session) => session.key)).not.toContain(extraSessionKey);
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      registerOpenClawAgentDatabase({ agentId: "main", env: state.env, path: extraDatabasePath });
+      const registered = await listSessions({ client, context, request });
+      expect(registered.sessions.map((session) => session.key)).toContain(extraSessionKey);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+      expect(await listSessions({ client, context, request })).toBe(registered);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+
+      unregisterOpenClawAgentDatabase({ agentId: "main", env: state.env, path: extraDatabasePath });
+      const unregistered = await listSessions({ client, context, request });
+      expect(unregistered.sessions.map((session) => session.key)).not.toContain(extraSessionKey);
+      expect(loader.calls).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("fences configured lists when incognito membership opens and closes", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      client.connect.scopes = [...(client.connect.scopes ?? []), "operator.admin"];
+      const request = { archived: "all" as const, configuredAgentsOnly: true, limit: 100 };
+      const childKey = "agent:guest:subagent:incognito-cache-fence";
+      const first = await listSessions({ client, context, request });
+      expect(first.sessions.map((session) => session.key)).not.toContain(childKey);
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      const incognitoPath = resolveIncognitoOpenClawAgentSqlitePath({
+        agentId: "guest",
+        env: state.env,
+      });
+      const generationBeforeOpen = readOpenIncognitoAgentDatabaseGeneration();
+      const database = openOpenClawAgentDatabase({
+        agentId: "guest",
+        env: state.env,
+        path: incognitoPath,
+      });
+      const openedGeneration = readOpenIncognitoAgentDatabaseGeneration();
+      expect(openedGeneration).toBeGreaterThan(generationBeforeOpen);
+      expect(
+        openOpenClawAgentDatabase({ agentId: "guest", env: state.env, path: incognitoPath }),
+      ).toBe(database);
+      expect(readOpenIncognitoAgentDatabaseGeneration()).toBe(openedGeneration);
+      const entry = {
+        sessionId: "incognito-cache-fence",
+        updatedAt: 600,
+        incognito: true,
+        parentSessionKey: "agent:main:active",
+      };
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, parent_session_key) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          childKey,
+          entry.sessionId,
+          JSON.stringify(entry),
+          entry.updatedAt,
+          entry.parentSessionKey,
+        );
+      database.db
+        .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+        .run(childKey);
+
+      const opened = await listSessions({ client, context, request });
+      expect(opened.sessions.map((session) => session.key)).toContain(childKey);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+
+      expect(closeOpenClawAgentDatabaseByPath(incognitoPath)).toBe(true);
+      const closed = await listSessions({ client, context, request });
+      expect(closed.sessions.map((session) => session.key)).not.toContain(childKey);
       expect(loader.calls).toHaveBeenCalledTimes(3);
     });
   });

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -3,11 +3,13 @@
  * lookup store. That made `sessions.list` quadratic in entries even after
  * connection reuse removed the per-row SQLite opens.
  */
+import path from "node:path";
 import { expect, test, vi } from "vitest";
 import * as sessionsConfig from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import * as agentDatabaseRegistry from "../state/openclaw-agent-db-registry.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
 import type { SessionsListResult } from "./session-utils.types.js";
@@ -93,6 +95,34 @@ test("sessions.list reuses prepared store targets for sharing", async () => {
     expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(0);
   } finally {
     discoverySpy.mockRestore();
+  }
+});
+
+test("startup prewarm reuses requested durable targets when no incognito store is open", async () => {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json");
+  const storePath = storeTemplate.replace("{agentId}", "main");
+  await writeSessionStore({
+    entries: { main: sessionStoreEntry("sess-main") },
+    storePath,
+  });
+  const matcher = vi.spyOn(agentDatabaseRegistry, "createOpenClawAgentDatabasePathMatcher");
+  try {
+    expect(
+      sessionsConfig.canPrewarmCombinedSessionStoresForGateway(
+        {
+          agents: { list: [{ id: "main", default: true }] },
+          session: { store: storeTemplate },
+        },
+        { agentIds: ["main"], maxRows: 10 },
+      ),
+    ).toBe(true);
+    expect(matcher).toHaveBeenCalledTimes(1);
+  } finally {
+    matcher.mockRestore();
   }
 });
 

--- a/src/gateway/server.sessions.store-paths.test.ts
+++ b/src/gateway/server.sessions.store-paths.test.ts
@@ -1,7 +1,10 @@
+import fsSync from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import * as sessionDirs from "../agents/session-dirs.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import * as agentDatabaseRegistry from "../state/openclaw-agent-db-registry.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
@@ -51,6 +54,121 @@ test("sessions.list reports multiple physical agent stores", async () => {
   const listed = await directSessionReq<{ path: string }>("sessions.list", {});
 
   expect(listed).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+});
+
+test.runIf(process.platform !== "win32")(
+  "requested-agent path projection collapses physical store aliases",
+  async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+    }
+    const aliasStateDir = `${stateDir}-alias`;
+    fsSync.symlinkSync(stateDir, aliasStateDir, "dir");
+    try {
+      const realStore = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+      const aliasTemplate = path.join(
+        aliasStateDir,
+        "agents",
+        "{agentId}",
+        "sessions",
+        "sessions.json",
+      );
+      await writeSessionStore({
+        agentId: "main",
+        entries: {
+          "agent:main:main": { sessionId: "alias-main", updatedAt: 10 },
+        },
+        storePath: realStore,
+      });
+      testState.sessionConfig = { store: aliasTemplate };
+      testState.agentsConfig = { list: [{ id: "main", default: true }] };
+
+      const listed = await directSessionReq<{
+        path: string;
+        sessions: Array<{ key: string }>;
+      }>("sessions.list", {
+        agentId: "main",
+      });
+
+      expect(listed).toMatchObject({
+        ok: true,
+        payload: {
+          path: resolveSqliteTargetFromSessionStorePath(realStore, { agentId: "main" }).path,
+          sessions: [expect.objectContaining({ key: "agent:main:main" })],
+        },
+      });
+    } finally {
+      fsSync.rmSync(aliasStateDir, { force: true });
+    }
+  },
+);
+
+test("configured-only multi-store target preparation is reused across distinct lists", async () => {
+  const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!rootStateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const stateDir = path.join(rootStateDir, "configured-path-scaling");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const agentIds = Array.from({ length: 29 }, (_, index) => `agent-${index}`);
+    const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json");
+    testState.sessionConfig = { store: storeTemplate };
+    testState.agentsConfig = { list: agentIds.map((id, index) => ({ id, default: index === 0 })) };
+    for (const agentId of agentIds) {
+      const storePath = storeTemplate.replace("{agentId}", agentId);
+      await writeSessionStore({
+        agentId,
+        entries: {
+          [`agent:${agentId}:main`]: { sessionId: `session-${agentId}`, updatedAt: 10 },
+        },
+        storePath,
+      });
+    }
+
+    const matcher = vi.spyOn(agentDatabaseRegistry, "createOpenClawAgentDatabasePathMatcher");
+    const lstat = vi.spyOn(fsSync, "lstatSync");
+    const readlink = vi.spyOn(fsSync, "readlinkSync");
+    const realpath = vi.spyOn(fsSync.realpathSync, "native");
+    const stat = vi.spyOn(fsSync, "statSync");
+    syncBuiltinESMExports();
+    try {
+      const first = await directSessionReq<{ path: string }>("sessions.list", {
+        configuredAgentsOnly: true,
+        includeGlobal: false,
+      });
+      expect(first).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+      expect(matcher).toHaveBeenCalledTimes(1);
+      expect({
+        realpath: realpath.mock.calls.length,
+        stat: stat.mock.calls.length,
+      }).toEqual({ realpath: agentIds.length, stat: agentIds.length });
+
+      for (const spy of [matcher, lstat, readlink, realpath, stat]) {
+        spy.mockClear();
+      }
+      const second = await directSessionReq<{ path: string }>("sessions.list", {
+        configuredAgentsOnly: true,
+        includeUnknown: false,
+      });
+
+      expect(second).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+      expect({
+        lstat: lstat.mock.calls.length,
+        matcher: matcher.mock.calls.length,
+        readlink: readlink.mock.calls.length,
+        realpath: realpath.mock.calls.length,
+        stat: stat.mock.calls.length,
+      }).toEqual({ lstat: 0, matcher: 0, readlink: 0, realpath: 0, stat: 0 });
+    } finally {
+      matcher.mockRestore();
+      lstat.mockRestore();
+      readlink.mockRestore();
+      realpath.mockRestore();
+      stat.mockRestore();
+      syncBuiltinESMExports();
+    }
+  });
 });
 
 test("configured-only parent-owned stores keep lineage children without directory discovery", async () => {

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -99,11 +99,17 @@ function buildGatewaySessionStoreScanTargets(params: {
   return [...targets];
 }
 
+type GatewaySessionStoreDiscovery = {
+  existing: SessionStoreTarget[];
+  fallback: SessionStoreTarget;
+  prepared?: true;
+};
+
 function resolveGatewaySessionStoreCandidates(
   cfg: OpenClawConfig,
   agentId: string,
   cache?: GatewaySessionStoreDiscoveryCache,
-): { existing: SessionStoreTarget[]; fallback: SessionStoreTarget } {
+): GatewaySessionStoreDiscovery {
   const cached = cache?.get(agentId);
   if (cached) {
     return cached;
@@ -137,14 +143,11 @@ export type GatewaySessionStoreCache = Map<string, Record<string, SessionEntry>>
  * Sharing resolves every returned row, but store targets are stable within one request.
  * Keep discovery agent-scoped here or each row repeats registry probes and agent-root scans.
  */
-export type GatewaySessionStoreDiscoveryCache = Map<
-  string,
-  { existing: SessionStoreTarget[]; fallback: SessionStoreTarget }
->;
+export type GatewaySessionStoreDiscoveryCache = Map<string, GatewaySessionStoreDiscovery>;
 
 export function createGatewaySessionStoreDiscoveryCache(params: {
   cfg: OpenClawConfig;
-  targets: SessionStoreTarget[];
+  targets: readonly SessionStoreTarget[];
   agentIds: Iterable<string>;
 }): GatewaySessionStoreDiscoveryCache {
   const cache: GatewaySessionStoreDiscoveryCache = new Map();
@@ -161,8 +164,12 @@ export function createGatewaySessionStoreDiscoveryCache(params: {
       agentId,
       storePath: resolveSessionStorePathCore(params.cfg.session?.store, { agentId }),
     };
-    const existing = target ? [target] : params.targets.length > 0 ? params.targets : [fallback];
-    cache.set(agentId, { existing, fallback });
+    const existing = target
+      ? [target]
+      : params.targets.length > 0
+        ? [...params.targets]
+        : [fallback];
+    cache.set(agentId, { existing, fallback, prepared: true });
   };
   for (const target of params.targets) {
     prepare(target.agentId, target);
@@ -261,15 +268,18 @@ function resolveGatewaySessionStoreLookup(params: {
   canonicalValidationError?: Error;
 } {
   const scanTargets = buildGatewaySessionStoreScanTargets(params);
-  const { existing, fallback } = resolveGatewaySessionStoreCandidates(
+  const discovery = resolveGatewaySessionStoreCandidates(
     params.cfg,
     params.agentId,
     params.targetDiscoveryCache,
   );
+  const { existing, fallback } = discovery;
   const configured = isConfiguredSessionStoreAgentId(params.cfg, params.agentId);
-  const candidates = configured
-    ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
-    : existing;
+  const candidates = discovery.prepared
+    ? existing
+    : configured
+      ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
+      : existing;
   if (candidates.length === 0) {
     // Discovery is read-only. Only configured agents may cross the fallback edge that creates a
     // missing SQLite store; retired/manual agents must already have a discovered store.

--- a/src/state/openclaw-agent-db-registry-listing.ts
+++ b/src/state/openclaw-agent-db-registry-listing.ts
@@ -20,7 +20,8 @@ type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_da
 let registeredAgentDatabasesMemo:
   | {
       pathname: string;
-      entries: readonly OpenClawRegisteredAgentDatabase[];
+      token: symbol;
+      entries?: readonly OpenClawRegisteredAgentDatabase[];
     }
   | undefined;
 
@@ -28,12 +29,31 @@ function resolveAgentDatabaseRegistryPath(options: OpenClawStateDatabaseOptions)
   return path.resolve(options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env));
 }
 
+function activateRegisteredAgentDatabasesMemo(
+  options: OpenClawStateDatabaseOptions,
+): NonNullable<typeof registeredAgentDatabasesMemo> {
+  const pathname = resolveAgentDatabaseRegistryPath(options);
+  if (registeredAgentDatabasesMemo?.pathname !== pathname) {
+    // One active pathname keeps registry metadata process-stable without retaining
+    // an unbounded generation map. Switching back creates a fresh generation.
+    registeredAgentDatabasesMemo = { pathname, token: Symbol(pathname) };
+  }
+  return registeredAgentDatabasesMemo;
+}
+
+/** Return the process-stable generation for the active agent database registry. */
+export function readOpenClawAgentDatabaseRegistryToken(
+  options: OpenClawStateDatabaseOptions = {},
+): symbol {
+  return activateRegisteredAgentDatabasesMemo(options).token;
+}
+
 export function invalidateRegisteredAgentDatabasesMemo(
   options: OpenClawStateDatabaseOptions,
 ): void {
   const pathname = resolveAgentDatabaseRegistryPath(options);
   if (registeredAgentDatabasesMemo?.pathname === pathname) {
-    registeredAgentDatabasesMemo = undefined;
+    registeredAgentDatabasesMemo = { pathname, token: Symbol(pathname) };
   }
 }
 
@@ -86,9 +106,10 @@ export function listOpenClawRegisteredAgentDatabases(
     includeIncompatibleSchemaVersions?: boolean;
   } = {},
 ): OpenClawRegisteredAgentDatabase[] {
-  const pathname = resolveAgentDatabaseRegistryPath(options);
-  if (registeredAgentDatabasesMemo?.pathname === pathname) {
-    const entries = cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
+  const memo = activateRegisteredAgentDatabasesMemo(options);
+  const { pathname } = memo;
+  if (memo.entries) {
+    const entries = cloneRegisteredAgentDatabases(memo.entries);
     return options.includeIncompatibleSchemaVersions
       ? entries
       : entries.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
@@ -97,7 +118,7 @@ export function listOpenClawRegisteredAgentDatabases(
     if (hasUnavailableMissingSqlitePath(pathname)) {
       throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
     }
-    registeredAgentDatabasesMemo = { pathname, entries: [] };
+    memo.entries = [];
     return [];
   }
   // Discovery runs per row in list hot paths, so the legacy-schema gate and the
@@ -135,7 +156,7 @@ export function listOpenClawRegisteredAgentDatabases(
       sizeBytes: row.size_bytes,
     }));
   }, options);
-  registeredAgentDatabasesMemo = { pathname, entries };
+  memo.entries = entries;
   const cloned = cloneRegisteredAgentDatabases(entries);
   return options.includeIncompatibleSchemaVersions
     ? cloned

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -13,7 +13,10 @@ import { invalidateRegisteredAgentDatabasesMemo } from "./openclaw-agent-db-regi
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
 
-export { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry-listing.js";
+export {
+  listOpenClawRegisteredAgentDatabases,
+  readOpenClawAgentDatabaseRegistryToken,
+} from "./openclaw-agent-db-registry-listing.js";
 
 type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
@@ -502,10 +505,11 @@ function resolveAgentDatabasePathIdentity(pathname: string): AgentDatabasePathId
   // resolves `link/..` from the link target. Anchor relative input without rewriting tokens.
   const lexicalPath = anchorDatabasePathWithoutNormalizing(pathname);
   try {
-    const stat = statSync(lexicalPath, { bigint: true });
+    const realPath = realpathSync.native(lexicalPath);
+    const stat = statSync(realPath, { bigint: true });
     return {
       lexicalPath,
-      realPath: realpathSync.native(lexicalPath),
+      realPath,
       device: stat.dev,
       inode: stat.ino,
     };
@@ -516,8 +520,8 @@ function resolveAgentDatabasePathIdentity(pathname: string): AgentDatabasePathId
     // Preserve symlink/alias identity before the leaf exists without lexically
     // collapsing unresolved components such as `missing/../live.sqlite`.
     const dangling = resolveDanglingSymlinkTargetPath(lexicalPath);
-    const parentStat = statSync(dangling.existingPath, { bigint: true });
     const parentRealPath = realpathSync.native(dangling.existingPath);
+    const parentStat = statSync(parentRealPath, { bigint: true });
     return {
       lexicalPath,
       parentDevice: parentStat.dev,

--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -5,10 +5,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
 import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabases,
   closeOpenClawAgentDatabasesForTest,
   IncognitoAgentDatabasePathCollisionError,
+  listOpenClawRegisteredAgentDatabases,
   listOpenIncognitoAgentDatabases,
   openOpenClawAgentDatabase,
+  readOpenIncognitoAgentDatabaseGeneration,
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "./openclaw-agent-db.js";
 
@@ -80,12 +84,17 @@ describe("incognito agent database", () => {
     tempDirs.push(stateDir);
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
+    const beforeGeneration = readOpenIncognitoAgentDatabaseGeneration();
 
     const first = openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
+    const openedGeneration = readOpenIncognitoAgentDatabaseGeneration();
     const reopened = openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
 
+    expect(openedGeneration).toBeGreaterThan(beforeGeneration);
+    expect(readOpenIncognitoAgentDatabaseGeneration()).toBe(openedGeneration);
     expect(reopened).toBe(first);
     expect(listOpenIncognitoAgentDatabases()).toEqual([{ agentId: "main", storePath: sentinel }]);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
     expect(
       withOpenClawAgentDatabaseReadOnly((database) => database.db === first.db, {
         agentId: "main",
@@ -103,5 +112,29 @@ describe("incognito agent database", () => {
     });
     expect(fs.existsSync(sentinel)).toBe(false);
     expect(fs.existsSync(path.dirname(sentinel))).toBe(false);
+
+    expect(closeOpenClawAgentDatabaseByPath(sentinel)).toBe(true);
+    const closedGeneration = readOpenIncognitoAgentDatabaseGeneration();
+    expect(closedGeneration).toBeGreaterThan(openedGeneration);
+    expect(closeOpenClawAgentDatabaseByPath(sentinel)).toBe(false);
+    expect(readOpenIncognitoAgentDatabaseGeneration()).toBe(closedGeneration);
+  });
+
+  it("advances once when close-all removes incognito membership", () => {
+    const stateDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-close-all-")),
+    );
+    tempDirs.push(stateDir);
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
+    openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
+    const openedGeneration = readOpenIncognitoAgentDatabaseGeneration();
+
+    closeOpenClawAgentDatabases();
+    const closedGeneration = readOpenIncognitoAgentDatabaseGeneration();
+    expect(closedGeneration).toBeGreaterThan(openedGeneration);
+
+    closeOpenClawAgentDatabases();
+    expect(readOpenIncognitoAgentDatabaseGeneration()).toBe(closedGeneration);
   });
 });

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -47,6 +47,7 @@ import {
   migrateOpenClawAgentDatabaseForMaintenance,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase as openOpenClawAgentDatabaseRuntime,
+  readOpenClawAgentDatabaseRegistryToken,
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
@@ -1075,9 +1076,10 @@ describe("openclaw agent database", () => {
     expect(fs.existsSync(stateDatabasePath)).toBe(false);
   });
 
-  it("invalidates the registered database memo after a registry write", () => {
+  it("rotates the registry token on pathname switches and committed writes", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
+    const otherEnv = { OPENCLAW_STATE_DIR: createTempStateDir() };
     const databasePath = path.join(
       stateDir,
       "agents",
@@ -1086,11 +1088,24 @@ describe("openclaw agent database", () => {
       "openclaw-agent.sqlite",
     );
 
+    const firstToken = readOpenClawAgentDatabaseRegistryToken({ env });
     expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    expect(readOpenClawAgentDatabaseRegistryToken({ env })).toBe(firstToken);
+    expect(readOpenClawAgentDatabaseRegistryToken({ env: otherEnv })).not.toBe(firstToken);
+    const returnedToken = readOpenClawAgentDatabaseRegistryToken({ env });
+    expect(returnedToken).not.toBe(firstToken);
+
     registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env });
+    const registeredToken = readOpenClawAgentDatabaseRegistryToken({ env });
+    expect(registeredToken).not.toBe(returnedToken);
     expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
       expect.objectContaining({ agentId: "worker-1", path: databasePath }),
     ]);
+    expect(readOpenClawAgentDatabaseRegistryToken({ env })).toBe(registeredToken);
+
+    unregisterOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env });
+    expect(readOpenClawAgentDatabaseRegistryToken({ env })).not.toBe(registeredToken);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
   });
 
   it("keeps incompatible schema versions maintenance-only", () => {
@@ -2122,6 +2137,77 @@ describe("openclaw agent database", () => {
       fs.unlinkSync(aliasDir);
       fs.symlinkSync(otherDir, aliasDir, "dir");
       expect(createOpenClawAgentDatabasePathMatcher()(realPath, aliasPath)).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps an existing alias identity consistent when realpath retargets it",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const firstDir = path.join(stateDir, "identity-first");
+      const secondDir = path.join(stateDir, "identity-second");
+      const aliasDir = path.join(stateDir, "identity-alias");
+      fs.mkdirSync(firstDir);
+      fs.mkdirSync(secondDir);
+      fs.symlinkSync(firstDir, aliasDir, "dir");
+      const firstPath = path.join(firstDir, "worker.sqlite");
+      const secondPath = path.join(secondDir, "worker.sqlite");
+      const aliasPath = path.join(aliasDir, "worker.sqlite");
+      fs.writeFileSync(firstPath, "first");
+      fs.writeFileSync(secondPath, "second");
+
+      const originalRealpathNative = fs.realpathSync.native;
+      let retargeted = false;
+      const realpathNative = vi.spyOn(fs.realpathSync, "native").mockImplementation((pathname) => {
+        if (!retargeted && path.resolve(String(pathname)) === aliasPath) {
+          fs.unlinkSync(aliasDir);
+          fs.symlinkSync(secondDir, aliasDir, "dir");
+          retargeted = true;
+        }
+        return originalRealpathNative(pathname);
+      });
+      try {
+        const matchesPath = createOpenClawAgentDatabasePathMatcher();
+        expect(matchesPath(aliasPath, firstPath)).toBe(false);
+        expect(matchesPath(aliasPath, secondPath)).toBe(true);
+        expect(retargeted).toBe(true);
+      } finally {
+        realpathNative.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps a missing-leaf identity consistent when its parent retargets",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const firstParent = path.join(stateDir, "missing-first");
+      const movedFirstParent = path.join(stateDir, "missing-first-moved");
+      const secondParent = path.join(stateDir, "missing-second");
+      fs.mkdirSync(firstParent);
+      fs.mkdirSync(secondParent);
+      const racedPath = path.join(firstParent, "future.sqlite");
+      const movedFirstPath = path.join(movedFirstParent, "future.sqlite");
+      const secondPath = path.join(secondParent, "future.sqlite");
+
+      const originalRealpathNative = fs.realpathSync.native;
+      let retargeted = false;
+      const realpathNative = vi.spyOn(fs.realpathSync, "native").mockImplementation((pathname) => {
+        if (!retargeted && path.resolve(String(pathname)) === firstParent) {
+          fs.renameSync(firstParent, movedFirstParent);
+          fs.symlinkSync(secondParent, firstParent, "dir");
+          retargeted = true;
+        }
+        return originalRealpathNative(pathname);
+      });
+      try {
+        const matchesPath = createOpenClawAgentDatabasePathMatcher();
+        expect(matchesPath(racedPath, movedFirstPath)).toBe(false);
+        expect(matchesPath(racedPath, secondPath)).toBe(true);
+        expect(retargeted).toBe(true);
+      } finally {
+        realpathNative.mockRestore();
+      }
     },
   );
 

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -75,7 +75,10 @@ export {
   migrateOpenClawAgentDatabaseForMaintenance,
 } from "./openclaw-agent-db-maintenance.js";
 export { ensureOpenClawAgentDatabasePermissions } from "./openclaw-agent-db-permissions.js";
-export { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry.js";
+export {
+  listOpenClawRegisteredAgentDatabases,
+  readOpenClawAgentDatabaseRegistryToken,
+} from "./openclaw-agent-db-registry.js";
 export { ensureOpenClawAgentDatabaseSchema } from "./openclaw-agent-db-schema.js";
 export {
   isIncognitoOpenClawAgentSqlitePath,
@@ -109,6 +112,7 @@ export const OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP = 64;
 const agentDbLog = createSubsystemLogger("state/agent-db");
 const cachedDatabases = new Map<string, OpenClawAgentDatabase>();
 const incognitoDatabases = new WeakSet<OpenClawAgentDatabase>();
+let incognitoDatabaseGeneration = 0;
 const cachedDatabaseOpenFailures = new Map<string, unknown>();
 const cachedDatabaseLeases = new Map<
   string,
@@ -261,6 +265,7 @@ export function openOpenClawAgentDatabase(
     incognitoDatabases.add(database);
     unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
     cachedDatabases.set(pathname, database);
+    incognitoDatabaseGeneration += 1;
     return database;
   }
   quarantineOrphanedSqliteSidecars(pathname);
@@ -581,6 +586,11 @@ export function listOpenIncognitoAgentDatabases(): Array<{ agentId: string; stor
     );
 }
 
+/** Return the generation of process-held incognito database membership. */
+export function readOpenIncognitoAgentDatabaseGeneration(): number {
+  return incognitoDatabaseGeneration;
+}
+
 /** Returns whether this exact process-held database is incognito/in-memory. */
 export function isIncognitoOpenClawAgentDatabase(database: OpenClawAgentDatabase): boolean {
   return incognitoDatabases.has(database);
@@ -606,9 +616,13 @@ export function closeOpenClawAgentDatabaseByPath(pathname: string): boolean {
   if (!database) {
     return false;
   }
+  const incognito = incognitoDatabases.has(database);
   closeCachedOpenClawAgentDatabase(database);
   cachedDatabases.delete(resolvedPath);
   cachedDatabaseOpenFailures.delete(resolvedPath);
+  if (incognito) {
+    incognitoDatabaseGeneration += 1;
+  }
   if (cachedDatabases.size === 0) {
     unregisterExitClose?.();
     unregisterExitClose = null;
@@ -655,11 +669,17 @@ export function disposeOpenClawAgentDatabaseByPath(
 export function closeOpenClawAgentDatabases(): void {
   unregisterExitClose?.();
   unregisterExitClose = null;
+  const removedIncognito = [...cachedDatabases.values()].some(
+    (database) => database.db.isOpen && incognitoDatabases.has(database),
+  );
   for (const database of cachedDatabases.values()) {
     closeCachedOpenClawAgentDatabase(database);
   }
   cachedDatabases.clear();
   cachedDatabaseOpenFailures.clear();
+  if (removedIncognito) {
+    incognitoDatabaseGeneration += 1;
+  }
 }
 
 /** Close cached agent handles and clear terminal failure latches for test isolation. */


### PR DESCRIPTION
Related: #124384

## What Problem This Solves

Fixes an issue where operators listing sessions across many configured agents could still see the Gateway saturate CPU and memory and time out, even after #124384 removed broad directory enumeration. On Molty, the exact #124384 merge remained at 149.6% CPU and 2.95 GB RSS, timed out over HTTP, and made 16,023 failed `readlink` calls in 8 seconds because every configured `sessions.list` cache miss rebuilt physical target identities.

This PR intentionally excludes #124372. That change addresses a separate path, is not bundled here, and is not a replacement for this cache-ownership repair.

## Why This Change Was Made

Configured Gateway listings now reuse one bounded prepared target snapshot keyed by the exact config identity, a durable-registry generation token, and the incognito membership generation. The completed list-cache fence carries both lifecycle generations, so registry or incognito membership changes rebuild the snapshot and invalidate completed results without restoring request-time filesystem discovery.

The prepared physical target set is also the authoritative sharing lookup set. This collapses requested-agent symlink aliases to one row, avoids redundant requested-agent prewarm dedupe when no incognito database is open, and keeps path identity internally consistent by resolving the real path before reading its stat identity. Generic CLI and Doctor dedupe remains fresh per call.

## User Impact

Operators with many configured agents should get responsive session listings without repeated matcher, stat, or symlink-resolution work on each distinct list request. Registry and incognito topology changes remain visible immediately through explicit generation fences, while fixed/shared stores, lineage, startup prewarm, and incognito behavior are retained.

Live Molty validation of this exact PR head is still pending and is required before merge.

## Evidence

- 29-target scaling regression: the first request performs matcher/stat/realpath work `1/29/29`; a second distinct request performs `0/0/0/0/0` matcher/stat/lstat/readlink/realpath work.
- Registry and incognito membership mutations rebuild prepared targets and fence previously completed list results.
- Requested-agent symlink aliases produce one authoritative row; fault-injected symlink retarget tests prove realpath/stat identity consistency.
- 227 focused tests passed, 4 skipped. Follow-up verification after independent findings passed alias/scaling 5/5, 3 targeted identity/token tests, and 124 lifecycle/ownership tests across 8 files.
- Trusted local `pnpm check:changed` passed every selected `core` and `coreTests` lane. Crabbox/Blacksmith CLI was unavailable, so the repository-authorized trusted-source fallback ran locally; this is not presented as remote proof.
- Formatting, lint, import-cycle, and `git diff --check` gates are clean. Fresh structured autoreview reported no accepted/actionable findings at 0.97 confidence.
- Production LOC: +200/-76 (net +124). Tests: +383/-2 (net +381). The production growth owns the required registry/incognito lifecycle generations, single-slot prepared target snapshot, and completed-list fencing that replace request-time filesystem work.
- Pending gates: exact-head `pull_request` CI attachment/completion and Molty live validation of this exact head. Do not merge until both are green.
