### PR TITLE
fix(heartbeat): emit the documented quiet-hours skip event

### DIFF
--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -184,6 +184,14 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     wakeSource !== "cron" &&
     !isWithinActiveHours(cfg, heartbeat, startedAt)
   ) {
+    // Documented observable skip (`system heartbeat last` / troubleshooting
+    // docs promise reason=quiet-hours); every sibling skip past this point
+    // emits, so a silent return here hides the window from operators.
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: "quiet-hours",
+      durationMs: Date.now() - startedAt,
+    });
     return { kind: "skipped", reason: "quiet-hours" } as const;
   }
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../test-utils/channel-plugins.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
+import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
 import {
   type HeartbeatDeps,
   isHeartbeatEnabledForAgent,
@@ -337,6 +338,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetSystemEventsForTest();
+  resetHeartbeatEventsForTest();
   if (testRegistry) {
     setActivePluginRegistry(testRegistry);
   }
@@ -862,6 +864,8 @@ describe("runHeartbeatOnce", () => {
     if (res.status === "skipped") {
       expect(res.reason).toBe("quiet-hours");
     }
+    // Documented observable skip: `system heartbeat last` must show the window.
+    expect(getLastHeartbeatEvent()).toMatchObject({ status: "skipped", reason: "quiet-hours" });
   });
 
   it("skips a routeless interval poll before the agent run", async () => {


### PR DESCRIPTION
## What Problem This Solves

The active-hours guard in `prepareHeartbeatRunStage` returned `skipped/quiet-hours` without emitting a heartbeat event — while every sibling skip in the same stage (`cron-in-progress`, `requests-in-flight`, preflight reasons, `no-route`, `alerts-disabled`) emits one. `openclaw system heartbeat last` reads `getLastHeartbeatEvent()`, and docs/gateway/troubleshooting.md explicitly tells operators to look for `heartbeat skipped` with `reason=quiet-hours` — a record the runner never produced. An operator debugging "why didn't my heartbeat fire overnight" got a stale last-event instead of the answer the docs promise.

## Why This Change Was Made

Sibling-symmetry + docs contract: the skip is documented as observable, so it must be recorded where its siblings record theirs. Emit the same `{status: "skipped", reason: "quiet-hours", durationMs}` event before returning.

## User Impact

`openclaw system heartbeat last` and heartbeat event listeners now show the quiet-hours skip exactly as the troubleshooting docs describe.

## Evidence

- Extended existing regression `skips outside active hours` asserts `getLastHeartbeatEvent()` records the skip — fails pre-fix (stash proof).
- `node scripts/run-vitest.mjs run src/infra/heartbeat-runner.returns-default-unset.test.ts` — 54/54.
- tsgo core clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +8 (event emission + invariant comment); tests +4.
