### PR TITLE
fix(line): replies are lost when a push hits a transient failure

### DIFF
--- a/extensions/line/src/send-retry.test.ts
+++ b/extensions/line/src/send-retry.test.ts
@@ -1,0 +1,202 @@
+// Line tests cover push retry and retry-key deduplication behavior.
+import { HTTPFetchError } from "@line/bot-sdk";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  requireRuntimeConfigMock,
+  resolveLineAccountMock,
+  resolveLineChannelAccessTokenMock,
+  recordChannelActivityMock,
+  logVerboseMock,
+} = vi.hoisted(() => ({
+  requireRuntimeConfigMock: vi.fn((cfg: unknown) => cfg ?? {}),
+  resolveLineAccountMock: vi.fn(() => ({ accountId: "default" })),
+  resolveLineChannelAccessTokenMock: vi.fn(() => "test-token-placeholder"),
+  recordChannelActivityMock: vi.fn(),
+  logVerboseMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-config-runtime", () => ({
+  requireRuntimeConfig: requireRuntimeConfigMock,
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveLineAccount: resolveLineAccountMock,
+}));
+
+vi.mock("./channel-access-token.js", () => ({
+  resolveLineChannelAccessToken: resolveLineChannelAccessTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", () => ({
+  recordChannelActivity: recordChannelActivityMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return { ...actual, logVerbose: logVerboseMock };
+});
+
+let sendModule: typeof import("./send.js");
+
+const LINE_TEST_CFG = {
+  channels: { line: { accounts: { default: {} } } },
+} satisfies OpenClawConfig;
+const LINE_TARGET = "line:user:U0123456789abcdef0123456789abcdef";
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function transportFailure(code: string): TypeError {
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error(`socket ${code}`), { code }),
+  });
+}
+
+function retryKeysOf(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>): (string | null)[] {
+  return fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("X-Line-Retry-Key"));
+}
+
+describe("LINE push retries", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeAll(async () => {
+    sendModule = await import("./send.js");
+  });
+
+  afterAll(() => {
+    vi.doUnmock("openclaw/plugin-sdk/plugin-config-runtime");
+    vi.doUnmock("./accounts.js");
+    vi.doUnmock("./channel-access-token.js");
+    vi.doUnmock("openclaw/plugin-sdk/channel-activity-runtime");
+    vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    requireRuntimeConfigMock.mockImplementation((cfg: unknown) => cfg ?? LINE_TEST_CFG);
+    resolveLineAccountMock.mockReturnValue({ accountId: "default" });
+    resolveLineChannelAccessTokenMock.mockReturnValue("test-token-placeholder");
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  async function resolveRetryRun<T>(run: Promise<T>): Promise<T> {
+    run.catch(() => {});
+    await vi.runAllTimersAsync();
+    return await run;
+  }
+
+  function pushText(text = "hello") {
+    return sendModule.pushMessagesLine(LINE_TARGET, [{ type: "text", text }], {
+      cfg: LINE_TEST_CFG,
+    });
+  }
+
+  it("retries a LINE server error under one retry key and delivers once", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ message: "Internal server error" }, 500))
+      .mockResolvedValueOnce(jsonResponse({ sentMessages: [{ id: "delivered-1" }] }));
+
+    const result = await resolveRetryRun(pushText());
+
+    expect(result.messageId).toBe("delivered-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryKeys = retryKeysOf(fetchMock);
+    expect(retryKeys[0]).toMatch(UUID_PATTERN);
+    expect(retryKeys[1]).toBe(retryKeys[0]);
+    expect(recordChannelActivityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys each push separately so an unrelated send cannot be deduplicated away", async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({ sentMessages: [{ id: "delivered-1" }] }),
+    );
+
+    await resolveRetryRun(pushText("first"));
+    await resolveRetryRun(pushText("second"));
+
+    const [firstKey, secondKey] = retryKeysOf(fetchMock);
+    expect(firstKey).toMatch(UUID_PATTERN);
+    expect(secondKey).toMatch(UUID_PATTERN);
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  it("retries a transport failure and keeps the accepted delivery when LINE reports a conflict", async () => {
+    fetchMock.mockRejectedValueOnce(transportFailure("ETIMEDOUT")).mockResolvedValueOnce(
+      jsonResponse(
+        {
+          message: "The retry key is already accepted",
+          sentMessages: [{ id: "accepted-earlier" }],
+        },
+        409,
+      ),
+    );
+
+    const result = await resolveRetryRun(pushText());
+
+    // The first attempt landed even though its outcome never reached us, so the
+    // accepted request's message id is the delivery — not a second send.
+    expect(result.messageId).toBe("accepted-earlier");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new Set(retryKeysOf(fetchMock)).size).toBe(1);
+  });
+
+  it("gives up after the configured attempts and surfaces the LINE failure", async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({ message: "Internal server error" }, 500),
+    );
+
+    await expect(resolveRetryRun(pushText())).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(new Set(retryKeysOf(fetchMock)).size).toBe(1);
+  });
+
+  it.each([
+    { label: "quota rejection", status: 429, message: "You have reached your monthly limit." },
+    { label: "request rejection", status: 400, message: "The request body has 1 error(s)" },
+  ])("does not retry a LINE $label", async ({ status, message }) => {
+    fetchMock.mockResolvedValue(jsonResponse({ message }, status));
+
+    await expect(resolveRetryRun(pushText())).rejects.toBeInstanceOf(HTTPFetchError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry once LINE accepted a request with an unreadable receipt", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ sentMessages: [{}] }));
+
+    await expect(resolveRetryRun(pushText())).rejects.toSatisfy(isChannelPartialDeliveryError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never retries a reply, which LINE cannot deduplicate", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ message: "Internal server error" }, 500));
+
+    await expect(
+      resolveRetryRun(
+        sendModule.replyMessageLine("reply-token", [{ type: "text", text: "hello" }], {
+          cfg: LINE_TEST_CFG,
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(retryKeysOf(fetchMock)).toEqual([null]);
+  });
+});

--- a/extensions/line/src/send-retry.ts
+++ b/extensions/line/src/send-retry.ts
@@ -1,0 +1,37 @@
+// Line plugin module implements push retry policy behavior.
+import { HTTPFetchError } from "@line/bot-sdk";
+import { collectErrorGraphCandidates, extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
+import {
+  classifyTransientNetworkErrorCode,
+  createChannelApiRetryRunner,
+} from "openclaw/plugin-sdk/retry-runtime";
+
+function isRetryableLinePushError(error: unknown): boolean {
+  const candidates = collectErrorGraphCandidates(error, (candidate) => [
+    candidate.cause,
+    candidate.error,
+  ]);
+  const httpError = candidates.find(
+    (candidate): candidate is HTTPFetchError => candidate instanceof HTTPFetchError,
+  );
+  if (httpError) {
+    // LINE documents server errors and transport failures as the retriable
+    // outcomes; every 4xx (429 included) answers "retries don't change the result".
+    return httpError.status >= 500;
+  }
+  // A transport failure never reached a LINE response, so the retry key decides
+  // whether the earlier attempt already landed.
+  return candidates.some(
+    (candidate) => classifyTransientNetworkErrorCode(extractErrorCode(candidate)) !== undefined,
+  );
+}
+
+/**
+ * Pushes are non-idempotent without a retry key, so the generic message-matching
+ * fallback stays off and only the classification above may replay a request.
+ */
+export const runLinePushWithRetries = createChannelApiRetryRunner({
+  shouldRetry: isRetryableLinePushError,
+  strictShouldRetry: true,
+  verbose: true,
+});

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -1,4 +1,5 @@
 // Line plugin module implements send behavior.
+import { randomUUID } from "node:crypto";
 import { HTTPFetchError, messagingApi } from "@line/bot-sdk";
 import lineBotSdkPackage from "@line/bot-sdk/package.json" with { type: "json" };
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
@@ -14,6 +15,7 @@ import { messageAction, normalizeLineMessageActions } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import { validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
+import { runLinePushWithRetries } from "./send-retry.js";
 import type { LineChannelData, LineOutboundMediaKind, LineSendResult } from "./types.js";
 
 type Message = messagingApi.Message;
@@ -172,6 +174,7 @@ async function sendLineProviderMessages(
   operation: "push" | "reply",
   token: string,
   request: messagingApi.PushMessageRequest | messagingApi.ReplyMessageRequest,
+  retryKey?: string,
 ): Promise<messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse> {
   const response = await fetchWithRuntimeDispatcherOrMockedGlobal(
     `https://api.line.me/v2/bot/message/${operation}`,
@@ -181,12 +184,18 @@ async function sendLineProviderMessages(
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
         "User-Agent": `@line/bot-sdk/${lineBotSdkPackage.version}`,
+        ...(retryKey ? { "X-Line-Retry-Key": retryKey } : {}),
       },
       body: JSON.stringify(request),
     },
   );
 
-  if (!response.ok) {
+  // LINE answers a retried key with 409 and the accepted request's sent messages
+  // instead of delivering the batch a second time, so that conflict is the
+  // earlier attempt's success rather than a failure of this one.
+  const acceptedRetryConflict = retryKey !== undefined && response.status === 409;
+
+  if (!response.ok && !acceptedRetryConflict) {
     throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {
       status: response.status,
       statusText: response.statusText,
@@ -325,17 +334,25 @@ async function pushLineMessages(
 
   const { account, token, chatId } = createLinePushContext(to, opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
-  const pushRequest = sendLineProviderMessages("push", token, {
-    to: chatId,
-    messages: normalizedMessages,
-  });
+  // One retry key per logical push: every attempt reuses it so LINE deduplicates
+  // an attempt that was accepted before its outcome reached us.
+  const retryKey = randomUUID();
 
-  const response = behavior.errorContext
-    ? await pushRequest.catch((err: unknown) => {
-        logLineHttpError(err, behavior.errorContext!);
-        throw err;
-      })
-    : await pushRequest;
+  const response = await runLinePushWithRetries(async () => {
+    try {
+      return await sendLineProviderMessages(
+        "push",
+        token,
+        { to: chatId, messages: normalizedMessages },
+        retryKey,
+      );
+    } catch (err) {
+      if (behavior.errorContext) {
+        logLineHttpError(err, behavior.errorContext);
+      }
+      throw err;
+    }
+  }, "line:push");
   const { messageId, messageIds } = resolveLineProviderMessageIds(response, "push");
   const result: LineSendResult = {
     messageId,


### PR DESCRIPTION
Closes #86012
Related: #94680 (alternative fix for the same issue)

## What Problem This Solves

A LINE reply is lost whenever the single push attempt behind it fails for a transient reason. The user asks something, the agent answers, the answer never appears in LINE, and nothing surfaces the loss — the send path made exactly one attempt and gave up.

The reason it was never simply retried is that a LINE push is not idempotent. When a push fails with a timeout or a dropped connection, the request may still have been accepted; a naive retry then delivers the same reply twice. So the channel was left with a choice between losing replies and duplicating them.

Reported in #86012 (`impact:message-loss`).

## Why This Change Was Made

When a push fails in a way that might have been accepted, the user should still see that reply exactly once — neither dropped nor duplicated.

The platform provides the primitive that makes this decidable. LINE's [retry documentation](https://developers.line.biz/en/docs/messaging-api/retrying-api-request/) specifies `X-Line-Retry-Key`: "If you specify the retry key, the request is executed only once, no matter how many times you make the request. Once the request is accepted, subsequent retried requests are blocked and you'll get the status code `409`." For push messages the 409 body carries "the same `sentMessages.id` and `sentMessages.quoteToken` as when the API request was accepted."

So every push now carries one retry key that is reused across all attempts of that push. A retried attempt is either delivered for the first time, or answered with 409 — which resolves to the *original* delivery's message id rather than a second message. Retrying stops being a trade against duplication.

Which failures are retried follows LINE's documented table exactly, rather than a heuristic:

| Status | LINE's guidance | Behavior |
| --- | --- | --- |
| 500 | ✅ "Retry. Your next request may be successful." | retried |
| Timeout / transport failure | ✅ "Retry. Your next request may be successful." | retried |
| 2xx | ❌ "Don't retry. Additional retries aren't accepted." | not retried |
| 409 | ❌ "Don't retry. The retried request is already accepted." | resolved as the earlier delivery |
| 4xx (429 included) | ❌ "Don't retry. Retries don't change the result." | not retried |

Two consequences of that table are worth calling out, because both are load-bearing:

- **429 is not retried.** It is a 4xx, and LINE additionally warns that "a retry with a retry key is counted as one API request, so frequent retries may cause the API rate limit to be reached" — retrying a rate-limit rejection makes the rate-limit worse.
- **Replies are left single-attempt.** LINE lists exactly four endpoints that accept a retry key — push, multicast, narrowcast, broadcast — and states that sending the header to any other endpoint means "your request is rejected and you'll get the status code `400`." A reply therefore cannot be made idempotent, so it is not retried. The remaining reply-token exposure is tracked separately in #102279.

The retry envelope itself is the shared `createChannelApiRetryRunner` from the plugin SDK, in `strictShouldRetry` mode. That mode exists for exactly this case — its contract documents it as being for "non-idempotent operations (e.g. sendMessage) where the regex fallback would cause duplicate message delivery" — and it keeps the generic message-matching fallback from widening the retry set behind the classification above. Transport codes are classified with the SDK's `classifyTransientNetworkErrorCode` rather than a local list, which covers the timeout family LINE's table marks retryable (`ETIMEDOUT`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, `UND_ERR_SOCKET`) alongside the pre-connect failures.

Every push the channel makes already funnels through one `pushLineMessages` choke point, so the key and the classification apply uniformly — text, media, flex, template, location, quick replies, and batched sends. The only send that bypasses it is the reply-token branch of `sendMessageLine`, which is the branch LINE does not accept a retry key for.

#94680 fixes the same issue with the same primitive. Two differences are worth a maintainer's attention rather than a coin flip: it retries `429` on the reading that a monthly-limit rejection can be transient, where LINE's table classifies `429` as a `4xx` that must not be retried and separately warns that retried requests count against the rate limit; and it carries a startup quota probe, which this change leaves out so the diff stays confined to the delivery defect.

## User Impact

- A LINE reply that previously vanished on a transient network or 5xx failure now arrives.
- A push whose acceptance was never observed is not delivered a second time; the retry resolves to the message the user already received.
- Rate-limit and malformed-request rejections fail as fast as before — no added latency, no added quota consumption.
- Replies and reply-token behavior are unchanged.

## Evidence

### Live LINE API, before the change

Real pushes against a disposable LINE channel, with failures injected at the transport boundary. Message ids are real; quote tokens truncated.

```
  attempt 1
    -> injected transport failure (request never reaches LINE)
  (no further attempt; the reply is lost)

  attempt 1
    -> real LINE call: status=200 retryKey=(none)
       body={"sentMessages":[{"id":"627437346601566566","quoteToken":"7Z-_1TCkp6s5FjtiuM0RoOWw…"}]}
       x-line-accepted-request-id=null
    -> dropping the accepted response (simulated read timeout)
  (no further attempt; delivery recorded as failed although the user received it)
```

### Live LINE API, after the change

```
SCENARIO B — first attempt never reaches LINE
  attempt 1
    -> injected transport failure (request never reaches LINE)
  attempt 2
    -> real LINE call: status=200 retryKey=032cbe0e-1920-4f0c-9702-b55740df726b
       body={"sentMessages":[{"id":"627441456851714276","quoteToken":"Fd29cHIEhDhnLyKlOm7JTADk…"}]}
  RESULT messageId=627441456851714276 attempts=2

SCENARIO A — first attempt is accepted, its response is lost
  attempt 1
    -> real LINE call: status=200 retryKey=65c11b19-2386-4f7f-8511-62956b83baef
       body={"sentMessages":[{"id":"627441457120149596","quoteToken":"546peBCuoz2_HSDar93-jBjz…"}]}
    -> dropping the accepted response (simulated read timeout)
  attempt 2
    -> real LINE call: status=409 retryKey=65c11b19-2386-4f7f-8511-62956b83baef
       body={"message":"The retry key is already accepted","sentMessages":[{"id":"627441457120149596",…}]}
       x-line-accepted-request-id=0e4433a0-c3ca-41eb-b482-ccba23c44c3b
  RESULT messageId=627441457120149596 attempts=2
```

Scenario B recovers a reply that is lost on `main`. Scenario A is the duplication guard: the second attempt returns 409 with the *first* attempt's message id `627441457120149596`, so the recipient's device shows one message and the delivery resolves to it. The `x-line-accepted-request-id` header is present only on the 409, exactly as documented.

### Regression proof

`extensions/line/src/send-retry.test.ts` covers the matrix above. Reverting only `send.ts` to its pre-change state:

```
 ❯ extensions/line/src/send-retry.test.ts (8 tests | 4 failed)
     × retries a LINE server error under one retry key and delivers once
     × keys each push separately so an unrelated send cannot be deduplicated away
     × retries a transport failure and keeps the accepted delivery when LINE reports a conflict
     × gives up after the configured attempts and surfaces the LINE failure
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
```

With the change applied:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

### Verification

```
$ pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts
 Test Files  33 passed | 1 failed (34)
      Tests  518 passed | 17 failed | 1 skipped (536)
```

The 17 failures are `bot-message-context.test.ts` only, and reproduce identically on unmodified `origin/main` on this machine (`EBUSY: resource busy or locked, unlink …\openclaw-agent.codex.sqlite`, a Windows file-locking artifact unrelated to this change).

```
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit          # source types
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit  # test types
$ pnpm lint:extensions
$ pnpm exec oxfmt --check extensions/line/src/send.ts extensions/line/src/send-retry.ts extensions/line/src/send-retry.test.ts
All matched files use the correct format.
```

No errors in `extensions/line` from any lane. The residual errors in all three lanes are confined to `extensions/cua-computer` and come from a local `@trycua/cua-driver` version drift; they reproduce unchanged on `origin/main`.
