### PR TITLE
fix(settings): take the settings file lock before the first-write read

### DIFF
--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -98,10 +98,14 @@ export class SettingsManager {
   private static loadScope(storage: SettingsStorage, scope: SettingsScope): SettingsScopeState {
     let content: string | undefined;
     try {
-      storage.withLock(scope, (current) => {
-        content = current;
-        return undefined;
-      });
+      if (storage.readSettingsScope) {
+        content = storage.readSettingsScope(scope);
+      } else {
+        storage.withLock(scope, (current) => {
+          content = current;
+          return undefined;
+        });
+      }
       const settings = content
         ? SettingsManager.migrateSettings(JSON.parse(content) as Record<string, unknown>)
         : {};

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -1,0 +1,111 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { waitForChildClose, waitForFile } from "../../../test/helpers/process-wait.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { SettingsManager } from "./settings-manager.js";
+
+const writerScript = String.raw`
+  import { existsSync, readFileSync, writeFileSync } from "node:fs";
+  import { join } from "node:path";
+
+  const [moduleUrl, settingsDir, markerDir, field] = process.argv.slice(1);
+  const { FileSettingsStorage } = await import(moduleUrl);
+  const settingsPath = join(settingsDir, "settings.json");
+  const otherEntered = join(markerDir, "theme.entered");
+  const contenderSawLock = join(markerDir, "contender-saw-lock");
+
+  if (field === "theme" && existsSync(settingsPath + ".lock")) {
+    writeFileSync(contenderSawLock, "ready");
+  }
+
+  const storage = new FileSettingsStorage(settingsDir, settingsDir);
+  storage.withLock("global", (current) => {
+    writeFileSync(join(markerDir, field + ".entered"), "ready");
+    if (field === "defaultModel") {
+      const deadline = Date.now() + 5_000;
+      const pause = new Int32Array(new SharedArrayBuffer(4));
+      while (!existsSync(otherEntered) && !existsSync(contenderSawLock)) {
+        if (Date.now() >= deadline) {
+          throw new Error("contending writer did not reach the settings boundary");
+        }
+        Atomics.wait(pause, 0, 0, 10);
+      }
+    }
+    const settings = current ? JSON.parse(current) : {};
+    settings[field] = field === "theme" ? "dark" : "provider/model";
+    return JSON.stringify(settings, null, 2);
+  });
+`;
+
+const children = new Map<ChildProcess, Promise<unknown>>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(async () => {
+  for (const child of children.keys()) {
+    child.kill("SIGKILL");
+  }
+  await Promise.allSettled(children.values());
+  children.clear();
+});
+
+function spawnWriter(settingsDir: string, markerDir: string, field: string) {
+  const moduleUrl = pathToFileURL(resolve("src/agents/sessions/settings-storage.ts")).href;
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      writerScript,
+      moduleUrl,
+      settingsDir,
+      markerDir,
+      field,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const done = waitForChildClose(child, 10_000);
+  children.set(child, done);
+  let output = "";
+  child.stdout?.setEncoding("utf8").on("data", (chunk) => (output += chunk));
+  child.stderr?.setEncoding("utf8").on("data", (chunk) => (output += chunk));
+  return { child, done, output: () => output };
+}
+
+describe("FileSettingsStorage", () => {
+  it("loads missing settings without creating their directories", () => {
+    const root = tempDirs.make("openclaw-settings-read-");
+    const settingsDir = join(root, "agent");
+
+    SettingsManager.create(root, settingsDir);
+
+    expect(existsSync(settingsDir)).toBe(false);
+    expect(existsSync(join(root, ".openclaw"))).toBe(false);
+  });
+
+  it("preserves concurrent first writes from separate processes", async () => {
+    const root = tempDirs.make("openclaw-settings-first-write-");
+    const settingsDir = join(root, "agent");
+    const markerDir = join(root, "markers");
+    mkdirSync(markerDir);
+
+    const first = spawnWriter(settingsDir, markerDir, "defaultModel");
+    await waitForFile(join(markerDir, "defaultModel.entered"), 5_000);
+    const contender = spawnWriter(settingsDir, markerDir, "theme");
+
+    for (const writer of [first, contender]) {
+      const result = await writer.done;
+      children.delete(writer.child);
+      expect(result, writer.output()).toEqual({ code: 0, signal: null });
+    }
+
+    expect(JSON.parse(readFileSync(join(settingsDir, "settings.json"), "utf8"))).toEqual({
+      defaultModel: "provider/model",
+      theme: "dark",
+    });
+  }, 15_000);
+});

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -118,6 +118,8 @@ export type SettingsScope = "global" | "project";
 export const SETTINGS_SCOPES: SettingsScope[] = ["global", "project"];
 
 export interface SettingsStorage {
+  // Optional so shipped custom backends can keep serving reads through withLock.
+  readSettingsScope?(scope: SettingsScope): string | undefined;
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
 }
 
@@ -136,31 +138,36 @@ export class FileSettingsStorage implements SettingsStorage {
     };
   }
 
+  readSettingsScope(scope: SettingsScope): string | undefined {
+    const path = this.paths[scope];
+    if (!existsSync(path)) {
+      return undefined;
+    }
+    const release = acquireFileLockSyncWithRetry(path);
+    try {
+      return readFileSync(path, "utf-8");
+    } finally {
+      release();
+    }
+  }
+
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
     const path = this.paths[scope];
     const dir = dirname(path);
 
-    let release: (() => void) | undefined;
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    // Lock before reading, or concurrent first writers can merge from the same empty state.
+    const release = acquireFileLockSyncWithRetry(path);
     try {
-      // Only create directory and lock if file exists or we need to write
-      const fileExists = existsSync(path);
-      if (fileExists) {
-        release = acquireFileLockSyncWithRetry(path);
-      }
-      const current = fileExists ? readFileSync(path, "utf-8") : undefined;
+      const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
-        // Only create directory when we actually need to write
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
-        }
-        if (!release) {
-          release = acquireFileLockSyncWithRetry(path);
-        }
         writeFileSync(path, next, "utf-8");
       }
     } finally {
-      release?.();
+      release();
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Two OpenClaw processes can write distinct settings to the same absent `settings.json`. Both calls report success, but the second write can silently discard the first setting.

Fixes #124394.

## Root cause

`FileSettingsStorage.withLock` read a missing file before it acquired the file lock. Both processes could therefore merge their changes from the same empty object.

## Fix

- Keep missing-file loads lazy through `readSettingsScope`.
- Acquire the canonical settings-file lock before every read-modify-write callback.
- Preserve the shipped `SettingsStorage.withLock` path for custom storage implementations.

## Evidence

The proof started two real Node processes against one absent settings file. One process wrote `defaultModel`; the other wrote `theme`.

| Revision | Process results | Final file |
| --- | --- | --- |
| Main `f46f9b5aa39f` | Both exited successfully | `{"theme":"dark"}`; `defaultModel` was lost |
| This head `22f9230dd6f` | Both exited successfully | `{"defaultModel":"provider/model","theme":"dark"}` |

Current main `b4f85100f72d` has no later changes to the settings owner files.

Focused validation: `node scripts/run-vitest.mjs src/agents/sessions/settings-storage.test.ts src/agents/sessions/settings-manager.test.ts` passes 7 tests.
