### PR TITLE
fix(cli): restore archived sessions

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -101,6 +101,23 @@ wait for the placement to settle, then retry. Agent main sessions remain
 protected. Already archived sessions are successful no-ops. Use `--dry-run` to
 validate every key and preview the result without changing session state.
 
+## Restore sessions
+
+Restore one or more archived sessions through the running Gateway:
+
+```bash
+openclaw sessions restore "agent:main:scratch-1"
+openclaw sessions restore "agent:main:scratch-1" "agent:main:scratch-2"
+openclaw sessions restore "agent:work:scratch-1" --agent work
+openclaw sessions restore "agent:main:scratch-1" --dry-run
+openclaw sessions restore "agent:main:scratch-1" --json
+```
+
+Restore uses the same `sessions.patch` lifecycle operation as the Control UI.
+It clears the archived marker without deleting or rewriting the transcript.
+Already active sessions are successful no-ops. Use `--dry-run` to validate
+every key and preview the result without changing session state.
+
 ## Delete sessions
 
 Delete one or more sessions through the running Gateway:
@@ -127,7 +144,7 @@ a verified `.jsonl.deleted.<timestamp>` archive; incognito transcripts are
 removed without an archive. If a managed worktree cannot be removed safely,
 the command reports the preserved branch and path for manual cleanup.
 
-Both lifecycle commands:
+All lifecycle commands:
 
 - accept multiple keys and report one ordered result per key;
 - use `--agent <id>` to select the owning agent, which is required for a

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   sessionsTailCommand: vi.fn(),
   sessionsCompactCommand: vi.fn(),
   sessionsArchiveCommand: vi.fn(),
+  sessionsRestoreCommand: vi.fn(),
   sessionsDeleteCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
   tasksListCommand: vi.fn(),
@@ -38,6 +39,7 @@ const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
 const sessionsTailCommand = mocks.sessionsTailCommand;
 const sessionsCompactCommand = mocks.sessionsCompactCommand;
 const sessionsArchiveCommand = mocks.sessionsArchiveCommand;
+const sessionsRestoreCommand = mocks.sessionsRestoreCommand;
 const sessionsDeleteCommand = mocks.sessionsDeleteCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
 const tasksListCommand = mocks.tasksListCommand;
