### PR TITLE
fix(status): stop Gateway status from blocking on static catalog discovery

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
@@ -15,6 +15,9 @@ const providerMocks = vi.hoisted(() => ({
   resolveRuntimePluginDiscoveryProviders: vi.fn(),
   runProviderStaticCatalog: vi.fn(),
 }));
+const staticIdMocks = vi.hoisted(() => ({
+  createStaticModelIdMatcher: vi.fn(),
+}));
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: manifestMocks.getCurrentPluginMetadataSnapshot,
@@ -48,8 +51,20 @@ vi.mock("../../plugins/provider-discovery.js", async (importOriginal) => ({
   runProviderStaticCatalog: providerMocks.runProviderStaticCatalog,
 }));
 
+vi.mock("./model.static-id.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./model.static-id.js")>();
+  return {
+    ...actual,
+    createStaticModelIdMatcher: (...args: Parameters<typeof actual.createStaticModelIdMatcher>) => {
+      staticIdMocks.createStaticModelIdMatcher(...args);
+      return actual.createStaticModelIdMatcher(...args);
+    },
+  };
+});
+
 import {
   bundledStaticCatalogProviderUsesRuntimeAugment,
+  createBundledProviderStaticCatalogContextResolver,
   createBundledStaticCatalogModelResolver,
   loadBundledProviderStaticCatalogContextModels,
   resolveBundledStaticCatalogModel,
@@ -83,6 +98,7 @@ function createMistralManifestPlugin() {
 function setCurrentManifestPlugins(plugins: unknown[]) {
   const snapshot = { plugins, manifestRegistry: { plugins } };
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(snapshot);
+  return snapshot as unknown as PluginMetadataSnapshot;
 }
 
 function setManifestPlugins(plugins: unknown[]) {
@@ -114,6 +130,7 @@ beforeEach(() => {
   for (const mock of Object.values(providerMocks)) {
     mock.mockReset();
   }
+  staticIdMocks.createStaticModelIdMatcher.mockReset();
   manifestMocks.listOpenClawPluginManifestMetadata.mockReturnValue([]);
   manifestMocks.loadPluginManifestRegistryCore.mockReturnValue({ plugins: [] });
   providerMocks.resolveActivatableProviderOwnerPluginIds.mockImplementation(
@@ -173,6 +190,41 @@ describe("bundled static model catalog snapshot cache", () => {
     expect(resolveModel({ provider: "mistral", modelId: "mistral-medium-next" })?.name).toBe(
       "Mistral Medium Next",
     );
+    expect(manifestMocks.listOpenClawPluginManifestMetadata).not.toHaveBeenCalled();
+    expect(manifestMocks.loadPluginManifest).not.toHaveBeenCalled();
+  });
+
+  it("binds current snapshot model-id policies to the matching catalog generation", () => {
+    const cfg = {};
+    const plugin = {
+      id: "snapshot-only",
+      origin: "bundled",
+      providers: ["snapshot-only"],
+      modelCatalog: {
+        providers: {
+          "snapshot-only": {
+            models: [{ id: "snapshot-model-v1", name: "Snapshot Model V1" }],
+          },
+        },
+        discovery: { "snapshot-only": "static" },
+      },
+      modelIdNormalization: {
+        providers: {
+          "snapshot-only": {
+            aliases: { current: "snapshot-model-v1" },
+          },
+        },
+      },
+    };
+    const metadataSnapshot = setCurrentManifestPlugins([plugin]);
+
+    const resolveModel = createBundledStaticCatalogModelResolver({ cfg });
+
+    expect(resolveModel({ provider: "snapshot-only", modelId: "current" })?.id).toBe(
+      "snapshot-model-v1",
+    );
+    const matcherOptions = staticIdMocks.createStaticModelIdMatcher.mock.calls[0]?.[0];
+    expect(matcherOptions?.manifestPlugins).toBe(metadataSnapshot.plugins);
     expect(manifestMocks.listOpenClawPluginManifestMetadata).not.toHaveBeenCalled();
     expect(manifestMocks.loadPluginManifest).not.toHaveBeenCalled();
   });
@@ -341,5 +393,35 @@ describe("bundled static model catalog snapshot cache", () => {
       expect.objectContaining({ provider: "google", contextWindow: 1_048_576 }),
     ]);
     expect(manifestMocks.loadPluginManifestRegistryCore).not.toHaveBeenCalled();
+  });
+
+  it("pins provider context resolution to the current metadata snapshot", async () => {
+    const cfg = { plugins: { entries: { google: { enabled: true } } } };
+    const provider = { id: "google", pluginId: "google", label: "Google", auth: [] };
+    const metadataSnapshot = setCurrentManifestPlugins([
+      {
+        id: "google",
+        origin: "bundled",
+        providerDiscoverySource: "/fixtures/google/provider-discovery.ts",
+      },
+    ]);
+    providerMocks.resolveOwningPluginIdsForProviderRef.mockReturnValue(["google"]);
+    providerMocks.resolveBundledProviderCompatPluginIds.mockReturnValue(["google"]);
+    providerMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
+    providerMocks.normalizePluginDiscoveryResult.mockReturnValue({
+      google: {
+        models: [{ id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 }],
+      },
+    });
+
+    const resolveContext = createBundledProviderStaticCatalogContextResolver({ cfg });
+
+    await expect(
+      resolveContext({ provider: "google", modelId: "gemini-3.1-pro-preview" }),
+    ).resolves.toEqual({ contextWindow: 1_048_576 });
+    const ownerLookup = providerMocks.resolveOwningPluginIdsForProviderRef.mock.calls[0]?.[0];
+    const discoveryLookup = providerMocks.resolveRuntimePluginDiscoveryProviders.mock.calls[0]?.[0];
+    expect(ownerLookup?.metadataSnapshot).toBe(metadataSnapshot);
+    expect(discoveryLookup?.pluginMetadataSnapshot).toBe(metadataSnapshot);
   });
 });

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -146,6 +146,7 @@ type BundledStaticCatalogParams = {
 };
 
 type BundledStaticCatalogState = {
+  matchesStaticModelId: StaticModelIdMatcher;
   plugins: StaticCatalogPlugin[];
   plans: Map<string, ReturnType<typeof planEffectiveModelCatalogRows>>;
 };
@@ -223,6 +224,9 @@ function resolveSnapshotBundledStaticCatalogState(
     return cached;
   }
   const state = {
+    matchesStaticModelId: createStaticModelIdMatcher({
+      manifestPlugins: metadataSnapshot.plugins,
+    }),
     plugins: listBundledStaticCatalogPlugins(params, metadataSnapshot),
     plans: new Map<string, ReturnType<typeof planEffectiveModelCatalogRows>>(),
   };
@@ -307,9 +311,6 @@ export function createBundledStaticCatalogModelResolver(params?: {
     ...(params?.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
     workspaceDir: params?.workspaceDir,
   };
-  const matchesStaticModelId = params?.metadataSnapshot
-    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot.plugins })
-    : staticModelIdMatches;
   let standaloneState: BundledStaticCatalogState | undefined;
   return (lookup) => {
     const provider = normalizeProviderId(lookup.provider);
@@ -320,6 +321,7 @@ export function createBundledStaticCatalogModelResolver(params?: {
     const state = metadataSnapshot
       ? resolveSnapshotBundledStaticCatalogState(catalogParams, metadataSnapshot)
       : (standaloneState ??= {
+          matchesStaticModelId: staticModelIdMatches,
           plugins: listBundledStaticCatalogPlugins(catalogParams),
           plans: new Map(),
         });
@@ -350,7 +352,7 @@ export function createBundledStaticCatalogModelResolver(params?: {
           row: candidate,
           provider,
           modelId: lookup.modelId,
-          matchesStaticModelId,
+          matchesStaticModelId: state.matchesStaticModelId,
         }),
       );
       if (row) {
@@ -645,8 +647,25 @@ function createScopedBundledProviderStaticCatalogModelResolver(
 function createBundledProviderStaticCatalogModelResolver(
   params: BundledProviderStaticCatalogResolverParams = {},
 ): (lookup: BundledStaticCatalogLookup) => Promise<ProviderRuntimeModel | undefined> {
-  const resolveModel = createScopedBundledProviderStaticCatalogModelResolver(params);
+  const { resolverParams } = prepareBundledProviderStaticCatalogResolver(params);
+  const resolveModel = createScopedBundledProviderStaticCatalogModelResolver(resolverParams);
   return async (lookup) => await resolveModel(lookup);
+}
+
+function prepareBundledProviderStaticCatalogResolver(
+  params: BundledProviderStaticCatalogResolverParams,
+) {
+  const env = params.env ?? process.env;
+  const metadataSnapshot = resolveBundledStaticCatalogMetadataSnapshot({
+    cfg: params.cfg,
+    env,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+    workspaceDir: params.workspaceDir,
+  });
+  return {
+    env,
+    resolverParams: metadataSnapshot ? { ...params, metadataSnapshot } : params,
+  };
 }
 
 function resolveOwnedNestedProviderLookup(params: {
@@ -695,13 +714,13 @@ function resolveOwnedNestedProviderLookup(params: {
 export function createBundledProviderStaticCatalogContextResolver(
   params: BundledProviderStaticCatalogResolverParams = {},
 ): (lookup: BundledStaticCatalogLookup) => Promise<BundledStaticCatalogContext | undefined> {
-  const env = params.env ?? process.env;
-  const resolveModel = createScopedBundledProviderStaticCatalogModelResolver(params);
+  const { env, resolverParams } = prepareBundledProviderStaticCatalogResolver(params);
+  const resolveModel = createScopedBundledProviderStaticCatalogModelResolver(resolverParams);
   return async (lookup) => {
     const exactModel = await resolveModel(lookup);
     const nested = exactModel
       ? undefined
-      : resolveOwnedNestedProviderLookup({ lookup, resolverParams: params, env });
+      : resolveOwnedNestedProviderLookup({ lookup, resolverParams, env });
     const model =
       exactModel ?? (nested ? await resolveModel(nested.lookup, nested.pluginIds) : undefined);
     if (!model) {

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -1,6 +1,7 @@
 // Status summary tests cover aggregate status text for channels, sessions, tasks, and audit findings.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SESSION_TOTAL_TOKENS_VERSION } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import type { TaskAuditFinding } from "../tasks/task-registry.audit.js";
@@ -10,6 +11,14 @@ import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.
 const statusSummaryMocks = vi.hoisted(() => ({
   hasConfiguredChannelsForReadOnlyScope: vi.fn(() => true),
   buildChannelSummary: vi.fn(async () => ["ok"]),
+  createManifestModelResolver: vi.fn(
+    (_options?: { cfg?: OpenClawConfig; includeRuntimeDiscovery?: boolean }) =>
+      vi.fn(({ provider, modelId }) =>
+        provider === "openai" && modelId === "gpt-5.5"
+          ? { contextWindow: 1_000_000, contextTokens: 272_000 }
+          : undefined,
+      ),
+  ),
   resolveProviderStaticModel: vi.fn(),
   listSessionEntriesCore: vi.fn<
     (scope?: { agentId?: string; storePath?: string }) => Array<{
@@ -108,13 +117,7 @@ vi.mock("../agents/defaults.js", () => ({
 }));
 
 vi.mock("../agents/embedded-agent-runner/model.static-catalog.js", () => ({
-  createBundledStaticCatalogModelResolver: vi.fn(() =>
-    vi.fn(({ provider, modelId }) =>
-      provider === "openai" && modelId === "gpt-5.5"
-        ? { contextWindow: 1_000_000, contextTokens: 272_000 }
-        : undefined,
-    ),
-  ),
+  createBundledStaticCatalogModelResolver: statusSummaryMocks.createManifestModelResolver,
   createBundledProviderStaticCatalogModelResolver: vi.fn(
     () => statusSummaryMocks.resolveProviderStaticModel,
   ),
@@ -291,6 +294,16 @@ describe("getStatusSummary", () => {
     expect(summary.channelSummary).toEqual(["ok"]);
     expect(summary.tasks.active).toBe(0);
     expect(summary.taskAudit.warnings).toBe(1);
+  });
+
+  it("binds the manifest model resolver to the status request config", async () => {
+    const config = { plugins: { load: { paths: ["/tmp/status-plugin-root"] } } };
+
+    await getStatusSummary({ config, includeChannelSummary: false });
+
+    const resolverOptions = statusSummaryMocks.createManifestModelResolver.mock.calls.at(-1)?.[0];
+    expect(resolverOptions?.cfg).toBe(config);
+    expect(resolverOptions?.includeRuntimeDiscovery).toBe(true);
   });
 
   // waitingForRoute must follow the session the runner actually reads

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -62,10 +62,7 @@ const taskRegistryMaintenanceModuleLoader = createLazyImportLoader(
 const staticModelCatalogResolverLoader = createLazyImportLoader(async () => {
   const modelCatalog = await import("../agents/embedded-agent-runner/model.static-catalog.js");
   return {
-    resolveManifestModel: modelCatalog.createBundledStaticCatalogModelResolver({
-      // Runtime-discovery manifest rows still provide a cold-cache fallback.
-      includeRuntimeDiscovery: true,
-    }),
+    createManifestModelResolver: modelCatalog.createBundledStaticCatalogModelResolver,
     createProviderContextResolver: modelCatalog.createBundledProviderStaticCatalogContextResolver,
   };
 });
@@ -284,8 +281,13 @@ export async function getStatusSummary(
     options.sourceConfig !== undefined
       ? options.sourceConfig
       : projectConfigOntoRuntimeSourceSnapshot(cfg);
-  const { resolveManifestModel, createProviderContextResolver } =
+  const { createManifestModelResolver, createProviderContextResolver } =
     await loadStaticModelCatalogResolvers();
+  const resolveManifestModel = createManifestModelResolver({
+    cfg,
+    // Runtime-discovery manifest rows still provide a cold-cache fallback.
+    includeRuntimeDiscovery: true,
+  });
   const resolveProviderContext = createProviderContextResolver({ cfg });
   const modelContextCache = new Map<
     string,


### PR DESCRIPTION
Related: #124518

## What Problem This Solves

Fixes an issue where Gateway status reads could spend seconds resolving static model and provider metadata when plugin discovery used a non-default runtime configuration. Repeated status reads could delay other Gateway work even though the returned status payload was unchanged.

## Why This Change Was Made

The status path now creates static-catalog resolvers with the request configuration, carries one compatible lifecycle metadata snapshot through model and provider-context resolution, and keys model-ID matching to the same catalog generation. Discovery remains the cold fallback when no compatible snapshot exists.

The change is limited to status and static-catalog resolution. Model-selection semantics are unchanged.

This is an AI-assisted contribution. OpenAI Codex and Forge assisted with implementation and validation; ragesaq reviewed the submitted code and evidence.

## User Impact

Operators get faster warm Gateway status reads under plugin discovery configurations that previously triggered repeated synchronous metadata work. The canonical status payload remains unchanged.

## Evidence

Base: `main`. Exact PR head: `172ff2427b559e0a94290fddf5c5212b4906ba70`.

### Before and after

The same deterministic fixture was used for both runs: 34 agents, 10 models, 149 plugins, and 34 sessions on Node 22.23.2. Each run used 3 warmups and 10 measured samples.

| Measure | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Config-bound resolver, 3 lookups | 1,344.25 ms | 0.77 ms | 99.94% |
| Full status median | 4,047.79 ms | 278.70 ms | 93.11% |
| Full status p95 | 4,243.03 ms | 305.81 ms | 92.79% |
| Event-loop-delay p95 | 4,255.12 ms | 306.45 ms | 92.80% |
| 50 ms timer lateness p95 | 4,193.71 ms | 256.27 ms | 93.89% |

The canonical before and after status payloads were byte-identical after removing only documented volatile `age` and storage-assigned `updatedAt` fields. Both canonical payloads have SHA-256 `802fa98edd527a079140b75f62143bb695cda1e978fd452972dcc5e02aca4d9c`.

The benchmark snapshots were captured before the final mechanical rebase: before source `de4104c84d7`, after source `5b96cbc52d1fea16df3a29ef4cbece73d53332fe`. The final PR head retains the same patch bytes; diff SHA-256 is `d4ebb6102e14996c80f7cb8444eb67a0eee1d5e8b320a4e63eadb7dd6e6b7fa8`.

### Validation

- Focused Vitest validation: 3 shards, 55 tests passed.
- Formatting and static checks passed: `oxfmt --check`, `git diff --check`, changed-file classification, typechecks, lint, import-cycle checks, runtime guards, and database guards.
- Repository validation passed: `pnpm build` and `pnpm check`.
- Full `pnpm test` was attempted but is not reported as passing. The run was stopped after 20 minutes because unrelated UI fixture/blob failures, Gateway startup-test timeouts, and more than 8 GiB of Vitest memory growth prevented a trustworthy suite result.
- No UI surface changed, so screenshots are not applicable.