### PR TITLE
fix(agents): continue uncached when Google prompt-cache responses fail

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1772,7 +1772,7 @@ src/agents/embedded-agent-runner/direct-compaction-preparation.ts	1
 src/agents/embedded-agent-runner/empty-assistant-turn.ts	1
 src/agents/embedded-agent-runner/extensions.ts	1
 src/agents/embedded-agent-runner/extra-params.ts	12
-src/agents/embedded-agent-runner/google-prompt-cache.ts	6
+src/agents/embedded-agent-runner/google-prompt-cache.ts	5
 src/agents/embedded-agent-runner/history.ts	2
 src/agents/embedded-agent-runner/message-visibility.ts	13
 src/agents/embedded-agent-runner/model-context-tokens.ts	1

--- a/src/agents/embedded-agent-runner/google-prompt-cache.failures.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.failures.test.ts
@@ -1,0 +1,652 @@
+import crypto from "node:crypto";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { SessionTranscriptWriterClaimReboundError } from "../../config/sessions/transcript-write-context.js";
+import { attachModelProviderRequestTransport } from "../provider-request-config.js";
+import { buildGuardedModelFetch } from "../provider-transport-fetch.js";
+import {
+  createCacheFetchMock,
+  createCapturingStreamFn,
+  createOversizedJsonResponse,
+  fetchUrl,
+  makeGoogleModel,
+  makeSessionManager,
+  preparePromptCacheStream,
+  type SessionCustomEntry,
+  streamContext,
+} from "./google-prompt-cache.test-support.js";
+
+const NOW = 1_000_000;
+const TOOLS = [
+  {
+    name: "lookup",
+    description: "Look up a value",
+    parameters: { type: "object" },
+  },
+];
+
+function promptContext() {
+  return {
+    systemPrompt: "Follow policy.",
+    messages: [],
+    tools: TOOLS,
+  } as never;
+}
+
+function invoke(
+  wrapped: Awaited<ReturnType<typeof preparePromptCacheStream>>,
+  model = makeGoogleModel(),
+  context = promptContext(),
+) {
+  return Promise.resolve(wrapped?.(model, context, {} as never));
+}
+
+const plainPromptContext = { systemPrompt: "Follow policy.", messages: [] } as never;
+
+function readyEntry(params: {
+  cachedContent?: string;
+  expireTime?: unknown;
+  now?: number;
+}): SessionCustomEntry {
+  const now = params.now ?? NOW;
+  return {
+    id: "entry-ready",
+    parentId: null,
+    timestamp: new Date(now - 5_000).toISOString(),
+    type: "custom",
+    customType: "openclaw.google-prompt-cache",
+    data: {
+      status: "ready",
+      timestamp: now - 5_000,
+      provider: "google",
+      modelId: "gemini-3.1-pro-preview",
+      modelApi: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      systemPromptDigest: crypto.createHash("sha256").update("Follow policy.").digest("hex"),
+      cacheRetention: "long",
+      cachedContent: params.cachedContent ?? "cachedContents/existing",
+      ...(params.expireTime === undefined ? {} : { expireTime: params.expireTime }),
+    },
+  };
+}
+
+function failedEntry(retryAfter: number): SessionCustomEntry {
+  return {
+    id: "entry-failed",
+    parentId: null,
+    timestamp: new Date(NOW - 5_000).toISOString(),
+    type: "custom",
+    customType: "openclaw.google-prompt-cache",
+    data: {
+      status: "failed",
+      timestamp: NOW - 5_000,
+      provider: "google",
+      modelId: "gemini-3.1-pro-preview",
+      modelApi: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      systemPromptDigest: crypto.createHash("sha256").update("Follow policy.").digest("hex"),
+      cacheRetention: "long",
+      retryAfter,
+    },
+  };
+}
+
+describe("google prompt cache failure handling", () => {
+  it.each([
+    ["malformed JSON", () => new Response("not-json{{{", { status: 200 })],
+    [
+      "invalid UTF-8",
+      () =>
+        new Response(new Uint8Array([0x7b, 0x22, 0x6b, 0x22, 0x3a, 0xff, 0x7d]), {
+          status: 200,
+        }),
+    ],
+    ["JSON null", () => new Response("null", { status: 200 })],
+    ["JSON primitive", () => new Response("42", { status: 200 })],
+    ["JSON array", () => new Response("[]", { status: 200 })],
+    ["oversized JSON", () => createOversizedJsonResponse().response],
+    [
+      "body read failure",
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              throw new Error("broken cache response body");
+            },
+          }),
+          { status: 200 },
+        ),
+    ],
+  ])("continues uncached after %s", async (_name, responseFactory) => {
+    const entries: SessionCustomEntry[] = [];
+    const fetchMock = vi.fn(async () => responseFactory());
+    const innerStreamFn = vi.fn(() => "visible-output" as never);
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).resolves.toBe("visible-output");
+    expect(streamContext(innerStreamFn)).toMatchObject({
+      systemPrompt: "Follow policy.",
+      tools: TOOLS,
+    });
+    expect(entries.at(-1)?.data).toMatchObject({ status: "failed" });
+  });
+
+  it.each([
+    ["missing name", { expireTime: new Date(NOW + 60_000).toISOString() }],
+    ["blank name", { name: " ", expireTime: new Date(NOW + 60_000).toISOString() }],
+    [
+      "wrong name prefix",
+      { name: "files/cache-id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "multi-segment name",
+      { name: "cachedContents/cache/id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "C0 null name",
+      { name: "cachedContents/cache\u0000id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "C0 unit-separator name",
+      { name: "cachedContents/cache\u001fid", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "DEL name",
+      { name: "cachedContents/cache\u007fid", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "C1 next-line name",
+      { name: "cachedContents/cache\u0085id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "lone high-surrogate name",
+      { name: "cachedContents/cache\ud800id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "lone low-surrogate name",
+      { name: "cachedContents/cache\udc00id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "NFC Unicode name",
+      { name: "cachedContents/caf\u00e9", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "NFD Unicode name",
+      { name: "cachedContents/cafe\u0301", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "embedded-whitespace name",
+      { name: "cachedContents/cache id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "query-delimited name",
+      { name: "cachedContents/cache-id?bad", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "fragment-delimited name",
+      { name: "cachedContents/cache-id#bad", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "backslash-delimited name",
+      { name: "cachedContents/cache\\id", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "percent-encoded separator name",
+      { name: "cachedContents/cache%2Fid", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "current-directory name",
+      { name: "cachedContents/.", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    [
+      "parent-directory name",
+      { name: "cachedContents/..", expireTime: new Date(NOW + 60_000).toISOString() },
+    ],
+    ["missing expiry", { name: "cachedContents/cache-id" }],
+    ["non-string expiry", { name: "cachedContents/cache-id", expireTime: 123 }],
+    ["unparseable expiry", { name: "cachedContents/cache-id", expireTime: "not-a-date" }],
+    [
+      "nonfuture expiry",
+      { name: "cachedContents/cache-id", expireTime: new Date(NOW).toISOString() },
+    ],
+  ])("rejects automatic cache creation with %s", async (_name, payload) => {
+    const entries: SessionCustomEntry[] = [];
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 }));
+    const { streamFn, getCapturedPayload } = createCapturingStreamFn("visible-output");
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn,
+    });
+
+    await expect(invoke(wrapped)).resolves.toBe("visible-output");
+    expect(streamFn).toHaveBeenCalledOnce();
+    expect(streamContext(streamFn)).toMatchObject({
+      systemPrompt: "Follow policy.",
+      tools: TOOLS,
+    });
+    expect(getCapturedPayload()).not.toHaveProperty("cachedContent");
+    expect(entries.at(-1)?.data).toMatchObject({
+      status: "failed",
+      retryAfter: NOW + 10 * 60_000,
+    });
+  });
+
+  it.each([
+    ["HTTP failure", async () => new Response("denied", { status: 403 })],
+    [
+      "network failure",
+      async () => {
+        throw new Error("network unavailable");
+      },
+    ],
+    [
+      "transport timeout",
+      async () => {
+        throw new Error("model request timed out");
+      },
+    ],
+    [
+      "provider abort",
+      async () => {
+        throw new DOMException("provider stopped", "AbortError");
+      },
+    ],
+  ])("continues uncached after %s", async (_name, fetchImpl) => {
+    const entries: SessionCustomEntry[] = [];
+    const innerStreamFn = vi.fn(() => "visible-output" as never);
+    const wrapped = await preparePromptCacheStream({
+      fetchMock: vi.fn(fetchImpl),
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).resolves.toBe("visible-output");
+    expect(streamContext(innerStreamFn)).toMatchObject({
+      systemPrompt: "Follow policy.",
+      tools: TOOLS,
+    });
+    expect(entries.at(-1)?.data).toMatchObject({ status: "failed" });
+  });
+
+  it("propagates the caller abort reason without persisting failure or streaming", async () => {
+    const reason = new Error("caller cancelled");
+    const controller = new AbortController();
+    controller.abort(reason);
+    const entries: SessionCustomEntry[] = [];
+    const innerStreamFn = vi.fn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock: vi.fn(async () => {
+        throw new DOMException("fetch aborted", "AbortError");
+      }),
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      signal: controller.signal,
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).rejects.toBe(reason);
+    expect(entries).toHaveLength(0);
+    expect(innerStreamFn).not.toHaveBeenCalled();
+  });
+
+  it("keeps unregistered auth sentinel failures outside optional cache handling", async () => {
+    const innerStreamFn = vi.fn();
+    const fetchMock = vi.fn();
+    const wrapped = await preparePromptCacheStream({
+      apiKey: "oc-sent-v2.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.end",
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).rejects.toThrow("is not registered in this process");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(innerStreamFn).not.toHaveBeenCalled();
+  });
+
+  it("keeps request-header construction failures outside optional cache handling", async () => {
+    const constructionFailure = new Error("request headers unavailable");
+    const model = makeGoogleModel();
+    Object.defineProperty(model, "headers", {
+      get() {
+        throw constructionFailure;
+      },
+    });
+    const entries: SessionCustomEntry[] = [];
+    const fetchMock = vi.fn();
+    const innerStreamFn = vi.fn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      model,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped, model)).rejects.toBe(constructionFailure);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(entries).toHaveLength(0);
+    expect(innerStreamFn).not.toHaveBeenCalled();
+  });
+
+  it("propagates writer-claim rebound while recording cache failure", async () => {
+    const rebound = new SessionTranscriptWriterClaimReboundError();
+    const innerStreamFn = vi.fn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock: vi.fn(async () => new Response("denied", { status: 403 })),
+      now: NOW,
+      sessionManager: {
+        appendCustomEntry: vi.fn(async () => {
+          throw rebound;
+        }),
+        getEntries: () => [],
+      },
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).rejects.toBe(rebound);
+    expect(innerStreamFn).not.toHaveBeenCalled();
+  });
+
+  it("continues when failure metadata persistence fails generically", async () => {
+    const innerStreamFn = vi.fn(() => "visible-output" as never);
+    const wrapped = await preparePromptCacheStream({
+      fetchMock: vi.fn(async () => new Response("denied", { status: 403 })),
+      now: NOW,
+      sessionManager: {
+        appendCustomEntry: vi.fn(async () => {
+          throw new Error("metadata unavailable");
+        }),
+        getEntries: () => [],
+      },
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).resolves.toBe("visible-output");
+  });
+
+  it.each([
+    ["missing expiry", { expireTime: undefined }],
+    ["malformed expiry", { expireTime: "not-a-date" }],
+    ["nonfuture expiry", { expireTime: new Date(NOW).toISOString() }],
+    [
+      "invalid cache name",
+      {
+        cachedContent: "files/cache-id",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "query-delimited cache name",
+      {
+        cachedContent: "cachedContents/cache-id?bad",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "fragment-delimited cache name",
+      {
+        cachedContent: "cachedContents/cache-id#bad",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "backslash-delimited cache name",
+      {
+        cachedContent: "cachedContents/cache\\id",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "percent-encoded separator cache name",
+      {
+        cachedContent: "cachedContents/cache%2Fid",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "current-directory cache name",
+      {
+        cachedContent: "cachedContents/.",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "parent-directory cache name",
+      {
+        cachedContent: "cachedContents/..",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "C0 cache name",
+      {
+        cachedContent: "cachedContents/cache\u0000id",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "lone-surrogate cache name",
+      {
+        cachedContent: "cachedContents/cache\ud800id",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+    [
+      "Unicode cache name",
+      {
+        cachedContent: "cachedContents/caf\u00e9",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      },
+    ],
+  ])("rebuilds persisted ready state with %s", async (_name, entry) => {
+    const entries = [readyEntry(entry)];
+    const fetchMock = createCacheFetchMock({
+      name: "cachedContents/rebuilt",
+      expireTime: new Date(NOW + 3_600_000).toISOString(),
+    });
+    const { streamFn, getCapturedPayload } = createCapturingStreamFn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn,
+    });
+
+    await invoke(wrapped, makeGoogleModel(), plainPromptContext);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchUrl(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/cachedContents",
+    );
+    expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/rebuilt");
+  });
+
+  it("continues uncached when an invalid persisted name cannot be rebuilt", async () => {
+    const entries = [
+      readyEntry({
+        cachedContent: "cachedContents/cache\u0000id",
+        expireTime: new Date(NOW + 3_600_000).toISOString(),
+      }),
+    ];
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            name: "cachedContents/cache\u0000id",
+            expireTime: new Date(NOW + 3_600_000).toISOString(),
+          }),
+          { status: 200 },
+        ),
+    );
+    const { streamFn, getCapturedPayload } = createCapturingStreamFn("visible-output");
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn,
+    });
+
+    await expect(invoke(wrapped)).resolves.toBe("visible-output");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchUrl(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/cachedContents",
+    );
+    expect(streamContext(streamFn)).toMatchObject({
+      systemPrompt: "Follow policy.",
+      tools: TOOLS,
+    });
+    expect(getCapturedPayload()).not.toHaveProperty("cachedContent");
+    expect(entries.at(-1)?.data).toMatchObject({
+      status: "failed",
+      retryAfter: NOW + 10 * 60_000,
+    });
+  });
+
+  it("refreshes a transport-stable punctuation name at the exact URL", async () => {
+    const cachedContent = "cachedContents/cache-_.!~*'()";
+    const entries = [
+      readyEntry({
+        cachedContent,
+        expireTime: new Date(NOW + 60_000).toISOString(),
+      }),
+    ];
+    const fetchMock = createCacheFetchMock({
+      name: cachedContent,
+      expireTime: new Date(NOW + 3_600_000).toISOString(),
+    });
+    const { streamFn, getCapturedPayload } = createCapturingStreamFn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn,
+    });
+
+    await invoke(wrapped, makeGoogleModel(), plainPromptContext);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchUrl(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/cachedContents/cache-_.!~*'()?updateMask=ttl",
+    );
+    expect(getCapturedPayload()?.cachedContent).toBe(cachedContent);
+  });
+
+  it.each([
+    ["malformed JSON", "not-json{{{"],
+    ["missing expiry", "{}"],
+    ["nonfuture expiry", JSON.stringify({ expireTime: new Date(NOW).toISOString() })],
+  ])("retains a valid existing cache after refresh returns %s", async (_name, body) => {
+    const entries = [
+      readyEntry({
+        cachedContent: "cachedContents/existing",
+        expireTime: new Date(NOW + 60_000).toISOString(),
+      }),
+    ];
+    const fetchMock = vi.fn(async () => new Response(body, { status: 200 }));
+    const { streamFn, getCapturedPayload } = createCapturingStreamFn();
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager(entries),
+      streamFn,
+    });
+
+    await invoke(wrapped, makeGoogleModel(), plainPromptContext);
+    expect(fetchUrl(fetchMock)).toContain("cachedContents/existing?updateMask=ttl");
+    expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/existing");
+    expect(entries).toHaveLength(1);
+  });
+
+  it("honors failed-cache backoff without another create attempt", async () => {
+    const fetchMock = vi.fn();
+    const innerStreamFn = vi.fn(() => "visible-output" as never);
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now: NOW,
+      sessionManager: makeSessionManager([failedEntry(NOW + 60_000)]),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped, makeGoogleModel(), plainPromptContext)).resolves.toBe(
+      "visible-output",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not swallow primary stream failures after cache degradation", async () => {
+    const primaryFailure = new Error("primary stream failed");
+    const innerStreamFn = vi.fn(async () => {
+      throw primaryFailure;
+    }) as unknown as StreamFn;
+    const wrapped = await preparePromptCacheStream({
+      fetchMock: vi.fn(async () => new Response("denied", { status: 403 })),
+      now: NOW,
+      sessionManager: makeSessionManager(),
+      streamFn: innerStreamFn,
+    });
+
+    await expect(invoke(wrapped)).rejects.toBe(primaryFailure);
+  });
+
+  it("continues through the guarded network path when cache creation is malformed", async () => {
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      requests.push(request.url ?? "");
+      if (request.url?.endsWith("/cachedContents")) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("not-json{{{");
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("visible-generation-output");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("loopback server did not expose a TCP address");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}/v1beta`;
+      const model = attachModelProviderRequestTransport(
+        { ...makeGoogleModel(), baseUrl },
+        { allowPrivateNetwork: true },
+      );
+      const entries: SessionCustomEntry[] = [];
+      const innerStreamFn = vi.fn(async () => {
+        const response = await buildGuardedModelFetch(model)(
+          `${baseUrl}/models/${model.id}:streamGenerateContent`,
+          { method: "POST", body: "{}" },
+        );
+        return await response.text();
+      }) as unknown as StreamFn;
+      const wrapped = await preparePromptCacheStream({
+        model,
+        now: NOW,
+        sessionManager: makeSessionManager(entries),
+        streamFn: innerStreamFn,
+      });
+
+      await expect(invoke(wrapped, model)).resolves.toBe("visible-generation-output");
+      expect(requests).toEqual([
+        "/v1beta/cachedContents",
+        `/v1beta/models/${model.id}:streamGenerateContent`,
+      ]);
+      expect(entries.at(-1)?.data).toMatchObject({ status: "failed" });
+    } finally {
+      server.close();
+      await once(server, "close");
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test-support.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test-support.ts
@@ -1,0 +1,174 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { vi } from "vitest";
+import { prepareGooglePromptCacheStreamFn } from "./google-prompt-cache.js";
+
+export type SessionCustomEntry = {
+  type: "custom";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  customType: string;
+  data: unknown;
+};
+
+export type TestGooglePromptCacheSessionManager = {
+  appendCustomEntry(customType: string, data: unknown): void | Promise<void>;
+  getEntries(): SessionCustomEntry[];
+};
+
+export function makeSessionManager(entries: SessionCustomEntry[] = []) {
+  let counter = 0;
+  return {
+    appendCustomEntry(customType: string, data: unknown) {
+      counter += 1;
+      entries.push({
+        type: "custom" as const,
+        id: `entry-${counter}`,
+        parentId: null,
+        timestamp: new Date(counter * 1_000).toISOString(),
+        customType,
+        data,
+      });
+    },
+    getEntries() {
+      return entries;
+    },
+  };
+}
+
+export function makeGoogleModel(id = "gemini-3.1-pro-preview") {
+  return {
+    id,
+    name: id,
+    api: "google-generative-ai",
+    provider: "google",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+    headers: { "X-Provider": "google" },
+  } satisfies Model<"google-generative-ai">;
+}
+
+export function createCacheFetchMock(params: { name: string; expireTime: string }) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(params), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+export function createOversizedJsonResponse(): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn(async () => undefined);
+  let pullCount = 0;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(new Uint8Array(pullCount === 1 ? 1024 * 1024 + 1 : 1));
+      },
+      cancel,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+  return { response, cancel };
+}
+
+export function createCapturingStreamFn(result = "stream") {
+  let capturedPayload: Record<string, unknown> | undefined;
+  const streamFn = vi.fn(
+    (
+      model: Parameters<StreamFn>[0],
+      _context: Parameters<StreamFn>[1],
+      options: Parameters<StreamFn>[2],
+    ) => {
+      const payload: Record<string, unknown> = {};
+      void options?.onPayload?.(payload, model);
+      capturedPayload = payload;
+      return result as never;
+    },
+  );
+  return {
+    streamFn,
+    getCapturedPayload: () => capturedPayload,
+  };
+}
+
+export function callArg(
+  mock: { mock: { calls: unknown[][] } },
+  callIndex: number,
+  argIndex: number,
+) {
+  const call = mock.mock.calls[callIndex];
+  if (!call || argIndex >= call.length) {
+    throw new Error(`Expected mock call ${callIndex} argument ${argIndex}`);
+  }
+  return call[argIndex];
+}
+
+export function fetchInit(fetchMock: { mock: { calls: unknown[][] } }, callIndex = 0): RequestInit {
+  const init = callArg(fetchMock, callIndex, 1);
+  if (!init || typeof init !== "object") {
+    throw new Error(`expected fetch init for call ${callIndex}`);
+  }
+  return init as RequestInit;
+}
+
+export function fetchUrl(fetchMock: { mock: { calls: unknown[][] } }, callIndex = 0): string {
+  return String(callArg(fetchMock, callIndex, 0));
+}
+
+export function streamContext(streamFn: { mock: { calls: unknown[][] } }, callIndex = 0) {
+  return callArg(streamFn, callIndex, 1) as {
+    systemPrompt?: unknown;
+    tools?: unknown;
+  };
+}
+
+export function streamOptions(streamFn: { mock: { calls: unknown[][] } }, callIndex = 0) {
+  return callArg(streamFn, callIndex, 2) as Record<string, unknown>;
+}
+
+export function preparePromptCacheStream(params: {
+  apiKey?: string;
+  buildGuardedFetch?: () => typeof fetch;
+  fetchMock?: ReturnType<typeof vi.fn>;
+  model?: ReturnType<typeof makeGoogleModel>;
+  now: number;
+  sessionManager: TestGooglePromptCacheSessionManager;
+  signal?: AbortSignal;
+  streamFn: StreamFn;
+}) {
+  const model = params.model ?? makeGoogleModel();
+  return prepareGooglePromptCacheStreamFn(
+    {
+      apiKey: params.apiKey ?? "gemini-api-key",
+      extraParams: { cacheRetention: "long" },
+      model,
+      modelId: model.id,
+      provider: "google",
+      sessionManager: params.sessionManager,
+      signal: params.signal,
+      streamFn: params.streamFn,
+      systemPrompt: "Follow policy.",
+    },
+    {
+      ...(params.buildGuardedFetch
+        ? { buildGuardedFetch: params.buildGuardedFetch }
+        : params.fetchMock
+          ? { buildGuardedFetch: () => params.fetchMock as typeof fetch }
+          : {}),
+      now: () => params.now,
+    },
+  );
+}

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -1,182 +1,25 @@
 // Coverage for Google prompt-cache creation, reuse, and request rewriting.
 import crypto from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
-import type { Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { SessionTranscriptWriterClaimReboundError } from "../../config/sessions/transcript-write-context.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
 import { mintSecretSentinel, resolveSecretSentinel } from "../../secrets/sentinel.js";
 import { prepareGooglePromptCacheStreamFn } from "./google-prompt-cache.js";
-
-type SessionCustomEntry = {
-  type: "custom";
-  id: string;
-  parentId: string | null;
-  timestamp: string;
-  customType: string;
-  data: unknown;
-};
-
-type TestGooglePromptCacheSessionManager = {
-  appendCustomEntry(customType: string, data: unknown): void | Promise<void>;
-  getEntries(): SessionCustomEntry[];
-};
-
-function makeSessionManager(entries: SessionCustomEntry[] = []) {
-  // Prompt-cache metadata is persisted as custom session entries, so the test
-  // manager preserves append order and timestamps like SessionManager does.
-  let counter = 0;
-  return {
-    appendCustomEntry(customType: string, data: unknown) {
-      counter += 1;
-      const id = `entry-${counter}`;
-      entries.push({
-        type: "custom",
-        id,
-        parentId: null,
-        timestamp: new Date(counter * 1_000).toISOString(),
-        customType,
-        data,
-      });
-    },
-    getEntries() {
-      return entries;
-    },
-  };
-}
-
-function makeGoogleModel(id = "gemini-3.1-pro-preview") {
-  return {
-    id,
-    name: id,
-    api: "google-generative-ai",
-    provider: "google",
-    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-    reasoning: false,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 128000,
-    maxTokens: 8192,
-    headers: { "X-Provider": "google" },
-  } satisfies Model<"google-generative-ai">;
-}
-
-function createCacheFetchMock(params: { name: string; expireTime: string }) {
-  return vi.fn().mockResolvedValue(
-    new Response(JSON.stringify(params), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    }),
-  );
-}
-
-// Builds a 200-OK response whose body streams more than 1 MiB with no
-// Content-Length, mirroring a buggy/hostile Google cachedContents endpoint.
-// The shared byte-cap reader must cancel the body before fully buffering it.
-function createOversizedJsonResponse(): { response: Response; cancel: ReturnType<typeof vi.fn> } {
-  const cancel = vi.fn(async () => undefined);
-  let pullCount = 0;
-  const response = new Response(
-    new ReadableStream<Uint8Array>({
-      pull(controller) {
-        pullCount += 1;
-        // First chunk already exceeds the 1 MiB cap so the reader truncates
-        // and cancels instead of waiting for the (never-ending) rest.
-        controller.enqueue(new Uint8Array(pullCount === 1 ? 1024 * 1024 + 1 : 1));
-      },
-      cancel,
-    }),
-    {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    },
-  );
-  return { response, cancel };
-}
-
-function createCapturingStreamFn(result = "stream") {
-  // The wrapper mutates payloads through onPayload before calling the real
-  // stream; capture that final payload instead of mocking Google responses.
-  let capturedPayload: Record<string, unknown> | undefined;
-  const streamFn = vi.fn(
-    (
-      model: Parameters<StreamFn>[0],
-      _context: Parameters<StreamFn>[1],
-      options: Parameters<StreamFn>[2],
-    ) => {
-      const payload: Record<string, unknown> = {};
-      void options?.onPayload?.(payload, model);
-      capturedPayload = payload;
-      return result as never;
-    },
-  );
-  return {
-    streamFn,
-    getCapturedPayload: () => capturedPayload,
-  };
-}
-
-function callArg(mock: { mock: { calls: unknown[][] } }, callIndex: number, argIndex: number) {
-  const call = mock.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`Expected mock call ${callIndex}`);
-  }
-  if (argIndex >= call.length) {
-    throw new Error(`Expected mock call ${callIndex} argument ${argIndex}`);
-  }
-  return call[argIndex];
-}
-
-function fetchInit(fetchMock: { mock: { calls: unknown[][] } }, callIndex = 0): RequestInit {
-  const init = callArg(fetchMock, callIndex, 1);
-  if (!init || typeof init !== "object") {
-    throw new Error(`expected fetch init for call ${callIndex}`);
-  }
-  return init as RequestInit;
-}
-
-function fetchUrl(fetchMock: { mock: { calls: unknown[][] } }, callIndex = 0): string {
-  return String(callArg(fetchMock, callIndex, 0));
-}
-
-function streamContext(streamFn: { mock: { calls: unknown[][] } }, callIndex = 0) {
-  return callArg(streamFn, callIndex, 1) as {
-    systemPrompt?: unknown;
-    tools?: unknown;
-  };
-}
-
-function streamOptions(streamFn: { mock: { calls: unknown[][] } }, callIndex = 0) {
-  return callArg(streamFn, callIndex, 2) as Record<string, unknown>;
-}
-
-function preparePromptCacheStream(params: {
-  apiKey?: string;
-  fetchMock: ReturnType<typeof vi.fn>;
-  now: number;
-  sessionManager: TestGooglePromptCacheSessionManager;
-  streamFn: StreamFn;
-}) {
-  // Keep provider/model/cache-retention constants centralized so individual
-  // tests can focus on cache lifecycle behavior.
-  return prepareGooglePromptCacheStreamFn(
-    {
-      apiKey: params.apiKey ?? "gemini-api-key",
-      extraParams: { cacheRetention: "long" },
-      model: makeGoogleModel(),
-      modelId: "gemini-3.1-pro-preview",
-      provider: "google",
-      sessionManager: params.sessionManager,
-      streamFn: params.streamFn,
-      systemPrompt: "Follow policy.",
-    },
-    {
-      buildGuardedFetch: () => params.fetchMock as typeof fetch,
-      now: () => params.now,
-    },
-  );
-}
+import {
+  callArg,
+  createCacheFetchMock,
+  createCapturingStreamFn,
+  createOversizedJsonResponse,
+  fetchInit,
+  fetchUrl,
+  makeGoogleModel,
+  makeSessionManager,
+  preparePromptCacheStream,
+  type SessionCustomEntry,
+  streamContext,
+  streamOptions,
+} from "./google-prompt-cache.test-support.js";
 
 describe("google prompt cache", () => {
   it("parses sentinel-backed OAuth JSON before guarded cache egress", async () => {
@@ -677,7 +520,7 @@ describe("google prompt cache", () => {
     expect(innerStreamFn).toHaveBeenCalledTimes(1);
   });
 
-  it("stays out of the way when cachedContent is already configured explicitly", async () => {
+  it("bypasses automatic validation for explicit cachedContent", async () => {
     const fetchMock = vi.fn();
 
     const wrapped = await prepareGooglePromptCacheStreamFn(
@@ -685,7 +528,7 @@ describe("google prompt cache", () => {
         apiKey: "gemini-api-key",
         extraParams: {
           cacheRetention: "long",
-          cachedContent: "cachedContents/already-set",
+          cachedContent: "cachedContents/operator?supplied#verbatim",
         },
         model: makeGoogleModel(),
         modelId: "gemini-3.1-pro-preview",
@@ -718,21 +561,20 @@ describe("google prompt cache", () => {
       streamFn: innerStreamFn,
     });
 
-    await expect(
-      Promise.resolve(
-        wrapped?.(
-          makeGoogleModel(),
-          { systemPrompt: "Follow policy.", messages: [] } as never,
-          {} as never,
-        ),
+    await Promise.resolve(
+      wrapped?.(
+        makeGoogleModel(),
+        { systemPrompt: "Follow policy.", messages: [] } as never,
+        {} as never,
       ),
-    ).rejects.toThrow(/Google prompt cache response too large: \d+ bytes/);
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(callArg(fetchMock, 0, 0)).toBe(
       "https://generativelanguage.googleapis.com/v1beta/cachedContents",
     );
     expect(cancel).toHaveBeenCalledOnce();
+    expect(innerStreamFn).toHaveBeenCalledOnce();
   });
 
   it("bounds an oversized cache-refresh response body instead of buffering it", async () => {

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -790,4 +790,29 @@ describe("google prompt cache", () => {
     expect(cancel).toHaveBeenCalledOnce();
     expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/system-cache-overflow");
   });
+
+  it("throws a descriptive error when the cache response is not valid JSON", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("not-json{{{", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { streamFn } = createCapturingStreamFn();
+
+    await expect(
+      preparePromptCacheStream({
+        fetchMock,
+        now: 1_000_000,
+        sessionManager: makeSessionManager([]),
+        streamFn,
+      }).then((wrapped) =>
+        wrapped?.(
+          makeGoogleModel(),
+          { systemPrompt: "Follow policy.", messages: [] } as never,
+          {} as never,
+        ),
+      ),
+    ).rejects.toThrow("Google prompt cache response is not valid JSON");
+  });
 });

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -14,11 +14,10 @@ import {
   parseDateStringTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { SessionTranscriptWriterClaimReboundError } from "../../config/sessions/transcript-write-context.js";
 import { parseGeminiAuth } from "../../infra/gemini-auth.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
-import { cancelUnreadResponseBody, readResponseWithLimit } from "../../infra/http-body.js";
+import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { streamWithPayloadPatch } from "../../llm/providers/stream-wrappers/stream-payload-utils.js";
 import type { Model } from "../../llm/types.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
@@ -27,6 +26,7 @@ import {
   mintSecretSentinel,
   resolveSecretSentinel,
 } from "../../secrets/sentinel.js";
+import { readProviderJsonObjectResponse } from "../provider-http-errors.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { buildGuardedModelFetch } from "../provider-transport-fetch.js";
 import type { StreamFn } from "../runtime/index.js";
@@ -69,7 +69,7 @@ type GooglePromptCacheEntry = {
   | {
       status: "ready";
       cachedContent: string;
-      expireTime?: string;
+      expireTime: string;
     }
   | {
       status: "failed";
@@ -203,8 +203,29 @@ async function appendGooglePromptCacheEntry(
   }
 }
 
-function parseExpireTimeMs(expireTime: string | undefined): number | null {
-  return parseDateStringTimestampMs(expireTime) ?? null;
+function readFutureExpireTime(
+  value: unknown,
+  now: number,
+): { value: string; timestamp: number } | null {
+  const timestamp = parseDateStringTimestampMs(value);
+  return typeof value === "string" && isFutureDateTimestampMs(timestamp, { nowMs: now })
+    ? { value, timestamp }
+    : null;
+}
+
+function readGooglePromptCacheName(value: unknown): string | null {
+  if (typeof value !== "string" || !value.startsWith("cachedContents/")) {
+    return null;
+  }
+  const id = value.slice("cachedContents/".length);
+  if (!id || id === "." || id === "..") {
+    return null;
+  }
+  try {
+    return encodeURIComponent(id) === id ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 function convertManagedGoogleTools(tools: NonNullable<GooglePromptCacheContext["tools"]>) {
@@ -283,19 +304,6 @@ function buildManagedContextForCachedContent(context: GooglePromptCacheContext) 
   };
 }
 
-/**
- * Reads a Google cachedContents JSON body under a byte cap and parses it.
- * Streams through the shared limiter so an oversized response is cancelled
- * mid-flight instead of being fully buffered by `response.json()`.
- */
-async function readGooglePromptCacheJson<T>(response: Response): Promise<T> {
-  const buffer = await readResponseWithLimit(response, GOOGLE_PROMPT_CACHE_RESPONSE_MAX_BYTES, {
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(`Google prompt cache response too large: ${size} bytes (limit: ${maxBytes} bytes)`),
-  });
-  return JSON.parse(buffer.toString("utf8")) as T;
-}
-
 function resolveGooglePromptCacheAuthHeaders(params: {
   apiKey: string;
   provider: string;
@@ -358,81 +366,72 @@ function buildGooglePromptCacheHeaders(params: {
   );
 }
 
-async function updateGooglePromptCacheTtl(params: {
-  apiKey: string;
-  baseUrl: string;
-  cacheRetention: CacheRetention;
-  cachedContent: string;
-  fetchImpl: typeof fetch;
-  headers?: Record<string, string>;
-  model: GooglePromptCacheModel;
-  signal?: AbortSignal;
-}): Promise<{ expireTime?: string } | null> {
-  let response: Response | undefined;
-  try {
-    response = await params.fetchImpl(`${params.baseUrl}/${params.cachedContent}?updateMask=ttl`, {
-      method: "PATCH",
-      headers: buildGooglePromptCacheHeaders({
-        apiKey: params.apiKey,
-        baseUrl: params.baseUrl,
-        headers: params.headers,
-        model: params.model,
-      }),
-      body: JSON.stringify({
-        ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
-      }),
-      signal: params.signal,
-    });
-    if (!response.ok) {
-      return null;
-    }
-    const json = await readGooglePromptCacheJson<{ expireTime?: string }>(response);
-    return json;
-  } finally {
-    await cancelUnreadResponseBody(response);
-  }
-}
-
-async function createGooglePromptCache(params: {
-  apiKey: string;
-  baseUrl: string;
-  cacheRetention: CacheRetention;
-  fetchImpl: typeof fetch;
-  headers?: Record<string, string>;
-  model: GooglePromptCacheModel;
-  modelId: string;
-  signal?: AbortSignal;
-  systemPrompt: string;
-  tools?: unknown;
-  toolConfig?: unknown;
-}): Promise<{ cachedContent: string; expireTime?: string } | null> {
-  let response: Response | undefined;
-  try {
-    response = await params.fetchImpl(`${params.baseUrl}/cachedContents`, {
-      method: "POST",
-      headers: buildGooglePromptCacheHeaders({
-        apiKey: params.apiKey,
-        baseUrl: params.baseUrl,
-        headers: params.headers,
-        model: params.model,
-      }),
-      body: JSON.stringify({
-        model: params.modelId.startsWith("models/") ? params.modelId : `models/${params.modelId}`,
-        ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
-        systemInstruction: {
-          parts: [{ text: params.systemPrompt }],
+async function requestGooglePromptCache(
+  params: {
+    apiKey: string;
+    baseUrl: string;
+    cacheRetention: CacheRetention;
+    fetchImpl: typeof fetch;
+    headers?: Record<string, string>;
+    model: GooglePromptCacheModel;
+    now: number;
+    signal?: AbortSignal;
+  } & (
+    | { cachedContent: string }
+    | {
+        modelId: string;
+        systemPrompt: string;
+        tools?: unknown;
+        toolConfig?: unknown;
+      }
+  ),
+): Promise<{ cachedContent: string; expireTime: string } | null> {
+  const refreshing = "cachedContent" in params;
+  const url = refreshing
+    ? `${params.baseUrl}/${params.cachedContent}?updateMask=ttl`
+    : `${params.baseUrl}/cachedContents`;
+  const headers = buildGooglePromptCacheHeaders(params);
+  const body = JSON.stringify(
+    refreshing
+      ? { ttl: resolveGooglePromptCacheTtl(params.cacheRetention) }
+      : {
+          model: params.modelId.startsWith("models/") ? params.modelId : `models/${params.modelId}`,
+          ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
+          systemInstruction: { parts: [{ text: params.systemPrompt }] },
+          ...(params.tools ? { tools: params.tools } : {}),
+          ...(params.toolConfig ? { toolConfig: params.toolConfig } : {}),
         },
-        ...(params.tools ? { tools: params.tools } : {}),
-        ...(params.toolConfig ? { toolConfig: params.toolConfig } : {}),
-      }),
+  );
+  let response: Response | undefined;
+  try {
+    response = await params.fetchImpl(url, {
+      method: refreshing ? "PATCH" : "POST",
+      headers,
+      body,
       signal: params.signal,
     });
     if (!response.ok) {
-      return null;
+      throw new Error(`Google prompt cache request failed (${response.status})`);
     }
-    const json = await readGooglePromptCacheJson<{ name?: string; expireTime?: string }>(response);
-    const cachedContent = normalizeOptionalString(json.name) ?? "";
-    return cachedContent ? { cachedContent, expireTime: json.expireTime } : null;
+    const payload = await readProviderJsonObjectResponse(response, "Google prompt cache", {
+      maxBytes: GOOGLE_PROMPT_CACHE_RESPONSE_MAX_BYTES,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google prompt cache response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+      requestHeaders: headers,
+    });
+    const expiry = readFutureExpireTime(payload.expireTime, params.now);
+    const cachedContent = refreshing
+      ? params.cachedContent
+      : readGooglePromptCacheName(payload.name);
+    if (!cachedContent || !expiry) {
+      throw new Error("Google prompt cache response is invalid");
+    }
+    return { cachedContent, expireTime: expiry.value };
+  } catch {
+    params.signal?.throwIfAborted();
+    return null;
   } finally {
     await cancelUnreadResponseBody(response);
   }
@@ -478,24 +477,26 @@ async function ensureGooglePromptCache(
 
   const fetchImpl = (deps.buildGuardedFetch ?? buildGuardedModelFetch)(params.model);
   const refreshWindowMs = resolveGooglePromptCacheRefreshWindowMs(params.cacheRetention);
-  if (latestEntry?.status === "ready" && latestEntry.cachedContent) {
-    const expiresAt = parseExpireTimeMs(latestEntry.expireTime);
-    const isExpired = expiresAt !== null && !isFutureDateTimestampMs(expiresAt, { nowMs: now });
-    if (!isExpired) {
-      const needsRefresh = expiresAt !== null && expiresAt - now <= refreshWindowMs;
+  const cachedContent =
+    latestEntry?.status === "ready" ? readGooglePromptCacheName(latestEntry.cachedContent) : null;
+  if (latestEntry?.status === "ready" && cachedContent) {
+    const expiry = readFutureExpireTime(latestEntry.expireTime, now);
+    if (expiry) {
+      const needsRefresh = expiry.timestamp - now <= refreshWindowMs;
       if (!needsRefresh) {
-        return latestEntry.cachedContent;
+        return cachedContent;
       }
-      const refreshed = await updateGooglePromptCacheTtl({
+      const refreshed = await requestGooglePromptCache({
         apiKey: params.apiKey,
         baseUrl,
         cacheRetention: params.cacheRetention,
-        cachedContent: latestEntry.cachedContent,
+        cachedContent,
         fetchImpl,
         headers: params.model.headers,
         model: params.model,
+        now,
         signal: params.signal,
-      }).catch(() => null);
+      });
       if (refreshed) {
         await appendGooglePromptCacheEntry(params.sessionManager, {
           status: "ready",
@@ -507,16 +508,16 @@ async function ensureGooglePromptCache(
           systemPromptDigest,
           cacheConfigDigest: params.cacheConfigDigest,
           cacheRetention: params.cacheRetention,
-          cachedContent: latestEntry.cachedContent,
-          expireTime: refreshed.expireTime ?? latestEntry.expireTime,
+          cachedContent,
+          expireTime: refreshed.expireTime,
         });
-        return latestEntry.cachedContent;
+        return cachedContent;
       }
-      return latestEntry.cachedContent;
+      return cachedContent;
     }
   }
 
-  const created = await createGooglePromptCache({
+  const created = await requestGooglePromptCache({
     apiKey: params.apiKey,
     baseUrl,
     cacheRetention: params.cacheRetention,
@@ -524,6 +525,7 @@ async function ensureGooglePromptCache(
     headers: params.model.headers,
     model: params.model,
     modelId: params.model.id,
+    now,
     signal: params.signal,
     systemPrompt: params.systemPrompt,
     tools: params.tools,

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -293,7 +293,11 @@ async function readGooglePromptCacheJson<T>(response: Response): Promise<T> {
     onOverflow: ({ size, maxBytes }) =>
       new Error(`Google prompt cache response too large: ${size} bytes (limit: ${maxBytes} bytes)`),
   });
-  return JSON.parse(buffer.toString("utf8")) as T;
+  try {
+    return JSON.parse(buffer.toString("utf8")) as T;
+  } catch {
+    throw new Error("Google prompt cache response is not valid JSON");
+  }
 }
 
 function resolveGooglePromptCacheAuthHeaders(params: {


### PR DESCRIPTION
Related: #123632
Related: #95417
Related: #109754

## What Problem This Solves

Fixes an issue where eligible Gemini runs could stop before primary generation when Google prompt-cache creation or refresh returned an invalid successful response, a transport error, or unusable cache metadata.

Prompt caching is an optional optimization. Provider-side cache failures must leave the system prompt, tools, and visible generation path intact unless the caller itself cancelled the run or another authoritative operation failed.

## Why This Change Was Made

The repair lives in the Google prompt-cache lifecycle owner. It removes the duplicate JSON reader and uses the shared provider response parser for the existing 1 MiB bound, fatal UTF-8 decoding, JSON parsing, top-level object validation, and credential-safe causes.

Request URL, authentication headers, sentinel resolution, and body serialization are completed before the optional-operation boundary, so construction failures remain fatal. Only fetch, non-2xx handling, response consumption, and automatic response validation degrade to uncached generation. Caller cancellation, transcript-writer authority loss, and primary stream failures remain fatal.

Automatic and persisted cache names share one transport-stability validator. It requires the `cachedContents/` prefix, a nonempty id other than `.` or `..`, and a throw-safe `encodeURIComponent(id) === id` result. This follows Google's published `cachedContents/{id}` contract while ensuring the maintained SDK's raw resource-name interpolation cannot alter the request URL. Ready state requires a parseable future expiry. Invalid ready entries rebuild, valid existing caches survive malformed refresh responses, and the existing failed-create backoff remains best effort.

This cache state is transient. There is no migration, configuration, schema, protocol, public API, or security-contract change. Explicit operator-provided `cachedContent` remains untouched.

The contributor's original approach was discarded because wrapping the local `JSON.parse` still left a duplicate parser and allowed optional cache failures to abort the primary stream.

## User Impact

Gemini users continue receiving normal uncached output when automatic prompt-cache creation or refresh fails or returns malformed metadata. Valid caches and explicit operator cache references continue working as before.

Contributor credit is preserved with the public noreply coauthor trailer for @coaiMax.

## Evidence

- Before repair: malformed successful cache JSON rejected before the primary stream; `innerCalls=0` and no visible generation output.
- After repair: the same failure records transient backoff and proceeds through the unchanged uncached system prompt/tools path.
- Persisted-name regression: `files/cache-id` previously bypassed creation with zero cache fetches. It now triggers one rebuild and injects `cachedContents/rebuilt`.
- Resource-name contract: the current Google Generative Language v1beta Discovery document (revision `20260829`) describes `CachedContent.name` as `cachedContents/{id}` and constrains get/update path parameters with `^cachedContents/[^/]+$`: https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta
- Maintained SDK proof: OpenClaw's pinned `@google/genai` `v2.18.0` source calls the name server-generated, then performs raw path substitution before `new URL()`: https://github.com/googleapis/js-genai/blob/128781fdfec5d33f24d8305d90964f3b75b0774f/src/types.ts#L6227-L6229, https://github.com/googleapis/js-genai/blob/128781fdfec5d33f24d8305d90964f3b75b0774f/src/_common.ts#L9-L21, https://github.com/googleapis/js-genai/blob/128781fdfec5d33f24d8305d90964f3b75b0774f/src/caches.ts#L332-L386, and https://github.com/googleapis/js-genai/blob/128781fdfec5d33f24d8305d90964f3b75b0774f/src/_api_client.ts#L443-L455.
- Transport-stability pre-fix reproduction: 12 focused cases failed on the prior regex. C0 controls, DEL/C1, lone high/low surrogates, and NFC/NFD Unicode creation names stripped the prompt/tools; representative persisted names bypassed rebuild; and a failed rebuild still suppressed uncached input.
- Transport-stability regression: automatic creation rejects controls, DEL/C1, whitespace, non-ASCII NFC/NFD, lone surrogates, slash/backslash, query/fragment delimiters, percent escapes, and dot segments. Every case preserves the original uncached system prompt/tools, omits `cachedContent`, and records the existing 10-minute backoff.
- Persisted invalid names never form a PATCH URL: representative encoded and throwing cases rebuild through the exact create URL, and a failed rebuild continues uncached. A valid punctuation id preserved by `encodeURIComponent` uses the exact PATCH URL. An otherwise-invalid explicit operator reference still bypasses automatic validation unchanged.
- Fixture proof through real `buildGuardedModelFetch`: a controlled loopback server returns malformed cache-creation JSON, then a valid generation stream. The generation endpoint is reached and emits `visible-generation-output`.
- This is fixture proof, not live Google proof. A real Google cache creation is an external write, and Google cannot be made to reliably return malformed JSON with a successful status, so the reported malformed-success response is not concretely inducible against the live service.
- Final focused owner suite: 73/73 passed.
- Relevant maintainer suite: 92/92 passed, including parser, lifecycle, runner integration, backoff, cancellation, authority, primary-stream, explicit-cache coverage, and the guarded-loopback fixture.
- Mandatory exact-commit autoreview and an independent exact-commit review both found no P0/P1 issue.
- Core types, core/targeted lint, formatting, assertion-safety ratchet, max-lines ratchet, dead-export scans, and targeted repository contracts passed.
- Production LOC: `+101/-99` (net `+2`). The small positive delta is the required prefix/id validation plus the throw-safe URI stability check; the duplicate parser and old lifecycle paths remain deleted.
- Tests and test support: `+849/-182` (net `+667`), covering the requested malformed-response, transport-stability, and lifecycle matrix.
- The pushed commit is GitHub-verified, authored by the authenticated maintainer, and preserves @coaiMax only through the public noreply coauthor trailer.
- Full local build/type aggregation is limited by the linked checkout's existing `pako` environment state: `ui:build` sees its CommonJS named-export mismatch, and the core-test type graph reports the missing declaration at `ui/vite.config.ts:9`. The changed core typecheck and focused tests pass; no dependency installation or unrelated repair was included.
