### PR TITLE
fix(agents): reject ambiguous apply_patch matches

### DIFF
--- a/src/agents/apply-patch-ambiguous-hunk.test.ts
+++ b/src/agents/apply-patch-ambiguous-hunk.test.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { applyUpdateHunk } from "./apply-patch-update.js";
+import { applyPatch } from "./apply-patch.test-support.js";
+
+type Chunk = Parameters<typeof applyUpdateHunk>[1][number];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function chunk(overrides: Partial<Chunk>): Chunk {
+  return {
+    oldLines: [],
+    newLines: [],
+    contextOldIndexes: [],
+    isEndOfFile: false,
+    ...overrides,
+  };
+}
+
+async function applyTo(source: string, chunks: Chunk[]): Promise<string> {
+  return applyUpdateHunk("source.txt", chunks, { readFile: async () => source });
+}
+
+describe("apply_patch ambiguous hunk matching", () => {
+  it.each([
+    {
+      tier: "exact",
+      source: "before\ntarget\ntarget\nafter\n",
+      pattern: "target",
+    },
+    {
+      tier: "trim-end",
+      source: "before\ntarget  \ntarget\t\nafter\n",
+      pattern: "target",
+    },
+    {
+      tier: "trim",
+      source: "before\n  target\n\ttarget\nafter\n",
+      pattern: "target",
+    },
+    {
+      tier: "punctuation",
+      source: "before\nIt\u2019s done\nIt\u2018s done\nafter\n",
+      pattern: "It's done",
+    },
+  ])("refuses duplicate matches at the $tier tier", async ({ source, pattern }) => {
+    await expect(applyTo(source, [chunk({ oldLines: [pattern] })])).rejects.toThrow(
+      /Found 2 occurrences.*include more surrounding lines/s,
+    );
+  });
+
+  it("refuses an exact duplicate @@ context", async () => {
+    const source = [
+      "function target() {",
+      "  return 1;",
+      "}",
+      "function target() {",
+      "  return 2;",
+      "}",
+      "",
+    ].join("\n");
+
+    await expect(
+      applyTo(source, [
+        chunk({
+          changeContext: "function target() {",
+          oldLines: ["  return 2;"],
+          newLines: ["  return 3;"],
+          contextOldIndexes: [undefined],
+        }),
+      ]),
+    ).rejects.toThrow(/Found 2 occurrences of context.*more specific @@ context line/s);
+  });
+
+  it.each([
+    {
+      tier: "exact",
+      source: "before\ntarget\nafter\n",
+      pattern: "target",
+      expected: "before\nafter\n",
+    },
+    {
+      tier: "trim-end",
+      source: "before\ntarget  \nafter\n",
+      pattern: "target",
+      expected: "before\nafter\n",
+    },
+    {
+      tier: "trim",
+      source: "before\n  target\nafter\n",
+      pattern: "target",
+      expected: "before\nafter\n",
+    },
+    {
+      tier: "punctuation",
+      source: "before\nIt\u2019s done\nafter\n",
+      pattern: "It's done",
+      expected: "before\nafter\n",
+    },
+  ])("applies a unique match at the $tier tier", async ({ source, pattern, expected }) => {
+    await expect(applyTo(source, [chunk({ oldLines: [pattern] })])).resolves.toBe(expected);
+  });
+
+  it("prefers a unique exact match over broader tolerant lookalikes", async () => {
+    const source = " target\ntarget\n\ttarget\n";
+
+    await expect(applyTo(source, [chunk({ oldLines: ["target"] })])).resolves.toBe(
+      " target\n\ttarget\n",
+    );
+  });
+
+  it("uses a unique @@ context to disambiguate repeated exact hunk text", async () => {
+    const source = [
+      "function first() {",
+      "  return 1;",
+      "}",
+      "function second() {",
+      "  return 1;",
+      "}",
+      "",
+    ].join("\n");
+
+    await expect(
+      applyTo(source, [
+        chunk({
+          changeContext: "function second() {",
+          oldLines: ["  return 1;"],
+          newLines: ["  return 2;"],
+          contextOldIndexes: [undefined],
+        }),
+      ]),
+    ).resolves.toBe(
+      [
+        "function first() {",
+        "  return 1;",
+        "}",
+        "function second() {",
+        "  return 2;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps sequential hunk searches after the prior match", async () => {
+    const source = "marker\ntarget\nmiddle\ntarget\n";
+
+    await expect(
+      applyTo(source, [
+        chunk({
+          oldLines: ["marker", "target"],
+          newLines: ["marker", "first"],
+          contextOldIndexes: [undefined, undefined],
+        }),
+        chunk({
+          oldLines: ["target"],
+          newLines: ["second"],
+          contextOldIndexes: [undefined],
+        }),
+      ]),
+    ).resolves.toBe("marker\nfirst\nmiddle\nsecond\n");
+  });
+
+  it("keeps end-of-file matching anchored to the final candidate", async () => {
+    const source = "\ttarget\nmiddle\n\ttarget\n";
+
+    await expect(
+      applyTo(source, [
+        chunk({
+          oldLines: ["  target"],
+          newLines: ["done"],
+          contextOldIndexes: [undefined],
+          isEndOfFile: true,
+        }),
+      ]),
+    ).resolves.toBe("\ttarget\nmiddle\ndone\n");
+  });
+
+  it("leaves the file byte-identical when an ambiguous patch is refused", async () => {
+    const dir = tempDirs.make("openclaw-patch-amb-");
+    const file = path.join(dir, "source.txt");
+    const source = "before\ntarget\ntarget\nafter\n";
+    await fs.writeFile(file, source);
+
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-target
+*** End Patch`;
+
+    await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(/Found 2 occurrences/);
+    await expect(fs.readFile(file, "utf8")).resolves.toBe(source);
+  });
+});

--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -63,11 +63,16 @@ function computeReplacements(
 
   for (const chunk of chunks) {
     if (chunk.changeContext) {
-      const ctxIndex = seekSequence(originalLines, [chunk.changeContext], lineIndex, false);
-      if (ctxIndex === null) {
+      const contextSearch = seekSequence(originalLines, [chunk.changeContext], lineIndex, false);
+      if (contextSearch.kind === "ambiguous") {
+        throw new Error(
+          `Found ${contextSearch.occurrences} occurrences of context '${chunk.changeContext}' in ${filePath}. The context must be unique; use a more specific @@ context line.`,
+        );
+      }
+      if (contextSearch.kind === "missing") {
         throw new Error(`Failed to find context '${chunk.changeContext}' in ${filePath}`);
       }
-      lineIndex = ctxIndex + 1;
+      lineIndex = contextSearch.index + 1;
     }
 
     if (chunk.oldLines.length === 0) {
@@ -84,23 +89,29 @@ function computeReplacements(
 
     let pattern = chunk.oldLines;
     let newSlice = chunk.newLines;
-    let found = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
+    let search = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
 
-    if (found === null && pattern[pattern.length - 1] === "") {
+    if (search.kind === "missing" && pattern[pattern.length - 1] === "") {
       // Parsed hunks may carry an EOF sentinel as a blank trailing line. Retry
       // without it so equivalent file contents still match.
       pattern = pattern.slice(0, -1);
       if (newSlice.length > 0 && newSlice[newSlice.length - 1] === "") {
         newSlice = newSlice.slice(0, -1);
       }
-      found = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
+      search = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
     }
 
-    if (found === null) {
+    if (search.kind === "ambiguous") {
+      throw new Error(
+        `Found ${search.occurrences} occurrences of these lines in ${filePath}. The lines must be unique; include more surrounding lines in the hunk:\n${chunk.oldLines.join("\n")}`,
+      );
+    }
+    if (search.kind === "missing") {
       throw new Error(
         `Failed to find expected lines in ${filePath}:\n${chunk.oldLines.join("\n")}`,
       );
     }
+    const found = search.index;
 
     replacements.push([
       found,
@@ -157,23 +168,28 @@ function applyReplacements(
   return result;
 }
 
+type SequenceSearch =
+  | { kind: "found"; index: number }
+  | { kind: "ambiguous"; occurrences: number }
+  | { kind: "missing" };
+
 function seekSequence(
   lines: string[],
   pattern: string[],
   start: number,
   eof: boolean,
-): number | null {
+): SequenceSearch {
   if (pattern.length === 0) {
-    return start;
+    return { kind: "found", index: start };
   }
   if (pattern.length > lines.length) {
-    return null;
+    return { kind: "missing" };
   }
 
   const maxStart = lines.length - pattern.length;
   const searchStart = eof && lines.length >= pattern.length ? maxStart : start;
   if (searchStart > maxStart) {
-    return null;
+    return { kind: "missing" };
   }
 
   // Fall back through increasingly tolerant comparisons. This preserves normal
@@ -186,14 +202,21 @@ function seekSequence(
     (value: string) => normalizePunctuation(value.trim()),
   ];
   for (const normalize of normalizers) {
+    let index: number | null = null;
+    let occurrences = 0;
     for (let i = searchStart; i <= maxStart; i += 1) {
       if (linesMatch(lines, pattern, i, normalize)) {
-        return i;
+        index ??= i;
+        occurrences += 1;
       }
+    }
+    if (index !== null) {
+      // Later tiers are broader, so only the first tier with any matches decides.
+      return occurrences === 1 ? { kind: "found", index } : { kind: "ambiguous", occurrences };
     }
   }
 
-  return null;
+  return { kind: "missing" };
 }
 
 function linesMatch(


### PR DESCRIPTION
Closes #124392

## What Problem This Solves

Fixes an issue where `apply_patch` could silently edit the wrong source block and report success when the requested hunk matched more than one location.

This affected exact duplicates and the progressively tolerant trim-end, trim, and punctuation-normalized matching tiers. A model could continue with a workspace state different from the one it intended to create.

## Why This Change Was Made

The hunk matcher now counts every candidate at the first comparison tier that produces a match. Exactly one candidate is required before a replacement is computed; zero remains "not found", and multiple candidates return an actionable ambiguity error that asks for more context.

Tier order, cursor/start behavior, sequential hunks, `@@` context handling, and end-of-file anchoring remain intact. A unique exact match still wins before broader tolerant tiers are considered.

Production LOC: +36/-13 (net +23) | Tests: +195/-0. The positive production delta adds the explicit missing/found/ambiguous safety state at the filesystem-mutation owner boundary; it prevents the P0 silent wrong-location write without adding a fallback path.

## User Impact

Ambiguous patches now fail without writing the file and tell the model to include more surrounding lines. Unique exact and tolerant patches continue to apply normally.

## Evidence

Current-main red proof at `ffdd0641c80f73c3868f730280674d3ab7aadcd6`:

- New 14-case regression suite before the production fix: 6 failed, 8 passed.
- Failures reproduced exact, trim-end, trim, punctuation, duplicate `@@` context, and end-to-end on-disk ambiguity.
- The on-disk case previously returned success and changed the file.

Exact-head green proof at `547783794d741284b573b9a69588301f51622d79`:

- `node scripts/run-vitest.mjs <all five src/agents/apply-patch*.test.ts files>`: 5 files, 93 tests passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`: clean.
- Blacksmith Testbox changed gate: success in 11m33s, including core/core-test typechecks, lint, format, dead-export, boundary, cycle, schema, and database-first guards. Run: https://github.com/openclaw/openclaw/actions/runs/32219553283
- Testbox reported no temp-directory migration warnings on the final head.

`main` advanced to `95ac5b27fa1471e3481ef2dc0159a9f94b1c22c0` during validation. Neither frozen file changed and the merge tree is conflict-free, so no drift-only rebase was performed.

Codex contract checked directly against `openai/codex`:

- `codex-rs/apply-patch/src/seek_sequence.rs`: exact, trim-end, trim, and punctuation-normalized tier order plus cursor and EOF anchoring.
- `codex-rs/apply-patch/src/parser.rs`: ordered update chunks and `@@`/EOF patch semantics.
- `codex-rs/apply-patch/src/lib.rs`: replacement computation precedes filesystem application.

The OpenClaw change intentionally strengthens Codex's first-hit matcher by refusing non-unique candidates while preserving its ordering and anchoring contracts.

## Credits

- Original PR implementation and commit authorship: Swagat Rathod (@MrSwagatRathod).
- Issue report, reproduction, and root-cause evidence: Yuval Dinodia (@yetval).

Punchcard-Session: calm-timber-lantern-kh
