### PR TITLE
fix(gateway): keep auth-none local clients connected after pairing

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -368,7 +368,9 @@ function redactLocalPairedDevice(device: InfraPairedDevice): PairedDevice {
 
 async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePairingList> {
   try {
-    return parseDevicePairingList(await callGatewayCli("device.pair.list", opts, {}));
+    return parseDevicePairingList(
+      await callGatewayCli("device.pair.list", opts, {}, { scopes: [PAIRING_SCOPE] }),
+    );
   } catch (error) {
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -208,7 +208,7 @@ describe("devices cli approve", () => {
     await runDevicesApprove(["req-123"]);
 
     expect(callGateway).toHaveBeenCalledTimes(2);
-    expectGatewayCall(0, { method: "device.pair.list" });
+    expectGatewayCall(0, { method: "device.pair.list", scopes: ["operator.pairing"] });
     expectGatewayCall(1, {
       method: "device.pair.approve",
       params: { requestId: "req-123" },

--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -202,52 +202,6 @@ describe("gateway silent scope-upgrade reconnect", () => {
     }
   });
 
-  test("does not let backend reconnect bypass the paired scope baseline", async () => {
-    const started = await startServerWithClient("secret");
-    const paired = await issueReadScopedOperatorToken({
-      name: "backend-scope-upgrade-reconnect-poc",
-      clientId: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-      clientMode: GATEWAY_CLIENT_MODES.BACKEND,
-    });
-
-    let watcherWs: WebSocket | undefined;
-    let backendReconnectWs: WebSocket | undefined;
-    let requestedEvent: Promise<unknown>;
-
-    try {
-      ({ ws: watcherWs, requestedEvent } = await watchScopeUpgradeRequests(started.port));
-
-      backendReconnectWs = await openTrackedWs(started.port);
-      const reconnectAttempt = await connectReq(backendReconnectWs, {
-        token: "secret",
-        deviceIdentityPath: paired.identityPath,
-        client: {
-          id: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-          version: "1.0.0",
-          platform: "node",
-          mode: GATEWAY_CLIENT_MODES.BACKEND,
-        },
-        role: "operator",
-        scopes: ["operator.admin"],
-      });
-      expect(reconnectAttempt.ok).toBe(false);
-      expect(reconnectAttempt.error?.message).toBe(
-        "pairing required: device is asking for more scopes than currently approved",
-      );
-
-      await expectRejectedScopeUpgradeAttempt({
-        attempt: reconnectAttempt,
-        requestedEvent,
-        deviceId: paired.deviceId,
-        token: paired.token,
-      });
-    } finally {
-      watcherWs?.close();
-      backendReconnectWs?.close();
-      await closeStartedGateway(started);
-    }
-  });
-
   test("keeps direct-local backend callGateway scoped calls off stale paired CLI baseline", async () => {
     const started = await startServerWithClient("secret");
     const identity = await approveReadScopedDevice({

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -464,7 +464,7 @@ export async function authenticateGatewayConnect(
     scopes = applyConnectionScopeCap({ scopes, upgradeReq });
     connectParams.scopes = scopes;
   }
-  const skipControlUiPairingForDevice = shouldSkipControlUiPairing(
+  const controlUiPairingKind = shouldSkipControlUiPairing(
     controlUiAuthPolicy,
     role,
     trustedProxyAuthOk,
@@ -510,7 +510,7 @@ export async function authenticateGatewayConnect(
     handoffBootstrapProfile,
     trustedProxyAuthOk,
     allowControlUiDeviceAuthMigration,
-    skipControlUiPairingForDevice,
+    controlUiPairingKind,
     skipLocalBackendSelfPairing,
     rejectUnauthorized,
   };

--- a/src/gateway/server/ws-connection/connect-device-pairing.test.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.test.ts
@@ -1,0 +1,174 @@
+// Gateway connect pairing tests protect session exemptions and durable device grant bounds.
+import { describe, expect, test } from "vitest";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
+import { replaceConfigFile } from "../../../config/config.js";
+import type { GatewayAuthConfig } from "../../../config/types.gateway.js";
+import { ensureDeviceToken, getPairedDevice } from "../../../infra/device-pairing.js";
+import {
+  loadDeviceIdentity,
+  openTrackedWs,
+  pairDeviceIdentity,
+} from "../../device-authz.test-helpers.js";
+import { CONTROL_UI_CLIENT, openTailscaleWs } from "../../server.auth.test-helpers.js";
+import {
+  connectReq,
+  installGatewayTestHooks,
+  startServer,
+  startServerWithClient,
+  testState,
+  testTailscaleWhois,
+} from "../../test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+await import("../../server.js");
+
+const BACKEND_CLIENT = {
+  id: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+  version: "1.0.0",
+  platform: "node",
+  mode: GATEWAY_CLIENT_MODES.BACKEND,
+} as const;
+
+const TUI_CLIENT = {
+  id: GATEWAY_CLIENT_NAMES.TUI,
+  version: "1.0.0",
+  platform: "test",
+  mode: GATEWAY_CLIENT_MODES.CLI,
+} as const;
+
+describe("gateway connect pairing exemptions", () => {
+  test.each([
+    {
+      name: "local backend self-call",
+      client: BACKEND_CLIENT,
+      approvedScopes: ["operator.pairing"],
+      pairingClientId: GATEWAY_CLIENT_NAMES.CLI,
+      pairingClientMode: GATEWAY_CLIENT_MODES.CLI,
+    },
+    {
+      name: "TUI operator client",
+      client: TUI_CLIENT,
+      approvedScopes: ["operator.read"],
+      pairingClientId: GATEWAY_CLIENT_NAMES.TUI,
+      pairingClientMode: GATEWAY_CLIENT_MODES.CLI,
+    },
+  ])(
+    "admits an auth-none $name before and after a narrower pairing row exists",
+    async ({ name, client, approvedScopes, pairingClientId, pairingClientMode }) => {
+      const started = await startServerWithClient(undefined, { auth: { mode: "none" } });
+      const identityName = `auth-none-${name.replaceAll(" ", "-")}`;
+      const loaded = loadDeviceIdentity(identityName);
+      let pairedWs: Awaited<ReturnType<typeof openTrackedWs>> | undefined;
+
+      try {
+        const unpaired = await connectReq(started.ws, {
+          client,
+          role: "operator",
+          scopes: ["operator.write"],
+          deviceIdentityPath: loaded.identityPath,
+          skipDefaultAuth: true,
+          prePairDevice: false,
+        });
+        expect(unpaired.ok, JSON.stringify(unpaired)).toBe(true);
+        started.ws.close();
+
+        await pairDeviceIdentity({
+          name: identityName,
+          role: "operator",
+          scopes: approvedScopes,
+          clientId: pairingClientId,
+          clientMode: pairingClientMode,
+        });
+        const tokenBefore = await ensureDeviceToken({
+          deviceId: loaded.identity.deviceId,
+          role: "operator",
+          scopes: approvedScopes,
+        });
+        expect(tokenBefore?.scopes).toEqual(approvedScopes);
+
+        pairedWs = await openTrackedWs(started.port);
+        const pairedConnect = await connectReq(pairedWs, {
+          client,
+          role: "operator",
+          scopes: ["operator.write"],
+          deviceIdentityPath: loaded.identityPath,
+          skipDefaultAuth: true,
+          prePairDevice: false,
+        });
+        expect(pairedConnect.ok, JSON.stringify(pairedConnect)).toBe(true);
+
+        const paired = await getPairedDevice(loaded.identity.deviceId);
+        expect(paired?.approvedScopes).toEqual(approvedScopes);
+        expect(paired?.tokens?.operator).toMatchObject({
+          token: tokenBefore?.token,
+          scopes: approvedScopes,
+        });
+        expect(paired?.lastSeenReason).toBe("connect");
+      } finally {
+        pairedWs?.close();
+        started.ws.close();
+        await started.server.close();
+        started.envSnapshot.restore();
+      }
+    },
+  );
+
+  test("keeps a narrow pairing row as the Tailscale Control UI scope cap", async () => {
+    const tailscaleOrigin = "https://gateway.tailnet.ts.net";
+    const auth = {
+      mode: "token",
+      token: "secret",
+      allowTailscale: true,
+    } satisfies GatewayAuthConfig;
+    testState.gatewayAuth = auth;
+    testState.gatewayControlUi = { allowedOrigins: [tailscaleOrigin] };
+    testTailscaleWhois.value = { login: "peter", name: "Peter" };
+    await replaceConfigFile({
+      nextConfig: {
+        gateway: {
+          auth,
+          controlUi: { allowedOrigins: [tailscaleOrigin] },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
+    const started = await startServer(undefined, { auth, controlUiEnabled: true });
+    const identityName = "tailscale-control-ui-scope-cap";
+    const paired = await pairDeviceIdentity({
+      name: identityName,
+      role: "operator",
+      scopes: ["operator.read"],
+      clientId: CONTROL_UI_CLIENT.id,
+      clientMode: CONTROL_UI_CLIENT.mode,
+    });
+    let ws: Awaited<ReturnType<typeof openTailscaleWs>> | undefined;
+
+    try {
+      ws = await openTailscaleWs(started.port, { origin: tailscaleOrigin });
+      const response = await connectReq(ws, {
+        skipDefaultAuth: true,
+        prePairDevice: false,
+        scopes: ["operator.write"],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: paired.identityPath,
+      });
+      expect(response.ok).toBe(false);
+      expect(response.error?.details).toMatchObject({
+        reason: "scope-upgrade",
+        approvedScopes: ["operator.read"],
+      });
+      expect((await getPairedDevice(paired.identity.deviceId))?.approvedScopes).toEqual([
+        "operator.read",
+      ]);
+    } finally {
+      ws?.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+      testTailscaleWhois.value = null;
+    }
+  });
+});

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -21,6 +21,7 @@ import {
   listDevicePairing,
   requestDevicePairing,
   resolveEffectiveOperatorDeviceIdentity,
+  updatePairedDeviceMetadata,
 } from "../../../infra/device-pairing.js";
 import {
   resolveBootstrapProfileScopesForRole,
@@ -121,7 +122,7 @@ export async function authorizeGatewayConnectDevice(
     bootstrapTokenCandidate,
     pairingLocality,
     skipLocalBackendSelfPairing,
-    skipControlUiPairingForDevice,
+    controlUiPairingKind,
     allowControlUiDeviceAuthMigration,
   } = state;
   let hasServerApprovedDeviceTokenBaseline = false;
@@ -631,8 +632,25 @@ export async function authorizeGatewayConnectDevice(
 
     const paired = await getPairedDevice(device.id);
     const isPaired = paired?.publicKey === devicePublicKey;
-    if (!isPaired) {
-      if (!(skipLocalBackendSelfPairing || skipControlUiPairingForDevice)) {
+    const pairingRecordDoesNotAuthorizeSession =
+      skipLocalBackendSelfPairing || controlUiPairingKind === "auth-none";
+    if (pairingRecordDoesNotAuthorizeSession) {
+      if (isPaired) {
+        // Locality plus auth mode authorizes this session; the pairing row only
+        // bounds durable grants and owns last-seen diagnostics. Reapplying its
+        // scope cap here would make an unrelated narrow row deny local access.
+        pairedClientId = paired.clientId;
+        pairedBrowserOrigin = paired.browserOrigin;
+        hasServerApprovedDeviceTokenBaseline = true;
+        await updatePairedDeviceMetadata(device.id, clientAccessMetadata);
+      } else if (
+        controlUiPairingKind === "auth-none" ||
+        (skipLocalBackendSelfPairing && authMethod !== "device-token")
+      ) {
+        hasServerApprovedDeviceTokenBaseline = true;
+      }
+    } else if (!isPaired) {
+      if (controlUiPairingKind === null) {
         const ok = await requirePairing("not-paired", paired);
         if (!ok) {
           return undefined;
@@ -647,10 +665,7 @@ export async function authorizeGatewayConnectDevice(
               : undefined;
           hasServerApprovedDeviceTokenBaseline = true;
         }
-      } else if (
-        skipControlUiPairingForDevice ||
-        (skipLocalBackendSelfPairing && authMethod !== "device-token")
-      ) {
+      } else {
         hasServerApprovedDeviceTokenBaseline = true;
       }
     } else {

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -61,7 +61,7 @@ function expectMissingDeviceDecision(
 function expectSkipPairing(
   policy: Parameters<typeof shouldSkipControlUiPairing>[0],
   role: PairingRole,
-  expected: boolean,
+  expected: ReturnType<typeof shouldSkipControlUiPairing>,
   params: {
     pairingComplete?: boolean;
     authMode?: PairingAuthMode;
@@ -272,9 +272,9 @@ describe("ws connect policy", () => {
   test("strict control-ui policy does not skip pairing", () => {
     const strict = authPolicy({ isControlUi: true });
 
-    expectSkipPairing(strict, "node", false);
-    expectSkipPairing(strict, "operator", false);
-    expectSkipPairing(strict, "operator", false, { pairingComplete: true });
+    expectSkipPairing(strict, "node", null);
+    expectSkipPairing(strict, "operator", null);
+    expectSkipPairing(strict, "operator", null, { pairingComplete: true });
   });
 
   test("auth.mode=none skips pairing for operator control-ui only", () => {
@@ -282,16 +282,16 @@ describe("ws connect policy", () => {
     const nonControlUi = authPolicy();
 
     // Control UI + operator + auth.mode=none: skip pairing (the fix for #42931)
-    expectSkipPairing(controlUi, "operator", true, { authMode: "none" });
+    expectSkipPairing(controlUi, "operator", "auth-none", { authMode: "none" });
     // Control UI + node role + auth.mode=none: still require pairing
-    expectSkipPairing(controlUi, "node", false, { authMode: "none" });
+    expectSkipPairing(controlUi, "node", null, { authMode: "none" });
     // Non-Control-UI + operator + auth.mode=none: still require pairing
     // (prevents #43478 regression where ALL clients bypassed pairing)
-    expectSkipPairing(nonControlUi, "operator", false, { authMode: "none" });
+    expectSkipPairing(nonControlUi, "operator", null, { authMode: "none" });
     // Control UI + operator + auth.mode=shared-key: no change
-    expectSkipPairing(controlUi, "operator", false, { authMode: "shared-key" });
+    expectSkipPairing(controlUi, "operator", null, { authMode: "shared-key" });
     // Control UI + operator + no authMode: no change
-    expectSkipPairing(controlUi, "operator", false);
+    expectSkipPairing(controlUi, "operator", null);
   });
 
   test("tailscale auth skips pairing only for operator control-ui with device identity", () => {
@@ -305,23 +305,23 @@ describe("ws connect policy", () => {
       deviceRaw: device,
     });
 
-    expectSkipPairing(controlUiWithDevice, "operator", true, {
+    expectSkipPairing(controlUiWithDevice, "operator", "tailscale-device", {
       authMode: "token",
       authMethod: "tailscale",
     });
-    expectSkipPairing(controlUiWithoutDevice, "operator", false, {
+    expectSkipPairing(controlUiWithoutDevice, "operator", null, {
       authMode: "token",
       authMethod: "tailscale",
     });
-    expectSkipPairing(controlUiWithDevice, "node", false, {
+    expectSkipPairing(controlUiWithDevice, "node", null, {
       authMode: "token",
       authMethod: "tailscale",
     });
-    expectSkipPairing(nonControlUiWithDevice, "operator", false, {
+    expectSkipPairing(nonControlUiWithDevice, "operator", null, {
       authMode: "token",
       authMethod: "tailscale",
     });
-    expectSkipPairing(controlUiWithDevice, "operator", false, {
+    expectSkipPairing(controlUiWithDevice, "operator", null, {
       authMode: "token",
       authMethod: "token",
     });

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -9,6 +9,8 @@ type ControlUiAuthPolicy = {
   deviceAuthMigrationPending: boolean;
 };
 
+export type ControlUiPairingKind = "tailscale-device" | "auth-none" | null;
+
 export function resolveControlUiAuthPolicy(params: {
   isControlUi: boolean;
   deviceRaw: ConnectParams["device"] | null | undefined;
@@ -46,9 +48,9 @@ export function shouldSkipControlUiPairing(
   _trustedProxyAuthOk = false,
   authMode?: string,
   authMethod?: string,
-): boolean {
+): ControlUiPairingKind {
   if (policy.isControlUi && role === "operator" && authMethod === "tailscale" && policy.device) {
-    return true;
+    return "tailscale-device";
   }
   // When auth is completely disabled (mode=none), there is no shared secret
   // or token to gate pairing. Requiring pairing in this configuration adds
@@ -58,9 +60,9 @@ export function shouldSkipControlUiPairing(
   // Scope to operator role so node-role sessions still need device identity
   // (#43478 was reverted for skipping ALL clients).
   if (policy.isControlUi && role === "operator" && authMode === "none") {
-    return true;
+    return "auth-none";
   }
-  return false;
+  return null;
 }
 
 export function isTrustedProxyControlUiOperatorAuth(params: {

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -18,7 +18,7 @@ import type { PluginNodeCapabilitySurface } from "../../plugin-node-capability.j
 import type { GatewayRole } from "../../role-policy.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
-import type { resolveControlUiAuthPolicy } from "./connect-policy.js";
+import type { ControlUiPairingKind, resolveControlUiAuthPolicy } from "./connect-policy.js";
 import type { resolvePairingLocality } from "./handshake-auth-helpers.js";
 import type { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
@@ -148,7 +148,7 @@ export type AuthenticatedGatewayConnect = {
   handoffBootstrapProfile: DeviceBootstrapProfile | null;
   trustedProxyAuthOk: boolean;
   allowControlUiDeviceAuthMigration: boolean;
-  skipControlUiPairingForDevice: boolean;
+  controlUiPairingKind: ControlUiPairingKind;
   skipLocalBackendSelfPairing: boolean;
   rejectUnauthorized: (failedAuth: GatewayAuthResult) => void;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local Gateway backend calls and TUI sessions on a loopback `gateway.auth.mode: "none"` Gateway could connect until any narrower pairing row existed for the same device identity. After that row appeared, the identical connection was rejected as an unapprovable scope upgrade even though locality plus the configured auth mode—not the pairing record—was the authority for that session class.

This PR is AI-assisted; the implementation and evidence were reviewed against the complete Gateway connect path and its durable device-token boundary.

## Why This Change Was Made

The Control UI pairing policy now returns a closed reason (`auth-none`, `tailscale-device`, or no exemption) instead of collapsing two different trust boundaries into one boolean. Local backend self-calls and auth-none operator UIs bypass stored pairing access checks both before and after a row exists, while paired reconnects still refresh last-seen metadata and retain the row as the durable token baseline. `ensureDeviceToken` remains unchanged and continues to reject token scopes beyond that approved baseline.

The Tailscale Control UI path is intentionally not hoisted: an existing pairing row remains its access cap. The device-approval recovery path also requests only `operator.pairing` when reading the pairing list.

Production LOC: +35/-16 (net +19) | Tests: +189/-61. The production growth encodes the closed auth-boundary reason and the explicit separation between session admission, metadata refresh, and durable grant issuance; the obsolete paired-backend rejection test was removed rather than preserved as compatibility.

## User Impact

Operators running an auth-none loopback Gateway can keep using local `gateway-client` backend calls and the TUI after another command has created a narrower pairing row for the shared device identity. Existing durable device tokens are not widened, remote/non-loopback clients are unchanged, and paired Tailscale Control UI sessions remain capped by their approved scopes.

## Evidence

Pre-fix owner-boundary proof (new regression test retained, production changes stashed):

- both auth-none paired reconnects failed with `PAIRING_REQUIRED`, `reason: scope-upgrade`
- the same clients passed while unpaired
- the Tailscale narrow-row guard passed unchanged

Focused and boundary suites:

- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/` — 58 files, 584 tests passed
- `node scripts/run-vitest.mjs src/gateway/server.auth*.test.ts` — 7 files, 135 tests passed
- `node scripts/run-vitest.mjs src/gateway/server.device-scope-upgrade.test.ts` — 10 tests passed
- `node scripts/run-vitest.mjs src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts` — 7 tests passed
- focused owner/policy/CLI run — 66 tests passed
- `pnpm format <changed paths>` — passed
- `pnpm check:changed` — passed on trusted remote Linux
- `pnpm build` — passed on trusted remote Linux
- Codex autoreview — clean, no accepted/actionable findings

Live isolated Gateway proof used a fresh state directory, port 19435, and config:

```json
{"gateway":{"mode":"local","port":19435,"auth":{"mode":"none"}}}
```

After seeding the shared device identity with an approved `operator.pairing` row, the patched built Gateway was started with:

```text
OPENCLAW_STATE_DIR=<isolated> pnpm openclaw gateway run --port 19435
```

The real `gateway-client` / `backend` connection requested `operator.write` and returned:

```json
{"verdict":"admitted","pairedBaseline":["operator.pairing"],"requestedScopes":["operator.write"],"healthOk":true,"storedTokenScopes":["operator.pairing"],"lastSeenReason":"connect"}
```

Gateway log excerpt:

```text
Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.
← connect client=gateway-client clientDisplayName=gateway:health version=2026.8.1 mode=backend clientId=gateway-client platform=node auth=none
→ hello-ok methods=382 events=50 presence=1 stateVersion=1
⇄ res ✓ health 8ms cached=true
```

The isolated Gateway was stopped cleanly and port 19435 was verified free afterward.

### Known gap / follow-up

Plain `cli` / `cli` clients remain non-exempt by design. On an auth-none install, the first CLI command can still pair the shared identity at a narrow scope and a later differently scoped command can become an unapprovable scope upgrade. That is a separate client-identity ownership issue: `src/gateway/call.ts:445` (`shouldOmitDeviceIdentityForGatewayCall`) requires shared-secret auth for `isLocalCliSharedAuth`, so auth-none CLI calls attach an identity while token-authenticated local CLI calls omit it. This PR does not change that policy, `shouldAllowSilentLocalPairing`, scope-upgrade silence, browser origins, browser-copilot checks, or remote behavior.
