### PR TITLE
fix(together): add size range validation for video dimensions

### DIFF
--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -426,4 +426,33 @@ describe("together video generation provider", () => {
     expect(media.reference_images).toHaveLength(1);
     expect(body).not.toHaveProperty("reference_images");
   });
+
+  it("rejects out-of-range size dimensions", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "video_size",
+        status: "completed",
+        outputs: { video_url: "https://example.com/size.mp4" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      headers: new Headers({ "content-type": "video/mp4" }),
+      arrayBuffer: async () => Buffer.from("mp4-bytes"),
+    });
+
+    const provider = buildTogetherVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "together",
+      model: "Wan-AI/Wan2.2-T2V-A14B",
+      prompt: "A test scene",
+      size: "9999x9999",
+      cfg: {},
+    });
+
+    const request = requireFirstPostJsonRequest(postJsonRequestMock, "Together request");
+    const body = requireRecord(request.body, "Together request body");
+    expect(body).not.toHaveProperty("width");
+    expect(body).not.toHaveProperty("height");
+  });
 });

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -234,8 +234,12 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
       if (size) {
         const match = /^(\d+)x(\d+)$/u.exec(size);
         if (match) {
-          body.width = Number.parseInt(match[1] ?? "", 10);
-          body.height = Number.parseInt(match[2] ?? "", 10);
+          const width = Number.parseInt(match[1] ?? "", 10);
+          const height = Number.parseInt(match[2] ?? "", 10);
+          if (width >= 1 && width <= 4096 && height >= 1 && height <= 4096) {
+            body.width = width;
+            body.height = height;
+          }
         }
       }
       if (req.inputImages?.[0]) {


### PR DESCRIPTION
## What Problem This Solves

The Together video generation provider parsed width/height from the size string but did not validate the range. Out-of-range values (e.g. 9999x9999) would be sent to the API, causing confusing server-side errors.

## Fix

Add range validation (1-4096) for both width and height before setting them on the request body.

## Evidence

Added a test that sends size `9999x9999` and verifies width/height are not included in the request body.
