### PR TITLE
fix(ui): chat send failures were invisible when the session pane was hidden

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 334391,
-  "reason": "cumulative 2026-08-15 UI growth plus folder group defaults catalog and lazy New Session route resolution",
-  "updatedAt": "2026-08-15"
+  "startupJsGzipBytes": 335452,
+  "reason": "chat delivery failures surface globally: toast + session-display naming joins startup chat path",
+  "updatedAt": "2026-08-16"
 }

--- a/src/gateway/worker-environments/workspace-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-sync.test.ts
@@ -57,6 +57,10 @@ function createWorkspaceActions(
 
 describe("worker workspace command transport retry", () => {
   it("runs never commands once without changing the selected port", async () => {
+    // Pin the clock: the impl derives the dispatch timeout from a Date.now()
+    // deadline, so real elapsed ms between admission and dispatch would turn
+    // the exact 777 assertion below into a loaded-runner flake.
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
     const run = vi.fn(async (argv: string[], _options: CommandOptions) =>
       argv.at(-1)?.includes("never-command") ? result(255) : result(),
     );

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -113,6 +113,9 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
 }
 
 export function showToast(options: ToastOptions): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
   const host = document.querySelector<OpenClawToastHost>("openclaw-toast-host");
   if (!host) {
     queuedToast = options;
@@ -136,7 +139,8 @@ export function showToast(options: ToastOptions): boolean {
   return true;
 }
 
-if (!customElements.get("openclaw-toast-host")) {
+// Guarded so DOM-free (node) consumers of send-failure surfacing can load this module.
+if (typeof customElements !== "undefined" && !customElements.get("openclaw-toast-host")) {
   customElements.define("openclaw-toast-host", OpenClawToastHost);
 }
 

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -234,6 +234,20 @@ describe("renderChatComposer controls", () => {
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
   });
 
+  it("shows the disabled reason even when draft text hides the placeholder", () => {
+    const reason = "This session is read-only.";
+    const { container } = renderComposer({
+      canSend: false,
+      disabledReason: reason,
+      draft: "a draft that hides the placeholder",
+    });
+
+    // The placeholder carries the reason only for an empty composer; the
+    // dedicated reason row must keep the explanation visible alongside a draft.
+    expect(container.querySelector(".agent-chat__disabled-reason")?.textContent).toContain(reason);
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
+  });
+
   it("switches the primary action between voice, send, queue, and stop", () => {
     const onToggleRealtimeTalk = vi.fn();
     let view = renderComposer({ onToggleRealtimeTalk });

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -30,12 +30,14 @@ import {
   type StoredChatOutbox,
   type StoredChatOutboxScope,
 } from "./composer-persistence.ts";
+import { formatConnectError } from "./connect-error.ts";
 import { isQueuedMessageBeingEdited } from "./queued-message-edit.ts";
 import { isChatBusy } from "./run-lifecycle.ts";
 import {
   chatMessagesContainQueuedSend,
   OFFLINE_QUEUE_STORAGE_ERROR,
   preserveQueuedUserTurn,
+  surfaceChatDeliveryFailure,
 } from "./steer-lifecycle.ts";
 
 export type QueuedChatSendResult = "sent" | "pending" | "failed";
@@ -179,16 +181,43 @@ async function readCurrentStoredChatHistory(
       limit: 1000,
     });
   } catch (err) {
+    const connectionCurrent =
+      host.client === client && host.connectionEpoch === connectionEpoch && host.connected;
     const retryDelayMs = retryableGatewayDelayMs(err);
-    if (
-      retryDelayMs !== null &&
-      host.client === client &&
-      host.connectionEpoch === connectionEpoch &&
-      host.connected
-    ) {
-      scheduleStoredChatOutboxRetry(host, outbox, retryDelayMs, dependencies);
+    if (retryDelayMs !== null) {
+      if (connectionCurrent) {
+        scheduleStoredChatOutboxRetry(host, outbox, retryDelayMs, dependencies);
+      }
+      return "blocked";
     }
-    return "blocked";
+    // An authoritative non-retryable rejection (auth loss, revoked scope) will
+    // repeat on every drain wakeup; leaving the head silently "blocked" wedges
+    // the whole FIFO lane forever. Fail or park it visibly so the operator sees
+    // the outcome and the lane can move past a never-attempted head.
+    if (!connectionCurrent || !(err instanceof GatewayRequestError)) {
+      return "blocked";
+    }
+    const attempted =
+      (item.sendAttempts ?? 0) > 0 ||
+      item.sendRequestStartedAtMs !== undefined ||
+      item.sendState === "unconfirmed";
+    const error = attempted ? UNCONFIRMED_CHAT_SEND_ERROR : formatConnectError(err);
+    const targetState = attempted ? ("unconfirmed" as const) : ("failed" as const);
+    if (item.sendState === targetState && item.sendError === error) {
+      return "blocked";
+    }
+    const parked = updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
+      ...entry,
+      sendError: error,
+      sendState: targetState,
+    }));
+    surfaceChatDeliveryFailure(
+      host,
+      outbox.sessionKey,
+      outbox.agentId,
+      parked ? error : OFFLINE_QUEUE_STORAGE_ERROR,
+    );
+    return parked && !attempted ? "continue" : "blocked";
   }
   const currentOutbox = readStoredChatOutbox(host, outbox);
   const currentItem = currentOutbox?.queue.find((entry) => entry.id === item.id);
@@ -272,8 +301,13 @@ async function reconcileStoredChatOutboxHead(
       sendError: UNCONFIRMED_CHAT_SEND_ERROR,
       sendState: "unconfirmed",
     }));
-    if (parked && visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)) {
-      dependencies.setChatError(host, UNCONFIRMED_CHAT_SEND_ERROR);
+    if (parked) {
+      surfaceChatDeliveryFailure(
+        host,
+        outbox.sessionKey,
+        outbox.agentId,
+        UNCONFIRMED_CHAT_SEND_ERROR,
+      );
     }
     return "blocked";
   }
@@ -411,12 +445,13 @@ async function drainStoredChatOutbox(
         visibleSessionMatches(host, outbox.sessionKey, outbox.agentId);
       const failCommand = (error: string, expose = false): "blocked" => {
         const updated = setCommandState("failed", error);
-        if (commandScopeIsCurrent()) {
-          if (!updated) {
-            dependencies.setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-          } else if (expose) {
-            dependencies.setChatError(host, error);
-          }
+        if (!updated || expose) {
+          surfaceChatDeliveryFailure(
+            host,
+            outbox.sessionKey,
+            outbox.agentId,
+            updated ? error : OFFLINE_QUEUE_STORAGE_ERROR,
+          );
         }
         return "blocked";
       };
@@ -466,9 +501,12 @@ async function drainStoredChatOutbox(
           }
         }
         if (!removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey)) {
-          if (commandScopeIsCurrent()) {
-            dependencies.setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-          }
+          surfaceChatDeliveryFailure(
+            host,
+            outbox.sessionKey,
+            outbox.agentId,
+            OFFLINE_QUEUE_STORAGE_ERROR,
+          );
           return "blocked";
         }
         if (dispatchResult === "uncertain") {

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -470,11 +470,17 @@ async function drainStoredChatOutbox(
           return "blocked";
         }
         if (dispatchResult === "failed") {
+          // A still-current scope already saw the dispatcher's inline error.
+          // After a route switch the dispatcher withholds it and the pane is
+          // gone, so the terminal failure must surface globally. A stale scope
+          // with the pane still visible (connection replaced) keeps the failed
+          // queue chip instead: the new connection owns the inline surface.
           const commandStillCurrent = commandScopeIsCurrent();
           const error =
             (commandStillCurrent ? host.lastError : null) ??
             `Command /${item.localCommandName} failed.`;
-          return failCommand(error);
+          const paneHidden = !visibleSessionMatches(host, outbox.sessionKey, outbox.agentId);
+          return failCommand(error, !commandStillCurrent && paneHidden);
         }
         if (dispatchResult === "uncertain") {
           const currentOutbox = readStoredChatOutbox(host, outbox);

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -207,11 +207,15 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       selectedSession.sharingRole === "viewer" &&
       isGatewayMethodAdvertised(gatewaySnapshot, "session.suggestions.add") === true &&
       isGatewayMethodAdvertised(gatewaySnapshot, "session.suggestions.list") === true;
+    // Every composer-disabling gate needs a visible reason here or a banner in
+    // sessionDisabledBanner; a silently disabled composer is a silent failure.
     const disabledReason = modelUnavailable
       ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
       : sessionParticipationBlocked && !suggestionViewer
         ? t("chat.sessionSharing.readOnlyNotice")
-        : null;
+        : cloudStartupPending
+          ? t("newSession.starting")
+          : null;
     const typingEnabled =
       multiIdentity &&
       hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null) &&

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -63,7 +63,11 @@ import { resetChatInputHistoryNavigation } from "./input-history.ts";
 import { controlUiNowMs, roundedControlUiDurationMs } from "./performance.ts";
 import { hasAbortableSessionRun, isChatBusy, reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { resetChatScroll, scheduleChatScroll } from "./scroll.ts";
-import { formatTerminalChatSendAckError, OFFLINE_QUEUE_STORAGE_ERROR } from "./steer-lifecycle.ts";
+import {
+  formatTerminalChatSendAckError,
+  OFFLINE_QUEUE_STORAGE_ERROR,
+  surfaceChatDeliveryFailure,
+} from "./steer-lifecycle.ts";
 import { resetToolStream } from "./tool-stream.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
@@ -224,9 +228,7 @@ async function sendQueuedChatMessage(
     const access = readChatResetTargetAccess(host, options.target);
     if (!access.allowed) {
       setState("failed", access.reason);
-      if (visibleSessionMatches(host, sessionKey, prepared.agentId)) {
-        setChatError(host, access.reason);
-      }
+      surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, access.reason);
       return "failed";
     }
   }
@@ -245,9 +247,7 @@ async function sendQueuedChatMessage(
     }
     if (!waiting) {
       setState("failed", OFFLINE_QUEUE_STORAGE_ERROR);
-      if (visibleSessionMatches(host, sessionKey, prepared.agentId)) {
-        setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-      }
+      surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, OFFLINE_QUEUE_STORAGE_ERROR);
     }
     return "pending";
   }
