### PR TITLE
fix(cli): guard against NaN timeout in health route

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -158,4 +158,27 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("falls back to default timeout when rpc.timeout is non-numeric", async () => {
+    const runtime = createRuntime();
+    const error = new Error("auth failed");
+    const callGateway = vi.fn(async () => {
+      throw error;
+    });
+    const emitReachableGatewayAuthDiagnostic = vi.fn(async () => true);
+
+    await runGatewayHealthJsonRoute(
+      { rpc: { json: true, timeout: "not-a-number" } },
+      runtime as never,
+      {
+        callGateway,
+        readBestEffortConfig: async () => ({}),
+        emitReachableGatewayAuthDiagnostic: emitReachableGatewayAuthDiagnostic as never,
+      },
+    );
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+  });
 });

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -87,7 +87,7 @@ export async function runGatewayHealthJsonRoute(
       error,
       config: rpc.config ?? (await readBestEffortConfig()),
       runtime,
-      timeoutMs: Number(rpc.timeout ?? "10000"),
+      timeoutMs: Number.isFinite(Number(rpc.timeout ?? "10000")) ? Number(rpc.timeout ?? "10000") : 10_000,
       token: rpc.token,
       password: rpc.password,
       localPortOverride: rpc.localPortOverride,


### PR DESCRIPTION
## Problem

`Number(rpc.timeout ?? '10000')` in `src/cli/gateway-cli/health-route.ts` can produce `NaN` when `rpc.timeout` is non-numeric.

## Fix

Use `Number.isFinite()` to validate, falling back to `10_000`.

## Testing

Regression test verifies fallback to `10_000` for non-numeric timeout.