### PR TITLE
fix(shared): validate port range for numeric proxy strings in tailscale status

### DIFF
--- a/src/shared/tailscale-status.test.ts
+++ b/src/shared/tailscale-status.test.ts
@@ -111,6 +111,22 @@ describe("shared/tailscale-status", () => {
     });
   });
 
+  it("rejects out-of-range numeric proxy ports", async () => {
+    const run = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({
+        TCP: { "443": { HTTPS: true } },
+        Web: {
+          "mac.tail.ts.net:443": {
+            Handlers: { "/": { Proxy: "0" } },
+          },
+        },
+      }),
+    });
+
+    await expect(resolveTailscaleServeGatewayUrlsWithRunner(0, run)).resolves.toEqual([]);
+  });
+
   it("ignores non-root, non-HTTPS, and non-loopback Serve handlers", async () => {
     const run = vi.fn().mockResolvedValue({
       code: 0,

--- a/src/shared/tailscale-status.ts
+++ b/src/shared/tailscale-status.ts
@@ -70,7 +70,8 @@ function extractTailnetHostFromStatusJson(raw: string): string | null {
 function parseLoopbackProxyPort(proxy: string): number | null {
   const trimmed = proxy.trim();
   if (/^\d+$/.test(trimmed)) {
-    return Number.parseInt(trimmed, 10);
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
   }
   const normalized = trimmed.includes("://") ? trimmed : `http://${trimmed}`;
   try {


### PR DESCRIPTION
## Problem
\parseLoopbackProxyPort\ returned the raw parsed integer for numeric-only proxy strings without validating the port range (1-65535). This was inconsistent with the URL-based branch which does validate the range, and could allow invalid port values like 0 or 99999.

## Fix
Add the same \>= 1 && <= 65_535\ range check to the numeric-only branch that already exists in the URL-parsing branch.

## Tests
Added a test that verifies port 0 is rejected.