### PR TITLE
fix(daemon): make Windows scheduled tasks noninteractive

### DIFF
--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -18,6 +18,14 @@ import type {
   GatewayServiceRenderArgs,
 } from "./service-types.js";
 
+const MANAGED_TASK_STDIN_REDIRECTION = " < NUL";
+
+function stripManagedTaskStdinRedirection(commandLine: string): string {
+  return commandLine.endsWith(MANAGED_TASK_STDIN_REDIRECTION)
+    ? commandLine.slice(0, -MANAGED_TASK_STDIN_REDIRECTION.length)
+    : commandLine;
+}
+
 export function resolveTaskName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
   if (override) {
@@ -248,7 +256,7 @@ export async function readScheduledTaskCommand(
     }
     const hasEnvironment = Object.keys(environment).length > 0;
     return {
-      programArguments: parseCmdScriptCommandLine(commandLine),
+      programArguments: parseCmdScriptCommandLine(stripManagedTaskStdinRedirection(commandLine)),
       ...(workingDirectory ? { workingDirectory } : {}),
       ...(hasEnvironment ? { environment } : {}),
       ...(hasEnvironment
@@ -288,7 +296,10 @@ export function buildTaskScript({
       lines.push(renderCmdSetAssignment(key, value));
     }
   }
-  lines.push(programArguments.map(quoteCmdScriptArg).join(" "));
+  const commandLine = programArguments.map(quoteCmdScriptArg).join(" ");
+  // Scheduled tasks have no operator terminal. Redirect stdin so permission
+  // clients cannot open an invisible prompt and stall the gateway service.
+  lines.push(`${commandLine}${MANAGED_TASK_STDIN_REDIRECTION}`);
   return `${lines.join("\r\n")}\r\n`;
 }
 

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -386,6 +386,7 @@ describe("installScheduledTask", () => {
       const captured = xmlPayloadCaptures.find((entry) => entry.index === 2);
       expect(captured?.xml).toContain("gateway.vbs</Command>");
       expect(script).toContain('set "OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Custom Gateway"');
+      expect(script).toMatch(/node gateway\.js < NUL\r?\n$/u);
       expect(launcher).toContain("WScript.Shell");
       expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
       expectTaskRunCall(3, "OpenClaw Custom Gateway");
@@ -641,6 +642,8 @@ describe("installScheduledTask", () => {
       });
 
       const command = await readScheduledTaskCommand(env);
+      const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
+      expect(script).toMatch(/node gateway\.js < NUL\r?\n$/u);
       expect(command).toStrictEqual({
         programArguments: ["node", "gateway.js"],
         environment: {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -262,6 +262,51 @@ describe("readScheduledTaskCommand", () => {
     );
   });
 
+  it("removes the managed stdin redirection from command readback", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          '"C:/Program Files/Node/node.exe" gateway.js --profile work < NUL',
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["C:/Program Files/Node/node.exe", "gateway.js", "--profile", "work"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("keeps legacy task commands without managed stdin redirection readable", async () => {
+    await withScheduledTaskScript(
+      { scriptLines: ["@echo off", "node gateway.js --port 18789"] },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result?.programArguments).toEqual(["node", "gateway.js", "--port", "18789"]);
+      },
+    );
+  });
+
+  it("does not strip redirection tokens inside a legacy command", async () => {
+    await withScheduledTaskScript(
+      { scriptLines: ["@echo off", "node gateway.js < input.txt --profile work"] },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result?.programArguments).toEqual([
+          "node",
+          "gateway.js",
+          "<",
+          "input.txt",
+          "--profile",
+          "work",
+        ]);
+      },
+    );
+  });
+
   it("reads legacy UTF-8 scripts with CJK paths written before the encoding fix", async () => {
     await withScheduledTaskScript(
       {


### PR DESCRIPTION
## What Problem This Solves

Windows gateway services run through a hidden Scheduled Task launcher. The generated command script inherited stdin, so an ACP permission client could observe `stdin.isTTY=true`, open an invisible prompt, and stall the service indefinitely.

Fixes #112173.

## Why This Change Was Made

The Scheduled Task launcher is the owner boundary that knows the gateway has no interactive operator. The generated command now redirects stdin from `NUL`, while scheduled-task readback removes only that exact managed suffix so status and repair flows still recover the original program arguments. Legacy task scripts remain readable without migration or runtime compatibility branches.

The pinned `acpx@0.13.0` package resolves to git head [`47dc1c5`](https://github.com/openclaw/acpx/commit/47dc1c56b20da3c248a4a1b5c5106f52e65e6594). Its prompt gate requires both stdin and stderr to be TTY ([`permission-prompt.ts:9`](https://github.com/openclaw/acpx/blob/47dc1c56b20da3c248a4a1b5c5106f52e65e6594/src/permission-prompt.ts#L9)), and its noninteractive path applies the configured `deny` or `fail` policy without prompting ([`permissions.ts:321`](https://github.com/openclaw/acpx/blob/47dc1c56b20da3c248a4a1b5c5106f52e65e6594/src/permissions.ts#L321), [`permissions.ts:331`](https://github.com/openclaw/acpx/blob/47dc1c56b20da3c248a4a1b5c5106f52e65e6594/src/permissions.ts#L331)).

## User Impact

Hidden Windows gateway services no longer hang on permission prompts that nobody can see or answer. Foreground gateway launches are unchanged.

## Evidence

- `FS_SAFE_NATIVE_MODE=off npx -y node@24.15.0 scripts/run-vitest.mjs src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts` (54/54 passed)
- GitHub CI run [`31939150448`](https://github.com/openclaw/openclaw/actions/runs/31939150448): `checks-windows-node-test` passed and `openclaw/ci-gate` passed at `ae5b6a139ca`
- Direct dependency contract inspection at the published `acpx@0.13.0` git head, linked above
- `oxfmt --write` on all three changed files
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings; correctness confidence 0.99
- Scope: 3 files, +61/-2

Native Windows Scheduled Task execution was not available in this environment; the focused tests and Windows CI cover generated launcher bytes, managed readback, and legacy readback, but not a full installed service permission prompt.
