### PR TITLE
fix(gateway): render Claude CLI history turns once

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2786,7 +2786,7 @@ src/gateway/chat-sanitize.ts	3
 src/gateway/chat-tool-titles.ts	2
 src/gateway/cli-session-history.claude-activity.ts	1
 src/gateway/cli-session-history.claude.ts	15
-src/gateway/cli-session-history.merge.ts	6
+src/gateway/cli-session-history.merge.ts	1
 src/gateway/config-reload-plan.ts	5
 src/gateway/control-ui-plugin-auth-cookie.ts	1
 src/gateway/control-ui-session-pr-subscriptions.ts	2

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -544,6 +544,17 @@ export async function runPreparedCliAgent(
           usage: output.usage,
           stopReason: resolveCliAssistantStopReason(output),
           yielded: output.yielded,
+          // This is the one point that sees both the flattened aggregate and the
+          // native records it came from, so it is where the relation is recorded.
+          // A backend that reported no terminal record leaves it unset.
+          ...(effectiveCliSessionId && output.resumeCheckpointId
+            ? {
+                nativeTurn: {
+                  cliSessionId: effectiveCliSessionId,
+                  terminalRecordId: output.resumeCheckpointId,
+                },
+              }
+            : {}),
         });
         await finalizeCliContextEngineTurn({
           context,

--- a/src/agents/cli-runner/cli-run-transcript.test.ts
+++ b/src/agents/cli-runner/cli-run-transcript.test.ts
@@ -98,3 +98,62 @@ it.each([
     }
   },
 );
+
+type NativeTurnCase = {
+  nativeTurn?: { cliSessionId: string; terminalRecordId: string };
+  expected?: { cliSessionId: string; terminalRecordId: string };
+};
+
+it.each<[string, NativeTurnCase]>([
+  [
+    "records the native turn a CLI aggregate flattens",
+    {
+      nativeTurn: { cliSessionId: "native-session-1", terminalRecordId: "native-record-9" },
+      expected: { cliSessionId: "native-session-1", terminalRecordId: "native-record-9" },
+    },
+  ],
+  ["omits the link when the run reported no native turn", {}],
+])("%s", async (_label, testCase) => {
+  // The aggregate is the only record written at the point where both the
+  // flattened text and the native records that produced it are known, so the
+  // link has to be stamped here or readers are left inferring it.
+  const root = tempDirs.make("openclaw-cli-native-turn-");
+  const target = {
+    agentId: "main",
+    sessionId: "cli-native-turn-session",
+    sessionKey: "agent:main:cli-native-turn",
+    storePath: path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite"),
+  };
+  await upsertSessionEntry({
+    ...target,
+    entry: { sessionId: target.sessionId, updatedAt: Date.now() },
+  });
+  const updates: InternalSessionTranscriptUpdate[] = [];
+  const unsubscribe = onInternalSessionTranscriptUpdate((update) => updates.push(update));
+  try {
+    const result = await persistCliAssistantTranscript({
+      runParams: {
+        ...target,
+        sessionFile: `sqlite://agents/main/${target.sessionId}`,
+        workspaceDir: root,
+        prompt: "run it",
+        provider: "claude-cli",
+        runId: "cli-native-turn-run",
+        timeoutMs: 1_000,
+        persistAssistantTranscript: true,
+      },
+      text: "part one\n\npart two",
+      modelId: "claude-sonnet-4-6",
+      stopReason: "stop",
+      ...(testCase.nativeTurn ? { nativeTurn: testCase.nativeTurn } : {}),
+    });
+
+    expect(result.owned).toBe(true);
+    expect(updates).toHaveLength(1);
+    const persisted = updates[0]?.message as Record<string, unknown> | undefined;
+    expect(persisted?.idempotencyKey).toBe(result.idempotencyKey);
+    expect(persisted?.cliNativeTurn).toEqual(testCase.expected);
+  } finally {
+    unsubscribe();
+  }
+});

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -1,7 +1,10 @@
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { resolvePersistedSessionStoreOwnerForTarget } from "../../config/sessions/session-store-owner.js";
-import { appendExactAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
+import {
+  appendExactAssistantMessageToSessionTranscript,
+  type CliNativeTurnRef,
+} from "../../config/sessions/transcript.js";
 import { buildGenericCliContextEngineHostSupport } from "../../context-engine/host-compat.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { StopReason } from "../../llm/types.js";
@@ -138,6 +141,11 @@ export async function persistCliAssistantTranscript(params: {
   };
   stopReason: StopReason;
   yielded?: true;
+  // The native turn this aggregate flattens, when the backend reported one.
+  // Absent for backends that write no native transcript, and for runs whose
+  // terminal native record could not be identified; readers then keep the
+  // aggregate rather than guess which imported turn it duplicates.
+  nativeTurn?: CliNativeTurnRef;
 }): Promise<{
   owned: boolean;
   idempotencyKey?: string;
@@ -209,6 +217,7 @@ export async function persistCliAssistantTranscript(params: {
               },
             }
           : {}),
+        ...(params.nativeTurn ? { cliNativeTurn: params.nativeTurn } : {}),
       },
     });
     if (!result.ok) {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -109,9 +109,25 @@ type InternalSessionTranscriptDeliveryMirror =
       kind: typeof CRON_DIRECT_DELIVERY_CONTEXT_KIND;
     };
 
