### PR TITLE
perf(test): avoid Canvas Git timeout wait

### DIFF
--- a/extensions/canvas/scripts/bundle-a2ui.d.mts
+++ b/extensions/canvas/scripts/bundle-a2ui.d.mts
@@ -2,3 +2,15 @@ export declare function isBundleHashInputPath(filePath: string, repoRoot?: strin
 export declare function getLocalRolldownCliCandidates(repoRoot?: string): string[];
 export declare function getBundleHashRepoInputPaths(repoRoot?: string): string[];
 export declare function compareNormalizedPaths(left: string, right: string): number;
+
+export declare function listTrackedInputFiles(
+  runGit: (
+    command: string,
+    args: string[],
+    options: object,
+  ) => {
+    status: number | null;
+    stdout: string;
+  },
+  repoRoot?: string,
+): string[] | null;

--- a/extensions/canvas/scripts/bundle-a2ui.mjs
+++ b/extensions/canvas/scripts/bundle-a2ui.mjs
@@ -23,10 +23,6 @@ const outputFile =
   path.join(pluginDir, "src", "host", "a2ui", "a2ui.bundle.js");
 const a2uiAppDir = path.join(pluginDir, "src", "host", "a2ui-app");
 const GIT_INPUT_DISCOVERY_TIMEOUT_MS = 5_000;
-const repoInputPaths = getBundleHashRepoInputPaths(rootDir);
-const relativeRepoInputPaths = repoInputPaths.map((inputPath) =>
-  normalizePath(path.relative(rootDir, inputPath)),
-);
 
 function fail(message) {
   console.error(message);
@@ -108,9 +104,12 @@ async function walkFiles(entryPath, files) {
   }
 }
 
-function listTrackedInputFiles() {
-  const result = spawnSync("git", ["ls-files", "--", ...relativeRepoInputPaths], {
-    cwd: rootDir,
+export function listTrackedInputFiles(runGit, repoRoot = rootDir) {
+  const relativeRepoInputPaths = getBundleHashRepoInputPaths(repoRoot).map((inputPath) =>
+    normalizePath(path.relative(repoRoot, inputPath)),
+  );
+  const result = runGit("git", ["ls-files", "--", ...relativeRepoInputPaths], {
+    cwd: repoRoot,
     encoding: "utf8",
     killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "pipe"],
@@ -122,14 +121,14 @@ function listTrackedInputFiles() {
   const trackedFiles = result.stdout
     .split("\n")
     .filter(Boolean)
-    .map((filePath) => path.join(rootDir, filePath))
+    .map((filePath) => path.join(repoRoot, filePath))
     .filter((filePath) => existsSync(filePath))
     .filter((filePath) => isBundleHashInputPath(filePath));
   return trackedFiles;
 }
 
 async function computeHash() {
-  let files = listTrackedInputFiles();
+  let files = listTrackedInputFiles(spawnSync);
   if (!files) {
     files = [];
     for (const inputPath of getBundleHashRepoInputPaths(rootDir)) {

--- a/extensions/canvas/scripts/bundle-a2ui.test.ts
+++ b/extensions/canvas/scripts/bundle-a2ui.test.ts
@@ -3,12 +3,13 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   compareNormalizedPaths,
   getBundleHashRepoInputPaths,
   getLocalRolldownCliCandidates,
   isBundleHashInputPath,
+  listTrackedInputFiles,
 } from "./bundle-a2ui.mjs";
 
 describe("scripts/bundle-a2ui.mjs", () => {
@@ -62,43 +63,66 @@ describe("scripts/bundle-a2ui.mjs", () => {
     );
   });
 
+  it("bounds tracked-input discovery and treats a timeout as a fallback", () => {
+    const repoRoot = path.resolve("repo-root");
+    const runGit = vi.fn(() => ({ status: null, stdout: "" }));
+
+    expect(listTrackedInputFiles(runGit, repoRoot)).toBeNull();
+    expect(runGit).toHaveBeenCalledWith(
+      "git",
+      ["ls-files", "--", "package.json", "pnpm-lock.yaml", "extensions/canvas/src/host/a2ui-app"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5_000,
+      },
+    );
+  });
+
   it.skipIf(process.platform === "win32")(
-    "falls back when tracked-input discovery stalls",
+    "matches the tracked-input hash when Git discovery fails",
     async () => {
       await withTempWorkspace(
-        { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-a2ui-git-timeout-" },
+        { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-a2ui-git-fallback-" },
         async ({ dir }) => {
           const fakeBinDir = path.join(dir, "bin");
           const fakeGitPath = path.join(fakeBinDir, "git");
           const outputFile = path.join(dir, "a2ui.bundle.js");
           const hashFile = path.join(dir, "a2ui.bundle.hash");
+          const scriptPath = path.resolve("extensions/canvas/scripts/bundle-a2ui.mjs");
+          const baseEnv = {
+            ...process.env,
+            OPENCLAW_A2UI_BUNDLE_HASH_FILE: hashFile,
+            OPENCLAW_A2UI_BUNDLE_OUT: outputFile,
+          };
           await fs.mkdir(fakeBinDir, { recursive: true });
-          await fs.writeFile(
-            fakeGitPath,
-            `#!${process.execPath}\nsetTimeout(() => {}, 30_000);\n`,
-            "utf8",
-          );
+          await fs.writeFile(fakeGitPath, `#!${process.execPath}\nprocess.exit(1);\n`, "utf8");
           await fs.chmod(fakeGitPath, 0o755);
 
-          execFileSync(
-            process.execPath,
-            [path.resolve("extensions/canvas/scripts/bundle-a2ui.mjs")],
-            {
-              cwd: process.cwd(),
-              encoding: "utf8",
-              env: {
-                ...process.env,
-                OPENCLAW_A2UI_BUNDLE_HASH_FILE: hashFile,
-                OPENCLAW_A2UI_BUNDLE_OUT: outputFile,
-                PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
-              },
-              killSignal: "SIGKILL",
-              timeout: 12_000,
-            },
-          );
+          execFileSync(process.execPath, [scriptPath], {
+            cwd: process.cwd(),
+            encoding: "utf8",
+            env: baseEnv,
+            killSignal: "SIGKILL",
+            timeout: 12_000,
+          });
+          const trackedHash = await fs.readFile(hashFile, "utf8");
 
+          execFileSync(process.execPath, [scriptPath], {
+            cwd: process.cwd(),
+            encoding: "utf8",
+            env: {
+              ...baseEnv,
+              PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            },
+            killSignal: "SIGKILL",
+            timeout: 12_000,
+          });
+
+          await expect(fs.readFile(hashFile, "utf8")).resolves.toBe(trackedHash);
           await expect(fs.stat(outputFile)).resolves.toBeDefined();
-          await expect(fs.stat(hashFile)).resolves.toBeDefined();
         },
       );
     },


### PR DESCRIPTION
## What Problem This Solves

The Canvas A2UI bundle regression spends the full five-second production Git timeout proving that stalled tracked-input discovery falls back to filesystem hashing. That one case accounts for essentially the entire six-test file runtime.

## Why This Change Was Made

Split the regression at the side-effect boundary it owns:

- `listTrackedInputFiles` now receives its Git runner explicitly, letting the test prove the exact five-second timeout, SIGKILL policy, command shape, and timeout result classification without sleeping.
- A fast real subprocess integration now computes the tracked-input hash, makes Git fail immediately, and proves filesystem fallback produces the identical hash and retained bundle output.

The production timeout, fallback behavior, hash inputs, and bundle policy are unchanged.

## User Impact

Maintainer Canvas test feedback is about five seconds faster while timeout and fallback regressions now fail directly instead of only after a real deadline.

## Evidence

Controlled same-Testbox A/B on `tbx_01m055cvpx01134s8q61sn1h3m`, with one excluded warmup and two retained samples per state, the same command, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 8.47s | 3.44s | -5.04s (-59.4%) |
| Vitest | 5.77s | 0.79s | -86.3% |
| Test body | 5.14s | 0.17s | -96.7% |
| Imports | 1.85s | 1.83s | effectively flat |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 7/7 focused Canvas bundle tests.
- Removing the production `timeout` option fails the new owner-boundary assertion immediately.
- The real fallback integration proves failed Git discovery matches the normal tracked-input hash.
- Full extension changed gate, including native A2UI resource reproducibility, production/test typechecks, targeted lint, plugin boundaries, dead exports, and import cycles.
- Fresh autoreview: no accepted/actionable findings.
- Runtime script LOC: `+8/-9`; declaration surface: `+12/-0`; test LOC: `+49/-25`.

Testbox benchmark and hydration: https://github.com/openclaw/openclaw/actions/runs/31944514338

Final post-rebase changed gate: https://github.com/openclaw/openclaw/actions/runs/31945366263

AI-assisted: yes. The change and evidence were reviewed by the maintainer agent and fresh autoreview.