@@ -99,6 +101,7 @@ vi.mock("../../commands/sessions-compact.js", () => ({
 
 vi.mock("../../commands/sessions-lifecycle.js", () => ({
   sessionsArchiveCommand: mocks.sessionsArchiveCommand,
+  sessionsRestoreCommand: mocks.sessionsRestoreCommand,
   sessionsDeleteCommand: mocks.sessionsDeleteCommand,
 }));
 
@@ -150,6 +153,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     sessionsTailCommand.mockResolvedValue(undefined);
     sessionsCompactCommand.mockResolvedValue(undefined);
     sessionsArchiveCommand.mockResolvedValue(undefined);
+    sessionsRestoreCommand.mockResolvedValue(undefined);
     sessionsDeleteCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
     tasksListCommand.mockResolvedValue(undefined);
@@ -415,6 +419,25 @@ describe("registerStatusHealthSessionsCommands", () => {
       agent: "work",
       dryRun: false,
       yes: true,
+      json: true,
+    });
+  });
+
+  it("forwards restore options through the stock lifecycle command", async () => {
+    await runCli([
+      "sessions",
+      "restore",
+      "agent:work:scratch-1",
+      "--agent",
+      "work",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expectCommandOptions(sessionsRestoreCommand, {
+      keys: ["agent:work:scratch-1"],
+      agent: "work",
+      dryRun: true,
       json: true,
     });
   });

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -125,7 +125,7 @@ async function runSessionsListCli(opts: SessionsListCliOptions): Promise<void> {
 
 function registerSessionsLifecycleCommand(
   sessionsCmd: Command,
-  operation: "archive" | "delete",
+  operation: "archive" | "restore" | "delete",
 ): void {
   const destructive = operation === "delete";
   const examples: Array<[string, string]> = destructive
@@ -140,23 +140,37 @@ function registerSessionsLifecycleCommand(
           "Preview an agent-scoped delete.",
         ],
       ]
-    : [
-        ['openclaw sessions archive "agent:main:scratch-1"', "Archive one session."],
-        [
-          'openclaw sessions archive "agent:main:scratch-1" "agent:main:scratch-2"',
-          "Archive several sessions.",
-        ],
-        [
-          'openclaw sessions archive "agent:work:scratch-1" --agent work --dry-run',
-          "Preview an agent-scoped archive.",
-        ],
-      ];
+    : operation === "archive"
+      ? [
+          ['openclaw sessions archive "agent:main:scratch-1"', "Archive one session."],
+          [
+            'openclaw sessions archive "agent:main:scratch-1" "agent:main:scratch-2"',
+            "Archive several sessions.",
+          ],
+          [
+            'openclaw sessions archive "agent:work:scratch-1" --agent work --dry-run',
+            "Preview an agent-scoped archive.",
+          ],
+        ]
+      : [
+          ['openclaw sessions restore "agent:main:scratch-1"', "Restore one archived session."],
+          [
+            'openclaw sessions restore "agent:main:scratch-1" "agent:main:scratch-2"',
+            "Restore several archived sessions.",
+          ],
+          [
+            'openclaw sessions restore "agent:work:scratch-1" --agent work --dry-run',
+            "Preview an agent-scoped restore.",
+          ],
+        ];
   const command = sessionsCmd
     .command(`${operation} <keys...>`)
     .description(
       destructive
         ? "Delete stored sessions and their live artifacts via the running gateway"
-        : "Archive stored sessions via the running gateway",
+        : operation === "archive"
+          ? "Archive stored sessions via the running gateway"
+          : "Restore archived sessions via the running gateway",
     )
     .option(`--dry-run`, `Preview ${operation} actions without writing`, false);
   if (destructive) {
@@ -196,7 +210,9 @@ function registerSessionsLifecycleCommand(
         const lifecycleCommands = await import("../../commands/sessions-lifecycle.js");
         const handler = destructive
           ? lifecycleCommands.sessionsDeleteCommand
-          : lifecycleCommands.sessionsArchiveCommand;
+          : operation === "archive"
+            ? lifecycleCommands.sessionsArchiveCommand
+            : lifecycleCommands.sessionsRestoreCommand;
         await handler(
           {
             keys,
@@ -512,6 +528,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     });
 
   registerSessionsLifecycleCommand(sessionsCmd, "archive");
+  registerSessionsLifecycleCommand(sessionsCmd, "restore");
   registerSessionsLifecycleCommand(sessionsCmd, "delete");
 
   addSessionsGatewayOptions(sessionsCmd.command("compact <key>"))

--- a/src/commands/sessions-lifecycle.test.ts
+++ b/src/commands/sessions-lifecycle.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sessionsArchiveCommand, sessionsDeleteCommand } from "./sessions-lifecycle.js";
+import {
+  sessionsArchiveCommand,
+  sessionsDeleteCommand,
+  sessionsRestoreCommand,
+} from "./sessions-lifecycle.js";
 
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
@@ -137,6 +141,42 @@ describe("sessions lifecycle commands", () => {
     );
   });
 
+  it("restores through sessions.patch and confirms the archived marker is cleared", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(
+        listResult([{ key: "agent:work:scratch-1", sessionId: "session-1", archived: true }]),
+      )
+      .mockResolvedValueOnce({ ok: true, key: "agent:work:scratch-1", entry: {} });
+    const runtime = createRuntime();
+
+    await sessionsRestoreCommand(
+      { keys: ["agent:work:scratch-1"], agent: "work", json: true },
+      runtime,
+    );
+
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
+      "sessions.patch",
+      expect.any(Object),
+      {
+        key: "agent:work:scratch-1",
+        agentId: "work",
+        expectedSessionId: "session-1",
+        archived: false,
+      },
+      { defaultTimeoutMs: 10 * 60_000 },
+    );
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "restore",
+        dryRun: false,
+        results: [{ key: "agent:work:scratch-1", ok: true, status: "restored" }],
+      },
+      2,
+    );
+  });
+
   it.each([
     ["archive", sessionsArchiveCommand, {}],
     ["delete", sessionsDeleteCommand, { yes: true }],
@@ -169,6 +209,33 @@ describe("sessions lifecycle commands", () => {
       expect(runtime.exit).toHaveBeenCalledWith(1);
     },
   );
+
+  it("rejects an archived key-only session before restore mutation", async () => {
+    mocks.callGateway.mockResolvedValueOnce(
+      listResult([{ key: "agent:main:key-only", archived: true }]),
+    );
+    const runtime = createRuntime();
+
+    await sessionsRestoreCommand({ keys: ["agent:main:key-only"], json: true }, runtime);
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: false,
+        operation: "restore",
+        dryRun: false,
+        results: [
+          {
+            key: "agent:main:key-only",
+            ok: false,
+            status: "failed",
+            error: "Session has no durable identity; lifecycle mutation was not attempted.",
+          },
+        ],
+      },
+      2,
+    );
+  });
 
   it("deletes archived sessions with the same gated artifact contract as Control UI", async () => {
     mocks.callGateway

--- a/src/commands/sessions-lifecycle.ts
+++ b/src/commands/sessions-lifecycle.ts
@@ -18,13 +18,16 @@ type SessionsLifecycleCliOptions = {
   json?: boolean;
 };
 
-type SessionsLifecycleOperation = "archive" | "delete";
+type SessionsLifecycleOperation = "archive" | "restore" | "delete";
 
 type SessionsLifecycleStatus =
   | "archived"
   | "already_archived"
+  | "restored"
+  | "already_active"
   | "deleted"
   | "would_archive"
+  | "would_restore"
   | "would_delete"
   | "not_found"
   | "failed";
@@ -148,6 +151,12 @@ function outputLifecycleResults(
         case "already_archived":
           runtime.log(`Session ${result.key} is already archived.`);
           break;
+        case "restored":
+          runtime.log(`Restored session ${result.key}.`);
+          break;
+        case "already_active":
+          runtime.log(`Session ${result.key} is already active.`);
+          break;
         case "deleted":
           runtime.log(`Deleted session ${result.key}.`);
           for (const archived of result.archived ?? []) {
@@ -161,6 +170,9 @@ function outputLifecycleResults(
           break;
         case "would_archive":
           runtime.log(`[dry-run] archive session ${result.key}`);
+          break;
+        case "would_restore":
+          runtime.log(`[dry-run] restore session ${result.key}`);
           break;
         case "would_delete":
           runtime.log(`[dry-run] delete session ${result.key} and its live transcript state`);
@@ -213,7 +225,10 @@ async function runSessionsLifecycleCommand(
     return session ? [{ index, session }] : [];
   });
   const validTargets = listedTargets.filter(({ index, session }) => {
-    const needsMutation = !opts.dryRun && !(operation === "archive" && session.archived === true);
+    const alreadyTerminal =
+      (operation === "archive" && session.archived === true) ||
+      (operation === "restore" && session.archived !== true);
+    const needsMutation = !opts.dryRun && !alreadyTerminal;
     if (!needsMutation || session.sessionId) {
       return true;
     }
@@ -261,7 +276,11 @@ async function runSessionsLifecycleCommand(
             ? session.archived === true
               ? "already_archived"
               : "would_archive"
-            : "would_delete",
+            : operation === "restore"
+              ? session.archived === true
+                ? "would_restore"
+                : "already_active"
+              : "would_delete",
       };
       continue;
     }
@@ -269,8 +288,13 @@ async function runSessionsLifecycleCommand(
       results[index] = { key: session.key, ok: true, status: "already_archived" };
       continue;
     }
+    if (operation === "restore" && session.archived !== true) {
+      results[index] = { key: session.key, ok: true, status: "already_active" };
+      continue;
+    }
     try {
-      if (operation === "archive") {
+      if (operation === "archive" || operation === "restore") {
+        const archived = operation === "archive";
         const response = (await callGatewayFromCliWithTransport(
           "sessions.patch",
           rpcOptions,
@@ -278,14 +302,25 @@ async function runSessionsLifecycleCommand(
             key: session.key,
             ...(opts.agent ? { agentId: opts.agent } : {}),
             ...(session.sessionId ? { expectedSessionId: session.sessionId } : {}),
-            archived: true,
+            archived,
           },
           { defaultTimeoutMs: SESSION_ARCHIVE_REQUEST_TIMEOUT_MS },
         )) as SessionsPatchResult;
-        if (response?.ok !== true || response.entry?.archivedAt === undefined) {
-          throw new Error("Gateway did not confirm that the session was archived.");
+        if (
+          response?.ok !== true ||
+          (archived
+            ? response.entry?.archivedAt === undefined
+            : response.entry?.archivedAt !== undefined)
+        ) {
+          throw new Error(
+            `Gateway did not confirm that the session was ${archived ? "archived" : "restored"}.`,
+          );
         }
-        results[index] = { key: response.key ?? session.key, ok: true, status: "archived" };
+        results[index] = {
+          key: response.key ?? session.key,
+          ok: true,
+          status: archived ? "archived" : "restored",
+        };
       } else {
         const response = (await callGatewayFromCliWithTransport(
           "sessions.delete",
@@ -336,6 +371,14 @@ export async function sessionsArchiveCommand(
   runtime: RuntimeEnv,
 ): Promise<void> {
   await runSessionsLifecycleCommand("archive", opts, runtime);
+}
+
+/** Restore one or more archived sessions through the same Gateway patch used by Control UI. */
+export async function sessionsRestoreCommand(
+  opts: SessionsLifecycleCliOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  await runSessionsLifecycleCommand("restore", opts, runtime);
 }
 
 /** Delete one or more stored sessions through the same Gateway lifecycle owner used by Control UI. */


### PR DESCRIPTION
Closes #124491

AI-assisted: yes. I reviewed the CLI, Gateway lifecycle contract, focused tests, public docs, and a real isolated Gateway run.

## What Problem This Solves

Headless users could archive a session with the stock CLI but could not restore it. Once archived, a fixed routing key rejected new work and told the operator to restore it, while the CLI offered only destructive deletion.

## Why This Change Was Made

Adds `openclaw sessions restore <keys...>` to the existing lifecycle command family. It calls the same `sessions.patch` operation used by the Control UI with the caller-observed session identity and `archived: false`; no new Gateway protocol, persistence, compatibility path, or configuration is introduced.

Restore supports the existing agent, Gateway credential, timeout, JSON, multi-key, and dry-run options. Active sessions return `already_active`, and an archived row without durable identity is refused before mutation. The Sessions CLI reference now documents the non-destructive restore flow alongside archive and delete.

## User Impact

CLI and SSH operators can resume archived sessions safely under the same routing key without deleting transcripts or invoking raw Gateway RPC.

## Evidence

Focused validation after rebasing onto current main:

```text
Test Files: 2 passed (2)
Tests: 52 passed (52)
```

Documentation validation:

```text
Docs formatting clean (758 files)
markdownlint: 0 issues
Docs MDX check passed
checked_internal_links=6496
broken_links=0
```

Real behavior proof used an isolated temporary state directory and a foreground stock Gateway built from this branch. The session identity stayed constant across both lifecycle transitions:

```json
{"ok":true,"operation":"archive","results":[{"key":"agent:main:restore-proof","ok":true,"status":"archived"}]}
{"gatewayAfterArchive":{"key":"agent:main:restore-proof","archived":true,"sessionId":"d7ebae9c-a647-49da-90c7-c53d07935b74"}}
{"ok":true,"operation":"restore","results":[{"key":"agent:main:restore-proof","ok":true,"status":"restored"}]}
{"gatewayAfterRestore":{"key":"agent:main:restore-proof","archived":false,"sessionId":"d7ebae9c-a647-49da-90c7-c53d07935b74"}}
```

The temporary Gateway shut down cleanly and its temporary state directory was removed.

Production LOC remains the missing public CLI capability plus user-facing help/examples; it reuses the existing lifecycle owner and adds no duplicate runtime path.