### PR TITLE
fix(claws): wrap JSON.parse in try/catch in rowToRef

### DIFF
--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -222,4 +222,20 @@ describe("installClawCronJobs", () => {
     expect(first[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
     expect(second[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
   });
+
+  it("throws a descriptive error when job_json is malformed", async () => {
+    const current = await fixture();
+    const { openOpenClawStateDatabase } = await import("../state/openclaw-state-db.js");
+    const database = openOpenClawStateDatabase({ env: current.env });
+    database.db
+      .prepare(
+        `INSERT INTO claw_cron_refs (agent_id, manifest_id, schema_version, declaration_key, status, job_json, created_at_ms, updated_at_ms)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("worker-two", "bad-job", "openclaw.clawCronRef.v1", "claw:worker-two:bad-job", "pending", "not-valid-json", 1, 1);
+    const { readClawCronRefs: readRefs } = await import("./cron.js");
+    expect(() => readRefs("worker-two", { env: current.env })).toThrow(
+      /Failed to parse cron job JSON/,
+    );
+  });
 });

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -59,6 +59,12 @@ export class ClawCronInstallError extends Error {
 }
 
 function rowToRef(row: CronRefRow): PersistedClawCronRef {
+  let job: ClawCronJob;
+  try {
+    job = JSON.parse(row.job_json) as ClawCronJob;
+  } catch {
+    throw new Error(`Failed to parse cron job JSON for row ${row.declaration_key}`);
+  }
   return {
     schemaVersion: CLAW_CRON_REF_SCHEMA_VERSION,
     agentId: row.agent_id,
@@ -66,7 +72,7 @@ function rowToRef(row: CronRefRow): PersistedClawCronRef {
     declarationKey: row.declaration_key,
     ...(row.scheduler_job_id ? { schedulerJobId: row.scheduler_job_id } : {}),
     status: row.status,
-    job: JSON.parse(row.job_json) as ClawCronJob,
+    job,
     ...(row.error ? { error: row.error } : {}),
     createdAtMs: Number(row.created_at_ms),
     updatedAtMs: Number(row.updated_at_ms),


### PR DESCRIPTION
## Problem
\owToRef\ called \JSON.parse(row.job_json)\ without a try/catch. A corrupted database row would throw an unhelpful syntax error.

## Fix
Wrap \JSON.parse\ in a try/catch and throw a descriptive error including the declaration key.

## Tests
Added a test that inserts a row with malformed JSON and verifies the descriptive error is thrown.