### PR TITLE
fix(agents): add contextWindow fallback and default in readAgentModelContextTokens

### DIFF
--- a/src/agents/embedded-agent-runner/model-context-tokens.test.ts
+++ b/src/agents/embedded-agent-runner/model-context-tokens.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { Model } from "../../llm/types.js";
+import { readAgentModelContextTokens } from "./model-context-tokens.js";
+
+function makeModel(overrides: Partial<Model> & { contextTokens?: number; contextWindow?: number } = {}) {
+  return {
+    id: "test-model",
+    name: "Test Model",
+    provider: "test",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    maxTokens: 4096,
+    ...overrides,
+  } as Model & { contextTokens?: number; contextWindow?: number };
+}
+
+describe("readAgentModelContextTokens", () => {
+  it("returns contextTokens when present and positive", () => {
+    const model = makeModel({ contextTokens: 32000 });
+    expect(readAgentModelContextTokens(model)).toBe(32000);
+  });
+
+  it("falls back to contextWindow when contextTokens is undefined", () => {
+    const model = makeModel({ contextWindow: 64000 });
+    expect(readAgentModelContextTokens(model)).toBe(64000);
+  });
+
+  it("falls back to contextWindow when contextTokens is 0", () => {
+    const model = makeModel({ contextTokens: 0, contextWindow: 64000 });
+    expect(readAgentModelContextTokens(model)).toBe(64000);
+  });
+
+  it("returns the default when both contextTokens and contextWindow are 0 or undefined", () => {
+    expect(readAgentModelContextTokens(makeModel())).toBe(128000);
+    expect(readAgentModelContextTokens(makeModel({ contextWindow: 0 }))).toBe(128000);
+  });
+
+  it("returns the default for null or undefined model", () => {
+    expect(readAgentModelContextTokens(null)).toBe(128000);
+    expect(readAgentModelContextTokens(undefined)).toBe(128000);
+  });
+});

--- a/src/agents/embedded-agent-runner/model-context-tokens.ts
+++ b/src/agents/embedded-agent-runner/model-context-tokens.ts
@@ -11,9 +11,19 @@ type AgentModelWithOptionalContextTokens = Model & {
   contextTokens?: number;
 };
 
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+
 /** Returns finite context-token metadata when a model discovery source provided it. */
 /** Prefer contextTokens, then contextWindow, when present on model metadata. */
 export function readAgentModelContextTokens(model: Model | null | undefined): number | undefined {
-  const value = (model as AgentModelWithOptionalContextTokens | null | undefined)?.contextTokens;
-  return asFiniteNumber(value);
+  const cast = model as AgentModelWithOptionalContextTokens | null | undefined;
+  const contextTokens = asFiniteNumber(cast?.contextTokens);
+  if (contextTokens !== undefined && contextTokens > 0) {
+    return contextTokens;
+  }
+  const contextWindow = asFiniteNumber((cast as Model & { contextWindow?: number })?.contextWindow);
+  if (contextWindow !== undefined && contextWindow > 0) {
+    return contextWindow;
+  }
+  return DEFAULT_CONTEXT_WINDOW;
 }


### PR DESCRIPTION
## Problem
\eadAgentModelContextTokens\ only checked \contextTokens\ on model metadata. When \contextTokens\ was 0 or undefined but \contextWindow\ was available, the function returned \undefined\ instead of falling back to \contextWindow\. This caused downstream context budget calculations to silently degrade.

## Fix
- Prefer \contextTokens\ when present and positive
- Fall back to \contextWindow\ when \contextTokens\ is 0 or undefined
- Return a default of 128,000 when neither field is available

## Tests
Added tests covering: contextTokens present, contextWindow fallback, zero-value fallback, and null/undefined model inputs.