### PR TITLE
fix(logging): set truncated flag when line count exceeds limit

### DIFF
--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -100,6 +100,20 @@ describe("readConfiguredLogTail", () => {
     expect(result).toBe(devLog);
   });
 
+  it("sets truncated flag when line count exceeds limit", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const lines = Array.from({ length: 10 }, (_, i) => `line-${i}`);
+    await fs.writeFile(file, lines.join("\n") + "\n");
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredLogTail({ limit: 5 });
+
+    expect(result.lines).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+    expect(result.truncated).toBe(true);
+  });
+
   it("does not reinterpret an explicit profile-shaped logging.file as rolling", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -139,6 +139,7 @@ async function readLogSlice(params: {
     }
     if (lines.length > limit) {
       lines = lines.slice(lines.length - limit);
+      truncated = true;
     }
 
     cursor = size;


### PR DESCRIPTION
## Problem
In \eadLogSlice\, when the number of lines read from the log file exceeds the configured \limit\, the lines are truncated to the last \limit\ entries. However, the \	runcated\ flag was not being set to \	rue\ in this case, leaving callers unaware that earlier lines were dropped.

## Fix
Set \	runcated = true\ when \lines.length > limit\ in the \eadLogSlice\ function, so callers can correctly detect that line-count truncation occurred.

## Tests
Added a test that writes 10 lines, reads with a limit of 5, and asserts that \	runcated\ is \	rue\ and only the last 5 lines are returned.