### PR TITLE
fix(cli): merge nested MCP configure and tools patches

### DIFF
--- a/src/cli/mcp-cli.oauth.test.ts
+++ b/src/cli/mcp-cli.oauth.test.ts
@@ -196,6 +196,88 @@ describe("mcp cli OAuth", () => {
     });
   });
 
+  it.each([
+    {
+      name: "per-requester identity and redirect metadata",
+      oauth: {
+        identity: "per-requester",
+        scope: "docs.read",
+        redirectUrl: "https://gateway.example.com/oauth/mcp/callback",
+        clientMetadataUrl: "https://gateway.example.com/oauth/mcp.json",
+      },
+    },
+    {
+      name: "auth-profile binding",
+      oauth: { authProfileId: "docs:mcp", scope: "docs.read" },
+    },
+  ])("preserves $name when updating OAuth scope", async ({ oauth }) => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        JSON.stringify({
+          url: "https://mcp.example.com",
+          transport: "streamable-http",
+          auth: "oauth",
+          oauth,
+          toolFilter: { include: ["old_*"], exclude: ["admin_*"] },
+        }),
+      ]);
+
+      await runMcpCommand([
+        "mcp",
+        "configure",
+        "docs",
+        "--oauth-scope",
+        "docs.write",
+        "--include",
+        "search",
+      ]);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        oauth: { ...oauth, scope: "docs.write" },
+        toolFilter: { include: ["search"], exclude: ["admin_*"] },
+      });
+    });
+  });
+
+  it("does not restore previous OAuth metadata after an explicit clear", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        JSON.stringify({
+          url: "https://mcp.example.com",
+          auth: "oauth",
+          oauth: { authProfileId: "docs:mcp", scope: "docs.read" },
+        }),
+      ]);
+
+      await runMcpCommand([
+        "mcp",
+        "configure",
+        "docs",
+        "--clear-auth",
+        "--auth",
+        "oauth",
+        "--oauth-scope",
+        "docs.write",
+      ]);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine()).oauth).toEqual({ scope: "docs.write" });
+    });
+  });
+
   it("rejects operator login and logout for per-requester OAuth", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -426,6 +426,57 @@ describe("mcp cli", () => {
     });
   });
 
+  it.each([
+    {
+      command: "configure",
+      flag: "--include",
+      value: "search,read_*",
+      expected: { include: ["search", "read_*"], exclude: ["admin_*"] },
+    },
+    {
+      command: "configure",
+      flag: "--exclude",
+      value: "write_*",
+      expected: { include: ["old_*"], exclude: ["write_*"] },
+    },
+    {
+      command: "tools",
+      flag: "--include",
+      value: "search,read_*",
+      expected: { include: ["read_*", "search"], exclude: ["admin_*"] },
+    },
+    {
+      command: "tools",
+      flag: "--exclude",
+      value: "write_*",
+      expected: { include: ["old_*"], exclude: ["write_*"] },
+    },
+  ])(
+    "preserves sibling tool filters for $command $flag",
+    async ({ command, flag, value, expected }) => {
+      await withTempHome("openclaw-cli-mcp-home-", async () => {
+        const workspaceDir = await createWorkspace();
+        vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+        await runMcpCommand([
+          "mcp",
+          "set",
+          "docs",
+          JSON.stringify({
+            command: "node",
+            args: ["server.mjs"],
+            toolFilter: { include: ["old_*"], exclude: ["admin_*"] },
+          }),
+        ]);
+        await runMcpCommand(["mcp", command, "docs", flag, value]);
+
+        mockLog.mockClear();
+        await runMcpCommand(["mcp", "show", "docs", "--json"]);
+        expect(JSON.parse(lastLogLine()).toolFilter).toEqual(expected);
+      });
+    },
+  );
+
   it("requires an explicit MCP tool filter operation", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();
@@ -438,14 +489,17 @@ describe("mcp cli", () => {
     });
   });
 
