### PR TITLE
fix(cron): keep error class names out of run history

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -186,3 +186,59 @@ The generated total contains only the tracked Swift protocol model. The JSON sch
 - Foreign-language UI bundles were not edited; the requested `en.ts` plus baseline workflow was used.
 - `dist/protocol.schema.json` is absent from branch history and `git ls-files`, while final status reports it only as `!! dist/protocol.schema.json` after generation. Swift and both Kotlin targets were verified with `git cat-file -e origin/main:<path>`; no state-generated files changed.
 - Final branch status after proof: feature work is committed and the tracked worktree is clean. `origin/main` advanced by six commits after the successful gate; no push or further moving-base chase was performed.
+
+---
+
+# PR #124511 follow-up 2: preserve specific abort reasons
+
+## Outcome
+
+Rebased `steipete/cron-run-error-text` onto `origin/main` at `77902b185d4`, replaced the stale-lifecycle-only exclusion with the general abort-reason property, extended sibling coverage, and pushed commit `0bd0599487b` to PR #124511. No changelog or message-tool-policy assertion was changed, and the PR was not landed.
+
+## Final predicate
+
+`resolveCronAbortReasonText` is now the canonical abort-reason rule used both by `abortErrorMessage` and `normalizeCronRunErrorText`:
+
+- an `AbortError` with a structured `code` retains `message | code`;
+- an `AbortError` with any noncanonical, nonempty message retains that message;
+- an empty uncoded `AbortError` collapses to `cron: job execution timed out` because it carries no specific reason;
+- an uncoded abort already carrying the canonical cron timeout text also collapses to that same text because it adds no distinct reason.
+
+This removes the `isAgentRunStaleLifecycleError` import and the one-class comment. Direct, restart, superseded, and stale-lifecycle aborts now all flow through `formatErrorMessageWithCode`.
+
+## Restart recovery
+
+Main-session restart recovery does not consume the outer cron result/task-history text. It classifies persisted assistant transcript tails: current transports copy the abort reason's `code` into `errorCode`, and `resolveMainSessionResumePolicy` prefers `AGENT_RUN_RESTART_ABORT_ERROR_CODE`; only old uncoded transcript tails consult `LEGACY_RESTART_ABORT_ERROR_MESSAGES`.
+
+The cron lifecycle interrupt at `src/cron/isolated-agent/run.ts` aborts the runner signal with `createAgentRunRestartAbortError()`. The embedded transport persists that structured reason independently of the outer cron result, while the cron-normalized text goes to the cron return value, diagnostics, and task ledger. Therefore the old timeout rewrite did not feed restart resume-policy classification, but it did destroy the reason in cron-visible history. The new shared rule preserves both the cron-visible message and code without changing recovery authority.
+
+## Regression and validation
+
+- Pre-fix direct owner-boundary probe reproduced all three missing siblings:
+  - `OPENCLAW_DIRECT_ABORT` -> `cron: job execution timed out`
+  - `OPENCLAW_RESTART_ABORT` -> `cron: job execution timed out`
+  - `AGENT_RUN_SUPERSEDED_ABORT` -> `cron: job execution timed out`
+  - empty uncoded `AbortError` -> canonical timeout
+- Post-fix probe preserved every coded message/code while the empty abort still produced the canonical timeout.
+- `rg -l "AbortError" src/cron` covered `src/cron/trigger-script.ts`, `src/cron/isolated-agent/run.ts`, `src/cron/service/task-runs.test.ts`, and `src/cron/service/execution-errors.ts`.
+- Final focused Blacksmith Testbox proof:
+  - provider/id: `blacksmith-testbox` / `tbx_01m04z0arhfn9m4fw8qhb9xasj`
+  - Actions: `https://github.com/openclaw/openclaw/actions/runs/31939592612`
+  - formatting: 4 changed files clean
+  - cron shard: 5 files, 176 tests passed
+  - E2E shard: 1 file, 8 tests passed
+  - the table proves direct, restart, superseded, and stale-lifecycle errors retain their message and code; canonical timeout coverage remains green
+  - `run.message-tool-policy.test.ts` passed unchanged
+- `node scripts/check-changed.mjs`:
+  - provider/id: `blacksmith-testbox` / `tbx_01m04z8yt26ws3h6ng7p9xvknj`
+  - Actions: `https://github.com/openclaw/openclaw/actions/runs/31939801003`
+  - exit 0 in 9m50s; core/core-test typechecks, both lint partitions, formatting, dependency/boundary/database guards, dead exports, and zero runtime import cycles passed
+- Autoreview:
+  - command: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`
+  - result: `autoreview clean: no accepted/actionable findings reported`
+  - no findings accepted or rejected; overall confidence 0.97
+- `git diff --check`: clean.
+
+## LOC and publication
+
+Follow-up commit classification: production `+14/-15` (net `-1`); tests `+17/-6`. Commit `0bd0599487b` (`fix(cron): preserve coded abort reasons`) was force-with-lease pushed over prior PR head `77ab08e4f5d`. PR #124511 remains open and unlanded.

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -2,6 +2,11 @@ import { createServer, type Server } from "node:net";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../agents/failover-error.js";
+import {
+  createAgentRunDirectAbortError,
+  createAgentRunRestartAbortError,
+  createAgentRunSupersededAbortError,
+} from "../agents/run-termination.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
@@ -256,17 +261,23 @@ describe.sequential("cron execution diagnostics", () => {
     expect(history.errorReason).toBe("model_not_found");
   });
 
-  it("persists stale gateway lifecycle rejections instead of reporting a timeout", async () => {
+  it.each([
+    ["direct abort", createAgentRunDirectAbortError],
+    ["gateway restart", createAgentRunRestartAbortError],
+    ["superseded run", createAgentRunSupersededAbortError],
+    ["stale gateway lifecycle", createAgentRunStaleLifecycleError],
+  ])("persists the coded %s reason instead of reporting a timeout", async (name, createError) => {
     const modelRef = { provider: "openai", model: "gpt-5.4" };
     resolveConfiguredModelRefMock.mockReturnValue(modelRef);
-    runWithModelFallbackMock.mockRejectedValueOnce(createAgentRunStaleLifecycleError());
+    const rejection = createError() as Error & { code: string };
+    runWithModelFallbackMock.mockRejectedValueOnce(rejection);
 
     const { finished, history, lastError } = await runPersistedDiagnosticCase({
       cfg: configFor(modelRef),
       modelRef,
-      name: "stale gateway lifecycle",
+      name,
     });
-    const expected = "Agent run belongs to a stale gateway lifecycle | ERR_STALE_GATEWAY_LIFECYCLE";
+    const expected = `${rejection.message} | ${rejection.code}`;
 
     for (const outcome of [finished, history]) {
       expect(outcome).toMatchObject({

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from "node:net";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../agents/failover-error.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
@@ -253,6 +254,28 @@ describe.sequential("cron execution diagnostics", () => {
     }
     expect(lastError).toBe(`${message} | MODEL_NOT_FOUND`);
     expect(history.errorReason).toBe("model_not_found");
+  });
+
+  it("persists stale gateway lifecycle rejections instead of reporting a timeout", async () => {
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    runWithModelFallbackMock.mockRejectedValueOnce(createAgentRunStaleLifecycleError());
+
+    const { finished, history, lastError } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "stale gateway lifecycle",
+    });
+    const expected = "Agent run belongs to a stale gateway lifecycle | ERR_STALE_GATEWAY_LIFECYCLE";
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        error: expected,
+      });
+      expect(outcome.error).not.toContain("timed out");
+    }
+    expect(lastError).toBe(expected);
   });
 
   it("persists and emits a fatal execution-denial diagnostic", async () => {

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -1,6 +1,7 @@
 import { createServer, type Server } from "node:net";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../agents/failover-error.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -128,7 +129,11 @@ async function runPersistedDiagnosticCase(params: {
         }).entries[0];
         expect(finished).toBeDefined();
         expect(history).toBeDefined();
-        return { finished: finished!, history: history! };
+        return {
+          finished: finished!,
+          history: history!,
+          lastError: cron.getJob(job.id)?.state.lastError,
+        };
       } finally {
         cron.stop();
         resetTaskRegistryForTests({ persist: false });
@@ -213,6 +218,41 @@ describe.sequential("cron execution diagnostics", () => {
         },
       });
     }
+  });
+
+  it("persists provider failures without internal class names", async () => {
+    const message =
+      "The selected model was not found by the provider. Check the model id or choose a different model.";
+    const modelRef = { provider: "openai", model: "not-a-real-model" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    resolveAllowedModelRefMock.mockReturnValue({ ref: modelRef });
+    runWithModelFallbackMock.mockRejectedValueOnce(
+      new FailoverError(message, {
+        reason: "model_not_found",
+        provider: modelRef.provider,
+        model: modelRef.model,
+        code: "MODEL_NOT_FOUND",
+      }),
+    );
+
+    const { finished, history, lastError } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "missing provider model",
+    });
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        provider: modelRef.provider,
+        model: modelRef.model,
+        error: `${message} | MODEL_NOT_FOUND`,
+        diagnostics: { summary: message },
+      });
+      expect(outcome.error).not.toContain("FailoverError");
+    }
+    expect(lastError).toBe(`${message} | MODEL_NOT_FOUND`);
+    expect(history.errorReason).toBe("model_not_found");
   });
 
   it("persists and emits a fatal execution-denial diagnostic", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2341,7 +2341,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectResultFields(state.result, {
       status: "error",
-      error: String(rejection),
+      error: "payload rejected | OPENCLAW_PLATFORM_MESSAGE_NOT_DISPATCHED | invalid payload",
       deliveryAttempted: true,
     });
   });
@@ -2388,7 +2388,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectResultFields(state.result, {
       status: "error",
-      error: "Error: read ECONNRESET after send",
+      error: "read ECONNRESET after send | ECONNRESET",
       deliveryAttempted: true,
     });
   });
@@ -2452,7 +2452,8 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectResultFields(state.result, {
       status: "error",
-      error: String(notDispatchedError),
+      error:
+        "second payload stopped before final dispatch | OPENCLAW_PLATFORM_MESSAGE_NOT_DISPATCHED | connect ECONNREFUSED | ECONNREFUSED",
       deliveryAttempted: true,
     });
     expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
@@ -2801,7 +2802,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectResultFields(state.result, {
       status: "error",
-      error: "Error: chat not found",
+      error: "chat not found",
       deliveryAttempted: true,
     });
   });
@@ -2827,7 +2828,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     expectResultFields(state.result, {
       status: "error",
-      error: String(deliveryError),
+      error: deliveryError.message,
       deliveryAttempted: true,
     });
     expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
@@ -2874,7 +2875,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     expectResultFields(state.result, {
       status: "error",
-      error: String(deliveryError),
+      error: deliveryError.message,
       deliveryAttempted: true,
     });
     expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
@@ -2902,7 +2903,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectResultFields(state.result, {
       status: "error",
-      error: "Error: boom",
+      error: "boom",
       deliveryAttempted: true,
     });
   });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -15,6 +15,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { isCronSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { normalizeCronRunErrorText } from "../service/execution-errors.js";
 import {
   appendAdmittedDirectCronDeliveryTranscriptMirror,
   buildDirectCronTranscriptMirrorPayloads,
@@ -490,7 +491,7 @@ export async function dispatchCronDelivery(
           status: "error",
           summary,
           outputText,
-          error: String(err),
+          error: normalizeCronRunErrorText(err),
           deliveryAttempted,
           ...params.telemetry,
         });

--- a/src/cron/isolated-agent/model-preflight.runtime.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.test.ts
@@ -280,7 +280,7 @@ describe("preflightCronModelProvider", () => {
     expect(first.retryAfterMs).toBe(300000);
     expect(first.reason).toContain("the local provider preflight failed");
     expect(first.reason).not.toContain("endpoint is not reachable");
-    expect(first.reason).toContain("Last error: Error: ECONNREFUSED");
+    expect(first.reason).toContain("Last error: ECONNREFUSED");
     expect(first.reason).not.toContain("timed out after");
     expect(second.status).toBe("unavailable");
     if (second.status !== "unavailable") {
@@ -325,7 +325,7 @@ describe("preflightCronModelProvider", () => {
     }
     expect(result.reason).toContain(
       "Last error: Local provider preflight exceeded its configured 2500ms deadline | " +
-        "TypeError: fetch failed | TimeoutError: request timed out",
+        "fetch failed | request timed out",
     );
     expect(result.reason).not.toContain("ECONNREFUSED");
   });
@@ -362,8 +362,7 @@ describe("preflightCronModelProvider", () => {
       throw new Error(`expected preflight unavailable, got ${result.status}`);
     }
     expect(result.reason).toContain(
-      "Last error: AbortError: request aborted (code=ABORT_ERR) | " +
-        "ConnectError: connect ECONNREFUSED (code=ECONNREFUSED)",
+      "Last error: request aborted | ABORT_ERR | connect ECONNREFUSED | ECONNREFUSED",
     );
     expect(result.reason).not.toContain("timed out after");
     expect(result.reason).not.toContain("endpoint is not reachable");
@@ -404,8 +403,9 @@ describe("preflightCronModelProvider", () => {
       throw new Error(`expected preflight unavailable, got ${result.status}`);
     }
     expect(result.reason.match(/failure-0/g)).toHaveLength(1);
-    expect(result.reason).toContain("NestedError7: failure-7 (code=ELOOP7)");
-    expect(result.reason).not.toContain("failure-8");
+    expect(result.reason).toContain("failure-7 | ELOOP7");
+    expect(result.reason).toContain("failure-11 | ELOOP11");
+    expect(result.reason).not.toContain("NestedError");
   });
 
   it("bounds long diagnostics without splitting UTF-16 surrogate pairs", async () => {
@@ -433,8 +433,7 @@ describe("preflightCronModelProvider", () => {
     }
     const diagnostic = result.reason.split("Last error: ")[1];
     expect(diagnostic).toHaveLength(1_000);
-    expect(diagnostic).toMatch(/^Error: x+…$/u);
-    expect(diagnostic).not.toContain("😀");
+    expect(diagnostic).toMatch(/^x{992}😀trunc…$/u);
     expect(diagnostic).not.toContain("truncated-detail");
     expect(/[\uD800-\uDBFF]$/u.test(diagnostic ?? "")).toBe(false);
   });

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -5,9 +5,9 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isLocalProviderBaseUrl } from "../../agents/model-provider-local.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
-import { redactSensitiveText } from "../../logging/redact.js";
 
 const PREFLIGHT_CACHE_TTL_MS = 5 * 60_000;
 const PREFLIGHT_TIMEOUT_MS = 2_500;
@@ -123,45 +123,18 @@ function collectPreflightErrorCauseChain(error: unknown): unknown[] {
   return chain;
 }
 
-function stringifyPreflightErrorValue(error: unknown): string {
-  try {
-    return String(error);
-  } catch {
-    return "Unknown error";
-  }
-}
-
-function formatPreflightErrorDetail(error: unknown): string {
-  const rawName = readErrorProperty(error, "name");
-  const rawMessage = readErrorProperty(error, "message");
-  const rawCode = readErrorProperty(error, "code");
-  const name = typeof rawName === "string" ? rawName.trim() : "";
-  const message = typeof rawMessage === "string" ? rawMessage.trim() : "";
-  const code =
-    typeof rawCode === "string" || typeof rawCode === "number" ? String(rawCode) : undefined;
-  const detail =
-    name && message
-      ? `${name}: ${message}`
-      : message || name || (code ? `code=${code}` : stringifyPreflightErrorValue(error));
-  return code && detail !== `code=${code}` ? `${detail} (code=${code})` : detail;
-}
-
 function formatPreflightError(error: unknown): string {
   const causeChain = collectPreflightErrorCauseChain(error);
-  const details = causeChain
-    .map(formatPreflightErrorDetail)
-    .filter((detail, index, all) => detail && all.indexOf(detail) === index);
-  const causeDetails = details.join(" | ") || stringifyPreflightErrorValue(error);
+  const causeDetails = formatErrorMessageWithCode(error);
   // fetchWithSsrFGuard propagates only its owned deadline as TimeoutError.
   const classified = causeChain.some(
     (candidate) => readErrorProperty(candidate, "name") === "TimeoutError",
   )
     ? `Local provider preflight exceeded its configured ${PREFLIGHT_TIMEOUT_MS}ms deadline | ${causeDetails}`
     : causeDetails;
-  const redacted = redactSensitiveText(classified);
-  return redacted.length <= MAX_PREFLIGHT_ERROR_CHARS
-    ? redacted
-    : `${truncateUtf16Safe(redacted, MAX_PREFLIGHT_ERROR_CHARS - 1)}…`;
+  return classified.length <= MAX_PREFLIGHT_ERROR_CHARS
+    ? classified
+    : `${truncateUtf16Safe(classified, MAX_PREFLIGHT_ERROR_CHARS - 1)}…`;
 }
 
 function formatUnavailableReason(params: {

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -251,7 +251,7 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
     expect(result).toEqual(
       expect.objectContaining({
         status: "error",
-        error: "agent run aborted for restart",
+        error: "agent run aborted for restart | OPENCLAW_RESTART_ABORT",
       }),
     );
     expect(mutationCommitted).toBe(true);

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -402,7 +402,7 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
       runCronIsolatedAgentTurn(makePersistentCronParams(sessionKey)),
     ).resolves.toMatchObject({
       status: "error",
-      error: `CronSessionLifecycleClaimError: Session "${sessionKey}" changed while starting work. Retry.`,
+      error: `Session "${sessionKey}" changed while starting work. Retry.`,
       executionStarted: true,
     });
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -24,7 +24,10 @@ import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { removeCronRunContinuationSessionIfIdle } from "../../tasks/cron-run-continuation-cleanup.js";
 import { createCronRunDiagnosticsFromError, mergeCronRunDiagnostics } from "../run-diagnostics.js";
-import { resolveCronAbortReasonText } from "../service/execution-errors.js";
+import {
+  normalizeCronRunErrorText,
+  resolveCronAbortReasonText,
+} from "../service/execution-errors.js";
 import { getActiveCronTaskRunId } from "../service/task-runs.js";
 import type {
   CronAgentExecutionPhaseUpdate,
@@ -286,7 +289,7 @@ export async function runCronIsolatedAgentTurn(params: {
   } catch (err) {
     consumeCronNextCheckProposal(initialSessionId, params.job.id);
     const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
-    const error = isCronLaneTimeout ? abortReason() : String(err);
+    const error = isCronLaneTimeout ? abortReason() : normalizeCronRunErrorText(err);
     outcome = "error";
     outcomeError = error;
     return prepared.context.withRunSession({

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -690,8 +690,7 @@ describe("CronService", () => {
   it("retries one-shot lifecycle claim conflicts instead of disabling the job (#106875)", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,
-      error:
-        'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+      error: 'Session "agent:main:cron:job-1" changed while starting work. Retry.',
     }));
     const { store, cron, events } = await createIsolatedAnnounceHarness(runIsolatedAgentJob);
     const job = await runIsolatedAnnounceJobAndWait({
@@ -714,8 +713,7 @@ describe("CronService", () => {
   it("does not retry a lifecycle claim conflict after agent execution starts (#108428)", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,
-      error:
-        'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+      error: 'Session "agent:main:cron:job-1" changed while starting work. Retry.',
       executionStarted: true,
     }));
     const { store, cron, events } = await createIsolatedAnnounceHarness(runIsolatedAgentJob);

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -1,5 +1,6 @@
 /** Formats stable cron timeout and execution error messages. */
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
+import { isAgentRunStaleLifecycleError } from "../../infra/agent-lifecycle-error.js";
 import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import {
   CRON_JOB_EXECUTION_TIMEOUT_ERROR,
@@ -69,8 +70,10 @@ export function abortErrorMessage(signal?: AbortSignal): string {
   return resolveCronAbortReasonText(signal?.reason) ?? timeoutErrorMessage();
 }
 
-function isAbortError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
+function isUnspecifiedAbortError(err: unknown): boolean {
+  // A stale lifecycle rejection is a coordination failure with its own durable code;
+  // reporting it as elapsed cron time destroys the operator's recovery reason.
+  if (!(err instanceof Error) || isAgentRunStaleLifecycleError(err)) {
     return false;
   }
   return err.name === "AbortError" || err.message === timeoutErrorMessage();
@@ -78,7 +81,7 @@ function isAbortError(err: unknown): boolean {
 
 /** Normalizes thrown cron run failures into stable log/run-history text. */
 export function normalizeCronRunErrorText(err: unknown): string {
-  if (isAbortError(err)) {
+  if (isUnspecifiedAbortError(err)) {
     return timeoutErrorMessage();
   }
   return formatErrorMessageWithCode(err);

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -1,5 +1,6 @@
 /** Formats stable cron timeout and execution error messages. */
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
+import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import {
   CRON_JOB_EXECUTION_TIMEOUT_ERROR,
   CRON_PRE_EXECUTION_TIMEOUT_ERROR,
@@ -80,8 +81,5 @@ export function normalizeCronRunErrorText(err: unknown): string {
   if (isAbortError(err)) {
     return timeoutErrorMessage();
   }
-  if (typeof err === "string") {
-    return err === `Error: ${timeoutErrorMessage()}` ? timeoutErrorMessage() : err;
-  }
-  return String(err);
+  return formatErrorMessageWithCode(err);
 }

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -1,7 +1,6 @@
 /** Formats stable cron timeout and execution error messages. */
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
-import { isAgentRunStaleLifecycleError } from "../../infra/agent-lifecycle-error.js";
-import { formatErrorMessageWithCode } from "../../infra/errors.js";
+import { extractErrorCode, formatErrorMessageWithCode } from "../../infra/errors.js";
 import {
   CRON_JOB_EXECUTION_TIMEOUT_ERROR,
   CRON_PRE_EXECUTION_TIMEOUT_ERROR,
@@ -59,8 +58,14 @@ export function resolveCronAbortReasonText(reason: unknown): string | undefined 
   if (typeof reason === "string" && reason.trim()) {
     return reason.trim();
   }
-  if (reason instanceof Error && reason.message.trim()) {
-    return reason.message.trim();
+  if (reason instanceof Error) {
+    const message = reason.message.trim();
+    // Only an empty abort or one already carrying cron's canonical timeout text
+    // is unspecified. Coded aborts and other messages retain their exact reason.
+    if (extractErrorCode(reason) === undefined && (!message || message === timeoutErrorMessage())) {
+      return undefined;
+    }
+    return formatErrorMessageWithCode(reason);
   }
   return undefined;
 }
@@ -70,19 +75,13 @@ export function abortErrorMessage(signal?: AbortSignal): string {
   return resolveCronAbortReasonText(signal?.reason) ?? timeoutErrorMessage();
 }
 
-function isUnspecifiedAbortError(err: unknown): boolean {
-  // A stale lifecycle rejection is a coordination failure with its own durable code;
-  // reporting it as elapsed cron time destroys the operator's recovery reason.
-  if (!(err instanceof Error) || isAgentRunStaleLifecycleError(err)) {
-    return false;
-  }
-  return err.name === "AbortError" || err.message === timeoutErrorMessage();
-}
-
 /** Normalizes thrown cron run failures into stable log/run-history text. */
 export function normalizeCronRunErrorText(err: unknown): string {
-  if (isUnspecifiedAbortError(err)) {
-    return timeoutErrorMessage();
+  if (
+    err instanceof Error &&
+    (err.name === "AbortError" || err.message.trim() === timeoutErrorMessage())
+  ) {
+    return resolveCronAbortReasonText(err) ?? timeoutErrorMessage();
   }
   return formatErrorMessageWithCode(err);
 }

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isCronJobActive } from "../active-jobs.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
@@ -381,7 +382,7 @@ export function recordScheduleComputeError(params: {
 }): boolean {
   const { state, job, err } = params;
   const errorCount = (job.state.scheduleErrorCount ?? 0) + 1;
-  const errText = String(err);
+  const errText = formatErrorMessageWithCode(err);
 
   job.state.scheduleErrorCount = errorCount;
   job.state.nextRunAtMs = undefined;

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -116,7 +116,7 @@ describe("cron schedule error isolation", () => {
         jobId: "bad-job",
         name: "Bad Job",
         errorCount: 1,
-        err: "TypeError: CronPattern: invalid configuration format ('not valid'), exactly five, six, or seven space separated parts are required.",
+        err: "CronPattern: invalid configuration format ('not valid'), exactly five, six, or seven space separated parts are required.",
       },
       "cron: failed to compute next run for job (skipping)",
     );
@@ -146,7 +146,7 @@ describe("cron schedule error isolation", () => {
         jobId: "bad-job",
         name: "Bad Job",
         errorCount: 3,
-        err: "TypeError: CronPattern: invalid configuration format ('garbage'), exactly five, six, or seven space separated parts are required.",
+        err: "CronPattern: invalid configuration format ('garbage'), exactly five, six, or seven space separated parts are required.",
       },
       "cron: auto-disabled job after repeated schedule errors",
     );

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1351,8 +1351,7 @@ describe("cron service ops seam coverage", () => {
           action: "finished",
           job,
           status: "error",
-          error:
-            'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+          error: 'Session "agent:main:cron:job-1" changed while starting work. Retry.',
           runAtMs: startedAt,
           durationMs: endedAt - startedAt,
         },
@@ -1704,8 +1703,7 @@ describe("cron service ops seam coverage", () => {
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => ({
           status: "error" as const,
-          error:
-            'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+          error: 'Session "agent:main:cron:job-1" changed while starting work. Retry.',
           executionStarted: true,
         })),
       });

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -794,7 +794,9 @@ describe("cron task run terminal records", () => {
     "cron: isolated agent setup timed out before runner start (last phase: preparing)",
     "cron: isolated agent run stalled before execution start",
     "cron: isolated agent run stalled before execution start (last phase: preparing)",
-  ])("preserves %j as a provisional timed-out task", async (error) => {
+    Object.assign(new Error("request aborted"), { name: "AbortError" }),
+  ])("preserves a provisional timed-out task for case %#", async (input) => {
+    const expected = input instanceof Error ? timeoutErrorMessage() : input;
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-cron-provisional-watchdog-timeout-" },
       async () => {
@@ -829,7 +831,7 @@ describe("cron task run terminal records", () => {
         tryFinishCronTaskRunWithoutHistory(state, {
           taskRunId,
           status: "error",
-          error,
+          error: input,
           endedAt: startedAt + 100,
         });
 
@@ -841,7 +843,7 @@ describe("cron task run terminal records", () => {
         ).toEqual([
           expect.objectContaining({
             status: "timed_out",
-            error,
+            error: expected,
             endedAt: startedAt + 100,
           }),
         ]);

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -794,7 +794,7 @@ describe("cron task run terminal records", () => {
     "cron: isolated agent setup timed out before runner start (last phase: preparing)",
     "cron: isolated agent run stalled before execution start",
     "cron: isolated agent run stalled before execution start (last phase: preparing)",
-    Object.assign(new Error("request aborted"), { name: "AbortError" }),
+    Object.assign(new Error(), { name: "AbortError" }),
   ])("preserves a provisional timed-out task for case %#", async (input) => {
     const expected = input instanceof Error ? timeoutErrorMessage() : input;
     await withOpenClawTestState(

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -41,6 +41,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessageWithCode } from "../infra/errors.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -478,7 +479,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
             : error instanceof CodeModeHeadlessAbortError
               ? "aborted"
               : "internal_error",
-        error: error instanceof Error ? error.message : String(error),
+        error: formatErrorMessageWithCode(error),
       };
     } finally {
       evaluationScope.cleanup();
@@ -508,7 +509,7 @@ function validateCronState(candidate: Record<string, unknown>, label: string) {
     return {
       ok: false as const,
       code: "internal_error" as const,
-      error: `${label} state is not JSON-serializable: ${String(error)}`,
+      error: `${label} state is not JSON-serializable: ${formatErrorMessageWithCode(error)}`,
     };
   }
   if (serialized === undefined) {


### PR DESCRIPTION
## What Problem This Solves

Cron converted thrown failures with `String(error)`, so JavaScript implementation names such as `FailoverError:` became durable `cron runs` history and `job.state.lastError`. The same text could reach failure webhooks. This continued the operator-output defect family fixed in #123929, #124075, and #124329, but on a persisted surface.

During review, the shared normalization also exposed a distinct lifecycle bug: every thrown `AbortError` was treated as proof that the cron watchdog expired. A stale Gateway lifecycle rejection therefore became `cron: job execution timed out`, losing both the real recovery reason and `ERR_STALE_GATEWAY_LIFECYCLE` in durable history.

## Why This Change Was Made

`src/cron/service/execution-errors.ts` is the canonical cron run-error text owner. It delegates ordinary failures to the redacting, code-preserving `formatErrorMessageWithCode`; the one-off `Error: <timeout>` string equality workaround is deleted. The isolated runner now reaches that owner before stringifying failures.

Abort classification is intentionally structural. `isAgentRunStaleLifecycleError` identifies the unsignaled Gateway coordination rejection, so it bypasses the unspecified-abort timeout branch and retains `Agent run belongs to a stale gateway lifecycle | ERR_STALE_GATEWAY_LIFECYCLE`. Generic unsignaled `AbortError` values without a more specific cron-owned identity still normalize to the canonical timeout sentence. Real cron watchdog timeouts abort the run signal with the canonical execution/setup/pre-execution reason; Gateway restart, operator cancellation, and shutdown also abort the signal with their own reason. `run.ts` resolves those signal reasons before generic thrown-error normalization.

The bounded cron sweep also found four producer paths that had stringified before reaching the owner: isolated agent execution, required direct delivery, schedule errors, and trigger-script failures. They now use the same formatter. The local-provider preflight's custom formatter also explicitly included `Error.name`; it was replaced with the canonical formatter while retaining structural timeout classification and the 1,000-code-unit bound.

No record-shape change or new error-type field is needed. `errorReason`, task status, and diagnostics already carry classification separately. Historical prefixed rows are display-only text and remain untouched; no shipped contract justifies a migration or read-time stripper.

## User Impact

New automation failures show the actionable sentence and structured code without JavaScript class names in run history, `lastError`, and failure-webhook text. A stale Gateway lifecycle is no longer falsely reported as a job timeout. Chat alerts continue to use the structured cause (for example `model_not_found`). Existing history remains readable as originally recorded.

## Evidence

Reported before (`063ce57caf2`):

```json
{
  "status": "error",
  "error": "FailoverError: The selected model was not found by the provider. Check the model id or choose a different model.",
  "errorReason": "model_not_found",
  "diagnostics": {
    "summary": "The selected model was not found by the provider. Check the model id or choose a different model."
  }
}
```

Isolated live Gateway after this change, with a scratch `OPENCLAW_STATE_DIR`, free port, and `OPENCLAW_SKIP_CHANNELS=1`:

```json
{
  "status": "error",
  "error": "Unknown model: openai/not-a-real-model",
  "errorReason": "model_not_found",
  "diagnostics": {
    "summary": "Unknown model: openai/not-a-real-model"
  },
  "model": "not-a-real-model",
  "provider": "openai"
}
```

The provider boundary regression injects a coded `FailoverError` and proves the finished event, durable task-history row, and `lastError` contain the clean sentence plus `MODEL_NOT_FOUND`; history keeps `errorReason: model_not_found`, diagnostics keep the clean sentence, and the class name is absent. A second durable-history regression injects the real stale-lifecycle error and proves the finished event, history row, and `lastError` retain its message plus `ERR_STALE_GATEWAY_LIFECYCLE` and do not contain timeout text. The existing boundary tests continue to prove canonical timeout text and generic unspecified-abort normalization.

Exact-head validation at `77ab08e4f5db30e3a493c530917857c108da1ee1`:

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.session-lifecycle.test.ts src/cron/service/ops.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/retry-hint.test.ts` — 163 passed
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/cron/cron-execution-diagnostics.e2e.test.ts` — 5 passed
- `node scripts/run-vitest.mjs src/cron/service/task-runs.test.ts` — 25 passed
- `node scripts/run-vitest.mjs src/cron` — 2,218 passed across 177 files
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01m04xvchh1ca38c21s7w5ecxm` ([run 31938703223](https://github.com/openclaw/openclaw/actions/runs/31938703223))
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings

Consumer audit found no class-prefix dependency: `resolveCronRunErrorReason` is structured/content-based, timeout helpers match canonical cron text, OAuth recovery is content-based, and auto-disable uses `lastErrorReason`. `run.ts` discriminates `CronSessionLifecycleClaimError` with `instanceof`; `retry-hint.test.ts` deliberately retains prefixed variants as robustness fixtures.

Sweep follow-up: transient Gateway RPC error shaping still has a larger separate family of `formatForLog`/raw coercion sites; those are not durable cron state and are intentionally outside this PR.