@@ -267,9 +267,7 @@ async function sendQueuedChatMessage(
     agentId: prepared.agentId,
   }));
   if (!sendingItem) {
-    if (visibleSessionMatches(host, sessionKey, prepared.agentId)) {
-      setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-    }
+    surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, OFFLINE_QUEUE_STORAGE_ERROR);
     return "pending";
   }
   registerChatSendTiming(host, sendingItem, runId, requestStartedAtMs);
@@ -349,9 +347,9 @@ async function sendQueuedChatMessage(
           publishRunStatus: false,
           armLocalTerminalReconcile: ack.runId === runId,
         });
-        setChatError(host, error);
         restoreComposer(host, options ?? {});
       }
+      surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, error);
       recordChatSendTiming(host, sendingItem, "failed", sendingItem.sendSubmittedAtMs, {
         error,
         ackStatus: ack.status,
@@ -431,9 +429,7 @@ async function sendQueuedChatMessage(
     }
     discardChatAttachmentDataUrls(excludeComposerAttachments(host, attachments));
     if (retirementFailed) {
-      if (isVisible()) {
-        setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-      }
+      surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, OFFLINE_QUEUE_STORAGE_ERROR);
       return "pending";
     }
     return retireOnAck ? "sent" : "pending";
@@ -478,9 +474,12 @@ async function sendQueuedChatMessage(
             sendState: safelyRejected ? "failed" : "unconfirmed",
           }));
         }
