### PR TITLE
fix: failed message send no longer rewrites the main session route to an unreachable channel target

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1393,8 +1393,8 @@ describe("gateway send mirroring", () => {
   });
 
   it("does not send after delegated authority closes during session preparation", async () => {
-    const preparation = createDeferred<undefined>();
-    mocks.ensureOutboundSessionEntry.mockReturnValueOnce(preparation.promise);
+    const preparation = createDeferred<null>();
+    mocks.resolveOutboundSessionRoute.mockReturnValueOnce(preparation.promise);
     let authorityActive = true;
     const context = {
       ...makeContext(),
@@ -1411,14 +1411,15 @@ describe("gateway send mirroring", () => {
       agentRuntimeClient("agent:main:slack:channel:C1"),
       context,
     );
-    await vi.waitFor(() => expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(mocks.resolveOutboundSessionRoute).toHaveBeenCalledOnce());
     authorityActive = false;
-    preparation.resolve(undefined);
+    preparation.resolve(null);
 
     const { respond } = await request;
     expect(firstRespondCall(respond)[0]).toBe(false);
     expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(mocks.ensureOutboundSessionEntry).not.toHaveBeenCalled();
   });
 
   it("cancels a prepared terminal receipt when authority closes before action dispatch", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -1352,14 +1352,23 @@ export const sendHandlers: GatewayRequestHandlers = {
               };
             }
           }
-          if (outboundRoute) {
+          // Durable route/session persistence commits only after platform
+          // evidence: a failed send must not rebind the folded main session's
+          // delivery route. Once-only across multi-payload results, and before
+          // the in-delivery transcript mirror so first contacts have a row.
+          let outboundRoutePersisted = false;
+          const commitOutboundSessionRoute = async () => {
+            if (outboundRoutePersisted || !outboundRoute) {
+              return;
+            }
+            outboundRoutePersisted = true;
             await ensureOutboundSessionEntry({
               cfg,
               channel,
               accountId,
               route: outboundRoute,
             });
-          }
+          };
           const outboundSession = buildOutboundSessionContext({
             cfg,
             agentId: effectiveAgentId,
@@ -1386,6 +1395,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             gatewayClientScopes: client?.connect?.scopes ?? [],
             silent: request.silent,
             formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
+            onDeliveryResult: commitOutboundSessionRoute,
             mirror: outboundSessionKey
               ? {
                   sessionKey: outboundSessionKey,
@@ -1396,6 +1406,11 @@ export const sendHandlers: GatewayRequestHandlers = {
                 }
               : undefined,
           });
+          // Safety net for adapters whose results carry no platform identity:
+          // any partially or fully sent batch still binds the route.
+          if (send.status === "sent" || send.status === "partial_failed") {
+            await commitOutboundSessionRoute();
+          }
           if (send.status === "failed" || send.status === "partial_failed") {
             throw send.error;
           }

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -8,7 +8,6 @@ import {
   resolveAndApplyOutboundThreadId,
 } from "./message-action-threading.js";
 
-const ensureOutboundSessionEntry = vi.fn(async () => undefined);
 const resolveOutboundSessionRoute = vi.fn();
 
 function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<string, unknown> {
@@ -46,7 +45,6 @@ const defaultForumToolContext = {
 
 describe("message action threading helpers", () => {
   beforeEach(() => {
-    ensureOutboundSessionEntry.mockClear();
     resolveOutboundSessionRoute.mockReset();
   });
 
@@ -92,13 +90,11 @@ describe("message action threading helpers", () => {
       agentId: "main",
       resolveAutoThreadId: ({ toolContext }) => toolContext?.currentThreadTs,
       resolveOutboundSessionRoute,
-      ensureOutboundSessionEntry,
     });
 
     expect(result.outboundRoute?.sessionKey).toBe(testCase.expectedSessionKey);
     expect(actionParams["__sessionKey"]).toBe(testCase.expectedSessionKey);
     expect(actionParams["__agentId"]).toBe("main");
-    expect(ensureOutboundSessionEntry).toHaveBeenCalledTimes(1);
   });
 
   it("prepares the outbound route with a canonicalized reply root", async () => {
@@ -123,7 +119,6 @@ describe("message action threading helpers", () => {
         threadId: threadId ?? null,
       }),
       resolveOutboundSessionRoute,
-      ensureOutboundSessionEntry,
     });
 
     expect(resolveOutboundSessionRoute).toHaveBeenCalledOnce();

--- a/src/infra/outbound/message-action-send.mirror-order.test.ts
+++ b/src/infra/outbound/message-action-send.mirror-order.test.ts
@@ -1,0 +1,142 @@
+// Regression: outbound mirror route persistence must commit only after a
+// successful send. A failed probe (missing channel credentials) previously
+// rewrote the folded main session's durable delivery route and minted a
+// conversation identity before the send was attempted.
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { jsonResult } from "../../agents/tools/common.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  loadExactSessionEntry,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import {
+  normalizeSessionDeliveryState,
+  sessionDeliveryOrigin,
+} from "../../utils/delivery-context.shared.js";
+import { runMessageAction } from "./message-action-runner.js";
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
+}));
+
+const MAIN_SESSION_KEY = "agent:main:main";
+
+describe("outbound mirror route ordering", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let storePath: string;
+  let cfg: OpenClawConfig;
+  const handleAction = vi.fn();
+
+  function registerTestChannel() {
+    const plugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({ id: "testchat" }),
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction,
+      },
+      outbound: {
+        deliveryMode: "direct",
+        // The plugin action path above owns the send; core delivery must not run.
+        sendText: async () => {
+          throw new Error("unexpected core sendText");
+        },
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "testchat", source: "test", plugin }]));
+  }
+
+  async function seedMainSessionWithDiscordOrigin() {
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey: MAIN_SESSION_KEY, storePath },
+      {
+        sessionId: "main-session",
+        updatedAt: 100,
+        chatType: "direct",
+        delivery: normalizeSessionDeliveryState({
+          context: { channel: "discord", accountId: "default", to: "user:operator" },
+          origin: { provider: "discord", accountId: "default", from: "discord:operator" },
+        }),
+      },
+    );
+  }
+
+  function mainSessionOrigin() {
+    const persisted = loadExactSessionEntry({
+      agentId: "main",
+      sessionKey: MAIN_SESSION_KEY,
+      storePath,
+    });
+    return sessionDeliveryOrigin(persisted?.entry);
+  }
+
+  beforeEach(async () => {
+    storePath = path.join(tempDirs.make("openclaw-mirror-order-"), "sessions.json");
+    cfg = {
+      session: { store: storePath },
+      channels: { testchat: { enabled: true } },
+    } as OpenClawConfig;
+    handleAction.mockReset();
+    registerTestChannel();
+    await seedMainSessionWithDiscordOrigin();
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("leaves the main session route untouched when the send fails", async () => {
+    handleAction.mockRejectedValue(
+      new Error("testchat bot token missing. Set channels.testchat.botToken."),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg,
+        action: "send",
+        params: { channel: "testchat", to: "user:12345", message: "hi" },
+        agentId: "main",
+        dryRun: false,
+      }),
+    ).rejects.toThrow("token missing");
+
+    expect(handleAction).toHaveBeenCalledOnce();
+    expect(mainSessionOrigin()).toMatchObject({
+      provider: "discord",
+      from: "discord:operator",
+    });
+  });
+
+  it("persists the outbound mirror route after a successful send", async () => {
+    handleAction.mockResolvedValue(jsonResult({ ok: true, messageId: "m1" }));
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "testchat", to: "user:12345", message: "hi" },
+      agentId: "main",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(mainSessionOrigin()).toMatchObject({
+      provider: "testchat",
+      from: "testchat:12345",
+    });
+  });
+});

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -413,8 +413,19 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     resolveReplyTransport: channelPlugin?.threading?.resolveReplyTransport,
     replyToIsExplicit,
     resolveOutboundSessionRoute,
