### PR TITLE
fix(context-engine): wrap JSON.parse in try/catch in context-engine-turn-outbox.ts

### DIFF
--- a/src/agents/harness/context-engine-turn-outbox.test.ts
+++ b/src/agents/harness/context-engine-turn-outbox.test.ts
@@ -638,4 +638,72 @@ describe("context-engine turn outbox", () => {
       "pending durable turn advancement could not be completed before the next turn",
     );
   });
+
+  it("throws a descriptive error when existing outbox payload JSON is malformed", () => {
+    const stateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-context-outbox-malformed-write-"),
+    );
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const payload = createPayload({
+      advancementKey: "session-a:malformed-write",
+      databasePath: database.path,
+      sequence: 1,
+      sessionId: "session-a",
+    });
+    enqueueContextEngineTurnCommit({ database, engineId: "test", payload });
+
+    // Corrupt the stored payload_json so the next write hits the JSON.parse path.
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{not-valid-json' WHERE advancement_key = ?",
+      )
+      .run(payload.boundary.admission.logicalTurnId);
+
+    expect(() =>
+      enqueueContextEngineTurnCommit({ database, engineId: "test", payload }),
+    ).toThrow(/Failed to parse existing outbox payload JSON/);
+  });
+
+  it("skips outbox rows with malformed payload JSON during recovery", () => {
+    const stateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-context-outbox-malformed-recover-"),
+    );
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const payload = createPayload({
+      advancementKey: "session-a:malformed-recover",
+      databasePath: database.path,
+      sequence: 1,
+      sessionId: "session-a",
+    });
+    enqueueContextEngineTurnCommit({ database, engineId: "test", payload });
+
+    // Corrupt the stored payload_json so recovery hits the JSON.parse path.
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{not-valid-json' WHERE advancement_key = ?",
+      )
+      .run(payload.boundary.admission.logicalTurnId);
+
+    const warn = vi.fn();
+    recoverContextEngineTurnOutbox({
+      database,
+      engineId: "test",
+      sessionId: payload.boundary.admission.sessionId,
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "skipping outbox row with malformed payload JSON: session-a:malformed-recover",
+      ),
+    );
+  });
 });

