### PR TITLE
fix(skills): allow disposal of malformed proposals

### DIFF
--- a/src/agents/tools/skill-workshop-tool-schema.ts
+++ b/src/agents/tools/skill-workshop-tool-schema.ts
@@ -148,7 +148,7 @@ export function buildSkillWorkshopToolSchema(collectionOnly: boolean, proposalRe
       expected_revision_hash: Type.Optional(
         Type.String({
           description:
-            "Optional exact proposal revision hash for revise/evaluate/apply/reject/quarantine. The action fails if content or support files changed.",
+            "Optional exact recorded proposal revision hash for revise/evaluate/apply/reject/quarantine. The action fails if the stored proposal record changed. Revise, evaluate, and apply verify proposal artifacts. Reject and quarantine run interrupted-apply recovery first, then use only the stored record.",
         }),
       ),
       correlation_id: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.lifecycle.test.ts
+++ b/src/agents/tools/skill-workshop-tool.lifecycle.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { listSkillProposalEvents } from "../../skills/workshop/service.js";
+import { readSkillProposalRecord } from "../../skills/workshop/store.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+async function proposalDraftPath(proposalId: string): Promise<string> {
+  const record = await readSkillProposalRecord(proposalId, { env: testState.env });
+  if (!record) {
+    throw new Error(`expected stored proposal ${proposalId}`);
+  }
+  return path.join(testState.stateDir, "skill-workshop", "proposals", proposalId, record.draftFile);
+}
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-lifecycle-state-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+describe("skill_workshop terminal lifecycle", () => {
+  it("disposes of proposals without reading damaged draft artifacts", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-damaged-drafts-");
+    const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
+    const draftDamageCases: Array<readonly [string, (draft: string) => Promise<void>]> = [
+      ["altered", async (draft) => await fs.writeFile(draft, "# Altered\n", "utf8")],
+      ["missing", async (draft) => await fs.unlink(draft)],
+      [
+        "oversized",
+        async (draft) => await fs.writeFile(draft, Buffer.alloc(1024 * 1024 + 1, 0x78)),
+      ],
+    ];
+    if (process.platform !== "win32") {
+      draftDamageCases.push(
+        [
+          "symlinked",
+          async (draft) => {
+            const target = `${draft}.target`;
+            await fs.rename(draft, target);
+            await fs.symlink(target, draft);
+          },
+        ],
+        ["hardlinked", async (draft) => await fs.link(draft, `${draft}.alias`)],
+      );
+    }
+
+    for (const action of ["reject", "quarantine"] as const) {
+      const expectedStatus = action === "reject" ? "rejected" : "quarantined";
+      for (const [damage, damageDraft] of draftDamageCases) {
+        const created = await tool.execute(`create-${action}-${damage}`, {
+          action: "create",
+          name: `${action} ${damage}`,
+          description: `Dispose of a ${damage} proposal`,
+          proposal_content: `# ${action} ${damage}\n\nDisposable draft.\n`,
+        });
+        const details = created.details as { id: string; revisionHash: string };
+        await damageDraft(await proposalDraftPath(details.id));
+
+        await expect(
+          tool.execute(`apply-${action}-${damage}`, {
+            action: "apply",
+            proposal_id: details.id,
+            expected_revision_hash: details.revisionHash,
+          }),
+        ).rejects.toThrow();
+        await expect(
+          tool.execute(`${action}-${damage}`, {
+            action,
+            proposal_id: details.id,
+            expected_revision_hash: details.revisionHash,
+          }),
+        ).resolves.toMatchObject({ details: { id: details.id, status: expectedStatus } });
+        await expect(
+          readSkillProposalRecord(details.id, { env: testState.env }),
+        ).resolves.toMatchObject({ status: expectedStatus });
+        expect(
+          listSkillProposalEvents({
+            workspaceDir,
+            proposalId: details.id,
+            env: testState.env,
+          }).events.at(-1)?.type,
+        ).toBe(expectedStatus);
+        await expect(
+          fs.access(path.join(workspaceDir, "skills", `${action}-${damage}`, "SKILL.md")),
+        ).rejects.toThrow();
+      }
+    }
+  });
+});

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -206,6 +206,10 @@ describe("skill_workshop tool", () => {
     expect(schema).toContain("max 160 bytes");
     expect(schema).toContain("shortens the proposal listing entry");
     expect(schema).toContain("artifact_path");
+    expect(schema).toContain("stored proposal record changed");
+    expect(schema).toContain("run interrupted-apply recovery first");
+    expect(schema).toContain("then use only the stored record");
+    expect(schema).not.toContain("action fails if content or support files changed");
     expect(tool.description).toContain(lazyDescription);
     expect(tool.description).toContain(SKILL_AUTHORING_STANDARDS_PROMPT);
   });

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1216,6 +1216,53 @@ describe("skill workshop proposals", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "recovers a partial create through the quarantine config",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const targetSkillsDir = await tempDirs.make("openclaw-workshop-quarantine-symlink-");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      const config = {
+        skills: {
+          load: { allowSymlinkTargets: [targetSkillsDir] },
+          workshop: { allowSymlinkTargetWrites: true },
+        },
+      };
+      const proposal = await proposeCreateSkill({
+        workspaceDir,
+        config,
+        name: "Quarantine Symlink",
+        description: "Recover before quarantining an allowed symlink target",
+        content: "# Quarantine Symlink\n\nRecover before terminal disposal.\n",
+        supportFiles: [{ path: "references/proof.md", content: "Partial support.\n" }],
+      });
+      const targetSupportFile = path.join(
+        targetSkillsDir,
+        "quarantine-symlink",
+        "references",
+        "proof.md",
+      );
+      await writeSkillProposalRollback({
+        proposalId: proposal.record.id,
+        rollback: createSkillProposalRollback({
+          proposalId: proposal.record.id,
+          targetSkillFile: proposal.record.target.skillFile,
+          action: "create",
+          supportFiles: [{ path: "references/proof.md", existed: false }],
+        }),
+      });
+      await fs.mkdir(path.dirname(targetSupportFile), { recursive: true });
+      await fs.writeFile(targetSupportFile, "Partial support.\n", "utf8");
+
+      closeOpenClawStateDatabaseForTest();
+      await expect(
+        quarantineSkillProposal({ workspaceDir, config, proposalId: proposal.record.id }),
+      ).resolves.toMatchObject({ status: "quarantined" });
+      await expect(fs.access(targetSupportFile)).rejects.toThrow();
+      await expect(readSkillProposalRollback(proposal.record.id)).resolves.toBeNull();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "uses the proposal environment for symlink recovery",
     async () => {
       const workspaceDir = await makeWorkspace();

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -83,7 +83,7 @@ export async function reviseSkillProposal(
     throw new Error("Skill proposal revision requires at least one changed field.");
   }
   const config = resolveSkillWorkshopConfig(input.config);
-  const revision = withPendingSkillProposalMutation(input, "revised", async (read) => {
+  const revision = withPendingSkillProposalRevision(input, async (read) => {
     const { record } = read;
     assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
     assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
@@ -224,41 +224,7 @@ export async function rejectSkillProposal(
 export async function quarantineSkillProposal(
   input: SkillProposalActionInput,
 ): Promise<SkillProposalRecord> {
-  const result = await withPendingSkillProposalMutation(input, "quarantined", async (read) => {
-    const now = new Date().toISOString();
-    const record: SkillProposalRecord = {
-      ...read.record,
-      status: "quarantined",
-      updatedAt: now,
-      quarantinedAt: now,
-      statusReason: normalizeOptionalString(input.reason),
-      scan: {
-        ...read.record.scan,
-        state: "quarantined",
-      },
-    };
-    const event = await updateSkillProposalRecord({
-      record,
-      event: createSkillProposalEvent({
-        record,
-        type: "quarantined",
-        actor: input.eventActor,
-        ...(input.correlationId ? { correlationId: input.correlationId } : {}),
-        occurredAt: now,
-      }),
-      store: proposalStoreOptions(input.env),
-    });
-    return { record, event };
-  });
-  if (result.event) {
-    await dispatchSkillProposalChanged({
-      event: result.event,
-      record: result.record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
-  return result.record;
+  return await markProposal(input, "quarantined");
 }
 
 export async function applySkillProposal(
@@ -269,7 +235,7 @@ export async function applySkillProposal(
 
 async function markProposal(
   input: SkillProposalActionInput,
-  status: "rejected",
+  status: "quarantined" | "rejected",
 ): Promise<SkillProposalRecord> {
   const scope = {
     ...(input.agentId ? { agentId: input.agentId } : {}),
@@ -279,6 +245,7 @@ async function markProposal(
     input.proposalId,
     proposalStoreOptions(input.env),
     scope,
+    input.config ? { config: input.config } : undefined,
   );
   if (!initial) {
     throw new Error(`Skill proposal not found: ${input.proposalId}`);
@@ -297,18 +264,25 @@ async function markProposal(
       }
       if (current.status !== "pending") {
         throw new Error(
-          `Only pending proposals can be rejected. Current status: ${current.status}.`,
+          `Only pending proposals can be ${status}. Current status: ${current.status}.`,
         );
       }
       assertExpectedRevisionHash(hashSkillProposalRevision(current), input.expectedRevisionHash);
       const now = new Date().toISOString();
-      const record: SkillProposalRecord = {
+      const base = {
         ...current,
         status,
         updatedAt: now,
-        rejectedAt: now,
         statusReason: normalizeOptionalString(input.reason),
       };
+      const record: SkillProposalRecord =
+        status === "rejected"
+          ? { ...base, rejectedAt: now }
+          : {
+              ...base,
+              quarantinedAt: now,
+              scan: { ...current.scan, state: "quarantined" },
+            };
       const event = await updateSkillProposalRecord({
         record,
         event: createSkillProposalEvent({
@@ -335,18 +309,11 @@ async function markProposal(
   return result.record;
 }
 
-async function withPendingSkillProposalMutation<T>(
+async function withPendingSkillProposalRevision<T>(
   input: Pick<
     SkillProposalActionInput,
-    | "agentId"
-    | "config"
-    | "env"
-    | "eventActor"
-    | "expectedRevisionHash"
-    | "proposalId"
-    | "workspaceDir"
+    "agentId" | "config" | "env" | "expectedRevisionHash" | "proposalId" | "workspaceDir"
   >,
-  action: "applied" | "quarantined" | "rejected" | "revised",
   fn: (read: SkillProposalReadResult) => Promise<T>,
 ): Promise<T> {
   const recoveryReadOptions = input.config ? { config: input.config } : undefined;
@@ -373,7 +340,7 @@ async function withPendingSkillProposalMutation<T>(
       );
       if (read.record.status !== "pending") {
         throw new Error(
-          `Only pending proposals can be ${action}. Current status: ${read.record.status}.`,
+          `Only pending proposals can be revised. Current status: ${read.record.status}.`,
         );
       }
       assertExpectedRevisionHash(read.revisionHash, input.expectedRevisionHash);


### PR DESCRIPTION
Closes #124486

AI-assisted: yes. I reviewed the affected lifecycle code and understand the change.

## What Problem This Solves

Skill Workshop could not quarantine a pending proposal when `PROPOSAL.md` was changed, missing, oversized, symlinked, or hardlinked. The terminal action read the damaged draft before it updated the proposal record, so malformed proposals remained pending.

## Root cause

Manual quarantine shared the full artifact-reading path used by revision. That path correctly rejects untrusted draft bytes, but quarantine does not consume those bytes. Current main already gave rejection a record-only path, which left the two terminal actions inconsistent.

## Fix

- Reuse one target-locked, record-only transition for rejection and quarantine.
- Preserve pending-state and recorded-revision checks under the lock.
- Forward caller configuration through interrupted-apply recovery before terminal disposal.
- Preserve the quarantine timestamp and `scan.state = quarantined` update.
- Keep full draft verification for revise, evaluate, and apply.
- Correct the model-facing `expected_revision_hash` description.

## Evidence

The real `skill_workshop` agent tool ran with fresh SQLite state on exact current main `f46f9b5aa39feaec7eda5d9d480972566b6aabf5` and exact repaired head `f978943c16c86b7a23d61d2ae45200ade76c3967`.

| Draft state | Current main quarantine | Repaired quarantine |
| --- | --- | --- |
| Altered | Failed; stayed pending | Quarantined |
| Missing | Failed; stayed pending | Quarantined |
| Oversized | Failed; stayed pending | Quarantined |
| Symlinked | Failed; stayed pending | Quarantined |
| Hardlinked | Failed; stayed pending | Quarantined |

The same run proved rejection still records all five terminal outcomes. It also proved revise, evaluate, and apply reject changed draft content and leave each proposal pending.

The configured interrupted-apply regression failed on the prior head because a partial allowed-symlink support file remained. It passes on the repaired tree: recovery removes the partial file and clears rollback state before quarantine commits.

## Validation

- Skill Workshop service and evaluation suites: 70 passed.
- Agent-tool lifecycle suites: 25 passed.
- Oxfmt: all three changed files match.
- `git diff --check`: passed.

Production LOC: +18/-51 (net -33). Tests: +155/-0.
