### PR TITLE
fix(agents): agents delete leaves stale agent files when database sidecars reappear during deletion

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1646,7 +1646,7 @@ describe("agents.delete", () => {
     expectRespondOk(recreated.respond, { ok: true, agentId: "test-agent" });
   });
 
-  it("preserves a replacement whose identity differs from the journal", async () => {
+  it("sweeps leaked files that appeared at prepared-absent journal paths", async () => {
     const workspaceDir = "/journal/workspace";
     const workspaceAlias = "/journal/workspace-alias";
     const journal = {
@@ -1715,12 +1715,13 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { failed: [] });
-    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceDir);
-    const replacementRecord = journal.cleanupPaths.find((entry) => entry.path === workspaceDir);
-    expect(replacementRecord).toMatchObject({
-      done: true,
-      note: "cleanup path appeared after deletion preparation",
-    });
+    // The journal fence blocked legitimate claims while this path was prepared
+    // absent, so the appeared occupant is leaked deleted-agent state: sweep it
+    // instead of preserving it and finishing over a surviving tree.
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceDir);
+    const appearedRecord = journal.cleanupPaths.find((entry) => entry.path === workspaceDir);
+    expect(appearedRecord).toMatchObject({ done: true });
+    expect(appearedRecord).not.toHaveProperty("note");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2827,6 +2828,49 @@ describe("agents.delete", () => {
       allowedAgentRosterRemovals: ["test-agent"],
     });
     expect(mocks.movePathToTrash).toHaveBeenCalled();
+  });
+
+  it("sweeps WAL sidecars recreated between deletion preparation and cleanup", async () => {
+    const agentDir = "/agents/test-agent";
+    const walPath = `${agentDir}/openclaw-agent.sqlite-wal`;
+    const shmPath = `${agentDir}/openclaw-agent.sqlite-shm`;
+    const presentStats = new Map<string, { dev: number; ino: number; file: boolean }>([
+      [agentDir, { dev: 1, ino: 10, file: false }],
+      ["/workspace/test-agent", { dev: 1, ino: 20, file: false }],
+      ["/transcripts/test-agent", { dev: 1, ino: 30, file: false }],
+    ]);
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      const stat = presentStats.get(String(pathname));
+      if (!stat) {
+        throw createEnoentError();
+      }
+      return {
+        dev: stat.dev,
+        ino: stat.ino,
+        isFile: () => stat.file,
+        isSymbolicLink: () => false,
+        nlink: 1,
+      } as unknown as import("node:fs").Stats;
+    });
+    // The live runtime reopens the agent database while deletion awaits config,
+    // cron, and session-purge work, recreating -wal/-shm after preparation.
+    mocks.cronRemoveAgentJobsTransactional.mockImplementation(
+      async (_agentId: string, commit: () => Promise<unknown>) => {
+        presentStats.set(walPath, { dev: 1, ino: 40, file: true });
+        presentStats.set(shmPath, { dev: 1, ino: 41, file: true });
+        return await commit();
+      },
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([pathname]) => pathname);
+    expect(trashedPaths).toContain(walPath);
+    expect(trashedPaths).toContain(shmPath);
+    expect(trashedPaths).toContain(agentDir);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
   it("deletes workspace state after removing the last owner's workspace", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -394,11 +394,11 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
   }
   const identity = cleanupPathIdentity(stat);
   if (cleanupPath.preparedIdentity === null) {
-    if (identity !== null) {
-      throw new AgentCleanupIdentityMismatchError(
-        "cleanup path appeared after deletion preparation",
-      );
-    }
+    // The journal fence blocks legitimate claims on prepared-absent paths, so a
+    // file that appeared here is leaked deleted-agent state (recreated WAL
+    // sidecars, runtime home rewrites). Adopt it and sweep it; preserving it
+    // cascades ancestor protection and finishes over a surviving tree.
+    cleanupPath.preparedIdentity = identity;
   } else if (
     identity === null ||
     identity.dev !== cleanupPath.preparedIdentity.dev ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw agents delete <id>` against a gateway would see the command exit 0 and report success while ~157 files survived under `$OPENCLAW_STATE_DIR/agents/<id>/` — the agent directory was never actually removed.

During the deletion window, the session purge reopens the agent database and recreates the `-wal`/`-shm` sidecars after cleanup preparation had already recorded those journal paths as absent. The sweep's identity guard classified the recreated files as foreign replacements ("cleanup path appeared after deletion preparation"), preserved them, ancestor protection cascaded over the entire agent tree, and the deletion journal finished "complete" over a surviving tree — a silent failure on the default path.

## Why This Change Was Made

The deletion journal fence already blocks legitimate claims beneath prepared paths for the duration of the deletion, so a file that appears at a prepared-absent path during the window can only be leaked deleted-agent state (recreated WAL sidecars, runtime home rewrites). The fix adopts the appeared occupant's identity at prepared-absent paths so the sweep removes it, instead of preserving it and poisoning the ancestor chain. Prepared-present paths keep the existing identity-mismatch protection unchanged, so genuine operator file replacements are still preserved.

Named accepted tradeoff: a same-user process deliberately planting a file at a prepared-absent path during the deletion window now gets swept with the agent tree. This is the same local trust boundary already accepted by the existing Trash-race comment in this module — processes running as the operator's user inside the state dir are trusted.

Production LOC delta: net 0 (5 added / 5 removed in `src/gateway/server-methods/agents.ts`); the fix replaces the mistaken guard branch in the owner rather than adding a downstream compensation.

## User Impact

`openclaw agents delete` now actually deletes the agent directory on the gateway path. Previously the command reported success while leaving the full agent state tree (database, sessions, config residue) on disk, which also blocked re-creating an agent with a clean identity.

## Evidence

- Regression tests fail pre-fix (verified by stashing the production change): recreated WAL sidecars between preparation and cleanup are trashed with the agent directory, and recovery sweeps a file that appeared at a journaled prepared-absent path.
- `node scripts/run-vitest.mjs src/gateway/server-methods/agents-mutate.test.ts` — 100/100 passed (rerun after rebase onto current `main`).
- CLI delete suite: 19/19 passed; sibling gateway server-method suites green.
- Autoreview clean (0.96, no actionable findings).
