### PR TITLE
feat(codex): record why settled-turn finalization context is unavailable

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -30,7 +30,10 @@ import {
 } from "./run-attempt-state.js";
 import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
-import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
+import {
+  bindCodexSettledTurnFinalizationRejectionReceipt,
+  captureCodexSettledTurnFinalizationContext,
+} from "./settled-turn-context.js";
 import { normalizeCodexTrajectoryError, recordCodexTrajectoryCompletion } from "./trajectory.js";
 import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
 import {
@@ -326,7 +329,7 @@ export async function finalizeCodexAttempt(
     result.assistantTexts.every((text) => !text.trim()) &&
     result.messagesSnapshot.some((message) => message.role === "toolResult") &&
     (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
-  const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
+  const settledTurnFinalizationCapture = shouldCaptureSettledTurnFinalizationContext
     ? await captureCodexSettledTurnFinalizationContext({
         ...activeTranscriptTarget,
         mirroredMessages: mirrorOutcome.mirroredMessages,
@@ -334,13 +337,25 @@ export async function finalizeCodexAttempt(
         turnId: activeTurnId,
       })
     : undefined;
-  if (shouldCaptureSettledTurnFinalizationContext && !settledTurnFinalizationContext) {
+  const settledTurnFinalizationContext = settledTurnFinalizationCapture?.ok
+    ? settledTurnFinalizationCapture.context
+    : undefined;
+  if (
+    shouldCaptureSettledTurnFinalizationContext &&
+    settledTurnFinalizationCapture &&
+    !settledTurnFinalizationCapture.ok
+  ) {
     // The isolated child must not infer around a partial or drifting transcript.
     // Omitting this field preserves the existing incomplete-turn failure.
-    embeddedAgentLog.warn("codex settled-turn finalization context is unavailable", {
-      threadId: resourceState.thread.threadId,
-      turnId: activeTurnId,
-    });
+    embeddedAgentLog.warn(
+      "codex settled-turn finalization context is unavailable",
+      bindCodexSettledTurnFinalizationRejectionReceipt({
+        reason: settledTurnFinalizationCapture.reason,
+        threadId: resourceState.thread.threadId,
+        turnId: activeTurnId,
+        runId: params.runId,
+      }),
+    );
   }
   runAgentHarnessLlmOutputHook({
     event: {

--- a/extensions/codex/src/app-server/settled-turn-context.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.test.ts
@@ -1,6 +1,10 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
+import {
+  bindCodexSettledTurnFinalizationRejectionReceipt,
+  captureCodexSettledTurnFinalizationContext,
+  type CodexSettledTurnFinalizationRejectionReason,
+} from "./settled-turn-context.js";
 import { attachCodexMirrorAttestation } from "./transcript-mirror-attestation.js";
 import {
   attachCodexMirrorIdentity,
@@ -94,32 +98,44 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     const later = message({ role: "user", content: "later message" }, "turn-3:prompt");
     const historyMessages = [prior, ...settledMessages, later];
 
-    const context = await captureContext({
+    const result = await captureContext({
       historyMessages,
       mirroredMessages: settledMessages,
       settledMessages,
       turnId: "turn-2",
     });
-
-    expect(context).toEqual({
-      source: "openclaw-transcript",
+    const expected = {
+      source: "openclaw-transcript" as const,
       messages: [prior, ...settledMessages],
-    });
-    expect(Object.isFrozen(context?.messages)).toBe(true);
-    expect(context?.messages).not.toBe(historyMessages);
+    };
+
+    expect(result).toEqual({ ok: true, context: expected });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(JSON.stringify(result.context)).toBe(JSON.stringify(expected));
+    expect(Object.isFrozen(result.context.messages)).toBe(true);
+    expect(result.context.messages).not.toBe(historyMessages);
   });
 
   it("adopts an exact host-persisted prompt without rewriting its canonical metadata", async () => {
     const { persistedPrompt, ...turn } = settledHostPromptTurn();
 
-    const context = await captureContext(turn);
+    const result = await captureContext(turn);
+    const expected = { source: "openclaw-transcript" as const, messages: turn.historyMessages };
 
-    expect(context).toEqual({ source: "openclaw-transcript", messages: turn.historyMessages });
-    expect(Object.isFrozen(context?.messages)).toBe(true);
-    expect(context?.messages[0]).toEqual(persistedPrompt);
-    expect(readMirrorIdentity(context!.messages[0]!)).toBeUndefined();
-    expect(readUpstreamUserText(context!.messages[0]!)).toBeUndefined();
-    expect(context?.messages[0]).toMatchObject({
+    expect(result).toEqual({ ok: true, context: expected });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(JSON.stringify(result.context)).toBe(JSON.stringify(expected));
+    expect(Object.isFrozen(result.context.messages)).toBe(true);
+    expect(result.context.messages[0]).toEqual(persistedPrompt);
+    expect(readMirrorIdentity(result.context.messages[0]!)).toBeUndefined();
+    expect(readUpstreamUserText(result.context.messages[0]!)).toBeUndefined();
+    expect(result.context.messages[0]).toMatchObject({
       __openclaw: { senderIsOwner: true, transport: { messageId: "transport-message" } },
     });
   });
@@ -154,83 +170,134 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     const turn = settledHostPromptTurn();
     turn.historyMessages[0] = change(turn.persistedPrompt) as AgentMessage;
 
-    await expect(captureContext(turn)).resolves.toBeUndefined();
+    await expect(captureContext(turn)).resolves.toEqual({
+      ok: false,
+      reason: "mirror-boundary-order",
+    });
   });
 
   it("rejects duplicate host-persisted prompt idempotency keys", async () => {
     const turn = settledHostPromptTurn();
     turn.historyMessages.unshift({ ...turn.persistedPrompt });
 
-    await expect(captureContext(turn)).resolves.toBeUndefined();
+    await expect(captureContext(turn)).resolves.toEqual({
+      ok: false,
+      reason: "mirror-boundary-order",
+    });
   });
 
   it.each([
     {
-      name: "missing current prompt",
-      settledMessages: settledTurn().slice(1),
-      historyMessages: settledTurn(),
-    },
-    {
-      name: "missing current tool call",
+      name: "missing history",
+      reason: "missing-history" as const,
+      historyMessages: undefined,
+      mirroredMessages: settledTurn(),
       settledMessages: settledTurn(),
-      historyMessages: [settledTurn()[0]!, settledTurn()[2]!],
-    },
-    {
-      name: "duplicate persisted identity",
-      settledMessages: settledTurn(),
-      historyMessages: [...settledTurn(), settledTurn()[2]!],
     },
     {
       name: "foreign boundary turn",
-      settledMessages: settledTurn(),
+      reason: "missing-boundary-identity" as const,
       historyMessages: settledTurn(),
+      mirroredMessages: settledTurn(),
+      settledMessages: settledTurn(),
       turnId: "turn-3",
     },
-  ])("fails closed for $name", async ({ settledMessages, historyMessages, turnId }) => {
-    await expect(
-      captureContext({
-        historyMessages,
-        mirroredMessages: settledMessages,
+    {
+      name: "missing current prompt",
+      reason: "required-identity-shape" as const,
+      historyMessages: settledTurn(),
+      mirroredMessages: settledTurn().slice(1),
+      settledMessages: settledTurn().slice(1),
+    },
+    {
+      name: "duplicate persisted identity",
+      reason: "duplicate-history-identity" as const,
+      historyMessages: [...settledTurn(), settledTurn()[2]!],
+      mirroredMessages: settledTurn(),
+      settledMessages: settledTurn(),
+    },
+    {
+      name: "duplicate mirrored identity",
+      reason: "duplicate-mirror-identity" as const,
+      historyMessages: settledTurn(),
+      mirroredMessages: [...settledTurn(), settledTurn()[2]!],
+      settledMessages: settledTurn(),
+    },
+    {
+      name: "reordered mirrored messages",
+      reason: "mirror-boundary-order" as const,
+      historyMessages: settledTurn(),
+      mirroredMessages: (() => {
+        const settledMessages = settledTurn();
+        return [settledMessages[1]!, settledMessages[0]!, settledMessages[2]!];
+      })(),
+      settledMessages: settledTurn(),
+    },
+    {
+      name: "missing history boundary",
+      reason: "history-boundary" as const,
+      historyMessages: settledTurn().slice(0, 2),
+      mirroredMessages: settledTurn(),
+      settledMessages: settledTurn(),
+    },
+    {
+      name: "reordered history through the boundary",
+      reason: "history-boundary-order" as const,
+      historyMessages: (() => {
+        const settledMessages = settledTurn();
+        return [settledMessages[0]!, settledMessages[2]!, settledMessages[1]!];
+      })(),
+      mirroredMessages: settledTurn(),
+      settledMessages: settledTurn(),
+    },
+    {
+      name: "persisted payload drift under the same identity",
+      reason: "source-evidence-mismatch" as const,
+      historyMessages: (() => {
+        const historyMessages = settledTurn();
+        historyMessages[2] = message(
+          {
+            role: "toolResult",
+            toolCallId: "call-2",
+            toolName: "message",
+            content: [{ type: "text", text: "different result" }],
+          },
+          "turn-2:tool:call-2:result",
+        );
+        return historyMessages;
+      })(),
+      mirroredMessages: settledTurn(),
+      settledMessages: settledTurn(),
+    },
+  ] satisfies Array<{
+    name: string;
+    reason: CodexSettledTurnFinalizationRejectionReason;
+    historyMessages: AgentMessage[] | undefined;
+    mirroredMessages: AgentMessage[];
+    settledMessages: AgentMessage[];
+    turnId?: string;
+  }>)(
+    "rejects $name with $reason",
+    async ({ reason, historyMessages, mirroredMessages, settledMessages, turnId }) => {
+      if (historyMessages === undefined) {
+        mocks.readHistory.mockResolvedValue(undefined);
+      } else {
+        mocks.readHistory.mockResolvedValue(historyMessages);
+      }
+      const result = await captureCodexSettledTurnFinalizationContext({
+        sessionFile: "/tmp/session.jsonl",
+        sessionId: "session-1",
+        mirroredMessages,
         settledMessages,
         turnId: turnId ?? "turn-2",
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("fails closed when a persisted payload drifts under the same mirror identity", async () => {
-    const settledMessages = settledTurn();
-    const historyMessages = settledTurn();
-    historyMessages[2] = message(
-      {
-        role: "toolResult",
-        toolCallId: "call-2",
-        toolName: "message",
-        content: [{ type: "text", text: "different result" }],
-      },
-      "turn-2:tool:call-2:result",
-    );
-
-    await expect(
-      captureContext({
-        historyMessages,
-        mirroredMessages: settledMessages,
-        settledMessages,
-        turnId: "turn-2",
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("fails closed when current mirrored messages are reordered", async () => {
-    const settledMessages = settledTurn();
-    await expect(
-      captureContext({
-        historyMessages: settledMessages,
-        mirroredMessages: [settledMessages[1]!, settledMessages[0]!, settledMessages[2]!],
-        settledMessages,
-        turnId: "turn-2",
-      }),
-    ).resolves.toBeUndefined();
-  });
+      });
+      expect(result).toEqual({ ok: false, reason });
+      expect(result).not.toHaveProperty("context");
+      expect(JSON.stringify(result)).not.toMatch(
+        /Send it|different result|session\.jsonl|session-1|arguments/,
+      );
+    },
+  );
 
   it("contains transcript read failures after tools have settled", async () => {
     mocks.readHistory.mockRejectedValue(new Error("read failed"));
@@ -243,7 +310,7 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
         settledMessages: settledTurn(),
         turnId: "turn-2",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ ok: false, reason: "capture-error" });
   });
 
   it("contains transcript clone failures after tools have settled", async () => {
@@ -259,6 +326,25 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
         settledMessages: historyMessages,
         turnId: "turn-2",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ ok: false, reason: "capture-error" });
+  });
+
+  it("binds rejection receipts to reason and existing identities only", () => {
+    const receipt = bindCodexSettledTurnFinalizationRejectionReceipt({
+      reason: "source-evidence-mismatch",
+      threadId: "thread-1",
+      turnId: "turn-2",
+      runId: "run-9",
+    });
+    expect(Object.keys(receipt).sort()).toEqual(["reason", "runId", "threadId", "turnId"]);
+    expect(receipt).toEqual({
+      reason: "source-evidence-mismatch",
+      threadId: "thread-1",
+      turnId: "turn-2",
+      runId: "run-9",
+    });
+    expect(JSON.stringify(receipt)).not.toMatch(
+      /Send it|different result|session\.jsonl|toolCall|arguments|content/,
+    );
   });
 });

--- a/extensions/codex/src/app-server/settled-turn-context.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.ts
@@ -21,6 +21,45 @@ import {
 
 type SettledTurnFinalizationContext = EmbeddedRunAttemptResult["settledTurnFinalizationContext"];
 
+/** Closed capture-rejection codes. Do not add payload, paths, or evidence. */
+export type CodexSettledTurnFinalizationRejectionReason =
+  | "missing-history"
+  | "missing-boundary-identity"
+  | "required-identity-shape"
+  | "duplicate-history-identity"
+  | "duplicate-mirror-identity"
+  | "mirror-boundary-order"
+  | "history-boundary"
+  | "history-boundary-order"
+  | "source-evidence-mismatch"
+  | "capture-error";
+
+export type CodexSettledTurnFinalizationCaptureResult =
+  | { ok: true; context: SettledTurnFinalizationContext }
+  | { ok: false; reason: CodexSettledTurnFinalizationRejectionReason };
+
+export type CodexSettledTurnFinalizationRejectionReceipt = {
+  reason: CodexSettledTurnFinalizationRejectionReason;
+  threadId: string;
+  turnId: string;
+  runId?: string;
+};
+
+/** Caller warning fields: reason plus existing thread/turn/run identities only. */
+export function bindCodexSettledTurnFinalizationRejectionReceipt(params: {
+  reason: CodexSettledTurnFinalizationRejectionReason;
+  threadId: string;
+  turnId: string;
+  runId?: string;
+}): CodexSettledTurnFinalizationRejectionReceipt {
+  return {
+    reason: params.reason,
+    threadId: params.threadId,
+    turnId: params.turnId,
+    ...(params.runId ? { runId: params.runId } : {}),
+  };
+}
+
 function collectUniqueMessageIdentities(
   messages: readonly AgentMessage[],
 ): Map<string, number> | undefined {
@@ -104,7 +143,7 @@ function buildCodexSettledTurnFinalizationContext(params: {
   mirroredMessages: readonly AgentMessage[];
   settledMessages: readonly AgentMessage[];
   turnId: string;
-}): SettledTurnFinalizationContext | undefined {
+}): CodexSettledTurnFinalizationCaptureResult {
   const { historyMessages, mirroredMessages } = adoptPersistedHostPrompt(params);
   const boundaryMessage = params.settledMessages.findLast(
     (message) => message.role === "toolResult",
@@ -115,7 +154,7 @@ function buildCodexSettledTurnFinalizationContext(params: {
     !boundaryIdentity ||
     !boundaryIdentity.startsWith(`${params.turnId}:tool:`)
   ) {
-    return undefined;
+    return { ok: false, reason: "missing-boundary-identity" };
   }
 
   const settledBoundaryIndex = params.settledMessages.indexOf(boundaryMessage);
@@ -128,17 +167,20 @@ function buildCodexSettledTurnFinalizationContext(params: {
     new Set(requiredIdentities).size !== requiredIdentities.length ||
     !requiredIdentities.includes(`${params.turnId}:prompt`)
   ) {
-    return undefined;
+    return { ok: false, reason: "required-identity-shape" };
   }
 
   const historyIdentities = collectUniqueMessageIdentities(historyMessages);
+  if (!historyIdentities) {
+    return { ok: false, reason: "duplicate-history-identity" };
+  }
   const mirroredIdentities = collectUniqueMessageIdentities(mirroredMessages);
-  if (!historyIdentities || !mirroredIdentities) {
-    return undefined;
+  if (!mirroredIdentities) {
+    return { ok: false, reason: "duplicate-mirror-identity" };
   }
   const mirroredBoundaryIndex = mirroredIdentities.get(boundaryIdentity);
   if (mirroredBoundaryIndex === undefined) {
-    return undefined;
+    return { ok: false, reason: "mirror-boundary-order" };
   }
   const mirroredThroughBoundary = mirroredMessages.slice(0, mirroredBoundaryIndex + 1);
   if (
@@ -147,11 +189,11 @@ function buildCodexSettledTurnFinalizationContext(params: {
       (message, index) => readMirrorIdentity(message) !== requiredIdentities[index],
     )
   ) {
-    return undefined;
+    return { ok: false, reason: "mirror-boundary-order" };
   }
   const historyBoundaryIndex = historyIdentities.get(boundaryIdentity);
   if (historyBoundaryIndex === undefined) {
-    return undefined;
+    return { ok: false, reason: "history-boundary" };
   }
   let previousHistoryIndex = -1;
   for (const mirroredMessage of mirroredThroughBoundary) {
@@ -162,11 +204,15 @@ function buildCodexSettledTurnFinalizationContext(params: {
       historyIndex === undefined ||
       historyIndex <= previousHistoryIndex ||
       historyIndex > historyBoundaryIndex ||
-      !historyMessage ||
-      serializeCodexMirrorSourceEvidence(historyMessage) !==
-        serializeCodexMirrorSourceEvidence(mirroredMessage)
+      !historyMessage
     ) {
-      return undefined;
+      return { ok: false, reason: "history-boundary-order" };
+    }
+    if (
+      serializeCodexMirrorSourceEvidence(historyMessage) !==
+      serializeCodexMirrorSourceEvidence(mirroredMessage)
+    ) {
+      return { ok: false, reason: "source-evidence-mismatch" };
     }
     previousHistoryIndex = historyIndex;
   }
@@ -176,7 +222,7 @@ function buildCodexSettledTurnFinalizationContext(params: {
   const messages = Object.freeze(
     structuredClone(params.historyMessages.slice(0, historyBoundaryIndex + 1)),
   );
-  return { source: "openclaw-transcript", messages };
+  return { ok: true, context: { source: "openclaw-transcript", messages } };
 }
 
 /** Reads and freezes the current active transcript branch after mirroring has settled. */
@@ -186,11 +232,11 @@ export async function captureCodexSettledTurnFinalizationContext(
     settledMessages: readonly AgentMessage[];
     turnId: string;
   },
-): Promise<SettledTurnFinalizationContext | undefined> {
+): Promise<CodexSettledTurnFinalizationCaptureResult> {
   try {
     const historyMessages = await readCodexMirroredSessionHistoryMessages(params);
     if (!historyMessages) {
-      return undefined;
+      return { ok: false, reason: "missing-history" };
     }
     return buildCodexSettledTurnFinalizationContext({
       historyMessages,
@@ -205,6 +251,6 @@ export async function captureCodexSettledTurnFinalizationContext(
       error: formatErrorMessage(error),
       turnId: params.turnId,
     });
-    return undefined;
+    return { ok: false, reason: "capture-error" };
   }
 }


### PR DESCRIPTION
Related: https://github.com/karmaterminal/openclaw/issues/1256
Coordinates with #124176 (does not absorb its `sessions_yield` skip).


## What Problem This Solves

Fixes an issue where operators would see an undifferentiated
`codex settled-turn finalization context is unavailable` warning when a Codex
turn had a tool result and no assistant text. The specific attestation failure
was erased, so the same warning covered missing history, duplicate identities,
boundary-order drift, and capture errors.

This is instrumentation only. It does not repair zero-payload delivery.

## Why This Change Was Made

The capture owner now returns a private closed-reason result instead of
collapsing every rejection to `undefined`. Valid frozen transcript context is
unchanged. Invalid branches stay fail-closed: no synthesized history and no
Codex `turn/completed` summary substitute.

The existing warning may add only the reason plus existing thread/turn/run
identities. Yield-specific capture skipping remains #124176's job.

## User Impact

When settled-turn context capture fails, the existing warning now includes a
closed reason code. Successful turns are unchanged. No Plugin SDK, queue, or
delivery behavior change.

## Evidence

Base: `acbbff19bad0a5539cd4725e6a6c8ae8e53f6694`. Head: `d74c71c0a3e585f5411c6ea1fac236ee30445299`.

- Fossil table in `extensions/codex/src/app-server/settled-turn-context.test.ts`
  requires one exact reason per rejection branch.
- Causal closure: unpatched prod is semantically RED (`undefined`); patch GREEN
  (21/21); patch-only revert RED; reapply GREEN.
- Valid context remains JSON-byte-equivalent and frozen.
- Warning receipt keys are only `reason`, `threadId`, `turnId`, optional `runId`.
- Owner/sibling tests passed. Autoreview on HEAD: clean. Independent Grok
  review: no significant issues.
- Codex `0.147.0` (`rust-v0.147.0` / `3ed6f04f6bf8b7c46299d1cb1ff99c74ce21a51d`):
  `turn/completed` is last-agent-message summary only; OpenClaw still owns
  mirror attestation.
- Copied-store replay is required before any C2 behavioral repair; not claimed
  here. No live fleet DB access.

Production LOC: +83/-22 (net +61) | Tests: +155/-69.