-    ensureOutboundSessionEntry,
   });
+  // Durable route/session persistence commits only on send success. A failed
+  // probe (missing channel credentials above all) must not rebind the folded
+  // main session's delivery route or mint a conversation identity. Once-only:
+  // multi-payload sends report several platform results for one route.
+  let outboundRoutePersisted = false;
+  const commitOutboundSessionRoute = async () => {
+    if (outboundRoutePersisted || !outboundRoute) {
+      return;
+    }
+    outboundRoutePersisted = true;
+    await ensureOutboundSessionEntry({ cfg, channel, accountId, route: outboundRoute });
+  };
   const resolvedReplyToId = readToolStringParam(params, "replyTo");
   throwIfAborted(abortSignal);
 
@@ -479,6 +490,7 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
         }),
       });
   if (gatewayPluginAction) {
+    await commitOutboundSessionRoute();
     return annotateSourceDelivery(
       withSendNormalization(gatewayPluginAction, sendPayload.normalization),
       {
@@ -543,7 +555,14 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
       deliveryIntentId: input.deliveryIntentId,
       deliveryCompletion: input.deliveryCompletion,
       onDeliveryIntent: input.onDeliveryIntent,
-      onDeliveryResult: input.onDeliveryResult,
+      // Identified platform evidence is the first success proof on the core
+      // path; commit the route here so the transcript mirror (which runs later
+      // in the same delivery) can resolve a just-created session entry.
+      onDeliveryResult: async (result) => {
+        await commitOutboundSessionRoute();
+        await input.onDeliveryResult?.(result);
+      },
+      onPluginSendAccepted: commitOutboundSessionRoute,
       mirror:
         !dryRun && input.transcriptMirror
           ? {
@@ -579,6 +598,14 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     replyToIdSource: resolvedReplyToId ? (replyToIsExplicit ? "explicit" : "implicit") : undefined,
     threadId: resolvedThreadId ?? undefined,
   });
+
+  // Gateway-relayed core sends return no identified platform result locally;
+  // a non-failed, non-suppressed return is their success proof. Failed and
+  // suppressed sends leave the durable route untouched.
+  const coreDeliveryStatus = send.sendResult?.deliveryStatus;
+  if (coreDeliveryStatus !== "failed" && coreDeliveryStatus !== "suppressed") {
+    await commitOutboundSessionRoute();
+  }
 
   const result: Extract<MessageActionResult, { kind: "send" }> = {
     kind: "send",

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -180,12 +180,6 @@ export async function prepareOutboundMirrorRoute(params: {
   resolveOutboundSessionRoute: (
     params: ResolveOutboundSessionRouteParams,
   ) => Promise<OutboundSessionRoute | null>;
-  ensureOutboundSessionEntry: (params: {
-    cfg: OpenClawConfig;
-    channel: ChannelId;
-    accountId?: string | null;
-    route: OutboundSessionRoute;
-  }) => Promise<void>;
 }): Promise<{
   resolvedThreadId?: string;
   outboundRoute: OutboundSessionRoute | null;
@@ -200,6 +194,9 @@ export async function prepareOutboundMirrorRoute(params: {
     replyToIsExplicit: params.replyToIsExplicit,
   });
   const replyToId = readToolStringParam(params.actionParams, "replyTo");
+  // Route resolution is read-only here; the durable session/route write happens
+  // in ensureOutboundSessionEntry only after the send succeeds. Persisting
+  // before delivery let a failed CLI probe rebind the main session's route.
   const outboundRoute =
     params.agentId && !params.dryRun
       ? await params.resolveOutboundSessionRoute({
@@ -214,14 +211,6 @@ export async function prepareOutboundMirrorRoute(params: {
           threadId: resolvedThreadId,
         })
       : null;
-  if (outboundRoute && params.agentId && !params.dryRun) {
-    await params.ensureOutboundSessionEntry({
-      cfg: params.cfg,
-      channel: params.channel,
-      accountId: params.accountId,
-      route: outboundRoute,
-    });
-  }
   if (outboundRoute && !params.dryRun) {
     params.actionParams["__sessionKey"] = outboundRoute.sessionKey;
   }

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -95,6 +95,8 @@ type OutboundSendContext = {
   onDeliveryIntent?: (intent: DurableMessageSendIntent) => void;
   /** Runs on identified platform evidence before queue acknowledgement. */
   onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
+  /** Runs once a plugin action accepted the send, before transcript mirroring. */
+  onPluginSendAccepted?: () => Promise<void>;
 };
 
 type PluginHandledResult = {
@@ -420,6 +422,9 @@ export async function executeSendAction(params: {
         ctx: pluginCtx,
         action: "send",
         onHandled: async () => {
+          // The accepted-send commit must precede the transcript mirror below:
+          // first-contact outbound routes create their session row in it.
+          await params.ctx.onPluginSendAccepted?.();
           if (!params.ctx.mirror) {
             return;
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed outbound send to an unconfigured channel (for example `openclaw message send --channel telegram --target 12345` with no Telegram token configured) would durably hijack the agent's main session identity before any credential validation ran. The pre-send persistence rewrote the main session's delivery route/origin and minted a phantom conversations-registry row for the never-reached target, so the Control UI showed the wrong channel identity (e.g. `telegram:12345`), webchat turns recorded the wrong `sourceChannel`, and the web composer bound itself to a phantom conversation whose sends failed silently.

## Why This Change Was Made

Route resolution in `prepareOutboundMirrorRoute` is now read-only; the durable route/origin write commits once per send at the first success evidence — identified platform delivery result (`onDeliveryResult`) or plugin action acceptance (`onPluginSendAccepted`) — with a post-return safety net for adapters whose results carry no platform identity. Both commit points run before the in-delivery transcript mirror so first-contact routes still create their session row. The gateway send RPC sibling had the same pre-send persistence and receives the same commit-on-success-evidence ordering; the pre-persist branch is deleted in both owners.

## User Impact

A failed send no longer corrupts the main session: the Control UI keeps the correct session identity, webchat turns record the correct source channel, and the web composer stays bound to the real conversation. Successful sends behave exactly as before, including first-contact route creation.

## Evidence

- Regression test `src/infra/outbound/message-action-send.mirror-order.test.ts` proves a failed send leaves the seeded main-session origin and conversation identity untouched while a successful send still persists the mirror route; verified failing on pre-fix code.
- Post-rebase on current `main` (507e8b985e5): `node scripts/run-vitest.mjs src/infra/outbound/message-action-send.mirror-order.test.ts src/gateway/server-methods/send.test.ts` — 109 + 2 tests passed.
- Full affected suites green pre-rebase (142 + 51 + 109); tsgo, oxlint, oxfmt clean; autoreview clean (0.98).
- Production LOC delta: net +36 prod (+142 test). Growth is the two success-evidence commit points, which did not previously exist; the pre-persist branch and its duplicated threading persistence were deleted.

### Notes / follow-up product question

Today a successful outbound DM send replaces a differing pre-existing main-session origin under `dmScope=main` (last-write-wins). Should it? If the main session already has an established origin from a real inbound conversation, silently rebinding it on an operator-initiated outbound send to a different target may deserve an explicit decision (keep, warn, or refuse). Flagging for maintainer product judgment; this PR preserves the shipped last-write-wins behavior on success and only fixes the failure-path corruption.