-        if (isVisible()) {
-          setChatError(host, restore ? error : OFFLINE_QUEUE_STORAGE_ERROR);
-        }
+        surfaceChatDeliveryFailure(
+          host,
+          sessionKey,
+          prepared.agentId,
+          restore ? error : OFFLINE_QUEUE_STORAGE_ERROR,
+        );
         recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, {
           error: restore ? error : OFFLINE_QUEUE_STORAGE_ERROR,
         });
@@ -503,9 +502,7 @@ async function sendQueuedChatMessage(
             sendState: "failed",
           }));
         }
-        if (isVisible()) {
-          setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-        }
+        surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, OFFLINE_QUEUE_STORAGE_ERROR);
         recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, {
           error: OFFLINE_QUEUE_STORAGE_ERROR,
         });
@@ -534,12 +531,12 @@ async function sendQueuedChatMessage(
     }
     setState("failed", error);
     if (isVisible()) {
-      setChatError(host, error);
       restoreComposer(host, options ?? {});
       if (activeLeafChanged) {
         void Promise.all([loadChatHistory(host), loadChatBranches(host)]);
       }
     }
+    surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, error);
     recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, { error });
     return "failed";
   } finally {

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -20,7 +20,7 @@ import { storedChatOutboxScopeKey, type StoredChatOutboxScope } from "./composer
 import { controlUiNowMs } from "./performance.ts";
 import { hasAbortableSessionRun, isChatBusy } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-import { OFFLINE_QUEUE_STORAGE_ERROR } from "./steer-lifecycle.ts";
+import { OFFLINE_QUEUE_STORAGE_ERROR, surfaceChatDeliveryFailure } from "./steer-lifecycle.ts";
 
 const SKILL_WORKSHOP_CONNECTION_CHANGED_ERROR =
   "Skill Workshop revision request cancelled because the Gateway connection changed.";
@@ -132,9 +132,12 @@ export function failSkillWorkshopRevisionConnectionChange(
     sessionKey,
     item.id,
   )("failed", SKILL_WORKSHOP_CONNECTION_CHANGED_ERROR);
-  if (visibleSessionMatches(host, sessionKey, item.agentId)) {
-    setChatError(host, SKILL_WORKSHOP_CONNECTION_CHANGED_ERROR);
-  }
+  surfaceChatDeliveryFailure(
+    host,
+    sessionKey,
+    item.agentId,
+    SKILL_WORKSHOP_CONNECTION_CHANGED_ERROR,
+  );
   return "failed";
 }
 

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -9566,6 +9566,81 @@ describe("handleSendChat", () => {
     });
     expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
   });
