### PR TITLE
fix(agents): guard JSON.parse in hasDuplicateJsonObjectKeys with try/catch

### DIFF
--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -853,4 +853,20 @@ describe("createModelExecAutoReviewer", () => {
     expect(prepare).toHaveBeenCalledTimes(2);
     expect(complete).toHaveBeenCalledTimes(2);
   });
+
+  it("handles JSON with escaped keys without throwing in duplicate-key detection", async () => {
+    // The hasDuplicateJsonObjectKeys function parses each key string via JSON.parse.
+    // Verify that escaped keys are handled correctly without throwing.
+    const text = JSON.stringify({
+      decision: "allow",
+      risk: "low",
+      rationale: "key with \"escaped\" quotes",
+    });
+
+    await expect(reviewExecResponse(text)).resolves.toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: 'key with "escaped" quotes',
+    });
+  });
 });

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -175,7 +175,12 @@ function hasDuplicateJsonObjectKeys(text: string): boolean {
         next += 1;
       }
       if (text[next] === ":") {
-        const key = JSON.parse(text.slice(index, end + 1)) as string;
+        let key: string;
+        try {
+          key = JSON.parse(text.slice(index, end + 1)) as string;
+        } catch {
+          continue;
+        }
         if (keys.has(key)) {
           return true;
         }


### PR DESCRIPTION
## Problem
`hasDuplicateJsonObjectKeys` calls `JSON.parse` on key strings without error handling.

## Fix

Wrap in try/catch, skip key on failure.

## Testing

Regression test for escaped keys.