### PR TITLE
fix(claws): wrap JSON.parse in try/catch in rowToRef

### DIFF
--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -222,4 +222,25 @@ describe("installClawCronJobs", () => {
     expect(first[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
     expect(second[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
   });
+
+  it("throws a descriptive error when stored job JSON is malformed", async () => {
+    const current = await fixture();
+    // Install a valid cron job first to create the row.
+    await installClawCronJobs(current.plan, {
+      env: current.env,
+      gateway: { add: vi.fn().mockResolvedValue({ id: "scheduler-123" }) },
+    });
+
+    // Corrupt the stored job_json to trigger the JSON.parse error path.
+    const { openOpenClawStateDatabase } = await import("../state/openclaw-state-db.js");
+    const database = openOpenClawStateDatabase(current.env);
+    database.db
+      .prepare("UPDATE claw_cron_refs SET job_json = '{not-valid-json' WHERE manifest_id = ?")
+      .run("daily-report");
+    closeOpenClawStateDatabaseForTest();
+
+    expect(() => readClawCronRefs("worker-two", { env: current.env })).toThrow(
+      /Failed to parse cron job JSON/,
+    );
+  });
 });

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -59,6 +59,12 @@ export class ClawCronInstallError extends Error {
 }
 
 function rowToRef(row: CronRefRow): PersistedClawCronRef {
+  let job: ClawCronJob;
+  try {
+    job = JSON.parse(row.job_json) as ClawCronJob;
+  } catch {
+    throw new Error(`Failed to parse cron job JSON for row ${row.declaration_key}`);
+  }
   return {
     schemaVersion: CLAW_CRON_REF_SCHEMA_VERSION,
     agentId: row.agent_id,
@@ -66,7 +72,7 @@ function rowToRef(row: CronRefRow): PersistedClawCronRef {
     declarationKey: row.declaration_key,
     ...(row.scheduler_job_id ? { schedulerJobId: row.scheduler_job_id } : {}),
     status: row.status,
-    job: JSON.parse(row.job_json) as ClawCronJob,
+    job,
     ...(row.error ? { error: row.error } : {}),
     createdAtMs: Number(row.created_at_ms),
     updatedAtMs: Number(row.updated_at_ms),


### PR DESCRIPTION
## Problem

`JSON.parse(row.job_json)` in `rowToRef` (`src/claws/cron.ts`) has no error handling. Corrupted JSON throws unhandled `SyntaxError`.

## Fix

Wrap in try/catch, re-throwing with `declaration_key` for context.

## Testing

Regression test corrupts `job_json` and verifies error message.