### PR TITLE
fix(mattermost): preserve durable ingress failure causes

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -8,6 +8,7 @@ import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-i
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import {
   createMessageReceiptFromOutboundResults,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -589,26 +590,37 @@ describe("mattermost inbound user posts", () => {
     });
   });
 
-  it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {
+  it("dead-letters an aged exhausted flush failure with its error and unblocks its lane", async () => {
     vi.useFakeTimers();
-    const now = Date.UTC(2026, 0, 2);
-    vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-abandon-"));
+    let clock = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(clock);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-failure-"));
     const stateDir = await fs.realpath(created);
     type Payload = { version: 1; receivedAt: number; rawEvent: string };
     const queue = createChannelIngressQueueForTests<Payload>({
       channelId: "mattermost",
       accountId: "default",
       stateDir,
+      now: () => clock,
     });
     mockState.ingressQueue = queue;
     mockState.runtimeCore = createRuntimeCore(testConfig, undefined, {
       inboundDebounceMs: 0,
       createInboundDebouncer,
     });
-    mockState.dispatchInboundMessage.mockRejectedValue(
-      new Error("Mattermost dispatch failed before adoption"),
-    );
+    const dispatchError = new Error("archived Mattermost session rejected before admission");
+    let failDispatch = true;
+    mockState.dispatchInboundMessage.mockImplementation(async (params) => {
+      if (failDispatch) {
+        throw dispatchError;
+      }
+      const lifecycle = (
+        params.replyOptions as {
+          turnAdoptionLifecycle?: { onAdopted?: () => void | Promise<void> };
+        }
+      ).turnAdoptionLifecycle;
+      await lifecycle?.onAdopted?.();
+    });
 
     const activeProviders: Array<{ stop: () => Promise<void> }> = [];
     const startProvider = async () => {
@@ -641,85 +653,69 @@ describe("mattermost inbound user posts", () => {
       activeProviders.push(provider);
       return provider;
     };
-    const send = async (provider: Awaited<ReturnType<typeof startProvider>>) => {
+    const send = async (
+      provider: Awaited<ReturnType<typeof startProvider>>,
+      id: string,
+      message: string,
+    ) => {
       await emitMattermostChannelPost(provider.socket, {
-        id: "post-abandon-retry",
-        message: "retry me",
+        id,
+        message,
       });
     };
-    const pendingAttempt = async (attempts: number) => {
-      let observed: Awaited<ReturnType<typeof queue.listPending>>[number] | undefined;
+    const expectPendingAttempt = async (attempts: number) => {
       await vi.waitFor(async () => {
         const pending = await queue.listPending({ limit: "all" });
         expect(pending).toEqual([
           expect.objectContaining({
-            id: "post-abandon-retry",
+            id: "post-original-error",
             attempts,
             lastAttemptAt: expect.any(Number),
-            lastError: "turn-abandoned",
+            lastError: dispatchError.message,
           }),
         ]);
-        observed = pending[0];
       });
-      const lastAttemptAt = observed?.lastAttemptAt;
-      if (lastAttemptAt === undefined) {
-        throw new Error(`Missing Mattermost retry timestamp for attempt ${attempts}`);
-      }
-      return { ...observed, lastAttemptAt };
     };
 
     try {
       const first = await startProvider();
-      await send(first);
-      const firstAttempt = await pendingAttempt(1);
+      await send(first, "post-original-error", "retry me");
+      await expectPendingAttempt(1);
       expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
       await first.stop();
 
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
-      const blocked = await startProvider();
-      await send(blocked);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
-      await blocked.stop();
-
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
-      const second = await startProvider();
-      await send(second);
-      const secondAttempt = await pendingAttempt(2);
-      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(2);
-      await second.stop();
-
-      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
-        const claim = await queue.claim("post-abandon-retry", { ownerId: `seed-${attempt}` });
+      for (let attempt = 2; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim("post-original-error", { ownerId: `seed-${attempt}` });
         if (!claim) {
           throw new Error(`Expected Mattermost seed claim ${attempt}`);
         }
         await queue.release(claim, {
-          lastError: "turn-abandoned",
-          releasedAt: secondAttempt.lastAttemptAt,
+          lastError: dispatchError.message,
+          releasedAt: clock,
         });
       }
 
-      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
-      const threshold = await startProvider();
-      await send(threshold);
-      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
-      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(3);
-      await threshold.stop();
+      clock += DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS + 1;
+      vi.setSystemTime(clock);
+      const exhausted = await startProvider();
+      await vi.waitFor(async () => {
+        expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+          {
+            id: "post-original-error",
+            laneKey: "channel:chan-1",
+            reason: "retry-limit-exceeded",
+            message: dispatchError.message,
+          },
+        ]);
+      });
 
-      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
-      const beyond = await startProvider();
-      await send(beyond);
-      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
-      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(4);
-      await beyond.stop();
-
-      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
-      const blockedRestart = await startProvider();
-      await send(blockedRestart);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(4);
-      await blockedRestart.stop();
+      failDispatch = false;
+      await send(exhausted, "post-after-error", "continue");
+      await vi.waitFor(async () => {
+        expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(2);
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      });
+      await exhausted.stop();
     } finally {
       await Promise.allSettled(activeProviders.map(async (provider) => await provider.stop()));
       mockState.ingressQueue = undefined;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -299,7 +299,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             );
             await settle();
           } catch (error) {
-            await admissionLifecycle.onAbandoned();
+            if (admissionLifecycle.onFailed) {
+              await admissionLifecycle.onFailed(error);
+            } else {
+              await admissionLifecycle.onAbandoned();
+            }
             throw error;
           }
         },


### PR DESCRIPTION
## What Problem This Solves

Mattermost's durable inbound debounce catches a pre-adoption dispatch error and reports it as abandonment. The shared ingress drain then persists the generic `turn-abandoned` marker instead of the original failure, so retry and dead-letter records lose the actionable cause.

## Why This Change Was Made

The Mattermost owner now forwards caught dispatch exceptions through the existing optional `onFailed(error)` lifecycle contract, with the prior abandonment callback retained only for source-compatible lifecycles that do not expose `onFailed`.

The existing SQLite integration regression was updated to cover the full owner path: the original error is retained after the first attempt, an aged exhausted item dead-letters with that same cause, and a later event in the same channel lane is delivered.

## User Impact

Operators diagnosing failed Mattermost inbound turns see the real dispatch error instead of `turn-abandoned`. Once an exhausted item is dead-lettered, later messages in that channel lane continue normally. No configuration, schema, dependency, or public API changes are introduced.

## Evidence

- `FS_SAFE_NATIVE_MODE=off OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-mattermost-retry npx -y node@24.15.0 scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - 1 file, 32 tests passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 npx -y node@24.15.0 scripts/run-oxlint.mjs extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - passed.
- `node_modules/.bin/oxfmt --write extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - clean.
- `git diff --check` - passed before commit.
- Fresh Codex autoreview through the repository helper with `--max-priority P1` - clean, no actionable findings, overall correctness 0.91.
- Direct contract proof: `src/plugin-sdk/channel-ingress-runtime.ts` fans `onFailed(error)` to every durable claim, while `src/channels/message/ingress-drain.ts` persists that error and reserves `turn-abandoned` for actual abandonment.
- Not run: a credentialed live Mattermost workspace. The SQLite owner-path regression exercises the real durable queue and message handler, but is not presented as provider-level live proof.
