### PR TITLE
fix(release): exclude RoboClaw from contributor credit

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -32,6 +32,7 @@ const excludedHandles = new Set([
   "claude",
   "codex",
   "hugin-bot",
+  "roboclaw-bot",
   "steipete",
   "steipete-oai",
 ]);

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -55,6 +55,7 @@ describe("release-note verification", () => {
     expect(isEligibleHandle("steipete")).toBe(false);
     expect(isEligibleHandle("steipete-oai")).toBe(false);
     expect(isEligibleHandle("hugin-bot")).toBe(false);
+    expect(isEligibleHandle("roboclaw-bot")).toBe(false);
   });
 
   it("accepts only canonical commit PR suffixes", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release-note generation could credit `roboclaw-bot` as a human contributor when a release commit preserved the automation account as a co-author.

## Why This Change Was Made

The canonical contributor eligibility filter now excludes the RoboClaw automation identity alongside the existing bot and maintainer exclusions. Focused coverage keeps the release-note attribution policy from regressing.

AI-assisted: yes. The maintainer reviewed the implementation and proof.

## User Impact

GitHub release notes and `CHANGELOG.md` contribution records no longer thank RoboClaw as a human contributor. Human contributor credit is unchanged.

## Evidence

- `pnpm test test/scripts/verify-release-notes.test.ts` — 32 tests passed.
- `pnpm format .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs test/scripts/verify-release-notes.test.ts` — passed.
- `git diff --check` — passed.
- Fresh Codex autoreview — clean, no accepted or actionable findings.