+/**
+ * Producer-owned link from a persisted CLI turn aggregate to the native CLI
+ * record it flattens. A CLI backend persists one synthetic assistant message
+ * per run whose text is that run's assistant text blocks joined; the same turn
+ * also exists as native records in the backend's own transcript. Only the
+ * producer sees both at once, so it records the relation here instead of
+ * leaving readers to infer it from text and timing.
+ */
+export type CliNativeTurnRef = {
+  /** Native CLI session that owns the turn. */
+  cliSessionId: string;
+  /** Native record id of the turn's terminal assistant message. */
+  terminalRecordId: string;
+};
+
 export type SessionTranscriptAssistantMessage = Parameters<SessionManager["appendMessage"]>[0] & {
   role: "assistant";
   [ASSISTANT_DISPLAY_CONTENT_FIELD]?: Array<Record<string, unknown>>;
+  cliNativeTurn?: CliNativeTurnRef;
 };
 
 type AssistantTranscriptText = {

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -26,6 +26,21 @@ type ComparableHistoryMessage = {
   role?: string;
   text?: string;
   timestamp?: number;
+  // CLI turn facts, derived from the same single read of each raw field, so
+  // turn-level suppression adds no second pass over the messages.
+  isCliAggregate?: boolean;
+  hasNonTextContent?: boolean;
+  isToolResultOnly?: boolean;
+  provider?: string;
+  importedFrom?: string;
+  // Set when this imported block belongs to a turn that replaced a persisted
+  // aggregate: it is then the only copy of that text, so weak text dedupe must
+  // not discard it against an unrelated local message repeating it.
+  claimedAggregate?: boolean;
+  // Local-turn facts the image correlation needs, read from the same
+  // `__openclaw` record as the provenance fields above.
+  entryId?: string;
+  hasImageMediaFacts?: boolean;
 };
 
 type TimestampSummary = {
@@ -34,6 +49,47 @@ type TimestampSummary = {
 };
 
 type RoleTextIndex = Map<string, Map<string, TimestampSummary>>;
+
+function normalizeContentBlockType(block: unknown): string | undefined {
+  const record = asOptionalRecord(block);
+  if (!record) {
+    return undefined;
+  }
+  const normalized = readStringValue(record.type)?.toLowerCase();
+  return normalized ? normalized.replace(/_/g, "") : undefined;
+}
+
+// One walk over the content blocks yields every fact the merge needs from them:
+// the display text, whether the row carries non-text blocks, and whether it is
+// the tool-result-only shape that continues an assistant turn.
+function summarizeContent(rawContent: unknown): {
+  hasNonText: boolean;
+  textParts: string[];
+  toolResultOnly: boolean;
+} {
+  const directText = readStringValue(rawContent);
+  if (directText !== undefined) {
+    return { hasNonText: false, textParts: [directText], toolResultOnly: false };
+  }
+  if (!Array.isArray(rawContent)) {
+    return { hasNonText: false, textParts: [], toolResultOnly: false };
+  }
+  const textParts: string[] = [];
+  let hasNonText = false;
+  let toolResultOnly = rawContent.length > 0;
+  for (const block of rawContent) {
+    const type = normalizeContentBlockType(block);
+    hasNonText ||= type !== undefined && type !== "text";
+    toolResultOnly &&= type === "toolresult";
+    if (block && typeof block === "object" && "text" in block) {
+      const blockText = readStringValue(block.text);
+      if (blockText !== undefined) {
+        textParts.push(blockText);
+      }
+    }
+  }
+  return { hasNonText, textParts, toolResultOnly };
+}
 
 // Claude records CLI-injected @cache-path suffixes as user text. Keep the
 // stored content intact; this normalized view is only for proving a redundant
@@ -56,44 +112,32 @@ function stripTrailingCliImageMentions(text: string): {
     : { text: lines.slice(0, end).join("\n").trimEnd(), stripped: true };
 }
 
-function isClaudeCliImportedUserMessage(message: unknown, role: string | undefined): boolean {
-  if (role !== "user") {
-    return false;
-  }
-  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
-  return normalizeOptionalString(meta?.importedFrom) === "claude-cli";
+function isClaudeCliImportedUserMessage(
+  role: string | undefined,
+  importedFrom: string | undefined,
+): boolean {
+  return role === "user" && importedFrom === "claude-cli";
 }
 
-function extractComparableText(
-  message: unknown,
-  role: string | undefined,
-): {
+// Every raw field arrives already read by `prepareComparableMessage`, so the
+// comparable view — text plus the image-mention facts the merge correlates on —
+// costs no second property read.
+function extractComparableText(params: {
+  rawText: unknown;
+  contentTextParts: string[];
+  role: string | undefined;
+  meta: Record<string, unknown> | undefined;
+  importedFrom: string | undefined;
+}): {
   hasCliImageMentions: boolean;
   cliImageTurnKey?: string;
   text?: string;
 } {
-  if (!message || typeof message !== "object") {
-    return { hasCliImageMentions: false };
-  }
-  const record = message as { role?: unknown; text?: unknown; content?: unknown };
-  const parts: string[] = [];
-  const text = readStringValue(record.text);
+  const { rawText, contentTextParts, role, meta, importedFrom } = params;
+  const parts = [...contentTextParts];
+  const text = readStringValue(rawText);
   if (text !== undefined) {
-    parts.push(text);
-  }
-  const rawContent = record.content;
-  const content = readStringValue(rawContent);
-  if (content !== undefined) {
-    parts.push(content);
-  } else if (Array.isArray(rawContent)) {
-    for (const block of rawContent) {
-      if (block && typeof block === "object" && "text" in block) {
-        const blockText = readStringValue(block.text);
-        if (blockText !== undefined) {
-          parts.push(blockText);
-        }
-      }
-    }
+    parts.unshift(text);
   }
   if (parts.length === 0) {
     return { hasCliImageMentions: false };
@@ -102,18 +146,18 @@ function extractComparableText(
   if (!joined) {
     return { hasCliImageMentions: false };
   }
-  const stripResult = isClaudeCliImportedUserMessage(message, role)
+  const importedUserMessage = isClaudeCliImportedUserMessage(role, importedFrom);
+  const stripResult = importedUserMessage
     ? stripTrailingCliImageMentions(joined)
     : { text: joined, stripped: false };
   const visible = stripInlineDirectiveTagsForDisplay(
     role === "user" ? stripInboundMetadata(stripResult.text) : stripResult.text,
   ).text;
   const normalized = visible.replace(/\s+/g, " ").trim();
-  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
   const storedImageTurnKey = normalizeOptionalString(meta?.cliImageTurnKey);
   return {
     hasCliImageMentions: stripResult.stripped,
-    ...(stripResult.stripped && isClaudeCliImportedUserMessage(message, role)
+    ...(stripResult.stripped && importedUserMessage
       ? { cliImageTurnKey: storedImageTurnKey ?? readCliImageTurnContext(joined) }
       : {}),
     ...(normalized ? { text: normalized } : {}),
@@ -128,9 +172,28 @@ function prepareComparableMessage(
   if (!message || typeof message !== "object") {
     return { message, order, hasCliImageMentions: false };
   }
-  const record = message as { role?: unknown; timestamp?: unknown };
+  // Each raw field is read exactly once here; every derived fact below reuses
+  // these locals so the merge keeps its one-read-per-field invariant.
+  const record = message as {
+    role?: unknown;
+    text?: unknown;
+    content?: unknown;
+    timestamp?: unknown;
+    api?: unknown;
+    idempotencyKey?: unknown;
+    provider?: unknown;
+  };
   const role = readStringValue(record.role);
-  const comparableText = extractComparableText(message, role);
+  const content = summarizeContent(record.content);
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  const importedFrom = normalizeOptionalString(meta?.importedFrom);
+  const comparableText = extractComparableText({
+    rawText: record.text,
+    contentTextParts: content.textParts,
+    role,
+    meta,
+    importedFrom,
+  });
   return {
     message,
     order,
@@ -140,25 +203,26 @@ function prepareComparableMessage(
     role,
     text: comparableText.text,
     timestamp: asFiniteNumber(record.timestamp),
+    isCliAggregate: isPersistedCliAggregate(record.api, record.idempotencyKey),
+    hasNonTextContent: content.hasNonText,
+    isToolResultOnly: role === "user" && content.toolResultOnly,
+    provider: normalizeOptionalString(record.provider),
+    importedFrom,
+    entryId: normalizeOptionalString(meta?.id),
+    hasImageMediaFacts: hasPersistedImageMediaFacts(role, meta),
   };
 }
 
 // External identity survives text edits, so it is the strongest match signal
 // for imported messages from Claude CLI or similar external histories.
 function resolveImportedExternalIdentityKey(message: unknown): string | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  const rawMeta = (message as { __openclaw?: unknown })["__openclaw"];
-  if (!rawMeta || typeof rawMeta !== "object") {
-    return undefined;
-  }
-  const externalId = normalizeOptionalString((rawMeta as { externalId?: unknown }).externalId);
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  const externalId = normalizeOptionalString(meta?.externalId);
   return externalId
     ? JSON.stringify([
         externalId,
-        normalizeOptionalString((rawMeta as { importedFrom?: unknown }).importedFrom),
-        normalizeOptionalString((rawMeta as { cliSessionId?: unknown }).cliSessionId),
+        normalizeOptionalString(meta?.importedFrom),
+        normalizeOptionalString(meta?.cliSessionId),
       ])
     : undefined;
 }
@@ -231,12 +295,198 @@ function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMess
   return summaryMatchesTimestamp(index.get(entry.role)?.get(entry.text), entry.timestamp);
 }
 
-function hasLocalImageMediaFacts(entry: ComparableHistoryMessage): boolean {
-  if (entry.role !== "user") {
+// Reads the durable media facts out of the metadata `prepareComparableMessage`
+// already holds, so proving a local image turn costs no second `__openclaw` read.
+function hasPersistedImageMediaFacts(
+  role: string | undefined,
+  meta: Record<string, unknown> | undefined,
+): boolean {
+  if (role !== "user" || !meta) {
     return false;
   }
-  const message = asOptionalRecord(entry.message);
-  return message ? (readPersistedMediaFacts(message) ?? []).some(isImageMediaFact) : false;
+  return (readPersistedMediaFacts({ __openclaw: meta }) ?? []).some(isImageMediaFact);
+}
+
+// CLI backends persist each assistant turn as one synthetic aggregate
+// (`api: "cli"`) whose text is the turn's text blocks joined with blank lines.
+const CLI_AGGREGATE_API = "cli";
+// `api: "cli"` alone is not unique to the synthetic aggregate — ordinary CLI
+// assistant replies share that shape. The aggregate producer stamps
+// `idempotencyKey: "cli-assistant:<runId>"`, which the transcript append copies
+// onto the stored message, so that key is the authoritative discriminator.
+const CLI_AGGREGATE_IDEMPOTENCY_PREFIX = "cli-assistant:";
+
+function isPersistedCliAggregate(rawApi: unknown, rawIdempotencyKey: unknown): boolean {
+  if (readStringValue(rawApi) !== CLI_AGGREGATE_API) {
+    return false;
+  }
+  const idempotencyKey = normalizeOptionalString(rawIdempotencyKey);
+  return (
+    idempotencyKey !== undefined && idempotencyKey.startsWith(CLI_AGGREGATE_IDEMPOTENCY_PREFIX)
+  );
+}
+
+type PartialAssistantTurn = {
+  fragments: string[];
+  entries: ComparableHistoryMessage[];
+  hasNonTextContent: boolean;
+  importedFrom?: string;
+  terminalTimestamp?: number;
+};
+
+type AggregateCandidate = {
+  entry: ComparableHistoryMessage;
+  timestamp: number;
+};
+
+type TurnGroup = {
+  aggregateCandidates: AggregateCandidate[];
+  turns: { terminalTimestamp: number; entries: ComparableHistoryMessage[] }[];
+};
+
+// Keyed by the text a covering aggregate carries and then by producer, so each
+// aggregate reaches its candidates with two lookups instead of a scan that
+// grows with the imported history.
+type ImportedTurnIndex = Map<string, Map<string, TurnGroup>>;
+
+function resolveTurnGroup(index: ImportedTurnIndex, text: string, provider: string): TurnGroup {
+  let byProvider = index.get(text);
+  if (!byProvider) {
+    byProvider = new Map();
+    index.set(text, byProvider);
+  }
+  let group = byProvider.get(provider);
+  if (!group) {
+    group = { aggregateCandidates: [], turns: [] };
+    byProvider.set(provider, group);
+  }
+  return group;
+}
+
+/**
+ * Indexes the imported assistant turns by the aggregate text that would cover
+ * them. Reads no raw fields: every fact comes from the prepared entries.
+ */
+function indexImportedAssistantTurns(
+  importedEntries: ComparableHistoryMessage[],
+): ImportedTurnIndex {
+  const index: ImportedTurnIndex = new Map();
+  let current: PartialAssistantTurn | undefined;
+  const closeTurn = (): void => {
+    const turn = current;
+    current = undefined;
+    if (!turn || turn.fragments.length === 0) {
+      return;
+    }
+    // Turns that can never cover an aggregate stay out of the index instead of
+    // being re-rejected once per aggregate: no timestamp to place them in the
+    // dedupe window, no provider to match, or — for a lone text-only fragment —
+    // an exact-equality case the per-message dedupe already resolves by
+    // keeping the local copy.
+    if (turn.terminalTimestamp === undefined || turn.importedFrom === undefined) {
+      return;
+    }
+    if (turn.fragments.length < 2 && !turn.hasNonTextContent) {
+      return;
+    }
+    resolveTurnGroup(index, turn.fragments.join(" "), turn.importedFrom).turns.push({
+      terminalTimestamp: turn.terminalTimestamp,
+      entries: turn.entries,
+    });
+  };
+  for (const entry of importedEntries) {
+    if (entry.role === "assistant") {
+      current ??= { fragments: [], entries: [], hasNonTextContent: false };
+      current.entries.push(entry);
+      if (entry.text !== undefined) {
+        current.fragments.push(entry.text);
+      }
+      current.hasNonTextContent ||= entry.hasNonTextContent === true;
+      current.importedFrom ??= entry.importedFrom;
+      if (
+        entry.timestamp !== undefined &&
+        (current.terminalTimestamp === undefined || entry.timestamp > current.terminalTimestamp)
+      ) {
+        current.terminalTimestamp = entry.timestamp;
+      }
+      continue;
+    }
+    // A tool result the importer could not pair stays a user-role record, but
+    // it continues the surrounding assistant turn rather than starting a new one.
+    if (current && entry.isToolResultOnly) {
+      current.hasNonTextContent = true;
+      continue;
+    }
+    closeTurn();
+  }
+  closeTurn();
+  return index;
+}
+
+/**
+ * Pairs each persisted aggregate with the imported turn it duplicates. The
+ * aggregate is written once the CLI turn completes, so within one text and
+ * producer the two sides are matched in timestamp order: the earliest turn that
+ * completed no more than the dedupe window before an aggregate owns it. Pairing
+ * is one-to-one, so two genuinely repeated replies with identical text are only
+ * both suppressed when the import actually holds both turns.
+ */
+function findCoveredAggregates(
+  localEntries: ComparableHistoryMessage[],
+  importedEntries: ComparableHistoryMessage[],
+): Set<ComparableHistoryMessage> {
+  const groups = indexImportedAssistantTurns(importedEntries);
+  for (const entry of localEntries) {
+    if (
+      entry.role !== "assistant" ||
+      entry.isCliAggregate !== true ||
+      // A local row that already carries an external identity came from a
+      // previous import, so it is not a locally persisted aggregate.
+      entry.externalIdentityKey !== undefined ||
+      entry.provider === undefined ||
+      entry.text === undefined ||
+      entry.timestamp === undefined
+    ) {
+      continue;
+    }
+    groups
+      .get(entry.text)
+      ?.get(entry.provider)
+      ?.aggregateCandidates.push({ entry, timestamp: entry.timestamp });
+  }
+
+  const covered = new Set<ComparableHistoryMessage>();
+  for (const byProvider of groups.values()) {
+    for (const group of byProvider.values()) {
+      if (group.aggregateCandidates.length === 0) {
+        continue;
+      }
+      group.turns.sort((left, right) => left.terminalTimestamp - right.terminalTimestamp);
+      group.aggregateCandidates.sort((left, right) => left.timestamp - right.timestamp);
+      let turnIndex = 0;
+      let aggregateIndex = 0;
+      while (turnIndex < group.turns.length && aggregateIndex < group.aggregateCandidates.length) {
+        const turn = group.turns[turnIndex]!;
+        const aggregate = group.aggregateCandidates[aggregateIndex]!;
+        const elapsed = aggregate.timestamp - turn.terminalTimestamp;
+        if (elapsed < 0) {
+          aggregateIndex += 1;
+          continue;
+        }
+        if (elapsed > DEDUPE_TIMESTAMP_WINDOW_MS) {
+          turnIndex += 1;
+          continue;
+        }
+        covered.add(aggregate.entry);
+        for (const entry of turn.entries) {
+          entry.claimedAggregate = true;
+        }
+        turnIndex += 1;
+        aggregateIndex += 1;
+      }
+    }
+  }
+  return covered;
 }
 
 function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistoryMessage): number {
@@ -246,7 +496,11 @@ function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistor
   return a.order - b.order;
 }
 
-/** Merges imported CLI transcript messages into local history without duplicating overlaps. */
+/**
+ * Merges imported CLI transcript messages into local history without duplicating overlaps.
+ * Returns `params.localMessages` (same reference) when the merge changes nothing, so
+ * callers can detect imports and replacements by identity rather than by length.
+ */
 export function mergeImportedChatHistoryMessages(params: {
   localMessages: unknown[];
   importedMessages: unknown[];
@@ -254,9 +508,33 @@ export function mergeImportedChatHistoryMessages(params: {
   if (params.importedMessages.length === 0) {
     return params.localMessages;
   }
-  const merged = params.localMessages.map((message, order) =>
+  const localEntries = params.localMessages.map((message, order) =>
     prepareComparableMessage(message, order, resolveImportedExternalIdentityKey(message)),
   );
+  // The aggregate and the imported native blocks are two shapes of the same
+  // turn, so per-message equality can never pair them and the turn renders
+  // twice (openclaw/openclaw#123792). Dropping the covered aggregate keeps the
+  // native blocks, which are the copy that carries the tool calls.
+  //
+  // Grouping needs every imported row prepared up front, which only pays for
+  // itself when a local aggregate could actually be covered. A session without
+  // one keeps the lazy, skip-on-identity path below exactly as it is.
+  const importedEntries = localEntries.some((entry) => entry.isCliAggregate)
+    ? params.importedMessages.map((message, index) =>
+        prepareComparableMessage(
+          message,
+          localEntries.length + index,
+          resolveImportedExternalIdentityKey(message),
+        ),
+      )
+    : undefined;
+  const coveredAggregates = importedEntries
+    ? findCoveredAggregates(localEntries, importedEntries)
+    : undefined;
+  const merged = coveredAggregates?.size
+    ? localEntries.filter((entry) => !coveredAggregates.has(entry))
+    : localEntries;
+  const suppressedAggregate = merged.length !== localEntries.length;
   const exactExternalIdentityIndex = new Set<string>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
@@ -271,23 +549,28 @@ export function mergeImportedChatHistoryMessages(params: {
   };
   for (const entry of merged) {
     indexEntry(entry);
-    if (!hasLocalImageMediaFacts(entry)) {
+    if (!entry.hasImageMediaFacts) {
       continue;
     }
-    const localMeta = asOptionalRecord(asOptionalRecord(entry.message)?.["__openclaw"]);
-    const localEntryId = normalizeOptionalString(localMeta?.id);
-    const turnKey = localEntryId ? hashCliImageTurnEntryId(localEntryId) : entry.cliImageTurnKey;
+    const turnKey = entry.entryId ? hashCliImageTurnEntryId(entry.entryId) : entry.cliImageTurnKey;
     if (turnKey) {
       localImageMediaCounts.set(turnKey, (localImageMediaCounts.get(turnKey) ?? 0) + 1);
     }
   }
-  let nextOrder = merged.length;
-  for (const message of params.importedMessages) {
-    const externalIdentityKey = resolveImportedExternalIdentityKey(message);
+  // Local orders stay as prepared, so appending must start past the whole local
+  // range: after a suppression `merged.length` is short of it and would collide.
+  let nextOrder = localEntries.length;
+  let addedImportedMessage = false;
+  for (const [index, message] of params.importedMessages.entries()) {
+    const prepared = importedEntries?.[index];
+    const externalIdentityKey = prepared
+      ? prepared.externalIdentityKey
+      : resolveImportedExternalIdentityKey(message);
     if (externalIdentityKey && exactExternalIdentityIndex.has(externalIdentityKey)) {
       continue;
     }
-    const imported = prepareComparableMessage(message, nextOrder, externalIdentityKey);
+    const imported = prepared ?? prepareComparableMessage(message, nextOrder, externalIdentityKey);
+    imported.order = nextOrder;
     const turnKey = imported.hasCliImageMentions ? imported.cliImageTurnKey : undefined;
     const matches = turnKey ? localImageMediaCounts.get(turnKey) : undefined;
     if (turnKey && matches) {
@@ -296,15 +579,23 @@ export function mergeImportedChatHistoryMessages(params: {
       localImageMediaCounts.set(turnKey, matches - 1);
       continue;
     }
-    const duplicate = imported.externalIdentityKey
-      ? hasRoleTextCandidate(identitylessRoleTextIndex, imported)
-      : hasRoleTextCandidate(allMessageRoleTextIndex, imported);
+    // A block whose turn replaced an aggregate is the only surviving copy of
+    // that text, so weak role/text dedupe must not discard it as well.
+    const duplicate =
+      imported.claimedAggregate !== true &&
+      (imported.externalIdentityKey
+        ? hasRoleTextCandidate(identitylessRoleTextIndex, imported)
+        : hasRoleTextCandidate(allMessageRoleTextIndex, imported));
     if (!imported.hasCliImageMentions && duplicate) {
       continue;
     }
     merged.push(imported);
     indexEntry(imported);
     nextOrder += 1;
+    addedImportedMessage = true;
+  }
+  if (!addedImportedMessage && !suppressedAggregate) {
+    return params.localMessages;
   }
   merged.sort(compareHistoryMessages);
   return merged.map((entry) => entry.message);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -29,10 +29,13 @@ type ComparableHistoryMessage = {
   // CLI turn facts, derived from the same single read of each raw field, so
   // turn-level suppression adds no second pass over the messages.
   isCliAggregate?: boolean;
-  hasNonTextContent?: boolean;
   isToolResultOnly?: boolean;
-  provider?: string;
-  importedFrom?: string;
+  // The native turn a persisted aggregate flattens, as recorded by its producer.
+  cliNativeTurn?: CliNativeTurnRef;
+  // Native record identity of an imported row, kept apart from the composite
+  // dedupe key so aggregate matching can name a single record.
+  externalId?: string;
+  cliSessionId?: string;
   // Set when this imported block belongs to a turn that replaced a persisted
   // aggregate: it is then the only copy of that text, so weak text dedupe must
   // not discard it against an unrelated local message repeating it.
@@ -59,28 +62,24 @@ function normalizeContentBlockType(block: unknown): string | undefined {
   return normalized ? normalized.replace(/_/g, "") : undefined;
 }
 
-// One walk over the content blocks yields every fact the merge needs from them:
-// the display text, whether the row carries non-text blocks, and whether it is
-// the tool-result-only shape that continues an assistant turn.
+// One walk over the content blocks yields both facts the merge needs from them:
+// the display text, and whether the row is the tool-result-only shape that
+// continues an assistant turn rather than starting a new one.
 function summarizeContent(rawContent: unknown): {
-  hasNonText: boolean;
   textParts: string[];
   toolResultOnly: boolean;
 } {
   const directText = readStringValue(rawContent);
   if (directText !== undefined) {
-    return { hasNonText: false, textParts: [directText], toolResultOnly: false };
+    return { textParts: [directText], toolResultOnly: false };
   }
   if (!Array.isArray(rawContent)) {
-    return { hasNonText: false, textParts: [], toolResultOnly: false };
+    return { textParts: [], toolResultOnly: false };
   }
   const textParts: string[] = [];
-  let hasNonText = false;
   let toolResultOnly = rawContent.length > 0;
   for (const block of rawContent) {
-    const type = normalizeContentBlockType(block);
-    hasNonText ||= type !== undefined && type !== "text";
-    toolResultOnly &&= type === "toolresult";
+    toolResultOnly &&= normalizeContentBlockType(block) === "toolresult";
     if (block && typeof block === "object" && "text" in block) {
       const blockText = readStringValue(block.text);
       if (blockText !== undefined) {
@@ -88,7 +87,7 @@ function summarizeContent(rawContent: unknown): {
       }
     }
   }
-  return { hasNonText, textParts, toolResultOnly };
+  return { textParts, toolResultOnly };
 }
 
 // Claude records CLI-injected @cache-path suffixes as user text. Keep the
@@ -181,7 +180,7 @@ function prepareComparableMessage(
     timestamp?: unknown;
     api?: unknown;
     idempotencyKey?: unknown;
-    provider?: unknown;
+    cliNativeTurn?: unknown;
   };
   const role = readStringValue(record.role);
   const content = summarizeContent(record.content);
@@ -204,10 +203,10 @@ function prepareComparableMessage(
     text: comparableText.text,
     timestamp: asFiniteNumber(record.timestamp),
     isCliAggregate: isPersistedCliAggregate(record.api, record.idempotencyKey),
-    hasNonTextContent: content.hasNonText,
     isToolResultOnly: role === "user" && content.toolResultOnly,
-    provider: normalizeOptionalString(record.provider),
-    importedFrom,
+    cliNativeTurn: readCliNativeTurnRef(record.cliNativeTurn),
+    externalId: normalizeOptionalString(meta?.externalId),
+    cliSessionId: normalizeOptionalString(meta?.cliSessionId),
     entryId: normalizeOptionalString(meta?.id),
     hasImageMediaFacts: hasPersistedImageMediaFacts(role, meta),
   };
@@ -326,95 +325,75 @@ function isPersistedCliAggregate(rawApi: unknown, rawIdempotencyKey: unknown): b
   );
 }
 
+type CliNativeTurnRef = {
+  cliSessionId: string;
+  terminalRecordId: string;
+};
+
+/**
+ * Reads the producer-owned link from a persisted aggregate to the native turn
+ * it flattens. The CLI runner records it at the one point that sees both; an
+ * aggregate written before that existed, or by a backend with no native
+ * transcript, simply carries nothing and is never replaced.
+ */
+function readCliNativeTurnRef(value: unknown): CliNativeTurnRef | undefined {
+  const record = asOptionalRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  const cliSessionId = normalizeOptionalString(record.cliSessionId);
+  const terminalRecordId = normalizeOptionalString(record.terminalRecordId);
+  return cliSessionId && terminalRecordId ? { cliSessionId, terminalRecordId } : undefined;
+}
+
+type ImportedAssistantTurn = {
+  cliSessionId?: string;
+  text: string;
+  entries: ComparableHistoryMessage[];
+};
+
 type PartialAssistantTurn = {
   fragments: string[];
   entries: ComparableHistoryMessage[];
-  hasNonTextContent: boolean;
-  importedFrom?: string;
-  terminalTimestamp?: number;
 };
-
-type AggregateCandidate = {
-  entry: ComparableHistoryMessage;
-  timestamp: number;
-};
-
-type TurnGroup = {
-  aggregateCandidates: AggregateCandidate[];
-  turns: { terminalTimestamp: number; entries: ComparableHistoryMessage[] }[];
-};
-
-// Keyed by the text a covering aggregate carries and then by producer, so each
-// aggregate reaches its candidates with two lookups instead of a scan that
-// grows with the imported history.
-type ImportedTurnIndex = Map<string, Map<string, TurnGroup>>;
-
-function resolveTurnGroup(index: ImportedTurnIndex, text: string, provider: string): TurnGroup {
-  let byProvider = index.get(text);
-  if (!byProvider) {
-    byProvider = new Map();
-    index.set(text, byProvider);
-  }
-  let group = byProvider.get(provider);
-  if (!group) {
-    group = { aggregateCandidates: [], turns: [] };
-    byProvider.set(provider, group);
-  }
-  return group;
-}
 
 /**
- * Indexes the imported assistant turns by the aggregate text that would cover
- * them. Reads no raw fields: every fact comes from the prepared entries.
+ * Indexes imported assistant turns by the native record their last message came
+ * from, which is the identity the producer stamped on the matching aggregate.
+ * Reads no raw fields: every fact comes from the prepared entries.
  */
 function indexImportedAssistantTurns(
   importedEntries: ComparableHistoryMessage[],
-): ImportedTurnIndex {
-  const index: ImportedTurnIndex = new Map();
+): Map<string, ImportedAssistantTurn> {
+  const index = new Map<string, ImportedAssistantTurn>();
   let current: PartialAssistantTurn | undefined;
   const closeTurn = (): void => {
     const turn = current;
     current = undefined;
-    if (!turn || turn.fragments.length === 0) {
+    const terminal = turn?.entries.at(-1);
+    // Only a turn whose last message kept its native record id can be named by
+    // an aggregate, and a turn already indexed under that id is not a new one.
+    if (!turn || !terminal?.externalId || index.has(terminal.externalId)) {
       return;
     }
-    // Turns that can never cover an aggregate stay out of the index instead of
-    // being re-rejected once per aggregate: no timestamp to place them in the
-    // dedupe window, no provider to match, or — for a lone text-only fragment —
-    // an exact-equality case the per-message dedupe already resolves by
-    // keeping the local copy.
-    if (turn.terminalTimestamp === undefined || turn.importedFrom === undefined) {
-      return;
-    }
-    if (turn.fragments.length < 2 && !turn.hasNonTextContent) {
-      return;
-    }
-    resolveTurnGroup(index, turn.fragments.join(" "), turn.importedFrom).turns.push({
-      terminalTimestamp: turn.terminalTimestamp,
+    index.set(terminal.externalId, {
+      ...(terminal.cliSessionId ? { cliSessionId: terminal.cliSessionId } : {}),
+      text: turn.fragments.join(" "),
       entries: turn.entries,
     });
   };
   for (const entry of importedEntries) {
     if (entry.role === "assistant") {
-      current ??= { fragments: [], entries: [], hasNonTextContent: false };
+      current ??= { fragments: [], entries: [] };
       current.entries.push(entry);
       if (entry.text !== undefined) {
         current.fragments.push(entry.text);
-      }
-      current.hasNonTextContent ||= entry.hasNonTextContent === true;
-      current.importedFrom ??= entry.importedFrom;
-      if (
-        entry.timestamp !== undefined &&
-        (current.terminalTimestamp === undefined || entry.timestamp > current.terminalTimestamp)
-      ) {
-        current.terminalTimestamp = entry.timestamp;
       }
       continue;
     }
     // A tool result the importer could not pair stays a user-role record, but
     // it continues the surrounding assistant turn rather than starting a new one.
     if (current && entry.isToolResultOnly) {
-      current.hasNonTextContent = true;
       continue;
     }
     closeTurn();
@@ -424,66 +403,43 @@ function indexImportedAssistantTurns(
 }
 
 /**
- * Pairs each persisted aggregate with the imported turn it duplicates. The
- * aggregate is written once the CLI turn completes, so within one text and
- * producer the two sides are matched in timestamp order: the earliest turn that
- * completed no more than the dedupe window before an aggregate owns it. Pairing
- * is one-to-one, so two genuinely repeated replies with identical text are only
- * both suppressed when the import actually holds both turns.
+ * Resolves each persisted aggregate against the native turn its producer named.
+ * Identity is the stamped record id, never text or timing, so an aggregate is
+ * only ever replaced by the turn it was actually written from. The text
+ * comparison that follows is a completeness check on that identified pair: a
+ * trimmed or partially imported turn no longer carries the aggregate's text,
+ * and the aggregate is kept as the durable copy.
  */
 function findCoveredAggregates(
   localEntries: ComparableHistoryMessage[],
   importedEntries: ComparableHistoryMessage[],
 ): Set<ComparableHistoryMessage> {
-  const groups = indexImportedAssistantTurns(importedEntries);
+  const turns = indexImportedAssistantTurns(importedEntries);
+  const covered = new Set<ComparableHistoryMessage>();
+  const claimedTurns = new Set<string>();
   for (const entry of localEntries) {
-    if (
-      entry.role !== "assistant" ||
-      entry.isCliAggregate !== true ||
-      // A local row that already carries an external identity came from a
-      // previous import, so it is not a locally persisted aggregate.
-      entry.externalIdentityKey !== undefined ||
-      entry.provider === undefined ||
-      entry.text === undefined ||
-      entry.timestamp === undefined
-    ) {
+    if (entry.role !== "assistant" || entry.isCliAggregate !== true) {
       continue;
     }
-    groups
-      .get(entry.text)
-      ?.get(entry.provider)
-      ?.aggregateCandidates.push({ entry, timestamp: entry.timestamp });
-  }
-
-  const covered = new Set<ComparableHistoryMessage>();
-  for (const byProvider of groups.values()) {
-    for (const group of byProvider.values()) {
-      if (group.aggregateCandidates.length === 0) {
-        continue;
-      }
-      group.turns.sort((left, right) => left.terminalTimestamp - right.terminalTimestamp);
-      group.aggregateCandidates.sort((left, right) => left.timestamp - right.timestamp);
-      let turnIndex = 0;
-      let aggregateIndex = 0;
-      while (turnIndex < group.turns.length && aggregateIndex < group.aggregateCandidates.length) {
-        const turn = group.turns[turnIndex]!;
-        const aggregate = group.aggregateCandidates[aggregateIndex]!;
-        const elapsed = aggregate.timestamp - turn.terminalTimestamp;
-        if (elapsed < 0) {
-          aggregateIndex += 1;
-          continue;
-        }
-        if (elapsed > DEDUPE_TIMESTAMP_WINDOW_MS) {
-          turnIndex += 1;
-          continue;
-        }
-        covered.add(aggregate.entry);
-        for (const entry of turn.entries) {
-          entry.claimedAggregate = true;
-        }
-        turnIndex += 1;
-        aggregateIndex += 1;
-      }
+    // A local row that already carries an external identity came from a
+    // previous import, so it is not a locally persisted aggregate.
+    const ref = entry.externalIdentityKey === undefined ? entry.cliNativeTurn : undefined;
+    // Turns are consumed one-to-one: a second aggregate naming the same record
+    // is a different turn the import does not hold.
+    if (!ref || claimedTurns.has(ref.terminalRecordId)) {
+      continue;
+    }
+    const turn = turns.get(ref.terminalRecordId);
+    if (!turn || turn.cliSessionId !== ref.cliSessionId) {
+      continue;
+    }
+    if (entry.text === undefined || turn.text !== entry.text) {
+      continue;
+    }
+    claimedTurns.add(ref.terminalRecordId);
+    covered.add(entry);
+    for (const claimed of turn.entries) {
+      claimed.claimedAggregate = true;
     }
   }
   return covered;
@@ -513,13 +469,16 @@ export function mergeImportedChatHistoryMessages(params: {
   );
   // The aggregate and the imported native blocks are two shapes of the same
   // turn, so per-message equality can never pair them and the turn renders
-  // twice (openclaw/openclaw#123792). Dropping the covered aggregate keeps the
-  // native blocks, which are the copy that carries the tool calls.
+  // twice (openclaw/openclaw#123792). The producer records which native turn
+  // each aggregate flattens, so the duplicate is resolved by that recorded
+  // identity; dropping the covered aggregate keeps the native blocks, which
+  // are the copy that carries the tool calls.
   //
   // Grouping needs every imported row prepared up front, which only pays for
-  // itself when a local aggregate could actually be covered. A session without
-  // one keeps the lazy, skip-on-identity path below exactly as it is.
-  const importedEntries = localEntries.some((entry) => entry.isCliAggregate)
+  // itself when some local aggregate actually names a native turn. Every other
+  // session — including every aggregate persisted before the producer recorded
+  // that link — keeps the lazy, skip-on-identity path below exactly as it is.
+  const importedEntries = localEntries.some((entry) => entry.cliNativeTurn)
     ? params.importedMessages.map((message, index) =>
         prepareComparableMessage(
           message,

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -1968,19 +1968,55 @@ describe("harness rows inside a CLI turn", () => {
       .join("\n");
   }
 
-  async function importTurn(lines: string): Promise<unknown[]> {
+  const boundEntry = () => ({
+    sessionId: "openclaw-session",
+    updatedAt: Date.now(),
+    cliSessionBindings: { "claude-cli": { sessionId: NATIVE_SESSION_ID } },
+  });
+
+  async function withTurnFixture<T>(
+    lines: string,
+    read: (homeDir: string) => Promise<T>,
+  ): Promise<T> {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-turn-"));
     const homeDir = path.join(root, "home");
     const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(path.join(projectsDir, `${NATIVE_SESSION_ID}.jsonl`), lines, "utf-8");
     try {
-      return await withEnvAsync({ HOME: homeDir }, async () =>
-        readClaudeCliSessionMessages({ cliSessionId: NATIVE_SESSION_ID, homeDir }),
-      );
+      return await withEnvAsync({ HOME: homeDir }, async () => await read(homeDir));
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
+  }
+
+  /** Synchronous decoder: every line is parsed on the loop, whatever its size. */
+  async function importTurn(lines: string): Promise<unknown[]> {
+    return await withTurnFixture(lines, async (homeDir) =>
+      readClaudeCliSessionMessages({ cliSessionId: NATIVE_SESSION_ID, homeDir }),
+    );
+  }
+
+  /** Async snapshot: lines past 1 MiB go through the bounded worker projection. */
+  async function importTurnAsync(lines: string): Promise<unknown[]> {
+    return await withTurnFixture(lines, async (homeDir) =>
+      readChatHistoryCliSessionImportSnapshot({
+        entry: boundEntry(),
+        provider: "claude-cli",
+        localMessages: [],
+        homeDir,
+      }),
+    );
+  }
+
+  /** Drives the production resolver, not the merge helper, over one import. */
+  function resolveAgainstAggregate(importedMessages: unknown[]) {
+    return resolveChatHistoryWithCliSessionImports({
+      entry: boundEntry(),
+      provider: "claude-cli",
+      localMessages: localAggregate(),
+      preparedImportedMessages: importedMessages,
+    });
   }
 
   function localAggregate(): Record<string, unknown>[] {
@@ -2000,6 +2036,22 @@ describe("harness rows inside a CLI turn", () => {
 
   function countAggregates(messages: unknown[]): number {
     return messages.filter((message) => readRecord(message).api === "cli").length;
+  }
+
+  function assistantTexts(messages: unknown[]): string[] {
+    return messages.flatMap((message) => {
+      const record = readRecord(message);
+      if (record.role !== "assistant") {
+        return [];
+      }
+      const content = Array.isArray(record.content) ? record.content : [];
+      return content.flatMap((block) => {
+        const blockRecord = readRecord(block);
+        return blockRecord.type === "text" && typeof blockRecord.text === "string"
+          ? [blockRecord.text]
+          : [];
+      });
+    });
   }
 
   it("keeps a skill instruction row inside the turn it belongs to", async () => {
@@ -2046,6 +2098,71 @@ describe("harness rows inside a CLI turn", () => {
     // A summary really does end the turn, so no turn covers the aggregate and
     // it survives as the durable fallback.
     expect(countAggregates(merged)).toBe(1);
+  });
+
+  // The async snapshot routes any JSONL line past 1 MiB through a bounded
+  // worker projection instead of the synchronous decoder. That projection
+  // rebuilds the entry from a fixed field list, so the turn-boundary facts the
+  // grouping reads have to survive it: a harness row that is dropped on one
+  // path and kept on the other would split the turn on that path alone.
+  const OVERSIZED_TEXT = "s".repeat(1024 * 1024 + 1);
+
+  function expectOversizedMidTurnRow(lines: string): void {
+    const midTurnRow = lines.split("\n")[3] ?? "";
+    expect(midTurnRow.length).toBeGreaterThan(1024 * 1024);
+  }
+
+  it("projects an oversized skill instruction row exactly as the sync reader does", async () => {
+    const lines = turnLines({
+      uuid: "u-2",
+      timestamp: at(3000),
+      type: "user",
+      isMeta: true,
+      sourceToolUseID: "toolu_1",
+      message: { role: "user", content: [{ type: "text", text: OVERSIZED_TEXT }] },
+    });
+    expectOversizedMidTurnRow(lines);
+
+    const [asyncMessages, syncMessages] = await Promise.all([
+      importTurnAsync(lines),
+      importTurn(lines),
+    ]);
+
+    // `isMeta` survives the bounded projection and still drops the row, so the
+    // two readers agree message for message.
+    expect(asyncMessages).toEqual(syncMessages);
+
+    const resolved = resolveAgainstAggregate(asyncMessages);
+    expect(resolved.imported).toBe(true);
+    expect(countAggregates(resolved.messages)).toBe(0);
+    expect(assistantTexts(resolved.messages)).toEqual(["part one", "part two"]);
+  });
+
+  it("keeps an oversized compaction summary a turn boundary through the async projection", async () => {
+    const lines = turnLines({
+      uuid: "u-2",
+      timestamp: at(3000),
+      type: "user",
+      isCompactSummary: true,
+      message: { role: "user", content: [{ type: "text", text: OVERSIZED_TEXT }] },
+    });
+    expectOversizedMidTurnRow(lines);
+
+    const asyncMessages = await importTurnAsync(lines);
+
+    // The summary is retained as a bounded placeholder, not as its megabyte of
+    // text, and it still ends the turn.
+    const summaries = asyncMessages
+      .map(readRecord)
+      .filter(
+        (message) => typeof message.content === "string" && message.content.includes("1 MiB"),
+      );
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.role).toBe("user");
+    expect(JSON.stringify(asyncMessages)).not.toContain(OVERSIZED_TEXT);
+
+    const resolved = resolveAgainstAggregate(asyncMessages);
+    expect(countAggregates(resolved.messages)).toBe(1);
   });
 });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -9,9 +9,12 @@ import {
   formatCliImageTurnContext,
   hashCliImageTurnEntryId,
 } from "../agents/cli-image-turn-correlation.js";
+import { persistCliAssistantTranscript } from "../agents/cli-runner/cli-run-transcript.js";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
+import { upsertSessionEntry } from "../plugin-sdk/session-store-runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
@@ -20,6 +23,7 @@ import {
   resolveChatHistoryWithCliSessionImports,
 } from "./cli-session-history.js";
 import { mergeImportedChatHistoryMessages } from "./cli-session-history.merge.js";
+import { readSessionMessagesAsync } from "./session-transcript-readers.js";
 import { expectRecordFields, requireGatewayRecord } from "./test-helpers.assertions.js";
 
 type ClaudeCliFallbackSeed = NonNullable<ReturnType<typeof readClaudeCliFallbackSeed>>;
@@ -2028,6 +2032,9 @@ describe("harness rows inside a CLI turn", () => {
         model: "claude-opus-5",
         stopReason: "stop",
         idempotencyKey: "cli-assistant:run-1",
+        // The producer names the turn's terminal assistant record. Whether the
+        // harness row splits that turn decides whether `a-3` still terminates it.
+        cliNativeTurn: { cliSessionId: NATIVE_SESSION_ID, terminalRecordId: "a-3" },
         content: [{ type: "text", text: "part one\n\npart two" }],
         timestamp: TURN_START + 5000,
       },
@@ -2453,20 +2460,36 @@ describe("readClaudeCliFallbackSeed", () => {
 
 describe("persisted CLI aggregate suppression", () => {
   const TURN_START = Date.parse("2026-03-26T16:29:55.000Z");
+  const NATIVE_SESSION_ID = "session-1";
 
-  // Mirrors what `persistCliTurnTranscript` stores: the synthetic aggregate
-  // carries `idempotencyKey: "cli-assistant:<runId>"`, ordinary CLI replies do not.
+  // The producer records which native turn an aggregate flattens. A turn is
+  // named by its terminal assistant record, which for `importedMultiBlockTurn`
+  // is the final text block.
+  function nativeTurnRef(
+    terminalRecordId: string,
+    cliSessionId: string = NATIVE_SESSION_ID,
+  ): Record<string, unknown> {
+    return { cliSessionId, terminalRecordId };
+  }
+
+  // Mirrors what `persistCliAssistantTranscript` stores: the synthetic aggregate
+  // carries `idempotencyKey: "cli-assistant:<runId>"`, ordinary CLI replies do
+  // not, and `cliNativeTurn` names the native turn it flattens. Passing null for
+  // either models a record written before that field existed.
   function buildCliAggregate(params: {
     text: string;
     timestamp?: number;
     provider?: string;
     idempotencyKey?: string | null;
     runId?: string;
+    nativeTurn?: Record<string, unknown> | null;
   }): Record<string, unknown> {
     const idempotencyKey =
       params.idempotencyKey === null
         ? undefined
         : (params.idempotencyKey ?? `cli-assistant:${params.runId ?? "run-1"}`);
+    const nativeTurn =
+      params.nativeTurn === null ? undefined : (params.nativeTurn ?? nativeTurnRef("assistant-3"));
     return {
       role: "assistant",
       api: "cli",
@@ -2475,6 +2498,7 @@ describe("persisted CLI aggregate suppression", () => {
       stopReason: "stop",
       content: [{ type: "text", text: params.text }],
       ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
+      ...(nativeTurn === undefined ? {} : { cliNativeTurn: nativeTurn }),
       ...(params.timestamp === undefined ? {} : { timestamp: params.timestamp }),
     };
   }
@@ -2484,31 +2508,35 @@ describe("persisted CLI aggregate suppression", () => {
     offsetMs: number;
     externalId?: string;
     role?: "assistant" | "user";
+    cliSessionId?: string;
   }): Record<string, unknown> {
+    const cliSessionId = params.cliSessionId ?? NATIVE_SESSION_ID;
     return {
       role: params.role ?? "assistant",
       provider: "claude-cli",
       content: params.content,
       timestamp: TURN_START + params.offsetMs,
       __openclaw: {
-        id: params.externalId ?? "claude-cli:session-1:line:9",
+        id: params.externalId ?? `claude-cli:${cliSessionId}:line:9`,
         importedFrom: "claude-cli",
-        cliSessionId: "session-1",
+        cliSessionId,
         ...(params.externalId ? { externalId: params.externalId } : {}),
       },
     };
   }
 
   function importedMultiBlockTurn(
-    params: { offsetMs?: number; idPrefix?: string } = {},
+    params: { offsetMs?: number; idPrefix?: string; cliSessionId?: string } = {},
   ): Record<string, unknown>[] {
     const base = params.offsetMs ?? 0;
     const prefix = params.idPrefix ?? "";
+    const session = params.cliSessionId ?? NATIVE_SESSION_ID;
     return [
       importedTurnMessage({
         content: [{ type: "text", text: "part one" }],
         offsetMs: base,
         externalId: `${prefix}assistant-1`,
+        cliSessionId: session,
       }),
       importedTurnMessage({
         content: [
@@ -2521,17 +2549,35 @@ describe("persisted CLI aggregate suppression", () => {
         ],
         offsetMs: base + 1000,
         externalId: `${prefix}assistant-2`,
+        cliSessionId: session,
       }),
       importedTurnMessage({
         content: [{ type: "text", text: "part two" }],
         offsetMs: base + 2000,
         externalId: `${prefix}assistant-3`,
+        cliSessionId: session,
       }),
     ];
   }
 
   function isCliAggregate(message: unknown): boolean {
     return readRecord(message).api === "cli";
+  }
+
+  function assistantTexts(messages: unknown[]): string[] {
+    return messages.flatMap((message) => {
+      const record = readRecord(message);
+      if (record.role !== "assistant") {
+        return [];
+      }
+      const content = Array.isArray(record.content) ? record.content : [];
+      return content.flatMap((block) => {
+        const blockRecord = readRecord(block);
+        return blockRecord.type === "text" && typeof blockRecord.text === "string"
+          ? [blockRecord.text]
+          : [];
+      });
+    });
   }
 
   it("replaces a persisted aggregate with the imported native turn blocks", () => {
@@ -2553,86 +2599,80 @@ describe("persisted CLI aggregate suppression", () => {
 
     expect(merged).toHaveLength(4);
     expect(merged.some(isCliAggregate)).toBe(false);
-    expect(merged[0]).toBe(localMessages[0]);
-    expect(readRecord(merged[2]).content).toEqual([
-      {
-        type: "toolcall",
-        id: "toolu_1",
-        name: "Bash",
-        arguments: { command: "pwd" },
-      },
-    ]);
+    expect(assistantTexts(merged)).toEqual(["part one", "part two"]);
   });
 
   it("keeps the turn together across an unmatched tool-result user row", () => {
+    // An unpaired tool result stays a user-role record. It continues the turn,
+    // so the turn's terminal record is still its final text block.
     const localMessages = [
       buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
     ];
+    const [first, toolCall, last] = importedMultiBlockTurn();
     const importedMessages = [
+      first,
+      toolCall,
       importedTurnMessage({
-        content: [{ type: "text", text: "part one" }],
-        offsetMs: 0,
-        externalId: "assistant-1",
-      }),
-      importedTurnMessage({
-        content: [{ type: "tool_result", tool_use_id: "toolu_9", content: "done" }],
-        offsetMs: 1000,
-        externalId: "user-tool-result",
+        content: [{ type: "tool_result", tool_use_id: "toolu_orphan", content: "ok" }],
+        offsetMs: 1500,
+        externalId: "tool-result-1",
         role: "user",
       }),
-      importedTurnMessage({
-        content: [{ type: "text", text: "part two" }],
-        offsetMs: 2000,
-        externalId: "assistant-2",
-      }),
+      last,
     ];
 
-    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMessages as Record<string, unknown>[],
+    });
 
-    expect(merged).toHaveLength(3);
     expect(merged.some(isCliAggregate)).toBe(false);
+    expect(assistantTexts(merged)).toEqual(["part one", "part two"]);
   });
 
-  it("keeps a lone text turn deduplicated against its persisted aggregate", () => {
-    // The base case of openclaw/openclaw#123792: a single-block turn is not
-    // indexed as covering, so only weak text dedupe keeps it from rendering
-    // twice. No other test pins it, and it is the case a narrower fix breaks.
+  it("replaces a lone text turn with the native record it names", () => {
+    // The base case of openclaw/openclaw#123792. Text alone could never tell a
+    // one-block turn from an unrelated reply; the recorded identity can.
     const localMessages = [
-      buildCliAggregate({ text: "hello there", timestamp: TURN_START + 2000 }),
+      buildCliAggregate({
+        text: "hello there",
+        timestamp: TURN_START + 2000,
+        nativeTurn: nativeTurnRef("assistant-solo"),
+      }),
     ];
     const importedMessages = [
       importedTurnMessage({
         content: [{ type: "text", text: "hello there" }],
         offsetMs: 1000,
-        externalId: "assistant-1",
+        externalId: "assistant-solo",
       }),
     ];
 
     const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
 
     expect(merged).toHaveLength(1);
-    expect(merged[0]).toBe(localMessages[0]);
+    expect(merged.some(isCliAggregate)).toBe(false);
+    expect(assistantTexts(merged)).toEqual(["hello there"]);
   });
 
-  it("keeps a claimed turn's covering blocks when an earlier aggregate repeats one", () => {
-    // Regression for the mixed short-earlier/long-later shape: the later
-    // aggregate is claimed and dropped, so its first native block must survive
-    // weak text dedupe against the unrelated earlier aggregate that happens to
-    // carry the same text inside the five-minute window.
+  it("keeps a covered turn's blocks when an unrelated aggregate repeats one", () => {
+    // The covered turn is the only remaining copy of its text, so weak role/text
+    // dedupe must not drop its first block against an unrelated aggregate that
+    // happens to carry the same text.
     const localMessages = [
-      buildCliAggregate({ text: "part one", timestamp: TURN_START, runId: "run-0" }),
+      buildCliAggregate({
+        text: "part one",
+        timestamp: TURN_START,
+        runId: "run-0",
+        nativeTurn: null,
+      }),
       buildCliAggregate({
         text: "part one\n\npart two",
         timestamp: TURN_START + 64_000,
         runId: "run-1",
+        nativeTurn: nativeTurnRef("later-assistant-3"),
       }),
     ];
-    const claimedTurn = importedMultiBlockTurn({ offsetMs: 61_000, idPrefix: "later-" }).map(
-      (message) => {
-        delete readRecord(readRecord(message)["__openclaw"]).externalId;
-        return message;
-      },
-    );
     const importedMessages = [
       importedTurnMessage({
         content: "second prompt",
@@ -2640,74 +2680,31 @@ describe("persisted CLI aggregate suppression", () => {
         externalId: "user-2",
         role: "user",
       }),
-      ...claimedTurn,
+      ...importedMultiBlockTurn({ offsetMs: 61_000, idPrefix: "later-" }),
     ];
 
     const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
 
-    // The earlier aggregate is unrelated to the imported turn and stays put.
+    // The earlier aggregate names no native turn, so it is never touched.
     expect(merged).toContain(localMessages[0]);
-    // The claimed turn keeps every block that covered the dropped aggregate.
-    const assistantTexts = merged
-      .filter((message) => readRecord(message).role === "assistant")
-      .flatMap((message) => {
-        const content = readRecord(message).content;
-        return Array.isArray(content)
-          ? content
-              .filter((block) => readRecord(block).type === "text")
-              .flatMap((block) => {
-                const text = readRecord(block).text;
-                return typeof text === "string" ? [text] : [];
-              })
-          : [];
-      });
-    expect(assistantTexts).toContain("part two");
-    expect(assistantTexts.filter((text) => text === "part one")).toHaveLength(2);
+    expect(merged).not.toContain(localMessages[1]);
+    const texts = assistantTexts(merged);
+    expect(texts).toContain("part two");
+    expect(texts.filter((text) => text === "part one")).toHaveLength(2);
   });
 
-  it.each([
-    [
-      "the aggregate has no timestamp",
-      { aggregateTimestamp: undefined, stripImportedTimestamps: false },
-    ],
-    [
-      "the imported turn has no timestamps",
-      { aggregateTimestamp: TURN_START + 3000, stripImportedTimestamps: true },
-    ],
-    [
-      "the aggregate is outside the dedupe window",
-      { aggregateTimestamp: TURN_START + 10 * 60 * 1000, stripImportedTimestamps: false },
-    ],
-    [
-      "the aggregate predates the imported turn",
-      { aggregateTimestamp: TURN_START - 1000, stripImportedTimestamps: false },
-    ],
-  ])("keeps the aggregate when %s", (_label, caseParams) => {
-    const localMessages = [
-      buildCliAggregate({
-        text: "part one\n\npart two",
-        timestamp: caseParams.aggregateTimestamp,
-      }),
-    ];
-    const importedMessages = importedMultiBlockTurn().map((message) => {
-      if (caseParams.stripImportedTimestamps) {
-        delete message.timestamp;
-      }
-      return message;
-    });
-
-    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
-
-    expect(merged).toHaveLength(4);
-    expect(merged.some(isCliAggregate)).toBe(true);
-  });
-
-  it("keeps an aggregate persisted by a different CLI provider", () => {
+  it("keeps the only local aggregate when the import holds a different turn with the same text", () => {
+    // The crossed partial-history case. Local history holds one aggregate whose
+    // own native turn is missing from the import, while the import holds an
+    // earlier turn with identical text whose aggregate is missing locally.
+    // Text, provider and time all match; the recorded identity does not, and it
+    // is the identity that decides.
     const localMessages = [
       buildCliAggregate({
         text: "part one\n\npart two",
         timestamp: TURN_START + 3000,
-        provider: "codex-cli",
+        runId: "run-later",
+        nativeTurn: nativeTurnRef("later-assistant-3"),
       }),
     ];
 
@@ -2716,16 +2713,83 @@ describe("persisted CLI aggregate suppression", () => {
       importedMessages: importedMultiBlockTurn(),
     });
 
-    expect(merged).toHaveLength(4);
-    expect(merged.some(isCliAggregate)).toBe(true);
+    expect(merged).toContain(localMessages[0]);
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
   });
 
-  it("suppresses one aggregate per imported turn when replies repeat verbatim", () => {
-    // Two genuine repeated replies, but only one of them is in the import:
-    // consuming turns one-to-one must keep the unrepresented aggregate.
+  it("keeps an aggregate whose named turn was rebound to another native session", () => {
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        nativeTurn: nativeTurnRef("assistant-3", "session-before-rebind"),
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged).toContain(localMessages[0]);
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+  });
+
+  it("keeps an aggregate whose named turn is only partially imported", () => {
+    // The turn is identified, but the import no longer carries all of its text.
+    // The aggregate stays as the durable copy of what was trimmed away.
+    const [, toolCall, last] = importedMultiBlockTurn();
     const localMessages = [
       buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
-      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 4000 }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: [toolCall, last] as Record<string, unknown>[],
+    });
+
+    expect(merged).toContain(localMessages[0]);
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+  });
+
+  it.each([
+    ["names no native turn", { nativeTurn: null }],
+    ["names a record the import does not hold", { nativeTurn: nativeTurnRef("assistant-absent") }],
+    ["names a non-terminal record of the turn", { nativeTurn: nativeTurnRef("assistant-1") }],
+  ])("keeps an aggregate that %s", (_label, refParams) => {
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        ...refParams,
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged).toContain(localMessages[0]);
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+  });
+
+  it("replaces only the aggregate whose turn the import holds when replies repeat verbatim", () => {
+    // Two genuine repeated replies with identical text. Only the first turn is
+    // in the import, and identity — not proximity — decides which is covered.
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        runId: "run-a",
+        nativeTurn: nativeTurnRef("assistant-3"),
+      }),
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 4000,
+        runId: "run-b",
+        nativeTurn: nativeTurnRef("repeat-assistant-3"),
+      }),
     ];
 
     const merged = mergeImportedChatHistoryMessages({
@@ -2734,19 +2798,24 @@ describe("persisted CLI aggregate suppression", () => {
     });
 
     expect(merged.filter(isCliAggregate)).toHaveLength(1);
-    // The nearer aggregate is the one the imported turn represents.
     expect(merged).toContain(localMessages[1]);
   });
 
-  it("suppresses both aggregates when the import holds both repeated turns", () => {
+  it("replaces both aggregates when the import holds both repeated turns", () => {
     const localMessages = [
-      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
-      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 30_000 }),
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        runId: "run-a",
+        nativeTurn: nativeTurnRef("assistant-3"),
+      }),
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 30_000,
+        runId: "run-b",
+        nativeTurn: nativeTurnRef("repeat-assistant-3"),
+      }),
     ];
-    const secondTurn = importedMultiBlockTurn({ offsetMs: 27_000, idPrefix: "repeat-" });
-
-    // The repeated prompt separates the two imported turns, exactly as it
-    // does in a real transcript.
     const repeatedPrompt = importedTurnMessage({
       content: "say it again",
       offsetMs: 25_000,
@@ -2756,10 +2825,39 @@ describe("persisted CLI aggregate suppression", () => {
 
     const merged = mergeImportedChatHistoryMessages({
       localMessages,
-      importedMessages: [...importedMultiBlockTurn(), repeatedPrompt, ...secondTurn],
+      importedMessages: [
+        ...importedMultiBlockTurn(),
+        repeatedPrompt,
+        ...importedMultiBlockTurn({ offsetMs: 27_000, idPrefix: "repeat-" }),
+      ],
     });
 
     expect(merged.some(isCliAggregate)).toBe(false);
+  });
+
+  it("consumes each named turn once when two aggregates name the same record", () => {
+    // A duplicated stamp is a producer bug, not two turns. The import holds one
+    // turn, so at most one aggregate may be replaced by it.
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        runId: "run-a",
+      }),
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 4000,
+        runId: "run-b",
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+    expect(merged).toContain(localMessages[1]);
   });
 
   it.each([
@@ -2797,8 +2895,8 @@ describe("persisted CLI aggregate suppression", () => {
             message: { role: "user", content: "hi" },
           },
           {
-            // No uuid: the importer must accept its stable fallback identity.
             type: "assistant",
+            uuid: "assistant-terminal",
             timestamp: "2026-03-26T16:29:55.500Z",
             message: {
               role: "assistant",
@@ -2819,6 +2917,7 @@ describe("persisted CLI aggregate suppression", () => {
         buildCliAggregate({
           text: "hello from Claude",
           timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+          nativeTurn: nativeTurnRef("assistant-terminal", sessionId),
         }),
       ];
 
@@ -2848,4 +2947,127 @@ describe("persisted CLI aggregate suppression", () => {
     });
   });
 });
+
+describe("persisted CLI aggregate suppression end to end", () => {
+  // The producer stamps the native turn, the store keeps it, the reader
+  // projects it, and only then does the merge decide. A field lost at any of
+  // those seams turns the fix into a silent no-op, so this drives all four.
+  it("carries the recorded native turn from the CLI producer through to the merge", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-native-turn-e2e-"));
+    const homeDir = path.join(root, "home");
+    const cliSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    await fs.mkdir(projectsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectsDir, `${cliSessionId}.jsonl`),
+      [
+        {
+          type: "user",
+          uuid: "u-1",
+          timestamp: "2026-03-26T16:29:54.000Z",
+          message: { role: "user", content: "run it" },
+        },
+        {
+          type: "assistant",
+          uuid: "a-1",
+          timestamp: "2026-03-26T16:29:55.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "part one" }] },
+        },
+        {
+          type: "assistant",
+          uuid: "a-2",
+          timestamp: "2026-03-26T16:29:56.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "pwd" } }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "a-3",
+          timestamp: "2026-03-26T16:29:57.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "part two" }] },
+        },
+      ]
+        .map((row) => JSON.stringify({ ...row, sessionId: cliSessionId, cwd: "/demo" }))
+        .join("\n"),
+      "utf-8",
+    );
+
+    const target = {
+      agentId: "main",
+      sessionId: "cli-native-turn-e2e",
+      sessionKey: "agent:main:cli-native-turn-e2e",
+      storePath: path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite"),
+    };
+    try {
+      await upsertSessionEntry({
+        ...target,
+        entry: {
+          sessionId: target.sessionId,
+          updatedAt: Date.now(),
+          cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
+        },
+      });
+      const persisted = await persistCliAssistantTranscript({
+        runParams: {
+          ...target,
+          sessionFile: `sqlite://agents/main/${target.sessionId}`,
+          workspaceDir: root,
+          prompt: "run it",
+          provider: "claude-cli",
+          runId: "cli-native-turn-e2e-run",
+          timeoutMs: 1_000,
+          persistAssistantTranscript: true,
+        },
+        text: "part one\n\npart two",
+        modelId: "claude-opus-5",
+        stopReason: "stop",
+        nativeTurn: { cliSessionId, terminalRecordId: "a-3" },
+      });
+      expect(persisted.owned).toBe(true);
+
+      const localMessages = await readSessionMessagesAsync(target, {
+        mode: "full",
+        reason: "cli native turn end-to-end proof",
+      });
+      // The seam that would silently break the fix: the stamp has to survive
+      // storage and display projection, not just the producer call.
+      expect(
+        localMessages.filter((message) => readRecord(message).cliNativeTurn !== undefined),
+      ).toHaveLength(1);
+
+      const resolved = await withEnvAsync({ HOME: homeDir }, async () =>
+        resolveChatHistoryWithCliSessionImports({
+          entry: {
+            sessionId: target.sessionId,
+            updatedAt: Date.now(),
+            cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
+          },
+          provider: "claude-cli",
+          localMessages,
+          homeDir,
+        }),
+      );
+
+      expect(resolved.imported).toBe(true);
+      expect(resolved.messages.some((message) => readRecord(message).api === "cli")).toBe(false);
+      const blocks = resolved.messages.flatMap((message) => {
+        const content = readRecord(message).content;
+        return Array.isArray(content) ? content.map((block) => readRecord(block)) : [];
+      });
+      expect(blocks.filter((block) => block.type === "text").map((block) => block.text)).toEqual([
+        "part one",
+        "part two",
+      ]);
+      expect(blocks.filter((block) => block.type === "toolcall")).toEqual([
+        { type: "toolcall", id: "toolu_1", name: "Bash", arguments: { command: "pwd" } },
+      ]);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -1930,6 +1930,125 @@ describe("cli session history", () => {
   });
 });
 
+describe("harness rows inside a CLI turn", () => {
+  const TURN_START = Date.parse("2026-03-26T16:29:55.000Z");
+  const NATIVE_SESSION_ID = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+  const at = (offsetMs: number) => new Date(TURN_START + offsetMs).toISOString();
+
+  // One CLI turn whose mid-turn user row is written by the harness. A skill
+  // instruction body is an isMeta row the importer drops entirely, so it cannot
+  // split the turn; a compaction summary stays visible and remains a boundary.
+  function turnLines(midTurnRow: Record<string, unknown>): string {
+    return [
+      { uuid: "u-1", timestamp: at(0), type: "user", message: { role: "user", content: "run it" } },
+      {
+        uuid: "a-1",
+        timestamp: at(1000),
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "part one" }] },
+      },
+      {
+        uuid: "a-2",
+        timestamp: at(2000),
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "Skill", input: { skill: "demo" } }],
+        },
+      },
+      midTurnRow,
+      {
+        uuid: "a-3",
+        timestamp: at(4000),
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "part two" }] },
+      },
+    ]
+      .map((row) => JSON.stringify({ ...row, sessionId: NATIVE_SESSION_ID, cwd: "/demo" }))
+      .join("\n");
+  }
+
+  async function importTurn(lines: string): Promise<unknown[]> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-turn-"));
+    const homeDir = path.join(root, "home");
+    const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    await fs.mkdir(projectsDir, { recursive: true });
+    await fs.writeFile(path.join(projectsDir, `${NATIVE_SESSION_ID}.jsonl`), lines, "utf-8");
+    try {
+      return await withEnvAsync({ HOME: homeDir }, async () =>
+        readClaudeCliSessionMessages({ cliSessionId: NATIVE_SESSION_ID, homeDir }),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+
+  function localAggregate(): Record<string, unknown>[] {
+    return [
+      {
+        role: "assistant",
+        api: "cli",
+        provider: "claude-cli",
+        model: "claude-opus-5",
+        stopReason: "stop",
+        idempotencyKey: "cli-assistant:run-1",
+        content: [{ type: "text", text: "part one\n\npart two" }],
+        timestamp: TURN_START + 5000,
+      },
+    ];
+  }
+
+  function countAggregates(messages: unknown[]): number {
+    return messages.filter((message) => readRecord(message).api === "cli").length;
+  }
+
+  it("keeps a skill instruction row inside the turn it belongs to", async () => {
+    const importedMessages = await importTurn(
+      turnLines({
+        uuid: "u-2",
+        timestamp: at(3000),
+        type: "user",
+        isMeta: true,
+        sourceToolUseID: "toolu_1",
+        message: { role: "user", content: [{ type: "text", text: "SKILL INSTRUCTIONS: demo" }] },
+      }),
+    );
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: localAggregate(),
+      importedMessages,
+    });
+
+    // The isMeta row never reaches the projection, so the turn still covers
+    // `part one\n\npart two` and the flat aggregate goes.
+    expect(countAggregates(merged)).toBe(0);
+  });
+
+  it("keeps a compaction summary as a turn boundary", async () => {
+    const importedMessages = await importTurn(
+      turnLines({
+        uuid: "u-2",
+        timestamp: at(3000),
+        type: "user",
+        isCompactSummary: true,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "SUMMARY OF PRIOR CONVERSATION" }],
+        },
+      }),
+    );
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: localAggregate(),
+      importedMessages,
+    });
+
+    // A summary really does end the turn, so no turn covers the aggregate and
+    // it survives as the durable fallback.
+    expect(countAggregates(merged)).toBe(1);
+  });
+});
+
 describe("readClaudeCliFallbackSeed", () => {
   let tmpRoot: string;
   let homeDir: string;
@@ -2212,6 +2331,404 @@ describe("readClaudeCliFallbackSeed", () => {
 
     const seed = readFallbackSeed();
     expect(seed?.summaryText).toBe("trailing summary without boundary");
+  });
+});
+
+describe("persisted CLI aggregate suppression", () => {
+  const TURN_START = Date.parse("2026-03-26T16:29:55.000Z");
+
+  // Mirrors what `persistCliTurnTranscript` stores: the synthetic aggregate
+  // carries `idempotencyKey: "cli-assistant:<runId>"`, ordinary CLI replies do not.
+  function buildCliAggregate(params: {
+    text: string;
+    timestamp?: number;
+    provider?: string;
+    idempotencyKey?: string | null;
+    runId?: string;
+  }): Record<string, unknown> {
+    const idempotencyKey =
+      params.idempotencyKey === null
+        ? undefined
+        : (params.idempotencyKey ?? `cli-assistant:${params.runId ?? "run-1"}`);
+    return {
+      role: "assistant",
+      api: "cli",
+      provider: params.provider ?? "claude-cli",
+      model: "claude-opus-5",
+      stopReason: "stop",
+      content: [{ type: "text", text: params.text }],
+      ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
+      ...(params.timestamp === undefined ? {} : { timestamp: params.timestamp }),
+    };
+  }
+
+  function importedTurnMessage(params: {
+    content: unknown;
+    offsetMs: number;
+    externalId?: string;
+    role?: "assistant" | "user";
+  }): Record<string, unknown> {
+    return {
+      role: params.role ?? "assistant",
+      provider: "claude-cli",
+      content: params.content,
+      timestamp: TURN_START + params.offsetMs,
+      __openclaw: {
+        id: params.externalId ?? "claude-cli:session-1:line:9",
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        ...(params.externalId ? { externalId: params.externalId } : {}),
+      },
+    };
+  }
+
+  function importedMultiBlockTurn(
+    params: { offsetMs?: number; idPrefix?: string } = {},
+  ): Record<string, unknown>[] {
+    const base = params.offsetMs ?? 0;
+    const prefix = params.idPrefix ?? "";
+    return [
+      importedTurnMessage({
+        content: [{ type: "text", text: "part one" }],
+        offsetMs: base,
+        externalId: `${prefix}assistant-1`,
+      }),
+      importedTurnMessage({
+        content: [
+          {
+            type: "toolcall",
+            id: `${prefix}toolu_1`,
+            name: "Bash",
+            arguments: { command: "pwd" },
+          },
+        ],
+        offsetMs: base + 1000,
+        externalId: `${prefix}assistant-2`,
+      }),
+      importedTurnMessage({
+        content: [{ type: "text", text: "part two" }],
+        offsetMs: base + 2000,
+        externalId: `${prefix}assistant-3`,
+      }),
+    ];
+  }
+
+  function isCliAggregate(message: unknown): boolean {
+    return readRecord(message).api === "cli";
+  }
+
+  it("replaces a persisted aggregate with the imported native turn blocks", () => {
+    const localMessages = [
+      { role: "user", content: "hi", timestamp: TURN_START - 1000 },
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
+    ];
+    const importedMessages = [
+      importedTurnMessage({
+        content: "hi",
+        offsetMs: -1100,
+        externalId: "user-1",
+        role: "user",
+      }),
+      ...importedMultiBlockTurn(),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    expect(merged).toHaveLength(4);
+    expect(merged.some(isCliAggregate)).toBe(false);
+    expect(merged[0]).toBe(localMessages[0]);
+    expect(readRecord(merged[2]).content).toEqual([
+      {
+        type: "toolcall",
+        id: "toolu_1",
+        name: "Bash",
+        arguments: { command: "pwd" },
+      },
+    ]);
+  });
+
+  it("keeps the turn together across an unmatched tool-result user row", () => {
+    const localMessages = [
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
+    ];
+    const importedMessages = [
+      importedTurnMessage({
+        content: [{ type: "text", text: "part one" }],
+        offsetMs: 0,
+        externalId: "assistant-1",
+      }),
+      importedTurnMessage({
+        content: [{ type: "tool_result", tool_use_id: "toolu_9", content: "done" }],
+        offsetMs: 1000,
+        externalId: "user-tool-result",
+        role: "user",
+      }),
+      importedTurnMessage({
+        content: [{ type: "text", text: "part two" }],
+        offsetMs: 2000,
+        externalId: "assistant-2",
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    expect(merged).toHaveLength(3);
+    expect(merged.some(isCliAggregate)).toBe(false);
+  });
+
+  it("keeps a lone text turn deduplicated against its persisted aggregate", () => {
+    // The base case of openclaw/openclaw#123792: a single-block turn is not
+    // indexed as covering, so only weak text dedupe keeps it from rendering
+    // twice. No other test pins it, and it is the case a narrower fix breaks.
+    const localMessages = [
+      buildCliAggregate({ text: "hello there", timestamp: TURN_START + 2000 }),
+    ];
+    const importedMessages = [
+      importedTurnMessage({
+        content: [{ type: "text", text: "hello there" }],
+        offsetMs: 1000,
+        externalId: "assistant-1",
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(localMessages[0]);
+  });
+
+  it("keeps a claimed turn's covering blocks when an earlier aggregate repeats one", () => {
+    // Regression for the mixed short-earlier/long-later shape: the later
+    // aggregate is claimed and dropped, so its first native block must survive
+    // weak text dedupe against the unrelated earlier aggregate that happens to
+    // carry the same text inside the five-minute window.
+    const localMessages = [
+      buildCliAggregate({ text: "part one", timestamp: TURN_START, runId: "run-0" }),
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 64_000,
+        runId: "run-1",
+      }),
+    ];
+    const claimedTurn = importedMultiBlockTurn({ offsetMs: 61_000, idPrefix: "later-" }).map(
+      (message) => {
+        delete readRecord(readRecord(message)["__openclaw"]).externalId;
+        return message;
+      },
+    );
+    const importedMessages = [
+      importedTurnMessage({
+        content: "second prompt",
+        offsetMs: 60_000,
+        externalId: "user-2",
+        role: "user",
+      }),
+      ...claimedTurn,
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    // The earlier aggregate is unrelated to the imported turn and stays put.
+    expect(merged).toContain(localMessages[0]);
+    // The claimed turn keeps every block that covered the dropped aggregate.
+    const assistantTexts = merged
+      .filter((message) => readRecord(message).role === "assistant")
+      .flatMap((message) => {
+        const content = readRecord(message).content;
+        return Array.isArray(content)
+          ? content
+              .filter((block) => readRecord(block).type === "text")
+              .flatMap((block) => {
+                const text = readRecord(block).text;
+                return typeof text === "string" ? [text] : [];
+              })
+          : [];
+      });
+    expect(assistantTexts).toContain("part two");
+    expect(assistantTexts.filter((text) => text === "part one")).toHaveLength(2);
+  });
+
+  it.each([
+    [
+      "the aggregate has no timestamp",
+      { aggregateTimestamp: undefined, stripImportedTimestamps: false },
+    ],
+    [
+      "the imported turn has no timestamps",
+      { aggregateTimestamp: TURN_START + 3000, stripImportedTimestamps: true },
+    ],
+    [
+      "the aggregate is outside the dedupe window",
+      { aggregateTimestamp: TURN_START + 10 * 60 * 1000, stripImportedTimestamps: false },
+    ],
+    [
+      "the aggregate predates the imported turn",
+      { aggregateTimestamp: TURN_START - 1000, stripImportedTimestamps: false },
+    ],
+  ])("keeps the aggregate when %s", (_label, caseParams) => {
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: caseParams.aggregateTimestamp,
+      }),
+    ];
+    const importedMessages = importedMultiBlockTurn().map((message) => {
+      if (caseParams.stripImportedTimestamps) {
+        delete message.timestamp;
+      }
+      return message;
+    });
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    expect(merged).toHaveLength(4);
+    expect(merged.some(isCliAggregate)).toBe(true);
+  });
+
+  it("keeps an aggregate persisted by a different CLI provider", () => {
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        provider: "codex-cli",
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged).toHaveLength(4);
+    expect(merged.some(isCliAggregate)).toBe(true);
+  });
+
+  it("suppresses one aggregate per imported turn when replies repeat verbatim", () => {
+    // Two genuine repeated replies, but only one of them is in the import:
+    // consuming turns one-to-one must keep the unrepresented aggregate.
+    const localMessages = [
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 4000 }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+    // The nearer aggregate is the one the imported turn represents.
+    expect(merged).toContain(localMessages[1]);
+  });
+
+  it("suppresses both aggregates when the import holds both repeated turns", () => {
+    const localMessages = [
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 3000 }),
+      buildCliAggregate({ text: "part one\n\npart two", timestamp: TURN_START + 30_000 }),
+    ];
+    const secondTurn = importedMultiBlockTurn({ offsetMs: 27_000, idPrefix: "repeat-" });
+
+    // The repeated prompt separates the two imported turns, exactly as it
+    // does in a real transcript.
+    const repeatedPrompt = importedTurnMessage({
+      content: "say it again",
+      offsetMs: 25_000,
+      externalId: "user-repeat",
+      role: "user",
+    });
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: [...importedMultiBlockTurn(), repeatedPrompt, ...secondTurn],
+    });
+
+    expect(merged.some(isCliAggregate)).toBe(false);
+  });
+
+  it.each([
+    ["carries no idempotency key", { idempotencyKey: null }],
+    ["carries a non-aggregate idempotency key", { idempotencyKey: "cli-hook:run-1" }],
+  ])("retains a CLI assistant record that %s", (_label, keyParams) => {
+    // `api: "cli"` is not unique to the synthetic aggregate; only records
+    // stamped `cli-assistant:<runId>` may be suppressed.
+    const localMessages = [
+      buildCliAggregate({
+        text: "part one\n\npart two",
+        timestamp: TURN_START + 3000,
+        ...keyParams,
+      }),
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: importedMultiBlockTurn(),
+    });
+
+    expect(merged).toContain(localMessages[0]);
+    expect(merged.filter(isCliAggregate)).toHaveLength(1);
+  });
+
+  it("reports a one-for-one aggregate replacement as an import to the resolver", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "user-1",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: { role: "user", content: "hi" },
+          },
+          {
+            // No uuid: the importer must accept its stable fallback identity.
+            type: "assistant",
+            timestamp: "2026-03-26T16:29:55.500Z",
+            message: {
+              role: "assistant",
+              model: "claude-opus-5",
+              content: [
+                { type: "text", text: "hello from Claude" },
+                { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "pwd" } },
+              ],
+            },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+      const localMessages = [
+        { role: "user", content: "hi", timestamp: Date.parse("2026-03-26T16:29:54.900Z") },
+        buildCliAggregate({
+          text: "hello from Claude",
+          timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+        }),
+      ];
+
+      const result = resolveChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: { "claude-cli": { sessionId } },
+        },
+        provider: "claude-cli",
+        localMessages,
+        homeDir,
+      });
+
+      expect(result.imported).toBe(true);
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages.some(isCliAggregate)).toBe(false);
+      expect(readRecord(result.messages[1]).content).toEqual([
+        { type: "text", text: "hello from Claude" },
+        {
+          type: "toolcall",
+          id: "toolu_1",
+          name: "Bash",
+          arguments: { command: "pwd" },
+        },
+      ]);
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -61,9 +61,11 @@ export function resolveChatHistoryWithCliSessionImports(params: CliSessionHistor
     localMessages: params.localMessages,
     importedMessages,
   });
-  return messages.length > params.localMessages.length
-    ? { messages, imported: true }
-    : { messages: params.localMessages, imported: false };
+  // Identity, not length: replacing a persisted aggregate with the imported
+  // native turn can leave the count unchanged yet must count as an import.
+  return messages === params.localMessages
+    ? { messages: params.localMessages, imported: false }
+    : { messages, imported: true };
 }
 
 /** Acquires one request-local redacted view of the process-owned external snapshot. */


### PR DESCRIPTION
Closes #123792

## What Problem This Solves

Claude CLI history could render one assistant turn twice in the Control UI and Android app. The rich imported turn appeared first with native tool cards. A flat persisted copy appeared below it.

Telegram delivery is not affected because it does not render merged history.

## Root Cause

The CLI runner persists one synthetic assistant aggregate with `api: "cli"` and `idempotencyKey: "cli-assistant:<runId>"`. The Gateway also imports the bound Claude transcript as native text and tool-call blocks.

The old merge compared one message at a time. It could not match one aggregate such as `text one\n\ntext two` to several imported blocks from the same turn.

Underneath that, nothing linked the two shapes at all. Only the producer sees both the flattened aggregate and the native records it came from, and it recorded no relation, which left every reader inferring one from text, provider and timing.

## Fix

The producer records the relation, and the merge resolves it instead of inferring one.

- Run settlement already resolves the native record id of a run's terminal assistant message, for resume. It now records that id, with the native session that owns it, on the aggregate it persists: `cliNativeTurn: { cliSessionId, terminalRecordId }`, a declared field on the transcript message contract.
- The Gateway history owner groups imported assistant messages into turns and indexes them by the native record their last message came from.
- An aggregate is only ever replaced by the turn it names, in the native session it names.
- The remaining text comparison is a completeness check on that identified pair, not an identity test: a trimmed or partially imported turn no longer covers the aggregate's text, so the aggregate is kept as the durable copy.
- Imported native blocks are unchanged, including `toolcall` IDs, names, and arguments.

This removes the five-minute window for aggregates, the text-and-provider keyed index, the ordered pairing and the nearest-turn selection. The resolver uses result identity so a one-for-one replacement still counts as an import.

**Fail-open by construction.** An aggregate that names no native turn is never replaced. That covers every record persisted before this field existed, every backend that writes no native transcript, and every run whose terminal record was not reported. The consequence is deliberate: the duplicate stays visible for history already on disk until those sessions produce new turns. Removing those would require exactly the text-and-time inference this design rejects, because no rule built from text, provider and time can tell a true duplicate from a distinct same-text turn when either history is partial.

The async snapshot reader projects any JSONL line past 1 MiB through a bounded worker. That projection rebuilds the entry from a fixed field list, so the turn-boundary facts the grouping reads have to survive it; an importer/resolver parity regression covers both readers over the same oversized transcript.

The rebase onto current `main` integrates #130463 and #133316, the commits that have touched `cli-session-history.merge.ts` since this PR's original base. #133316's prepared-facts refactor is the base — its injected identity key, its `localImageMediaCounts` map — and the aggregate/turn matching is layered on top, so its tests and this PR's regressions both hold. Preparing the whole import ahead of the merge loop is gated on the session actually holding a persisted aggregate, so a session without one keeps #133316's lazy, skip-on-identity path unchanged.

## Evidence

Head: `8a7447409ff9c3ae3118a029116e1ab7a83fa2c6`, rebased onto `43e9a3d817` (current `main`). The evidence below was measured on `b538e9752c`, the same four commits before that rebase; the rebase carried them across 409 upstream commits with no conflicts and no diff change.

Current-main reproduction, re-run on that exact base: applying this PR's regression file to `86b6ec0afa` and leaving main's merge owner in place fails 11 tests.

```text
Test Files  1 failed (1)
     Tests  11 failed | 77 passed (88)
```

Four of them:

- `replaces a persisted aggregate with the imported native turn blocks` — expected a length of 4, got 5. The persisted aggregate remains beside the imported native blocks.
- `keeps a skill instruction row inside the turn it belongs to` — expected 0 aggregates, got 1. #130269 already hides the skill instruction row on that base, and the turn still renders twice.
- `projects an oversized skill instruction row exactly as the sync reader does` — expected 0 aggregates, got 1. The same defect through the async snapshot's bounded worker projection.
- `keeps the only local aggregate when the import holds a different turn with the same text` — the aggregate is deleted. This is the crossed partial-history loss path, and it is the reason this PR resolves aggregates by recorded identity rather than by text and time.

Focused proof on the head:

```text
node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts
88 passed

node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts \
  src/gateway/server-methods/chat-history-pages.test.ts \
  src/gateway/server.chat-history-cursor.test.ts \
  src/gateway/server.chat.gateway-server-chat-b.test.ts \
  src/agents/tools/embedded-gateway-stub.test.ts \
  src/agents/cli-runner/cli-run-transcript.test.ts
273 passed (3 shards)

node scripts/run-vitest.mjs ui/src/lib/chat/message-normalizer.test.ts \
  -t 'detects tool messages by toolcall content blocks'
1 passed | 85 skipped
```

One of those, `carries the recorded native turn from the CLI producer through to the merge`, drives the real producer, the real SQLite store, the real display projection, the real JSONL importer and the real resolver, so a field lost at any of those seams fails the suite instead of silently disabling the fix.

Repo checks on the head: `pnpm tsgo:core` and `pnpm tsgo:test:src` clean, `run-oxlint src/gateway src/agents` 0 warnings and 0 errors, the assertion-safety and max-lines ratchets OK, `oxfmt --check` clean. The `cli-session-history.merge.ts` assertion-safety baseline entry shrinks `6 → 1`.

The resolver test reads a real Claude JSONL fixture. It asserts the retained imported content is exactly the text block plus `{ type: "toolcall", id: "toolu_1", name: "Bash", arguments: { command: "pwd" } }`. The UI normalization test confirms that shape remains a native tool card.

Repeated-text benchmark with 24,000 imported turns and 24,000 aggregates. Measured on `6e25b0ae`, an earlier head, and not re-run since:

| Matcher | Three samples | Result |
| --- | --- | --- |
| Previous claim forests | 95–112 ms | 72,000 native messages, 0 aggregates |
| Ordered turn pairing | 80–95 ms | 72,000 native messages, 0 aggregates |

The Telegram fallback run, also on `6e25b0ae`, recorded one deterministic direct-message turn because this history-only change is not Telegram-visible. The bot typed and returned `OPENCLAW_E2E_OK`; the mock provider received one `POST /v1/responses`.

## Control UI Proof

Measured on two live Gateways, each built from source and serving its own `chat.history` from **the same store**: a copy of a production OpenClaw agent store holding 878 persisted `cli-assistant:<runId>` aggregates. Only the commit differs, and the Control UI is byte-identical on both sides because this PR changes 0 files under `ui/`.

| | commit |
| --- | --- |
| base | `86b6ec0afa` |
| head | `b538e9752c` |

The turn was produced by **running a real agent turn through the head build**, not by editing a store: Claude CLI 2.1.250 on the `claude-cli` backend, prompted for a line of text, then `pwd` through Bash, then a closing sentence — the two-text-blocks-around-a-tool-call shape this bug needs. The producer recorded the relation on that run:

```json
"idempotencyKey": "cli-assistant:be40a3bc-c230-4e59-bb83-c5fa6e8846c9",
"cliNativeTurn": {
  "cliSessionId": "881503c4-fa93-4da4-b514-b94ba6afd637",
  "terminalRecordId": "5d666065-18d8-4a2c-8651-d2dfa6e330c9"
}
```

`terminalRecordId` is the turn's terminal native assistant record.

| rendered rows | `86b6ec0afa` | `b538e9752c` |
| --- | --- | --- |
| imported native blocks | 3, incl. the `Bash` card | 3, unchanged |
| persisted aggregate `msg:id:687e4295-…` | present — the turn renders twice | absent |
| total | 6 | 5 |

The durable fallback holds on that same head: a session whose aggregate predates `cliNativeTurn` keeps its 6,781-character aggregate, because it names no native turn. In that store 1 aggregate carries the relation and 877 do not, and none of the 877 can be replaced.

Screenshots and the full measurement are in [this comment](https://github.com/openclaw/openclaw/pull/124543#issuecomment-5477930396), including what the capture does not cover: that store holds no `Skill` turn, so the skill case stays covered by the regressions rather than by a capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)