--- a/src/agents/harness/context-engine-turn-outbox.test.ts
+++ b/src/agents/harness/context-engine-turn-outbox.test.ts
@@ -44,6 +44,7 @@ function createPayload(params: {
   databasePath: string;
   sequence: number;
   sessionId: string;
+  messages?: ContextEngineTurnOutboxPayload["messages"];
 }): ContextEngineTurnOutboxPayload {
   const anchor = {
     agentId: "main",
@@ -73,7 +74,7 @@ function createPayload(params: {
   return {
     boundary,
     isHeartbeat: false,
-    messages: [],
+    messages: params.messages ?? [],
   };
 }
 
@@ -712,6 +713,349 @@ describe("context-engine turn outbox", () => {
 
     expect(degradeBeforeStart).toHaveBeenCalledWith(
       "pending durable turn advancement could not be completed before the next turn",
+    );
+  });
+
+  it("throws a descriptive error when existing outbox payload JSON is malformed", () => {
+    const stateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-context-outbox-malformed-write-"),
+    );
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const payload = createPayload({
+      advancementKey: "session-a:malformed-write",
+      databasePath: database.path,
+      sequence: 1,
+      sessionId: "session-a",
+    });
+    enqueueContextEngineTurnCommit({ database, engineId: "test", payload });
+
+    // Corrupt the stored payload_json so the next write hits the JSON.parse path.
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{not-valid-json' WHERE advancement_key = ?",
+      )
+      .run(payload.boundary.admission.logicalTurnId);
+
+    expect(() => enqueueContextEngineTurnCommit({ database, engineId: "test", payload })).toThrow(
+      /Failed to parse existing outbox payload JSON/,
+    );
+  });
+
+  it("skips outbox rows with malformed payload JSON during recovery", () => {
+    const stateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-context-outbox-malformed-recover-"),
+    );
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const payload = createPayload({
+      advancementKey: "session-a:malformed-recover",
+      databasePath: database.path,
+      sequence: 1,
+      sessionId: "session-a",
+    });
+    enqueueContextEngineTurnCommit({ database, engineId: "test", payload });
+
+    // Corrupt the stored payload_json so recovery hits the JSON.parse path.
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{not-valid-json' WHERE advancement_key = ?",
+      )
+      .run(payload.boundary.admission.logicalTurnId);
+
+    const warn = vi.fn();
+    recoverContextEngineTurnOutbox({
+      database,
+      engineId: "test",
+      sessionId: payload.boundary.admission.sessionId,
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "skipping outbox row with malformed payload JSON: session-a:malformed-recover",
+      ),
+    );
+  });
+
+  it("persists real turn messages through a durable plugin and reassembles them after a reopen past a malformed row", async () => {
+    const stateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-context-outbox-durable-plugin-"),
+    );
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const databasePath = database.path;
+    // Turn messages shaped exactly like the entries the transcript hands to
+    // commitTurn in production: plain { role, content } records.
+    const turnMessages = (user: string, assistant: string) =>
+      [
+        { role: "user", content: user },
+        { role: "assistant", content: assistant },
+      ] as unknown as ContextEngineTurnOutboxPayload["messages"];
+    // A real (minimal) durable context plugin. commitTurn persists each accepted
+    // turn's messages to the plugin's own on-disk context store and honours the
+    // atomic-idempotent contract, so a host retry of an already-committed key
+    // reports "duplicate" instead of storing the same messages twice.
+    const pluginStorePath = path.join(stateDir, "plugin-context-store.jsonl");
+    type PluginTurn = {
+      advancementKey: string;
+      sessionId: string;
+      messages: ContextEngineTurnOutboxPayload["messages"];
+    };
+    const readPluginStore = (): PluginTurn[] =>
+      fs.existsSync(pluginStorePath)
+        ? fs
+            .readFileSync(pluginStorePath, "utf8")
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as PluginTurn)
+        : [];
+    const commitTurn: NonNullable<ContextEngine["commitTurn"]> = async (params) => {
+      const alreadyCommitted = readPluginStore().some(
+        (turn) => turn.advancementKey === params.advancementKey,
+      );
+      if (alreadyCommitted) {
+        return { status: "duplicate" };
+      }
+      fs.appendFileSync(
+        pluginStorePath,
+        `${JSON.stringify({
+          advancementKey: params.advancementKey,
+          sessionId: params.sessionId,
+          messages: params.messages,
+        })}\n`,
+      );
+      return { status: "committed" };
+    };
+    const engine = {
+      info: {
+        id: "test",
+        name: "Test",
+        transcriptSemantics: {
+          currentTurnFence: "before-current-turn-entry-v1",
+          turnAdvancementIdempotency: "atomic-idempotent-v1",
+        },
+      },
+      ingest: async () => ({ ingested: true }),
+      assemble: async ({ sessionId, messages }) => {
+        // Reconstitute the persisted turns for this session, then append the
+        // incoming run's messages, so a later run continues from committed context.
+        const persisted = readPluginStore()
+          .filter((turn) => turn.sessionId === sessionId)
+          .flatMap((turn) => turn.messages);
+        const assembled = [...persisted, ...messages];
+        return { messages: assembled, estimatedTokens: assembled.length };
+      },
+      compact: async () => ({ ok: true, compacted: false }),
+      commitTurn,
+    } satisfies ContextEngine;
+    const createLease = () => {
+      const degradeBeforeStart = vi.fn();
+      const lease = {
+        engine,
+        effectiveEngine: engine,
+        effectiveEngineId: "test",
+        effectiveEnginePluginId: undefined,
+        degraded: false,
+        degradedReason: undefined,
+        selectForHost: vi.fn(),
+        degradeBeforeStart,
+        begin: vi.fn(),
+        deferDisposalUntil: vi.fn(),
+        dispose: vi.fn(async () => undefined),
+      } satisfies ContextEngineLogicalTurnLease;
+      return { degradeBeforeStart, lease };
+    };
+    const admissionFor = (advancementKey: string, sequence: number) =>
+      createPayload({ advancementKey, databasePath, sequence, sessionId: "session-a" }).boundary
+        .admission;
+    const outboxKeys = (target: typeof database) =>
+      (
+        target.db
+          .prepare(
+            "SELECT advancement_key FROM context_engine_turn_outbox ORDER BY advancement_key",
+          )
+          .all() as Array<{ advancement_key: string }>
+      ).map((row) => row.advancement_key);
+
+    enqueueContextEngineTurnCommit({
+      database,
+      engineId: "test",
+      payload: createPayload({
+        advancementKey: "session-a:malformed",
+        databasePath,
+        sequence: 1,
+        sessionId: "session-a",
+      }),
+    });
+    // Corrupt the first stored payload so recovery and every pending-work JSON
+    // projection meet invalid JSON before the later valid row.
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{not-valid-json' WHERE advancement_key = ?",
+      )
+      .run("session-a:malformed");
+    enqueueContextEngineTurnCommit({
+      database,
+      engineId: "test",
+      payload: createPayload({
+        advancementKey: "session-a:later-valid",
+        databasePath,
+        sequence: 3,
+        sessionId: "session-a",
+        messages: turnMessages("later valid user turn", "later valid assistant turn"),
+      }),
+    });
+
+    const warn = vi.fn();
+    const firstRun = createLease();
+    await drainPendingContextEngineTurnsBeforeRun({
+      admission: admissionFor("session-a:current-1", 5),
+      lease: firstRun.lease,
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "skipping outbox row with malformed payload JSON: session-a:malformed",
+      ),
+    );
+    // Before the json_valid guard the pending-work projection faulted on the
+    // corrupted row, so the pre-run owner reported a retry failure and degraded.
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to retry pending turn advancement"),
+    );
+    expect(firstRun.degradeBeforeStart).not.toHaveBeenCalled();
+    expect(readPluginStore()).toEqual([
+      {
+        advancementKey: "session-a:later-valid",
+        sessionId: "session-a",
+        messages: turnMessages("later valid user turn", "later valid assistant turn"),
+      },
+    ]);
+
+    // The pre-run owner admits the current turn after draining; drop that intent so
+    // the reopened run starts from the state the corrupted row actually produced.
+    database.db
+      .prepare("DELETE FROM context_engine_turn_outbox WHERE advancement_key = ?")
+      .run("session-a:current-1");
+
+    // Reopen the existing database so the next run sees durable state only.
+    closeOpenClawAgentDatabasesForTest();
+    const reopened = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const reopenedWarn = vi.fn();
+    recoverContextEngineTurnOutbox({
+      database: reopened,
+      engineId: "test",
+      sessionId: "session-a",
+      warn: reopenedWarn,
+    });
+    expect(reopenedWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "skipping outbox row with malformed payload JSON: session-a:malformed",
+      ),
+    );
+
+    // Continuation on the reopened database: a later accepted turn advances while a
+    // host retry of the already-committed turn stays idempotent.
+    enqueueContextEngineTurnCommit({
+      database: reopened,
+      engineId: "test",
+      payload: createPayload({
+        advancementKey: "session-a:after-reopen",
+        databasePath,
+        sequence: 9,
+        sessionId: "session-a",
+        messages: turnMessages("after reopen user turn", "after reopen assistant turn"),
+      }),
+    });
+    enqueueContextEngineTurnCommit({
+      database: reopened,
+      engineId: "test",
+      payload: createPayload({
+        advancementKey: "session-a:later-valid",
+        databasePath,
+        sequence: 3,
+        sessionId: "session-a",
+        messages: turnMessages("later valid user turn", "later valid assistant turn"),
+      }),
+    });
+    const drained = await drainContextEngineTurnOutbox({
+      database: reopened,
+      engine,
+      engineId: "test",
+      warn: reopenedWarn,
+    });
+
+    // The corrupted row is excluded from pending work, so the reopened database
+    // reports nothing outstanding and the next run keeps its full context path.
+    expect(drained.pending).toBe(false);
+    expect(readPluginStore()).toEqual([
+      {
+        advancementKey: "session-a:later-valid",
+        sessionId: "session-a",
+        messages: turnMessages("later valid user turn", "later valid assistant turn"),
+      },
+      {
+        advancementKey: "session-a:after-reopen",
+        sessionId: "session-a",
+        messages: turnMessages("after reopen user turn", "after reopen assistant turn"),
+      },
+    ]);
+    expect(outboxKeys(reopened)).toEqual(["session-a:malformed"]);
+    const retainedOutboxRows = outboxKeys(reopened);
+
+    const continuationRun = createLease();
+    await drainPendingContextEngineTurnsBeforeRun({
+      admission: admissionFor("session-a:current-2", 11),
+      lease: continuationRun.lease,
+      warn: reopenedWarn,
+    });
+    expect(continuationRun.degradeBeforeStart).not.toHaveBeenCalled();
+    expect(reopenedWarn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to retry pending turn advancement"),
+    );
+
+    // A subsequent run reassembles context straight from the plugin's durable
+    // store: the messages committed before the reopen come back and the incoming
+    // prompt is appended, proving persisted turn content is reused, not dropped.
+    const persistedTurns = readPluginStore();
+    const assembled = await engine.assemble({
+      sessionId: "session-a",
+      messages: turnMessages("next run user prompt", "next run assistant reply"),
+    });
+    expect(assembled.messages).toEqual([
+      ...turnMessages("later valid user turn", "later valid assistant turn"),
+      ...turnMessages("after reopen user turn", "after reopen assistant turn"),
+      ...turnMessages("next run user prompt", "next run assistant reply"),
+    ]);
+
+    // Terminal trace of the persisted production state, so the after-fix behaviour
+    // is visible in CI output without attaching a debugger.
+    console.log(
+      JSON.stringify({
+        scenario: "durable-plugin-message-persistence-and-reassembly",
+        database: path.basename(databasePath),
+        persistedTurns: persistedTurns.map((turn) => ({
+          advancementKey: turn.advancementKey,
+          messages: turn.messages,
+        })),
+        assembledContext: assembled.messages,
+        assembledTokenEstimate: assembled.estimatedTokens,
+        retainedOutboxRows,
+        leaseDegradations:
+          firstRun.degradeBeforeStart.mock.calls.length +
+          continuationRun.degradeBeforeStart.mock.calls.length,
+      }),
     );
   });
 });