+
+  it("surfaces a failed local command globally after a route switch", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const item = createQueuedLocalCommand("route-switched-command", "/think", {
+      sessionKey: "agent:main:first",
+    });
+    // The dispatcher reports failure after the operator navigated away, so its
+    // stale-scope guard withholds the inline error.
+    executeSlashCommandMock.mockImplementation(async () => {
+      host.sessionKey = "agent:main:second";
+      return { failed: true, content: "think mode rejected" };
+    });
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": () => idleChatHistory("agent:main:first"),
+      },
+      chatQueue: [item],
+      sessionKey: item.sessionKey,
+    });
+    admitHostQueueItems(host);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    // Pre-fix: the failure was recorded on the queue item with no visible outcome.
+    expect(host.lastError).toBeNull();
+    await waitForFast(() => expect(document.body.textContent).toContain("Command /think failed."));
+    expect(listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue)).toEqual([
+      expect.objectContaining({ id: item.id, sendState: "failed" }),
+    ]);
+    document.body.replaceChildren();
+  });
+
+  it("names the failed agent's global session in the toast, not another agent's row", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": idleChatHistory("global"),
+        "chat.send": () => {
+          throw new GatewayRequestError({
+            code: "UNAUTHORIZED",
+            message: "gateway auth failed",
+            retryable: false,
+          });
+        },
+      },
+      chatQueue: [
+        {
+          id: "global-agent-scoped-failure",
+          text: "fails on the second agent's global session",
+          createdAt: 1,
+          sendAttempts: 0,
+          sendRunId: "global-agent-scoped-run",
+          sendState: "waiting-idle",
+          sessionKey: "global",
+          agentId: "writer",
+        },
+      ],
+      sessionKey: "agent:main:elsewhere",
+      sessionsResult: createSessionsResult([
+        row("global", { agentId: "main", label: "Main global chat" }),
+        row("global", { agentId: "writer", label: "Writer global chat" }),
+      ]),
+    });
+    admitHostQueueItems(host);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    await waitForFast(() => expect(document.body.textContent).toContain("gateway auth failed"));
+    // Global rows share one key; the toast must borrow the failed agent's label.
+    expect(document.body.textContent).toContain("Writer global chat");
+    expect(document.body.textContent).not.toContain("Main global chat");
+    document.body.replaceChildren();
+  });
 });
 
 describe("handleAbortChat", () => {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -9414,6 +9414,158 @@ describe("handleSendChat", () => {
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
   });
+
+  it("surfaces a terminal send failure through the global toast when the pane is not visible", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": idleChatHistory("agent:other"),
+        "chat.send": () => {
+          throw new GatewayRequestError({
+            code: "UNAUTHORIZED",
+            message: "gateway auth failed",
+            retryable: false,
+          });
+        },
+      },
+      chatQueue: [
+        {
+          id: "hidden-terminal-failure",
+          text: "fails while another session is visible",
+          createdAt: 1,
+          sendAttempts: 0,
+          sendRunId: "hidden-terminal-run",
+          sendState: "waiting-idle",
+          sessionKey: "agent:other",
+          agentId: "other",
+        },
+      ],
+      sessionKey: "agent:main",
+      sessionsResult: createSessionsResult([
+        row("agent:other", { hasActiveRun: false, status: "done" }),
+      ]),
+    });
+    admitHostQueueItems(host);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    // The invisible pane's inline error stays untouched; the failure surfaces globally.
+    expect(host.lastError).toBeNull();
+    await waitForFast(() => expect(document.body.textContent).toContain("gateway auth failed"));
+    expect(
+      listStoredChatOutboxes(host)
+        .flatMap((outbox) => outbox.queue)
+        .find((entry) => entry.id === "hidden-terminal-failure"),
+    ).toMatchObject({ sendState: "failed", sendError: "gateway auth failed" });
+    document.body.replaceChildren();
+  });
+
+  it("fails a never-attempted head visibly and unblocks the lane when head reconcile is rejected as non-retryable", async () => {
+    const sends: string[] = [];
+    let historyCalls = 0;
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": () => {
+          historyCalls += 1;
+          if (historyCalls === 1) {
+            throw new GatewayRequestError({
+              code: "UNAUTHORIZED",
+              message: "gateway auth failed",
+              retryable: false,
+            });
+          }
+          return idleChatHistory();
+        },
+        "chat.send": (params: unknown) => {
+          const payload = requireRecord(params, "post-unblock send payload");
+          sends.push(String(payload.message));
+          return { runId: payload.idempotencyKey, status: "ok" };
+        },
+      },
+      chatQueue: [
+        {
+          id: "wedged-head",
+          text: "head the gateway rejects",
+          createdAt: 1,
+          sendAttempts: 0,
+          sendRunId: "wedged-head-run",
+          sendState: "waiting-idle",
+          sessionKey: "agent:main",
+        },
+        {
+          id: "queued-behind-head",
+          text: "message stuck behind the head",
+          createdAt: 2,
+          sendAttempts: 0,
+          sendRunId: "queued-behind-run",
+          sendState: "waiting-idle",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+    const surfacedErrors: (string | null)[] = [];
+    let trackedError: string | null = host.lastError ?? null;
+    Object.defineProperty(host, "lastError", {
+      get: () => trackedError,
+      set: (value: string | null) => {
+        trackedError = value;
+        surfacedErrors.push(value);
+      },
+    });
+
+    await retryReconnectableQueuedChatSends(host);
+
+    // Pre-fix: the head stayed silently "blocked" forever and nothing surfaced.
+    expect(surfacedErrors).toContain("gateway auth failed");
+    const stored = listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue);
+    expect(stored.find((entry) => entry.id === "wedged-head")).toMatchObject({
+      sendState: "failed",
+      sendError: "gateway auth failed",
+    });
+    // The lane moved past the terminally failed head instead of wedging.
+    await waitForFast(() => expect(sends).toContain("message stuck behind the head"));
+  });
+
+  it("parks an attempted head as unconfirmed instead of failing it on a non-retryable reconcile rejection", async () => {
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": () => {
+          throw new GatewayRequestError({
+            code: "UNAUTHORIZED",
+            message: "gateway auth failed",
+            retryable: false,
+          });
+        },
+      },
+      chatQueue: [
+        {
+          id: "attempted-head",
+          text: "head that may have reached the server",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRunId: "attempted-head-run",
+          sendState: "waiting-reconnect",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    // An attempted head may already be a server-side turn; it must park for
+    // review rather than fail-and-release, and the outcome must be visible.
+    expect(host.lastError).toBe(
+      "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+    );
+    const stored = listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue);
+    expect(stored.find((entry) => entry.id === "attempted-head")).toMatchObject({
+      sendState: "unconfirmed",
+    });
+    expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+  });
 });
 
 describe("handleAbortChat", () => {

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -4,8 +4,13 @@ import type { SessionsListResult } from "../../api/types.ts";
 import { setLastActiveSessionKey } from "../../app/settings.ts";
 import { compareChatQueueOrder } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
-import { uiSessionRowMatchesSelectedChat } from "../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  uiSessionRowMatchesSelectedChat,
+} from "../../lib/sessions/session-key.ts";
+import { showToast } from "../../lib/toast.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import {
   getChatAttachmentDataUrl,
@@ -313,6 +318,36 @@ function setChatError(host: SteerLifecycleHost, error: string | null): void {
   host.chatError = error;
 }
 
+type ChatDeliveryFailureHost = Parameters<typeof visibleSessionMatches>[0] & {
+  lastError?: string | null;
+  chatError?: string | null;
+  sessionsResult?: SessionsListResult | null;
+};
+
+/**
+ * Terminal delivery failures must always end in a visible outcome. The pane
+ * showing this session keeps the inline chat error; after reconnect or alias
+ * drift the owning pane may no longer be on screen, so anything else surfaces
+ * a global toast naming the session instead of recording the error only on
+ * the queued row where nobody sees it.
+ */
+export function surfaceChatDeliveryFailure(
+  host: ChatDeliveryFailureHost,
+  sessionKey: string,
+  agentId: string | undefined,
+  error: string,
+): void {
+  if (visibleSessionMatches(host, sessionKey, agentId)) {
+    host.lastError = error;
+    host.chatError = error;
+    return;
+  }
+  const row = host.sessionsResult?.sessions.find((session) =>
+    areUiSessionKeysEquivalent(session.key, sessionKey),
+  );
+  showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${error}` });
+}
+
 export async function sendQueuedChatMessageWithQueueMode(
   host: SteerSendHost,
   id: string,
@@ -446,9 +481,12 @@ export async function sendQueuedChatMessageWithQueueMode(
       sendError: result.error,
       sendState: "failed",
     }));
-    if (itemStillVisible) {
-      setChatError(host, failed ? result.error : OFFLINE_QUEUE_STORAGE_ERROR);
-    }
+    surfaceChatDeliveryFailure(
+      host,
+      itemSessionKey,
+      item.agentId,
+      failed ? result.error : OFFLINE_QUEUE_STORAGE_ERROR,
+    );
     return;
   }
   const ack = result;
@@ -462,9 +500,12 @@ export async function sendQueuedChatMessageWithQueueMode(
         setChatError(host, unconfirmedError);
       }
     } else {
-      if (itemStillVisible) {
-        setChatError(host, formatTerminalChatSendAckError(ack, isSteer ? "steer" : "chat"));
-      }
+      surfaceChatDeliveryFailure(
+        host,
+        itemSessionKey,
+        item.agentId,
+        formatTerminalChatSendAckError(ack, isSteer ? "steer" : "chat"),
+      );
       dependencies.resumeRestoredOutbox(host, id);
     }
     return;

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -8,6 +8,8 @@ import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
 import {
   areUiSessionKeysEquivalent,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
   uiSessionRowMatchesSelectedChat,
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
@@ -342,8 +344,15 @@ export function surfaceChatDeliveryFailure(
     host.chatError = error;
     return;
   }
-  const row = host.sessionsResult?.sessions.find((session) =>
-    areUiSessionKeysEquivalent(session.key, sessionKey),
+  // Global rows are agent-scoped while sharing one "global" key, so an
+  // agent-less equivalence match could borrow another agent's label.
+  const scopedAgentId = agentId ? normalizeAgentId(agentId) : undefined;
+  const row = host.sessionsResult?.sessions.find(
+    (session) =>
+      areUiSessionKeysEquivalent(session.key, sessionKey) &&
+      (!isUiGlobalSessionKey(sessionKey) ||
+        !scopedAgentId ||
+        (session.agentId !== undefined && normalizeAgentId(session.agentId) === scopedAgentId)),
   );
   showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${error}` });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators sending a chat message from the Control UI would see no outcome at all when the send terminally failed while the owning session pane was not visible (after navigating to another session, a reconnect, alias drift, or split-pane routing). The failure was recorded only on the stored queue item; nothing on screen changed.

