### PR TITLE
fix(gateway): stop reporting success when an unmanaged gateway is sti…

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -38,6 +38,9 @@ const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SI
 const writeGatewayRestartIntentSync = vi.fn();
 const clearGatewayRestartIntentSync = vi.fn();
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
+const assertGatewayPortFreeWhenPidUnknown = vi.fn<(port: number) => Promise<void>>(
+  async () => undefined,
+);
 const probeGateway = vi.fn<
   (opts: {
     url: string;
@@ -104,6 +107,7 @@ vi.mock("../../infra/gateway-processes.js", () => ({
   signalVerifiedGatewayPidSync: (pid: number, signal: "SIGTERM" | "SIGUSR1") =>
     signalVerifiedGatewayPidSync(pid, signal),
   formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
+  assertGatewayPortFreeWhenPidUnknown: (port: number) => assertGatewayPortFreeWhenPidUnknown(port),
 }));
 
 vi.mock("../../infra/gateway-lock.js", () => ({
@@ -261,6 +265,7 @@ describe("runDaemonRestart health checks", () => {
     writeGatewayRestartIntentSync.mockReset().mockReturnValue(true);
     clearGatewayRestartIntentSync.mockReset();
     formatGatewayPidList.mockReset().mockImplementation((pids) => pids.join(", "));
+    assertGatewayPortFreeWhenPidUnknown.mockReset().mockResolvedValue(undefined);
     probeGateway.mockReset();
     callGatewayCli.mockReset();
     isRestartEnabled.mockReset();
@@ -1114,6 +1119,22 @@ describe("runDaemonRestart health checks", () => {
 
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
     expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
+    // Only report "not running" once the port is confirmed free (openclaw#119065).
+    expect(assertGatewayPortFreeWhenPidUnknown).toHaveBeenCalled();
     expect(outcome).toBeNull();
+  });
+
+  it("fails instead of reporting a stopped gateway when the port is busy but no pid is identifiable (openclaw#119065)", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+    readActiveGatewayLockIdentity.mockResolvedValue(undefined);
+    const busyPortError =
+      'port 18789 is in use but the gateway process could not be identified (lsof unavailable or the gateway lock is missing/stale); run "openclaw gateway status --deep" to investigate';
+    assertGatewayPortFreeWhenPidUnknown.mockRejectedValue(new Error(busyPortError));
+
+    await expect(runUnmanagedStop()).rejects.toThrow(
+      /port 18789 is in use but the gateway process could not be identified/,
+    );
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -20,6 +20,7 @@ import {
   readActiveGatewayLockPort,
 } from "../../infra/gateway-lock.js";
 import {
+  assertGatewayPortFreeWhenPidUnknown,
   findVerifiedGatewayListenerPidsOnPortSync,
   formatGatewayPidList,
   signalVerifiedGatewayPidSync,
@@ -218,16 +219,14 @@ async function stopGatewayWithoutServiceManager(port: number, lockOwnerPid: numb
   // reporting the gateway as not running while it keeps serving.
   const pids = listenerPids.length > 0 ? listenerPids : lockOwnerPid ? [lockOwnerPid] : [];
   if (pids.length === 0) {
+    // Reporting "not loaded" without checking the port hands back a false
+    // success while the gateway keeps serving.
+    await assertGatewayPortFreeWhenPidUnknown(port);
     return null;
   }
   for (const pid of pids) {
     signalVerifiedGatewayPidSync(pid, "SIGTERM");
-    appendGatewayLifecycleAudit({
-      action: "stop",
-      source: "cli",
-      mode: "sigterm",
-      pid,
-    });
+    appendGatewayLifecycleAudit({ action: "stop", source: "cli", mode: "sigterm", pid });
   }
   return {
     result: "stopped" as const,

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -1,4 +1,5 @@
 // Covers gateway process discovery across platform process listings.
+import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import { getWindowsPowerShellExePath, getWindowsSystem32ExePath } from "./windows-install-roots.js";
@@ -9,6 +10,7 @@ const parseCmdScriptCommandLineMock = vi.hoisted(() => vi.fn());
 const parseProcCmdlineMock = vi.hoisted(() => vi.fn());
 const isGatewayArgvMock = vi.hoisted(() => vi.fn());
 const findGatewayPidsOnPortSyncMock = vi.hoisted(() => vi.fn());
+const probePortUsageMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -57,7 +59,16 @@ vi.mock("../channels/chat-meta.js", () => ({
   getChatChannelMeta: vi.fn(() => null),
 }));
 
+// Defaults to the real probe so the free/busy cases exercise actual sockets;
+// the indeterminate case overrides it, which no real socket can produce.
+vi.mock("./ports-probe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ports-probe.js")>();
+  probePortUsageMock.mockImplementation(actual.probePortUsage);
+  return { ...actual, probePortUsage: (...args: unknown[]) => probePortUsageMock(...args) };
+});
+
 const {
+  assertGatewayPortFreeWhenPidUnknown,
   findVerifiedGatewayListenerPidsOnPortSync,
   formatGatewayPidList,
   signalVerifiedGatewayPidSync,
@@ -65,6 +76,19 @@ const {
 
 function setPlatform(platform: NodeJS.Platform): void {
   mockProcessPlatform(platform);
+}
+
+async function findFreePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const port = (server.address() as net.AddressInfo).port;
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+  return port;
 }
 
 describe("gateway-processes", () => {
@@ -188,5 +212,53 @@ describe("gateway-processes", () => {
 
   it("formats pid lists as comma-separated output", () => {
     expect(formatGatewayPidList([1, 2, 3])).toBe("1, 2, 3");
+  });
+
+  it("accepts a port with no listener when the gateway pid is unknown", async () => {
+    const port = await findFreePort();
+
+    await expect(assertGatewayPortFreeWhenPidUnknown(port)).resolves.toBeUndefined();
+  });
+
+  it("rejects a port that still has a listener when the gateway pid is unknown", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      await expect(assertGatewayPortFreeWhenPidUnknown(port)).rejects.toThrow(
+        new RegExp(`port ${port} is in use but the gateway process could not be identified`),
+      );
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("distinguishes an indeterminate probe from an occupied port", async () => {
+    const port = await findFreePort();
+    probePortUsageMock.mockResolvedValueOnce("unknown");
+
+    const error = await assertGatewayPortFreeWhenPidUnknown(port).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(
+      new RegExp(`could not determine whether port ${port} is still in use`),
+    );
+    // The port has no listener, so the "in use" wording would be wrong here.
+    expect((error as Error).message).not.toMatch(/is in use but/);
+  });
+
+  it("stays fail-closed when the probe itself throws", async () => {
+    const port = await findFreePort();
+    probePortUsageMock.mockRejectedValueOnce(new Error("probe exploded"));
+
+    await expect(assertGatewayPortFreeWhenPidUnknown(port)).rejects.toThrow(
+      new RegExp(`could not determine whether port ${port} is still in use`),
+    );
   });
 });

--- a/src/infra/gateway-processes.ts
+++ b/src/infra/gateway-processes.ts
@@ -2,6 +2,7 @@
 import fsSync from "node:fs";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
+import { probePortUsage } from "./ports-probe.js";
 import { findGatewayPidsOnPortSync as findUnixGatewayPidsOnPortSync } from "./restart-stale-pids.js";
 import { spawnPsSync } from "./spawn-ps.js";
 import {
@@ -71,4 +72,29 @@ export function findVerifiedGatewayListenerPidsOnPortSync(port: number): number[
 /** Format gateway PIDs for human-facing diagnostics. */
 export function formatGatewayPidList(pids: number[]): string {
   return pids.join(", ");
+}
+
+/**
+ * Fail when `port` still has an owner that PID discovery could not name.
+ *
+ * Finding no PID does not prove the gateway is down: `lsof` may be missing on
+ * minimal containers and the gateway lock may be absent or stale while the
+ * process keeps serving. Callers that would otherwise report "not running"
+ * use this to turn that ambiguity into an explicit error instead of a
+ * false success.
+ */
+export async function assertGatewayPortFreeWhenPidUnknown(port: number): Promise<void> {
+  const status = await probePortUsage(port).catch(() => "unknown" as const);
+  if (status === "free") {
+    return;
+  }
+  // Both remaining statuses stay fail-closed, but they describe different
+  // situations: "busy" observed a listener, while "unknown" means the probe
+  // itself could not answer. Reporting the port as in use for "unknown" would
+  // send operators looking for a listener that may not exist.
+  throw new Error(
+    status === "busy"
+      ? `port ${port} is in use but the gateway process could not be identified (lsof unavailable or the gateway lock is missing/stale); run "openclaw gateway status --deep" to investigate`
+      : `could not determine whether port ${port} is still in use, so the gateway cannot be confirmed stopped; run "openclaw gateway status --deep" to investigate`,
+  );
 }


### PR DESCRIPTION
# fix(gateway): `gateway stop` reports success while the gateway is still running

Closes #119065

## What Problem This Solves

`openclaw gateway stop --json` returns a success result while the gateway is still alive and serving:

```console
$ openclaw gateway stop --json
{"ok":true,"result":"not-loaded"}

$ curl -s localhost:18789/health
{"ok":true,...}
```

The command claims the gateway is not loaded, the caller believes it has stopped, and the process keeps running. Scripts that stop the gateway before an upgrade, a port handover, or a state-directory migration proceed against a live process.

## Why This Change Was Made

When no service manager owns the gateway, `stopGatewayWithoutServiceManager` (`src/cli/daemon-cli/lifecycle.ts`) resolves a PID from two sources:

1. verified listener PIDs on the port (via `lsof` on Unix), and
2. the PID recorded in the gateway lock file.

If both come back empty, the old code treated that as proof the gateway was down and returned `null`, which the caller renders as `not-loaded`.

Finding no PID does not prove the gateway is down. Both sources fail independently while the process is perfectly healthy:

- `lsof` is not installed on minimal container images, so listener discovery returns nothing.
- The gateway lock can be missing or stale — for example after a state-directory change or an unclean previous run — so there is no recorded PID either.

In that state the only reliable signal left is the port itself. This change probes it and refuses to report a stop that did not happen, so an ambiguous result surfaces as an error the operator can act on instead of a silent false success.

The check is added as `assertGatewayPortFreeWhenPidUnknown` in `src/infra/gateway-processes.ts`, next to the existing gateway PID discovery helpers it complements, and reuses the existing `probePortUsage` helper. Placing it there also keeps `lifecycle.ts` under the repo's 700-line `max-lines` lint cap.

Behavior change, limited to the "no PID found" branch:

| Port state | Before | After |
| --- | --- | --- |
| free | `not-loaded` | `not-loaded` (unchanged) |
| busy / unknown | `not-loaded` (false success) | actionable error |

Paths that do find a PID are untouched. A probe failure is treated as `unknown` and therefore reported rather than swallowed, since claiming success is the more damaging outcome.

## User Impact

`openclaw gateway stop` no longer reports success when it could not stop anything. When the port is still occupied and the process cannot be identified, it fails with:

```
port 18789 is in use but the gateway process could not be identified
(lsof unavailable or the gateway lock is missing/stale);
run "openclaw gateway status --deep" to investigate
```

Users on containers without `lsof`, or with a missing/stale lock, get a clear pointer to the diagnostic command instead of a wrong answer. Normal stops on a genuinely free port are unaffected.

## Evidence

New regression tests, both verified to fail without the fix:

- `src/cli/daemon-cli/lifecycle.test.ts` — the unmanaged stop path fails instead of returning `not-loaded` when the port is busy, and the existing "not running" test now asserts the port is confirmed free first.
- `src/infra/gateway-processes.test.ts` — `assertGatewayPortFreeWhenPidUnknown` resolves for a free port and rejects against a real listening socket.

```
# with the fix
✓ src/cli/daemon-cli/lifecycle.test.ts (44 tests)
✓ src/infra/gateway-processes.test.ts (8 tests)
✓ src/infra/ports-probe.test.ts
  Test Files  3 passed (3)
       Tests  55 passed (55)

# with the fix reverted, tests kept
  Tests  2 failed | 42 passed (44)
   × fails instead of reporting a stopped gateway when the port is busy but no pid is identifiable
   × skips unmanaged signaling for pids that are not live gateway processes
```

Wider validation:

- `npx vitest run src/cli/daemon-cli/` → 42 files passed, 670 passed / 4 skipped
- `npx oxlint src/cli/daemon-cli/ src/infra/` → 0 warnings, 0 errors
- `npx oxfmt --check` on all touched files → clean
- `npx tsc -p tsconfig.json --noEmit` → no errors in touched files
- `node --import tsx scripts/check-src-extension-import-boundary.mts --json` → `[]`

Note: `src/infra/restart-stale-pids.test.ts` has 6 failures, confirmed pre-existing by stashing this change and re-running on a clean tree. They are unrelated to this PR and not addressed here.

## AI assistance

This change was AI-assisted. The diagnosis, fix, tests, and validation output above were reviewed against the reported reproduction in #119065.