### PR TITLE
fix: doctor --fix reports config changes that were never written when validation refuses the candidate

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1686,10 +1686,12 @@ describe("doctor config flow", () => {
     expect(result.cfg.agents?.entries).toEqual({
       main: { workspace: "/tmp/migrated-main" },
     });
-    expect(terminalNoteMock).toHaveBeenCalledWith(
+    // Repair panels defer to the atomic write runner; the flow itself must not
+    // claim the roster change happened before anything reached disk.
+    expect(result.pendingChangePanels).toContain(
       "Prepared the canonical agent roster without retired default markers for persistence.",
-      "Doctor changes",
     );
+    expect(terminalNoteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
     expect(terminalNoteMock.mock.calls.some(([message]) => message.includes("Persisted"))).toBe(
       false,
     );
@@ -2885,7 +2887,7 @@ describe("doctor config flow", () => {
   it("sanitizes config-derived doctor warnings and changes before logging", async () => {
     const noteSpy = resetTerminalNoteMock();
     try {
-      await runDoctorConfigWithInput({
+      const result = await runDoctorConfigWithInput({
         repair: true,
         config: {
           channels: {
@@ -2919,9 +2921,14 @@ describe("doctor config flow", () => {
         run: loadAndMaybeMigrateDoctorConfig,
       });
 
-      const outputs = noteSpy.mock.calls
-        .filter((call) => call[1] === "Doctor warnings" || call[1] === "Doctor changes")
-        .map((call) => call[0]);
+      // Repair-mode change panels defer to the write runner; sanitized change
+      // text travels through pendingChangePanels instead of immediate notes.
+      const outputs = [
+        ...noteSpy.mock.calls
+          .filter((call) => call[1] === "Doctor warnings" || call[1] === "Doctor changes")
+          .map((call) => call[0]),
+        ...(result.pendingChangePanels ?? []),
+      ];
       const joinedOutputs = outputs.join("\n");
       expect(outputs.some((line) => line.includes("\u001b"))).toBe(false);
       expect(outputs.some((line) => line.includes("\nforged"))).toBe(false);
@@ -3570,11 +3577,11 @@ describe("doctor config flow", () => {
   });
 
   it.each([
-    [false, "Doctor changes preview", false],
-    [true, "Doctor changes", true],
+    [false, false],
+    [true, true],
   ] as const)(
     "previews and repairs retired internal hook registrations (repair=%s)",
-    async (repair, panelTitle, shouldWriteConfig) => {
+    async (repair, shouldWriteConfig) => {
       const noteSpy = resetTerminalNoteMock();
       try {
         const result = await runDoctorConfigWithInput({
@@ -3595,13 +3602,21 @@ describe("doctor config flow", () => {
         ).toBeUndefined();
         expect(result.cfg.hooks?.internal?.enabled).toBeUndefined();
         expect(result.shouldWriteConfig).toBe(shouldWriteConfig);
-        expect(
-          noteSpy.mock.calls.some(
-            ([message, title]) =>
-              title === panelTitle &&
-              message.includes("Removed retired hooks.internal.handlers registrations"),
-          ),
-        ).toBe(true);
+        const removalLine = "Removed retired hooks.internal.handlers registrations";
+        if (repair) {
+          // Repair panels defer until the atomic write commits.
+          expect(
+            (result.pendingChangePanels ?? []).some((panel) => panel.includes(removalLine)),
+          ).toBe(true);
+          expect(noteSpy.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
+        } else {
+          expect(
+            noteSpy.mock.calls.some(
+              ([message, title]) =>
+                title === "Doctor changes preview" && message.includes(removalLine),
+            ),
+          ).toBe(true);
+        }
       } finally {
         noteSpy.mockClear();
       }
@@ -3633,10 +3648,10 @@ describe("doctor config flow", () => {
     }
   });
 
-  it("titles the legacy migration panel as applied when --fix is passed (#80817)", async () => {
+  it("defers the applied panel to the config write when --fix is passed (#80817)", async () => {
     const noteSpy = resetTerminalNoteMock();
     try {
-      await runDoctorConfigWithInput({
+      const result = await runDoctorConfigWithInput({
         repair: true,
         config: {
           heartbeat: {
@@ -3647,8 +3662,11 @@ describe("doctor config flow", () => {
         run: loadAndMaybeMigrateDoctorConfig,
       });
       const changeTitles = noteSpy.mock.calls.map(([, title]) => title);
-      expect(changeTitles).toContain("Doctor changes");
+      // The flow itself prints nothing as applied; the write runner reports
+      // "Doctor changes" only after the atomic write commits.
+      expect(changeTitles).not.toContain("Doctor changes");
       expect(changeTitles).not.toContain("Doctor changes preview");
+      expect(result.pendingChangePanels?.length).toBeGreaterThan(0);
     } finally {
       noteSpy.mockClear();
     }
@@ -3731,14 +3749,16 @@ describe("doctor config flow", () => {
           });
           noteSpy.mockClear();
 
-          await loadAndMaybeMigrateDoctorConfig({
+          const secondRun = await loadAndMaybeMigrateDoctorConfig({
             options: { nonInteractive: true, repair: true },
             confirm: async () => false,
           });
-          const secondRunTalkNormalizationLines = noteSpy.mock.calls
-            .filter((call) => call[1] === "Doctor changes")
-            .map((call) => call[0])
-            .filter((line) => line.includes("Normalized talk.provider/providers shape"));
+          const secondRunTalkNormalizationLines = [
+            ...noteSpy.mock.calls
+              .filter((call) => call[1] === "Doctor changes")
+              .map((call) => call[0]),
+            ...(secondRun.pendingChangePanels ?? []),
+          ].filter((line) => line.includes("Normalized talk.provider/providers shape"));
           expect(secondRunTalkNormalizationLines).toStrictEqual([]);
         } finally {
           noteSpy.mockClear();

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -95,20 +95,32 @@ function collectConfiguredChannelIds(cfg: OpenClawConfig): string[] {
   return Object.keys(channels).filter((channelId) => channelId !== "defaults");
 }
 
-// Past-tense "Removed X" lines must not appear under a "Doctor changes" panel
-// when the run did not write to disk; retitle to signal the preview state.
-function emitDoctorChangesPanel(
-  changeLines: ReadonlyArray<string>,
-  shouldRepair: boolean,
-  options: { sanitize?: boolean } = {},
-): void {
-  if (changeLines.length === 0) {
-    return;
-  }
-  const body = changeLines.join("\n");
-  const message = options.sanitize ? sanitizeDoctorNote(body) : body;
-  const title = shouldRepair ? "Doctor changes" : "Doctor changes preview";
-  note(message, title);
+// Repair-mode "Doctor changes" panels queue until the final candidate passes the
+// same validation the atomic writer enforces: printing "Doctor changes" and then
+// refusing the write would report repairs that never reached disk. Preview
+// panels print immediately — they promise nothing.
+type DoctorChangesPanelSink = {
+  emit: (changeLines: ReadonlyArray<string>, options?: { sanitize?: boolean }) => void;
+  drain: () => string[];
+};
+
+function createDoctorChangesPanelSink(shouldRepair: boolean): DoctorChangesPanelSink {
+  const pending: string[] = [];
+  return {
+    emit: (changeLines, options = {}) => {
+      if (changeLines.length === 0) {
+        return;
+      }
+      const body = changeLines.join("\n");
+      const message = options.sanitize ? sanitizeDoctorNote(body) : body;
+      if (shouldRepair) {
+        pending.push(message);
+        return;
+      }
+      note(message, "Doctor changes preview");
+    },
+    drain: () => pending.splice(0),
+  };
 }
 
 async function refreshGatewayAuthStateAfterAuthProfileRepair(): Promise<void> {
@@ -189,15 +201,12 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let shouldRepairCronCodexModelRefsAfterConfigWrite = false;
   let openAICodexAuthProfileIdMap: ReadonlyMap<string, string> | undefined;
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
+  const changesPanelSink = createDoctorChangesPanelSink(shouldRepair);
   const applyConfigMutation = (
     mutation: DoctorConfigMutationResult & { warnings?: string[] },
     options: { fixHint: string; sanitize?: boolean; emitWarnings?: boolean },
   ): void => {
-    emitDoctorChangesPanel(
-      mutation.changes,
-      shouldRepair,
-      options.sanitize ? { sanitize: true } : {},
-    );
+    changesPanelSink.emit(mutation.changes, options.sanitize ? { sanitize: true } : {});
     if (options.emitWarnings && mutation.warnings?.length) {
       emitDoctorNotes({ note, warningNotes: mutation.warnings });
     }
@@ -337,7 +346,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   if (legacyIssueLines.length > 0) {
     note(legacyIssueLines.join("\n"), "Legacy config keys detected");
   }
-  emitDoctorChangesPanel(legacyStep.changeLines, shouldRepair);
+  changesPanelSink.emit(legacyStep.changeLines);
   const hookTransformsDirWarnings = collectInvalidHookTransformsDirWarnings(
     state.cfg,
     snapshot.path,
@@ -482,11 +491,16 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     if (repairSequence.authProfilesRepaired) {
       await refreshGatewayAuthStateAfterAuthProfileRepair();
     }
+    // Committed side-effect repairs (SQLite/filesystem) already happened; report now.
+    // Candidate-config mutations stay queued until the atomic write commits.
     emitDoctorNotes({
       note,
       changeNotes: repairSequence.changeNotes,
       warningNotes: repairSequence.warningNotes,
     });
+    for (const configChange of repairSequence.configChangeNotes ?? []) {
+      changesPanelSink.emit([configChange]);
+    }
   } else {
     const { collectDoctorPreviewNotes } = await import("./doctor/shared/preview-warnings.js");
     const collectPreviewNotes = async () =>
@@ -529,8 +543,12 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     const lines = [
       ...unknownStep.removed.map((pathLocal) => `- ${pathLocal}`),
       ...unknownStep.repairs.map((change) => `- ${change}`),
-    ].join("\n");
-    note(lines, shouldRepair ? "Doctor changes" : "Unknown config keys");
+    ];
+    if (shouldRepair) {
+      changesPanelSink.emit(lines);
+    } else {
+      note(lines.join("\n"), "Unknown config keys");
+    }
   }
   if (unknownStep.warnings.length > 0) {
     note(unknownStep.warnings.join("\n"), "Doctor warnings");
@@ -579,10 +597,16 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   noteSandboxOriginProxyWarning(cfg);
   noteMcpOriginWarning(cfg);
 
+  // Queued repair panels describe candidate mutations; the write runner prints
+  // them as "Doctor changes" only after the atomic write commits. A blocked
+  // write drops them — its blocking note already states nothing was changed.
+  const pendingChangePanels = changesPanelSink.drain();
+
   return {
     cfg,
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig,
+    ...(shouldWriteConfig && pendingChangePanels.length > 0 ? { pendingChangePanels } : {}),
     sourceConfigValid: snapshot.valid,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),

--- a/src/commands/doctor-config-flow.validation-refusal.test.ts
+++ b/src/commands/doctor-config-flow.validation-refusal.test.ts
@@ -1,0 +1,83 @@
+// Regression: doctor --fix with a repairable unknown key plus an unrepairable
+// schema type error must not report "Doctor changes" (nothing persists), must
+// not crash with a raw Error, and must leave the config byte-identical while
+// telling the operator exactly what to fix by hand.
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { runWriteConfigHealth } from "../flows/doctor-health-contribution-runners.config.js";
+import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+
+const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
+  note: noteMock,
+}));
+
+describe("doctor --fix with a validation-blocked candidate", () => {
+  afterEach(() => {
+    noteMock.mockClear();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("never reports unpersisted fixes and leaves the config untouched", async () => {
+    await withTempHome(async (home) => {
+      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const configPath = await writeOpenClawConfig(home, {
+          gatway: { port: 12345 },
+          agents: { defaults: { heartbeat: { every: 5 } } },
+        });
+        const rawBefore = await fs.readFile(configPath, "utf-8");
+        const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+        const options: DoctorOptions = { nonInteractive: true, repair: true };
+        const prompter = createDoctorPrompter({ runtime, options });
+        const configResult = await loadAndMaybeMigrateDoctorConfig({
+          options,
+          confirm: (params) => prompter.confirm(params),
+          runtime,
+          prompter,
+        });
+
+        // The unknown-key repair is computed, but held until the write commits.
+        expect(configResult.shouldWriteConfig).toBe(true);
+        expect(
+          (configResult.pendingChangePanels ?? []).some((panel) => panel.includes("gatway")),
+        ).toBe(true);
+        expect(noteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
+
+        const ctx: DoctorHealthFlowContext = {
+          runtime,
+          options,
+          prompter,
+          configResult,
+          cfg: configResult.cfg,
+          cfgForPersistence: structuredClone(configResult.cfg),
+          sourceConfigValid: configResult.sourceConfigValid ?? true,
+          configPath,
+          stateDirExistedAtStart: true,
+          ...(configResult.runWithPluginMetadataSnapshot
+            ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
+            : {}),
+        };
+
+        // The write must refuse gracefully — no throw, no change panel, no file write.
+        await expect(runWriteConfigHealth(ctx)).resolves.toBeUndefined();
+
+        expect(ctx.configWriteBlockedByValidation).toBe(true);
+        expect(ctx.configResultWriteCommitted).not.toBe(true);
+        expect(noteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
+        const warning = noteMock.mock.calls.find(
+          ([message, title]) =>
+            title === "Doctor warnings" && message.includes("No config changes were written"),
+        );
+        expect(warning).toBeDefined();
+        expect(warning?.[0]).toContain("agents.defaults.heartbeat.every");
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(rawBefore);
+      });
+    });
+  });
+});

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -489,12 +489,13 @@ describe("doctor repair sequencing", () => {
 
     expect(result.state.pendingChanges).toBe(true);
     expect(result.state.candidate.channels?.discord?.allowFrom).toEqual(["123"]);
-    expect(result.changeNotes).toStrictEqual([
+    expect(result.changeNotes).toStrictEqual([]);
+    expect(result.configChangeNotes).toStrictEqual([
       "channels.discord.allowFrom: converted 1 numeric ID to strings",
       "channels.tools.exec.toolsBySender: migrated 1 legacy key to typed id: entries (bad-keynext -> id:bad-keynext)",
     ]);
-    expect(result.changeNotes.join("\n")).not.toContain("\u001B");
-    expect(result.changeNotes.join("\n")).not.toContain("\r");
+    expect(result.configChangeNotes.join("\n")).not.toContain("\u001B");
+    expect(result.configChangeNotes.join("\n")).not.toContain("\r");
     expect(result.warningNotes).toStrictEqual([
       "channels.signal.accounts.ops-teamnext.dmPolicy warning",
     ]);
@@ -526,7 +527,7 @@ describe("doctor repair sequencing", () => {
     });
 
     expect(result.state.candidate.auth?.order?.anthropic).toBeUndefined();
-    expect(result.changeNotes).toContain(
+    expect(result.configChangeNotes).toContain(
       "auth.order.anthropic: removed 1 missing profile reference to restore automatic per-agent auth selection.",
     );
     expect(result.authProfilesRepaired).toBe(false);
@@ -757,6 +758,8 @@ describe("doctor repair sequencing", () => {
     expect(result.state.candidate.plugins?.entries?.brave?.enabled).toBe(true);
     expect(result.changeNotes).toStrictEqual([
       'Installed missing configured plugin "brave" from @openclaw/brave-plugin.',
+    ]);
+    expect(result.configChangeNotes).toStrictEqual([
       "brave web search provider selected, enabled automatically.",
     ]);
   });
@@ -988,6 +991,8 @@ describe("doctor repair sequencing", () => {
     });
     expect(result.changeNotes).toStrictEqual([
       'Installed missing configured plugin "discord" from @openclaw/discord.',
+    ]);
+    expect(result.configChangeNotes).toStrictEqual([
       "discord installed for existing configuration, enabled automatically.",
       "Moved channels.discord.dm.policy → channels.discord.dmPolicy.\nMoved channels.discord.dm.allowFrom → channels.discord.allowFrom.",
       "channels.discord.allowFrom: converted 1 numeric ID to strings",
@@ -1037,6 +1042,8 @@ describe("doctor repair sequencing", () => {
     expect(result.state.candidate.plugins?.entries?.exa).toEqual({ enabled: true });
     expect(result.changeNotes).toStrictEqual([
       'Installed missing configured plugin "exa" from @openclaw/exa-plugin.',
+    ]);
+    expect(result.configChangeNotes).toStrictEqual([
       "exa installed for existing configuration, enabled automatically.",
     ]);
   });
@@ -1244,6 +1251,8 @@ describe("doctor repair sequencing", () => {
 
     expect(result.changeNotes).toStrictEqual([
       'Installed missing configured plugin "brave" from @openclaw/brave-plugin.',
+    ]);
+    expect(result.configChangeNotes).toStrictEqual([
       "- plugins.entries: removed 1 stale plugin entry (brave)",
     ]);
     expect(result.warningNotes).toStrictEqual([
@@ -1291,7 +1300,8 @@ describe("doctor repair sequencing", () => {
     expect(result.state.pendingChanges).toBe(true);
     expect(result.state.candidate.agents?.defaults?.model).toBe("openai/gpt-5.5");
     expect(result.state.candidate.agents?.defaults?.agentRuntime).toBeUndefined();
-    expect(result.changeNotes).toStrictEqual([
+    expect(result.changeNotes).toStrictEqual([]);
+    expect(result.configChangeNotes).toStrictEqual([
       'Repaired Codex model routes:- agents.defaults.model: openai-codex/gpt-5.5 -> openai/gpt-5.5.\nSet agents.defaults.models.openai/gpt-5.5.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
     ]);
   });
@@ -1353,7 +1363,7 @@ describe("doctor repair sequencing", () => {
       params: { reasoning_effort: "high" },
       agentRuntime: { id: "codex" },
     });
-    const changeNotes = result.changeNotes.join("\n");
+    const changeNotes = result.configChangeNotes.join("\n");
     expect(changeNotes).toContain("agents.defaults.model: openai-codex/gpt-5.5 -> openai/gpt-5.5");
     expect(changeNotes).toContain(
       "agents.defaults.models.openai-codex/gpt-5.5: openai-codex/gpt-5.5 -> openai/gpt-5.5",
@@ -1424,8 +1434,8 @@ describe("doctor repair sequencing", () => {
 
     expect(events).toEqual(["open-policy", "group-fallback"]);
     expect(result.state.candidate.channels?.signal?.groupAllowFrom).toEqual(["*"]);
-    expect(result.changeNotes).toContain('channels.signal.allowFrom: set to ["*"]');
-    expect(result.changeNotes).toContain(
+    expect(result.configChangeNotes).toContain('channels.signal.allowFrom: set to ["*"]');
+    expect(result.configChangeNotes).toContain(
       "channels.signal.groupAllowFrom: copied 1 sender entry from allowFrom",
     );
   });
@@ -1589,7 +1599,7 @@ describe("doctor repair sequencing", () => {
     expect(result.state.candidate.plugins?.entries?.brave?.enabled).toBe(true);
     expect(result.state.candidate.plugins?.entries?.["old-plugin"]).toBeUndefined();
     expect(result.state.pendingChanges).toBe(true);
-    expect(result.changeNotes).toContain(
+    expect(result.configChangeNotes).toContain(
       "plugins.entries: removed 1 stale plugin entry (old-plugin)",
     );
     expect(result.warningNotes).toStrictEqual([

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -65,7 +65,10 @@ export async function runDoctorRepairSequence(params: {
   runWithPluginMetadataSnapshot?: PluginMetadataSnapshotScopeRunner;
 }): Promise<{
   state: DoctorConfigMutationState;
+  /** Notes for repairs already committed to durable state (SQLite/filesystem). */
   changeNotes: string[];
+  /** Notes for candidate-config mutations that are durable only after the config write. */
+  configChangeNotes: string[];
   warningNotes: string[];
   authProfilesRepaired: boolean;
   openAICodexAuthProfileIdMap?: ReadonlyMap<string, string>;
@@ -74,6 +77,7 @@ export async function runDoctorRepairSequence(params: {
   let state = params.state;
   const pluginMetadataSnapshotState = params.pluginMetadataSnapshotState ?? {};
   const changeNotes: string[] = [];
+  const configChangeNotes: string[] = [];
   const warningNotes: string[] = [];
   const env = params.env ?? process.env;
   const resolveCurrentPluginMetadataScope = () => {
@@ -112,7 +116,8 @@ export async function runDoctorRepairSequence(params: {
     warnings?: string[];
   }) => {
     if (mutation.changes.length > 0) {
-      appendNotes(changeNotes, mutation.changes);
+      // Candidate-only mutation: report as applied only after the config write lands.
+      appendNotes(configChangeNotes, mutation.changes);
       state = applyDoctorConfigMutation({
         state,
         mutation,
@@ -363,6 +368,7 @@ export async function runDoctorRepairSequence(params: {
   return {
     state,
     changeNotes,
+    configChangeNotes,
     warningNotes,
     authProfilesRepaired,
     ...(openAICodexAuthProfileIdMap.size > 0 ? { openAICodexAuthProfileIdMap } : {}),

--- a/src/config/io.write-errors.ts
+++ b/src/config/io.write-errors.ts
@@ -22,6 +22,7 @@ export function isConfigValidationFailedError(
   return (
     error instanceof Error &&
     "code" in error &&
+    // SAFETY: the `"code" in error` guard proves the property exists; the cast only widens to unknown for comparison.
     (error as { code?: unknown }).code === CONFIG_VALIDATION_FAILED_CODE
   );
 }
@@ -29,7 +30,7 @@ export function isConfigValidationFailedError(
 const OPEN_DM_POLICY_ALLOW_FROM_RE =
   /^(?<policyPath>[a-z0-9_.-]+)\s*=\s*"open"\s+requires\s+(?<allowPath>[a-z0-9_.-]+)(?:\s+\(or\s+[a-z0-9_.-]+\))?\s+to include "\*"$/i;
 
-export function formatConfigValidationFailure(pathLabel: string, issueMessage: string): string {
+function formatConfigValidationFailure(pathLabel: string, issueMessage: string): string {
   const match = issueMessage.match(OPEN_DM_POLICY_ALLOW_FROM_RE);
   const policyPath = match?.groups?.policyPath?.trim();
   const allowPath = match?.groups?.allowPath?.trim();

--- a/src/config/io.write-errors.ts
+++ b/src/config/io.write-errors.ts
@@ -1,4 +1,31 @@
 // Formats stable user-facing config write failures.
+import type { ConfigValidationIssue } from "./types.js";
+
+const CONFIG_VALIDATION_FAILED_CODE = "CONFIG_VALIDATION_FAILED";
+
+/**
+ * Typed write refusal for a candidate that fails schema validation, so doctor
+ * can render "config left unchanged" plus the offending paths instead of crashing.
+ */
+export function createConfigValidationFailedError(issues: ConfigValidationIssue[]): Error {
+  const issue = issues[0];
+  return Object.assign(
+    new Error(formatConfigValidationFailure(issue?.path || "<root>", issue?.message ?? "invalid")),
+    { code: CONFIG_VALIDATION_FAILED_CODE, issues },
+  );
+}
+
+/** True when a config write was refused because the candidate failed schema validation. */
+export function isConfigValidationFailedError(
+  error: unknown,
+): error is Error & { issues: ConfigValidationIssue[] } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as { code?: unknown }).code === CONFIG_VALIDATION_FAILED_CODE
+  );
+}
+
 const OPEN_DM_POLICY_ALLOW_FROM_RE =
   /^(?<policyPath>[a-z0-9_.-]+)\s*=\s*"open"\s+requires\s+(?<allowPath>[a-z0-9_.-]+)(?:\s+\(or\s+[a-z0-9_.-]+\))?\s+to include "\*"$/i;
 

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { collectChangedPaths } from "./config-change-paths.js";
 import { applyUnsetPathsForWrite } from "./config-path-mutation.js";
 import { restoreEnvRefsFromMap, resolveWriteEnvSnapshotForPath } from "./env-preserve.js";
-import { formatConfigValidationFailure } from "./io.write-errors.js";
+import { createConfigValidationFailedError } from "./io.write-errors.js";
 import { resolvePersistCandidateForWrite } from "./io.write-prepare.js";
 import { tryResolveLegacyCompatibilityAgentId } from "./legacy.default-agent-owner.js";
 import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
@@ -1089,10 +1089,13 @@ describe("config io write prepare", () => {
   });
 
   it('formats actionable guidance for dmPolicy="open" without wildcard allowFrom', () => {
-    const message = formatConfigValidationFailure(
-      "channels.telegram.allowFrom",
-      'channels.telegram.dmPolicy = "open" requires channels.telegram.allowFrom to include "*"',
-    );
+    const message = createConfigValidationFailedError([
+      {
+        path: "channels.telegram.allowFrom",
+        message:
+          'channels.telegram.dmPolicy = "open" requires channels.telegram.allowFrom to include "*"',
+      },
+    ]).message;
     expect(message).toContain("openclaw config set channels.telegram.allowFrom '[\"*\"]'");
     expect(message).toContain('openclaw config set channels.telegram.dmPolicy "pairing"');
   });

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -63,7 +63,7 @@ import type {
 } from "./io.types.js";
 import { ConfigRuntimeRefreshError, configWritePostCommitRollback } from "./io.types.js";
 import { logConfigWarningsOnce } from "./io.warnings.js";
-import { formatConfigValidationFailure } from "./io.write-errors.js";
+import { createConfigValidationFailedError } from "./io.write-errors.js";
 import {
   preserveIncludeOwnedConfigForWrite,
   resolvePersistCandidateForWrite,
@@ -365,10 +365,7 @@ export async function writeConfigFileFromContext(
     preservedLegacyRootKeys: options.preservedLegacyRootKeys,
   });
   if (!validated.ok) {
-    const issue = validated.issues[0];
-    throw new Error(
-      formatConfigValidationFailure(issue?.path || "<root>", issue?.message ?? "invalid"),
-    );
+    throw createConfigValidationFailedError(validated.issues);
   }
   const previousWarningFingerprint = loggedConfigWarningFingerprints.get(configPath);
   // Capture before commit so rollback cannot restore a watcher-updated slot.

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -82,19 +82,24 @@ export async function runWriteConfigHealth(
     } catch (error) {
       const { isConfigValidationFailedError } = await import("../config/io.write-errors.js");
       if (isConfigValidationFailedError(error)) {
-        // The repaired candidate still fails validation, so nothing was persisted.
-        // Queued "Doctor changes" panels stay unprinted: reporting them would claim
-        // repairs that never reached disk. Tell the operator what remains manual.
+        // This refused write persisted nothing. Queued "Doctor changes" panels stay
+        // unprinted: reporting them would claim repairs that never reached disk.
+        // An earlier pass through this shared runner may have already committed, so
+        // describe only the pending write as unpersisted, never the whole run.
         const { note } = await import("../../packages/terminal-core/src/note.js");
         const { formatConfigIssueLines } = await import("../config/issue-format.js");
         const issueLines = Array.isArray(error.issues)
           ? formatConfigIssueLines(error.issues, "-", { normalizeRoot: true })
           : [error.message];
+        const unpersistedLine =
+          ctx.configResultWriteCommitted === true
+            ? "Earlier config fixes were already saved; the remaining changes were not written."
+            : "No config changes were written.";
         note(
           [
             "Doctor could not apply config fixes: the repaired config still fails validation.",
             ...issueLines,
-            `No config changes were written. Fix the value(s) above in ${shortenHomePath(ctx.configPath)} by hand, then rerun "openclaw doctor --fix".`,
+            `${unpersistedLine} Fix the value(s) above in ${shortenHomePath(ctx.configPath)} by hand, then rerun "openclaw doctor --fix".`,
           ].join("\n"),
           "Doctor warnings",
         );

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -34,6 +34,11 @@ export async function runWriteConfigHealth(
   if (ctx.configWriteDeferredByCronOwnership === true) {
     return;
   }
+  if (ctx.configWriteBlockedByValidation === true) {
+    // The initial write already reported the validation refusal; retrying the
+    // same candidate would fail identically and duplicate the warning.
+    return;
+  }
   const { applyWizardMetadata } = await import("../commands/onboard-helpers.js");
   const { replaceConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
@@ -75,6 +80,27 @@ export async function runWriteConfigHealth(
         },
       });
     } catch (error) {
+      const { isConfigValidationFailedError } = await import("../config/io.write-errors.js");
+      if (isConfigValidationFailedError(error)) {
+        // The repaired candidate still fails validation, so nothing was persisted.
+        // Queued "Doctor changes" panels stay unprinted: reporting them would claim
+        // repairs that never reached disk. Tell the operator what remains manual.
+        const { note } = await import("../../packages/terminal-core/src/note.js");
+        const { formatConfigIssueLines } = await import("../config/issue-format.js");
+        const issueLines = Array.isArray(error.issues)
+          ? formatConfigIssueLines(error.issues, "-", { normalizeRoot: true })
+          : [error.message];
+        note(
+          [
+            "Doctor could not apply config fixes: the repaired config still fails validation.",
+            ...issueLines,
+            `No config changes were written. Fix the value(s) above in ${shortenHomePath(ctx.configPath)} by hand, then rerun "openclaw doctor --fix".`,
+          ].join("\n"),
+          "Doctor warnings",
+        );
+        ctx.configWriteBlockedByValidation = true;
+        return;
+      }
       const { isCronOwnerWriteRefusalError } = await import("../config/io.cron-owner-refusal.js");
       if (!isCronOwnerWriteRefusalError(error)) {
         throw error;
@@ -90,6 +116,16 @@ export async function runWriteConfigHealth(
       );
       ctx.configWriteDeferredByCronOwnership = true;
       return;
+    }
+    // The atomic write committed: repair panels queued by the config flow are now
+    // true statements about disk state, so print them exactly once.
+    const pendingChangePanels = ctx.configResult.pendingChangePanels;
+    if (pendingChangePanels?.length) {
+      const { note } = await import("../../packages/terminal-core/src/note.js");
+      for (const panel of pendingChangePanels) {
+        note(panel, "Doctor changes");
+      }
+      delete ctx.configResult.pendingChangePanels;
     }
     // The final writer runs again after health repairs. Advance its baseline only
     // after the atomic write succeeds so later failures cannot mark volatile state durable.

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -13,6 +13,8 @@ type DoctorConfigResult = {
   cfg: OpenClawConfig;
   path?: string;
   shouldWriteConfig?: boolean;
+  /** Repair panels held back until the atomic config write commits. */
+  pendingChangePanels?: readonly string[];
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
@@ -39,6 +41,8 @@ export type DoctorHealthFlowContext = {
   configResultWriteCommitted?: boolean;
   /** Cron ownership could not be made safe, so every config write remains deferred this run. */
   configWriteDeferredByCronOwnership?: true;
+  /** The repaired candidate failed write validation; nothing was persisted this run. */
+  configWriteBlockedByValidation?: true;
   /** One-shot repairs that require a durable config write have completed. */
   postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1175,6 +1175,55 @@ describe("doctor health contributions", () => {
     expect(mocks.note).not.toHaveBeenCalled();
   });
 
+  it("describes only the failed later write after an earlier pass committed", async () => {
+    // First write pass commits; a later health repair then produces a candidate the
+    // writer refuses. The warning must not claim the whole run wrote nothing.
+    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+
+    await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
+    expect(ctx.configResultWriteCommitted).toBe(true);
+
+    // A later repair mutates the candidate; the final write pass is refused.
+    ctx.cfg = {
+      ...ctx.cfg,
+      agents: { defaults: { heartbeat: { every: 5 } } },
+    } as unknown as OpenClawConfig;
+    mocks.note.mockClear();
+    mocks.replaceConfigFile.mockRejectedValueOnce(
+      Object.assign(new Error("Config validation failed: agents.defaults.heartbeat.every"), {
+        code: "CONFIG_VALIDATION_FAILED",
+        issues: [
+          {
+            path: "agents.defaults.heartbeat.every",
+            message: "Invalid input: expected string, received number",
+          },
+        ],
+      }),
+    );
+    await requireDoctorContribution("doctor:write-config").run(ctx);
+
+    expect(ctx.configWriteBlockedByValidation).toBe(true);
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Earlier config fixes were already saved"),
+      "Doctor warnings",
+    );
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("No config changes were written"),
+      "Doctor warnings",
+    );
+  });
+
   it("prints held change panels as Doctor changes only after the write commits", async () => {
     const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
     const ctx = {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1091,6 +1091,7 @@ describe("doctor health contributions", () => {
       ),
     );
 
+    // Untyped write errors still propagate; only typed validation refusals render notes.
     await expect(
       requireDoctorContribution("doctor:write-config-migrations").run(ctx),
     ).rejects.toThrow("Config validation failed");
@@ -1098,6 +1099,109 @@ describe("doctor health contributions", () => {
     expect(ctx.configResultWriteCommitted).not.toBe(true);
     expect(ctx.cfgForPersistence).toEqual(cfg);
     expect(mocks.collectActiveToolSchemaProjectionWarnings).not.toHaveBeenCalled();
+  });
+
+  it("reports unapplied fixes and holds change panels when write validation refuses the candidate", async () => {
+    // Regression: unknown root key repaired + type error elsewhere. Doctor used to
+    // print "Doctor changes — gatway", then crash with a raw Error and persist nothing.
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: 5 } } },
+    } as unknown as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: {
+        cfg,
+        shouldWriteConfig: true,
+        pendingChangePanels: ["- gatway"],
+      },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: false,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.replaceConfigFile.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "Config validation failed: agents.defaults.heartbeat.every: Invalid input: expected string, received number",
+        ),
+        {
+          code: "CONFIG_VALIDATION_FAILED",
+          issues: [
+            {
+              path: "agents.defaults.heartbeat.every",
+              message: "Invalid input: expected string, received number",
+            },
+          ],
+        },
+      ),
+    );
+
+    const laterRun = vi.fn(async () => undefined);
+    await runDoctorHealthContributionList(ctx, [
+      requireDoctorContribution("doctor:write-config-migrations"),
+      createDoctorHealthContribution({
+        id: "doctor:test-later",
+        label: "Test later",
+        run: laterRun,
+      }),
+    ]);
+
+    // The refusal is a rendered warning, not a crash. Later repairs consume the
+    // candidate config, so the loop stops before they persist state derived
+    // from a config that never reached disk (same invariant as cron deferral).
+    expect(laterRun).not.toHaveBeenCalled();
+    expect(ctx.configWriteBlockedByValidation).toBe(true);
+    expect(ctx.configResultWriteCommitted).not.toBe(true);
+    expect(ctx.cfgForPersistence).toEqual(cfg);
+    // Never print "Doctor changes" for changes that were not persisted.
+    expect(mocks.note).not.toHaveBeenCalledWith(expect.anything(), "Doctor changes");
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("No config changes were written"),
+      "Doctor warnings",
+    );
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("agents.defaults.heartbeat.every"),
+      "Doctor warnings",
+    );
+
+    // A later write pass must not retry the identical candidate or duplicate the warning.
+    mocks.note.mockClear();
+    mocks.replaceConfigFile.mockClear();
+    await requireDoctorContribution("doctor:write-config").run(ctx);
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
+  it("prints held change panels as Doctor changes only after the write commits", async () => {
+    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: {
+        cfg,
+        shouldWriteConfig: true,
+        pendingChangePanels: ["- gatway"],
+      },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+
+    await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    expect(mocks.note).toHaveBeenCalledWith("- gatway", "Doctor changes");
+    expect(ctx.configResultWriteCommitted).toBe(true);
+    // Panels print exactly once even when the final writer runs again.
+    mocks.note.mockClear();
+    await requireDoctorContribution("doctor:write-config").run(ctx);
+    expect(mocks.note).not.toHaveBeenCalledWith(expect.anything(), "Doctor changes");
   });
 
   it("defers every config write after a cron ownership handoff refusal", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -449,6 +449,11 @@ async function runDoctorHealthContributionList(
         // ownership topology that the config writer deliberately left non-durable.
         return;
       }
+      if (ctx.configWriteBlockedByValidation === true) {
+        // Same invariant for a validation-refused write: the candidate never reached
+        // disk, so later repairs must not persist state derived from it.
+        return;
+      }
     } catch (error) {
       await (contribution.required ? Promise.reject(error as Error) : Promise.resolve());
       const { note } = await loadNoteModule();

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -133,9 +133,14 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
 
   if (ctx.configWriteBlockedByValidation) {
     // Config fixes were computed but refused by write validation; the warning
-    // above already lists the manual work. Exit non-zero so --fix callers see
-    // that the run did not converge.
-    outro("Doctor finished, but config fixes were not applied.");
+    // above already lists the manual work. When an earlier pass committed, only
+    // the later fixes are missing. Exit non-zero so --fix callers see that the
+    // run did not converge.
+    outro(
+      ctx.configResultWriteCommitted === true
+        ? "Doctor finished, but some config fixes were not applied."
+        : "Doctor finished, but config fixes were not applied.",
+    );
     effectiveRuntime.exit(1);
     return;
   }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -131,5 +131,13 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
     }
   }
 
+  if (ctx.configWriteBlockedByValidation) {
+    // Config fixes were computed but refused by write validation; the warning
+    // above already lists the manual work. Exit non-zero so --fix callers see
+    // that the run did not converge.
+    outro("Doctor finished, but config fixes were not applied.");
+    effectiveRuntime.exit(1);
+    return;
+  }
   outro("Doctor complete.");
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` would see "Doctor changes" panels claiming config repairs, then get a raw `Error:` crash and exit 1 — while the config file on disk stayed byte-identical. This happened when the repaired candidate config still failed the atomic writer's validation (e.g. a repairable unknown root key sitting next to an unrepairable schema type error elsewhere in the file). Doctor claimed fixes it never persisted, with no guidance on what to fix by hand.

## Why This Change Was Made

The compute -> print -> validate -> persist ordering was wrong: panels printed at mutation time, but validation only ran inside the atomic writer after every panel was already visible. The fix enforces "print only what persisted" at the owner boundaries: repair-mode change panels are queued in a sink and flushed only after the atomic write commits; `io.write` now throws a typed `CONFIG_VALIDATION_FAILED` error (`createConfigValidationFailedError` in `src/config/io.write-errors.ts`) carrying the full issue list; and `runWriteConfigHealth` renders a refusal as a "Doctor warnings" panel listing the exact offending paths with manual-fix guidance. When the initial write pass already committed and only the later post-repair write is refused, the warning says the earlier fixes were saved and only the remaining changes were not written. The contribution loop stops after refusal — the same invariant as the existing cron-ownership deferral. Preview (non-fix) panels and committed side-effect repair notes (SQLite/filesystem) keep printing immediately, since those reflect reality at print time; the repair sequence returns them separately (`changeNotes` vs. `configChangeNotes`).

## User Impact

`doctor --fix` output is now truthful: change panels appear only for repairs that actually reached disk. When validation refuses the candidate, operators get a clear warnings panel — exactly which write failed, exact paths that need manual attention — instead of a stack-trace-style `Error:` leak with no actionable next step. Exit code stays 1 on refusal, so scripted callers still observe failure.

## Evidence

- New regression test `src/commands/doctor-config-flow.validation-refusal.test.ts` fails on pre-fix code (verified via stash: pre-fix it printed change panels and leaked a raw `Error:` on refusal) and passes post-fix. Commit-then-refusal partial-persistence wording is covered by a dedicated regression test in `src/flows/doctor-health-contributions.test.ts`.
- Head `cf171c9d59b` (rebased on `main` @ `063ce57caf2`): `node scripts/run-vitest.mjs src/commands/doctor-config-flow.test.ts src/commands/doctor-config-flow.validation-refusal.test.ts src/commands/doctor/ src/flows/ src/config/` — 529 + 296 + 3289 + 223 + 560 tests, all green. `pnpm tsgo` and `pnpm check:test-types` clean; `check-changed` full local gate exit 0 (remote backend unavailable on this host, local fallback per policy) including the knip deadcode gate that failed on the first push.
- Production LOC delta: the growth is the deferred-panel sink, the typed refusal owner, and the committed/uncommitted refusal branching — state required to represent the durable write outcome; `src/config/io.write.ts` itself shrank.
- Autoreview clean on both the original change (0.96) and the post-rebase follow-up (0.99), no actionable findings.