Worse, a non-retryable Gateway rejection (e.g. auth loss) during the FIFO outbox head's history reconcile was treated as a silent retryable "blocked", wedging the head — and every message queued behind it — permanently with no visible outcome. This is the worst bug class under the repo's severity order: an action ending in silence.

A smaller sibling: the composer's cloud-startup-pending gate disabled the composer with no stated reason, and an existing draft hid the disabled-reason placeholder.

## Why This Change Was Made

Terminal delivery failures must always end in a visible outcome. A new canonical `surfaceChatDeliveryFailure()` helper in `steer-lifecycle.ts` (the shared error-text owner) routes every terminal failure: a visible pane keeps the inline chat error exactly as before; otherwise the failure surfaces through the existing global toast host, naming the owning session. All terminal failure sites in `chat-send-delivery.ts`, `chat-outbox-drain.ts`, `chat-send-queue-state.ts`, and `steer-lifecycle.ts` now use it — no per-site visibility gating remains.

For the wedged-head case, `reconcileStoredChatOutboxHead` now distinguishes non-retryable `GatewayRequestError` rejections: a never-attempted head terminally fails with a visible outcome and the lane continues draining; an attempted head parks as `unconfirmed` (duplicate-send safety — we cannot prove the Gateway never executed it). The composer's cloud-startup gate gets a stated reason, and the disabled reason renders even while a draft hides the placeholder.

