### PR TITLE
fix(sessions): align CLI lifecycle and runtime state

### DIFF
--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -4,7 +4,10 @@ import { applyAcpRuntimeOverlay, type AgentRuntimeMetadata } from "./acp-runtime
 import { isDefaultAgentRuntimeId } from "./agent-runtime-id.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { resolveDefaultModelForAgent } from "./model-selection.js";
-import { resolvePersistedSessionRuntimeId } from "./session-runtime-compat.js";
+import {
+  resolvePersistedSessionRuntimeId,
+  resolveSessionRuntimeOverrideForProvider,
+} from "./session-runtime-compat.js";
 
 /** Resolves the runtime id/source that should be reported for a model-backed agent session. */
 export function resolveModelAgentRuntimeMetadata(params: {
@@ -53,4 +56,26 @@ export function resolveModelAgentRuntimeMetadata(params: {
     source: policy.runtimeSource ?? "implicit",
   };
   return applyAcpRuntimeOverlay(meta, params.sessionKey, params.acpRuntime, params.acpBackend);
+}
+
+/** Resolves the runtime that would handle the next turn for an existing session. */
+export function resolveEffectiveSessionAgentRuntimeMetadata(
+  params: Parameters<typeof resolveModelAgentRuntimeMetadata>[0],
+): AgentRuntimeMetadata {
+  const configured = resolveModelAgentRuntimeMetadata({
+    ...params,
+    sessionEntry: undefined,
+  });
+  const persistedRuntime = resolveSessionRuntimeOverrideForProvider({
+    provider: params.provider,
+    entry: params.sessionEntry,
+    cfg: params.cfg,
+  });
+  if (params.acpRuntime || !persistedRuntime) {
+    return configured;
+  }
+  return {
+    id: persistedRuntime,
+    source: params.sessionEntry?.modelSelectionLocked === true ? "session" : "session-key",
+  };
 }

--- a/src/commands/sessions-table.test.ts
+++ b/src/commands/sessions-table.test.ts
@@ -1,6 +1,6 @@
 // Sessions table tests cover shared fixed-width cell formatting.
 import { describe, expect, it } from "vitest";
-import { formatSessionKeyCell, SESSION_KEY_PAD } from "./sessions-table.js";
+import { formatSessionFlagsCell, formatSessionKeyCell, SESSION_KEY_PAD } from "./sessions-table.js";
 
 describe("formatSessionKeyCell", () => {
   it("keeps both truncation boundaries UTF-16 safe", () => {
@@ -10,5 +10,11 @@ describe("formatSessionKeyCell", () => {
 
     expect(rendered).toBe(`${"a".repeat(15)}...${"z".repeat(5)}`.padEnd(SESSION_KEY_PAD));
     expect(rendered).toHaveLength(SESSION_KEY_PAD);
+  });
+});
+
+describe("formatSessionFlagsCell", () => {
+  it("marks archived sessions in the default table", () => {
+    expect(formatSessionFlagsCell({ archived: true }, false)).toBe("archived");
   });
 });

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -14,6 +14,8 @@ import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 /** Display row derived from a persisted session entry. */
 export type SessionDisplayRow = {
   key: string;
+  archived?: boolean;
+  archivedAt?: number;
   updatedAt: number | null;
   ageMs: number | null;
   sessionId?: string;
@@ -61,6 +63,8 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
   const updatedAt = entry?.updatedAt ?? null;
   return {
     key,
+    archived: entry?.archivedAt !== undefined,
+    archivedAt: entry?.archivedAt,
     updatedAt,
     ageMs: updatedAt ? Date.now() - updatedAt : null,
     sessionId: entry?.sessionId,
@@ -149,6 +153,7 @@ export function formatSessionFlagsCell(
     | "abortedLastRun"
     | "sessionId"
     | "runtimePolicySessionKey"
+    | "archived"
   >,
   rich: boolean,
 ): string {
@@ -160,6 +165,7 @@ export function formatSessionFlagsCell(
     row.elevatedLevel ? `elev:${row.elevatedLevel}` : null,
     row.responseUsage ? `usage:${row.responseUsage}` : null,
     row.groupActivation ? `activation:${row.groupActivation}` : null,
+    row.archived ? "archived" : null,
     row.systemSent ? "system" : null,
     row.abortedLastRun ? "aborted" : null,
     row.runtimePolicySessionKey ? `policy:${row.runtimePolicySessionKey}` : null,

--- a/src/commands/sessions.model-resolution.test.ts
+++ b/src/commands/sessions.model-resolution.test.ts
@@ -21,6 +21,8 @@ import { sessionsCommand } from "./sessions.js";
 type SessionsJsonPayload = {
   sessions?: Array<{
     key: string;
+    archived?: boolean;
+    archivedAt?: number;
     modelProvider?: string | null;
     model?: string | null;
     agentRuntime?: { id: string; source: string };
@@ -200,6 +202,77 @@ describe("sessionsCommand model resolution", () => {
           id: "codex",
           source: "session",
         });
+      },
+    );
+  });
+
+  it("reports archive state and current policy for an unlocked historical harness", async () => {
+    setMockSessionsConfig(() => ({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+          },
+          contextTokens: 200_000,
+        },
+      },
+    }));
+    const archivedAt = Date.now() - 30_000;
+    await withSqliteStore(
+      "sessions-archived-historical-runtime",
+      {
+        "agent:main:main": {
+          sessionId: "archived-historical-session",
+          updatedAt: Date.now() - 60_000,
+          archivedAt,
+          modelProvider: "openai",
+          model: "gpt-5.5",
+          agentHarnessId: "openclaw",
+        },
+      },
+      async (store) => {
+        const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+        const session = payload.sessions?.find((row) => row.key === "agent:main:main");
+
+        expect(session).toMatchObject({
+          archived: true,
+          archivedAt,
+          agentRuntime: { id: "codex", source: "model" },
+        });
+      },
+    );
+  });
+
+  it("reports an unlocked compatible runtime override as session-key policy", async () => {
+    setMockSessionsConfig(() => ({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+          },
+          contextTokens: 200_000,
+        },
+      },
+    }));
+    await withSqliteStore(
+      "sessions-runtime-override",
+      {
+        "agent:main:main": {
+          sessionId: "runtime-override-session",
+          updatedAt: Date.now() - 60_000,
+          modelProvider: "openai",
+          model: "gpt-5.5",
+          agentHarnessId: "codex",
+          agentRuntimeOverride: "openclaw",
+        },
+      },
+      async (store) => {
+        const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+        const session = payload.sessions?.find((row) => row.key === "agent:main:main");
+
+        expect(session?.agentRuntime).toEqual({ id: "openclaw", source: "session-key" });
       },
     );
   });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -11,7 +11,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
