### PR TITLE
fix(ci): trust QA tooling for frozen targets

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -153,6 +153,7 @@ jobs:
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
       skip_package_telegram_e2e: ${{ steps.inputs.outputs.skip_package_telegram_e2e }}
+      trusted_qa_tooling_eligible: ${{ steps.trusted_qa_tooling.outputs.eligible }}
       rerun_group: ${{ steps.inputs.outputs.rerun_group }}
       live_suite_filter: ${{ steps.inputs.outputs.live_suite_filter }}
       repo_live_suite_filter: ${{ steps.inputs.outputs.repo_live_suite_filter }}
@@ -201,6 +202,81 @@ jobs:
             echo "Expected expected_sha to be a full commit SHA; got: ${EXPECTED_SHA}" >&2
             exit 1
           fi
+
+      - name: Validate trusted QA tooling context
+        id: trusted_qa_context
+        if: inputs.target_context_ref != ''
+        env:
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
+          TARGET_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          normalized_context_ref="$TARGET_CONTEXT_REF"
+          case "$normalized_context_ref" in
+            refs/heads/*) normalized_context_ref="${normalized_context_ref#refs/heads/}" ;;
+            refs/tags/*) normalized_context_ref="${normalized_context_ref#refs/tags/}" ;;
+          esac
+          if [[ "$normalized_context_ref" =~ ^(release/[0-9]{4}\.([1-9]|1[0-2])\.[1-9][0-9]*|extended-stable/[0-9]{4}\.([1-9]|1[0-2])\.33)$ ]]; then
+            context_kind=branch
+            checkout_ref="refs/heads/${normalized_context_ref}"
+          elif [[ "$normalized_context_ref" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.[1-9][0-9]*(-(alpha|beta)\.[1-9][0-9]*)?$ ]]; then
+            context_kind=tag
+            checkout_ref="refs/tags/${normalized_context_ref}"
+          else
+            echo "target_context_ref must be a canonical OpenClaw release branch or tag." >&2
+            exit 1
+          fi
+          if [[ ! "$TARGET_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "target_context_ref requires ref to be a full 40-character commit SHA." >&2
+            exit 1
+          fi
+          echo "normalized_ref=${normalized_context_ref}" >> "$GITHUB_OUTPUT"
+          echo "context_kind=${context_kind}" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted QA tooling context
+        if: steps.trusted_qa_context.outputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.trusted_qa_context.outputs.checkout_ref }}
+          path: .release-qa-context
+          fetch-depth: 0
+          persist-credentials: false
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
+          submodules: false
+
+      - name: Validate trusted QA tooling eligibility
+        id: trusted_qa_tooling
+        if: steps.trusted_qa_context.outputs.checkout_ref != ''
+        env:
+          CONTEXT_KIND: ${{ steps.trusted_qa_context.outputs.context_kind }}
+          CONTEXT_REF: ${{ steps.trusted_qa_context.outputs.normalized_ref }}
+          TARGET_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          context_sha="$(git -C .release-qa-context rev-parse HEAD)"
+          normalized_context_sha="$(printf '%s' "$context_sha" | tr '[:upper:]' '[:lower:]')"
+          normalized_target_sha="$(printf '%s' "$TARGET_REF" | tr '[:upper:]' '[:lower:]')"
+          case "$CONTEXT_KIND" in
+            tag)
+              if [[ "$normalized_context_sha" != "$normalized_target_sha" ]]; then
+                echo "Trusted QA tooling tag ${CONTEXT_REF} resolves to ${context_sha} and does not match target ${TARGET_REF}." >&2
+                exit 1
+              fi
+              ;;
+            branch)
+              if ! git -C .release-qa-context merge-base --is-ancestor "$normalized_target_sha" "$normalized_context_sha" 2>/dev/null; then
+                echo "Target ${TARGET_REF} is not reachable from branch ${CONTEXT_REF} at ${context_sha}." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Trusted QA tooling context kind is invalid: ${CONTEXT_KIND}." >&2
+              exit 1
+              ;;
+          esac
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
 
       - name: Checkout trusted workflow helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1262,7 +1338,7 @@ jobs:
           fetch-depth: 1
 
       - name: Checkout trusted QA Anthropic mock tooling
-        if: inputs.target_context_ref != ''
+        if: needs.resolve_target.outputs.trusted_qa_tooling_eligible == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.sha }}
@@ -1275,7 +1351,7 @@ jobs:
           submodules: false
 
       - name: Install trusted QA Anthropic mock tooling
-        if: inputs.target_context_ref != ''
+        if: needs.resolve_target.outputs.trusted_qa_tooling_eligible == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1261,6 +1261,32 @@ jobs:
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
+      - name: Checkout trusted QA Anthropic mock tooling
+        if: inputs.target_context_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: .release-qa-tooling-trusted
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          sparse-checkout: extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
+          sparse-checkout-cone-mode: false
+          submodules: false
+
+      - name: Install trusted QA Anthropic mock tooling
+        if: inputs.target_context_ref != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_checkout=.release-qa-tooling-trusted
+          trap 'rm -rf -- "$trusted_checkout"' EXIT
+          install -m 0644 \
+            "$trusted_checkout/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts" \
+            extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
+          rm -rf -- "$trusted_checkout"
+          trap - EXIT
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -218,10 +218,10 @@ jobs:
           esac
           if [[ "$normalized_context_ref" =~ ^(release/[0-9]{4}\.([1-9]|1[0-2])\.[1-9][0-9]*|extended-stable/[0-9]{4}\.([1-9]|1[0-2])\.33)$ ]]; then
             context_kind=branch
-            checkout_ref="refs/heads/${normalized_context_ref}"
+            fetch_ref="refs/heads/${normalized_context_ref}"
           elif [[ "$normalized_context_ref" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.[1-9][0-9]*(-(alpha|beta)\.[1-9][0-9]*)?$ ]]; then
             context_kind=tag
-            checkout_ref="refs/tags/${normalized_context_ref}"
+            fetch_ref="refs/tags/${normalized_context_ref}"
           else
             echo "target_context_ref must be a canonical OpenClaw release branch or tag." >&2
             exit 1
@@ -232,30 +232,28 @@ jobs:
           fi
           echo "normalized_ref=${normalized_context_ref}" >> "$GITHUB_OUTPUT"
           echo "context_kind=${context_kind}" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout trusted QA tooling context
-        if: steps.trusted_qa_context.outputs.checkout_ref != ''
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ steps.trusted_qa_context.outputs.checkout_ref }}
-          path: .release-qa-context
-          fetch-depth: 0
-          persist-credentials: false
-          sparse-checkout: package.json
-          sparse-checkout-cone-mode: false
-          submodules: false
+          echo "fetch_ref=${fetch_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Validate trusted QA tooling eligibility
         id: trusted_qa_tooling
-        if: steps.trusted_qa_context.outputs.checkout_ref != ''
+        if: steps.trusted_qa_context.outputs.fetch_ref != ''
         env:
+          CONTEXT_FETCH_REF: ${{ steps.trusted_qa_context.outputs.fetch_ref }}
           CONTEXT_KIND: ${{ steps.trusted_qa_context.outputs.context_kind }}
           CONTEXT_REF: ${{ steps.trusted_qa_context.outputs.normalized_ref }}
           TARGET_REF: ${{ inputs.ref }}
+          TRUSTED_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
         run: |
           set -euo pipefail
-          context_sha="$(git -C .release-qa-context rev-parse HEAD)"
+          context_repo="$(mktemp -d)"
+          trap 'rm -rf -- "$context_repo"' EXIT
+          git init --bare --quiet "$context_repo"
+          if ! GIT_TERMINAL_PROMPT=0 git -C "$context_repo" fetch --quiet --no-tags --filter=blob:none \
+            "$TRUSTED_REPOSITORY_URL" "$CONTEXT_FETCH_REF"; then
+            echo "Failed to fetch trusted QA tooling context ${CONTEXT_REF}." >&2
+            exit 1
+          fi
+          context_sha="$(git -C "$context_repo" rev-parse --verify 'FETCH_HEAD^{commit}')"
           normalized_context_sha="$(printf '%s' "$context_sha" | tr '[:upper:]' '[:lower:]')"
           normalized_target_sha="$(printf '%s' "$TARGET_REF" | tr '[:upper:]' '[:lower:]')"
           case "$CONTEXT_KIND" in
@@ -266,7 +264,7 @@ jobs:
               fi
               ;;
             branch)
-              if ! git -C .release-qa-context merge-base --is-ancestor "$normalized_target_sha" "$normalized_context_sha" 2>/dev/null; then
+              if ! git -C "$context_repo" merge-base --is-ancestor "$normalized_target_sha" "$normalized_context_sha" 2>/dev/null; then
                 echo "Target ${TARGET_REF} is not reachable from branch ${CONTEXT_REF} at ${context_sha}." >&2
                 exit 1
               fi

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1339,7 +1339,7 @@ jobs:
         if: needs.resolve_target.outputs.trusted_qa_tooling_eligible == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
           path: .release-qa-tooling-trusted
           fetch-depth: 1
           fetch-tags: false

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4325,7 +4325,7 @@ describe("package artifact reuse", () => {
       uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
       with: {
         "persist-credentials": false,
-        ref: "${{ github.sha }}",
+        ref: "${{ github.workflow_sha }}",
         path: ".release-qa-tooling-trusted",
         "sparse-checkout": "extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts",
         "sparse-checkout-cone-mode": false,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4159,6 +4159,45 @@ describe("package artifact reuse", () => {
     expect(reportStep.if).toBe("steps.run_lane.outcome == 'success'");
   });
 
+  it("overlays only trusted Anthropic mock tooling for frozen-target QA parity", () => {
+    const job = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_lab_parity_lane_release_checks");
+    const trustedCheckout = workflowStep(job, "Checkout trusted QA Anthropic mock tooling");
+    const installTooling = workflowStep(job, "Install trusted QA Anthropic mock tooling");
+    const stepNames = job.steps?.map((step) => step.name) ?? [];
+
+    expect(trustedCheckout).toMatchObject({
+      if: "inputs.target_context_ref != ''",
+      uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+      with: {
+        "persist-credentials": false,
+        ref: "${{ github.sha }}",
+        path: ".release-qa-tooling-trusted",
+        "sparse-checkout": "extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts",
+        "sparse-checkout-cone-mode": false,
+      },
+    });
+    expect(installTooling.if).toBe("inputs.target_context_ref != ''");
+    expect(installTooling.run).toContain("trap 'rm -rf -- \"$trusted_checkout\"' EXIT");
+    const installLines = (installTooling.run ?? "").split("\n").map((line) => line.trim());
+    const sourceArgument =
+      '"$trusted_checkout/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts" \\';
+    const sourceArgumentIndex = installLines.indexOf(sourceArgument);
+    expect(sourceArgumentIndex).toBeGreaterThanOrEqual(0);
+    expect(installLines[sourceArgumentIndex + 1]).toBe(
+      "extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts",
+    );
+    expect(installTooling.run).toContain('rm -rf -- "$trusted_checkout"');
+    expect(stepNames.indexOf("Checkout selected ref")).toBeLessThan(
+      stepNames.indexOf("Checkout trusted QA Anthropic mock tooling"),
+    );
+    expect(stepNames.indexOf("Install trusted QA Anthropic mock tooling")).toBeLessThan(
+      stepNames.indexOf("Setup Node environment"),
+    );
+    expect(stepNames.indexOf("Install trusted QA Anthropic mock tooling")).toBeLessThan(
+      stepNames.indexOf("Build private QA runtime"),
+    );
+  });
+
   it("runs the core gateway restart pair on its pinned live model", () => {
     const job = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_runtime_token_efficiency");
     const credentialStep = workflowStep(job, "Validate required QA credential env");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -324,6 +324,48 @@ function runReleaseChecksInputValidation(
   return { outputPath, result };
 }
 
+function runReleaseChecksShellStep(
+  stepName: string,
+  env: Record<string, string>,
+  workdir = tempDirs.make("release-checks-shell-step-"),
+) {
+  const step = workflowStep(workflowJob(RELEASE_CHECKS_WORKFLOW, "resolve_target"), stepName);
+  const outputPath = resolve(workdir, "github-output");
+  writeFileSync(outputPath, "", "utf8");
+  const result = spawnSync("bash", ["-c", step.run ?? ""], {
+    cwd: workdir,
+    encoding: "utf8",
+    env: {
+      ...env,
+      GITHUB_OUTPUT: outputPath,
+      PATH: process.env.PATH,
+    },
+  });
+  return { output: readFileSync(outputPath, "utf8"), result };
+}
+
+function createReleaseChecksContextFixture() {
+  const root = tempDirs.make("release-checks-context-repo-");
+  const repo = resolve(root, ".release-qa-context");
+  mkdirSync(repo);
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+  git("init", "-q", "--initial-branch=release/2026.8.1");
+  git("config", "user.name", "OpenClaw Test");
+  git("config", "user.email", "openclaw-test@example.com");
+  writeFileSync(resolve(repo, "package.json"), '{"version":1}\n', "utf8");
+  git("add", "package.json");
+  git("commit", "-qm", "candidate");
+  const candidateSha = git("rev-parse", "HEAD");
+  writeFileSync(resolve(repo, "package.json"), '{"version":2}\n', "utf8");
+  git("commit", "-qam", "branch advance");
+  const branchHeadSha = git("rev-parse", "HEAD");
+  git("tag", "-a", "v2026.8.1", "-m", "release", branchHeadSha);
+  const tree = git("rev-parse", "HEAD^{tree}");
+  const unrelatedSha = git("commit-tree", tree, "-m", "unrelated root");
+  return { branchHeadSha, candidateSha, git, root, unrelatedSha };
+}
+
 function runFullReleaseTargetSummary(rerunGroup: string, skipTelegram: string) {
   const step = workflowStep(
     workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "resolve_target"),
@@ -4160,13 +4202,123 @@ describe("package artifact reuse", () => {
   });
 
   it("overlays only trusted Anthropic mock tooling for frozen-target QA parity", () => {
+    const resolveTarget = workflowJob(RELEASE_CHECKS_WORKFLOW, "resolve_target");
+    const contextValidation = workflowStep(resolveTarget, "Validate trusted QA tooling context");
+    const contextCheckout = workflowStep(resolveTarget, "Checkout trusted QA tooling context");
+    const eligibility = workflowStep(resolveTarget, "Validate trusted QA tooling eligibility");
+    const resolveStepNames = resolveTarget.steps?.map((step) => step.name) ?? [];
     const job = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_lab_parity_lane_release_checks");
     const trustedCheckout = workflowStep(job, "Checkout trusted QA Anthropic mock tooling");
     const installTooling = workflowStep(job, "Install trusted QA Anthropic mock tooling");
     const stepNames = job.steps?.map((step) => step.name) ?? [];
+    const targetSha = "a".repeat(40);
+    const eligibilityCondition =
+      "needs.resolve_target.outputs.trusted_qa_tooling_eligible == 'true'";
+
+    expect(resolveTarget.outputs?.trusted_qa_tooling_eligible).toBe(
+      "${{ steps.trusted_qa_tooling.outputs.eligible }}",
+    );
+    expect(contextValidation.if).toBe("inputs.target_context_ref != ''");
+    expect(contextCheckout).toMatchObject({
+      if: "steps.trusted_qa_context.outputs.checkout_ref != ''",
+      uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+      with: {
+        "fetch-depth": 0,
+        path: ".release-qa-context",
+        "persist-credentials": false,
+        ref: "${{ steps.trusted_qa_context.outputs.checkout_ref }}",
+        "sparse-checkout": "package.json",
+        "sparse-checkout-cone-mode": false,
+        submodules: false,
+      },
+    });
+    expect(eligibility.if).toBe("steps.trusted_qa_context.outputs.checkout_ref != ''");
+    expect(resolveStepNames.indexOf("Validate trusted QA tooling context")).toBeLessThan(
+      resolveStepNames.indexOf("Checkout trusted QA tooling context"),
+    );
+    expect(resolveStepNames.indexOf("Checkout trusted QA tooling context")).toBeLessThan(
+      resolveStepNames.indexOf("Validate trusted QA tooling eligibility"),
+    );
+
+    for (const contextRef of [
+      "release/2026.8.1",
+      "refs/heads/extended-stable/2026.8.33",
+      "v2026.8.1",
+      "refs/tags/v2026.8.1-alpha.2",
+      "v2026.8.1-beta.3",
+    ]) {
+      const { output, result } = runReleaseChecksShellStep("Validate trusted QA tooling context", {
+        TARGET_CONTEXT_REF: contextRef,
+        TARGET_REF: targetSha,
+      });
+      expect(result.status, `${contextRef}: ${result.stderr}`).toBe(0);
+      expect(output, contextRef).toContain(
+        `normalized_ref=${contextRef.replace(/^refs\/(heads|tags)\//u, "")}\n`,
+      );
+    }
+
+    for (const contextRef of [
+      "main",
+      "release-ci/2026.8.1-frozen",
+      "release/2026.8",
+      "v2026.8.1-rc.1",
+      "refs/heads/refs/tags/v2026.8.1",
+    ]) {
+      const { result } = runReleaseChecksShellStep("Validate trusted QA tooling context", {
+        TARGET_CONTEXT_REF: contextRef,
+        TARGET_REF: targetSha,
+      });
+      expect(result.status, contextRef).toBe(1);
+      expect(result.stderr).toContain(
+        "target_context_ref must be a canonical OpenClaw release branch or tag.",
+      );
+    }
+
+    for (const targetRef of ["release/2026.8.1", "a".repeat(39)]) {
+      const { result } = runReleaseChecksShellStep("Validate trusted QA tooling context", {
+        TARGET_CONTEXT_REF: "release/2026.8.1",
+        TARGET_REF: targetRef,
+      });
+      expect(result.status, targetRef).toBe(1);
+      expect(result.stderr).toContain(
+        "target_context_ref requires ref to be a full 40-character commit SHA.",
+      );
+    }
+
+    const fixture = createReleaseChecksContextFixture();
+    const relationshipCases = [
+      ["tag", "refs/tags/v2026.8.1", fixture.branchHeadSha, 0, ""],
+      ["tag", "refs/tags/v2026.8.1", fixture.candidateSha, 1, "does not match target"],
+      ["branch", "refs/heads/release/2026.8.1", fixture.branchHeadSha, 0, ""],
+      ["branch", "refs/heads/release/2026.8.1", fixture.candidateSha, 0, ""],
+      [
+        "branch",
+        "refs/heads/release/2026.8.1",
+        fixture.unrelatedSha,
+        1,
+        "is not reachable from branch",
+      ],
+    ] as const;
+    for (const [contextKind, checkoutRef, targetRef, expectedStatus, error] of relationshipCases) {
+      fixture.git("checkout", "-q", "--detach", checkoutRef);
+      const { output, result } = runReleaseChecksShellStep(
+        "Validate trusted QA tooling eligibility",
+        {
+          CONTEXT_KIND: contextKind,
+          CONTEXT_REF: checkoutRef.replace(/^refs\/(heads|tags)\//u, ""),
+          TARGET_REF: targetRef,
+        },
+        fixture.root,
+      );
+      expect(result.status, `${contextKind} ${targetRef}: ${result.stderr}`).toBe(expectedStatus);
+      expect(output).toBe(expectedStatus === 0 ? "eligible=true\n" : "");
+      if (error) {
+        expect(result.stderr).toContain(error);
+      }
+    }
 
     expect(trustedCheckout).toMatchObject({
-      if: "inputs.target_context_ref != ''",
+      if: eligibilityCondition,
       uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
       with: {
         "persist-credentials": false,
@@ -4176,7 +4328,7 @@ describe("package artifact reuse", () => {
         "sparse-checkout-cone-mode": false,
       },
     });
-    expect(installTooling.if).toBe("inputs.target_context_ref != ''");
+    expect(installTooling.if).toBe(eligibilityCondition);
     expect(installTooling.run).toContain("trap 'rm -rf -- \"$trusted_checkout\"' EXIT");
     const installLines = (installTooling.run ?? "").split("\n").map((line) => line.trim());
     const sourceArgument =

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { FULL_RELEASE_WAIT_TIMEOUT_MINUTES } from "../../scripts/full-release-validation-at-sha.mts";
@@ -346,7 +347,7 @@ function runReleaseChecksShellStep(
 
 function createReleaseChecksContextFixture() {
   const root = tempDirs.make("release-checks-context-repo-");
-  const repo = resolve(root, ".release-qa-context");
+  const repo = resolve(root, "context-source");
   mkdirSync(repo);
   const git = (...args: string[]) =>
     execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
@@ -363,7 +364,7 @@ function createReleaseChecksContextFixture() {
   git("tag", "-a", "v2026.8.1", "-m", "release", branchHeadSha);
   const tree = git("rev-parse", "HEAD^{tree}");
   const unrelatedSha = git("commit-tree", tree, "-m", "unrelated root");
-  return { branchHeadSha, candidateSha, git, root, unrelatedSha };
+  return { branchHeadSha, candidateSha, repoUrl: pathToFileURL(repo).href, unrelatedSha };
 }
 
 function runFullReleaseTargetSummary(rerunGroup: string, skipTelegram: string) {
@@ -4204,7 +4205,6 @@ describe("package artifact reuse", () => {
   it("overlays only trusted Anthropic mock tooling for frozen-target QA parity", () => {
     const resolveTarget = workflowJob(RELEASE_CHECKS_WORKFLOW, "resolve_target");
     const contextValidation = workflowStep(resolveTarget, "Validate trusted QA tooling context");
-    const contextCheckout = workflowStep(resolveTarget, "Checkout trusted QA tooling context");
     const eligibility = workflowStep(resolveTarget, "Validate trusted QA tooling eligibility");
     const resolveStepNames = resolveTarget.steps?.map((step) => step.name) ?? [];
     const job = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_lab_parity_lane_release_checks");
@@ -4219,26 +4219,22 @@ describe("package artifact reuse", () => {
       "${{ steps.trusted_qa_tooling.outputs.eligible }}",
     );
     expect(contextValidation.if).toBe("inputs.target_context_ref != ''");
-    expect(contextCheckout).toMatchObject({
-      if: "steps.trusted_qa_context.outputs.checkout_ref != ''",
-      uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
-      with: {
-        "fetch-depth": 0,
-        path: ".release-qa-context",
-        "persist-credentials": false,
-        ref: "${{ steps.trusted_qa_context.outputs.checkout_ref }}",
-        "sparse-checkout": "package.json",
-        "sparse-checkout-cone-mode": false,
-        submodules: false,
-      },
-    });
-    expect(eligibility.if).toBe("steps.trusted_qa_context.outputs.checkout_ref != ''");
+    expect(
+      resolveTarget.steps?.find((step) => step.name === "Checkout trusted QA tooling context"),
+    ).toBeUndefined();
+    expect(eligibility.if).toBe("steps.trusted_qa_context.outputs.fetch_ref != ''");
     expect(resolveStepNames.indexOf("Validate trusted QA tooling context")).toBeLessThan(
-      resolveStepNames.indexOf("Checkout trusted QA tooling context"),
-    );
-    expect(resolveStepNames.indexOf("Checkout trusted QA tooling context")).toBeLessThan(
       resolveStepNames.indexOf("Validate trusted QA tooling eligibility"),
     );
+    expect(eligibility.env?.TRUSTED_REPOSITORY_URL).toBe(
+      "https://github.com/${{ github.repository }}.git",
+    );
+    expect(eligibility.run).toContain('context_repo="$(mktemp -d)"');
+    expect(eligibility.run).toContain("git init --bare --quiet");
+    expect(eligibility.run).toContain("--filter=blob:none");
+    expect(eligibility.run).toContain("FETCH_HEAD^{commit}");
+    expect(eligibility.run).not.toContain("git checkout");
+    expect(eligibility.run).not.toContain("git worktree");
 
     for (const contextRef of [
       "release/2026.8.1",
@@ -4298,17 +4294,24 @@ describe("package artifact reuse", () => {
         1,
         "is not reachable from branch",
       ],
+      [
+        "tag",
+        "refs/tags/v2026.8.1-beta.99",
+        fixture.branchHeadSha,
+        1,
+        "Failed to fetch trusted QA tooling context",
+      ],
     ] as const;
-    for (const [contextKind, checkoutRef, targetRef, expectedStatus, error] of relationshipCases) {
-      fixture.git("checkout", "-q", "--detach", checkoutRef);
+    for (const [contextKind, fetchRef, targetRef, expectedStatus, error] of relationshipCases) {
       const { output, result } = runReleaseChecksShellStep(
         "Validate trusted QA tooling eligibility",
         {
           CONTEXT_KIND: contextKind,
-          CONTEXT_REF: checkoutRef.replace(/^refs\/(heads|tags)\//u, ""),
+          CONTEXT_FETCH_REF: fetchRef,
+          CONTEXT_REF: fetchRef.replace(/^refs\/(heads|tags)\//u, ""),
           TARGET_REF: targetRef,
+          TRUSTED_REPOSITORY_URL: fixture.repoUrl,
         },
-        fixture.root,
       );
       expect(result.status, `${contextKind} ${targetRef}: ${result.stderr}`).toBe(expectedStatus);
       expect(output).toBe(expectedStatus === 0 ? "eligible=true\n" : "");


### PR DESCRIPTION
## What Problem This Solves

Frozen-target Release Checks run the selected candidate's QA runtime. Candidate `8f382a202ff1e15833394b481615dcdda99b04d7` predates the replay-stable Anthropic mock tool IDs from #123153, so its baseline lane falsely fails `compaction-retry-mutating-tool` and `thread-memory-isolation` even though the current trusted QA tooling already repairs both scenarios.

## Why This Change Was Made

For runs with `target_context_ref`, the QA parity job now sparse-checks out only `extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts` from the exact trusted workflow SHA and installs that one file over the selected checkout before setup and build. The checkout is credential-free and trap-cleaned. Ordinary current-ref Release Checks skip the overlay and remain target-owned.

## User Impact

Release QA can evaluate frozen candidates with the current deterministic 40-character Anthropic mock ID adapter without changing candidate packages, production runtime, configuration, version, tag, or release state. The candidate's genuine missing `setup_id` migration remains visible in its separate upgrade/install/Docker failures.

## Evidence

- Failed baseline job: https://github.com/openclaw/openclaw/actions/runs/31934405000/job/95134075286
- Canonical QA repair: https://github.com/openclaw/openclaw/pull/123153 (`3f3256906690165773410bc72de629f141c1ff4a`)
- Direct comparison from the signed `v2026.8.1-beta.2` candidate to current `main` shows one QA runtime change in `mock-anthropic-wire.ts`: generated IDs move from `toolu_` plus 48 hex characters to deterministic `toolu` plus 35 hex characters.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` — 192 passed; the new contract test failed before the workflow repair because the trusted checkout step was absent.
- `actionlint .github/workflows/openclaw-release-checks.yml`, YAML parse, targeted `oxfmt --check`, `git diff --check`, and changed-lane classification (`tooling`, `testRoot`) passed.
- Fresh Codex autoreview reported no accepted/actionable findings.