## User Impact

Operators always see why a message did not deliver: inline in the chat pane when they are looking at it, or as a global toast naming the session when they are not. A dead credential no longer silently freezes a session's outgoing queue forever — the queue either fails visibly or parks unconfirmed with an explanation, and later messages still drain.

## Evidence

**Regression tests (fail pre-fix, stash-verified):** 3 new tests in `ui/src/pages/chat/chat-send.test.ts` (hidden-pane terminal failure surfaces via toast; non-retryable never-attempted head fails visibly and the lane drains the next message; attempted head parks unconfirmed) and 1 in `ui/src/pages/chat/chat-composer.test.ts` (disabled reason visible with draft text present). Full files pass post-rebase: 329 tests, 2 files (`node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-composer.test.ts`).

**Mock-gateway E2E lane:** `ui/src/e2e/chat-flow.messaging.e2e.test.ts` — 17 passed post-rebase.

**Before/after visual proof** (mocked Gateway, Playwright-driven Chromium; scenario: a queued send for "Deploy helper" drains after reconnect while the operator is viewing "Research notes", and the Gateway rejects `chat.send` non-retryably with `UNAUTHORIZED: gateway auth failed`):

Before (`origin/main` @ e2e070c927a) — send fails while another session is visible; **no visible outcome anywhere**:

![before: silent failure, no toast](https://github.com/user-attachments/assets/6cfa0085-6f23-4e2e-88b6-a998b6a26af1)

After (this branch) — global toast names the owning session and the error:

![after: toast "Deploy helper: gateway auth failed"](https://github.com/user-attachments/assets/5820abb0-e01a-44fe-8a63-185149ccf8e5)

Video of the after-fix flow:

https://github.com/user-attachments/assets/df19d3d3-4984-474d-94da-ac1a495b8af0

**LOC delta:** +87 production / +166 test (net). The production growth carries two missing capabilities that no existing owner could absorb: global failure-surface routing (`surfaceChatDeliveryFailure` + toast session naming) and terminal head handling in the outbox reconcile (fail-visible vs park-unconfirmed discrimination). Reviewed for a net-neutral absorbing refactor; the per-site `visibleSessionMatches` guards it replaces were the smaller shape only because they dropped the failure on the floor.

**Checks:** `node scripts/check-changed.mjs` clean (typecheck UI, lint, i18n verify, dead-export scan). Autoreview clean (0.98).
