### PR TITLE
fix(agents): image attachments fail for named (non-default) agents

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -5,6 +5,7 @@
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ImageContent } from "../../../llm/types.js";
+import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
 import { readPersistedMediaFacts } from "../../../media/media-facts.js";
 import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
@@ -315,6 +316,8 @@ function emptyPromptImages(): PromptImageResult {
 
 export async function prepareEmbeddedAttemptPromptExecution(input: {
   attempt: PromptExecutionAttempt;
+  /** Resolved run owner; scopes media roots to this agent's workspace. */
+  agentId?: string;
   effectiveFsWorkspaceOnly: boolean;
   effectiveWorkspace: string;
   prompt: string;
@@ -350,6 +353,10 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     maxBytes: MAX_IMAGE_BYTES,
     maxDimensionPx: resolveImageSanitizationLimits(attempt.config).maxDimensionPx,
     workspaceOnly: input.effectiveFsWorkspaceOnly,
+    localRoots:
+      input.effectiveFsWorkspaceOnly || !input.agentId
+        ? undefined
+        : getAgentScopedMediaLocalRoots(attempt.config ?? {}, input.agentId),
     sandbox:
       input.sandbox?.enabled && input.sandbox.fsBridge
         ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -238,6 +238,7 @@ export async function runEmbeddedAttemptSettledPhase(
         toolResultPromptProjectionState,
       },
       execution: {
+        agentId: input.setup.sessionAgentId,
         effectiveFsWorkspaceOnly: input.setup.effectiveFsWorkspaceOnly,
         effectiveWorkspace: input.setup.effectiveWorkspace,
         sandbox: input.setup.sandbox,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -10,6 +10,7 @@ import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-submit.j
 async function preparePluginHarnessPromptImages(params: {
   runParams: Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0]["attempt"];
   runtime: {
+    agentId?: string;
     workspaceDir: string;
     model: Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0]["attempt"]["model"];
   };
@@ -24,6 +25,7 @@ async function preparePluginHarnessPromptImages(params: {
   }
   const result = await prepareEmbeddedAttemptPromptExecution({
     attempt: { ...params.runParams, model: params.runtime.model },
+    agentId: params.runtime.agentId,
     effectiveWorkspace: params.runtime.workspaceDir,
     effectiveFsWorkspaceOnly: false,
     prompt: "",
@@ -189,6 +191,116 @@ describe("plugin harness prompt media", () => {
       expect(result.media).toBeUndefined();
       expect(JSON.stringify(result)).not.toContain(imagePath);
       expect(structuredClone(result).images).toEqual(result.images);
+    } finally {
+      envSnapshot.restore();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates named-agent workspace images without opening sibling workspaces", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-agent-media-"));
+    const workspaceDir = path.join(stateDir, "workspace-arthur");
+    const siblingWorkspaceDir = path.join(stateDir, "workspace-merlin");
+    const imagePath = path.join(workspaceDir, "media", "inbound", "photo.png");
+    const siblingImagePath = path.join(siblingWorkspaceDir, "media", "inbound", "photo.png");
+    const image = Buffer.from(TINY_PNG_BASE64, "base64");
+    await fs.mkdir(path.dirname(imagePath), { recursive: true });
+    await fs.mkdir(path.dirname(siblingImagePath), { recursive: true });
+    await fs.writeFile(imagePath, image);
+    await fs.writeFile(siblingImagePath, image);
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const config = {
+      agents: {
+        entries: {
+          arthur: { workspace: workspaceDir },
+          merlin: { workspace: siblingWorkspaceDir },
+        },
+      },
+    };
+
+    try {
+      const hydrate = (mediaPath: string, sessionId: string) =>
+        preparePluginHarnessPromptImages({
+          runParams: {
+            config,
+            media: [{ path: mediaPath, contentType: "image/png" }],
+            sessionId,
+            sessionKey: `agent:arthur:telegram:direct:${sessionId}`,
+          },
+          runtime: {
+            agentId: "arthur",
+            model: { input: ["text", "image"] },
+            sessionId,
+            workspaceDir,
+          },
+          pluginHarnessOwnsTransport: true,
+        } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]);
+
+      const result = await hydrate(imagePath, "session-agent-media");
+
+      expect(result.images).toEqual([
+        { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" },
+      ]);
+      await expect(hydrate(siblingImagePath, "session-agent-sibling-media")).rejects.toThrow(
+        "failed to hydrate 1 structured image attachment",
+      );
+    } finally {
+      envSnapshot.restore();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates named-agent workspace images on the embedded prompt path", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-embedded-agent-media-"));
+    const workspaceDir = path.join(stateDir, "workspace-arthur");
+    const siblingWorkspaceDir = path.join(stateDir, "workspace-merlin");
+    const imagePath = path.join(workspaceDir, "media", "inbound", "photo.png");
+    const siblingImagePath = path.join(siblingWorkspaceDir, "media", "inbound", "photo.png");
+    const image = Buffer.from(TINY_PNG_BASE64, "base64");
+    await fs.mkdir(path.dirname(imagePath), { recursive: true });
+    await fs.mkdir(path.dirname(siblingImagePath), { recursive: true });
+    await fs.writeFile(imagePath, image);
+    await fs.writeFile(siblingImagePath, image);
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+
+    try {
+      const hydrate = (mediaPath: string, sessionId: string) =>
+        prepareEmbeddedAttemptPromptExecution({
+          attempt: {
+            config: {
+              agents: {
+                entries: {
+                  arthur: { workspace: workspaceDir },
+                  merlin: { workspace: siblingWorkspaceDir },
+                },
+              },
+            },
+            media: [{ path: mediaPath, contentType: "image/png" }],
+            model: { input: ["text", "image"] },
+            sessionId,
+          },
+          agentId: "arthur",
+          effectiveWorkspace: workspaceDir,
+          effectiveFsWorkspaceOnly: false,
+          prompt: "",
+          skipPromptSubmission: false,
+        } as unknown as Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0]);
+
+      const owned = await hydrate(imagePath, "session-embedded-media");
+
+      expect(owned.images).toEqual([
+        { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" },
+      ]);
+      expect(owned.failedMediaCount).toBe(0);
+
+      // The embedded path returns before the plugin-harness throw, so a refused
+      // sibling read shows up as a failure count rather than a rejection.
+      const sibling = await hydrate(siblingImagePath, "session-embedded-sibling-media");
+
+      expect(sibling.images).toEqual([]);
+      expect(sibling.failedMediaCount).toBe(1);
     } finally {
       envSnapshot.restore();
       await fs.rm(stateDir, { recursive: true, force: true });

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -204,6 +204,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
         });
         return await prepareEmbeddedAttemptPromptExecution({
           attempt: { ...params, model: runtime.model },
+          agentId: runtime.agentId,
           effectiveFsWorkspaceOnly: workspace.effectiveFsWorkspaceOnly,
           effectiveWorkspace: workspace.effectiveWorkspace,
           prompt: "",


### PR DESCRIPTION
Related: #123273

Context: this follows the reproduction I posted at https://github.com/openclaw/openclaw/issues/123273#issuecomment-5307117112, which answers @obviyus's request on #123413 for a current-main reproduction. Happy to close this immediately if the conclusion is that main already covers it.

## What Problem This Solves

Fixes an issue where operators running named (non-default) agents would have image attachments silently fail to reach the model when the turn is handled by the embedded/plugin-harness runner, surfacing as `failed to hydrate 1 structured image attachment(s) for CLI input`. The same image sent to the default agent works. Because the failure lands at prompt assembly, the user sees a reply that ignores the image rather than an error explaining why.

## Why This Change Was Made

The embedded prompt path hydrated images without an agent-scoped media-root allowlist, so when `workspaceOnly` was false it fell back to the default roots — which cover `workspace` but not a named agent's own `workspace-<id>` directory.

Dispatch already resolves the run owner, so the fix threads that existing `runtime.agentId` into `prepareEmbeddedAttemptPromptExecution` and scopes the roots with `getAgentScopedMediaLocalRoots`. No new owner-resolution logic is introduced.

Deliberately unchanged: `workspaceOnly` semantics and sibling-workspace isolation. A named agent still cannot read another agent's workspace.

One thing worth flagging for review: the roots are passed **only** when `effectiveFsWorkspaceOnly` is false. That guard is load-bearing rather than defensive — `src/agents/embedded-agent-runner/run/images.ts:428` falls back to `[workspaceDir]` when `localRoots` is absent, so passing agent-scoped roots unconditionally (as `src/agents/cli-runner/execute.ts:188` does in its own context) would *widen* access under `workspaceOnly` instead of narrowing it.

## User Impact

Operators using named agents can send image attachments and have them reach the model, matching the default agent's behavior. No configuration change is required and no existing access is relaxed.

## Evidence

Regression test added to the existing suite in `src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts`, driving the real `prepareEmbeddedAttemptPromptExecution` through the harness helper the neighbouring tests already use, with the agent id supplied the same way dispatch supplies it.

Against unmodified `0c546979`:

```
× hydrates named-agent workspace images without opening sibling workspaces
  → expected [ { type: 'text', …(1) } ] to equal [ { type: 'text', …(1) }, …(2) ]

Tests  1 failed | 15 passed (16)
```

With the fix applied:

```
Tests  16 passed (16)
Test Files  1 passed (1)
```

Command: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts`

The test asserts both halves: the owning agent's workspace image hydrates, and a sibling agent's workspace image still refuses to hydrate.

Also run and green: `tsgo:core`, `tsgo:core:test`, oxfmt and oxlint on the touched files, `git diff --check`.

### Review feedback

- **Production LOC** — was +15, now **+9** (tests +112). Dropped the local session-key parsing and its helper in favour of the resolved agent id dispatch already carries, removing the duplicate owner-resolution the review flagged.
- **One-sided fix** — the review prompted me to re-trace the call graph, and the first version *was* one-sided. `prepareEmbeddedAttemptPromptExecution` has two call sites: `run-attempt-dispatch.ts` (plugin-harness, throws on failure) and `attempt-prompt-phase.ts` via the `execution` object built in `attempt-settle.ts` (embedded path, returns early and drops the image **silently**). Only the first was fixed. `attempt-settle.ts` now passes `setup.sessionAgentId`, and there is a second regression test covering the embedded path's silent-drop semantics.

## Real behavior proof

Both paths driven through `agentCommandFromIngress` with an isolated `OPENCLAW_STATE_DIR`, ephemeral ports, a real installed throwaway harness plugin, and a real ephemeral HTTP mock OpenAI Responses server. Two named agents, `arthur` and `merlin`, each with an image at `media/inbound/photo.png` — **byte-identical, same SHA-256** — so the only variable is which workspace owns it.

```json
{
  "ok": true,
  "level": "direct-agent-command-real-installed-plugin-harness-and-real-http-mock-provider",
  "agentId": "arthur",
  "siblingAgentId": "merlin",
  "rootBoundary": {
    "baseHasDefaultWorkspace": true,
    "baseHasArthurWorkspace": false,
    "baseHasMerlinWorkspace": false,
    "scopedHasArthurWorkspace": true,
    "scopedHasMerlinWorkspace": false
  },
  "pluginHarnessPath": {
    "ownWorkspaceImageReachedModel": true,
    "siblingWorkspaceImageBlocked": true,
    "siblingError": "failed to hydrate 1 structured image attachment(s) for plugin harness input",
    "siblingHarnessRunAttemptsAfterBlock": 0
  },
  "embeddedSettlePath": {
    "ownWorkspaceImageReachedModel": true,
    "siblingWorkspaceImageBlocked": true,
    "siblingProviderImageDataUrlCount": 0
  },
  "ownImageSha256": "e4a0df80102ec40b8c9fdbe8bc8aa354c0a408db094513df588127398f9b15c4"
}
```

The boundary line is `rootBoundary`: the base roots contain neither agent's workspace, and the scoped roots add `workspace-arthur` **only**. On the embedded path the owning image arrives at the provider as `imageDataUrlCount: 1` with a matching SHA-256, while the sibling image arrives as `imageDataUrlCount: 0` — the request still goes out, the image simply is not in it, which is the silent drop this PR fixes. On the plugin-harness path the sibling attempt raises the hydration error before dispatch and produces zero harness run attempts.

The harness is a purpose-built script, not part of this commit. Ports, run ids and durations vary between runs; the verdict booleans, the root boundary and the SHA-256 are stable across runs.

Caveats, stated plainly: this drives `agentCommandFromIngress` directly rather than starting the gateway listener (`secrets.resolve` falls back locally after an expected `ECONNREFUSED` to the isolated port), and it is not a live third-party channel run.

`scripts/check-changed.mjs` did not complete locally (Crabbox binary sanity check failed in this environment), so heavier fan-out proof is CI's.

Investigation and patch were AI-assisted; I have reviewed every changed line, and I re-ran both the tests and the proof harness myself.
