### PR TITLE
test(gateway): stabilize workspace timeout assertion

### DIFF
--- a/src/gateway/worker-environments/workspace-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-sync.test.ts
@@ -57,6 +57,7 @@ function createWorkspaceActions(
 
 describe("worker workspace command transport retry", () => {
   it("runs never commands once without changing the selected port", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
     const run = vi.fn(async (argv: string[], _options: CommandOptions) =>
       argv.at(-1)?.includes("never-command") ? result(255) : result(),
     );


### PR DESCRIPTION
## What Problem This Solves

The workspace command transport test uses the real wall clock while asserting an exact timeout budget. The production path correctly starts the deadline before awaiting tunnel preparation, so a one-millisecond wait makes the assertion receive 776 instead of 777.

## Why This Change Was Made

Freeze `Date.now()` in the exact-timeout test, matching the deterministic clock already used by the neighboring remaining-budget test. This preserves the production deadline behavior and removes scheduler timing from the assertion.

## Evidence

- Pre-fix: `pnpm test src/gateway/worker-environments/workspace-sync.test.ts` failed with `expected 776 to be 777`.
- Post-fix: the same command passed all 7 tests.
- Production delta: 0. Test delta: +1.
