### PR TITLE
fix(audit): reject filter combinations that cannot match

### DIFF
--- a/packages/gateway-protocol/src/schema/audit-activity.ts
+++ b/packages/gateway-protocol/src/schema/audit-activity.ts
@@ -14,8 +14,49 @@ export const AUDIT_ACTIVITY_STATUSES = [
   "blocked",
   "unknown",
 ] as const;
-export const AUDIT_ACTIVITY_KINDS = ["agent_run", "tool_action", "message"] as const;
+export const AUDIT_ACTIVITY_MESSAGE_KIND = "message" as const;
+export const AUDIT_ACTIVITY_KINDS = [
+  "agent_run",
+  "tool_action",
+  AUDIT_ACTIVITY_MESSAGE_KIND,
+] as const;
 export const AUDIT_ACTIVITY_DIRECTIONS = ["inbound", "outbound"] as const;
+
+type AuditActivityKind = (typeof AUDIT_ACTIVITY_KINDS)[number];
+const AUDIT_ACTIVITY_NON_MESSAGE_KINDS = ["agent_run", "tool_action"] as const;
+
+export function findAuditActivityFilterConflict(filters: {
+  kind?: AuditActivityKind;
+  sessionKey?: string;
+  direction?: string;
+  channel?: string;
+}) {
+  const messageField =
+    filters.direction !== undefined
+      ? "direction"
+      : filters.channel !== undefined
+        ? "channel"
+        : undefined;
+  const hasSessionFilter = filters.sessionKey !== undefined;
+  if (filters.kind === AUDIT_ACTIVITY_MESSAGE_KIND && hasSessionFilter) {
+    return {
+      type: "kind",
+      field: "sessionKey",
+      supportedKinds: AUDIT_ACTIVITY_NON_MESSAGE_KINDS,
+    } as const;
+  }
+  if (filters.kind !== undefined && filters.kind !== AUDIT_ACTIVITY_MESSAGE_KIND && messageField) {
+    return {
+      type: "kind",
+      field: messageField,
+      supportedKinds: [AUDIT_ACTIVITY_MESSAGE_KIND],
+    } as const;
+  }
+  if (filters.kind === undefined && hasSessionFilter && messageField) {
+    return { type: "filter", field: messageField, conflictingField: "sessionKey" } as const;
+  }
+  return undefined;
+}
 
 const AuditActivityStatusV1Schema: TSchema = Type.Union(
   AUDIT_ACTIVITY_STATUSES.map((value) => Type.Literal(value)),

--- a/packages/gateway-protocol/src/schema/audit.test.ts
+++ b/packages/gateway-protocol/src/schema/audit.test.ts
@@ -63,6 +63,7 @@ describe("audit activity protocol schemas", () => {
         limit: 500,
       }),
     ).toBe(true);
+    expect(validateAuditActivityListParams({ direction: "inbound" })).toBe(true);
     expect(validateAuditActivityListParams({ direction: "sideways" })).toBe(false);
     expect(validateAuditActivityListParams({ limit: 501 })).toBe(false);
   });

