### PR TITLE
fix(cli): show command-tree help for unknown subcommands

### DIFF
--- a/src/cli/program/command-suggestions.ts
+++ b/src/cli/program/command-suggestions.ts
@@ -16,25 +16,31 @@ function uniqueSortedCommandNames(commands: Iterable<string>): string[] {
   );
 }
 
-export function formatCliCommandSuggestions(input: string): string | undefined {
+export function formatCliCommandSuggestions(
+  input: string,
+  commandPath: readonly string[] = [],
+  candidates?: Iterable<string>,
+): string | undefined {
   const normalizedInput = input.trim().toLowerCase();
   if (!normalizedInput) {
     return undefined;
   }
 
-  const knownCommands = uniqueSortedCommandNames([
-    ...getCoreCliCommandNamesCore(),
-    ...getSubCliEntriesCore().map((entry) => entry.name),
-  ]);
+  const knownCommands = uniqueSortedCommandNames(
+    candidates ??
+      (commandPath.length === 0
+        ? [...getCoreCliCommandNamesCore(), ...getSubCliEntriesCore().map((entry) => entry.name)]
+        : []),
+  );
   const explicitAlias = EXPLICIT_COMMAND_ALIASES.get(normalizedInput);
   if (explicitAlias && knownCommands.includes(explicitAlias)) {
-    return formatCliSuggestionLines([explicitAlias]);
+    return formatCliSuggestionLines([explicitAlias], commandPath);
   }
   const suggestions = findCliCommandSuggestions(normalizedInput, knownCommands);
   if (suggestions.length === 0) {
     return undefined;
   }
-  return formatCliSuggestionLines(suggestions);
+  return formatCliSuggestionLines(suggestions, commandPath);
 }
 
 function findCliCommandSuggestions(input: string, candidates: readonly string[]): string[] {
@@ -49,9 +55,13 @@ function findCliCommandSuggestions(input: string, candidates: readonly string[])
     .map(({ command }) => command);
 }
 
-function formatCliSuggestionLines(suggestions: readonly string[]): string {
+function formatCliSuggestionLines(
+  suggestions: readonly string[],
+  commandPath: readonly string[],
+): string {
+  const commandPrefix = ["openclaw", ...commandPath].join(" ");
   const commandLines = suggestions
-    .map((command) => `  ${formatCliCommand(`openclaw ${command}`)}`)
+    .map((command) => `  ${formatCliCommand(`${commandPrefix} ${command}`)}`)
     .join("\n");
   return `Did you mean this?\n${commandLines}`;
 }

--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -103,3 +103,14 @@ export function getCommanderErrorCommandPath(program: Command): string[] | undef
   const command = activeErrorCommandByRoot.get(getRootCommand(program));
   return command ? getCommanderCommandPath(command) : undefined;
 }
+
+/** Return visible children of the non-root command synchronously emitting a parse error. */
+export function getCommanderErrorCommandNames(program: Command): string[] | undefined {
+  const command = activeErrorCommandByRoot.get(getRootCommand(program));
+  return command && getCommanderCommandPath(command).length
+    ? command
+        .createHelp()
+        .visibleCommands(command)
+        .map((child) => child.name())
+    : undefined;
+}

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -13,6 +13,29 @@ describe("formatCliParseErrorOutput", () => {
     );
   });
 
