### PR TITLE
fix(agents): persist sender identity for direct-message turns

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -786,7 +786,7 @@ describe("resolveIMessageReactionContext", () => {
 });
 
 describe("buildIMessageInboundContext", () => {
-  it("keeps numeric row id and provider GUID separately for action tooling", async () => {
+  it("keeps provider IDs separate and projects from-me identity", async () => {
     const message = {
       id: 12345,
       guid: "p:0/GUID-current",
@@ -801,18 +801,23 @@ describe("buildIMessageInboundContext", () => {
       return;
     }
 
-    const { ctxPayload } = await buildIMessageInboundContext({
+    const contextParams = {
       cfg: {} as OpenClawConfig,
       accountService: undefined,
       decision,
-      message,
       historyLimit: 0,
       groupHistories: new Map(),
-    });
+    } satisfies Omit<Parameters<typeof buildIMessageInboundContext>[0], "message">;
+    const { ctxPayload } = await buildIMessageInboundContext({ ...contextParams, message });
 
     expect(ctxPayload.MessageSid).toMatch(/^\d+$/u);
     expect(ctxPayload.MessageSid).not.toBe("12345");
     expect(ctxPayload.MessageSidFull).toBe("p:0/GUID-current");
+    const selfContext = await buildIMessageInboundContext({
+      ...contextParams,
+      message: { ...message, is_from_me: true },
+    });
+    expect(selfContext.ctxPayload.SenderIsSelf).toBe(true);
   });
 
   it("keeps generated media notices out of command input", async () => {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -1034,6 +1034,7 @@ export async function buildIMessageInboundContext(params: {
     sender: {
       id: decision.sender,
       name: decision.senderNormalized,
+      isSelf: params.message.is_from_me === true,
     },
     conversation: {
       kind: decision.isGroup ? "group" : "direct",

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -284,6 +284,21 @@ function groupAdmission(conversationId: string): TestAdmissionOverride {
 }
 
 describe("prepared WhatsApp inbound boundary", () => {
+  it("projects from-me messages as the operator's own sender identity", async () => {
+    const prepared = await prepareWhatsAppInboundContext({
+      combinedBody: "hello from me",
+      msg: makeMsg({ platform: { fromMe: true } }),
+      route: makeRoute(),
+      sender: { id: "+15550001111", name: "Operator" },
+    });
+
+    expect(prepared.inbound.sender.isSelf).toBe(true);
+    expect(prepared.ctxPayload).toMatchObject({
+      SenderId: "+15550001111",
+      SenderIsSelf: true,
+    });
+  });
+
   it("separates portable facts from WhatsApp transport callbacks", async () => {
     const msg = makeMsg({
       event: { id: "current-1", timestamp: 1_710_000_000 },

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -476,6 +476,7 @@ export async function prepareWhatsAppInboundContext(params: {
     sender: {
       id: params.sender.id ?? params.sender.e164,
       name: params.sender.name,
+      isSelf: params.msg.platform.fromMe === true,
     },
     conversation: {
       kind: conversationKind,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -210,7 +210,14 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
         })
       : undefined);
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
-  const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
+  // Direct sender identity is safe only after channel admission and an ingress-owned
+  // self check. Gateway-local and from-me turns must keep the operator identity.
+  const persistChannelSender =
+    replyRoute.chatType === "group" ||
+    replyRoute.chatType === "channel" ||
+    (replyRoute.chatType === "direct" &&
+      ctx.InboundAccessAuthorized === true &&
+      ctx.SenderIsSelf !== true);
   const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
   const unresolvedSourceIndexes = new Set(currentTurnImages.unresolvedSourceIndexes ?? []);
   const persistedCtxMedia = ctxMediaForPersistence.map((fact, index) =>
@@ -302,8 +309,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
           // is identical whether this turn is sent as the current turn or
           // replayed as history. See: https://github.com/openclaw/openclaw/issues/3658
           ...(userTurnTimestamp ? { timestamp: userTurnTimestamp } : {}),
-          // Direct transcripts keep their existing identity-storage boundary.
-          sender: persistGroupSender
+          sender: persistChannelSender
             ? {
                 id: normalizeOptionalString(sessionCtx.SenderId),
                 name: normalizeOptionalString(sessionCtx.SenderName),

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1760,37 +1760,39 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it.each([
-    ["group", true],
-    ["channel", true],
-    ["direct", false],
-  ] as const)("persists sender attribution for %s turns only", async (chatType, shouldPersist) => {
-    await runPrepared({
-      ctx: {
-        ...createInboundBody("hello"),
-        OriginatingChannel: "telegram",
-        OriginatingTo: "chat-1",
-        ChatType: chatType,
-      },
-      sessionCtx: {
-        ...createSessionBody("hello"),
-        Provider: "telegram",
-        OriginatingChannel: "telegram",
-        OriginatingTo: "chat-1",
-        ChatType: chatType,
-        SenderId: "user-42",
-        SenderName: "Ada",
-        SenderUsername: "ada",
-      },
-      sessionEntry: {
-        sessionId: "session-1",
-        updatedAt: 1,
-        chatType,
-        channel: "telegram",
-      } as SessionEntry,
-    });
+    ["group", false],
+    ["channel", false],
+    ["direct", true],
+  ] as const)(
+    "persists sender attribution for %s turns from external contacts",
+    async (chatType, requiresChannelAdmission) => {
+      await runPrepared({
+        ctx: {
+          ...createInboundBody("hello"),
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: chatType,
+          ...(requiresChannelAdmission ? { InboundAccessAuthorized: true } : {}),
+        },
+        sessionCtx: {
+          ...createSessionBody("hello"),
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: chatType,
+          SenderId: "user-42",
+          SenderName: "Ada",
+          SenderUsername: "ada",
+        },
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: 1,
+          chatType,
+          channel: "telegram",
+        } as SessionEntry,
+      });
 
-    const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
-    if (shouldPersist) {
+      const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
       expect(message).toMatchObject({
         __openclaw: {
           senderId: "user-42",
@@ -1798,11 +1800,73 @@ describe("runPreparedReply media-only handling", () => {
           senderUsername: "ada",
         },
       });
-    } else {
-      expect(message).not.toHaveProperty("__openclaw.senderId");
-      expect(message).not.toHaveProperty("__openclaw.senderName");
-      expect(message).not.toHaveProperty("__openclaw.senderUsername");
-    }
+    },
+  );
+
+  it("does not persist sender attribution for operator-authored direct turns", async () => {
+    await runPrepared({
+      ctx: {
+        ...createInboundBody("hello"),
+        OriginatingChannel: "telegram",
+        OriginatingTo: "chat-1",
+        ChatType: "direct",
+        InboundAccessAuthorized: true,
+        SenderIsSelf: true,
+      },
+      sessionCtx: {
+        ...createSessionBody("hello"),
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "chat-1",
+        ChatType: "direct",
+        SenderId: "user-42",
+        SenderName: "Ada",
+        SenderUsername: "ada",
+      },
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        chatType: "direct",
+        channel: "telegram",
+      } as SessionEntry,
+    });
+
+    const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
+    expect(message).not.toHaveProperty("__openclaw.senderId");
+    expect(message).not.toHaveProperty("__openclaw.senderName");
+    expect(message).not.toHaveProperty("__openclaw.senderUsername");
+  });
+
+  it("does not persist sender attribution for gateway-local direct turns without channel admission", async () => {
+    await runPrepared({
+      ctx: {
+        ...createInboundBody("hello"),
+        OriginatingChannel: "webchat",
+        OriginatingTo: "chat-1",
+        ChatType: "direct",
+      },
+      sessionCtx: {
+        ...createSessionBody("hello"),
+        Provider: "webchat",
+        OriginatingChannel: "webchat",
+        OriginatingTo: "chat-1",
+        ChatType: "direct",
+        SenderId: "gateway-cli",
+        SenderName: "Gateway CLI",
+        SenderUsername: "cli",
+      },
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        chatType: "direct",
+        channel: "webchat",
+      } as SessionEntry,
+    });
+
+    const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
+    expect(message).not.toHaveProperty("__openclaw.senderId");
+    expect(message).not.toHaveProperty("__openclaw.senderName");
+    expect(message).not.toHaveProperty("__openclaw.senderUsername");
   });
 
   it("normalizes second-based inbound timestamps before preparing user turns", async () => {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -318,6 +318,8 @@ export type MsgContext = Partial<CanonicalInboundText> & {
   SenderTag?: string;
   SenderE164?: string;
   SenderIsBot?: boolean;
+  /** Channel-ingress fact: sender is the operator's own account (from-me). */
+  SenderIsSelf?: boolean;
   Timestamp?: number;
   LocationLat?: number;
   LocationLon?: number;

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -261,6 +261,7 @@ describe("buildChannelInboundEventContext", () => {
       SenderUsername: "userone",
       SenderTag: "User#0001",
       SenderIsBot: true,
+      SenderIsSelf: undefined,
       MemberRoleIds: ["admin"],
       Timestamp: 123,
       Provider: "test-provider",
@@ -309,6 +310,18 @@ describe("buildChannelInboundEventContext", () => {
     });
     expect(ctx.Body).not.toContain("customSenderField");
     expect(ctx.BodyForAgent).not.toContain("customSenderField");
+  });
+
+  it("projects the ingress from-me sender fact as SenderIsSelf", () => {
+    const ctx = buildTestInboundEventContext({
+      sender: {
+        id: "u1",
+        name: "User One",
+        isSelf: true,
+      },
+    });
+
+    expect(ctx.SenderIsSelf).toBe(true);
   });
 
   it("uses resolved command authorization", async () => {

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -563,6 +563,7 @@ function buildChannelInboundEventContextValue(
     SenderUsername: params.sender.username,
     SenderTag: params.sender.tag,
     SenderIsBot: params.sender.isBot,
+    SenderIsSelf: params.sender.isSelf === true ? true : undefined,
     MemberRoleIds: params.sender.roles,
     Timestamp: params.timestamp,
     Provider: params.provider ?? params.channel,


### PR DESCRIPTION
Closes #123393

## What Problem This Solves

External direct-message turns reached the model with channel sender identity, but transcript persistence dropped that identity. Control UI then rendered the operator fallback label, `You`.

Current main `71d4a8c3e305c623aa3ffe92696eec18f116cfc6` reproduces the loss in `src/auto-reply/reply/get-reply-run-execute.ts`: an admitted direct turn stores no `senderId`, `senderName`, or `senderUsername`.

## Root cause

`executePreparedReplyRun` persisted sender metadata only for `group` and `channel` routes. The loss happened before `buildPersistedUserTurnMetadata`, so the existing Gateway and Control UI consumers had no durable identity to display.

## Fix

- Persist sender metadata for a `direct` route only when channel ingress admitted the turn and did not mark it as self-authored.
- Carry the existing iMessage `is_from_me` and WhatsApp `fromMe` facts through the shared inbound context.
- Keep group and channel behavior unchanged.
- Keep gateway-local and from-me direct turns attributed to the operator.
- Do not migrate old transcript rows.

## Evidence

- Pre-fix reproduction: the focused sender-attribution test fails on current main because the direct row has only owner and transport metadata.
- Exact head `4f18e6ad12ffdf639b11c2731ec7e3e8aa58dc3f`: 375 tests pass across reply persistence, shared inbound context, iMessage, WhatsApp, Gateway display projection, and Control UI normalization.
- Sibling matrix: admitted external direct persists; from-me direct does not; gateway-local direct does not; group and channel still persist without channel-admission metadata.
- Real Telegram direct-message run: one user message, two typing events, one bot reply, and one mock-provider request.
- Ephemeral Gateway verdict from the same run: `chat.history` returned the user turn with `senderId`, `senderName`, and `senderUsername`; the production Control UI grouping and label resolver returned `<redacted-peer-label>` with `renderedAsPeer: true`.
- Static proof: changed extension files pass Oxlint and the repository formatter.
- Exact-head CI: `openclaw/ci-gate` passed in run `33040236918`.
- Exact-head local ClawSweeper: patch correct, zero findings, security cleared, no maintainer decision, and zero rank-up moves.
- Contributor browser proof: [external peer label and operator label](https://github.com/user-attachments/assets/9d184fb3-f97b-435c-89c5-2b985c2f7613).

```json
{"externalDirectTurnFound":true,"gatewayHistoryRole":"user","storedSenderFields":["senderId","senderName","senderUsername"],"controlUiGroupRole":"user","renderedLabel":"<redacted-peer-label>","renderedAsPeer":true}
```

## Change size

- Production: +14/-3, net +11. The growth adds the self-origin fact and the admission-owned persistence decision.
- Tests: +121/-24, net +97. The tests cover the producer boundary and all sibling attribution cases.

## Compatibility

Future admitted external direct-message rows retain sender identifiers and names. This intentional display and transcript change is the feature. Existing rows and operator-authored rows stay unchanged.

## AI assistance

- AI-assisted repair and verification: Yes.
- Human contributor intent and authorship are preserved.