--- a/src/audit/audit-event-store.ts
+++ b/src/audit/audit-event-store.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
+import { AUDIT_ACTIVITY_MESSAGE_KIND } from "../../packages/gateway-protocol/src/schema/audit-activity.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -485,7 +486,8 @@ function projectMessageIdentities(db: DatabaseSync, input: MessageAuditEventInpu
 }
 
 function bindAuditEvent(db: DatabaseSync, input: AuditEventInput): Insertable<AuditEventsTable> {
-  const message = input.kind === "message" ? projectMessageIdentities(db, input) : undefined;
+  const message =
+    input.kind === AUDIT_ACTIVITY_MESSAGE_KIND ? projectMessageIdentities(db, input) : undefined;
   return {
     event_id: randomUUID(),
     source_id: input.sourceId,
@@ -499,13 +501,13 @@ function bindAuditEvent(db: DatabaseSync, input: AuditEventInput): Insertable<Au
     actor_type: input.actorType,
     actor_id: message?.actorId ?? input.actorId,
     agent_id: input.agentId ?? null,
-    session_key: input.kind === "message" ? null : (input.sessionKey ?? null),
-    session_id: input.kind === "message" ? null : (input.sessionId ?? null),
+    session_key: input.kind === AUDIT_ACTIVITY_MESSAGE_KIND ? null : (input.sessionKey ?? null),
+    session_id: input.kind === AUDIT_ACTIVITY_MESSAGE_KIND ? null : (input.sessionId ?? null),
     run_id: input.runId ?? null,
     tool_call_id: input.kind === "tool_action" ? (input.toolCallId ?? null) : null,
     tool_name: input.kind === "tool_action" ? input.toolName : null,
-    direction: input.kind === "message" ? input.direction : null,
-    channel: input.kind === "message" ? input.channel : null,
+    direction: input.kind === AUDIT_ACTIVITY_MESSAGE_KIND ? input.direction : null,
+    channel: input.kind === AUDIT_ACTIVITY_MESSAGE_KIND ? input.channel : null,
     conversation_kind: input.kind === "message" ? input.conversationKind : null,
     message_outcome: input.kind === "message" ? input.outcome : null,
     reason_code: input.kind === "message" ? (input.reasonCode ?? null) : null,

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -50,6 +50,8 @@ describe("audit command parsing", () => {
     callGateway.mockReset();
     callGateway.mockResolvedValue({ events: [] });
     vi.mocked(runtime.log).mockClear();
+    vi.mocked(runtime.error).mockClear();
+    vi.mocked(runtime.exit).mockClear();
   });
 
   it("converts ISO and millisecond timestamps before querying the Gateway", async () => {
@@ -127,8 +129,32 @@ describe("audit command parsing", () => {
       options: { direction: "sideways" as never },
       message: "--direction must be inbound or outbound.",
     },
+    {
+      options: { kind: "agent_run" as const, direction: "inbound" as const },
+      message: "--direction only applies to --kind message.",
+    },
+    {
+      options: { kind: "agent_run" as const, channel: "telegram" },
+      message: "--channel only applies to --kind message.",
+    },
+    {
+      options: { kind: "message" as const, sessionKey: "agent:main:main" },
+      message: "--session only applies to --kind agent_run or tool_action.",
+    },
+    {
+      options: { sessionKey: "agent:main:main", direction: "inbound" as const },
+      message: "--direction cannot be combined with --session.",
+    },
+    {
+      options: { sessionKey: "agent:main:main", channel: "telegram" },
+      message: "--channel cannot be combined with --session.",
+    },
   ])("rejects invalid audit filters before querying the Gateway", async ({ options, message }) => {
-    await expect(auditListCommand({ ...options, limit: "10" }, runtime)).rejects.toThrow(message);
+    await runCommandWithRuntime(runtime, () =>
+      auditListCommand({ ...options, limit: "10" }, runtime),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(message);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(callGateway).not.toHaveBeenCalled();
   });
 
@@ -200,20 +226,22 @@ describe("audit command gateway compatibility", () => {
     vi.mocked(runtime.exit).mockClear();
   });
 
-  it("forwards all filters to audit.activity.list", async () => {
-    await auditListCommand(
-      {
-        agentId: "main",
-        kind: "message",
-        status: "failed",
-        direction: "outbound",
-        channel: "telegram",
-        after: "100",
-        before: "200",
-        cursor: "42",
-        limit: "25",
-      },
-      runtime,
+  it("forwards valid filters unchanged and keeps an empty page successful", async () => {
+    await runCommandWithRuntime(runtime, () =>
+      auditListCommand(
+        {
+          agentId: "main",
+          kind: "message",
+          status: "failed",
+          direction: "inbound",
+          channel: "telegram",
+          after: "100",
+          before: "200",
+          cursor: "42",
+          limit: "25",
+        },
+        runtime,
+      ),
     );
 
     expect(callGateway).toHaveBeenCalledTimes(1);
@@ -224,13 +252,15 @@ describe("audit command gateway compatibility", () => {
         agentId: "main",
         kind: "message",
         status: "failed",
-        direction: "outbound",
+        direction: "inbound",
         channel: "telegram",
         after: 100,
         before: 200,
         cursor: "42",
       },
     });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   it("falls back to audit.list only with legacy-compatible filters", async () => {

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -19,6 +19,7 @@ import {
   AUDIT_ACTIVITY_DIRECTIONS,
   AUDIT_ACTIVITY_KINDS,
   AUDIT_ACTIVITY_STATUSES,
+  findAuditActivityFilterConflict,
 } from "../../packages/gateway-protocol/src/schema/audit-activity.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { parsePositiveAuditCursor } from "../audit/audit-cursor.js";
@@ -176,6 +177,26 @@ function validateAuditFilter(
   if (value !== undefined && !allowed.includes(value)) {
     throw new Error(`${flag} must be ${formatHumanList(allowed)}.`);
   }
+}
+
+const AUDIT_FILTER_FLAGS = {
+  sessionKey: "--session",
+  direction: "--direction",
+  channel: "--channel",
+} as const;
+
+function validateAuditFilterCombination(options: AuditListCommandOptions): void {
+  const conflict = findAuditActivityFilterConflict(options);
+  if (!conflict) {
+    return;
+  }
+  const flag = AUDIT_FILTER_FLAGS[conflict.field];
+  if (conflict.type === "kind") {
+    throw new Error(`${flag} only applies to --kind ${formatHumanList(conflict.supportedKinds)}.`);
+  }
+  throw new Error(
+    `${flag} cannot be combined with ${AUDIT_FILTER_FLAGS[conflict.conflictingField]}.`,
+  );
 }
 
 function formatAuditGatewayError(error: unknown): Error {
@@ -526,6 +547,7 @@ export async function auditListCommand(
   validateAuditFilter(options.kind, "--kind", AUDIT_ACTIVITY_KINDS);
   validateAuditFilter(options.status, "--status", AUDIT_ACTIVITY_STATUSES);
   validateAuditFilter(options.direction, "--direction", AUDIT_ACTIVITY_DIRECTIONS);
+  validateAuditFilterCombination(options);
   const after = parseAuditTimestamp(options.after, "--after");
   const before = parseAuditTimestamp(options.before, "--before");
   if (after !== undefined && before !== undefined && after > before) {

--- a/src/gateway/server-methods/audit.test.ts
+++ b/src/gateway/server-methods/audit.test.ts
@@ -217,6 +217,28 @@ describe("audit gateway methods", () => {
     });
   });
 
+  it.each([
+    { kind: "agent_run", direction: "inbound" },
+    { kind: "agent_run", channel: "telegram" },
+    { kind: "message", sessionKey: "agent:main:main" },
+    { sessionKey: "agent:main:main", direction: "inbound" },
+    { sessionKey: "agent:main:main", channel: "telegram" },
+  ])(
+    "rejects impossible activity filters before storage: $kind $direction $channel",
+    async (params) => {
+      const respond = await runAuditHandler("audit.activity.list", params);
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          message: expect.stringContaining("invalid audit.activity.list filters"),
+        }),
+      );
+      expect(listAuditEvents).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(["audit.list", "audit.activity.list"] as const)(
     "rejects malformed cursors and inverted ranges for %s",
     async (method) => {

--- a/src/gateway/server-methods/audit.ts
+++ b/src/gateway/server-methods/audit.ts
@@ -9,6 +9,7 @@ import {
   validateAuditListParams,
   validateAuditRunInspectParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { findAuditActivityFilterConflict } from "../../../packages/gateway-protocol/src/schema/audit-activity.js";
 import { parsePositiveAuditCursor } from "../../audit/audit-cursor.js";
 import { listAuditEvents } from "../../audit/audit-event-store.js";
 import type {
@@ -116,6 +117,19 @@ export const auditHandlers: GatewayRequestHandlers = {
     if (
       !assertValidParams(params, validateAuditActivityListParams, "audit.activity.list", respond)
     ) {
+      return;
+    }
+    const filterConflict = findAuditActivityFilterConflict(params);
+    if (filterConflict) {
+      const detail =
+        filterConflict.type === "kind"
+          ? `${filterConflict.field} only applies to kind ${filterConflict.supportedKinds.join(" or ")}`
+          : `${filterConflict.field} cannot be combined with ${filterConflict.conflictingField}`;
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `invalid audit.activity.list filters: ${detail}`),
+      );
       return;
     }
     const parsed = invalidRangeOrCursor(params);


### PR DESCRIPTION
Related: #124336

## What Problem This Solves

Fixes an issue where operators narrowing `openclaw audit` by a record kind and a field that kind can never contain received an empty table and exit 0. The result looked like a legitimate zero-match query even though the filter combination was impossible by construction.

## Why This Change Was Made

The protocol audit schema now owns the message/non-message filter relationship alongside the canonical kind enums. The SQLite writer uses that same message-kind constant, while both the CLI and `audit.activity.list` apply the shared conflict detector before querying storage. This covers explicit kind conflicts and the implicit conflict between `--session` and message-only filters without changing the RPC fields, successful output, or lone-filter behavior.

The complete exposed conflict set is:

- `agent_run` or `tool_action` with `direction`;
- `agent_run` or `tool_action` with `channel`;
- `message` with `sessionKey` / `--session`;
- `sessionKey` / `--session` with `direction` or `channel`, even when no kind is supplied.

Tool-call and tool-name fields remain tool-action-only in storage, but neither is exposed as a list filter. Status/event-terminal correlations are a separate invariant and are not changed here.

AI-assisted by Codex; implementation and proof were reviewed against the repository rules.

## User Impact

Impossible queries now fail immediately with actionable messages such as `--direction only applies to --kind message.` and exit 1 without making a Gateway request. A lone `--direction` or `--channel` remains valid and is forwarded unchanged, and a valid query that happens to match zero records still prints an empty table and exits 0.

Raw `audit.activity.list` callers receive the same semantic rejection before storage access, so the documented Gateway RPC no longer preserves the silent-empty failure outside the CLI.

## Evidence

Source-blind built-product proof used an isolated scratch state directory, loopback mock provider, ports 38000/38001, `OPENCLAW_SKIP_CHANNELS=1`, and Testbox `tbx_01m04s4tf0493mxc2kgj6bazsc` ([run](https://github.com/openclaw/openclaw/actions/runs/31935169693)). Port 18789 and `~/.openclaw` were untouched; the scratch processes and state were cleaned up.

The baseline Gateway first produced real records:

```text
agent_run  ...  succeeded  ...  audit-cross-e2e  agent.run.finished
agent_run  ...  started    ...  audit-cross-e2e  agent.run.started
```

Before, all three impossible queries printed only the table header and exited 0:

```text
openclaw audit --kind agent_run --direction inbound  # exit 0
openclaw audit --kind agent_run --channel telegram   # exit 0
openclaw audit --kind message --session agent:main:main  # exit 0
```

After:

```text
--direction only applies to --kind message.                 # exit 1
--channel only applies to --kind message.                   # exit 1
--session only applies to --kind agent_run or tool_action.  # exit 1
--direction cannot be combined with --session.              # exit 1
--channel cannot be combined with --session.                # exit 1
```

The valid empty controls `--kind message --direction inbound` and lone `--direction inbound` remained exit 0. A raw impossible `audit.activity.list` call failed with `invalid audit.activity.list filters: direction only applies to kind message`, while the valid message/direction RPC returned `{ "events": [] }`.

Validation:

- `node scripts/run-vitest.mjs src/commands/audit.test.ts` — 34 passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/audit.test.ts` — 18 passed
- `node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/audit.test.ts` — 6 passed
- `node scripts/run-vitest.mjs src/audit/audit-event-store.message.test.ts` — 10 passed
- `node scripts/check-changed.mjs` on Blacksmith Testbox — passed (format, production/test types, lint, guards, and routed tests)
- `pnpm build` on Blacksmith Testbox — passed
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings

Production LOC: +85/-6 (net +79). Tests: +69/-16 (net +53). The production growth is the shared protocol-owned conflict contract plus independent CLI and public-RPC enforcement; the writer's duplicated message literal was replaced on the filter-owned columns rather than adding a CLI-local kind map.