+  it("explains unknown subcommands within the active command tree", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'list'\n", {
+      argv: ["node", "openclaw", "webhooks", "list"],
+      commandPath: ["webhooks"],
+    });
+
+    expect(output).toBe(
+      'OpenClaw webhooks has no command "list".\nTry: openclaw webhooks --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("suggests sibling subcommands within the active command tree", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'gmial'\n", {
+      argv: ["node", "openclaw", "webhooks", "gmial"],
+      commandPath: ["webhooks"],
+      commandNames: ["gmail"],
+    });
+
+    expect(output).toBe(
+      'OpenClaw webhooks has no command "gmial".\nDid you mean this?\n  openclaw webhooks gmail\nTry: openclaw webhooks --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
   it("suggests close known commands for unknown commands", () => {
     const output = formatCliParseErrorOutput("error: unknown command 'upate'\n", {
       argv: ["node", "openclaw", "upate"],

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -8,6 +8,7 @@ import { formatCliCommandSuggestions } from "./command-suggestions.js";
 type FormatCliParseErrorOptions = {
   argv?: string[];
   commandPath?: string[];
+  commandNames?: readonly string[];
 };
 
 function stripCommanderErrorPrefix(raw: string): string {
@@ -23,11 +24,8 @@ function quote(value: string): string {
 
 function resolveHelpCommand(
   argv: string[] | undefined,
-  options?: { commandPath?: string[]; root?: boolean },
+  options?: { commandPath?: string[] },
 ): string {
-  if (options?.root) {
-    return formatCliCommand("openclaw --help");
-  }
   const commandPath = options?.commandPath ?? (argv ? getCommandPathWithRootOptions(argv, 2) : []);
   if (commandPath.length === 0) {
     return formatCliCommand("openclaw --help");
@@ -39,10 +37,7 @@ function lines(...items: Array<string | undefined>): string {
   return `${items.filter((item): item is string => Boolean(item)).join("\n")}\n`;
 }
 
-function formatHelpHint(
-  argv: string[] | undefined,
-  options?: { commandPath?: string[]; root?: boolean },
-): string {
+function formatHelpHint(argv: string[] | undefined, options?: { commandPath?: string[] }): string {
   return `${theme.muted("Try:")} ${theme.command(resolveHelpCommand(argv, options))}`;
 }
 
@@ -59,11 +54,19 @@ export function formatCliParseErrorOutput(
   const unknownCommand = message.match(/^unknown command ['"`](.+?)['"`]/i);
   if (unknownCommand) {
     const command = unknownCommand[1] ?? "";
+    const commandPath = options.commandPath ?? [];
+    const hasParentCommand = commandPath.length > 0;
     return lines(
-      theme.error(`OpenClaw does not know the command ${quote(command)}.`),
-      formatCliCommandSuggestions(command),
-      formatHelpHint(options.argv, { root: true }),
-      `${theme.muted("Plugin command?")} ${theme.command(formatCliCommand("openclaw plugins list"))}`,
+      theme.error(
+        hasParentCommand
+          ? `OpenClaw ${commandPath.join(" ")} has no command ${quote(command)}.`
+          : `OpenClaw does not know the command ${quote(command)}.`,
+      ),
+      formatCliCommandSuggestions(command, commandPath, options.commandNames),
+      formatHelpHint(options.argv, { commandPath }),
+      hasParentCommand
+        ? undefined
+        : `${theme.muted("Plugin command?")} ${theme.command(formatCliCommand("openclaw plugins list"))}`,
       formatDocsHint(),
     );
   }

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -167,9 +167,13 @@ describe("configureProgramHelp", () => {
     process.argv = ["node", "openclaw", "plugins", "list", "--still-wat"];
     const secondError = await program.parseAsync(process.argv).catch((error: unknown) => error);
     expect(secondError).toBeInstanceOf(CommanderError);
+    process.argv = ["node", "openclaw", "plugins", "lis"];
+    const thirdError = await program.parseAsync(process.argv).catch((error: unknown) => error);
+    expect(thirdError).toBeInstanceOf(CommanderError);
 
     expect(stderr.match(/Try: openclaw plugins list --help/g)).toHaveLength(2);
     expect(stderr).not.toContain("openclaw plugins list list --help");
+    expect(stderr).toContain("Did you mean this?\n  openclaw plugins list\n");
   });
 
   it("suppresses banner formatting when parent default help requests it", () => {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -9,7 +9,10 @@ import { isRootVersionInvocation } from "../argv.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-option.js";
-import { getCommanderErrorCommandPath } from "./commander-parse-facts.js";
+import {
+  getCommanderErrorCommandNames,
+  getCommanderErrorCommandPath,
+} from "./commander-parse-facts.js";
 import type { ProgramContext } from "./context.js";
 import { getCoreCliCommandsWithSubcommands } from "./core-command-descriptors.js";
 import { formatCliParseErrorOutput } from "./error-output.js";
@@ -119,13 +122,15 @@ export function configureProgramHelp(
       const message = formatProgramHelpOutput(str);
       process.stderr.write(formatConsoleDiagnosticBlock({ level: "error", message }));
     },
-    outputError: (str, write) =>
+    outputError: (str, write) => {
       write(
         formatCliParseErrorOutput(str, {
           argv: process.argv,
           commandPath: getCommanderErrorCommandPath(program),
+          commandNames: getCommanderErrorCommandNames(program),
         }),
-      ),
+      );
+    },
   });
 
   if (isRootVersionInvocation(process.argv)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who mistyped or guessed a subcommand under a valid command tree were sent to global help and plugin discovery instead of the help and sibling commands for the tree they had already reached.

## Why This Change Was Made

Unknown-subcommand errors now retain Commander's exact active command path and use that already-registered command node's visible children for suggestions. This keeps lazy sub-CLI registration lazy, avoids a second command catalog, and leaves root unknown-command wording, suggestions, and plugin guidance unchanged.

## User Impact

Operators now see which command tree rejected the subcommand, get that tree's help command, and receive suggestions from that tree. The top-level plugin hint appears only for an unknown root command, where plugins can actually add commands.

## Evidence

Before (`0c546979b2a`), `openclaw --profile r13 webhooks list` returned:

```text
OpenClaw does not know the command "list".
Try: openclaw --profile r13 --help
Plugin command? openclaw --profile r13 plugins list
Docs: https://docs.openclaw.ai/cli
```

After (`0d69b7f963f1f42e3af6f3acda4fe1ca7c4efdd1`), a scratch-profile build returned:

```text
$ openclaw --profile r13 webhooks list
OpenClaw webhooks has no command "list".
Try: openclaw --profile r13 webhooks --help
Docs: https://docs.openclaw.ai/cli
```

The full reported matrix produced the same scoped shape:

| Invocation | Scoped result |
| --- | --- |
| `webhooks list` | `OpenClaw webhooks has no command "list".` |
| `secrets status` | `OpenClaw secrets has no command "status".` |
| `proxy status` | `OpenClaw proxy has no command "status".` |
| `googlemeet list` | `OpenClaw googlemeet has no command "list".` |
| `backup list` | `OpenClaw backup has no command "list".` |
| `dns status` | `OpenClaw dns has no command "status".` |

Every row pointed to `<tree> --help`, omitted the root plugin hint, and exited 1. `system events` additionally suggested the registered sibling `openclaw --profile r13 system event`. The existing sibling behavior remained scoped: `sessions show x` still returned `Try: openclaw --profile r13 sessions --help` with exit 1. The exact root formatter assertion for `openclaw wat` remains unchanged and green.

Validation:

- Regression proof before the source fix: 2 intended test failures (root-scoped nested help and missing sibling suggestion).
- `node scripts/run-vitest.mjs src/cli/program/error-output.test.ts src/cli/program/help.test.ts` — 16 tests passed.
- Remote `pnpm build` plus isolated scratch-profile command matrix — passed on [Testbox run 31944900125](https://github.com/openclaw/openclaw/actions/runs/31944900125).
- Scoped `node scripts/check-changed.mjs -- <six changed files>` — passed on [Testbox run 31945128792](https://github.com/openclaw/openclaw/actions/runs/31945128792), including core and test typechecks and changed-file lint.
- Structured autoreview — clean, no actionable findings.
