### PR TITLE
fix(gateway): keep readiness truthful during restart

### DIFF
--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -18,6 +18,87 @@ import { createGatewayKernel } from "./server-kernel.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 
 describe("createGatewayKernel", () => {
+  it("keeps readiness red until deferred startup unlocks chat dispatch", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-kernel-deferred-readiness",
+      layout: "home",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+        VITEST: "1",
+      },
+    });
+    const token = "gateway-kernel-deferred-readiness-token";
+    let kernel: Awaited<ReturnType<typeof createGatewayKernel>> | undefined;
+    try {
+      await state.writeConfig({
+        gateway: {
+          auth: { mode: "token", token },
+          controlUi: { enabled: false },
+          port,
+        },
+      });
+      state.applyEnv();
+      kernel = await createGatewayKernel(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      });
+
+      const client = createSyntheticPluginRuntimeClient({
+        scopes: [...CLI_DEFAULT_OPERATOR_SCOPES],
+      });
+      const dispatchOptions = {
+        client,
+        context: kernel.gatewayRequestContext,
+        methodRegistry: kernel.getAttachedGatewayMethodRegistry(),
+      };
+      const runId = "deferred-readiness-chat";
+      const chatParams = {
+        sessionKey: "agent:main:deferred-readiness",
+        message: "readiness truth",
+        idempotencyKey: runId,
+      };
+
+      const getReadiness = kernel.createHttpTransportOptions().getReadiness;
+      expect(getReadiness()).toMatchObject({
+        ready: false,
+        failing: ["startup-sidecars"],
+      });
+      await expect(
+        dispatchGatewayRequestInProcess("chat.send", chatParams, dispatchOptions),
+      ).rejects.toThrow("chat.send unavailable during gateway startup");
+
+      kernel.dedupe.set(`chat:${runId}`, {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "ok" },
+      });
+      kernel.kernel.unlockStartupMethods();
+      kernel.kernel.markSidecarsReady();
+
+      expect(getReadiness()).toMatchObject({ ready: true, failing: [] });
+      await expect(
+        dispatchGatewayRequestInProcess("chat.send", chatParams, dispatchOptions),
+      ).resolves.toEqual({ runId, status: "ok" });
+    } finally {
+      try {
+        await kernel?.closeOnStartupFailure();
+      } finally {
+        await state.cleanup();
+      }
+    }
+  });
+
   it("dispatches health and an agent turn without creating a transport", async () => {
     const port = await getFreePort();
     const state = await createOpenClawTestState({

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -399,7 +399,7 @@ export async function prepareGatewayKernelState(params: {
   });
   channelManager.setAutostartSuppression(opts.channelAutostartSuppression ?? null);
   const sidecarStartup = opts.sidecarStartup ?? "start";
-  const isGatewayStartupPending = () => !startupState.sidecarsReady && sidecarStartup === "start";
+  const isGatewayStartupPending = () => !startupState.sidecarsReady;
   const startupCheckerDeps = {
     startedAt: serverStartedAt,
     getStartupPending: isGatewayStartupPending,

--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -105,12 +105,16 @@ export function resolvePlacementIdentity(
 export function requireActivePlacement(
   placement: WorkerSessionPlacementRecord,
 ): ActiveWorkerPlacement {
+  const failureDetail =
+    placement.state === "failed"
+      ? `: ${placement.terminalReason ?? placement.recoveryError}; redispatch the session so its worker can bootstrap the current build before retrying.`
+      : "";
   if (
     placement.state !== "active" ||
     !placement.remoteWorkspaceDir ||
     !placement.workerBundleHash
   ) {
-    throw new Error(`Worker turn rejected in placement ${placement.state}`);
+    throw new Error(`Worker turn rejected in placement ${placement.state}${failureDetail}`);
   }
   return placement;
 }

--- a/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
@@ -466,4 +466,38 @@ describe("worker turn launcher reclaimed placement", () => {
     expect(runLocal).not.toHaveBeenCalled();
     expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
   });
+
+  it("projects a failed placement cause with current-build recovery guidance", async () => {
+    placements.startDispatch({
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      agentId: "main",
+    });
+    placements.fail({
+      sessionId: SESSION_ID,
+      recoveryError: "cloud worker disappeared: environment state destroyed",
+    });
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments: unusedEnvironments(),
+      placements,
+    });
+    const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+
+    await expect(
+      provider.executeTurn(
+        {
+          sessionId: SESSION_ID,
+          sessionKey: SESSION_KEY,
+          agentId: "main",
+          runId: "run-failed",
+        },
+        turn("run-failed"),
+        runLocal,
+      ),
+    ).rejects.toThrow(
+      "Worker turn rejected in placement failed: cloud worker disappeared: environment state destroyed; redispatch the session so its worker can bootstrap the current build before retrying.",
+    );
+    expect(runLocal).not.toHaveBeenCalled();
+    expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+  });
 });


### PR DESCRIPTION
Related: #124309

AI-assisted: yes. I understand and reviewed the implementation.

## What Problem This Solves

Fixes an issue where operators restarting a Gateway with a preserved cloud-worker placement could receive HTTP 200 with `ready:true` from `/readyz`, then have the first `chat.send` rejected as `unavailable during gateway startup`. An unchanged retry could hit the same false-green window.

The same live verification found that a stale-build worker rejection reached `agent.wait` only as `Worker turn rejected in placement failed`, discarding the recorded cause and giving no current-build recovery instruction.

## Why This Change Was Made

Readiness now follows the authoritative sidecar-ready fact even when startup work is allowed to continue asynchronously. Deferred startup still controls whether the startup call waits; it no longer weakens `/startupz`, `/readyz`, or WebSocket admission while startup-gated chat methods remain locked.

Failed worker placements now project their immutable terminal reason and tell the operator to redispatch the session so a worker can bootstrap the current build. This remains at the placement-admission owner rather than adding client retry loops.

This is the narrow repair for behavior already present on `main`. #124309 contains broader startup-progress and lifecycle work; its overlapping readiness hunk becomes redundant when that branch is refreshed.

## User Impact

Operators can trust that a green `/readyz` means the primary chat dispatch surface accepts work after restart. Stale-build failures also identify the concrete placement cause and the recovery action instead of dead-ending at a generic state name.

## Evidence

- Pre-fix regression proof:
  - Kernel readiness returned `ready:true` while `chat.send` still returned `unavailable during gateway startup`.
  - Failed-placement turn admission returned only `Worker turn rejected in placement failed`.
- Post-fix focused proof, three consecutive runs: 3 files, 17 tests/run, 51/51 assertions passed.
- Source-blind built-product proof:
  - deferred startup `/readyz`: HTTP 503 with `ready:false` at 2436 ms;
  - first green `/readyz`: HTTP 200 with `ready:true` at 6514 ms;
  - two distinct post-ready `chat.send` calls both returned `{status:"started"}`;
  - `/readyz` remained green and shutdown released the owned port/processes.
- `node scripts/check-changed.mjs --timed`: passed all core/core-test lanes, including production/test typechecks, targeted lint, import cycles, and database-first guards. Both hosted backends failed before dispatch, so repository policy's local fallback produced this result.
- `pnpm build`: passed; no ineffective dynamic imports.
- `oxfmt` and `git diff --check`: passed.
- The first two exact-head CI attempts both hit the pre-existing one-millisecond `workspace-sync.test.ts` clock flake (`expected 777`, observed `776`) after 1,939 tests passed. While this branch was being refreshed, #124473 independently landed the same clock pin on `main`; the duplicate local commit was dropped during conflict resolution, and the rebased focused set passed.
- Autoreview on the final rebased readiness branch: clean, no accepted/actionable findings.
- Diff accounting: production +5/-2 (net +3); tests +115/-0. Production growth is the operator-visible failed-placement cause and recovery guidance.
