### PR TITLE
fix(signal): preserve exhausted ingress conflict causes

### DIFF
--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -335,11 +338,11 @@ describe("signal reply session init conflict retry", () => {
     }
   });
 
-  it("preserves durable abandon accounting through backoff, threshold, and restart", async () => {
+  it("dead-letters an aged exhausted conflict with its cause and unblocks its lane", async () => {
     vi.useFakeTimers();
-    const now = Date.UTC(2026, 0, 2);
-    vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-abandon-"));
+    let clock = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(clock);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-failure-"));
     const stateDir = await fs.realpath(created);
     type Queue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
@@ -347,6 +350,7 @@ describe("signal reply session init conflict retry", () => {
       channelId: "signal",
       accountId: "default",
       stateDir,
+      now: () => clock,
     });
     const timestamp = 1_700_000_000_777;
     const event = createSignalReceiveEvent({
@@ -354,7 +358,13 @@ describe("signal reply session init conflict retry", () => {
       dataMessage: { timestamp, message: "retry through durable ingress", attachments: [] },
     });
     const eventId = JSON.stringify(["number:+15550001111", timestamp]);
-    dispatchInboundMessageMock.mockRejectedValue(CONFLICT_ERROR);
+    let failDispatch = true;
+    dispatchInboundMessageMock.mockImplementation(async () => {
+      if (failDispatch) {
+        throw CONFLICT_ERROR;
+      }
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    });
 
     const createIntegratedMonitor = async () => {
       const tracked = createTrackedTaskHarness();
@@ -385,7 +395,7 @@ describe("signal reply session init conflict retry", () => {
           id: eventId,
           attempts,
           lastAttemptAt: expect.any(Number),
-          lastError: "turn-abandoned",
+          lastError: CONFLICT_ERROR.message,
         }),
       ]);
       const record = pending[0];
@@ -404,14 +414,16 @@ describe("signal reply session init conflict retry", () => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
       await first.monitor.stop();
 
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
+      clock = firstAttempt.lastAttemptAt + 999;
+      vi.setSystemTime(clock);
       const blocked = await createIntegratedMonitor();
       await vi.advanceTimersByTimeAsync(10);
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
       expect(blocked.tracked.tasks).toHaveLength(0);
       await blocked.monitor.stop();
 
-      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
+      clock = firstAttempt.lastAttemptAt + 1_001;
+      vi.setSystemTime(clock);
       const second = await createIntegratedMonitor();
       await finishOuterAttempt(second.tracked);
       const secondAttempt = await pendingAttempt(2);
@@ -424,31 +436,46 @@ describe("signal reply session init conflict retry", () => {
           throw new Error(`Expected Signal seed claim ${attempt}`);
         }
         await queue.release(claim, {
-          lastError: "turn-abandoned",
+          lastError: CONFLICT_ERROR.message,
           releasedAt: secondAttempt.lastAttemptAt,
         });
       }
 
-      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
-      const threshold = await createIntegratedMonitor();
-      await finishOuterAttempt(threshold.tracked);
-      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
+      clock += DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS + 1;
+      vi.setSystemTime(clock);
+      const exhausted = await createIntegratedMonitor();
+      await finishOuterAttempt(exhausted.tracked);
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(12);
-      await threshold.monitor.stop();
+      await vi.waitFor(async () => {
+        expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+          {
+            id: eventId,
+            laneKey: "direct:number:+15550001111",
+            reason: "retry-limit-exceeded",
+            message: CONFLICT_ERROR.message,
+          },
+        ]);
+      });
 
-      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
-      const beyond = await createIntegratedMonitor();
-      await finishOuterAttempt(beyond.tracked);
-      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(16);
-      await beyond.monitor.stop();
-
-      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
-      const blockedRestart = await createIntegratedMonitor();
+      failDispatch = false;
+      const nextTimestamp = timestamp + 1;
+      await exhausted.monitor.receive(
+        createSignalReceiveEvent({
+          timestamp: nextTimestamp,
+          dataMessage: {
+            timestamp: nextTimestamp,
+            message: "continue after failed conflict",
+            attachments: [],
+          },
+        }),
+      );
       await vi.advanceTimersByTimeAsync(10);
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(16);
-      expect(blockedRestart.tracked.tasks).toHaveLength(0);
-      await blockedRestart.monitor.stop();
+      await exhausted.monitor.waitForIdle();
+      await vi.waitFor(async () => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(13);
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      });
+      await exhausted.monitor.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
       await fs.rm(stateDir, { recursive: true, force: true });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -720,7 +720,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     entries: SignalInboundEntry[],
     createFlush: SignalInboundFlushFactory,
   ): SignalInboundFlush => {
-    const { lifecycle, settle } = fanInChannelIngressLifecycles(
+    const { lifecycle, settle, abandon } = fanInChannelIngressLifecycles(
       entries.map((entry) => entry.turnAdoptionLifecycle),
     );
     return createFlush({
@@ -747,7 +747,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             async (terminalError: unknown) => {
               // Exhausted retries: release the drain claims so queue retry policy
               // owns redelivery instead of the stall watchdog dead-lettering them.
-              await lifecycle?.onAbandoned();
+              await abandon(terminalError);
               throw terminalError;
             },
           );


### PR DESCRIPTION
## What Problem This Solves

Signal retries reply-session initialization conflicts inside its debounce owner. When those retries are exhausted before turn adoption, the terminal path reports generic abandonment. The durable ingress queue then persists `turn-abandoned` instead of the actual conflict, so retry and dead-letter records lose the actionable failure cause.

## Why This Change Was Made

The Signal owner now passes the terminal conflict through the existing error-aware `abandon(error)` fan-in helper. That helper forwards `onFailed(error)` to every source lifecycle while retaining the existing compatibility fallback for lifecycles that only expose abandonment.

The existing SQLite integration regression now covers the complete owner path: backoff and restart retain the original error, an aged exhausted row dead-letters with that cause, and a later direct message in the same lane is delivered.

## User Impact

Operators diagnosing exhausted Signal inbound conflicts see the real reply-session error instead of `turn-abandoned`. Once an exhausted row is dead-lettered, later messages from the same direct sender continue normally. No configuration, schema, dependency, or public API changes are introduced.

## Evidence

- `npx -y node@24.15.0 scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts` - 1 file, 8 tests passed.
- `node_modules/.bin/oxlint extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts` - passed.
- `node_modules/.bin/oxfmt --write extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts` - clean.
- `git diff --check` - passed before commit.
- Fresh Codex autoreview through the repository helper with `--max-priority P1` - clean, no actionable findings, overall correctness 0.94.
- Direct contract proof: `src/plugin-sdk/channel-ingress-runtime.ts` maps `abandon(error)` to every durable claim's `onFailed(error)`, while `src/channels/message/ingress-drain.ts` persists that error and reserves `turn-abandoned` for actual abandonment.
- Not run: a credentialed live Signal transport. The SQLite owner-path regression exercises the real durable queue, conflict backoff, dead-letter policy, and lane recovery, but is not presented as provider-level live proof.
