### PR TITLE
fix(qa): overlap prebuilt profile evidence producers

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -621,6 +621,7 @@ jobs:
           OPENCLAW_QA_CREDENTIAL_ROLE: ci
           OPENCLAW_QA_CREDENTIAL_SOURCE: convex
           OPENCLAW_QA_ALLOW_UPDATE_RUN_SELF: "1"
+          OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
         working-directory: selected
         run: |
           set -euo pipefail

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2200,19 +2200,92 @@ describe("qa suite runtime launcher", () => {
     expect(parallelScriptIds).toEqual([]);
 
     serial.resolve();
-    await vi.waitFor(() => expect(parallelScriptIds).toHaveLength(3));
+    await vi.waitFor(() => expect(parallelScriptIds).toHaveLength(4));
     expect(maxActiveParallelScripts).toBe(3);
-    expect(parallelScriptIds).not.toContain("diagnostic-events-boundary");
 
     parallel.resolve();
     await runPromise;
     expect(prepareDockerE2eEnvironment).toHaveBeenCalledTimes(1);
     expect(scriptEnvs.every((env) => env === preparedEnv)).toBe(true);
-    expect(parallelScriptIds.slice(0, 3)).toEqual(
-      expect.arrayContaining(["remote-log-tailing", "gateway-smoke", "logging-file-boundary"]),
+    expect(parallelScriptIds).toEqual(
+      expect.arrayContaining([
+        "remote-log-tailing",
+        "gateway-smoke",
+        "logging-file-boundary",
+        "diagnostic-events-boundary",
+      ]),
     );
-    expect(parallelScriptIds[3]).toBe("diagnostic-events-boundary");
     expect(maxActiveParallelScripts).toBe(3);
+  });
+
+  it("overlaps audited scripts with flow and native work when dist is prebuilt", async () => {
+    vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "1");
+    const repoRoot = await makeTempRepo("qa-suite-prebuilt-parallel-scripts-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultFlowImplementation || !defaultTestFileImplementation) {
+      throw new Error("expected default QA suite mock implementations");
+    }
+    const flow = createDeferred();
+    const native = createDeferred();
+    const serial = createDeferred();
+    const started: string[] = [];
+    const parallelScriptIds: string[] = [];
+    const parallelScriptEnvs: unknown[] = [];
+    const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
+    runQaFlowSuite.mockImplementationOnce(async (params) => {
+      started.push("flow");
+      await flow.promise;
+      return await defaultFlowImplementation(params);
+    });
+    prepareDockerE2eEnvironment.mockImplementationOnce(async () => {
+      started.push("prep");
+      return preparedEnv;
+    });
+    runQaTestFileScenarios.mockImplementation(async (params) => {
+      const scenarioIds = params.scenarios.map((scenario: QaTestFileScenario) => scenario.id);
+      const kind = params.scenarios[0]?.execution.kind;
+      if (kind === "playwright") {
+        started.push("native");
+        await native.promise;
+      } else if (scenarioIds.includes("docker-npm-onboard-channel-agent")) {
+        started.push("serial");
+        expect(params.env).toBe(preparedEnv);
+        await serial.promise;
+      } else {
+        started.push("parallel");
+        parallelScriptIds.push(...scenarioIds);
+        parallelScriptEnvs.push(params.env);
+      }
+      return await defaultTestFileImplementation(params);
+    });
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/prebuilt-parallel-scripts",
+      concurrency: 8,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+        "remote-log-tailing",
+        "gateway-smoke",
+        "logging-file-boundary",
+        "diagnostic-events-boundary",
+      ],
+    });
+    await vi.waitFor(() => expect(parallelScriptIds).toHaveLength(4));
+    expect(started).toEqual(expect.arrayContaining(["flow", "native", "parallel"]));
+    expect(started).not.toContain("prep");
+    expect(started).not.toContain("serial");
+    expect(parallelScriptEnvs.every((env) => env === undefined)).toBe(true);
+
+    flow.resolve();
+    native.resolve();
+    await vi.waitFor(() => expect(started).toContain("serial"));
+    expect(started.indexOf("prep")).toBeLessThan(started.indexOf("serial"));
+    serial.resolve();
+    await runPromise;
   });
 
   it("records Docker preparation failure without starting a script partition", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -464,8 +464,8 @@ function flowSuitePartitionOutputDir(outputDir: string, partition: string) {
   return path.join(suitePartitionOutputDir(outputDir, "flow"), partition);
 }
 
-function partitionSharedFlowScenarios(
-  scenarios: readonly QaSeedScenarioWithSource[],
+function partitionQaScenarios<Scenario>(
+  scenarios: readonly Scenario[],
   concurrency: number,
   maxPartitions = MAX_SHARED_FLOW_PARTITIONS,
 ) {
@@ -474,7 +474,7 @@ function partitionSharedFlowScenarios(
     Math.max(1, Math.floor(maxPartitions)),
     scenarios.length,
   );
-  const partitions = Array.from({ length: partitionCount }, (): QaSeedScenarioWithSource[] => []);
+  const partitions = Array.from({ length: partitionCount }, (): Scenario[] => []);
   for (const [index, scenario] of scenarios.entries()) {
     const partition = partitions[index % partitionCount];
     if (!partition) {
@@ -834,7 +834,7 @@ async function runUnifiedQaSuite(params: {
       // Single-scenario fail-fast tasks keep retries and failure evidence attributable.
       const sharedFlowPartitions = failFast
         ? sharedFlowScenarios.map((scenario) => [scenario])
-        : partitionSharedFlowScenarios(
+        : partitionQaScenarios(
             sharedFlowScenarios,
             usesContributedChannelDriver && !channelGroup.isolatesAdapterInstances
               ? 1
@@ -1151,19 +1151,26 @@ async function runUnifiedQaSuite(params: {
           createTestFilePartitionTask(new Map([["script", serialScenarios]])),
         );
       }
-      for (const scenario of scriptScenarios) {
-        if (isParallelSafeScript(scenario)) {
-          parallelScriptPartitionTasks.push(
-            createTestFilePartitionTask(new Map([["script", [scenario]]])),
-          );
-        }
+      const parallelScenarios = scriptScenarios.filter(isParallelSafeScript);
+      for (const scenarios of partitionQaScenarios(
+        parallelScenarios,
+        concurrency,
+        MAX_PARALLEL_SCRIPT_CONCURRENCY,
+      )) {
+        parallelScriptPartitionTasks.push(
+          createTestFilePartitionTask(new Map([["script", scenarios]])),
+        );
       }
     }
   }
+  // The profile workflow builds immutable dist output before execution. In that
+  // mode audited producers can share the global budget without extending the tail.
+  const overlapParallelScripts = process.env.OPENCLAW_E2E_USE_PREBUILT_DIST === "1";
   const concurrentPartitionTasks = [
     ...sharedFlowPartitionTasks,
     ...testFilePartitionTasks,
     ...isolatedFlowPartitionTasks,
+    ...(overlapParallelScripts ? parallelScriptPartitionTasks : []),
   ];
   const scenarioDefinitionsById = new Map(
     params.plan.scenarios.map((scenario) => [scenario.id, scenario]),
@@ -1328,8 +1335,8 @@ async function runUnifiedQaSuite(params: {
       progress?.recordResults(scriptPreparationFailure.scenarioResults);
     }
   }
-  // Unmarked scripts may rebuild shared checkout state. Run them exclusively
-  // after every flow and native partition settles, then start only audited peers.
+  // Unmarked scripts may rebuild shared checkout state, so they remain exclusive
+  // after every concurrent partition settles in both execution modes.
   const serialScriptPartitionResults =
     concurrentFailed || scriptPreparationFailure
       ? []
@@ -1337,10 +1344,12 @@ async function runUnifiedQaSuite(params: {
   const parallelScriptPartitionResults =
     scriptPreparationFailure || (failFast && serialScriptPartitionResults.some(partitionFailed))
       ? []
-      : await runPartitionTasks(
-          parallelScriptPartitionTasks,
-          Math.min(concurrency, MAX_PARALLEL_SCRIPT_CONCURRENCY),
-        );
+      : overlapParallelScripts
+        ? []
+        : await runPartitionTasks(
+            parallelScriptPartitionTasks,
+            Math.min(concurrency, MAX_PARALLEL_SCRIPT_CONCURRENCY),
+          );
   const partitionResults = [
     ...concurrentPartitionResults,
     ...(scriptPreparationFailure ? [scriptPreparationFailure] : []),

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7789,6 +7789,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       (step: WorkflowStep) => step.name === "Run QA profile shard",
     );
     expect(runProfileStep.env?.OPENCLAW_QA_ALLOW_UPDATE_RUN_SELF).toBe("1");
+    expect(runProfileStep.env?.OPENCLAW_E2E_USE_PREBUILT_DIST).toBe("1");
     expect(runProfileStep.env?.OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS).toBe("120000");
     expect(runProfileStep.env?.PROTOCOL_SINCE_BASE_SHA).toBe(
       "${{ needs.validate_selected_ref.outputs.protocol_base_revision }}",


### PR DESCRIPTION
## What Problem This Solves

Full QA profile runs build the private runtime before execution, but child E2E Vitest processes could still enter global setup and clean/rebuild shared `packages/ai/dist`. Audited script producers then remained in a long post-flow tail even when the workflow had already established immutable built output.

Original failed evidence: https://github.com/openclaw/openclaw/actions/runs/31810966137

## Changes

- Mark the profile shard execution as a prebuilt-dist consumer after the private QA runtime build.
- Partition audited `parallelSafe` producers into at most three tasks and schedule them with flow/native work under the existing global weighted concurrency budget.
- Keep unmarked producers, Docker candidate preparation, and fail-fast script work serialized.
- Preserve the non-prebuilt execution order for other callers.

## Validation

- Blacksmith Testbox focused Vitest: `suite-launch.runtime.test.ts` plus `ci-workflow-guards.test.ts` — 183 passed.
- `pnpm check:workflows` passed on the pre-split head.
- Path-scoped `pnpm check:changed` passed on the pre-split head.
- Autoreview clean.
- Current-main split: `git diff --check` passed; repository-configured `actionlint` passed.
- Exact-head pull-request CI is running after the branch rewrite.

## LOC

- Runtime/workflow: +26/-16, net +10. The positive delta establishes the prebuilt activation boundary and bounded scheduler overlap.
- Tests: +79/-5, net +74.

## Split Follow-up

The separate 140-minute operational timeout budget is in #125303. Land this owner-boundary and bounded-overlap PR first, then evaluate the independent timeout headroom.