### PR TITLE
feat: attach typed redacted reasons to prepared route materialization

### DIFF
--- a/src/agents/runtime-plan/credential-scoped-model.test.ts
+++ b/src/agents/runtime-plan/credential-scoped-model.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPreparedRuntimeModelMaterializer } from "./credential-scoped-model.js";
+import { readPreparedRuntimeModelMaterializationReason } from "./materialize-model.js";
+import type { AgentRuntimeAuthPlan } from "./types.js";
+
+const plan: AgentRuntimeAuthPlan = {
+  providerForAuth: "openai",
+  authProfileProviderForAuth: "openai",
+  forwardedAuthProfileId: "openai:subscription",
+  selectedAuthMode: "token",
+  modelRoute: {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    api: "openai-chatgpt-responses",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    authRequirement: "subscription",
+    requestTransportOverrides: "none",
+  },
+};
+
+const matchingModel = {
+  provider: "openai",
+  id: "gpt-5.5",
+  api: "openai-chatgpt-responses",
+  baseUrl: "https://chatgpt.com/backend-api/codex",
+};
+
+describe("createPreparedRuntimeModelMaterializer", () => {
+  it("caches a typed rejection for the same prepared plan", async () => {
+    const resolveModel = vi.fn(async () => ({
+      error:
+        "Unable to refresh SecretRef token=sk-secret-token for https://chatgpt.com/backend-api/codex profile openai:subscription",
+    }));
+    const { materialize } = createPreparedRuntimeModelMaterializer({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      getModel: () => matchingModel,
+      nativeModelOwned: false,
+      providerUsesProfileScopedModelMetadata: false,
+      resolveModel,
+    });
+
+    const first = materialize(plan);
+    const second = materialize(plan);
+    expect(second).toBe(first);
+    await expect(first).rejects.toThrow(/SecretRef token=sk-secret-token/u);
+    await expect(second).rejects.toSatisfy((error) => {
+      const reason = readPreparedRuntimeModelMaterializationReason(error);
+      expect(reason).toMatchObject({
+        code: "resolved-model-missing",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        authRequirement: "subscription",
+      });
+      expect(JSON.stringify(reason)).not.toMatch(
+        /https?:\/\/|openai:subscription|sk-secret-token/u,
+      );
+      return true;
+    });
+    expect(resolveModel).toHaveBeenCalledOnce();
+  });
+
+  it("does not let a cached failure reorder a later distinct plan", async () => {
+    const otherPlan: AgentRuntimeAuthPlan = {
+      ...plan,
+      forwardedAuthProfileId: "openai:backup",
+      modelRoute: {
+        ...plan.modelRoute!,
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        authRequirement: "api-key",
+      },
+    };
+    const resolveModel = vi.fn(async (request: { authProfileId?: string }) => {
+      if (request.authProfileId === "openai:subscription") {
+        return { error: "Unable to refresh SecretRef token=sk-secret-token" };
+      }
+      return {
+        model: {
+          provider: "openai",
+          id: "gpt-5.5",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+        },
+      };
+    });
+    const { materialize } = createPreparedRuntimeModelMaterializer({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      getModel: () => matchingModel,
+      nativeModelOwned: false,
+      providerUsesProfileScopedModelMetadata: false,
+      resolveModel,
+    });
+
+    await expect(materialize(plan)).rejects.toSatisfy((error) => {
+      expect(readPreparedRuntimeModelMaterializationReason(error)?.code).toBe(
+        "resolved-model-missing",
+      );
+      return true;
+    });
+    await expect(materialize(otherPlan)).resolves.toMatchObject({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+    });
+    expect(resolveModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves native-owned models on the caller tuple", async () => {
+    const resolveModel = vi.fn();
+    const { materialize } = createPreparedRuntimeModelMaterializer({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      getModel: () => matchingModel,
+      nativeModelOwned: true,
+      providerUsesProfileScopedModelMetadata: false,
+      resolveModel,
+    });
+
+    await expect(materialize(plan)).resolves.toBe(matchingModel);
+    expect(resolveModel).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/runtime-plan/credential-scoped-model.ts
+++ b/src/agents/runtime-plan/credential-scoped-model.ts
@@ -206,6 +206,7 @@ export function createPreparedRuntimeModelMaterializer<Model extends RuntimeRout
     }
     // Prepared plans are immutable within one run. Carry their exact model
     // tuple into auth initialization instead of repeating provider discovery.
+    // A rejected promise keeps the typed materialization reason for fallback.
     const materialized = materializeUncached(plan);
     materializedRouteModels.set(plan, materialized);
     return materialized;

--- a/src/agents/runtime-plan/materialize-model.test.ts
+++ b/src/agents/runtime-plan/materialize-model.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { materializePreparedRuntimeModel } from "./materialize-model.js";
+import {
+  materializePreparedRuntimeModel,
+  PREPARED_RUNTIME_MODEL_MATERIALIZATION_REASON_CODES,
+  readPreparedRuntimeModelMaterializationReason,
+  type PreparedRuntimeModelMaterializationReason,
+} from "./materialize-model.js";
 import type { AgentRuntimeAuthPlan } from "./types.js";
 
 const plan: AgentRuntimeAuthPlan = {
@@ -310,5 +315,282 @@ describe("materializePreparedRuntimeModel", () => {
         })),
       }),
     ).rejects.toThrow(/prepared subscription route/u);
+  });
+});
+
+const SECRET_BEARING_ERROR =
+  "Unable to refresh SecretRef token=sk-secret-token for https://chatgpt.com/backend-api/codex profile openai:subscription Authorization: Bearer leaked";
+
+function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  return Object.values(value).flatMap(collectStrings);
+}
+
+function expectReasonRedacted(reason: PreparedRuntimeModelMaterializationReason | undefined) {
+  expect(reason).toBeDefined();
+  const serialized = JSON.stringify(reason);
+  expect(serialized).not.toMatch(/https?:\/\//u);
+  expect(serialized).not.toMatch(/chatgpt\.com|api\.openai\.com/u);
+  expect(serialized).not.toMatch(/openai:(?:subscription|backup|key)/u);
+  expect(serialized).not.toMatch(/SecretRef|Bearer|Authorization|sk-secret-token/u);
+  for (const text of collectStrings(reason)) {
+    expect(text).not.toMatch(/https?:\/\//u);
+    expect(text).not.toContain("openai:subscription");
+    expect(text).not.toContain("sk-secret-token");
+  }
+}
+
+async function expectClosedReason(
+  run: () => Promise<unknown>,
+  expected: Partial<PreparedRuntimeModelMaterializationReason> &
+    Pick<PreparedRuntimeModelMaterializationReason, "code">,
+) {
+  try {
+    await run();
+    throw new Error(`expected ${expected.code} materialization failure`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("Error");
+    expect(Object.keys(error as object)).not.toContain("reason");
+    expect(JSON.stringify(error)).not.toMatch(/https?:\/\//u);
+    const reason = readPreparedRuntimeModelMaterializationReason(error);
+    expect(reason).toMatchObject(expected);
+    expectReasonRedacted(reason);
+    return { error: error as Error, reason };
+  }
+}
+
+describe("materializePreparedRuntimeModel closed reasons", () => {
+  it("assigns a distinct closed reason to every fail-closed predicate", async () => {
+    const missing = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          resolveModel: vi.fn(async () => ({ error: SECRET_BEARING_ERROR })),
+        }),
+      {
+        code: "resolved-model-missing",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        authRequirement: "subscription",
+      },
+    );
+    expect(missing.error.message).toBe(SECRET_BEARING_ERROR);
+
+    const providerMismatch = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          resolveModel: vi.fn(async () => ({
+            error: SECRET_BEARING_ERROR,
+            model: {
+              provider: "github-copilot",
+              id: "gpt-5.5",
+              api: "openai-chatgpt-responses",
+              baseUrl: "https://chatgpt.com/backend-api/codex",
+            },
+          })),
+        }),
+      {
+        code: "resolved-provider-mismatch",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        actualProvider: "github-copilot",
+        api: "openai-chatgpt-responses",
+        authRequirement: "subscription",
+      },
+    );
+
+    const modelMismatch = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          resolveModel: vi.fn(async () => ({
+            model: {
+              provider: "openai",
+              id: "gpt-5.4",
+              api: "openai-chatgpt-responses",
+              baseUrl: "https://chatgpt.com/backend-api/codex",
+            },
+          })),
+        }),
+      {
+        code: "resolved-model-mismatch",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        actualModelId: "gpt-5.4",
+        api: "openai-chatgpt-responses",
+        authRequirement: "subscription",
+      },
+    );
+
+    const routeMismatch = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          resolveModel: vi.fn(async () => ({
+            model: {
+              provider: "openai",
+              id: "gpt-5.5",
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+            },
+          })),
+        }),
+      {
+        code: "resolved-route-mismatch",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        actualApi: "openai-responses",
+        authRequirement: "subscription",
+      },
+    );
+
+    const preparedTarget = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.6",
+          resolveModel: vi.fn(),
+        }),
+      {
+        code: "prepared-target-mismatch",
+        provider: "openai",
+        modelId: "gpt-5.6",
+        actualProvider: "openai",
+        actualModelId: "gpt-5.5",
+      },
+    );
+
+    const callerMismatch = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          rejectMismatchedModel: true,
+          model: {
+            provider: "openai",
+            id: "gpt-5.5",
+            api: "openai-completions",
+            baseUrl: "https://api.openai.com/v1",
+          },
+          resolveModel: vi.fn(),
+        }),
+      {
+        code: "caller-model-mismatch",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        actualProvider: "openai",
+        actualModelId: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        actualApi: "openai-completions",
+        authRequirement: "subscription",
+      },
+    );
+
+    const resolvedCodes = [
+      missing.reason?.code,
+      providerMismatch.reason?.code,
+      modelMismatch.reason?.code,
+      routeMismatch.reason?.code,
+    ];
+    expect(new Set(resolvedCodes).size).toBe(4);
+    expect(providerMismatch.error.message).toBe(SECRET_BEARING_ERROR);
+    expect(modelMismatch.error.message).toBe(
+      "Unable to materialize openai/gpt-5.5 for its prepared subscription route.",
+    );
+    expect(routeMismatch.error.message).toBe(modelMismatch.error.message);
+    expect(preparedTarget.error.message).toMatch(/does not match target/u);
+    expect(callerMismatch.error.message).toMatch(/does not match its prepared subscription route/u);
+    expect(PREPARED_RUNTIME_MODEL_MATERIALIZATION_REASON_CODES).toEqual([
+      "resolved-model-missing",
+      "resolved-provider-mismatch",
+      "resolved-model-mismatch",
+      "resolved-route-mismatch",
+      "prepared-target-mismatch",
+      "caller-model-mismatch",
+    ]);
+  });
+
+  it("keeps exact-route success and fail-closed order as controls", async () => {
+    const matching = {
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    };
+    const resolveModel = vi.fn(async () => ({
+      model: {
+        provider: "github-copilot",
+        id: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        baseUrl: matching.baseUrl,
+      },
+    }));
+
+    await expect(
+      materializePreparedRuntimeModel({
+        plan,
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: matching,
+        resolveModel,
+      }),
+    ).resolves.toBe(matching);
+    expect(resolveModel).not.toHaveBeenCalled();
+
+    const missingThenMismatch = vi.fn(async () => ({
+      error: SECRET_BEARING_ERROR,
+      model: {
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    }));
+    const ordered = await expectClosedReason(
+      () =>
+        materializePreparedRuntimeModel({
+          plan,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          resolveModel: missingThenMismatch,
+        }),
+      { code: "resolved-provider-mismatch" },
+    );
+    expect(ordered.error.message).toBe(SECRET_BEARING_ERROR);
+    expect(missingThenMismatch).toHaveBeenCalledOnce();
+  });
+
+  it("does not attach a reason to ordinary resolve throws", async () => {
+    const failure = new Error(SECRET_BEARING_ERROR);
+    await expect(
+      materializePreparedRuntimeModel({
+        plan,
+        provider: "openai",
+        modelId: "gpt-5.5",
+        resolveModel: vi.fn(async () => {
+          throw failure;
+        }),
+      }),
+    ).rejects.toBe(failure);
+    expect(readPreparedRuntimeModelMaterializationReason(failure)).toBeUndefined();
   });
 });

