### PR TITLE
feat(minimax): expose T2V-01 text-to-video models in the video catalog

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -275,8 +275,8 @@ See [Music Generation](/tools/music-generation) for shared tool parameters, prov
 The bundled MiniMax plugin registers video generation through the shared `video_generate` tool for both `minimax` and `minimax-portal`.
 
 - Default video model: `minimax/MiniMax-Hailuo-2.3` (OAuth: `minimax-portal/MiniMax-Hailuo-2.3`)
-- Also supports `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, `I2V-01-Director`, `I2V-01-live`, and `I2V-01`
-- Modes: text-to-video and single-image reference flows
+- Also supports `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, `T2V-01-Director`, `T2V-01`, `I2V-01-Director`, `I2V-01-live`, and `I2V-01`
+- Modes: text-to-video and single-image reference flows; `T2V-01-Director` and `T2V-01` are text-to-video only, `I2V-01*` are image-to-video only
 - Supports `resolution` (`768P` or `1080P` on Hailuo 2.3/02 models); `aspectRatio` is not supported and is ignored
 
 ```json5

--- a/extensions/minimax/video-generation-provider.test.ts
+++ b/extensions/minimax/video-generation-provider.test.ts
@@ -112,6 +112,18 @@ describe("minimax video generation provider", () => {
     expect(provider.capabilities.imageToVideo?.resolutions).toEqual(["768P", "1080P"]);
   });
 
+  it("advertises the dedicated text-to-video models for both provider ids", () => {
+    // video_generate can only route to models the provider advertises, so dropping the
+    // text-to-video entries silently removes T2V model selection from the shared tool.
+    for (const provider of [
+      buildMinimaxVideoGenerationProvider(),
+      buildMinimaxPortalVideoGenerationProvider(),
+    ]) {
+      expect(provider.models).toContain("T2V-01-Director");
+      expect(provider.models).toContain("T2V-01");
+    }
+  });
+
   it("creates a task, polls status, and downloads the generated video", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: jsonResponse({

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -384,6 +384,8 @@ function buildMinimaxVideoProvider(providerId: string): VideoGenerationProvider 
       DEFAULT_MINIMAX_VIDEO_MODEL,
       "MiniMax-Hailuo-2.3-Fast",
       "MiniMax-Hailuo-02",
+      "T2V-01-Director",
+      "T2V-01",
       "I2V-01-Director",
       "I2V-01-live",
       "I2V-01",


### PR DESCRIPTION
Reason: The MiniMax video catalog omitted the dedicated text-to-video models, so `video_generate` could not select `T2V-01-Director` or `T2V-01`.

## What Problem This Solves

`extensions/minimax/video-generation-provider.ts` advertised only the Hailuo family plus the `I2V-01*` image-to-video entries. The `I2V-01*` models require a first-frame image, so a pure text-to-video run had no way to reach the dedicated `T2V-01-Director` / `T2V-01` models on the same `/v1/video_generation` endpoint. `video_generate` routes strictly to the model ids a provider advertises, so those two models were unreachable from config and from the tool, and `docs/providers/minimax.md` documented the same incomplete list.

## Why This Change Was Made

The provider catalog is the only selection surface for video models here; the request shape for `T2V-01-Director` and `T2V-01` is the existing `POST /v1/video_generation` call with `model` + `prompt`, which this provider already implements. Nothing else in the runtime needed to change, so the fix is a catalog and docs correction rather than a new code path. Both models are added to the shared builder, which keeps `minimax` and `minimax-portal` consistent.

The per-model duration and resolution tables are intentionally left alone: they encode the Hailuo-family constraints, and models absent from those tables already pass the caller's requested `duration` / `resolution` through unchanged.

## User Impact

- `video_generate` and `mediaModels.video` can now select `minimax/T2V-01-Director`, `minimax/T2V-01`, and the matching `minimax-portal/*` refs.
- Default video model is unchanged (`minimax/MiniMax-Hailuo-2.3`), so existing configurations behave exactly as before.
- Docs now state which entries are text-to-video only and which are image-to-video only.

## Evidence

- `git diff --check` — clean.
- Diff is 3 files / +16 −2 (production: +2 lines in the model list; the rest is one test and docs).
- Added `extensions/minimax/video-generation-provider.test.ts` coverage: "advertises the dedicated text-to-video models for both provider ids" asserts both builders expose `T2V-01-Director` and `T2V-01`. It fails on the pre-change catalog for the intended reason (the ids are absent) and protects the selection contract against a silent catalog regression.
- Proof gap: this environment could not install the workspace dependencies (no disk headroom for `node_modules`), so the Vitest, format, lint, and typecheck lanes were not run locally. The new assertion is a plain catalog check with no new runtime branches, and CI covers `extensions/minimax` on this PR.