-  it("clears per-server MCP tool filters only when requested", async () => {
+  it.each([
+    ["tools", "--clear"],
+    ["configure", "--clear-tools"],
+  ])("clears per-server MCP tool filters with %s %s", async (command, clearFlag) => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
 
       await runMcpCommand(["mcp", "set", "docs", '{"command":"node","args":["server.mjs"]}']);
       await runMcpCommand(["mcp", "tools", "docs", "--include", "search"]);
-      await runMcpCommand(["mcp", "tools", "docs", "--clear"]);
+      await runMcpCommand(["mcp", command, "docs", clearFlag]);
 
       mockLog.mockClear();
       await runMcpCommand(["mcp", "show", "docs", "--json"]);

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1249,6 +1249,7 @@ export function registerMcpCli(program: Command) {
           const exclude = parseCsvList(opts.exclude);
           if (include || exclude) {
             next.toolFilter = {
+              ...asRecord(next.toolFilter),
               ...(include ? { include } : {}),
               ...(exclude ? { exclude } : {}),
             };
@@ -1305,7 +1306,7 @@ export function registerMcpCli(program: Command) {
           clientMetadataUrl: opts.oauthClientMetadataUrl,
         });
         if (oauth) {
-          next.oauth = oauth;
+          next.oauth = { ...asRecord(next.oauth), ...oauth };
         }
         if (opts.clearTls) {
           delete next.sslVerify;

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -218,6 +218,7 @@ async function updateConfiguredMcpServerTools(
         const exclude = normalizeToolSelectionList(params.tools.exclude);
         if (include || exclude) {
           server.toolFilter = {
+            ...(isRecord(server.toolFilter) ? server.toolFilter : {}),
             ...(include ? { include } : {}),
             ...(exclude ? { exclude } : {}),
           };


### PR DESCRIPTION
Closes #124550

## What Problem This Solves

`openclaw mcp configure` is documented as updating an existing server without replacing it, and `openclaw mcp tools` updates its tool filters. Both commands instead replaced nested objects wholesale. Updating an OAuth scope silently dropped the server's per-requester identity, redirect URL, and other OAuth metadata; the existing credential lifecycle then interpreted that as an identity change and removed requester credentials. Updating only the tool allow-list silently removed the existing deny-list, or vice versa.

## Why This Change Was Made

Preserve existing nested fields at their actual mutation owners when configuring OAuth/tool filters or updating tool filters. Explicit `--clear-auth`, `--clear-tools`, and `mcp tools --clear` remain destructive; whole-server `mcp set` and `mcp add` remain replacements. A deliberate identity change still invalidates requester credentials without removing operator credentials.

Compatibility: one-sided include/exclude updates now follow the documented patch/update contract and retain the other list. Automation intentionally depending on the previous destructive behavior must use the existing explicit clear operation first.

Maintainer refinement preserves the original contribution by @zyw02 while reducing the production change to **+3/-1 lines (net +2)** across the two existing mutation owners. Regression coverage adds **+138/-2 test lines**; no new configuration surface, schema, fallback, or dependency is introduced.

## Evidence

### Exact-head real operator and SQLite credential proof

This is the observed, redacted real production Commander command path loaded directly from the checked-out TypeScript source on the exact reviewed head. Configuration was isolated, OAuth operator/requester rows were stored in the actual SQLite credential database, and no packaged executable, mocked command, external provider, network, or real secret was used. Credential output below reports presence only; token values are never printed.

```text
$ git rev-parse HEAD
b4529aa338dbb16c493b30738cc8989afeceeadf

$ mcp set docs '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth","oauth":{"identity":"per-requester","scope":"docs.read","redirectUrl":"https://gateway.example.com/oauth/mcp/callback"},"toolFilter":{"include":["old_*"],"exclude":["admin_*"]}}'
Saved MCP server "docs".
SQLite OAuth credential presence after isolated fixture setup: operator=true requester=true

$ mcp configure docs --oauth-scope docs.write --include search
Updated MCP server "docs".
$ mcp show docs --json
{"oauth":{"identity":"per-requester","scope":"docs.write","redirectUrl":"https://gateway.example.com/oauth/mcp/callback"},"toolFilter":{"include":["search"],"exclude":["admin_*"]}}
SQLite OAuth credential presence: operator=true requester=true

$ mcp tools docs --exclude write_*
Updated MCP tool selection for "docs".
$ mcp show docs --json
{"oauth":{"identity":"per-requester","scope":"docs.write","redirectUrl":"https://gateway.example.com/oauth/mcp/callback"},"toolFilter":{"include":["search"],"exclude":["write_*"]}}
SQLite OAuth credential presence: operator=true requester=true

$ mcp configure docs --clear-tools
Updated MCP server "docs".
$ mcp tools docs --clear
Updated MCP tool selection for "docs".

$ mcp configure docs --clear-auth
Updated MCP server "docs".
OAuth metadata after explicit clear: absent
SQLite OAuth credential presence after deliberate identity change: operator=true requester=false

$ focused CLI and real SQLite credential-lifecycle regressions
Test Files  3 passed (3)
Tests      50 passed (50)
```

The command lines above name the real Commander-dispatched MCP subcommands; they are **source-backed**, not a claim that a packaged `openclaw` binary was built or run. Both include/exclude patch directions and both explicit clear forms were exercised. This resolves the current-head real-behavior and compatibility concerns from the latest review; canonical exact-head GitHub CI run `32699485270` and the PR context/evidence check both completed successfully.

- Six newly added user-facing regression cases fail against the pre-fix source and pass after the owner-boundary fix.
- **50 focused tests pass:** 44 real-command CLI parsing/configuration tests and six credential-lifecycle tests backed by the actual SQLite credential store.
- Source-backed production Commander commands exercised `mcp set`, `mcp configure`, `mcp tools`, `mcp show`, and both explicit clear paths against isolated configuration and actual SQLite credential rows. Observed per-requester identity, redirect/client metadata, auth-profile bindings, and existing deny-lists surviving partial updates; deliberate OAuth clearing removed requester credentials while retaining operator credentials.
- Focused lint, formatter, and whitespace checks pass; independent pre-publication review reported no actionable findings.
- Existing ClawSweeper production-growth and stale-branch concerns are addressed by the net-2-line owner fix and a clean single-parent current-main refresh. The compatibility tradeoff and explicit-clear behavior are documented above. Exact-head GitHub CI remains the final landing gate.

Exact reviewed head: `b4529aa338dbb16c493b30738cc8989afeceeadf`.
