### PR TITLE
fix(ci): stabilize workspace timeout budget assertion

### DIFF
--- a/src/gateway/worker-environments/workspace-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-sync.test.ts
@@ -57,6 +57,7 @@ function createWorkspaceActions(
 
 describe("worker workspace command transport retry", () => {
   it("runs never commands once without changing the selected port", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
     const run = vi.fn(async (argv: string[], _options: CommandOptions) =>
       argv.at(-1)?.includes("never-command") ? result(255) : result(),
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky main-branch CI failure where the workspace timeout test expected the full 777 ms budget even though `runWorkspaceCommand` intentionally accounts for elapsed tunnel-preparation time.

## Why This Change Was Made

The test now freezes `Date.now()` for the assertion that is not exercising elapsed-time behavior. This preserves the exact timeout assertion while the adjacent deadline test continues to verify remaining-budget accounting explicitly.

## User Impact

No runtime behavior changes. Gateway CI no longer depends on whether the wall clock advances by one millisecond between deadline creation and command dispatch.

## Evidence

- Before: [main CI run 31930975911](https://github.com/openclaw/openclaw/actions/runs/31930975911) failed `workspace-sync.test.ts` with `expected 776 to be 777`.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-sync.test.ts` — 7 tests passed.
- `node scripts/check-changed.mjs` — all changed-file gates passed via documented local fallback after no remote `ci-fast` provider was ready.
- AutoReview: clean, no actionable findings.
- Production LOC: +0/-0; tests: +1/-0.