-import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import { resolveEffectiveSessionAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import {
   prepareCliProviderClassifier,
@@ -57,7 +57,7 @@ import {
 type SessionRow = SessionDisplayRow & {
   agentId: string;
   kind: SessionKind;
-  agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
+  agentRuntime: ReturnType<typeof resolveEffectiveSessionAgentRuntimeMetadata>;
   runtimeLabel: string;
   /** Carry the prepared identity into JSON/table emission without re-resolving plugin metadata. */
   displayModelRef: { provider: string; model: string };
@@ -199,7 +199,7 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
 function resolveSessionRuntimeLabel(params: {
   cfg: OpenClawConfig;
   entry: SessionEntry;
-  agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
+  agentRuntime: ReturnType<typeof resolveEffectiveSessionAgentRuntimeMetadata>;
   modelProvider: string;
   classifyCliProvider: CliProviderClassifier;
 }): string {
@@ -390,7 +390,7 @@ export async function sessionsCommand(
       acpSessionKey,
       acpRuntime,
     );
-    const agentRuntime = resolveModelAgentRuntimeMetadata({
+    const agentRuntime = resolveEffectiveSessionAgentRuntimeMetadata({
       cfg,
       agentId,
       sessionEntry: entry,

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -4,7 +4,10 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
-import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import {
+  resolveEffectiveSessionAgentRuntimeMetadata,
+  resolveModelAgentRuntimeMetadata,
+} from "../agents/agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
@@ -25,7 +28,6 @@ import {
 import { resolveThinkingDefaultCore } from "../agents/model-thinking-default-core.js";
 import { publishedModelCatalogOwnerMatchesAgent } from "../agents/prepared-model-catalog-owner.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
-import { resolveSessionRuntimeOverrideForProvider } from "../agents/session-runtime-compat.js";
 import {
   concretizeAgentRuntime,
   resolveEffectiveAgentRuntime,
@@ -234,29 +236,16 @@ export function resolveGatewaySessionThinkingProjectionInternal(
     (params.entry && cachedAcpMeta?.has(params.entry)
       ? cachedAcpMeta.get(params.entry)
       : readAcpSessionMeta({ sessionKey: params.sessionKey, agentId: params.agentId }));
-  const configuredAgentRuntime = resolveModelAgentRuntimeMetadata({
+  const agentRuntime = resolveEffectiveSessionAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,
     provider: params.provider,
     model: params.model,
     sessionKey: params.sessionKey,
+    sessionEntry: params.entry,
     acpRuntime: acpMeta != null,
     acpBackend: acpMeta?.backend,
   });
-  const persistedAgentRuntime = resolveSessionRuntimeOverrideForProvider({
-    provider: params.provider,
-    entry: params.entry,
-    cfg: params.cfg,
-  });
-  const persistedAgentRuntimeSource: "session" | "session-key" =
-    params.entry?.modelSelectionLocked === true ? "session" : "session-key";
-  const agentRuntime =
-    acpMeta || !persistedAgentRuntime
-      ? configuredAgentRuntime
-      : {
-          id: persistedAgentRuntime,
-          source: persistedAgentRuntimeSource,
-        };
   const catalogEntry = params.modelCatalog
     ? findModelCatalogEntry(params.modelCatalog, {
         provider: params.provider,


### PR DESCRIPTION
Closes #124524

AI-assisted: yes. I traced the stock CLI and Gateway session projections against a real signed deployment, wrote failing parity regressions, and validated the shared owner change.

## What Problem This Solves

`openclaw sessions list` could disagree with the authoritative Gateway in two operator-visible ways:

- archived sessions had no archive marker in JSON or the default table;
- an unlocked historical `agentHarnessId` was shown as the current runtime, even though the next turn follows current policy unless a compatible explicit override or locked transcript owns it.

This made successful lifecycle cleanup look ineffective and made historical execution provenance look like active routing drift.

## Why This Change Was Made

The change extracts the Gateway existing effective-session runtime rule into one shared resolver and uses it from both the Gateway and CLI. The CLI also projects `archived`/`archivedAt` from the existing timestamp and adds an `archived` table flag.

No new persistence, schema, migration, background reconciliation, configuration, or compatibility path is introduced. The Gateway loses its duplicate inline runtime-resolution block.

## Evidence

Regression-first proof:

```text
Before fix: 2 failures
- archived fields absent; unlocked historical OpenClaw harness reported as session runtime
- compatible explicit override reported with source session instead of session-key

After fix:
Test Files: 2 passed
Tests: 9 passed
```

Broader relevant Gateway validation:

```text
Test Files: 3 passed
Tests: 483 passed
```

Repository validation:

```text
preflight guards: passed
package patch guard: passed (no new patches)
database-first legacy-store guard: passed
typecheck prod: passed
typecheck scripts: passed
typecheck test root: passed
targeted oxlint on all six changed files: passed
format check on all changed files: passed
git diff --check: passed
```

The repository-wide oxlint core and extensions shards did not complete on the local host: both were terminated by the stock lint runner after abnormal multi-thousand-second elapsed-time jumps. No lint diagnostic was emitted before timeout. This is reported as an infrastructure timeout, not a pass; upstream CI remains the full-matrix authority.

## User Impact

Operators can verify archive cleanup and see the runtime that will actually handle the next turn. Historical harness provenance no longer masquerades as an unlocked runtime pin, while compatible explicit overrides and locked ownership keep their existing semantics.