### PR TITLE
fix(whatsapp): sendReadReceipts=false silently stops group inbound delivery on linked devices

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -390,6 +390,10 @@ When the linked self number is also present in `allowFrom`, self-chat safeguards
 
     Per-account override: `channels.whatsapp.accounts.<id>.sendReadReceipts`. Self-chat turns skip read receipts even when globally enabled.
 
+    <Warning>
+      **WhatsApp Group Delivery Notice**: Disabling read receipts (`sendReadReceipts: false`) suppresses all inbound read receipts on the WhatsApp connection. On linked devices, WhatsApp servers require read receipts for group conversations; disabling them can cause WhatsApp servers to silently stop delivering group messages to the linked device while 1:1 direct messages continue to work. If your instance participates in WhatsApp groups, keep `sendReadReceipts: true` (default).
+    </Warning>
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -122,7 +122,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       textChunkLimit: 4000,
       streaming: { chunkMode: "length" }, // length | newline
       mediaMaxMb: 50,
-      sendReadReceipts: true, // blue ticks (false in self-chat mode)
+      sendReadReceipts: true, // blue ticks (keep true if in groups; false in self-chat mode)
       groups: {
         "*": { requireMention: true },
       },
@@ -134,6 +134,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 ```
 
 - Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for WhatsApp DMs and groups. Use an E.164 direct number or WhatsApp group JID in `match.peer.id`. Field semantics are shared in [ACP Agents](/tools/acp-agents#persistent-channel-bindings).
+- Disabling `sendReadReceipts` (`false`) suppresses all read receipts on the connection. On linked devices, WhatsApp servers mandate read receipts for groups; disabling them may cause WhatsApp servers to silently stop delivering group messages to the linked device while 1:1 DMs continue working. Keep `sendReadReceipts: true` if participating in WhatsApp groups.
 
 <Accordion title="Multi-account WhatsApp">
 

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -1,6 +1,8 @@
-// Doctor channel capability tests cover channel capability inspection and diagnostics.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { collectChannelDmPolicyDependencyWarnings } from "../../config/validation-channel-rules.js";
+import {
+  collectChannelDmPolicyDependencyWarnings,
+  collectWhatsAppReadReceiptsGroupWarnings,
+} from "../../config/validation-channel-rules.js";
 import {
   getDoctorChannelCapabilities,
   resolveDoctorChannelAccountIds,
@@ -138,5 +140,51 @@ describe("doctor channel capabilities", () => {
       configured: ["work"],
       runtime: ["default", "work"],
     });
+  });
+
+  it("warns when WhatsApp has sendReadReceipts: false with group messaging enabled", () => {
+    const warnings = collectWhatsAppReadReceiptsGroupWarnings({
+      channels: {
+        whatsapp: {
+          sendReadReceipts: false,
+          groupPolicy: "allowlist",
+          accounts: {
+            work: {
+              sendReadReceipts: false,
+              groupPolicy: "open",
+            },
+            personal: {
+              sendReadReceipts: false,
+              groupPolicy: "disabled",
+            },
+          },
+        },
+      },
+    });
+
+    expect(warnings.map(({ path }) => path)).toEqual([
+      "channels.whatsapp.sendReadReceipts",
+      "channels.whatsapp.accounts.work.sendReadReceipts",
+    ]);
+    expect(warnings[0]?.message).toContain("suppresses all read receipts");
+  });
+
+  it("does not warn when WhatsApp group messaging is disabled", () => {
+    const warnings = collectWhatsAppReadReceiptsGroupWarnings({
+      channels: {
+        whatsapp: {
+          sendReadReceipts: false,
+          groupPolicy: "disabled",
+          accounts: {
+            work: {
+              sendReadReceipts: false,
+              groupPolicy: "disabled",
+            },
+          },
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
   });
 });

--- a/src/config/schema.channel-field-help.ts
+++ b/src/config/schema.channel-field-help.ts
@@ -53,7 +53,8 @@ const SHARED_CHANNEL_FIELD_HELP: Record<string, string> = {
   replyToModeByChatType: "Per-chat-type override of replyToMode.",
   requireMention: "Only respond in group chats when the agent is mentioned.",
   responsePrefix: "Text prepended to every outbound reply.",
-  sendReadReceipts: "Mark inbound messages as read on this channel.",
+  sendReadReceipts:
+    "Mark inbound messages as read on this channel. Note: On WhatsApp, disabling this may cause WhatsApp servers to stop delivering group messages to linked devices.",
   streaming: "How replies stream back to this channel while the agent is still working.",
   systemPrompt: "Extra system prompt applied to runs started from this channel.",
   textChunkLimit: "Maximum characters per outbound message before OpenClaw splits it.",

--- a/src/config/validation-channel-rules.ts
+++ b/src/config/validation-channel-rules.ts
@@ -222,3 +222,48 @@ export function collectRawBundledChannelConfigIssues(
   }
   return issues;
 }
+
+/**
+ * Surface a warning when WhatsApp has sendReadReceipts disabled (false) while group messaging is enabled.
+ * Disabling read receipts suppresses all read receipts on the WhatsApp connection, which causes WhatsApp
+ * servers to silently throttle or stop group inbound message delivery to linked devices.
+ */
+export function collectWhatsAppReadReceiptsGroupWarnings(
+  config: OpenClawConfig,
+): ConfigValidationIssue[] {
+  if (!config.channels || !isRecord(config.channels)) {
+    return [];
+  }
+  const whatsapp = config.channels.whatsapp;
+  if (!isRecord(whatsapp) || !isConfigRecordEnabled(whatsapp)) {
+    return [];
+  }
+  const warnings: ConfigValidationIssue[] = [];
+  const rootGroupsEnabled = whatsapp.groupPolicy !== "disabled";
+
+  if (whatsapp.sendReadReceipts === false && rootGroupsEnabled) {
+    warnings.push({
+      path: "channels.whatsapp.sendReadReceipts",
+      message:
+        "channels.whatsapp.sendReadReceipts=false suppresses all read receipts. WhatsApp servers require read receipts for group messaging on linked devices, and disabling them may cause group inbound messages to silently stop arriving. Keep sendReadReceipts enabled (true) if participating in groups.",
+    });
+  }
+
+  if (isRecord(whatsapp.accounts)) {
+    for (const [accountId, account] of Object.entries(whatsapp.accounts)) {
+      if (!isRecord(account) || !isConfigRecordEnabled(account)) {
+        continue;
+      }
+      const accountGroupsEnabled =
+        account.groupPolicy !== undefined ? account.groupPolicy !== "disabled" : rootGroupsEnabled;
+      if (account.sendReadReceipts === false && accountGroupsEnabled) {
+        warnings.push({
+          path: `channels.whatsapp.accounts.${accountId}.sendReadReceipts`,
+          message: `channels.whatsapp.accounts.${accountId}.sendReadReceipts=false suppresses all read receipts. WhatsApp servers require read receipts for group messaging on linked devices, and disabling them may cause group inbound messages to silently stop arriving. Keep sendReadReceipts enabled (true) if participating in groups.`,
+        });
+      }
+    }
+  }
+
+  return warnings;
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -30,6 +30,7 @@ import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
 import {
   bundledChannelIds,
   collectChannelDmPolicyDependencyWarnings,
+  collectWhatsAppReadReceiptsGroupWarnings,
   formatRawChannelConfigIssueMessage,
   hasChannelDmPolicyDependencyWarningCandidates,
   normalizeBundledChannelId,
@@ -349,6 +350,7 @@ function validateConfigObjectWithPluginsBase(
         })
       : collectChannelDmPolicyDependencyWarnings(parsedConfig)),
   );
+  warnings.push(...collectWhatsAppReadReceiptsGroupWarnings(parsedConfig));
 
   let mutatedConfig = config;
   let channelsCloned = false;


### PR DESCRIPTION
Closes #124132

## What Problem This Solves

Fixes an issue where users setting `channels.whatsapp.sendReadReceipts: false` to hide blue ticks would experience complete group inbound silence — no WhatsApp group messages reaching the gateway — while direct/self-chat messages continued normally, `channels status` still reported healthy, and no error was logged.

## Why This Change Was Made

WhatsApp servers require linked devices to send read receipts for group conversations. When none are sent, the server silently throttles or cuts group message delivery to that device. The existing config allowed `sendReadReceipts: false` with no warning, making the breakage undetectable for hours or days. This change adds a config-validation warning whenever `sendReadReceipts: false` is combined with an active group policy, without changing runtime behaviour or rejecting existing configurations.

## User Impact

Users who set `sendReadReceipts: false` while participating in WhatsApp groups will now see a clear warning at startup and in `openclaw doctor` output, directing them to keep `sendReadReceipts: true` when groups are in use. Documentation in `docs/channels/whatsapp.md` and `docs/gateway/config-channels.md` now also calls out this side-effect explicitly. No behaviour change for DM-only or self-chat configurations.

## Evidence

New tests in `src/commands/doctor/channel-capabilities.test.ts`:
- Asserts warning fires on root config + per-account when group policy is active
- Asserts no warning fires when `groupPolicy: disabled`

```
Test Files  3 passed (3)
     Tests  62 passed (62)
  Duration  9.40s
```