--- a/src/agents/harness/context-engine-turn-outbox.ts
+++ b/src/agents/harness/context-engine-turn-outbox.ts
@@ -78,7 +78,10 @@ function oldestOutboxEnqueueSequence() {
 function outboxPayloadRequiresAdvancement() {
   // Blocked rows are terminal audit evidence, not retryable work. Keep them
   // inspectable without letting them hold later same-session turns behind them.
-  return /* kysely-allow-raw: Payload state is owned by the closed outbox union above. */ sql<boolean>`json_extract(context_engine_turn_outbox.payload_json, '$.state') IS NOT 'blocked'`;
+  // Malformed payload rows are contained the same way: json_valid excludes them
+  // before json_extract can fault on invalid JSON, so one corrupted durable row
+  // cannot block pending-work selection for later valid turns.
+  return /* kysely-allow-raw: Payload state is owned by the closed outbox union above. */ sql<boolean>`json_valid(context_engine_turn_outbox.payload_json) AND json_extract(context_engine_turn_outbox.payload_json, '$.state') IS NOT 'blocked'`;
 }
 
 export function isRetryableContextEngineTurnReadFailure(
@@ -127,7 +130,12 @@ function writeContextEngineTurnOutboxPayload(params: {
   );
   if (existing) {
     assertMatchingOutboxOwner(existing, params, advancementKey);
-    const existingPayload = JSON.parse(existing.payload_json) as ContextEngineTurnOutboxPayload;
+    let existingPayload: ContextEngineTurnOutboxPayload;
+    try {
+      existingPayload = JSON.parse(existing.payload_json) as ContextEngineTurnOutboxPayload;
+    } catch {
+      throw new Error(`Failed to parse existing outbox payload JSON for ${advancementKey}`);
+    }
     const transitionMatches =
       (params.payload.state === "accepted" &&
         existingPayload.state === "admitted" &&
@@ -279,7 +287,15 @@ export function recoverContextEngineTurnOutbox(params: {
       .orderBy(outboxEnqueueSequence(), "asc"),
   ).rows;
   for (const row of rows) {
-    const payload = JSON.parse(row.payload_json) as ContextEngineTurnOutboxPayload;
+    let payload: ContextEngineTurnOutboxPayload;
+    try {
+      payload = JSON.parse(row.payload_json) as ContextEngineTurnOutboxPayload;
+    } catch {
+      params.warn(
+        `[context-engine] skipping outbox row with malformed payload JSON: ${row.advancement_key}`,
+      );
+      continue;
+    }
     if (payload.state === "ready") {
       continue;
     }

--- a/src/agents/harness/context-engine-turn-outbox.ts
+++ b/src/agents/harness/context-engine-turn-outbox.ts
@@ -121,7 +121,12 @@ function writeContextEngineTurnOutboxPayload(params: {
   );
   if (existing) {
     assertMatchingOutboxOwner(existing, params, advancementKey);
-    const existingPayload = JSON.parse(existing.payload_json) as ContextEngineTurnOutboxPayload;
+    let existingPayload: ContextEngineTurnOutboxPayload;
+    try {
+      existingPayload = JSON.parse(existing.payload_json) as ContextEngineTurnOutboxPayload;
+    } catch {
+      throw new Error(`Failed to parse existing outbox payload JSON for ${advancementKey}`);
+    }
     const transitionMatches =
       (params.payload.state === "accepted" &&
         existingPayload.state === "admitted" &&
@@ -273,7 +278,15 @@ export function recoverContextEngineTurnOutbox(params: {
       .orderBy(outboxEnqueueSequence(), "asc"),
   ).rows;
   for (const row of rows) {
-    const payload = JSON.parse(row.payload_json) as ContextEngineTurnOutboxPayload;
+    let payload: ContextEngineTurnOutboxPayload;
+    try {
+      payload = JSON.parse(row.payload_json) as ContextEngineTurnOutboxPayload;
+    } catch {
+      params.warn(
+        `[context-engine] skipping outbox row with malformed payload JSON: ${row.advancement_key}`,
+      );
+      continue;
+    }
     if (payload.state === "ready") {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

In `src/agents/harness/context-engine-turn-outbox.ts`, two `JSON.parse()` calls are not wrapped in try/catch:
1. `writeContextEngineTurnOutboxPayload` parses `existing.payload_json` without error handling
2. `recoverContextEngineTurnOutbox` parses `row.payload_json` without error handling

If the stored JSON is corrupted, this throws an unhandled `SyntaxError` with no context about which row or advancement key caused the failure.

Worse, a corrupted row left in the table also breaks every pending-work query: `outboxPayloadRequiresAdvancement()` projects `json_extract(payload_json, '$.state')`, and SQLite raises `malformed JSON` on the invalid row before the query can reach later valid rows. The agent-run attempt path recovers the outbox and immediately drains it, so one corrupted durable row degrades the lease and blocks valid session turns from advancing.

## Fix

1. **writeContextEngineTurnOutboxPayload**: Wrap `JSON.parse` in try/catch, re-throwing with a descriptive error including the `advancementKey`.
2. **recoverContextEngineTurnOutbox**: Wrap `JSON.parse` in try/catch, logging a warning with the `advancement_key` and skipping the malformed row (`continue`). The row stays durable as audit evidence, matching how blocked rows are retained.
3. **outboxPayloadRequiresAdvancement**: Guard the JSON projection with `json_valid(payload_json)` before `json_extract(...)`, so malformed rows are excluded from every pending-work selection path (pending-session grouping, the per-session row pick, and `hasPendingContextEngineTurn`) instead of faulting the query. This follows the existing containment pattern used by the subagent SQLite registry (`json_valid(payload_json) AND ...`).

## Evidence

Regression tests in `src/agents/harness/context-engine-turn-outbox.test.ts` (the whole file — 11 tests — passes in CI):
- `throws a descriptive error when existing outbox payload JSON is malformed` — the write path re-throws with the `advancementKey` instead of a bare `SyntaxError`.
- `skips outbox rows with malformed payload JSON during recovery` — recovery logs a warning naming the `advancement_key` and keeps the row as inspectable audit evidence.

### After-fix production-path proof (real context plugin persisting messages + database reopen + context reassembly)

`persists real turn messages through a durable plugin and reassembles them after a reopen past a malformed row` drives the **production entry point** `drainPendingContextEngineTurnsBeforeRun` against a **real durable context plugin** — there is no mocked `commitTurn` and no pass-through `assemble`. The plugin's `commitTurn` persists each accepted turn's **actual messages** (`{ role, content }` records, shaped exactly like the entries the transcript hands to `commitTurn` in production) to its own on-disk JSONL context store, and honours the `atomic-idempotent-v1` contract so a host retry of an already-committed key returns `{ status: "duplicate" }` instead of storing the same messages twice. Its `assemble` reconstitutes a session's persisted turns from that store and appends the incoming run's messages — the same contract a real retrieval-oriented engine implements.

The test:
1. Enqueues a turn, corrupts its stored `payload_json` to `{not-valid-json`, then enqueues a later valid turn **carrying real user/assistant messages** in the same session.
2. Runs the pre-run owner (`drainPendingContextEngineTurnsBeforeRun`) — **corruption recovery + message persistence**: the malformed row is skipped with a warning, the later valid turn commits through the real plugin and its **messages are written to the plugin's durable store**, and the lease is **not** degraded. (Before the `json_valid` guard the pending-work projection faulted on the corrupted row, so the owner reported a retry failure and degraded the lease.)
3. **Closes and reopens the existing database**, then continues — **persistence across reopen**: a later accepted turn (`session-a:after-reopen`) advances and its messages are appended to the same on-disk store, while a host retry of the already-committed `session-a:later-valid` turn stays idempotent (`duplicate`, never stored twice).
4. Calls `assemble` for a **subsequent run** — **context reassembly**: the plugin returns the messages persisted before and after the reopen, followed by the next run's prompt, proving committed turn content is reused rather than dropped.
5. Asserts the reopened database reports `pending: false`, the corrupted row is the only retained outbox row (kept as audit evidence, excluded from pending work), and neither run degraded the lease.

Trace emitted by the test's terminal `console.log` and captured in CI output (reformatted below for readability; values are exact) — shard `agentic-agents-support-hosted-1`, job [`checks-node-compact-large-10`](https://github.com/openclaw/openclaw/actions/runs/34037447490/job/101498164469), where the full `context-engine-turn-outbox.test.ts` file passes 11/11:

```json
{
  "scenario": "durable-plugin-message-persistence-and-reassembly",
  "database": "openclaw-agent.sqlite",
  "persistedTurns": [
    { "advancementKey": "session-a:later-valid", "messages": [
      { "role": "user", "content": "later valid user turn" },
      { "role": "assistant", "content": "later valid assistant turn" } ] },
    { "advancementKey": "session-a:after-reopen", "messages": [
      { "role": "user", "content": "after reopen user turn" },
      { "role": "assistant", "content": "after reopen assistant turn" } ] }
  ],
  "assembledContext": [
    { "role": "user", "content": "later valid user turn" },
    { "role": "assistant", "content": "later valid assistant turn" },
    { "role": "user", "content": "after reopen user turn" },
    { "role": "assistant", "content": "after reopen assistant turn" },
    { "role": "user", "content": "next run user prompt" },
    { "role": "assistant", "content": "next run assistant reply" }
  ],
  "assembledTokenEstimate": 6,
  "retainedOutboxRows": ["session-a:malformed"],
  "leaseDegradations": 0
}
```

Read against the fix, the trace shows — through a real context plugin that persists message content, on a **reopened** database:
- **later-turn message persistence**: `persistedTurns` records the **actual `{ role, content }` messages** the plugin's `commitTurn` received and wrote to its durable store, not merely keys, session IDs, or a status;
- **database reopen**: `session-a:after-reopen` messages are persisted **after** the database is closed and reopened, and the retried `session-a:later-valid` turn is **not** duplicated (idempotent across the reopen);
- **subsequent context assembly**: `assembledContext` is the plugin's `assemble` output for a later run — the persisted turns reconstituted from the on-disk store, followed by the next run's prompt (`assembledTokenEstimate: 6`);
- **corruption containment**: `retainedOutboxRows: ["session-a:malformed"]` — the corrupted row survives as audit evidence but is excluded from pending work, and `leaseDegradations: 0` — no run degraded its context path.

Before the `json_valid` guard, step 2 fails: SQLite raises `malformed JSON` inside the pending-work query, the pre-run owner reports a retry failure and degrades the lease, so the later valid turn's messages are never persisted.
