### PR TITLE
fix(backup): diagnose invalid archive inputs

### DIFF
--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -12,7 +12,6 @@ import {
   type SecretRefSource,
 } from "../config/types.secrets.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
-import { hasErrnoCode } from "../infra/errors.js";
 import {
   formatExecSecretRefIdValidationMessage,
   isValidFileSecretRefId,
@@ -515,14 +514,7 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
   if (stdin) {
     raw = await readStdinText();
   } else {
-    try {
-      raw = readConfigMutationFileSync(file as string, "--file");
-    } catch (err) {
-      if (hasErrnoCode(err, "ENOENT")) {
-        throw new Error(`--file not found: ${file}`, { cause: err });
-      }
-      throw err;
-    }
+    raw = readConfigMutationFileSync(file as string, "--file");
   }
   try {
     return JSON5.parse(raw);

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2771,6 +2771,22 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
+    it("rejects a directory passed as --file", async () => {
+      const pathname = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-patch-directory-"));
+      try {
+        await expect(runConfigCommand(["config", "patch", "--file", pathname])).rejects.toThrow(
+          ExitError,
+        );
+      } finally {
+        fs.rmSync(pathname, { recursive: true, force: true });
+      }
+
+      expectErrorIncludes(
+        `--file must be a regular file: ${pathname}. Choose a JSON5 input file and try again.`,
+      );
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
     it("rejects --file patches above the config mutation limit", async () => {
       const pathname = path.join(
         os.tmpdir(),

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -123,6 +123,17 @@ describe("config set input parsing", () => {
     ).toThrow("--batch-file not found: /nonexistent/path/batch.json5");
   });
 
+  it("rejects a directory passed as --batch-file", () => {
+    const batchPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-directory-"));
+    try {
+      expect(() => parseBatchSource({ batchFile: batchPath })).toThrow(
+        `--batch-file must be a regular file: ${batchPath}. Choose a JSON5 input file and try again.`,
+      );
+    } finally {
+      fs.rmSync(batchPath, { recursive: true, force: true });
+    }
+  });
+
   it("rejects malformed --batch-file payloads", () => {
     withBatchFile("openclaw-config-set-input-invalid-", "{}", (batchPath) => {
       expect(() =>

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -52,8 +52,23 @@ export function readConfigMutationFileSync(
 ): string {
   // These explicit CLI file flags have historically followed user-provided
   // symlinks. Pin the opened descriptor, then bound the read without changing that contract.
-  const fd = fs.openSync(filePath, "r");
+  let fd: number;
   try {
+    fd = fs.openSync(filePath, "r");
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      throw new Error(`${sourceLabel} not found: ${filePath}. Check the path and try again.`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+  try {
+    if (!fs.fstatSync(fd).isFile()) {
+      throw new Error(
+        `${sourceLabel} must be a regular file: ${filePath}. Choose a JSON5 input file and try again.`,
+      );
+    }
     try {
       return readFileDescriptorBoundedSync(fd, CONFIG_MUTATION_FILE_MAX_BYTES).toString("utf8");
     } catch (error) {
@@ -163,14 +178,6 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
   }
-  let raw: string;
-  try {
-    raw = readConfigMutationFileSync(pathname, "--batch-file");
-  } catch (err) {
-    if (hasErrnoCode(err, "ENOENT")) {
-      throw new Error(`--batch-file not found: ${pathname}`, { cause: err });
-    }
-    throw err;
-  }
+  const raw = readConfigMutationFileSync(pathname, "--batch-file");
   return parseBatchEntries(raw, "--batch-file");
 }

--- a/src/commands/backup-sqlite.test.ts
+++ b/src/commands/backup-sqlite.test.ts
@@ -151,6 +151,15 @@ describe("SQLite backup commands", () => {
     expect(listed.snapshots).toHaveLength(1);
     expect(listed.snapshots[0]?.manifest.snapshotId).toBe(created.manifest.snapshotId);
 
+    const missingScratchPath = path.join(tempDir, "missing-scratch");
+    await expect(
+      backupSqliteVerifyCommand(runtime, created.snapshotPath, {
+        scratch: missingScratchPath,
+      }),
+    ).rejects.toThrow(
+      `SQLite validation root does not exist: ${missingScratchPath}. Create a private directory there or pass an existing directory with \`--scratch\`.`,
+    );
+
     const verified = await backupSqliteVerifyCommand(runtime, created.snapshotPath, {
       scratch: scratchPath,
       json: true,
@@ -181,6 +190,31 @@ describe("SQLite backup commands", () => {
     } finally {
       restoredDatabase.close();
     }
+  });
+
+  it("reports missing snapshot paths for verify and restore", async () => {
+    const tempDir = tempDirs.make("openclaw-backup-sqlite-missing-");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const snapshotPath = path.join(repositoryPath, "missing-snapshot");
+    const restorePath = path.join(tempDir, "restored.sqlite");
+    const runtime = createRuntimeCapture();
+    const missingRepositoryMessage = `SQLite snapshot repository does not exist: ${repositoryPath}. Check the snapshot path or create a snapshot with \`openclaw backup sqlite create\`.`;
+
+    await expect(backupSqliteVerifyCommand(runtime, snapshotPath, {})).rejects.toThrow(
+      missingRepositoryMessage,
+    );
+    await expect(
+      backupSqliteRestoreCommand(runtime, snapshotPath, { target: restorePath }),
+    ).rejects.toThrow(missingRepositoryMessage);
+
+    await fs.mkdir(repositoryPath, { mode: 0o700 });
+    const missingSnapshotMessage = `SQLite snapshot does not exist: ${snapshotPath}. Run \`openclaw backup sqlite list --repository ${repositoryPath}\` to inspect available snapshots.`;
+    await expect(backupSqliteVerifyCommand(runtime, snapshotPath, {})).rejects.toThrow(
+      missingSnapshotMessage,
+    );
+    await expect(
+      backupSqliteRestoreCommand(runtime, snapshotPath, { target: restorePath }),
+    ).rejects.toThrow(missingSnapshotMessage);
   });
 
   it("creates a snapshot for a normalized per-agent database", async () => {

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -7,6 +7,7 @@ import { gzipSync } from "node:zlib";
 import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { buildBackupArchivePath, buildBackupArchiveRoot } from "./backup-shared.js";
 import { backupVerifyCommand, testApi } from "./backup-verify.js";
@@ -241,6 +242,44 @@ describe("backupVerifyCommand", () => {
     } finally {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }
+  });
+
+  it.each([
+    {
+      name: "missing archive",
+      prepare: async (tempDir: string) => path.join(tempDir, "missing.tar.gz"),
+      detail:
+        "Archive does not exist. Check the path and run `openclaw backup verify <archive>` again.",
+    },
+    {
+      name: "directory",
+      prepare: async (tempDir: string) => tempDir,
+      detail:
+        "Archive must be a regular file. Choose a backup archive created by `openclaw backup create` and try again.",
+    },
+    {
+      name: "non-tar garbage",
+      prepare: async (tempDir: string) => {
+        const archivePath = path.join(tempDir, "garbage.tar.gz");
+        await fs.writeFile(archivePath, "garbage", "utf8");
+        return archivePath;
+      },
+      detail:
+        "Archive is not a valid OpenClaw backup. Unrecognized archive format. Choose another archive or create a new one with `openclaw backup create`.",
+    },
+  ])("reports an actionable failure for $name", async ({ prepare, detail }) => {
+    const tempDir = tempDirs.make("openclaw-backup-verify-input-");
+    const archivePath = await prepare(tempDir);
+    const runtime = createBackupVerifyRuntime();
+
+    await runCommandWithRuntime(runtime, async () => {
+      await backupVerifyCommand(runtime, { archive: archivePath });
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      `Backup archive verification failed: ${archivePath}. ${detail}`,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("verifies SQLite integrity and the canonical shared-state role", async () => {
@@ -933,7 +972,7 @@ describe("backupVerifyCommand", () => {
       async (archivePath) => {
         const runtime = createBackupVerifyRuntime();
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
-          /^Backup manifest is not valid JSON\.$/u,
+          `Backup archive verification failed: ${archivePath}. Backup manifest is not valid JSON.`,
         );
         await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.not.toThrow(
           /position|Unexpected|Expected|SyntaxError/u,

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -14,6 +14,7 @@ import {
 } from "../infra/backup-archive-path-policy.js";
 import { isTransientSqliteBackupPath } from "../infra/backup-volatile-filter.js";
 import { formatDiskSpaceBytes, tryReadDiskSpace } from "../infra/disk-space.js";
+import { formatErrorMessage, hasErrnoCode } from "../infra/errors.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -67,12 +68,18 @@ type SqliteSnapshotEntry = NormalizedArchiveEntry & {
 
 type ExpectedSqliteRole = "agent" | "global";
 
-async function listArchiveEntries(archivePath: string): Promise<ArchiveEntry[]> {
+async function listArchiveEntries(archivePath: string) {
   const entries: ArchiveEntry[] = [];
+  let invalidReason: string | undefined;
   await tar.t({
     file: archivePath,
     gzip: true,
     maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
+    onwarn: (code, message) => {
+      if (code === "TAR_BAD_ARCHIVE" && invalidReason === undefined) {
+        invalidReason = formatErrorMessage(message);
+      }
+    },
     onReadEntry: (entry) => {
       entries.push({
         path: entry.path,
@@ -82,7 +89,7 @@ async function listArchiveEntries(archivePath: string): Promise<ArchiveEntry[]> 
       });
     },
   });
-  return entries;
+  return { entries, invalidReason };
 }
 
 async function extractManifest(params: {
@@ -539,13 +546,39 @@ async function verifySqliteSnapshots(params: {
   }
 }
 
-/** Verify a backup archive and return its normalized, integrity-checked inventory. */
-export async function verifyBackupArchive(archive: string): Promise<BackupVerifyResult> {
-  const archivePath = resolveUserPath(archive);
-  const rawEntries = await listArchiveEntries(archivePath);
-  if (rawEntries.length === 0) {
-    throw new Error("Backup archive is empty.");
+async function verifyResolvedBackupArchive(archivePath: string): Promise<BackupVerifyResult> {
+  let archiveStat;
+  try {
+    archiveStat = await fs.stat(archivePath);
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      throw new Error(
+        "Archive does not exist. Check the path and run `openclaw backup verify <archive>` again.",
+        { cause: error },
+      );
+    }
+    throw new Error(
+      `Archive could not be inspected. ${formatErrorMessage(error)} Check the path and file permissions, then try again.`,
+      { cause: error },
+    );
   }
+  if (!archiveStat.isFile()) {
+    throw new Error(
+      "Archive must be a regular file. Choose a backup archive created by `openclaw backup create` and try again.",
+    );
+  }
+
+  const listing = await listArchiveEntries(archivePath).catch((error: unknown) => {
+    throw new Error(
+      `Archive could not be read or parsed. ${formatErrorMessage(error)} Check the file permissions and archive integrity, then try again.`,
+    );
+  });
+  if (listing.invalidReason) {
+    throw new Error(
+      `Archive is not a valid OpenClaw backup. ${listing.invalidReason.replace(/[.!?]*$/u, ".")} Choose another archive or create a new one with \`openclaw backup create\`.`,
+    );
+  }
+  const rawEntries = listing.entries;
 
   const entries = rawEntries.map((entry) => ({
     raw: entry.path,
@@ -611,6 +644,15 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
   };
 
   return result;
+}
+
+/** Verify a backup archive and return its normalized, integrity-checked inventory. */
+export async function verifyBackupArchive(archive: string): Promise<BackupVerifyResult> {
+  const archivePath = resolveUserPath(archive);
+  return await verifyResolvedBackupArchive(archivePath).catch((error: unknown) => {
+    const detail = error instanceof Error ? error.message : formatErrorMessage(error);
+    throw new Error(`Backup archive verification failed: ${archivePath}. ${detail}`);
+  });
 }
 
 /** Verify a backup archive, including snapshot shape and canonical SQLite integrity checks. */

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -597,9 +597,19 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
         `SQLite snapshot must be an immediate child of repository ${this.#repositoryPath}: ${snapshotDir}`,
       );
     }
-    const repositoryStat = await fs.lstat(this.#repositoryPath);
+    const repositoryStat = await lstatIfExists(this.#repositoryPath);
+    if (!repositoryStat) {
+      throw new Error(
+        `SQLite snapshot repository does not exist: ${this.#repositoryPath}. Check the snapshot path or create a snapshot with \`openclaw backup sqlite create\`.`,
+      );
+    }
     assertDirectory(repositoryStat, this.#repositoryPath, "SQLite snapshot repository");
-    const snapshotStat = await fs.lstat(snapshotDir);
+    const snapshotStat = await lstatIfExists(snapshotDir);
+    if (!snapshotStat) {
+      throw new Error(
+        `SQLite snapshot does not exist: ${snapshotDir}. Run \`openclaw backup sqlite list --repository ${this.#repositoryPath}\` to inspect available snapshots.`,
+      );
+    }
     assertDirectory(snapshotStat, snapshotDir, "SQLite snapshot");
     if (await lstatIfExists(path.join(snapshotDir, SNAPSHOT_PENDING_FILENAME))) {
       const snapshotState = await classifySnapshotDirectory(snapshotDir);
@@ -667,7 +677,12 @@ async function verifySnapshotDatabaseFile(
     throw new Error(`Snapshot artifact changed before SQLite verification: ${artifactPath}`);
   }
 
-  const validationRootIdentity = await fs.lstat(validationRootPath);
+  const validationRootIdentity = await lstatIfExists(validationRootPath);
+  if (!validationRootIdentity) {
+    throw new Error(
+      `SQLite validation root does not exist: ${validationRootPath}. Create a private directory there or pass an existing directory with \`--scratch\`.`,
+    );
+  }
   assertDirectory(validationRootIdentity, validationRootPath, "SQLite validation root");
   await withPrivateSqliteStagingDirectory({
     rootPath: validationRootPath,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw backup verify` received raw Node filesystem errors for missing or directory inputs, while a non-tar garbage file was incorrectly reported as an empty backup. These diagnostics are especially risky immediately before a restore because they point the operator at the wrong failure.

The original behavior came from #40163: archive listing discarded `tar`'s recoverable `TAR_BAD_ARCHIVE` warning and then treated the resulting zero-entry list as proof of emptiness.

## Why This Change Was Made

`verifyBackupArchive` now owns the archive preflight and wraps every verification failure with the resolved archive path, so direct verification, `backup restore`, and `backup create --verify` all share the same diagnostics. Archive listing preserves `TAR_BAD_ARCHIVE` evidence and reports zero-entry/unrecognized inputs as an invalid OpenClaw backup. A legal zero-entry tar and short garbage produce the same dependency signal, and neither can be a valid OpenClaw backup because the manifest is mandatory.

The bounded filesystem-path sweep also fixes raw missing-path errors shared by SQLite snapshot verify/restore and centralizes regular-file validation for `config set --batch-file` and `config patch --file`. Existing correct backup Git initialization, SQLite listing, plugin path installation, and normal media validation paths were left unchanged.

Production LOC: +86/-30 (net +56). Tests: +101/-1. The production growth is the operator-facing classification and recovery guidance at three existing owner boundaries; no compatibility layer, fallback, new public API, or new helper surface was added, and the shared config reader deletes duplicate caller-side error translation.

## User Impact

Operators now see the archive path, the actual problem, and a concrete recovery step. Exit codes and successful text/JSON output are unchanged.

Examples after this change:

```text
Backup archive verification failed: <scratch>/nope.tar.gz. Archive does not exist. Check the path and run `openclaw backup verify <archive>` again.  exit 1
Backup archive verification failed: <scratch>. Archive must be a regular file. Choose a backup archive created by `openclaw backup create` and try again.  exit 1
Backup archive verification failed: <scratch>/bad-archive.tar.gz. Archive is not a valid OpenClaw backup. Unrecognized archive format. Choose another archive or create a new one with `openclaw backup create`.  exit 1
```

## Evidence

Before, on macOS at `063ce57caf2`:

```text
ENOENT: no such file or directory, stat '/tmp/nope.tar.gz'  exit 1
EISDIR: illegal operation on a directory, read             exit 1
Backup archive is empty.                                   exit 1
```

After, on the exact synced patch in Blacksmith Testbox `tbx_01m04swtd9nvpctnw0n8me38fd`:

- all three repros produced the messages above at exit 1;
- `backup create --verify` created a real scratch-state archive;
- a separate `backup verify` passed with 1 asset and 3 archive entries;
- full `pnpm build` passed;
- `node scripts/check-changed.mjs` passed;
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts src/commands/backup-sqlite.test.ts src/cli/config-set-input.test.ts src/cli/config-cli.test.ts` passed: 242 tests, 1 skipped;
- autoreview reported no accepted/actionable findings.

Remote proof: https://github.com/openclaw/openclaw/actions/runs/31935737819

AI-assisted: yes. The implementation and observed behavior were reviewed and understood.
