### PR TITLE
fix(cli): guard against NaN timeout in health route

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -105,6 +105,30 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("falls back to default timeout when rpc.timeout is non-numeric", async () => {
+    const runtime = createRuntime();
+    const error = new Error("gateway health failed");
+    const callGateway = vi.fn(async () => { throw error; });
+    const emitReachableGatewayAuthDiagnostic = vi.fn(async () => false);
+
+    await runGatewayHealthJsonRoute(
+      { rpc: { json: true, timeout: "not-a-number" } },
+      runtime as never,
+      {
+        callGateway,
+        readBestEffortConfig: async () => ({}),
+        emitReachableGatewayAuthDiagnostic: emitReachableGatewayAuthDiagnostic as never,
+        formatGatewayAuthErrorJson: vi.fn(() => null) as never,
+        formatGatewayClientRequestErrorJson: vi.fn(() => null) as never,
+        formatGatewayTransportErrorJson: vi.fn(() => null) as never,
+      },
+    );
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+  });
+
   it("preserves structured transport errors", async () => {
     const runtime = createRuntime();
     const error = new Error("gateway unavailable");

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -87,7 +87,7 @@ export async function runGatewayHealthJsonRoute(
       error,
       config: rpc.config ?? (await readBestEffortConfig()),
       runtime,
-      timeoutMs: Number(rpc.timeout ?? "10000"),
+      timeoutMs: Number.isFinite(Number(rpc.timeout ?? "10000")) ? Number(rpc.timeout ?? "10000") : 10_000,
       token: rpc.token,
       password: rpc.password,
       localPortOverride: rpc.localPortOverride,


### PR DESCRIPTION
## Problem
\Number(rpc.timeout ?? '10000')\ could produce \NaN\ when \pc.timeout\ is a non-numeric string. This NaN would be passed as \	imeoutMs\ to downstream diagnostics, causing unpredictable behavior.

## Fix
Wrap the conversion with \Number.isFinite()\ and fall back to the default 10,000ms when the result is NaN or Infinity.

## Tests
Added a test that passes a non-numeric timeout string and verifies the fallback to 10,000ms.