### PR TITLE
fix(qa): stop shutdown from leaving bus poll timers

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -1,5 +1,6 @@
 // Qa Lab tests cover bus server plugin behavior.
 import { Agent, createServer, request } from "node:http";
+import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeQaHttpServer, handleQaBusRequest, startQaBusServer } from "./bus-server.js";
 import { createQaBusState } from "./bus-state.js";
@@ -111,10 +112,15 @@ describe("qa-bus server", () => {
     await Promise.all(stops.splice(0).map((stop) => stop()));
   });
 
-  it("wakes stale-cursor long polls as soon as matching account traffic arrives", async () => {
+  it("wakes matching long polls and settles late polls during shutdown", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });
-    stops.push(bus["stop"]);
+    let stopped = false;
+    stops.push(async () => {
+      if (!stopped) {
+        await bus.stop();
+      }
+    });
 
     const pending = pollQaBus({
       baseUrl: bus.baseUrl,
@@ -137,6 +143,40 @@ describe("qa-bus server", () => {
       cursor: 1,
       kind: "inbound-message",
     });
+
+    const waitForCursorAdvance = state.waitForCursorAdvance.bind(state);
+    let lateWaiterStarted = false;
+    let lateWaiterSettled = false;
+    state.waitForCursorAdvance = async (...args) => {
+      lateWaiterStarted = true;
+      try {
+        return await waitForCursorAdvance(...args);
+      } finally {
+        lateWaiterSettled = true;
+      }
+    };
+    const body = JSON.stringify({ accountId: "late-body", cursor: 0, timeoutMs: 30_000 });
+    const slowPoll = request({
+      host: "127.0.0.1",
+      port: bus.port,
+      path: "/v1/poll",
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) },
+    });
+    slowPoll.on("response", (response) => response.resume());
+    slowPoll.on("error", () => undefined);
+    slowPoll.write(body.slice(0, 1));
+    await sleep(10);
+
+    stopped = true;
+    const startedAt = Date.now();
+    const stopping = bus.stop();
+    setTimeout(() => slowPoll.end(body.slice(1)), 50);
+    await stopping;
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(lateWaiterStarted).toBe(true);
+    expect(lateWaiterSettled).toBe(true);
   });
 
   it("resumes an account after its last acknowledged cursor when the client restarts", async () => {

--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -112,7 +112,7 @@ describe("qa-bus server", () => {
     await Promise.all(stops.splice(0).map((stop) => stop()));
   });
 
-  it("wakes matching long polls and settles late polls during shutdown", async () => {
+  it("wakes matching polls and fences late polls and writes during shutdown", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });
     let stopped = false;
@@ -145,16 +145,22 @@ describe("qa-bus server", () => {
     });
 
     const waitForCursorAdvance = state.waitForCursorAdvance.bind(state);
-    let lateWaiterStarted = false;
-    let lateWaiterSettled = false;
+    let pollWaitersStarted = 0;
+    let pollWaitersSettled = 0;
     state.waitForCursorAdvance = async (...args) => {
-      lateWaiterStarted = true;
+      pollWaitersStarted += 1;
       try {
         return await waitForCursorAdvance(...args);
       } finally {
-        lateWaiterSettled = true;
+        pollWaitersSettled += 1;
       }
     };
+    const activePoll = fetch(`${bus.baseUrl}/v1/poll`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ accountId: "active", cursor: 1, timeoutMs: 30_000 }),
+    }).catch(() => undefined);
+    await vi.waitFor(() => expect(pollWaitersStarted).toBe(1));
     const body = JSON.stringify({ accountId: "late-body", cursor: 0, timeoutMs: 30_000 });
     const slowPoll = request({
       host: "127.0.0.1",
@@ -166,17 +172,40 @@ describe("qa-bus server", () => {
     slowPoll.on("response", (response) => response.resume());
     slowPoll.on("error", () => undefined);
     slowPoll.write(body.slice(0, 1));
+    const inboundBody = JSON.stringify({
+      conversation: { id: "late-room", kind: "direct" },
+      senderId: "late-sender",
+      text: "must not survive shutdown",
+    });
+    const slowInbound = request({
+      host: "127.0.0.1",
+      port: bus.port,
+      path: "/v1/inbound/message",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(inboundBody),
+      },
+    });
+    slowInbound.on("response", (response) => response.resume());
+    slowInbound.on("error", () => undefined);
+    slowInbound.write(inboundBody.slice(0, 1));
     await sleep(10);
 
     stopped = true;
     const startedAt = Date.now();
     const stopping = bus.stop();
-    setTimeout(() => slowPoll.end(body.slice(1)), 50);
+    setTimeout(() => {
+      slowPoll.end(body.slice(1));
+      slowInbound.end(inboundBody.slice(1));
+    }, 50);
     await stopping;
+    await activePoll;
 
     expect(Date.now() - startedAt).toBeLessThan(1_000);
-    expect(lateWaiterStarted).toBe(true);
-    expect(lateWaiterSettled).toBe(true);
+    expect(pollWaitersStarted).toBe(1);
+    expect(pollWaitersSettled).toBe(1);
+    expect(state.getSnapshot()).toMatchObject({ events: [], messages: [] });
   });
 
   it("resumes an account after its last acknowledged cursor when the client restarts", async () => {

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -287,11 +287,16 @@ function normalizeQaBusSearchInput(input: Record<string, unknown>): QaBusSearchM
   } as QaBusSearchMessagesInput;
 }
 
-export async function closeQaHttpServer(server: Server): Promise<void> {
+export async function closeQaHttpServer(
+  server: Server,
+  onCloseStarted?: () => void,
+): Promise<void> {
   let forceCloseTimer: NodeJS.Timeout | undefined;
   try {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
+      // Fence new requests before canceling owner state so no waiter can register after cleanup.
+      onCloseStarted?.();
       server.closeIdleConnections?.();
       forceCloseTimer = setTimeout(() => {
         server.closeAllConnections?.();
@@ -471,7 +476,7 @@ export async function startQaBusServer(params: { state: QaBusState; port?: numbe
     port: address.port,
     baseUrl: `http://127.0.0.1:${address.port}`,
     async stop() {
-      await closeQaHttpServer(server);
+      await closeQaHttpServer(server, () => params.state.reset());
     },
   };
 }

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -287,16 +287,12 @@ function normalizeQaBusSearchInput(input: Record<string, unknown>): QaBusSearchM
   } as QaBusSearchMessagesInput;
 }
 
-export async function closeQaHttpServer(
-  server: Server,
-  onCloseStarted?: () => void,
-): Promise<void> {
+export async function closeQaHttpServer(server: Server, state?: QaBusState): Promise<void> {
   let forceCloseTimer: NodeJS.Timeout | undefined;
   try {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
-      // Fence new requests before canceling owner state so no waiter can register after cleanup.
-      onCloseStarted?.();
+      state?.reset(true); // Fence first so late request bodies cannot add waiter timers.
       server.closeIdleConnections?.();
       forceCloseTimer = setTimeout(() => {
         server.closeAllConnections?.();
@@ -476,7 +472,7 @@ export async function startQaBusServer(params: { state: QaBusState; port?: numbe
     port: address.port,
     baseUrl: `http://127.0.0.1:${address.port}`,
     async stop() {
-      await closeQaHttpServer(server, () => params.state.reset());
+      await closeQaHttpServer(server, params.state);
     },
   };
 }

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -192,14 +192,14 @@ export function createQaBusState() {
   };
 
   return {
-    reset() {
+    reset(terminal = false) {
       conversations.clear();
       threads.clear();
       messages.clear();
       events.length = 0;
       // Keep the cursor monotonic across resets so long-poll clients do not
-      // miss fresh events and retained restart acknowledgements remain valid.
-      waiters.reset();
+      // miss events; terminal reset also fences late waiter timers.
+      waiters.reset(undefined, terminal);
     },
     getSnapshot() {
       return buildQaBusSnapshot({

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -10,7 +10,7 @@ import {
   requireQaBusMessageForAccount,
   searchQaBusMessages,
 } from "./bus-queries.js";
-import { createQaBusWaiterStore } from "./bus-waiters.js";
+import { createQaBusWaiterStore, throwQaBusClosed } from "./bus-waiters.js";
 import { sanitizeQaBusToolCalls } from "./qa-bus-protocol.js";
 import type {
   QaBusAttachment,
@@ -86,6 +86,7 @@ export function createQaBusState() {
   const events: QaBusEvent[] = [];
   const acknowledgedPollCursors = new Map<string, number>();
   let cursor = 0;
+  let assertWritable = () => {};
   const waiters = createQaBusWaiterStore(() =>
     buildQaBusSnapshot({
       cursor,
@@ -125,6 +126,7 @@ export function createQaBusState() {
   const requireActiveMessageForAccount = (
     input: Pick<QaBusReadMessageInput, "accountId" | "messageId">,
   ): QaBusMessage => {
+    assertWritable();
     const message = requireQaBusMessageForAccount({ messages, input });
     if (message.deleted) {
       throw new Error(`qa-bus message was deleted: ${input.messageId}`);
@@ -149,6 +151,7 @@ export function createQaBusState() {
     nativeCommand?: QaBusInboundMessageInput["nativeCommand"];
     toolCalls?: QaBusToolCall[];
   }): QaBusMessage => {
+    assertWritable();
     const thread = params.threadId ? threads.get(params.threadId) : undefined;
     if (
       thread &&
@@ -193,6 +196,7 @@ export function createQaBusState() {
 
   return {
     reset(terminal = false) {
+      assertWritable = terminal ? throwQaBusClosed : assertWritable;
       conversations.clear();
       threads.clear();
       messages.clear();
@@ -263,6 +267,7 @@ export function createQaBusState() {
       return cloneMessage(message);
     },
     createThread(input: QaBusCreateThreadInput) {
+      assertWritable();
       const accountId = normalizeAccountId(input.accountId);
       const thread: QaBusThread = {
         id: `thread-${randomUUID()}`,
@@ -340,6 +345,7 @@ export function createQaBusState() {
       return searchQaBusMessages({ messages, input });
     },
     resolvePollCursor(input: QaBusPollInput = {}) {
+      assertWritable();
       const accountId = normalizeAccountId(input.accountId);
       const requestedCursor = input.cursor ?? 0;
       const acknowledgedCursor = acknowledgedPollCursors.get(accountId) ?? 0;

--- a/extensions/qa-lab/src/bus-waiters.ts
+++ b/extensions/qa-lab/src/bus-waiters.ts
@@ -10,6 +10,10 @@ import type {
 
 export const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
 
+function throwQaBusClosed(): never {
+  throw new Error("qa-bus closed");
+}
+
 export type QaBusWaitMatch = QaBusEvent | QaBusMessage | QaBusThread;
 
 type Waiter = {
@@ -51,9 +55,11 @@ function createQaBusMatcher(
 export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
   const waiters = new Set<Waiter>();
   const cursorWaiters = new Set<CursorWaiter>();
+  let readSnapshot = getSnapshot;
 
   return {
-    reset(reason = "qa-bus reset") {
+    reset(reason = "qa-bus reset", terminal = false) {
+      readSnapshot = terminal ? throwQaBusClosed : readSnapshot;
       for (const waiter of waiters) {
         clearTimeout(waiter.timer);
         waiter.reject(new Error(reason));
@@ -69,7 +75,7 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
       if (waiters.size === 0 && cursorWaiters.size === 0) {
         return;
       }
-      const snapshot = getSnapshot();
+      const snapshot = readSnapshot();
       for (const waiter of Array.from(waiters)) {
         const match = waiter.matcher(snapshot);
         if (!match) {
@@ -93,7 +99,7 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
     },
     async waitFor(input: QaBusWaitForInput) {
       const matcher = createQaBusMatcher(input);
-      const immediate = matcher(getSnapshot());
+      const immediate = matcher(readSnapshot());
       if (immediate) {
         return immediate;
       }
@@ -116,7 +122,7 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
       timeoutMs: number,
       shouldResolve?: (snapshot: QaBusStateSnapshot) => boolean,
     ) {
-      const snapshot = getSnapshot();
+      const snapshot = readSnapshot();
       if (snapshot.cursor > afterCursor && (!shouldResolve || shouldResolve(snapshot))) {
         return;
       }

--- a/extensions/qa-lab/src/bus-waiters.ts
+++ b/extensions/qa-lab/src/bus-waiters.ts
@@ -10,7 +10,7 @@ import type {
 
 export const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
 
-function throwQaBusClosed(): never {
+export function throwQaBusClosed(): never {
   throw new Error("qa-bus closed");
 }
 

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -1,6 +1,6 @@
 // QA Lab tests cover lab server plugin behavior.
 import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -942,6 +942,21 @@ describe("qa-lab server", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ accountId: "cleanup", cursor: 0, timeoutMs: 30_000 }),
     }).catch(() => undefined);
+    const inboundBody = JSON.stringify({
+      conversation: { id: "late-room", kind: "direct" },
+      senderId: "late-sender",
+      text: "must not survive shutdown",
+    });
+    const slowInbound = httpRequest(new URL("/api/inbound/message", lab.listenUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(inboundBody),
+      },
+    });
+    slowInbound.on("response", (response) => response.resume());
+    slowInbound.on("error", () => undefined);
+    slowInbound.write(inboundBody.slice(0, 1));
     await vi.waitFor(() => expect(pollWaiterStarted).toBe(true));
     const stopping = lab.stop();
     await gatewayStopping;
@@ -950,10 +965,12 @@ describe("qa-lab server", () => {
       expect(pollWaiterSettled).toBe(false);
     } finally {
       finishGatewayStop();
+      setTimeout(() => slowInbound.end(inboundBody.slice(1)), 50);
       await stopping;
     }
     await poll;
     expect(pollWaiterSettled).toBe(true);
+    expect(lab.state.getSnapshot()).toMatchObject({ events: [], messages: [] });
     await expect(fetch(`${lab.baseUrl}/healthz`)).rejects.toThrow();
   });
 

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -926,14 +926,34 @@ describe("qa-lab server", () => {
     );
 
     const lab = await startQaLabServer({ host: "127.0.0.1", port: 0 });
+    const waitForCursorAdvance = lab.state.waitForCursorAdvance.bind(lab.state);
+    let pollWaiterStarted = false;
+    let pollWaiterSettled = false;
+    lab.state.waitForCursorAdvance = async (...args) => {
+      pollWaiterStarted = true;
+      try {
+        return await waitForCursorAdvance(...args);
+      } finally {
+        pollWaiterSettled = true;
+      }
+    };
+    const poll = fetch(`${lab.listenUrl}/v1/poll`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ accountId: "cleanup", cursor: 0, timeoutMs: 30_000 }),
+    }).catch(() => undefined);
+    await vi.waitFor(() => expect(pollWaiterStarted).toBe(true));
     const stopping = lab.stop();
     await gatewayStopping;
     try {
       await expect(fetch(`${lab.baseUrl}/healthz`)).resolves.toMatchObject({ status: 200 });
+      expect(pollWaiterSettled).toBe(false);
     } finally {
       finishGatewayStop();
       await stopping;
     }
+    await poll;
+    expect(pollWaiterSettled).toBe(true);
     await expect(fetch(`${lab.baseUrl}/healthz`)).rejects.toThrow();
   });
 

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -957,7 +957,9 @@ export async function startQaLabServer(
       cleanupError = toQaError(error);
     }
     const results = await Promise.allSettled([
-      Promise.resolve().then(() => (serverListening ? closeQaHttpServer(server) : undefined)),
+      Promise.resolve().then(() =>
+        serverListening ? closeQaHttpServer(server, () => state.reset()) : undefined,
+      ),
       Promise.resolve().then(releaseCaptureStore),
     ]);
     const failed = results.find((result) => result.status === "rejected");

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -957,9 +957,7 @@ export async function startQaLabServer(
       cleanupError = toQaError(error);
     }
     const results = await Promise.allSettled([
-      Promise.resolve().then(() =>
-        serverListening ? closeQaHttpServer(server, () => state.reset()) : undefined,
-      ),
+      serverListening ? closeQaHttpServer(server, state) : undefined,
       Promise.resolve().then(releaseCaptureStore),
     ]);
     const failed = results.find((result) => result.status === "rejected");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source-checkout QA runs could leave pending QA bus long-poll waiters and timers alive when the standalone bus or combined QA Lab server stopped. That could delay process exit and leave lifecycle state beyond the scenario that owned it.

## Why This Change Was Made

The combined lab still completes embedded Gateway shutdown before touching the shared HTTP bus. The HTTP server now fences new requests first, then terminally resets the bus waiter owner so active polls settle and already-admitted late request bodies cannot register a new timer. The standalone bus uses the same terminal shutdown path; ordinary scenario resets remain reusable.

Production code is net +7 lines. No changelog entry is needed because QA Lab and QA Channel are private, source-checkout-only surfaces.

## User Impact

QA operators get deterministic shutdown, restart, and scenario isolation without lingering poll timers, handler work, state, or ports. Standard builds and published packages remain unchanged and continue to omit QA Lab and QA Channel.

## Evidence

- Pre-fix negative controls failed for both combined-lab shutdown and a standalone delayed-body poll: the waiter remained unsettled after stop (standalone stop completed in about 307 ms).
- The fixed standalone probe completed in about 252 ms with the late waiter settled; the combined Gateway-before-bus ordering regression also passed.
- Focused lifecycle and isolation gate: 8 files, 118 tests passed. An additional 7 parity-cleanup tests also passed.
- Blacksmith Testbox `tbx_01m04p2nzfqdf51x2v0h1t8sdg` / run https://github.com/openclaw/openclaw/actions/runs/31932900181: private-QA build passed; source-checkout self-check passed 1 scenario, 3/3 steps, 8 events, zero failures; standard build omitted QA Lab/QA Channel; scoped `check:changed` passed assertion-safety, types, lint, formatting, plugin boundaries, dead exports, database-first guards, and import cycles.
- Fresh whole-branch autoreview reported no accepted or actionable findings.
- Duplicate search found no competing QA Lab bus shutdown issue or pull request.
