### PR TITLE
fix(feishu): preserve durable ingress failure causes

### DIFF
--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -229,7 +229,10 @@ export function buildFeishuFlushIngressLifecycle(
     kind: NonNullable<typeof terminal>,
     action: () => Promise<void>,
   ) => {
-    while (!terminal) {
+    for (;;) {
+      if (terminal) {
+        return;
+      }
       if (terminalAction) {
         await terminalAction.catch(() => undefined);
         continue;

--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -218,91 +218,72 @@ export function buildFeishuFlushIngressLifecycle(
     return { lifecycle: undefined, settle: async () => {} };
   }
   let handedOff = false;
-  let terminal: "adopted" | "abandoned" | undefined;
-  let adopting: Promise<void> | undefined;
-  let abandoning: Promise<void> | undefined;
+  let terminal: "adopted" | "failed" | "abandoned" | undefined;
+  let terminalAction: Promise<void> | undefined;
   const releaseReplayClaims = () => {
     for (const claim of replayClaims) {
       claim.release({ error: new Error("feishu-ingress-not-adopted") });
     }
   };
-  const runAbandon = async () => {
-    if (terminal) {
-      return;
-    }
-    releaseReplayClaims();
-    await transportLifecycle.onAbandoned();
-    terminal = "abandoned";
-  };
-  const ensureAbandoned = async () => {
-    if (terminal) {
-      return;
-    }
-    const activeAbandonment = abandoning ?? runAbandon();
-    abandoning = activeAbandonment;
-    try {
-      await activeAbandonment;
-    } finally {
-      if (abandoning === activeAbandonment && terminal !== "abandoned") {
-        abandoning = undefined;
+  const runTerminalAction = async (
+    kind: NonNullable<typeof terminal>,
+    action: () => Promise<void>,
+  ) => {
+    while (!terminal) {
+      if (terminalAction) {
+        await terminalAction.catch(() => undefined);
+        continue;
+      }
+      const activeAction = (async () => {
+        await action();
+        terminal = kind;
+      })();
+      terminalAction = activeAction;
+      try {
+        await activeAction;
+        return;
+      } finally {
+        if (terminalAction === activeAction) {
+          terminalAction = undefined;
+        }
       }
     }
   };
-  const abandonAll = async () => {
-    if (terminal) {
-      return;
-    }
-    if (adopting) {
-      await adopting.catch(() => undefined);
-      if (terminal) {
+  const abandonAll = () =>
+    runTerminalAction("abandoned", async () => {
+      releaseReplayClaims();
+      await transportLifecycle.onAbandoned();
+    });
+  const failAll = (error: unknown) =>
+    runTerminalAction("failed", async () => {
+      releaseReplayClaims();
+      if (transportLifecycle.onFailed) {
+        await transportLifecycle.onFailed(error);
         return;
       }
-    }
-    await ensureAbandoned();
-  };
+      await transportLifecycle.onAbandoned();
+    });
   const adoptAll = async () => {
-    if (terminal) {
-      return;
-    }
-    if (abandoning) {
-      await abandoning.catch(() => undefined);
-      if (terminal) {
-        return;
-      }
-    }
-    const activeAdoption =
-      adopting ??
-      (async () => {
-        try {
-          await transportLifecycle.onAdopted();
-          terminal = "adopted";
-          // Queue adoption is authoritative. Logical twin guards commit only
-          // afterward: partial best-effort guard writes may admit a duplicate,
-          // but can never split or suppress recovery of an unadopted turn.
-          const results = await Promise.allSettled(
-            replayClaims.map(async (claim) => claim.commit()),
-          );
-          for (const result of results) {
-            if (result.status === "rejected") {
-              try {
-                options?.onReplayCommitError?.(result.reason);
-              } catch {
-                // Reporting cannot undo an already adopted durable turn.
-              }
+    try {
+      await runTerminalAction("adopted", async () => {
+        await transportLifecycle.onAdopted();
+        // Queue adoption is authoritative. Logical twin guards commit only
+        // afterward: partial best-effort guard writes may admit a duplicate,
+        // but can never split or suppress recovery of an unadopted turn.
+        const results = await Promise.allSettled(replayClaims.map(async (claim) => claim.commit()));
+        for (const result of results) {
+          if (result.status === "rejected") {
+            try {
+              options?.onReplayCommitError?.(result.reason);
+            } catch {
+              // Reporting cannot undo an already adopted durable turn.
             }
           }
-        } catch (error) {
-          await ensureAbandoned().catch(() => undefined);
-          throw error;
         }
-      })();
-    adopting = activeAdoption;
-    try {
-      await activeAdoption;
-    } finally {
-      if (adopting === activeAdoption && terminal !== "adopted") {
-        adopting = undefined;
-      }
+      });
+    } catch (error) {
+      await abandonAll().catch(() => undefined);
+      throw error;
     }
   };
   return {
@@ -319,6 +300,10 @@ export function buildFeishuFlushIngressLifecycle(
       onAdoptionFinalizing: () => {
         transportLifecycle.onAdoptionFinalizing();
       },
+      onFailed: async (error) => {
+        handedOff = true;
+        await failAll(error);
+      },
       onAbandoned: async () => {
         handedOff = true;
         await abandonAll();
@@ -331,13 +316,14 @@ export function buildFeishuFlushIngressLifecycle(
         return;
       }
       handedOff = true;
-      releaseReplayClaims();
       try {
-        transportLifecycle.onAdoptionFinalizing();
-        await transportLifecycle.onAdopted();
-        terminal = "adopted";
+        await runTerminalAction("adopted", async () => {
+          releaseReplayClaims();
+          transportLifecycle.onAdoptionFinalizing();
+          await transportLifecycle.onAdopted();
+        });
       } catch (error) {
-        await ensureAbandoned().catch(() => undefined);
+        await abandonAll().catch(() => undefined);
         throw error;
       }
     },

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -490,7 +490,6 @@ describe("Feishu durable ingress debounce lifecycle", () => {
         expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
           {
             id: "evt-original-error",
-            attempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
             laneKey: "chat:oc-chat",
             reason: "retry-limit-exceeded",
             message: dispatchError.message,

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
-import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -56,6 +59,7 @@ function createLifecycle() {
     adopted: vi.fn(async () => {}),
     deferred: vi.fn(),
     finalizing: vi.fn(),
+    failed: vi.fn(async (_error: unknown) => {}),
     abandoned: vi.fn(async () => {}),
   };
   const lifecycle: FeishuIngressLifecycle = {
@@ -63,6 +67,7 @@ function createLifecycle() {
     onAdopted: calls.adopted,
     onDeferred: calls.deferred,
     onAdoptionFinalizing: calls.finalizing,
+    onFailed: calls.failed,
     onAbandoned: async () => {
       await Promise.all([...abandonHandlers].map(async (handler) => await handler()));
       await calls.abandoned();
@@ -380,11 +385,11 @@ describe("Feishu durable ingress debounce lifecycle", () => {
     expect(second.calls.adopted).not.toHaveBeenCalled();
   });
 
-  it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {
+  it("dead-letters an aged exhausted flush failure with its error and unblocks its lane", async () => {
     vi.useFakeTimers();
-    const now = Date.UTC(2026, 0, 2);
-    vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-abandon-"));
+    let clock = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(clock);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-failure-"));
     const stateDir = await fs.realpath(created);
     type Queue = NonNullable<Parameters<typeof createFeishuDurableIngress>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
@@ -392,13 +397,23 @@ describe("Feishu durable ingress debounce lifecycle", () => {
       channelId: "feishu",
       accountId: "default",
       stateDir,
+      now: () => clock,
     });
-    const event = {
-      ...createTextEvent("evt-abandon-retry", "om-abandon-retry", "retry me"),
+    const failedEvent = {
+      ...createTextEvent("evt-original-error", "om-original-error", "retry me"),
       event_type: "im.message.receive_v1",
     };
-    const handleMessage = vi.fn(async () => {
-      throw new Error("Feishu dispatch failed before adoption");
+    const nextEvent = {
+      ...createTextEvent("evt-after-error", "om-after-error", "continue"),
+      event_type: "im.message.receive_v1",
+    };
+    const dispatchError = new Error("archived session rejected before admission");
+    const handleMessage = vi.fn(async (turn: HandleMessageParams) => {
+      if (turn.event.message.message_id === "om-original-error") {
+        throw dispatchError;
+      }
+      turn.turnAdoptionLifecycle?.onAdoptionFinalizing();
+      await turn.turnAdoptionLifecycle?.onAdopted();
     });
     vi.spyOn(dedup, "claimUnprocessedFeishuMessage").mockImplementation(async () => ({
       kind: "claimed",
@@ -434,85 +449,68 @@ describe("Feishu durable ingress debounce lifecycle", () => {
       });
       return ingress;
     };
-    const pendingAttempt = async (attempts: number) => {
-      let observed: Awaited<ReturnType<typeof queue.listPending>>[number] | undefined;
+    const expectPendingAttempt = async (attempts: number) => {
       await vi.waitFor(async () => {
         const pending = await queue.listPending({ limit: "all" });
         expect(pending).toEqual([
           expect.objectContaining({
-            id: "evt-abandon-retry",
+            id: "evt-original-error",
             attempts,
             lastAttemptAt: expect.any(Number),
-            lastError: "turn-abandoned",
+            lastError: dispatchError.message,
           }),
         ]);
-        observed = pending[0];
       });
-      const lastAttemptAt = observed?.lastAttemptAt;
-      if (lastAttemptAt === undefined) {
-        throw new Error(`Missing Feishu retry timestamp for attempt ${attempts}`);
-      }
-      return { ...observed, lastAttemptAt };
     };
 
     try {
       const first = createIntegratedIngress();
       first.start();
-      await first.invokeWebhook(event);
-      const firstAttempt = await pendingAttempt(1);
+      await first.invokeWebhook(failedEvent);
+      await expectPendingAttempt(1);
       expect(handleMessage).toHaveBeenCalledTimes(1);
       await first.stop();
 
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
-      const blocked = createIntegratedIngress();
-      blocked.start();
-      await blocked.invokeWebhook(event);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(handleMessage).toHaveBeenCalledTimes(1);
-      await blocked.stop();
-
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
-      const second = createIntegratedIngress();
-      second.start();
-      await second.invokeWebhook(event);
-      const secondAttempt = await pendingAttempt(2);
-      expect(handleMessage).toHaveBeenCalledTimes(2);
-      await second.stop();
-
-      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
-        const claim = await queue.claim("evt-abandon-retry", { ownerId: `seed-${attempt}` });
+      for (let attempt = 2; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim("evt-original-error", { ownerId: `seed-${attempt}` });
         if (!claim) {
           throw new Error(`Expected Feishu seed claim ${attempt}`);
         }
         await queue.release(claim, {
-          lastError: "turn-abandoned",
-          releasedAt: secondAttempt.lastAttemptAt,
+          lastError: dispatchError.message,
+          releasedAt: clock,
         });
       }
 
-      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
-      const threshold = createIntegratedIngress();
-      threshold.start();
-      await threshold.invokeWebhook(event);
-      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
-      expect(handleMessage).toHaveBeenCalledTimes(3);
-      await threshold.stop();
+      clock += DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS + 1;
+      vi.setSystemTime(clock);
+      const exhausted = createIntegratedIngress();
+      exhausted.start();
+      await vi.waitFor(async () => {
+        expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+          {
+            id: "evt-original-error",
+            attempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+            laneKey: "chat:oc-chat",
+            reason: "retry-limit-exceeded",
+            message: dispatchError.message,
+          },
+        ]);
+      });
 
-      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
-      const beyond = createIntegratedIngress();
-      beyond.start();
-      await beyond.invokeWebhook(event);
-      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
-      expect(handleMessage).toHaveBeenCalledTimes(4);
-      await beyond.stop();
-
-      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
-      const blockedRestart = createIntegratedIngress();
-      blockedRestart.start();
-      await blockedRestart.invokeWebhook(event);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(handleMessage).toHaveBeenCalledTimes(4);
-      await blockedRestart.stop();
+      await exhausted.invokeWebhook(nextEvent);
+      await vi.waitFor(() => {
+        expect(handleMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: expect.objectContaining({
+              message: expect.objectContaining({ message_id: "om-after-error" }),
+            }),
+          }),
+        );
+      });
+      await exhausted.waitForIdle();
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      await exhausted.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
       await fs.rm(stateDir, { recursive: true, force: true });

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -376,7 +376,11 @@ export function createFeishuMessageReceiveHandler({
               );
               await settle();
             } catch (err) {
-              await admissionLifecycle.onAbandoned();
+              if (admissionLifecycle.onFailed) {
+                await admissionLifecycle.onFailed(err);
+              } else {
+                await admissionLifecycle.onAbandoned();
+              }
               throw err;
             }
           },


### PR DESCRIPTION
## What Problem This Solves

When Feishu dispatch fails before adoption, the channel converted the original exception into a generic abandonment. Durable ingress therefore persisted `turn-abandoned` instead of the real failure, and an aged exhausted item could remain opaque while blocking later work in the same lane.

This addresses the Feishu owner path reported in #108865.

## Why This Change Was Made

The generic durable-ingress contract already exposes `onFailed(error)` and owns retry/dead-letter accounting. This change forwards Feishu's original dispatch error into that contract, serializes terminal adoption/failure/abandonment, and retains the legacy abandonment fallback for lifecycle implementations without `onFailed`.

The regression test uses the real SQLite queue to prove that the original message is retained through retries, becomes `retry-limit-exceeded` after the age/attempt thresholds, and no longer blocks a later event in the same `chat:oc-chat` lane.

## User Impact

Feishu ingress failures retain their actionable cause, exhausted items dead-letter correctly, and later messages in the same conversation can continue instead of remaining behind an opaque failed turn.

## Evidence

- Exact head `0fca51e244610e1a1c9e5ef6f8c8c2e44b0f9909`: GitHub CI run https://github.com/openclaw/openclaw/actions/runs/31940851073 passed all required checks, including changed Node tests, lint, test types, build artifacts, boundaries, and `openclaw/ci-gate`.
- `FS_SAFE_NATIVE_MODE=off npx -y node@24.15.0 scripts/run-vitest.mjs src/plugin-sdk/channel-ingress-runtime.test.ts` - 7 tests passed.
- `oxfmt --write` on all three changed files - clean.
- `git diff --check` - passed before commit.
- Fresh Codex autoreview through the repository helper - clean, no accepted/actionable findings, overall correctness 0.98.
- Direct contract proof: `src/plugin-sdk/channel-ingress-runtime.ts` fans `onFailed(error)` to every durable claim, while `src/channels/message/ingress-drain.ts` persists that error and reserves `turn-abandoned` for actual abandonment.
- Remaining proof gap: no credentialed live Feishu workspace or approved mock-gateway boundary trace was available. The SQLite owner-path regression and green clean-install CI are not presented as provider-level live proof.