--- a/src/agents/runtime-plan/materialize-model.ts
+++ b/src/agents/runtime-plan/materialize-model.ts
@@ -19,6 +19,34 @@ type RuntimeRouteModel = {
   baseUrl?: string;
 };
 
+export const PREPARED_RUNTIME_MODEL_MATERIALIZATION_REASON_CODES = [
+  "resolved-model-missing",
+  "resolved-provider-mismatch",
+  "resolved-model-mismatch",
+  "resolved-route-mismatch",
+  "prepared-target-mismatch",
+  "caller-model-mismatch",
+] as const;
+
+export type PreparedRuntimeModelMaterializationReasonCode =
+  (typeof PREPARED_RUNTIME_MODEL_MATERIALIZATION_REASON_CODES)[number];
+
+/** Secret-free identity and already-authoritative route classes for one failure. */
+export type PreparedRuntimeModelMaterializationReason = {
+  code: PreparedRuntimeModelMaterializationReasonCode;
+  provider: string;
+  modelId: string;
+  actualProvider?: string;
+  actualModelId?: string;
+  api?: string;
+  actualApi?: string;
+  authRequirement?: NonNullable<AgentRuntimeAuthPlan["modelRoute"]>["authRequirement"];
+};
+
+const MATERIALIZATION_REASON_CODES = new Set<string>(
+  PREPARED_RUNTIME_MODEL_MATERIALIZATION_REASON_CODES,
+);
+
 function modelMatchesPreparedTarget(params: {
   model: RuntimeRouteModel;
   provider: string;
@@ -45,6 +73,121 @@ type PreparedRuntimeModelRequest = {
   authProfileMode?: ProviderModelRouteMaterializationAuthMode;
 };
 
+function resolveNormalizedModelRef(provider: string, modelId: string) {
+  return {
+    provider: normalizeProviderId(provider),
+    modelId: canonicalizeProviderModelId(provider, modelId),
+  };
+}
+
+function resolveApiClass(api?: string | null): string | undefined {
+  if (typeof api !== "string") {
+    return undefined;
+  }
+  const trimmed = api.trim();
+  return trimmed || undefined;
+}
+
+function resolveRouteClasses(route: NonNullable<AgentRuntimeAuthPlan["modelRoute"]>): {
+  api?: string;
+  authRequirement: NonNullable<AgentRuntimeAuthPlan["modelRoute"]>["authRequirement"];
+} {
+  const api = resolveApiClass(route.api);
+  return {
+    ...(api ? { api } : {}),
+    authRequirement: route.authRequirement,
+  };
+}
+
+function freezeMaterializationReason(
+  reason: PreparedRuntimeModelMaterializationReason,
+): PreparedRuntimeModelMaterializationReason {
+  return Object.freeze({
+    code: reason.code,
+    provider: reason.provider,
+    modelId: reason.modelId,
+    ...(reason.actualProvider ? { actualProvider: reason.actualProvider } : {}),
+    ...(reason.actualModelId ? { actualModelId: reason.actualModelId } : {}),
+    ...(reason.api ? { api: reason.api } : {}),
+    ...(reason.actualApi ? { actualApi: reason.actualApi } : {}),
+    ...(reason.authRequirement ? { authRequirement: reason.authRequirement } : {}),
+  });
+}
+
+/** Private typed failure for prepared-route materialization. Message stays user-facing. */
+export class PreparedRuntimeModelMaterializationError extends Error {
+  readonly reason: PreparedRuntimeModelMaterializationReason;
+
+  constructor(message: string, reason: PreparedRuntimeModelMaterializationReason) {
+    super(message);
+    this.name = "Error";
+    this.reason = freezeMaterializationReason(reason);
+    Object.defineProperty(this, "reason", {
+      value: this.reason,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  }
+}
+
+function resolveResolvedModelFailure(params: {
+  model?: RuntimeRouteModel | null;
+  provider: string;
+  modelId: string;
+  route?: AgentRuntimeAuthPlan["modelRoute"];
+}): PreparedRuntimeModelMaterializationReason | undefined {
+  const target = resolveNormalizedModelRef(params.provider, params.modelId);
+  const routeClasses = params.route ? resolveRouteClasses(params.route) : {};
+  if (!params.model) {
+    return { code: "resolved-model-missing", ...target, ...routeClasses };
+  }
+  const actualProvider = normalizeProviderId(params.model.provider ?? "");
+  if (actualProvider !== normalizeProviderId(params.provider)) {
+    return {
+      code: "resolved-provider-mismatch",
+      ...target,
+      actualProvider,
+      ...routeClasses,
+    };
+  }
+  const actualModelId = canonicalizeProviderModelId(params.provider, params.model.id ?? "");
+  if (actualModelId !== canonicalizeProviderModelId(params.provider, params.modelId)) {
+    return { code: "resolved-model-mismatch", ...target, actualModelId, ...routeClasses };
+  }
+  if (
+    params.route &&
+    !modelMatchesPreparedTarget({
+      model: params.model,
+      provider: params.provider,
+      modelId: params.modelId,
+      route: params.route,
+    })
+  ) {
+    const actualApi = resolveApiClass(params.model.api);
+    return {
+      code: "resolved-route-mismatch",
+      ...target,
+      ...routeClasses,
+      ...(actualApi ? { actualApi } : {}),
+    };
+  }
+  return undefined;
+}
+
+/** Reads the private closed reason without changing external error text. */
+export function readPreparedRuntimeModelMaterializationReason(
+  error: unknown,
+): PreparedRuntimeModelMaterializationReason | undefined {
+  if (!(error instanceof PreparedRuntimeModelMaterializationError)) {
+    return undefined;
+  }
+  if (!MATERIALIZATION_REASON_CODES.has(error.reason.code)) {
+    return undefined;
+  }
+  return error.reason;
+}
+
 /** Resolves the exact model tuple selected by a prepared runtime auth plan. */
 export async function materializePreparedRuntimeModel<Model extends RuntimeRouteModel>(params: {
   plan: AgentRuntimeAuthPlan;
@@ -69,8 +212,14 @@ export async function materializePreparedRuntimeModel<Model extends RuntimeRoute
       canonicalizeProviderModelId(route.provider, route.modelId) !==
         canonicalizeProviderModelId(params.provider, params.modelId))
   ) {
-    throw new Error(
+    throw new PreparedRuntimeModelMaterializationError(
       `Prepared runtime auth route ${route.provider}/${route.modelId} does not match target ${params.provider}/${params.modelId}.`,
+      {
+        code: "prepared-target-mismatch",
+        ...resolveNormalizedModelRef(params.provider, params.modelId),
+        actualProvider: normalizeProviderId(route.provider),
+        actualModelId: canonicalizeProviderModelId(route.provider, route.modelId),
+      },
     );
   }
   const callerModelMatches =
@@ -89,10 +238,24 @@ export async function materializePreparedRuntimeModel<Model extends RuntimeRoute
     return params.model;
   }
   if (params.model && !callerModelMatches && params.rejectMismatchedModel) {
-    throw new Error(
+    const callerProvider = normalizeProviderId(params.model.provider ?? "");
+    const callerApi = resolveApiClass(params.model.api);
+    throw new PreparedRuntimeModelMaterializationError(
       route
         ? `Caller-provided ${params.provider}/${params.modelId} metadata does not match its prepared ${route.authRequirement} route.`
         : `Caller-provided model metadata does not match ${params.provider}/${params.modelId}.`,
+      {
+        code: "caller-model-mismatch",
+        ...resolveNormalizedModelRef(params.provider, params.modelId),
+        ...(callerProvider ? { actualProvider: callerProvider } : {}),
+        ...(params.model.id
+          ? {
+              actualModelId: canonicalizeProviderModelId(params.provider, params.model.id),
+            }
+          : {}),
+        ...(route ? resolveRouteClasses(route) : {}),
+        ...(callerApi ? { actualApi: callerApi } : {}),
+      },
     );
   }
 
@@ -112,25 +275,20 @@ export async function materializePreparedRuntimeModel<Model extends RuntimeRoute
         })
       : resolveProviderModelMaterializationAuthMode(params.plan.selectedAuthMode),
   });
-  if (
-    !resolved.model ||
-    normalizeProviderId(resolved.model.provider ?? "") !== normalizeProviderId(params.provider) ||
-    canonicalizeProviderModelId(params.provider, resolved.model.id ?? "") !==
-      canonicalizeProviderModelId(params.provider, params.modelId) ||
-    (route &&
-      !modelMatchesPreparedTarget({
-        model: resolved.model,
-        provider: params.provider,
-        modelId: params.modelId,
-        route,
-      }))
-  ) {
-    throw new Error(
+  const resolvedFailure = resolveResolvedModelFailure({
+    model: resolved.model,
+    provider: params.provider,
+    modelId: params.modelId,
+    route,
+  });
+  if (resolvedFailure) {
+    throw new PreparedRuntimeModelMaterializationError(
       resolved.error ??
         (route
           ? `Unable to materialize ${params.provider}/${params.modelId} for its prepared ${route.authRequirement} route.`
           : `Unable to rematerialize ${params.provider}/${params.modelId} for its resolved auth profile.`),
+      resolvedFailure,
     );
   }
-  return resolved.model;
+  return resolved.model as Model;
 }


### PR DESCRIPTION
Related: https://github.com/karmaterminal/openclaw/issues/1259

## What Problem This Solves

Fixes an issue where operators debugging prepared-route fallback could not tell which exactness predicate failed. Missing resolved models, provider mismatches, model-id mismatches, and route API/auth mismatches all collapsed into one generic materialization error, so Elliott-style 401 fallback chains could not be attributed.

## Why This Change Was Made

`materializePreparedRuntimeModel` now throws the same user-facing messages with a private, non-enumerable, redacted closed reason. The credential-scoped plan cache keeps that typed rejection. This is instrumentation only: no provider, config, auth, fallback-order, or catalog changes.

## User Impact

No change to visible error text or fail-closed route behavior. Internal fallback decisions can now distinguish:

- `resolved-model-missing`
- `resolved-provider-mismatch`
- `resolved-model-mismatch`
- `resolved-route-mismatch`
- `prepared-target-mismatch`
- `caller-model-mismatch`

Reasons carry only normalized provider/model IDs and authoritative API/auth-requirement classes. They never carry URLs, profile IDs, tokens, SecretRefs, or headers.

## Evidence

- Base: `a4407f638af0d0147e3712eb6202ba7bf5d3d7fc`
- Owner tests 15/15 after RED → GREEN → revert RED → reapply GREEN
- Sibling runtime-plan auth tests 86/86
- Redaction negatives reject URL/profile/token/SecretRef payload fields
- Valid exact-route reuse and mismatch fail-closed remain controls
- Independent review: no high-confidence findings
- No live/authenticated probe in this PR
- Full local `node --import tsx scripts/test-projects.mts` aborted on host Node SIGILL/SIGSEGV; Crabbox/Testbox unavailable

Production: `materialize-model.ts` +175/-17; `credential-scoped-model.ts` +1.
