### PR TITLE
fix(logging): set truncated flag when line count exceeds limit

### DIFF
--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -113,4 +113,20 @@ describe("readConfiguredLogTail", () => {
     expect(result.file).toBe(configured);
     expect(result.lines).toEqual([]);
   });
+
+  it("sets truncated flag when line count exceeds the limit", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-truncated-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+
+    // Write more lines than the default limit (500) to trigger truncation.
+    const lines = Array.from({ length: 600 }, (_, i) => `line-${i}`);
+    await fs.writeFile(file, lines.join("\n") + "\n");
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredLogTail({ limit: 100 });
+
+    expect(result.lines).toHaveLength(100);
+    expect(result.truncated).toBe(true);
+  });
 });

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -139,6 +139,7 @@ async function readLogSlice(params: {
     }
     if (lines.length > limit) {
       lines = lines.slice(lines.length - limit);
+      truncated = true;
     }
 
     cursor = size;


### PR DESCRIPTION
## Problem

`readLogSlice` in `src/logging/log-tail.ts` truncates lines when `lines.length > limit` but does not set `truncated = true`. Callers cannot detect when lines were truncated.

## Fix

Set `truncated = true` when lines are sliced to the limit.

## Testing

Added regression test verifying `truncated` is `true` when lines exceed the limit.