### PR TITLE
fix(tasks): reject invalid CLI filter values

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.activity.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.test.ts
@@ -1,0 +1,34 @@
+// Browser tests cover Playwright observation filtering behavior.
+import { describe, expect, it } from "vitest";
+import {
+  getPwToolsCoreSessionMocks,
+  installPwToolsCoreTestHooks,
+  setPwToolsCoreCurrentPage,
+} from "./pw-tools-core.test-harness.js";
+
+installPwToolsCoreTestHooks();
+const { getConsoleMessagesViaPlaywright } = await import("./pw-tools-core.activity.js");
+
+describe("getConsoleMessagesViaPlaywright", () => {
+  it("treats the documented warn filter as warning priority", async () => {
+    setPwToolsCoreCurrentPage({});
+    getPwToolsCoreSessionMocks().ensurePageState.mockReturnValueOnce({
+      console: [
+        { type: "error", text: "error", timestamp: "1" },
+        { type: "warning", text: "warning", timestamp: "2" },
+        { type: "info", text: "info", timestamp: "3" },
+      ],
+      armIdUpload: 0,
+      armIdDownload: 0,
+      downloadWaiterDepth: 0,
+    });
+
+    const messages = await getConsoleMessagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      level: "warn",
+    });
+
+    expect(messages.map((message) => message.type)).toEqual(["error", "warning"]);
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.activity.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.ts
@@ -47,6 +47,7 @@ function consolePriority(level: string) {
   switch (level) {
     case "error":
       return 3;
+    case "warn":
     case "warning":
       return 2;
     case "info":

--- a/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
@@ -58,6 +58,15 @@ describe("browser action observe commands", () => {
     expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
   });
 
+  it("rejects unknown console levels before dispatch", async () => {
+    const program = createActionObserveProgram();
+
+    await expect(
+      program.parseAsync(["browser", "console", "--level", "bogus"], { from: "user" }),
+    ).rejects.toThrow(/error.*warn.*info/u);
+    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+  });
+
   it("passes responsebody limits through to the request and outer timeout", async () => {
     const program = createActionObserveProgram();
 

--- a/extensions/browser/src/cli/browser-cli-actions-observe.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.ts
@@ -13,6 +13,18 @@ import {
 } from "./browser-cli-shared.js";
 import { defaultRuntime, shortenHomePath } from "./core-api.js";
 
+const BROWSER_CONSOLE_LEVELS = ["error", "warn", "info"] as const;
+
+function parseBrowserConsoleLevel(value: string): (typeof BROWSER_CONSOLE_LEVELS)[number] {
+  const level = BROWSER_CONSOLE_LEVELS.find((candidate) => candidate === value);
+  if (!level) {
+    throw new Error(
+      `--level must be ${BROWSER_CONSOLE_LEVELS.slice(0, -1).join(", ")}, or ${BROWSER_CONSOLE_LEVELS.at(-1)}.`,
+    );
+  }
+  return level;
+}
+
 /** Registers Browser commands that observe current page state without direct input. */
 export function registerBrowserActionObserveCommands(
   browser: Command,
@@ -21,7 +33,11 @@ export function registerBrowserActionObserveCommands(
   browser
     .command("console")
     .description("Get recent console messages")
-    .option("--level <level>", "Filter by level (error, warn, info)")
+    .option(
+      "--level <level>",
+      `Filter by level (${BROWSER_CONSOLE_LEVELS.join(", ")})`,
+      parseBrowserConsoleLevel,
+    )
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .action(async (opts, cmd) => {
       const parent = parentOpts(cmd);

--- a/src/cli/enum-filter.ts
+++ b/src/cli/enum-filter.ts
@@ -1,0 +1,19 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { formatHumanList } from "../shared/human-list.js";
+
+/** Parses an optional exact-match CLI enum before command-owned work begins. */
+export function parseCliEnumFilter<T extends string>(
+  raw: string | undefined,
+  flag: string,
+  values: readonly T[],
+): T | undefined {
+  const normalized = normalizeOptionalString(raw);
+  if (normalized === undefined) {
+    return undefined;
+  }
+  const match = values.find((value) => value === normalized);
+  if (!match) {
+    throw new Error(`${flag} must be ${formatHumanList(values)}.`);
+  }
+  return match;
+}

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -5,6 +5,14 @@ import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { setVerbose } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
+import { TASK_FLOW_STATUSES } from "../../tasks/task-flow-registry.types.js";
+import { TASK_RUNTIMES, TASK_STATUSES } from "../../tasks/task-registry.types.js";
+import {
+  TASK_SYSTEM_AUDIT_CODES,
+  TASK_SYSTEM_AUDIT_SEVERITIES,
+  type TaskSystemAuditCode,
+  type TaskSystemAuditSeverity,
+} from "../../tasks/task-system-audit.types.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
 
@@ -591,11 +599,8 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("tasks")
     .description("Inspect durable background tasks and TaskFlow state")
     .option("--json", "Output as JSON", false)
-    .option("--runtime <name>", "Filter by kind (subagent, acp, cron, cli)")
-    .option(
-      "--status <name>",
-      "Filter by status (queued, running, succeeded, failed, timed_out, cancelled, lost)",
-    )
+    .option("--runtime <name>", `Filter by kind (${TASK_RUNTIMES.join(", ")})`)
+    .option("--status <name>", `Filter by status (${TASK_STATUSES.join(", ")})`)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { tasksListCommand } = await loadTasksCommands();
@@ -615,11 +620,8 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("list")
     .description("List tracked background tasks")
     .option("--json", "Output as JSON", false)
-    .option("--runtime <name>", "Filter by kind (subagent, acp, cron, cli)")
-    .option(
-      "--status <name>",
-      "Filter by status (queued, running, succeeded, failed, timed_out, cancelled, lost)",
-    )
+    .option("--runtime <name>", `Filter by kind (${TASK_RUNTIMES.join(", ")})`)
+    .option("--status <name>", `Filter by status (${TASK_STATUSES.join(", ")})`)
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as
         | {
@@ -645,11 +647,8 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("audit")
     .description("Show stale or broken background tasks and TaskFlows")
     .option("--json", "Output as JSON", false)
-    .option("--severity <level>", "Filter by severity (warn, error)")
-    .option(
-      "--code <name>",
-      "Filter by finding code (stale_queued, stale_running, lost, delivery_failed, missing_cleanup, inconsistent_timestamps, restore_failed, stale_waiting, stale_blocked, cancel_stuck, missing_linked_tasks, blocked_task_missing)",
-    )
+    .option("--severity <level>", `Filter by severity (${TASK_SYSTEM_AUDIT_SEVERITIES.join(", ")})`)
+    .option("--code <name>", `Filter by finding code (${TASK_SYSTEM_AUDIT_CODES.join(", ")})`)
     .option("--limit <n>", "Limit displayed findings")
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
@@ -662,21 +661,8 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         await tasksAuditCommand(
           {
             json: Boolean(opts.json || parentOpts?.json),
-            severity: opts.severity as "warn" | "error" | undefined,
-            code: opts.code as
-              | "stale_queued"
-              | "stale_running"
-              | "lost"
-              | "delivery_failed"
-              | "missing_cleanup"
-              | "inconsistent_timestamps"
-              | "restore_failed"
-              | "stale_waiting"
-              | "stale_blocked"
-              | "cancel_stuck"
-              | "missing_linked_tasks"
-              | "blocked_task_missing"
-              | undefined,
+            severity: opts.severity as TaskSystemAuditSeverity | undefined,
+            code: opts.code as TaskSystemAuditCode | undefined,
             limit,
           },
           defaultRuntime,
@@ -784,10 +770,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("list")
     .description("List tracked TaskFlows")
     .option("--json", "Output as JSON", false)
-    .option(
-      "--status <name>",
-      "Filter by status (queued, running, waiting, blocked, succeeded, failed, cancelled, lost)",
-    )
+    .option("--status <name>", `Filter by status (${TASK_FLOW_STATUSES.join(", ")})`)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { flowsListCommand } = await loadFlowsCommands();

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -1,10 +1,12 @@
 // Flows command tests cover task creation, task execution, and runtime command output.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
+import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createRunningTaskRunCore as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
+import * as taskFlowRuntime from "../tasks/task-flow-runtime-internal.js";
 import { markTaskLostById, markTaskTerminalById } from "../tasks/task-registry.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import {
@@ -159,6 +161,14 @@ describe("flows commands", () => {
           },
         ],
       });
+
+      const emptyRuntime = createRuntime();
+      await flowsListCommand({ json: true, status: "waiting" }, emptyRuntime);
+      expect(jsonRoundTrip(emptyRuntime.writeJson.mock.calls[0]?.[0])).toStrictEqual({
+        count: 0,
+        status: "waiting",
+        flows: [],
+      });
     });
   });
 
@@ -183,6 +193,25 @@ describe("flows commands", () => {
         flows: [expect.objectContaining(jsonRoundTrip(flow))],
       });
     });
+  });
+
+  it("rejects invalid TaskFlow status filters before querying", async () => {
+    const query = vi.spyOn(taskFlowRuntime, "listTaskFlowRecords").mockImplementation(() => {
+      throw new Error("TaskFlow query performed");
+    });
+    const runtime = createRuntime();
+
+    try {
+      await runCommandWithRuntime(runtime, () => flowsListCommand({ status: "bogus" }, runtime));
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        "--status must be queued, running, waiting, blocked, succeeded, failed, cancelled, or lost.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(query).not.toHaveBeenCalled();
+    } finally {
+      query.mockRestore();
+    }
   });
 
   it("counts pending cancellation intent in TaskFlow pressure", async () => {
@@ -549,16 +578,19 @@ describe("flows commands", () => {
     await withTaskFlowCommandStateDir(async () => {
       const unsafe = "\u001b]52;c;Zm9yZ2Vk\u0007\nforged: yes";
       const filterRuntime = createRuntime();
-      await flowsListCommand({ status: `running${unsafe}` }, filterRuntime);
+      await runCommandWithRuntime(filterRuntime, () =>
+        flowsListCommand({ status: `running${unsafe}` }, filterRuntime),
+      );
 
       const lookupRuntime = createRuntime();
       await flowsShowCommand({ lookup: `missing${unsafe}` }, lookupRuntime);
 
       const lines = [
         ...vi.mocked(filterRuntime.log).mock.calls.map(([line]) => String(line)),
+        ...vi.mocked(filterRuntime.error).mock.calls.map(([line]) => String(line)),
         ...vi.mocked(lookupRuntime.error).mock.calls.map(([line]) => String(line)),
       ];
-      expect(lines.some((line) => line.includes("Status filter: running"))).toBe(true);
+      expect(lines.some((line) => line.includes("--status must be queued"))).toBe(true);
       expect(lines.some((line) => line.includes("TaskFlow not found: missing"))).toBe(true);
       for (const line of lines) {
         expect(line).not.toContain("\u001b");

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -6,13 +6,18 @@ import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-co
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { parseCliEnumFilter } from "../cli/enum-filter.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { writeRuntimeJson } from "../runtime.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
-import type { TaskFlowRecord, TaskFlowStatus } from "../tasks/task-flow-registry.types.js";
+import {
+  TASK_FLOW_STATUSES,
+  type TaskFlowRecord,
+  type TaskFlowStatus,
+} from "../tasks/task-flow-registry.types.js";
 import {
   getTaskFlowById,
   listTaskFlowRecords,
@@ -161,7 +166,7 @@ export async function flowsListCommand(
   opts: { json?: boolean; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const statusFilter = normalizeOptionalString(opts.status);
+  const statusFilter = parseCliEnumFilter(opts.status, "--status", TASK_FLOW_STATUSES);
   const flows = listTaskFlowRecords().filter((flow) => {
     if (statusFilter && flow.status !== statusFilter) {
       return false;

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -32,6 +32,19 @@ const mocks = vi.hoisted(() => {
     plugins: [],
     diagnostics: [],
   };
+  const knownModelProviderOwners = new Map(
+    [
+      "anthropic",
+      "azure-openai-responses",
+      "codex",
+      "google",
+      "moonshot",
+      "openai",
+      "opencode-go",
+      "xiaomi",
+      "z.ai",
+    ].map((providerId) => [providerId, ["test-provider-plugin"]]),
+  );
   const emptyPluginMetadataSnapshot = {
     policyHash: "models-list-command-forward-compat-test",
     configFingerprint: "models-list-command-forward-compat-test",
@@ -45,7 +58,7 @@ const mocks = vi.hoisted(() => {
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),
-      providers: new Map(),
+      providers: knownModelProviderOwners,
       modelCatalogProviders: new Map(),
       cliBackends: new Map(),
       setupProviders: new Map(),
@@ -150,7 +163,7 @@ function resetMocks() {
 }
 
 function createRuntime() {
-  return { log: vi.fn(), error: vi.fn() };
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 }
 
 function primeModelRegistry(
@@ -416,6 +429,31 @@ describe("modelsListCommand forward-compat", () => {
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-agent-research");
   });
 
+  it("rejects unknown provider filters before loading the model registry", async () => {
+    const runtime = createRuntime();
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let observedExitCode: number | undefined;
+
+    try {
+      await modelsListCommand(
+        { provider: "autoqa-no-such-provider", json: true },
+        runtime as never,
+      );
+      observedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown provider filter "autoqa-no-such-provider"'),
+    );
+    expect(observedExitCode).toBe(1);
+    expect(mocks.loadModelRegistry).not.toHaveBeenCalled();
+    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.printModelTable).not.toHaveBeenCalled();
+  });
+
   describe("empty model lists", () => {
     it.each([
       { name: "JSON", options: { json: true } },
@@ -423,7 +461,7 @@ describe("modelsListCommand forward-compat", () => {
     ])("renders empty $name output through the canonical model table", async ({ options }) => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
       const runtime = createRuntime();
-      const opts = { ...options, provider: "autoqa-no-such-provider" };
+      const opts = { ...options, provider: "openai" };
 
       await modelsListCommand(opts, runtime as never);
 
@@ -438,7 +476,7 @@ describe("modelsListCommand forward-compat", () => {
       mocks.startPromotionsFeedRefresh.mockReturnValueOnce(refreshToken);
       const runtime = createRuntime();
 
-      await modelsListCommand({ provider: "autoqa-no-such-provider" }, runtime as never);
+      await modelsListCommand({ provider: "openai" }, runtime as never);
 
       expect(runtime.log).toHaveBeenCalledWith("No models found.");
       expect(mocks.printModelTable).not.toHaveBeenCalled();

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -1,7 +1,9 @@
 /** Implementation of `openclaw models list`. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { parseModelRef } from "../../agents/model-selection-normalize.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import { requestExitAfterOneShotOutput } from "../../cli/one-shot-exit.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
@@ -15,7 +17,7 @@ import { ensureFlagCompatibility } from "./list.options.js";
 import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
-import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
+import { createModelCatalogProviderAliasCanonicalizer } from "./provider-aliases.js";
 import { resolveModelsTargetAgent } from "./shared.js";
 
 const DISPLAY_MODEL_PARSE_OPTIONS = { allowPluginNormalization: false } as const;
@@ -55,20 +57,24 @@ export async function modelsListCommand(
   runtime: RuntimeEnv,
 ) {
   ensureFlagCompatibility(opts);
+  const rawProviderFilter = opts.provider?.trim();
   const parsedProviderFilter = (() => {
-    const raw = opts.provider?.trim();
-    if (!raw) {
+    if (!rawProviderFilter) {
       return undefined;
     }
-    if (/\s/u.test(raw)) {
+    if (/\s/u.test(rawProviderFilter)) {
       runtime.error(
-        `Invalid provider filter "${raw}". Use a provider id such as "moonshot", not a display label.`,
+        `Invalid provider filter "${sanitizeTerminalText(rawProviderFilter)}". Use a provider id such as "moonshot", not a display label.`,
       );
       process.exitCode = 1;
       return null;
     }
-    const parsed = parseModelRef(`${raw}/_`, DEFAULT_PROVIDER, DISPLAY_MODEL_PARSE_OPTIONS);
-    return parsed?.provider ?? normalizeLowercaseStringOrEmpty(raw);
+    const parsed = parseModelRef(
+      `${rawProviderFilter}/_`,
+      DEFAULT_PROVIDER,
+      DISPLAY_MODEL_PARSE_OPTIONS,
+    );
+    return parsed?.provider ?? normalizeLowercaseStringOrEmpty(rawProviderFilter);
   })();
   if (parsedProviderFilter === null) {
     return;
@@ -88,20 +94,38 @@ export async function modelsListCommand(
     runtime,
   });
   const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
-  const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const metadataSnapshot = loadManifestMetadataSnapshot({
     config: cfg,
     workspaceDir,
     env: process.env,
   });
+  const providerAliasCanonicalizer = createModelCatalogProviderAliasCanonicalizer({
+    cfg,
+    metadataSnapshot,
+  });
   const providerFilter = parsedProviderFilter
-    ? canonicalizeModelCatalogProviderAlias(parsedProviderFilter, {
-        cfg,
-        metadataSnapshot,
-      })
+    ? providerAliasCanonicalizer.provider(parsedProviderFilter)
     : undefined;
   const { entries } = resolveConfiguredEntries(cfg, metadataSnapshot);
+  if (providerFilter) {
+    const knownProviderIds = new Set(
+      [
+        ...metadataSnapshot.owners.providers.keys(),
+        ...metadataSnapshot.owners.modelCatalogProviders.keys(),
+        ...Object.keys(cfg.models?.providers ?? {}),
+        ...entries.map((entry) => entry.ref.provider),
+      ].map((providerId) => providerAliasCanonicalizer.provider(providerId)),
+    );
+    if (!knownProviderIds.has(providerFilter)) {
+      runtime.error(
+        `Unknown provider filter "${sanitizeTerminalText(rawProviderFilter ?? providerFilter)}" for this installation. Run ${formatCliCommand("openclaw plugins list --json")} to see installed providers, or configure it under models.providers.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+  }
+  const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
   const authIndex = createModelListAuthIndex({
     cfg,
     authStore,

--- a/src/commands/tasks-audit-system.ts
+++ b/src/commands/tasks-audit-system.ts
@@ -1,24 +1,17 @@
 // Combines task and task-flow audit findings for CLI output.
 // The combined shape lets list/json commands filter and sort both registries together.
 
-import type {
-  TaskFlowAuditCode,
-  TaskFlowAuditFinding,
-  TaskFlowAuditSeverity,
-} from "../tasks/task-flow-registry.audit.js";
+import type { TaskFlowAuditFinding } from "../tasks/task-flow-registry.audit.js";
 import { summarizeTaskFlowAuditFindings } from "../tasks/task-flow-registry.audit.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
-import type {
-  TaskAuditCode,
-  TaskAuditFinding,
-  TaskAuditSeverity,
-} from "../tasks/task-registry.audit.js";
+import type { TaskAuditFinding } from "../tasks/task-registry.audit.js";
 import { summarizeTaskAuditFindings } from "../tasks/task-registry.audit.js";
 import { compareTaskAuditFindingSortKeys } from "../tasks/task-registry.audit.shared.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
-
-export type TaskSystemAuditCode = TaskAuditCode | TaskFlowAuditCode;
-export type TaskSystemAuditSeverity = TaskAuditSeverity | TaskFlowAuditSeverity;
+import type {
+  TaskSystemAuditCode,
+  TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
 
 export type TaskSystemAuditFinding = {
   kind: "task" | "task_flow";

--- a/src/commands/tasks-json.test.ts
+++ b/src/commands/tasks-json.test.ts
@@ -1,6 +1,8 @@
 // Tasks JSON tests cover structured task command output and managed task flow state.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import type { RuntimeEnv } from "../runtime.js";
+import * as taskRuntime from "../tasks/runtime-internal.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import { createTaskRecord as createTaskRecordOrNull } from "../tasks/task-registry.js";
@@ -11,6 +13,10 @@ import {
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
 } from "../tasks/task-runtime.test-helpers.js";
+import type {
+  TaskSystemAuditCode,
+  TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { tasksAuditJsonCommand, tasksListJsonCommand } from "./tasks-json.js";
 
@@ -110,6 +116,15 @@ describe("tasks JSON commands", () => {
         runtime: "cli",
         status: "running",
         tasks: [jsonRoundTrip(cliTask)],
+      });
+
+      const emptyRuntime = createRuntime();
+      await tasksListJsonCommand({ json: true, runtime: "subagent" }, emptyRuntime);
+      expect(readJsonLog(emptyRuntime)).toStrictEqual({
+        count: 0,
+        runtime: "subagent",
+        status: null,
+        tasks: [],
       });
     });
   });
@@ -237,6 +252,49 @@ describe("tasks JSON commands", () => {
         },
       });
     });
+  });
+
+  it.each([
+    {
+      run: (runtime: RuntimeEnv) => tasksListJsonCommand({ json: true, runtime: "bogus" }, runtime),
+      message: "--runtime must be subagent, acp, cron, or cli.",
+    },
+    {
+      run: (runtime: RuntimeEnv) =>
+        tasksListJsonCommand({ json: true, status: "RUNNING" }, runtime),
+      message:
+        "--status must be queued, running, succeeded, failed, timed_out, cancelled, or lost.",
+    },
+    {
+      run: (runtime: RuntimeEnv) =>
+        tasksAuditJsonCommand(
+          { json: true, severity: "bogus" as TaskSystemAuditSeverity },
+          runtime,
+        ),
+      message: "--severity must be warn or error.",
+    },
+    {
+      run: (runtime: RuntimeEnv) =>
+        tasksAuditJsonCommand({ json: true, code: "bogus-code" as TaskSystemAuditCode }, runtime),
+      message:
+        "--code must be stale_queued, stale_running, lost, delivery_failed, missing_cleanup, inconsistent_timestamps, restore_failed, stale_waiting, stale_blocked, cancel_stuck, missing_linked_tasks, or blocked_task_missing.",
+    },
+  ])("rejects invalid routed filters before reading task state", async ({ run, message }) => {
+    const query = vi.spyOn(taskRuntime, "listTaskRecords").mockImplementation(() => {
+      throw new Error("task JSON query performed");
+    });
+    const runtime = createRuntime();
+
+    try {
+      await runCommandWithRuntime(runtime, () => run(runtime));
+
+      expect(runtime.error).toHaveBeenCalledWith(message);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(query).not.toHaveBeenCalled();
+      expect(runtime.log).not.toHaveBeenCalled();
+    } finally {
+      query.mockRestore();
+    }
   });
 
   it("keeps task-flow restore failures inspectable in audit JSON", async () => {

--- a/src/commands/tasks-json.ts
+++ b/src/commands/tasks-json.ts
@@ -1,18 +1,22 @@
 // JSON-only task command helpers.
 // These paths avoid maintenance reconciliation so short-lived JSON CLI processes stay read-only and exit cleanly.
 
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { parseCliEnumFilter } from "../cli/enum-filter.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { writeRuntimeJson } from "../runtime.js";
 import { listTaskRecords } from "../tasks/runtime-internal.js";
 import { listTaskFlowAuditFindings } from "../tasks/task-flow-registry.audit.js";
 import { listTaskAuditFindings } from "../tasks/task-registry.audit.js";
-import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { TASK_RUNTIMES, TASK_STATUSES, type TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  TASK_SYSTEM_AUDIT_CODES,
+  TASK_SYSTEM_AUDIT_SEVERITIES,
+  type TaskSystemAuditCode,
+  type TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
 import {
   buildTaskSystemAuditJsonPayload,
   buildTaskSystemAuditFindings,
-  type TaskSystemAuditCode,
-  type TaskSystemAuditSeverity,
 } from "./tasks-audit-system.js";
 
 function listTaskJsonRecords(): TaskRecord[] {
@@ -51,8 +55,8 @@ function toSystemAuditFindings(params: {
 }
 
 function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
-  const runtimeFilter = normalizeOptionalString(opts.runtime);
-  const statusFilter = normalizeOptionalString(opts.status);
+  const runtimeFilter = parseCliEnumFilter(opts.runtime, "--runtime", TASK_RUNTIMES);
+  const statusFilter = parseCliEnumFilter(opts.status, "--status", TASK_STATUSES);
   const tasks = listTaskJsonRecords().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -71,10 +75,14 @@ function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
 }
 
 function buildTasksAuditJsonPayload(opts: TasksAuditJsonArgs) {
-  const severityFilter = normalizeOptionalString(opts.severity) as
-    | TaskSystemAuditSeverity
+  const severityFilter = parseCliEnumFilter(
+    opts.severity,
+    "--severity",
+    TASK_SYSTEM_AUDIT_SEVERITIES,
+  ) as TaskSystemAuditSeverity | undefined;
+  const codeFilter = parseCliEnumFilter(opts.code, "--code", TASK_SYSTEM_AUDIT_CODES) as
+    | TaskSystemAuditCode
     | undefined;
-  const codeFilter = normalizeOptionalString(opts.code) as TaskSystemAuditCode | undefined;
   const result = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/commands/tasks.filter-validation.test.ts
+++ b/src/commands/tasks.filter-validation.test.ts
@@ -1,0 +1,125 @@
+// Tasks command tests cover filter rejection before registry queries.
+import { describe, expect, it, vi } from "vitest";
+import { runCommandWithRuntime } from "../cli/cli-utils.js";
+import type { RuntimeEnv } from "../runtime.js";
+import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
+import * as taskRegistryReconcile from "../tasks/task-registry.reconcile.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import type {
+  TaskSystemAuditCode,
+  TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
+import { tasksAuditCommand, tasksListCommand } from "./tasks.js";
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+describe("tasks command filter validation", () => {
+  it("keeps valid matching and empty filters successful", async () => {
+    const task: TaskRecord = {
+      taskId: "task-1",
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Inspect filters",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      createdAt: 1,
+    };
+    const query = vi
+      .spyOn(taskRegistryReconcile, "reconcileInspectableTasks")
+      .mockReturnValue([task]);
+    const matchingRuntime = createRuntime();
+    const emptyRuntime = createRuntime();
+
+    try {
+      await tasksListCommand({ json: true, status: "running" }, matchingRuntime);
+      await tasksListCommand({ json: true, runtime: "cron" }, emptyRuntime);
+
+      expect(JSON.parse(String(vi.mocked(matchingRuntime.log).mock.calls[0]?.[0]))).toStrictEqual({
+        count: 1,
+        runtime: null,
+        status: "running",
+        tasks: [task],
+      });
+      expect(JSON.parse(String(vi.mocked(emptyRuntime.log).mock.calls[0]?.[0]))).toStrictEqual({
+        count: 0,
+        runtime: "cron",
+        status: null,
+        tasks: [],
+      });
+    } finally {
+      query.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      options: { runtime: "bogus" },
+      message: "--runtime must be subagent, acp, cron, or cli.",
+    },
+    {
+      options: { status: "bogus" },
+      message:
+        "--status must be queued, running, succeeded, failed, timed_out, cancelled, or lost.",
+    },
+    {
+      options: { status: "RUNNING" },
+      message:
+        "--status must be queued, running, succeeded, failed, timed_out, cancelled, or lost.",
+    },
+  ])("rejects invalid task list filters before querying", async ({ options, message }) => {
+    const query = vi
+      .spyOn(taskRegistryReconcile, "reconcileInspectableTasks")
+      .mockImplementation(() => {
+        throw new Error("task query performed");
+      });
+    const runtime = createRuntime();
+
+    try {
+      await runCommandWithRuntime(runtime, () => tasksListCommand(options, runtime));
+
+      expect(runtime.error).toHaveBeenCalledWith(message);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(query).not.toHaveBeenCalled();
+    } finally {
+      query.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      options: { severity: "bogus" as TaskSystemAuditSeverity },
+      message: "--severity must be warn or error.",
+    },
+    {
+      options: { code: "bogus-code" as TaskSystemAuditCode },
+      message:
+        "--code must be stale_queued, stale_running, lost, delivery_failed, missing_cleanup, inconsistent_timestamps, restore_failed, stale_waiting, stale_blocked, cancel_stuck, missing_linked_tasks, or blocked_task_missing.",
+    },
+  ])("rejects invalid task audit filters before querying", async ({ options, message }) => {
+    const query = vi
+      .spyOn(taskRegistryMaintenance, "configureTaskRegistryMaintenance")
+      .mockImplementation(() => {
+        throw new Error("task audit query performed");
+      });
+    const runtime = createRuntime();
+
+    try {
+      await runCommandWithRuntime(runtime, () => tasksAuditCommand(options, runtime));
+
+      expect(runtime.error).toHaveBeenCalledWith(message);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(query).not.toHaveBeenCalled();
+    } finally {
+      query.mockRestore();
+    }
+  });
+});

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -25,9 +25,12 @@ import {
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
 } from "../tasks/task-runtime.test-helpers.js";
+import type {
+  TaskSystemAuditCode,
+  TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import type { TaskSystemAuditCode, TaskSystemAuditSeverity } from "./tasks-audit-system.js";
 import {
   tasksAuditCommand,
   tasksCancelCommand,
@@ -795,22 +798,6 @@ describe("tasks commands", () => {
         runId: `run${unsafe}`,
         error: `error${unsafe}`,
       });
-      const filteredListRuntime = createRuntime();
-      await tasksListCommand(
-        { runtime: `cron${unsafe}`, status: `running${unsafe}` },
-        filteredListRuntime,
-      );
-      const filteredAuditRuntime = createRuntime();
-      await tasksAuditCommand(
-        {
-          severity: `warn${unsafe}` as TaskSystemAuditSeverity,
-          code: `lost${unsafe}` as TaskSystemAuditCode,
-        },
-        filteredAuditRuntime,
-      );
-      for (const runtime of [filteredListRuntime, filteredAuditRuntime]) {
-        expectSafeTaskOutput(runtime);
-      }
       const lookupRuntime = createRuntime();
       await tasksShowCommand({ lookup: `missing${unsafe}` }, lookupRuntime);
       expectSafeTaskOutput(lookupRuntime, "error");

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -7,6 +7,7 @@ import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { parseCliEnumFilter } from "../cli/enum-filter.js";
 import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
@@ -42,14 +43,23 @@ import {
   reconcileTaskLookupToken,
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
-import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  TASK_RUNTIMES,
+  TASK_STATUSES,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+} from "../tasks/task-registry.types.js";
 import { formatTaskStatusDetail } from "../tasks/task-status.js";
+import {
+  TASK_SYSTEM_AUDIT_CODES,
+  TASK_SYSTEM_AUDIT_SEVERITIES,
+  type TaskSystemAuditCode,
+  type TaskSystemAuditSeverity,
+} from "../tasks/task-system-audit.types.js";
 import {
   buildTaskSystemAuditJsonPayload,
   buildTaskSystemAuditFindings,
-  type TaskSystemAuditCode,
   type TaskSystemAuditFinding,
-  type TaskSystemAuditSeverity,
 } from "./tasks-audit-system.js";
 
 const RUNTIME_PAD = 8;
@@ -350,8 +360,8 @@ export async function tasksListCommand(
   opts: { json?: boolean; runtime?: string; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const runtimeFilter = normalizeOptionalString(opts.runtime);
-  const statusFilter = normalizeOptionalString(opts.status);
+  const runtimeFilter = parseCliEnumFilter(opts.runtime, "--runtime", TASK_RUNTIMES);
+  const statusFilter = parseCliEnumFilter(opts.status, "--status", TASK_STATUSES);
   const tasks = reconcileInspectableTasks().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -596,11 +606,15 @@ export async function tasksAuditCommand(
   },
   runtime: RuntimeEnv,
 ) {
-  configureTaskMaintenanceFromConfig();
-  const severityFilter = normalizeOptionalString(opts.severity) as
-    | TaskSystemAuditSeverity
+  const severityFilter = parseCliEnumFilter(
+    opts.severity,
+    "--severity",
+    TASK_SYSTEM_AUDIT_SEVERITIES,
+  ) as TaskSystemAuditSeverity | undefined;
+  const codeFilter = parseCliEnumFilter(opts.code, "--code", TASK_SYSTEM_AUDIT_CODES) as
+    | TaskSystemAuditCode
     | undefined;
-  const codeFilter = normalizeOptionalString(opts.code) as TaskSystemAuditCode | undefined;
+  configureTaskMaintenanceFromConfig();
   const auditResult = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -7,11 +7,8 @@ import {
   createRunningTaskRunCore as createRunningTaskRunOrNull,
   finalizeTaskRunByRunIdCore as finalizeTaskRunByRunId,
 } from "./task-executor.js";
-import {
-  listTaskFlowAuditFindings,
-  type TaskFlowAuditCode,
-  type TaskFlowAuditFinding,
-} from "./task-flow-registry.audit.js";
+import { listTaskFlowAuditFindings } from "./task-flow-registry.audit.js";
+import type { TaskFlowAuditCode, TaskFlowAuditFinding } from "./task-flow-registry.audit.types.js";
 import {
   createManagedTaskFlow as createManagedTaskFlowOrNull,
   requestFlowCancel,

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -1,36 +1,20 @@
 // Produces task-flow registry audit summaries for diagnostics and maintenance.
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { isTaskFlowCancellationPending } from "./task-cancellation-state.js";
+import type {
+  TaskFlowAuditCode,
+  TaskFlowAuditFinding,
+  TaskFlowAuditSeverity,
+  TaskFlowAuditSummary,
+} from "./task-flow-registry.audit.types.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
-/** Severity used by task-flow registry audit findings. */
-export type TaskFlowAuditSeverity = "warn" | "error";
-export type TaskFlowAuditCode =
-  | "restore_failed"
-  | "stale_running"
-  | "stale_waiting"
-  | "stale_blocked"
-  | "cancel_stuck"
-  | "missing_linked_tasks"
-  | "blocked_task_missing"
-  | "inconsistent_timestamps";
-
-export type TaskFlowAuditFinding = {
-  severity: TaskFlowAuditSeverity;
-  code: TaskFlowAuditCode;
-  detail: string;
-  ageMs?: number;
-  flow?: TaskFlowRecord;
-};
-
-export type TaskFlowAuditSummary = {
-  total: number;
-  warnings: number;
-  errors: number;
-  byCode: Record<TaskFlowAuditCode, number>;
-};
+export type {
+  TaskFlowAuditFinding,
+  TaskFlowAuditSummary,
+} from "./task-flow-registry.audit.types.js";
 
 type TaskFlowAuditOptions = {
   now?: number;

--- a/src/tasks/task-flow-registry.audit.types.ts
+++ b/src/tasks/task-flow-registry.audit.types.ts
@@ -1,0 +1,31 @@
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskAuditSeverity } from "./task-registry.audit.shared.js";
+
+/** Canonical task-flow audit finding vocabulary. */
+export const TASK_FLOW_AUDIT_CODES = [
+  "restore_failed",
+  "stale_running",
+  "stale_waiting",
+  "stale_blocked",
+  "cancel_stuck",
+  "missing_linked_tasks",
+  "blocked_task_missing",
+  "inconsistent_timestamps",
+] as const;
+export type TaskFlowAuditSeverity = TaskAuditSeverity;
+export type TaskFlowAuditCode = (typeof TASK_FLOW_AUDIT_CODES)[number];
+
+export type TaskFlowAuditFinding = {
+  severity: TaskFlowAuditSeverity;
+  code: TaskFlowAuditCode;
+  detail: string;
+  ageMs?: number;
+  flow?: TaskFlowRecord;
+};
+
+export type TaskFlowAuditSummary = {
+  total: number;
+  warnings: number;
+  errors: number;
+  byCode: Record<TaskFlowAuditCode, number>;
+};

--- a/src/tasks/task-flow-registry.types.ts
+++ b/src/tasks/task-flow-registry.types.ts
@@ -6,19 +6,8 @@ export type { JsonValue } from "./task-registry.types.js";
 
 export type TaskFlowSyncMode = "task_mirrored" | "managed";
 
-/** Lifecycle status for multi-step task flows. */
-export type TaskFlowStatus =
-  | "queued"
-  | "running"
-  | "waiting"
-  | "blocked"
-  | "succeeded"
-  | "failed"
-  | "cancelled"
-  | "lost";
-
-const TASK_FLOW_SYNC_MODES = new Set<TaskFlowSyncMode>(["task_mirrored", "managed"]);
-const TASK_FLOW_STATUSES = new Set<TaskFlowStatus>([
+/** Lifecycle statuses for multi-step task flows. */
+export const TASK_FLOW_STATUSES = [
   "queued",
   "running",
   "waiting",
@@ -27,7 +16,11 @@ const TASK_FLOW_STATUSES = new Set<TaskFlowStatus>([
   "failed",
   "cancelled",
   "lost",
-]);
+] as const;
+export type TaskFlowStatus = (typeof TASK_FLOW_STATUSES)[number];
+
+const TASK_FLOW_SYNC_MODES = new Set<TaskFlowSyncMode>(["task_mirrored", "managed"]);
+const TASK_FLOW_STATUS_SET = new Set<TaskFlowStatus>(TASK_FLOW_STATUSES);
 
 function parsePersistedFlowValue<T extends string>(
   value: unknown,
@@ -48,7 +41,7 @@ export function parseOptionalTaskFlowSyncMode(value: unknown): TaskFlowSyncMode 
 }
 
 export function parseTaskFlowStatus(value: unknown): TaskFlowStatus {
-  return parsePersistedFlowValue(value, TASK_FLOW_STATUSES, "status");
+  return parsePersistedFlowValue(value, TASK_FLOW_STATUS_SET, "status");
 }
 
 export type TaskFlowRecord = {

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -1,15 +1,18 @@
 // Shares task audit classification helpers across registry audit modules.
 import type { TaskRecord } from "./task-registry.types.js";
 
-/** Severity used by task registry audit findings. */
-export type TaskAuditSeverity = "warn" | "error";
-export type TaskAuditCode =
-  | "stale_queued"
-  | "stale_running"
-  | "lost"
-  | "delivery_failed"
-  | "missing_cleanup"
-  | "inconsistent_timestamps";
+/** Canonical task registry audit vocabulary. */
+export const TASK_AUDIT_SEVERITIES = ["warn", "error"] as const;
+export const TASK_AUDIT_CODES = [
+  "stale_queued",
+  "stale_running",
+  "lost",
+  "delivery_failed",
+  "missing_cleanup",
+  "inconsistent_timestamps",
+] as const;
+export type TaskAuditSeverity = (typeof TASK_AUDIT_SEVERITIES)[number];
+export type TaskAuditCode = (typeof TASK_AUDIT_CODES)[number];
 
 export type TaskAuditFinding = {
   severity: TaskAuditSeverity;

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -24,7 +24,7 @@ export type RetainedLostTaskAuditSummary = {
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
-export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
+export type { TaskAuditFinding, TaskAuditSummary };
 
 let taskAuditTaskProvider: () => TaskRecord[] = () => [];
 

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -10,17 +10,20 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
-/** Runtime family that owns a task run lifecycle. */
-export type TaskRuntime = "subagent" | "acp" | "cli" | "cron";
+/** Runtime families that own task run lifecycles. */
+export const TASK_RUNTIMES = ["subagent", "acp", "cron", "cli"] as const;
+export const TASK_STATUSES = [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "timed_out",
+  "cancelled",
+  "lost",
+] as const;
 
-export type TaskStatus =
-  | "queued"
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "timed_out"
-  | "cancelled"
-  | "lost";
+export type TaskRuntime = (typeof TASK_RUNTIMES)[number];
+export type TaskStatus = (typeof TASK_STATUSES)[number];
 
 export type TaskDeliveryStatus =
   | "pending"
@@ -40,16 +43,8 @@ export type TaskScopeKind = "session" | "system";
 export type TaskStatusCounts = Record<TaskStatus, number>;
 export type TaskRuntimeCounts = Record<TaskRuntime, number>;
 
-const TASK_RUNTIMES = new Set<TaskRuntime>(["subagent", "acp", "cli", "cron"]);
-const TASK_STATUSES = new Set<TaskStatus>([
-  "queued",
-  "running",
-  "succeeded",
-  "failed",
-  "timed_out",
-  "cancelled",
-  "lost",
-]);
+const TASK_RUNTIME_SET = new Set<TaskRuntime>(TASK_RUNTIMES);
+const TASK_STATUS_SET = new Set<TaskStatus>(TASK_STATUSES);
 const TASK_DELIVERY_STATUSES = new Set<TaskDeliveryStatus>([
   "pending",
   "delivered",
@@ -75,11 +70,11 @@ function parsePersistedTaskValue<T extends string>(
 }
 
 export function parseTaskRuntime(value: unknown): TaskRuntime {
-  return parsePersistedTaskValue(value, TASK_RUNTIMES, "runtime");
+  return parsePersistedTaskValue(value, TASK_RUNTIME_SET, "runtime");
 }
 
 export function parseTaskStatus(value: unknown): TaskStatus {
-  return parsePersistedTaskValue(value, TASK_STATUSES, "status");
+  return parsePersistedTaskValue(value, TASK_STATUS_SET, "status");
 }
 
 export function parseTaskDeliveryStatus(value: unknown): TaskDeliveryStatus {

--- a/src/tasks/task-system-audit.types.ts
+++ b/src/tasks/task-system-audit.types.ts
@@ -1,0 +1,19 @@
+import { TASK_FLOW_AUDIT_CODES, type TaskFlowAuditCode } from "./task-flow-registry.audit.types.js";
+import {
+  TASK_AUDIT_CODES,
+  TASK_AUDIT_SEVERITIES,
+  type TaskAuditCode,
+  type TaskAuditSeverity,
+} from "./task-registry.audit.shared.js";
+
+export type TaskSystemAuditCode = TaskAuditCode | TaskFlowAuditCode;
+export type TaskSystemAuditSeverity = TaskAuditSeverity;
+
+/** De-duplicated vocabulary accepted by the combined tasks audit command. */
+export const TASK_SYSTEM_AUDIT_CODES: readonly TaskSystemAuditCode[] = [
+  ...TASK_AUDIT_CODES,
+  ...TASK_FLOW_AUDIT_CODES.filter(
+    (flowCode) => !TASK_AUDIT_CODES.some((taskCode) => taskCode === flowCode),
+  ),
+];
+export const TASK_SYSTEM_AUDIT_SEVERITIES = TASK_AUDIT_SEVERITIES;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closed-set CLI filters silently accepted invalid values and reported empty task, TaskFlow, audit, or model results. In human mode this could confidently tell an operator that no tasks or models existed after a typo.

The same sweep found `browser console --level`: unknown values were accepted, and the documented `warn` value was treated as `info` because the collector only recognized `warning`.

## Why This Change Was Made

Task runtimes/statuses now come from canonical tuples in the task registry domain, with a distinct TaskFlow status tuple because flows genuinely own `waiting` and `blocked`. Task and TaskFlow audit codes remain producer-owned and feed one de-duplicated system-audit vocabulary. Both Commander handlers and the route-first JSON task path validate before reading registry state, while help text is generated from those same owners.

`models list --provider` remains dynamic: after config, manifest metadata, and configured entries are loaded, it canonicalizes the requested id and checks it against the already-loaded installed/configured provider inventory before any model registry/catalog discovery. A known provider with no rows remains a successful empty result.

## User Impact

Invalid task, TaskFlow, audit, model-provider, and browser-console filters now name the accepted values or recovery command and exit non-zero. Lowercase task enums remain exact-match, matching the existing audit and Commander enum behavior; `RUNNING` is rejected rather than silently normalized.

Successful JSON shapes are unchanged. Valid filters that match no rows still exit 0, and valid filters with rows still return them.

## Evidence

Before, each reported value exited 0 with an empty result. After the isolated built-artifact run:

| Command/filter | After |
| --- | --- |
| `tasks list --status bogus --json` | valid task statuses, exit 1 |
| `tasks list --status RUNNING --json` | valid task statuses, exit 1 |
| `tasks list --runtime bogus --json` | valid runtimes, exit 1 |
| `tasks flow list --status bogus --json` | valid TaskFlow statuses, exit 1 |
| `tasks audit --severity bogus` | `warn or error`, exit 1 |
| `tasks audit --code bogus-code` | valid audit codes, exit 1 |
| `models list --provider bogus --json` | unknown-provider recovery guidance, exit 1 |
| `browser console --level bogus --json` | `error, warn, or info`, exit 1 |

Must-not-break proof in the same isolated state:

- `tasks list --status running --json` -> unchanged empty task payload, exit 0.
- configured `empty-provider` with `models: []`, then `models list --provider empty-provider --json` -> `{ "count": 0, "models": [] }`, exit 0.
- `models list --provider openai --json` -> one model row, exit 0.
- Human invalid task/model filters print only the actionable error; neither prints `No background tasks found` or `No models found`.

Validation:

- Pre-fix regression proof: task list/audit, routed task JSON, TaskFlow, provider, and browser cases failed because the query/dispatch happened first; documented browser `warn` also included `info` rows.
- Focused Vitest: task commands + routed JSON, TaskFlow commands, model list unit/E2E, CLI registration/cold imports, and browser CLI/activity suites.
- `node scripts/check-changed.mjs` on Blacksmith Testbox `tbx_01m04rfn0dzc5n2mkdey4cs74r`: clean.
- `pnpm build` on the same Testbox: clean.
- Isolated built CLI: `OPENCLAW_STATE_DIR=$(mktemp -d)`, `OPENCLAW_SKIP_CHANNELS=1`, direct `dist/entry.js`; no live operator state or Gateway port used.
- Autoreview: clean, no accepted/actionable findings.
- LOC: production +241/-153 (net +88); tests +308/-28 (net +280). Production growth is the shared CLI validation boundary, lightweight canonical audit/type owners, dynamic provider-inventory distinction, and the bounded browser sweep fix; duplicated help/type lists and stale exports were removed.

AI-assisted: yes. The implementation and evidence above were inspected and verified.
