### PR TITLE
fix(ui): redact errors across Control UI surfaces

### DIFF
--- a/ui/src/app/cloud-session-startup.runtime.ts
+++ b/ui/src/app/cloud-session-startup.runtime.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewaySessionRow } from "../api/types.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import {
   createGatewayConnectionLifecycle,
   type GatewayConnectionScope,
@@ -281,7 +282,7 @@ export default function createApplicationCloudStartupRuntime(
       })
       .catch((error: unknown) => {
         if (findEntry(entry.owner.sessionKey)?.entry === entry) {
-          setEntryState(entry, "failed", { error: String(error), retryable: true });
+          setEntryState(entry, "failed", { error: formatUiError(error), retryable: true });
           if (entry.persistRecovery) {
             entry.recovery = null;
           }

--- a/ui/src/app/cloud-session-startup.ts
+++ b/ui/src/app/cloud-session-startup.ts
@@ -1,3 +1,4 @@
+import { formatUiError } from "../lib/format-error.ts";
 import type { CloudSessionRecovery } from "../lib/sessions/cloud-recovery.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import type { ApplicationGateway } from "./gateway.ts";
@@ -77,7 +78,7 @@ export function createApplicationCloudStartup(
       },
       (error: unknown) => {
         runtimeLoad = undefined;
-        runtimeError = error instanceof Error ? error.message : String(error);
+        runtimeError = formatUiError(error);
         publish();
       },
     ));

--- a/ui/src/app/device-auth-migration-loader.ts
+++ b/ui/src/app/device-auth-migration-loader.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import type {
   DeviceAuthMigrationController,
   DeviceAuthMigrationSnapshot,
@@ -40,7 +41,7 @@ export function createDeviceAuthMigrationLoader(params: {
           params.onChange({
             ...EMPTY_DEVICE_AUTH_MIGRATION,
             error: t("login.deviceAuthMigration.loadFailed", {
-              error: error instanceof Error ? error.message : String(error),
+              error: formatUiError(error),
             }),
           });
         }

--- a/ui/src/app/device-auth-migration.ts
+++ b/ui/src/app/device-auth-migration.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { peekStoredDeviceIdentityId } from "../lib/nodes/index.ts";
 import type { ApplicationGateway } from "./gateway.ts";
 import "../components/device-auth-migration-banner.ts";
@@ -70,7 +71,7 @@ export function createDeviceAuthMigrationController(params: {
         });
       } catch (error) {
         if (refreshGeneration === generation && params.isCurrent(client, epoch)) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message = formatUiError(error);
           update({
             error: t("login.deviceAuthMigration.loadFailed", {
               error: message,
@@ -103,7 +104,7 @@ export function createDeviceAuthMigrationController(params: {
         params.gateway.connect();
       } catch (error) {
         if (!disposed && params.isCurrent(client, epoch)) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message = formatUiError(error);
           update({
             busy: false,
             error: t("login.deviceAuthMigration.approvalFailed", {

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -359,6 +359,29 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.lastError).toContain("4008");
   });
 
+  it("redacts a secret-shaped WebSocket close reason", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1006,
+      reason: "OPENAI_API_KEY=sk-1234567890abcdef",
+      willRetry: true,
+    });
+
+    expect(gateway.snapshot.lastError).toContain("OPENAI_API_KEY=sk-123...cdef");
+    expect(gateway.snapshot.lastError).not.toContain("sk-1234567890abcdef");
+  });
+
+  it("uses translated fallback copy for an empty WebSocket close reason", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({ code: 1006, reason: "", willRetry: true });
+
+    expect(gateway.snapshot.lastError).toBe("disconnected (1006): Unknown");
+  });
+
   it("starts a newly selected Gateway as a fresh connection", () => {
     const { gateway, clients, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -449,8 +449,8 @@ export function createApplicationGateway(
           hello: null,
           canvasPluginSurfaceUrl: null,
           selfUser: null,
-          lastError: error
-            ? formatUiError(error)
+          lastError: error?.message
+            ? formatUiError(error.message)
             : `disconnected (${code}): ${reason || "no reason"}`,
           lastErrorCode: resolveGatewayErrorDetailCode(error) ?? error?.code ?? null,
         });

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -12,6 +12,7 @@ import {
 } from "../api/gateway.ts";
 import { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } from "../build-info.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
@@ -448,7 +449,9 @@ export function createApplicationGateway(
           hello: null,
           canvasPluginSurfaceUrl: null,
           selfUser: null,
-          lastError: error?.message ?? `disconnected (${code}): ${reason || "no reason"}`,
+          lastError: error
+            ? formatUiError(error)
+            : `disconnected (${code}): ${reason || "no reason"}`,
           lastErrorCode: resolveGatewayErrorDetailCode(error) ?? error?.code ?? null,
         });
       },

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -11,8 +11,9 @@ import {
   type GatewayHelloOk,
 } from "../api/gateway.ts";
 import { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } from "../build-info.ts";
+import { t } from "../i18n/index.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
-import { formatUiError } from "../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
@@ -451,7 +452,7 @@ export function createApplicationGateway(
           selfUser: null,
           lastError: error?.message
             ? formatUiError(error.message)
-            : `disconnected (${code}): ${reason || "no reason"}`,
+            : `disconnected (${code}): ${formatUiExternalText(reason, t("common.unknown"))}`,
           lastErrorCode: resolveGatewayErrorDetailCode(error) ?? error?.code ?? null,
         });
       },

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -19,6 +19,7 @@ import {
   setDevicePairSetupAccess as setPairAccess,
   syncDevicePairSetupCountdown,
 } from "../lib/device-pair-setup.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import {
   createDeviceAuthMigrationLoader,
   EMPTY_DEVICE_AUTH_MIGRATION,
@@ -518,7 +519,7 @@ export function createApplicationOverlays(
           updateStatusBanner: {
             tone: "danger",
             text: t("updates.error", {
-              error: error instanceof Error ? error.message : String(error),
+              error: formatUiError(error),
             }),
           },
         };
@@ -570,7 +571,7 @@ export function createApplicationOverlays(
         return response.ok;
       } catch (error) {
         if (!disposed && gateway.snapshot.client === client) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message = formatUiError(error);
           publishUpdateBanner({ tone: "danger", text: t("updates.error", { error: message }) });
         }
         return false;
@@ -634,10 +635,7 @@ export function createApplicationOverlays(
           isCurrentOperation() &&
           promptState.execApprovalQueue.some((entry) => entry.id === active.id)
         ) {
-          promptState.execApprovalErrors.set(
-            active.id,
-            `Approval failed: ${error instanceof Error ? error.message : String(error)}`,
-          );
+          promptState.execApprovalErrors.set(active.id, `Approval failed: ${formatUiError(error)}`);
         }
       } finally {
         // Reconnect can admit a new decision while this request is still settling.

--- a/ui/src/app/question-prompt.ts
+++ b/ui/src/app/question-prompt.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, type GatewayEventFrame } from "../api/gateway.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import {
   publishQuestionClientResolution,
   registerQuestionClientOwner,
@@ -714,7 +715,7 @@ async function resolveQuestionPrompt(
     }
     current.submitting = false;
     if (current.status === "pending") {
-      current.error = error instanceof Error ? error.message : String(error);
+      current.error = formatUiError(error);
       current.revision = ++state.revision;
       state.onChange();
       return;

--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -1,6 +1,7 @@
 import type { GatewayBrowserClient, GatewayHelloOk } from "../api/gateway.ts";
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiExternalText } from "../lib/format-error.ts";
 import { formatCountdown } from "../lib/format.ts";
 import { readUpdateAvailableValue, readUpdateScheduleValue } from "./update-schedule-dto.ts";
 
@@ -98,7 +99,7 @@ function readUpdateFailureCause(
     : undefined;
   const detail = lastLogLine(failed?.log?.stderrTail) ?? lastLogLine(failed?.log?.stdoutTail);
   const step = failed?.name?.trim();
-  return step && detail ? { step, detail } : null;
+  return step && detail ? { step, detail: formatUiExternalText(detail) } : null;
 }
 
 export type UpdateRunResponse = {

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { generateUUID } from "../lib/uuid.ts";
@@ -253,7 +254,7 @@ export class SessionCatalogLiveState {
 
   warnRequestError(error: unknown) {
     const code = error instanceof GatewayRequestError ? error.gatewayCode : "UNAVAILABLE";
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatUiError(error);
     const signature = `${code}\u0000${message}`;
     if (this.warnedRequestErrors.has(signature)) {
       return;

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -8,6 +8,7 @@ import type { GatewaySessionRow } from "../api/types.ts";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { handleContextMenuEvent } from "../lib/keyboard-shortcuts.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogSessionKey } from "../lib/sessions/catalog-key.ts";
@@ -101,7 +102,7 @@ function catalogErrorMessages(catalog: SessionCatalog): string[] {
   const messages = new Set<string>();
   const add = (error: SessionCatalog["error"]) => {
     if (error) {
-      messages.add(`[${error.code}] ${error.message}`);
+      messages.add(formatUiError(`[${error.code}] ${error.message}`));
     }
   };
   add(catalog.error);
@@ -296,7 +297,9 @@ function renderCatalogHostGroup(
   liveRowsByKey: ReadonlyMap<string, GatewaySessionRow>,
   params: SessionCatalogGroupsParams,
 ) {
-  const errorHelp = host.error ? `[${host.error.code}] ${host.error.message}` : undefined;
+  const errorHelp = host.error
+    ? formatUiError(`[${host.error.code}] ${host.error.message}`)
+    : undefined;
   const projectGroups =
     params.projectGrouping === "project"
       ? groupCatalogSessionsByProject(host.sessions)

--- a/ui/src/components/app-sidebar-session-catalog-state.ts
+++ b/ui/src/components/app-sidebar-session-catalog-state.ts
@@ -5,12 +5,13 @@ import type {
   SessionsCatalogListResult,
 } from "../../../packages/gateway-protocol/src/index.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { sessionCatalogHostKey } from "./app-sidebar-session-types.ts";
 
 export function sessionCatalogRequestError(error: unknown): NonNullable<SessionCatalog["error"]> {
   return {
     code: error instanceof GatewayRequestError ? error.gatewayCode : "UNAVAILABLE",
-    message: error instanceof Error ? error.message : String(error),
+    message: formatUiError(error),
   };
 }
 

--- a/ui/src/components/board/board-mcp-app-lifecycle.ts
+++ b/ui/src/components/board/board-mcp-app-lifecycle.ts
@@ -1,5 +1,6 @@
 import type { BoardWidget } from "../../lib/board/types.ts";
 import type { BoardWidgetAppViewState } from "../../lib/board/view-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 
 const REFRESH_LEAD_MS = 5_000;
 type AppViewMode = "cached" | "refresh" | "expired";
@@ -278,7 +279,7 @@ export class BoardMcpAppLifecycle {
       this.clearTimers();
       this.state = {
         status: "stale",
-        error: error instanceof Error ? error.message : String(error),
+        error: formatUiError(error),
       };
       this.loading = false;
       this.notify();

--- a/ui/src/components/board/board-widget-cell-render.ts
+++ b/ui/src/components/board/board-widget-cell-render.ts
@@ -3,6 +3,7 @@ import { t } from "../../i18n/index.ts";
 import type { BoardTab } from "../../lib/board/types.ts";
 import type { BoardWidget } from "../../lib/board/types.ts";
 import type { BoardGrantDecision } from "../../lib/board/view-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { renderBoardPendingCapabilities } from "./board-widget-capabilities.ts";
 
 export const BOARD_SIZE_PRESETS = {
@@ -131,7 +132,7 @@ export function renderBoardDisabledPlugin(options: {
 }
 
 export function renderBoardWidgetError(error: unknown, onRetry?: () => void): TemplateResult {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatUiError(error);
   return html`
     <div class="board-widget__error" role="alert" data-test-id="board-widget-error">
       <strong>${t("board.widget.errorTitle")}</strong>

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -19,6 +19,7 @@ import {
   pluginIdForWidgetKind,
   type PluginBoardWidgetRenderer,
 } from "../../lib/board/widgets/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { renderBoardMcpAppContent } from "./board-mcp-app-content.ts";
 import { BoardMcpAppLifecycle } from "./board-mcp-app-lifecycle.ts";
@@ -162,7 +163,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     try {
       await action();
     } catch (error) {
-      this.actionError = error instanceof Error ? error.message : String(error);
+      this.actionError = formatUiError(error);
     } finally {
       this.actionPending = false;
     }
@@ -314,7 +315,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       })
       .catch((error: unknown) => {
         if (this.pluginRendererLoadToken === loadToken) {
-          this.pluginRendererError = error instanceof Error ? error.message : String(error);
+          this.pluginRendererError = formatUiError(error);
           this.requestUpdate();
         }
       });

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -5,6 +5,7 @@ import type { BoardWidget } from "../../lib/board/types.ts";
 import type { BoardWidgetFrameUrl } from "../../lib/board/view-types.ts";
 import { BoardWidgetSandboxHost } from "../../lib/board/widget-sandbox-host.ts";
 import { remainingBoardWidgetTicketTtlMs } from "../../lib/board/widget-ticket-lifetime.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { resolveGatewayHttpOrigin, resolveSandboxHostUrl } from "../sandbox-host.ts";
 
 // Keep in sync with the identical literal in chat widget-card.ts: a shared
@@ -310,7 +311,7 @@ export class BoardWidgetFrameLifecycle {
     }
     this.frameRefreshAttempts += 1;
     void refreshFrame(widget.name).catch((error: unknown) => {
-      this.setError(error instanceof Error ? error.message : String(error));
+      this.setError(formatUiError(error));
     });
     if (this.frameRefreshAttempts >= MAX_FRAME_REFRESH_ATTEMPTS) {
       this.setError(resolveBoardFrameFailureMessage(widget, this.sandboxOrigin));
@@ -406,7 +407,7 @@ export class BoardWidgetFrameLifecycle {
         this.setError("");
       },
       onError: (error) => {
-        this.setError(error instanceof Error ? error.message : String(error));
+        this.setError(formatUiError(error));
       },
     };
   }

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -1,6 +1,7 @@
 import type { ReactiveController } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type { AnnotationStroke } from "./browser-annotation.ts";
 import type { BrowserInspectedNode, BrowserPanelTab } from "./browser-client.ts";
 import {
@@ -125,7 +126,7 @@ export class BrowserPanelController implements ReactiveController {
   }
 
   reportError(error: unknown): void {
-    const detail = error instanceof Error ? error.message : String(error);
+    const detail = formatUiError(error);
     this.setState("errorText", t("browser.errors.requestFailed", { error: detail }));
   }
 

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -564,11 +564,9 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       return;
     }
     this.state = "disconnected";
-    this.disconnectedReason = reason
-      ? formatUiExternalText(reason)
-      : code
-        ? t("desktop.closeCode", { code: String(code) })
-        : null;
+    this.disconnectedReason =
+      formatUiExternalText(reason, code ? t("desktop.closeCode", { code: String(code) }) : "") ||
+      null;
   }
 
   private async launchApp(app: DesktopAppId): Promise<void> {

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -10,7 +10,7 @@ import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
 import { scrollbarShadowStyles } from "../../lit/scrollbar-styles.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
@@ -477,7 +477,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         onSecurityFailure: (detail) => {
           if (pending.operationId === this.operationId) {
             this.errorText = t("desktop.errors.securityFailed", {
-              reason: detail.reason ?? t("desktop.unknownReason"),
+              reason: formatUiExternalText(detail.reason, t("desktop.unknownReason")),
             });
           }
         },
@@ -546,7 +546,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       };
       this.state = "credentials";
       this.errorText = t("desktop.errors.securityFailed", {
-        reason: reason || t("desktop.unknownReason"),
+        reason: formatUiExternalText(reason, t("desktop.unknownReason")),
       });
       return;
     }
@@ -564,8 +564,11 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       return;
     }
     this.state = "disconnected";
-    this.disconnectedReason =
-      reason || (code ? t("desktop.closeCode", { code: String(code) }) : null);
+    this.disconnectedReason = reason
+      ? formatUiExternalText(reason)
+      : code
+        ? t("desktop.closeCode", { code: String(code) })
+        : null;
   }
 
   private async launchApp(app: DesktopAppId): Promise<void> {

--- a/ui/src/components/input-dialog.ts
+++ b/ui/src/components/input-dialog.ts
@@ -1,6 +1,7 @@
 // Control UI helper presents Promise-based text input without relying on a native prompt bridge.
 import { html, nothing, render } from "lit";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import "./modal-dialog.ts";
 
 type InputDialogOptions = {
@@ -104,7 +105,7 @@ function presentInputDialog(options: InputDialogOptions): Promise<string | null>
       try {
         message = await options.submit(value);
       } catch (error) {
-        message = String(error);
+        message = formatUiError(error);
       }
       if (settled) {
         return;

--- a/ui/src/components/lazy-view-error.ts
+++ b/ui/src/components/lazy-view-error.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { icon } from "./icons.ts";
 
 export function renderLazyViewError({
@@ -13,7 +14,7 @@ export function renderLazyViewError({
   render?: () => unknown;
   stale?: boolean;
 }) {
-  const detail = error instanceof Error ? error.message : String(error);
+  const detail = formatUiError(error);
   const errorClasses = `lazy-view-error${render ? " lazy-view-error--inline" : ""}${stale ? " lazy-view-error--stale" : ""}`;
   return html`
     ${render?.() ?? nothing}

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -12,6 +12,7 @@ import {
   shouldShowInsecureContextHint,
 } from "../lib/connection-hints.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { renderConnectCommand } from "./connect-command.ts";
 import { icons } from "./icons.ts";
@@ -78,7 +79,7 @@ function resolveDocsLabel(href: string): string {
 
 // Shared with offline presentation so no disconnected surface prints credentials.
 export function redactLoginFailureError(value: string): string {
-  return value
+  const redacted = value
     .replace(
       /([?#&])(?:access_token|auth|deviceToken|password|refresh_token|token)=([^&#\s]+)/gi,
       "$1[redacted-credential]",
@@ -88,6 +89,7 @@ export function redactLoginFailureError(value: string): string {
       /(["']?(?:access|accessToken|deviceToken|password|refresh|refreshToken|token)["']?\s*[:=]\s*)["']?[^"',\s}]+/gi,
       "$1[redacted]",
     );
+  return formatUiError(redacted);
 }
 
 function buildFeedback(params: {

--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -13,6 +13,7 @@ import { property } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
 import { I18nController, t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { openExternalUrlSafe } from "../lib/open-external-url.ts";
 import {
   buildMcpAppHostCapabilities,
@@ -498,12 +499,7 @@ export class McpAppView extends LitElement {
     const error = this.setupTask.status === TaskStatus.ERROR ? this.setupTask.error : null;
     const errorText = error
       ? t("mcpApp.unavailable", {
-          error:
-            error instanceof Error
-              ? error.message
-              : typeof error === "string"
-                ? error
-                : t("mcpApp.errors.requestFailed"),
+          error: formatUiError(error, t("mcpApp.errors.requestFailed")),
         })
       : null;
     return html`<div ${ref(this.mount)} class="mount"></div>

--- a/ui/src/components/mcp-servers-card.ts
+++ b/ui/src/components/mcp-servers-card.ts
@@ -16,6 +16,7 @@ import {
   type McpServerSummary,
   type McpServersPatchBuildResult,
 } from "../lib/config/mcp-servers.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons } from "./icons.ts";
@@ -68,7 +69,7 @@ class McpServersCard extends OpenClawLightDomElement {
           .catch((error: unknown) => {
             this.message = {
               kind: "error",
-              text: error instanceof Error ? error.message : String(error),
+              text: formatUiError(error),
             };
           });
         return runtimeConfig.subscribe(() => this.syncRows());

--- a/ui/src/components/onboarding-memory-import.test.ts
+++ b/ui/src/components/onboarding-memory-import.test.ts
@@ -401,7 +401,7 @@ describe("OnboardingMemoryImport", () => {
         return createPlan(["codex", "claude"]);
       }
       if (params?.providerId === "codex") {
-        throw new Error("Codex import unavailable");
+        throw new Error("Codex import unavailable: OPENAI_API_KEY=sk-1234567890abcdef");
       }
       return createApplyResult("claude", 1, 0);
     });
@@ -429,7 +429,8 @@ describe("OnboardingMemoryImport", () => {
       .filter(([method]) => method === "migrations.memory.apply")
       .map(([, params]) => (params as { providerId: string }).providerId);
     expect(applyProviders).toEqual(["codex", "claude"]);
-    expect(element.textContent).toContain("Codex import unavailable");
+    expect(element.textContent).toContain("Codex import unavailable: OPENAI_API_KEY=sk-123...cdef");
+    expect(element.textContent).not.toContain("sk-1234567890abcdef");
     expect(element.textContent).toContain("Migrated 1, skipped 0");
   });
 });

--- a/ui/src/components/onboarding-memory-import.ts
+++ b/ui/src/components/onboarding-memory-import.ts
@@ -10,6 +10,7 @@ import type { RouteId } from "../app-routes.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { hasOperatorAdminAccess } from "../app/operator-access.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import "../styles/onboarding-memory-import.css";
@@ -23,11 +24,7 @@ type ProviderResult =
   | { kind: "error"; message: string };
 
 function toErrorMessage(error: unknown): string {
-  return error instanceof Error && error.message.trim()
-    ? error.message
-    : typeof error === "string"
-      ? error
-      : t("onboarding.memoryImport.unknownError");
+  return formatUiError(error, t("onboarding.memoryImport.unknownError"));
 }
 
 function createIdempotencyKey(): string {

--- a/ui/src/components/onboarding-memory-import.ts
+++ b/ui/src/components/onboarding-memory-import.ts
@@ -10,7 +10,7 @@ import type { RouteId } from "../app-routes.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { hasOperatorAdminAccess } from "../app/operator-access.ts";
 import { t } from "../i18n/index.ts";
-import { formatUiError } from "../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import "../styles/onboarding-memory-import.css";
@@ -346,7 +346,9 @@ class OnboardingMemoryImport extends OpenClawLightDomElement {
                   </span>`
                 : result?.kind === "error"
                   ? html`<span role="alert">
-                      ${t("onboarding.memoryImport.providerError", { error: result.message })}
+                      ${t("onboarding.memoryImport.providerError", {
+                        error: formatUiExternalText(result.message),
+                      })}
                     </span>`
                   : nothing}
         </div>

--- a/ui/src/components/panel-refresh-status.ts
+++ b/ui/src/components/panel-refresh-status.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 
 export type PanelRefreshStatus = Readonly<{
   error: string | null;
@@ -27,7 +28,7 @@ export function completePanelRefresh(): PanelRefreshStatus {
 
 export function failPanelRefresh(status: PanelRefreshStatus, error: string): PanelRefreshStatus {
   return {
-    error,
+    error: formatUiError(error),
     hasLoaded: status.hasLoaded,
     stale: status.hasLoaded,
   };
@@ -40,7 +41,8 @@ export function renderPanelRefreshStatus(params: {
   className?: string;
 }): TemplateResult | typeof nothing {
   const { status } = params;
-  const error = params.errorMessage ?? status.error;
+  const rawError = params.errorMessage ?? status.error;
+  const error = rawError ? formatUiError(rawError) : rawError;
   if (!error && !status.stale) {
     return nothing;
   }

--- a/ui/src/components/provider-usage.ts
+++ b/ui/src/components/provider-usage.ts
@@ -4,6 +4,7 @@
 import { html, nothing } from "lit";
 import type { ProviderUsageSnapshot } from "../../../src/infra/provider-usage.types.js";
 import { t } from "../i18n/index.ts";
+import { formatUiExternalText } from "../lib/format-error.ts";
 import { formatCompactTokenCount } from "../lib/format.ts";
 
 function formatProviderAmount(amount: number, unit: string): string {
@@ -181,7 +182,7 @@ function renderProviderCostHistory(snapshot: ProviderUsageSnapshot) {
  */
 export function renderProviderUsageDetails(snapshot: ProviderUsageSnapshot) {
   if (snapshot.error) {
-    return html`<div class="provider-usage-error">${snapshot.error}</div>`;
+    return html`<div class="provider-usage-error">${formatUiExternalText(snapshot.error)}</div>`;
   }
   return html`
     ${snapshot.windows.length > 0

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -9,6 +9,7 @@ import {
 } from "../app/approval-presentation.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { readPresenceEntries, type PresencePayload } from "../app/user-profile.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import {
   CATALOG_SESSION_CONTINUED_EVENT,
   type CatalogSessionContinuedDetail,
@@ -771,7 +772,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   publishSessionMutationError(scope: SidebarSessionMutationScope, error: unknown): void {
     if (this.isSessionMutationScopeCurrent(scope)) {
-      this.sessionMutationError = error instanceof Error ? error.message : String(error);
+      this.sessionMutationError = formatUiError(error);
       this.notify();
     }
   }

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -2,6 +2,7 @@ import { readMissingScopeError } from "@openclaw/gateway-client/browser";
 import { html, nothing, render } from "lit";
 import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
 import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import { renderSessionMenuItem } from "../pages/new-session/cloud-target.ts";
 import type { BrowserTarget } from "../pages/new-session/discovery.ts";
 import { folderDisplayName, isAbsolutePath } from "../pages/new-session/path.ts";
@@ -65,7 +66,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
           worktree: data.get("mode") === "worktree",
         });
       } catch (error) {
-        failure = String(error);
+        failure = formatUiError(error);
       }
       if (!failure) {
         finish();
@@ -123,9 +124,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
         }
         browserError = readMissingScopeError(error)?.missingScope
           ? t("newSession.browseRequiresAdmin")
-          : error instanceof Error
-            ? error.message
-            : t("newSession.browserLoadFailed");
+          : formatUiError(error, t("newSession.browserLoadFailed"));
       } finally {
         if (requestToken === browserRequestToken) {
           browserLoading = false;

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -198,7 +198,7 @@ export async function patchSessionRows(
   const successful = dispatched.flatMap(({ rows: chunkRows, result }) =>
     result.outcomes.flatMap((outcome, index) => {
       if (!outcome.ok) {
-        errors.push(`${outcome.key}: ${formatUiError(outcome.error)}`);
+        errors.push(`${outcome.key}: ${formatUiError(outcome.error.message)}`);
         return [];
       }
       const row = chunkRows[index];

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -198,7 +198,7 @@ export async function patchSessionRows(
   const successful = dispatched.flatMap(({ rows: chunkRows, result }) =>
     result.outcomes.flatMap((outcome, index) => {
       if (!outcome.ok) {
-        errors.push(`${outcome.key}: ${outcome.error.message}`);
+        errors.push(`${outcome.key}: ${formatUiError(outcome.error)}`);
         return [];
       }
       const row = chunkRows[index];

--- a/ui/src/components/terminal/terminal-panel-chrome.ts
+++ b/ui/src/components/terminal/terminal-panel-chrome.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type { DockPanelPlacement } from "../dock-panel-layout.ts";
 import { icons } from "../icons.ts";
 import { renderPanelEmptyState } from "../panel-empty-state.ts";
@@ -106,5 +107,5 @@ export function terminalOpenErrorText(error: unknown): string {
   if (error instanceof TerminalOpenUnusableSessionError) {
     return t("terminal.unavailable");
   }
-  return error instanceof Error ? error.message : String(error);
+  return formatUiError(error);
 }

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -1,6 +1,7 @@
 import type { GhosttyTerminalController } from "@openclaw/libterminal/browser";
 import type { ReactiveController } from "lit";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import {
   TerminalConnection,
   type TerminalGatewayClient,
@@ -665,7 +666,7 @@ export class TerminalPanelSessionController
     tab.exitReason = info.reason;
     tab.exitCode = info.exitCode;
     if (info.error?.trim()) {
-      this.host.terminalPanelErrorText = info.error.trim();
+      this.host.terminalPanelErrorText = formatUiExternalText(info.error);
     }
     // The connection drops its own sink on exit delivery, so no release() here —
     // the session id may not be recorded yet when an early exit is replayed.

--- a/ui/src/components/terminal/terminal-panel-upload.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.ts
@@ -1,6 +1,7 @@
 import type { GhosttyTerminalController } from "@openclaw/libterminal/browser";
 import { html, nothing } from "lit";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { renderDockDestinations } from "../dock-destination-controls.ts";
 import { icons } from "../icons.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
@@ -192,7 +193,7 @@ export class TerminalPanelUploadController {
       return;
     }
     batch.state = "failed";
-    batch.error = error instanceof Error ? error.message : String(error);
+    batch.error = formatUiError(error);
     batch.retryable = retryable;
     this.host.requestUpdate();
   }

--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { WizardStep } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiExternalText } from "../lib/format-error.ts";
 import { renderChannelPicker } from "./channel-picker.ts";
 import { handleCopyButton } from "./copy-button.ts";
 import { renderPicker } from "./select-picker.ts";
@@ -35,7 +36,9 @@ function stepClass(props: WizardStepControlsProps, name: string): string {
 
 function renderMessage(props: WizardStepControlsProps) {
   return props.step.message
-    ? html`<div class=${stepClass(props, "message")}>${props.step.message}</div>`
+    ? html`<div class=${stepClass(props, "message")}>
+        ${formatUiExternalText(props.step.message)}
+      </div>`
     : nothing;
 }
 
@@ -66,7 +69,9 @@ function renderDeviceCode(step: WizardStep) {
   const copyLabel = t("modelSetup.wizard.copy");
   return html`
     <div class="wizard-step__device-code">
-      ${deviceCode.message ? html`<div class="muted">${deviceCode.message}</div>` : nothing}
+      ${deviceCode.message
+        ? html`<div class="muted">${formatUiExternalText(deviceCode.message)}</div>`
+        : nothing}
       <code>${deviceCode.code}</code>
       <button
         type="button"
@@ -226,7 +231,7 @@ function renderTextStep(props: WizardStepControlsProps) {
     >
       ${step.message
         ? html`<div class=${stepClass(props, "message")}>
-            <label for=${props.inputId}>${step.message}</label>
+            <label for=${props.inputId}>${formatUiExternalText(step.message)}</label>
           </div>`
         : nothing}
       ${input} ${renderAnswerButton(props, t("modelSetup.wizard.submit"))}

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -206,7 +206,7 @@ suite.define(() => {
         await page.getByText("Needs attention", { exact: true }).first().waitFor();
         await page
           .getByText(
-            "Could not refresh Control UI configuration: GatewayRequestError: authoritative snapshot unavailable",
+            "Could not refresh Control UI configuration: authoritative snapshot unavailable",
           )
           .waitFor();
         expect(await page.getByText("Could not update Active memory").count()).toBe(0);

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -424,55 +424,69 @@ suite.define(() => {
   });
 
   it("keeps identity refresh single-flight and retries after a failed request", async () => {
-    await suite.withPage(undefined, async ({ page }) => {
-      const gateway = await installMockGateway(page, {
-        basePath,
-        deferredMethods: ["users.self"],
-        presenceUsers: testPresenceUsers,
-        methodResponses: {
-          "users.self": { profile: testProfile },
-        },
-      });
+    await suite.withPage(
+      {
+        ...(captureUiProof
+          ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
+          : {}),
+        viewport: { width: 1280, height: 800 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          basePath,
+          deferredMethods: ["users.self"],
+          presenceUsers: testPresenceUsers,
+          methodResponses: {
+            "users.self": { profile: testProfile },
+          },
+        });
 
-      const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
+        expect(response?.status()).toBe(200);
 
-      const refresh = page.locator(".profile-refresh");
-      await gateway.waitForRequest("users.self");
-      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
-      await expect.poll(() => refresh.isDisabled()).toBe(true);
-      expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
+        const refresh = page.locator(".profile-refresh");
+        await gateway.waitForRequest("users.self");
+        await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
+        await expect.poll(() => refresh.isDisabled()).toBe(true);
+        expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
 
-      await refresh.evaluate((element) => {
-        const button = element as HTMLButtonElement;
-        button.click();
-        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      });
-      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
+        await refresh.evaluate((element) => {
+          const button = element as HTMLButtonElement;
+          button.click();
+          button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
 
-      await gateway.rejectDeferred("users.self", { message: "identity unavailable" });
-      await page.getByText("identity unavailable", { exact: true }).waitFor({ timeout: 10_000 });
-      await expect.poll(() => refresh.isEnabled()).toBe(true);
-      expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
+        await gateway.rejectDeferred("users.self", {
+          message: "identity unavailable: OPENAI_API_KEY=sk-1234567890abcdef",
+        });
+        await page
+          .getByText("identity unavailable: OPENAI_API_KEY=sk-123...cdef", { exact: true })
+          .waitFor({ timeout: 10_000 });
+        await expect(page.getByText("sk-1234567890abcdef").count()).resolves.toBe(0);
+        await expect.poll(() => refresh.isEnabled()).toBe(true);
+        expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
+        await screenshot(page, "07-redacted-identity-error.png");
 
-      await gateway.deferNext("users.self");
-      await refresh.click();
-      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
-      await expect.poll(() => refresh.isDisabled()).toBe(true);
-      expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
+        await gateway.deferNext("users.self");
+        await refresh.click();
+        await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+        await expect.poll(() => refresh.isDisabled()).toBe(true);
+        expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
 
-      await refresh.evaluate((element) => {
-        (element as HTMLButtonElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      });
-      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+        await refresh.evaluate((element) => {
+          (element as HTMLButtonElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
 
-      await gateway.resolveDeferred("users.self", { profile: testProfile });
-      const displayName = page.locator('.identity-name-control input[type="text"]');
-      await displayName.waitFor({ timeout: 10_000 });
-      await expect(displayName.inputValue()).resolves.toBe(testProfile.displayName);
-      await expect.poll(() => refresh.isEnabled()).toBe(true);
-      expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
-    });
+        await gateway.resolveDeferred("users.self", { profile: testProfile });
+        const displayName = page.locator('.identity-name-control input[type="text"]');
+        await displayName.waitFor({ timeout: 10_000 });
+        await expect(displayName.inputValue()).resolves.toBe(testProfile.displayName);
+        await expect.poll(() => refresh.isEnabled()).toBe(true);
+        expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
+      },
+    );
   });
 
   it("keeps event revisions through same-timestamp avatar responses", async () => {

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -367,7 +367,7 @@ describe("loadToolsCatalog", () => {
     await loadToolsCatalog(state, "main");
 
     expect(state.toolsCatalogResult).toBeNull();
-    expect(state.toolsCatalogError).toBe("Error: gateway unavailable");
+    expect(state.toolsCatalogError).toBe("gateway unavailable");
     expect(state.toolsCatalogLoading).toBe(false);
   });
 
@@ -475,7 +475,7 @@ describe("loadToolsEffective", () => {
 
     expect(state.toolsEffectiveResult).toBeNull();
     expect(state.toolsEffectiveResultKey).toBeNull();
-    expect(state.toolsEffectiveError).toBe("Error: gateway unavailable");
+    expect(state.toolsEffectiveError).toBe("gateway unavailable");
     expect(state.toolsEffectiveLoading).toBe(false);
   });
 

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -7,6 +7,7 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
+import { formatUiError } from "../format-error.ts";
 import {
   createGatewayConnectionLifecycle,
   type GatewayConnectionSnapshot,
@@ -117,7 +118,7 @@ function resolveToolsErrorMessage(
 ): string {
   return isMissingOperatorReadScopeError(err)
     ? formatMissingOperatorReadScopeMessage(target)
-    : String(err);
+    : formatUiError(err);
 }
 
 export async function loadToolsCatalog(state: AgentToolsState, agentId: string) {
@@ -304,7 +305,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         if (lifecycle.isCurrent(scope) && state.listRevision === revision) {
           state.agentsError = isMissingOperatorReadScopeError(err)
             ? formatMissingOperatorReadScopeMessage("agent list")
-            : String(err);
+            : formatUiError(err);
         }
         return null;
       })
@@ -355,7 +356,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
       })
       .catch((err: unknown) => {
         if (lifecycle.isCurrent(scope) && fileRequestOwners.get(agentId) === owner) {
-          status.error = String(err);
+          status.error = formatUiError(err);
         }
         return null;
       })

--- a/ui/src/lib/agents/tools-effective.ts
+++ b/ui/src/lib/agents/tools-effective.ts
@@ -1,4 +1,3 @@
-// Shared effective-tools loading for agent and Chat model changes.
 import type {
   ModelCatalogEntry,
   SessionsListResult,
@@ -9,6 +8,8 @@ import {
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "../chat/model-ref.ts";
+// Shared effective-tools loading for agent and Chat model changes.
+import { formatUiError } from "../format-error.ts";
 import type { SessionCapability } from "../sessions/index.ts";
 import { resolveAgentIdFromSessionKey } from "../sessions/session-key.ts";
 
@@ -83,7 +84,7 @@ export async function loadToolsEffective(
     if (shouldIgnoreResponse()) {
       return;
     }
-    state.toolsEffectiveError = options.onError?.(error) ?? String(error);
+    state.toolsEffectiveError = options.onError?.(error) ?? formatUiError(error);
   } finally {
     if (isCurrentRequest() && state.toolsEffectiveLoadingKey === requestKey) {
       state.toolsEffectiveLoadingKey = null;

--- a/ui/src/lib/board/mcp-app-view-cache.ts
+++ b/ui/src/lib/board/mcp-app-view-cache.ts
@@ -1,4 +1,5 @@
 import type { BoardWidget, BoardWidgetAppViewResult } from "@openclaw/gateway-protocol";
+import { formatUiError } from "../format-error.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 
 type AppViewRequest = () => Promise<BoardWidgetAppViewResult>;
@@ -43,7 +44,7 @@ export class BoardMcpAppViewCache {
       .then<BoardWidgetAppViewState>((result) => ({ status: "ready", ...result }))
       .catch<BoardWidgetAppViewState>((error: unknown) => ({
         status: "stale",
-        error: error instanceof Error ? error.message : String(error),
+        error: formatUiError(error),
       }));
     this.entries.set(key, pending);
     const resolved = await pending;

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -1,3 +1,4 @@
+import { formatUiError } from "../format-error.ts";
 import type { BoardWidget } from "./types.ts";
 import type { BoardWidgetFrameUrl } from "./view-types.ts";
 import {
@@ -256,13 +257,7 @@ export class BoardWidgetSandboxHost {
         this.completeRequest(data.id, generation, true, result);
       })
       .catch((error: unknown) => {
-        this.completeRequest(
-          data.id,
-          generation,
-          false,
-          undefined,
-          error instanceof Error ? error.message : String(error),
-        );
+        this.completeRequest(data.id, generation, false, undefined, formatUiError(error));
       });
   }
 

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -6,6 +6,7 @@ import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../../app/context.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../../lit/subscriptions-controller.ts";
+import { formatUiError } from "../../format-error.ts";
 import { isActiveWorkboardCard, nextWorkboardCardPosition } from "../../workboard/card-state.ts";
 import { moveWorkboardCard } from "../../workboard/mutations.ts";
 import { normalizeCardsPayload } from "../../workboard/normalization.ts";
@@ -164,7 +165,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
       }
     },
     onError: (error) => {
-      this.error = error instanceof Error ? error.message : String(error);
+      this.error = formatUiError(error);
       this.requestRender();
     },
   });

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -326,7 +326,7 @@ describe("channels controller WhatsApp logout", () => {
 
     await channels.logoutWhatsApp();
 
-    expect(channels.state.whatsappLoginMessage).toBe("Error: credential cleanup failed");
+    expect(channels.state.whatsappLoginMessage).toBe("credential cleanup failed");
     expect(channels.state.whatsappLoginQrDataUrl).toBe("data:image/png;base64,current-qr");
     expect(channels.state.whatsappLoginConnected).toBe(true);
     expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(1);
@@ -457,7 +457,7 @@ describe("channels controller DM pairing", () => {
     await approval;
 
     expect(channels.state.pairingSnapshot?.requests).toEqual([]);
-    expect(channels.state.pairingError).toBe("Error: refresh unavailable");
+    expect(channels.state.pairingError).toBe("refresh unavailable");
     channels.dispose();
   });
 
@@ -613,7 +613,7 @@ describe("channels controller DM pairing", () => {
     await channels.refreshPairing();
 
     expect(channels.state.pairingSnapshot).toBe(emptyPairing);
-    expect(channels.state.pairingError).toBe("Error: gateway unavailable");
+    expect(channels.state.pairingError).toBe("gateway unavailable");
     channels.dispose();
   });
 });

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -221,7 +222,7 @@ async function loadChannels(
         state.channelsSnapshot = null;
         state.channelsError = formatMissingOperatorReadScopeMessage("channel status");
       } else {
-        state.channelsError = String(err);
+        state.channelsError = formatUiError(err);
       }
     } finally {
       if (isCurrentChannelRefresh(state, client, refreshSeq)) {
@@ -278,7 +279,7 @@ async function loadChannelPairing(
     state.pairingLastSuccess = Date.now();
   } catch (error) {
     if (isCurrentPairingRefresh(state, client, refreshSeq)) {
-      state.pairingError = String(error);
+      state.pairingError = formatUiError(error);
     }
   } finally {
     if (isCurrentPairingRefresh(state, client, refreshSeq)) {
@@ -349,7 +350,7 @@ async function approveChannelPairing(
     return isCurrentPairingMutation(state, mutation) ? result : null;
   } catch (error) {
     if (isCurrentPairingMutation(state, mutation)) {
-      state.pairingError = String(error);
+      state.pairingError = formatUiError(error);
     }
     return null;
   } finally {
@@ -386,7 +387,7 @@ async function dismissChannelPairing(
     return isCurrentPairingMutation(state, mutation);
   } catch (error) {
     if (isCurrentPairingMutation(state, mutation)) {
-      state.pairingError = String(error);
+      state.pairingError = formatUiError(error);
     }
     return false;
   } finally {
@@ -464,14 +465,14 @@ async function startWhatsAppLogin(
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = res.message ?? null;
+    state.whatsappLoginMessage = res.message ? formatUiError(res.message) : null;
     state.whatsappLoginQrDataUrl = res.qrDataUrl ?? null;
     state.whatsappLoginConnected = typeof res.connected === "boolean" ? res.connected : null;
   } catch (err) {
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = String(err);
+    state.whatsappLoginMessage = formatUiError(err);
     state.whatsappLoginQrDataUrl = null;
     state.whatsappLoginConnected = null;
   } finally {
@@ -501,7 +502,7 @@ async function waitWhatsAppLogin(state: ChannelsState, accountId?: string): Prom
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = res.message ?? null;
+    state.whatsappLoginMessage = res.message ? formatUiError(res.message) : null;
     state.whatsappLoginConnected = res.connected ?? null;
     if (res.qrDataUrl) {
       state.whatsappLoginQrDataUrl = res.qrDataUrl;
@@ -512,7 +513,7 @@ async function waitWhatsAppLogin(state: ChannelsState, accountId?: string): Prom
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = String(err);
+    state.whatsappLoginMessage = formatUiError(err);
     state.whatsappLoginConnected = null;
   } finally {
     if (isCurrentWhatsAppOperation(state, operation)) {
@@ -546,7 +547,7 @@ async function logoutWhatsApp(state: ChannelsState, accountId?: string): Promise
     if (!isCurrentWhatsAppOperation(state, operation)) {
       return false;
     }
-    state.whatsappLoginMessage = String(err);
+    state.whatsappLoginMessage = formatUiError(err);
   } finally {
     if (isCurrentWhatsAppOperation(state, operation)) {
       state.whatsappBusy = false;

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -14,6 +14,7 @@ import {
   serializeConfigForm,
   setPathValue,
 } from "../config-form-utils.ts";
+import { formatUiError } from "../format-error.ts";
 import { parseJson5Text, warmJson5 } from "../json5-runtime.ts";
 import {
   resolveAgentConfigEntryTarget,
@@ -29,7 +30,8 @@ export function clearConfigDraftTracking(state: RuntimeConfigState): void {
 }
 
 export function formatConfigMutationError(error: unknown, submittedRaw: string | null): string {
-  let message = String(error);
+  const formatted = formatUiError(error);
+  let message = error instanceof GatewayRequestError ? `${error.name}: ${formatted}` : formatted;
   if (!submittedRaw || !(error instanceof GatewayRequestError) || !isRecord(error.details)) {
     return message;
   }

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -4,6 +4,7 @@ import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gatewa
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { copyToClipboard } from "../clipboard.ts";
 import { serializeConfigForm } from "../config-form-utils.ts";
+import { formatUiError } from "../format-error.ts";
 import {
   adoptConfigSetAck,
   applyConfigSnapshot,
@@ -35,7 +36,7 @@ function readAckHash(ack: unknown): string | null {
  * their edit, so callers surface a reload affordance instead.
  */
 function isConfigBaseHashConflictError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
+  const message = formatUiError(err);
   return message.includes("config changed since last load");
 }
 
@@ -155,7 +156,7 @@ export async function executeConfigExternalMutation<T>(
         : isDefinitiveConfigMutationRejection(error)
           ? "rejected"
           : "error",
-      error: error instanceof Error ? error.message : String(error),
+      error: formatUiError(error),
     };
   }
   const refreshFailure = (error: string): RuntimeConfigExternalMutationResult<T> => ({
@@ -179,7 +180,7 @@ export async function executeConfigExternalMutation<T>(
     }
     return { ok: true, value, refresh: { ok: true } };
   } catch (error) {
-    return refreshFailure(error instanceof Error ? error.message : String(error));
+    return refreshFailure(formatUiError(error));
   }
 }
 
@@ -206,7 +207,7 @@ export async function loadConfig(
     return true;
   } catch (err) {
     if (isCurrentRequest(state, "config", version, client, connectionEpoch)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
     return false;
   } finally {
@@ -235,7 +236,7 @@ export async function loadConfigSchema(state: RuntimeConfigState) {
     applyConfigSchema(state, res);
   } catch (err) {
     if (isCurrentRequest(state, "schema", version, client, connectionEpoch)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
   } finally {
     if (isCurrentRequest(state, "schema", version, client, connectionEpoch)) {
@@ -542,7 +543,7 @@ export async function patchConfig(
     return true;
   } catch (err) {
     if (isCurrentConfigConnection(state, client, connectionEpoch)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
     return false;
   }
@@ -627,7 +628,7 @@ export async function openConfigFile(state: RuntimeConfigState): Promise<void> {
     if (!isCurrent()) {
       return;
     }
-    const errorMessage = String(err);
+    const errorMessage = formatUiError(err);
     const path = state.configSnapshot?.path;
     if (path) {
       await copyToClipboard(path);

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -4,7 +4,7 @@ import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gatewa
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { copyToClipboard } from "../clipboard.ts";
 import { serializeConfigForm } from "../config-form-utils.ts";
-import { formatUiError } from "../format-error.ts";
+import { formatUiError, formatUiExternalText } from "../format-error.ts";
 import {
   adoptConfigSetAck,
   applyConfigSnapshot,
@@ -611,7 +611,7 @@ export async function openConfigFile(state: RuntimeConfigState): Promise<void> {
       return;
     }
     if (!res.ok) {
-      let errorMessage = res.error || "Failed to open config file";
+      let errorMessage = formatUiExternalText(res.error, "Failed to open config file");
       const path = res.path || state.configSnapshot?.path;
       if (path) {
         if (await copyToClipboard(path)) {
@@ -621,7 +621,7 @@ export async function openConfigFile(state: RuntimeConfigState): Promise<void> {
         }
       }
       if (isCurrent()) {
-        state.lastError = errorMessage;
+        state.lastError = formatUiExternalText(errorMessage);
       }
     }
   } catch (err) {

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -565,7 +565,7 @@ describe("config write coordinator", () => {
     expect(result).toEqual({
       ok: true,
       value: { ok: true },
-      refresh: { ok: false, error: "Error: refresh unavailable" },
+      refresh: { ok: false, error: "refresh unavailable" },
     });
     expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
     runtimeConfig.dispose();

--- a/ui/src/lib/config/mcp-servers.ts
+++ b/ui/src/lib/config/mcp-servers.ts
@@ -1,6 +1,7 @@
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../format-error.ts";
 import type { RuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 export const MCP_SERVER_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
@@ -227,6 +228,6 @@ export async function patchMcpServers(
     await runtimeConfig.refresh();
     return { ok: true };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { ok: false, error: formatUiError(error) };
   }
 }

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1952,7 +1952,7 @@ describe("cron controller", () => {
 
     const olderLoad = loadCronRuns(state, null);
     await expect(loadCronRuns(state, null)).resolves.toBe("error");
-    expect(state.cronError).toBe("Error: current cron history unavailable");
+    expect(state.cronError).toBe("current cron history unavailable");
 
     olderOverview.resolve({
       entries: [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale" }],
@@ -1963,7 +1963,7 @@ describe("cron controller", () => {
 
     await expect(olderLoad).resolves.toBe("skipped");
     expect(state.cronRuns).toEqual([]);
-    expect(state.cronError).toBe("Error: current cron history unavailable");
+    expect(state.cronError).toBe("current cron history unavailable");
   });
 
   it("scopes jobs and run history requests to the selected agent", async () => {
@@ -1997,7 +1997,7 @@ describe("cron controller", () => {
 
     await expect(loadCronRuns(state, null)).resolves.toBe("error");
 
-    expect(state.cronError).toBe("Error: cron.runs unavailable");
+    expect(state.cronError).toBe("cron.runs unavailable");
   });
 
   it("runs cron job in due mode when requested", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveCronJobLastRunStatus } from "../cron-status.ts";
+import { formatUiError } from "../format-error.ts";
 import { toNumber } from "../format.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -384,7 +385,7 @@ export async function loadCronStatus(state: CronState) {
       state.cronStatus = null;
       state.cronError = formatMissingOperatorReadScopeMessage("cron status");
     } else {
-      state.cronError = String(err);
+      state.cronError = formatUiError(err);
     }
   }
 }
@@ -504,7 +505,7 @@ async function withCronBusy(
   try {
     await run(client);
   } catch (err) {
-    state.cronError = String(err);
+    state.cronError = formatUiError(err);
   } finally {
     state.cronBusy = false;
   }
@@ -677,7 +678,7 @@ export async function loadCronJobsPage(
       clearCronEditState(state);
     }
   } catch (err) {
-    state.cronError = String(err);
+    state.cronError = formatUiError(err);
   } finally {
     if (append) {
       state.cronJobsLoadingMore = false;
@@ -1401,7 +1402,7 @@ export async function loadCronRuns(
     if (!ownsCronRunsRequest(state, request)) {
       return "skipped";
     }
-    state.cronError = String(err);
+    state.cronError = formatUiError(err);
     return "error";
   } finally {
     if (append && activeCronRunsRequests.get(state) === request) {

--- a/ui/src/lib/device-pair-setup.test.ts
+++ b/ui/src/lib/device-pair-setup.test.ts
@@ -245,7 +245,7 @@ describe("device pairing setup state", () => {
       phase: "error",
       source: "create",
       access: "full",
-      message: "Error: setup unavailable",
+      message: "setup unavailable",
     });
     expect(state.devicePairSetupExpiryTimer).toBeNull();
   });
@@ -266,7 +266,7 @@ describe("device pairing setup state", () => {
       source: "create",
       access: "full",
       message:
-        "Error: Gateway does not provide pairing lifecycle metadata. Update the Gateway and try again.",
+        "Gateway does not provide pairing lifecycle metadata. Update the Gateway and try again.",
     });
     expect(state.devicePairSetupExpiryTimer).toBeNull();
   });
@@ -502,7 +502,7 @@ describe("device pairing setup state", () => {
       async () => {
         throw new Error("offline");
       },
-      "Error: offline",
+      "offline",
     ],
     [
       "the recorded completion belongs to another setup",

--- a/ui/src/lib/device-pair-setup.ts
+++ b/ui/src/lib/device-pair-setup.ts
@@ -6,6 +6,7 @@ import type {
   DevicePairSetupDeliveryUncertainEvent,
   DevicePairSetupStatusResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { formatUiError } from "./format-error.ts";
 
 type GatewayRequestClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
@@ -176,7 +177,7 @@ async function readGatewaySetupCompletion(
       ? { status: "found", completion }
       : { status: "unavailable", message: "Invalid setup status response" };
   } catch (err) {
-    return { status: "unavailable", message: String(err) };
+    return { status: "unavailable", message: formatUiError(err) };
   }
 }
 
@@ -381,7 +382,7 @@ export async function refreshDevicePairSetup(state: DevicePairSetupState) {
         phase: "error",
         source: "create",
         access,
-        message: String(err),
+        message: formatUiError(err),
       };
     }
   } finally {

--- a/ui/src/lib/format-error.ts
+++ b/ui/src/lib/format-error.ts
@@ -4,3 +4,8 @@ import { redactToolDetail } from "./browser-redact.ts";
 export function formatUiError(error: unknown, fallback = ""): string {
   return formatErrorMessage(error, { redact: redactToolDetail }) || fallback;
 }
+
+export function formatUiExternalText(value: string | null | undefined, fallback = ""): string {
+  const text = value?.trim();
+  return text ? redactToolDetail(text) : fallback;
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -7,6 +7,7 @@ import {
   formatDurationHuman as formatDurationHumanCore,
 } from "../../../src/infra/format-time/format-duration.ts";
 import { i18n, t } from "../i18n/index.ts";
+import { formatUiError } from "./format-error.ts";
 
 export { formatByteSize } from "@openclaw/normalization-core";
 
@@ -183,7 +184,7 @@ export function formatUnknownText(
     // Fall back when value is not JSON-serializable.
   }
   if (value instanceof Error) {
-    return value.message || value.name;
+    return formatUiError(value);
   }
   return Object.prototype.toString.call(value);
 }

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -1,4 +1,3 @@
-// Shared Nodes operations used by the Control UI page and Gateway event hooks.
 // Presentation-free by contract: confirmations and secret reveals belong to the owning
 // page, because native window.confirm/window.prompt silently answer in webviews with no
 // dialog bridge and would end the action with no outcome and no recorded reason.
@@ -13,6 +12,8 @@ import {
 } from "../../../../src/shared/device-auth.js";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import { cloneConfigObject, removePathValue, setPathValue } from "../config-form-utils.ts";
+// Shared Nodes operations used by the Control UI page and Gateway event hooks.
+import { formatUiError } from "../format-error.ts";
 
 type GatewayRequestClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
@@ -231,7 +232,7 @@ export async function loadNodes(state: NodesState, opts?: { quiet?: boolean }) {
     }
   } catch (err) {
     if (!opts?.quiet && isCurrentNodesRequest(state, client, generation)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {
@@ -263,7 +264,7 @@ export async function loadDevices(state: DevicesState, opts?: { quiet?: boolean 
     }
   } catch (err) {
     if (!opts?.quiet && isCurrentNodesRequest(state, client, generation)) {
-      state.devicesError = String(err);
+      state.devicesError = formatUiError(err);
     }
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {
@@ -285,7 +286,7 @@ export async function approveDevicePairing(state: DevicesState, requestId: strin
     }
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.devicesError = String(err);
+      state.devicesError = formatUiError(err);
     }
   }
 }
@@ -303,7 +304,7 @@ export async function rejectDevicePairing(state: DevicesState, requestId: string
     }
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.devicesError = String(err);
+      state.devicesError = formatUiError(err);
     }
   }
 }
@@ -352,7 +353,7 @@ export async function removeInventoryEntry(state: InventoryState, entry: Invento
     await removeInventoryEntryRpc(client, entry);
     await reloadInventory(state);
   } catch (err) {
-    await reloadInventory(state, { error: String(err) });
+    await reloadInventory(state, { error: formatUiError(err) });
   }
 }
 
@@ -369,7 +370,7 @@ export async function removeStaleInventoryEntries(
     try {
       await removeInventoryEntryRpc(client, entry);
     } catch (err) {
-      failures.push(`${entry.name}: ${String(err)}`);
+      failures.push(`${entry.name}: ${formatUiError(err)}`);
     }
   }
   await reloadInventory(
@@ -390,7 +391,7 @@ export async function approveNodePairingRequest(state: InventoryState, requestId
     await state.client.request("node.pair.approve", { requestId });
     await reloadInventory(state);
   } catch (err) {
-    await reloadInventory(state, { error: String(err) });
+    await reloadInventory(state, { error: formatUiError(err) });
   }
 }
 
@@ -402,7 +403,7 @@ export async function rejectNodePairingRequest(state: InventoryState, requestId:
     await state.client.request("node.pair.reject", { requestId });
     await reloadInventory(state);
   } catch (err) {
-    await reloadInventory(state, { error: String(err) });
+    await reloadInventory(state, { error: formatUiError(err) });
   }
 }
 
@@ -528,7 +529,7 @@ export async function rotateDeviceToken(
     return outcome;
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.devicesError = String(err);
+      state.devicesError = formatUiError(err);
     }
     return null;
   }
@@ -565,7 +566,7 @@ export async function revokeDeviceToken(
     }
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.devicesError = String(err);
+      state.devicesError = formatUiError(err);
     }
   }
 }
@@ -616,7 +617,7 @@ export async function loadExecApprovals(
     }
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {
@@ -680,7 +681,7 @@ export async function saveExecApprovals(
     await loadExecApprovals(state, target);
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
-      state.lastError = String(err);
+      state.lastError = formatUiError(err);
     }
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -321,9 +321,7 @@ describe("session connection hydration", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(sessions.state.result).toBe(result);
-      expect(sessions.state.error).toBe(
-        "GatewayRequestError: session observer temporarily unavailable",
-      );
+      expect(sessions.state.error).toBe("session observer temporarily unavailable");
       expect(subscriptionCalls).toBe(1);
 
       await vi.advanceTimersByTimeAsync(99);
@@ -589,7 +587,7 @@ describe("session connection hydration", () => {
       try {
         connect();
         await vi.advanceTimersByTimeAsync(0);
-        const observerError = "GatewayRequestError: broad session observer unavailable";
+        const observerError = "broad session observer unavailable";
         expect(sessions.state.error).toBe(observerError);
 
         reconcile(sessions);
@@ -642,7 +640,7 @@ describe("session connection hydration", () => {
         connect();
         await vi.advanceTimersByTimeAsync(0);
         await sessions.refresh({ force: true });
-        const operationError = "Error: newer session list failure";
+        const operationError = "newer session list failure";
         expect(sessions.state.error).toBe(operationError);
 
         reconcile(sessions);
@@ -689,12 +687,12 @@ describe("session connection hydration", () => {
       connect();
       await vi.advanceTimersByTimeAsync(0);
       await sessions.refresh({ force: true });
-      expect(sessions.state.error).toBe("Error: newer session list failure");
+      expect(sessions.state.error).toBe("newer session list failure");
 
       await vi.advanceTimersByTimeAsync(100);
 
       expect(subscriptionCalls).toBe(2);
-      expect(sessions.state.error).toBe("Error: newer session list failure");
+      expect(sessions.state.error).toBe("newer session list failure");
     } finally {
       sessions.dispose();
       vi.useRealTimers();
@@ -740,13 +738,13 @@ describe("session connection hydration", () => {
       connect();
       await vi.advanceTimersByTimeAsync(0);
       await sessions.refresh({ force: true });
-      expect(sessions.state.error).toBe("GatewayRequestError: same failure message");
+      expect(sessions.state.error).toBe("same failure message");
 
       await vi.advanceTimersByTimeAsync(100);
 
       expect(subscriptionCalls).toBe(2);
       expect(listCalls).toBe(3);
-      expect(sessions.state.error).toBe("GatewayRequestError: same failure message");
+      expect(sessions.state.error).toBe("same failure message");
       completeCatchUpList(emptySessionsResult());
       await vi.advanceTimersByTimeAsync(0);
       expect(sessions.state.error).toBeNull();

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -179,7 +179,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability(gateway);
 
     await expect(sessions.groupsRename("Alpha", "Beta")).rejects.toThrow("rename failed");
-    expect(sessions.state.error).toBe("Error: rename failed");
+    expect(sessions.state.error).toBe("rename failed");
     sessions.dispose();
   });
 
@@ -195,7 +195,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability(gateway);
 
     await expect(sessions.groupsPut(["Alpha"])).rejects.toThrow("group catalog rejected");
-    expect(sessions.state.error).toBe("Error: group catalog rejected");
+    expect(sessions.state.error).toBe("group catalog rejected");
     sessions.dispose();
   });
 
@@ -211,7 +211,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability(gateway);
 
     await expect(sessions.groupsDelete("Alpha")).rejects.toThrow("delete failed");
-    expect(sessions.state.error).toBe("Error: delete failed");
+    expect(sessions.state.error).toBe("delete failed");
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/session-event-subscription.ts
+++ b/ui/src/lib/sessions/session-event-subscription.ts
@@ -3,6 +3,7 @@ import {
   GatewayProtocolRequestTimeoutError,
 } from "@openclaw/gateway-client/browser";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import { formatUiError } from "../format-error.ts";
 
 type SessionEventSubscriptionScope = {
   client: GatewayBrowserClient;
@@ -78,7 +79,7 @@ export function createSessionEventSubscriptionOwner(params: {
                 retryable: true,
               })
             : error;
-        params.onError(scope, String(failure));
+        params.onError(scope, formatUiError(failure));
         const delayMs = params.retryDelayMs(failure);
         if (delayMs === null || !isCurrent(scope, expectedGeneration)) {
           return;

--- a/ui/src/lib/sessions/session-group-catalog.ts
+++ b/ui/src/lib/sessions/session-group-catalog.ts
@@ -1,4 +1,5 @@
 import { getSafeLocalStorage } from "../../local-storage.ts";
+import { formatUiError } from "../format-error.ts";
 import { isGatewayMethodAdvertised } from "../gateway-methods.ts";
 import { readSessionMethodAccess } from "../session-method-access.ts";
 import {
@@ -123,7 +124,7 @@ export function createSessionGroupCatalog(host: SessionGroupCatalogHost) {
     if (!current) {
       return "stale";
     }
-    host.publish({ ...host.readState(), error: String(error) }, "operation");
+    host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
     throw error;
   };
 

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -155,7 +155,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       if (options.reconciliation === "background") {
         void reconciliation.catch((error: unknown) => {
           if (host.connection.isCurrent(scope)) {
-            host.publish({ ...host.readState(), error: String(error) }, "operation");
+            host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
           }
         });
       } else {
@@ -167,7 +167,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       return result;
     } catch (error) {
       if (host.connection.isCurrent(scope)) {
-        host.publish({ ...host.readState(), error: String(error) }, "operation");
+        host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
       }
       return null;
     }
@@ -191,7 +191,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       return host.connection.isCurrent(scope) ? result : null;
     } catch (error) {
       if (host.connection.isCurrent(scope)) {
-        host.publish({ ...host.readState(), error: String(error) }, "operation");
+        host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
       }
       return null;
     }
@@ -389,7 +389,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return null;
       }
       if (ownsModelOverride()) {
-        host.publish({ ...host.readState(), error: String(error) }, "operation");
+        host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
       }
       throw error;
     }
@@ -489,7 +489,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       return host.connection.isCurrent(scope) ? "completed" : "uncertain";
     } catch (error) {
       if (host.connection.isCurrent(scope)) {
-        host.publish({ ...host.readState(), error: String(error) }, "operation");
+        host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
       }
       // Reset can commit before awaited lifecycle work rejects; never infer safe retry.
       return "uncertain";

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,4 +1,5 @@
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { formatUiError } from "../format-error.ts";
 import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
 import { appendSessionResults, reconcileRosterPresentationMetadata } from "./reconcile.ts";
 import type {
@@ -158,7 +159,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           if (!isCurrent()) {
             return;
           }
-          publishFilteredList(entry, { ...entry.snapshot, loading: false, error: String(error) });
+          publishFilteredList(entry, {
+            ...entry.snapshot,
+            loading: false,
+            error: formatUiError(error),
+          });
         }
         if (!isCurrent()) {
           return;
@@ -295,7 +300,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           {
             ...state,
             loading: backgroundHydrate ? state.loading : false,
-            error: String(error),
+            error: formatUiError(error),
             deletedSessions: [],
           },
           "operation",

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -9,7 +9,7 @@ import type {
   SkillStatusEntry,
   SkillStatusReport,
 } from "../../api/types.ts";
-import { formatUiError } from "../format-error.ts";
+import { formatUiError, formatUiExternalText } from "../format-error.ts";
 import type { ClawHubSearchResult } from "./clawhub-search.ts";
 import {
   normalizeSkillApiKeyReplacement,
@@ -631,7 +631,7 @@ export async function installSkill(
     });
     return {
       kind: "success",
-      message: result?.message ?? "Installed",
+      message: formatUiExternalText(result?.message, "Installed"),
     };
   });
 }
@@ -709,7 +709,10 @@ export async function installFromClawHub(
     }
     state.clawhubInstallMessage = {
       kind: "success",
-      text: formatClawHubInstallMessage(result?.message ?? `Installed ${ref}`, result?.warning),
+      text: formatClawHubInstallMessage(
+        formatUiExternalText(result?.message, `Installed ${ref}`),
+        result?.warning ? formatUiExternalText(result.warning) : undefined,
+      ),
     };
   } catch (err) {
     if (

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { formatUiExternalText } from "./format-error.ts";
 
 type ToastDismissReason = "action" | "dismiss" | "disconnected" | "replaced" | "timeout";
 
@@ -84,7 +85,11 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
     }
     return html`
       <div class="app-toast" role="status" aria-live="polite" aria-atomic="true">
-        <span class="app-toast__message">${toast.message}</span>
+        <span class="app-toast__message"
+          >${typeof toast.message === "string"
+            ? formatUiExternalText(toast.message)
+            : toast.message}</span
+        >
         ${toast.actionLabel && toast.onAction
           ? html`
               <button

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -499,7 +499,7 @@ describe("workboard controller", () => {
   it("keeps loading cards when diagnostics refresh fails", async () => {
     const client = createClient((method) => {
       if (method === "workboard.cards.diagnostics.refresh") {
-        throw new Error("diagnostics denied");
+        throw new Error("diagnostics denied: OPENAI_API_KEY=sk-1234567890abcdef");
       }
       return listResult([sampleCard], ["todo", "done"]);
     });
@@ -510,7 +510,7 @@ describe("workboard controller", () => {
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.list", {});
     expect(state.cards).toEqual([sampleCard]);
     expect(state.error).toBeNull();
-    expect(state.lastRefreshError).toBe("diagnostics denied");
+    expect(state.lastRefreshError).toBe("diagnostics denied: OPENAI_API_KEY=sk-123...cdef");
   });
 
   it("links loaded cards to matching Gateway tasks", async () => {

--- a/ui/src/lib/workboard/normalization-utils.ts
+++ b/ui/src/lib/workboard/normalization-utils.ts
@@ -1,14 +1,5 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatUiError } from "../format-error.ts";
 
 export function formatError(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  if (typeof error === "string" && error.trim()) {
-    return error.trim();
-  }
-  if (isRecord(error) && typeof error.message === "string" && error.message.trim()) {
-    return error.message.trim();
-  }
-  return "Unknown workboard error.";
+  return formatUiError(error, "Unknown workboard error.");
 }

--- a/ui/src/pages/agents/agent-file-lifecycle.test.ts
+++ b/ui/src/pages/agents/agent-file-lifecycle.test.ts
@@ -105,7 +105,7 @@ describe("agent file lifecycle", () => {
     page.saveSelectedAgentFile("main", "AGENTS.md", "updated");
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(page.agentFilesError).toBe("Error: workspace write failed"));
+    await vi.waitFor(() => expect(page.agentFilesError).toBe("workspace write failed"));
     expect(refreshFiles).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -38,6 +38,7 @@ import {
   runCronJob,
   type CronState,
 } from "../../lib/cron/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   canCallGatewayMethod,
   type GatewayMethodOperatorScope,
@@ -491,7 +492,7 @@ class AgentsPage
       .ensure(ids)
       .catch((err: unknown) => {
         if (this.isCurrentRequest(client, generation, undefined, { agentIdentity })) {
-          this.agentIdentityError = String(err);
+          this.agentIdentityError = formatUiError(err);
         }
       })
       .finally(() => {
@@ -590,7 +591,7 @@ class AgentsPage
       .catch((error: unknown) => {
         if (this.isCurrentRequest(client, generation, agentId)) {
           this.chatModelCatalogAgentId = null;
-          this.chatModelCatalogError = error instanceof Error ? error.message : String(error);
+          this.chatModelCatalogError = formatUiError(error);
         }
       })
       .finally(() => {

--- a/ui/src/pages/agents/files.ts
+++ b/ui/src/pages/agents/files.ts
@@ -6,6 +6,7 @@ import type {
   AgentsFilesListResult,
   AgentsFilesSetResult,
 } from "../../api/types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 
 type AgentFilesState = {
   client: GatewayBrowserClient | null;
@@ -75,7 +76,7 @@ export async function loadAgentFileContent(
     }
   } catch (err) {
     if (isCurrent()) {
-      state.agentFilesError = String(err);
+      state.agentFilesError = formatUiError(err);
     }
     return false;
   } finally {
@@ -119,7 +120,7 @@ export async function saveAgentFile(
     }
   } catch (err) {
     if (isCurrent()) {
-      state.agentFilesError = String(err);
+      state.agentFilesError = formatUiError(err);
     }
     return false;
   } finally {

--- a/ui/src/pages/agents/identity-actions.ts
+++ b/ui/src/pages/agents/identity-actions.ts
@@ -120,7 +120,7 @@ export async function saveIdentityDraft(params: {
     }
   } catch (err) {
     if (params.isCurrent()) {
-      host.identityError = String(err);
+      host.identityError = formatUiError(err);
     }
   } finally {
     if (params.isCurrent()) {

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -1234,7 +1234,7 @@ describe("dreaming controller", () => {
 
     await loadDreamDiary(state);
 
-    expect(state.dreamDiaryError).toBe("Error: dream diary read failed");
+    expect(state.dreamDiaryError).toBe("dream diary read failed");
     expect(state.dreamDiaryLoading).toBe(false);
   });
 

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -11,6 +11,7 @@ import type { ConfigSnapshot } from "../../../api/types.ts";
 import { t } from "../../../i18n/index.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import type { RuntimeConfigCapability } from "../../../lib/config/runtime-config-capability.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import {
   canCallGatewayMethod,
   isGatewayMethodAdvertised,
@@ -433,7 +434,7 @@ async function loadDreamingResource<Key extends DreamingResourceKey>(
     state[agentKey] = agentId;
   } catch (error) {
     if (state.resourceRequests[key] === request && resolveSelectedAgentId(state) === agentId) {
-      state[errorKey] = String(error);
+      state[errorKey] = formatUiError(error);
     }
   } finally {
     if (state.resourceRequests[key] === request) {
@@ -503,7 +504,7 @@ async function runDreamDiaryAction(
     };
     return true;
   } catch (err) {
-    const message = String(err);
+    const message = formatUiError(err);
     state.dreamingStatusError = message;
     state.lastError = message;
     state.dreamDiaryActionArchivePath = null;

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -14,6 +14,7 @@ import {
 import { renderSettingsDefaultState } from "../../../components/settings-ui.ts";
 import { t } from "../../../i18n/index.ts";
 import { currentConfigObject } from "../../../lib/config/config-state-model.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import { formatTimeMs } from "../../../lib/format.ts";
 import { isPluginEnabledInConfigSnapshot } from "../../../lib/plugin-activation.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
@@ -411,8 +412,10 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       return saved;
     } catch (error) {
       if (this.isTaskScopeCurrent(scope) && this.context.runtimeConfig === runtimeConfig) {
-        this.dreaming.dreamingStatusError =
-          error instanceof Error ? error.message : t("dreaming.actions.updateFailed");
+        this.dreaming.dreamingStatusError = formatUiError(
+          error,
+          t("dreaming.actions.updateFailed"),
+        );
       }
       return false;
     } finally {

--- a/ui/src/pages/agents/memory/view.ts
+++ b/ui/src/pages/agents/memory/view.ts
@@ -10,9 +10,10 @@ import {
   lobsterPetSeed,
   renderLobsterSvg,
 } from "../../../components/lobster-pet.ts";
-import "../../../components/modal-dialog.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
+import "../../../components/modal-dialog.ts";
 import { t } from "../../../i18n/index.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import "../../../styles/dreams.css";
 import type { DreamingEntry, WikiImportInsights, WikiOverview } from "./dreaming.ts";
 
@@ -588,7 +589,7 @@ async function openWikiPreview(lookup: string, props: DreamingProps): Promise<vo
     state.wikiPreviewTruncated = preview.truncated === true;
   } catch (error) {
     if (state.wikiPreviewRequestId === requestId && state.wikiPreviewOpen) {
-      state.wikiPreviewError = String(error);
+      state.wikiPreviewError = formatUiError(error);
     }
   } finally {
     if (state.wikiPreviewRequestId === requestId && state.wikiPreviewOpen) {

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -27,6 +27,7 @@ import {
   resolveToolProfile,
   resolveToolSections,
 } from "../../lib/agents/display.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import type { SkillGroup } from "../../lib/skills-grouping.ts";
 import { groupSkills } from "../../lib/skills-grouping.ts";
 import {
@@ -192,7 +193,7 @@ function renderEffectiveToolNotices(result: ToolsEffectiveResult | null) {
             class="callout ${notice.severity === "warning" ? "warning" : "info"}"
             style="margin-top: 12px"
           >
-            ${notice.message}
+            ${formatUiExternalText(notice.message)}
           </div>
         `,
       )}

--- a/ui/src/pages/agents/skills.ts
+++ b/ui/src/pages/agents/skills.ts
@@ -2,6 +2,7 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SkillStatusReport } from "../../api/types.ts";
 import type { RuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { loadSkillStatusReport } from "../../lib/skills/index.ts";
 
 type AgentSkillsState = {
@@ -35,7 +36,7 @@ export async function loadAgentSkills(state: AgentSkillsState, agentId: string) 
     }
   } catch (err) {
     if (isCurrent()) {
-      state.agentSkillsError = String(err);
+      state.agentSkillsError = formatUiError(err);
     }
   } finally {
     if (isCurrent()) {

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -22,6 +22,7 @@ import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import { renderDocsLink, renderSettingsPage } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 
@@ -251,7 +252,7 @@ class ApprovalsPage extends OpenClawLightDomElement {
       this.hasLoaded = true;
     } catch (error) {
       if (isCurrent()) {
-        this.error = String(error);
+        this.error = formatUiError(error);
         this.hasLoaded = true;
       }
     } finally {

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -15,7 +15,7 @@ import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveChannelPairingAuthSignature } from "../../lib/channels/index.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import {
   GatewayPageController,
@@ -430,11 +430,12 @@ class ChannelsPage extends OpenClawLightDomElement {
         this.nostrProfileFormState = {
           ...currentForm,
           saving: false,
-          error:
-            data?.error ??
+          error: formatUiExternalText(
+            data?.error,
             t("channels.nostr.notices.updateFailedStatus", {
               status: String(response.status),
             }),
+          ),
           success: null,
           fieldErrors: parseValidationErrors(data?.details),
         };
@@ -503,11 +504,12 @@ class ChannelsPage extends OpenClawLightDomElement {
         this.nostrProfileFormState = {
           ...currentForm,
           importing: false,
-          error:
-            data?.error ??
+          error: formatUiExternalText(
+            data?.error,
             t("channels.nostr.notices.importFailedStatus", {
               status: String(response.status),
             }),
+          ),
           success: null,
         };
         return;

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -15,6 +15,7 @@ import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveChannelPairingAuthSignature } from "../../lib/channels/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import {
   GatewayPageController,
@@ -47,7 +48,7 @@ type NostrOperation = {
 function formatNostrProfileOperationError(error: unknown, prefix: string): string {
   return error instanceof DOMException && error.name === "TimeoutError"
     ? t("channels.nostr.notices.timeout")
-    : t("channels.nostr.notices.operationFailed", { prefix, error: String(error) });
+    : t("channels.nostr.notices.operationFailed", { prefix, error: formatUiError(error) });
 }
 
 class ChannelsPage extends OpenClawLightDomElement {

--- a/ui/src/pages/channels/nostr-profile-ops.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.ts
@@ -1,6 +1,7 @@
 // Nostr profile HTTP operations for the channels page: gateway REST calls for
 // publishing and importing the relay profile, plus validation-error parsing.
 import type { NostrProfile } from "../../api/types.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 
 const NOSTR_PROFILE_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -53,7 +54,7 @@ export function parseValidationErrors(details: unknown): Record<string, string> 
     const field = rawField.trim();
     const message = rest.join(":").trim();
     if (field && message) {
-      errors[field] = message;
+      errors[field] = formatUiExternalText(message);
     }
   }
   return errors;

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -5,7 +5,7 @@ import type { ChannelAccountSnapshot } from "../../api/types.ts";
 import { renderSettingsSection, renderSettingsStatus } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { channelSnapshotEntryIsActive, resolveChannelAccounts } from "../../lib/channels/index.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import type { ChannelKey, ChannelsProps } from "./view.types.ts";
 
@@ -135,7 +135,9 @@ export function renderChannelProbeRow(probe: {
   status?: number | string | null;
   error?: string | null;
 }) {
-  const detail = [probe.status ?? "", probe.error ?? ""].filter(Boolean).join(" ");
+  const detail = formatUiExternalText(
+    [probe.status ?? "", probe.error ?? ""].filter(Boolean).join(" "),
+  );
   return html`
     <div class="settings-row">
       <div class="settings-row__text">
@@ -176,7 +178,7 @@ export function renderChannelAccountRow(params: {
         <span class="settings-row__title">${params.title}</span>
         <span class="settings-row__desc">${factLine}</span>
         ${params.lastError
-          ? html`<span class="settings-row__desc">${params.lastError}</span>`
+          ? html`<span class="settings-row__desc">${formatUiExternalText(params.lastError)}</span>`
           : nothing}
       </div>
       <div class="settings-row__control">

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -5,6 +5,7 @@ import type { ChannelAccountSnapshot } from "../../api/types.ts";
 import { renderSettingsSection, renderSettingsStatus } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { channelSnapshotEntryIsActive, resolveChannelAccounts } from "../../lib/channels/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import type { ChannelKey, ChannelsProps } from "./view.types.ts";
 
@@ -122,7 +123,7 @@ export function renderChannelErrorRow(message: unknown) {
         <span class="settings-row__title"
           >${renderSettingsStatus({ kind: "danger", label: t("channels.lastError") })}</span
         >
-        <span class="settings-row__desc">${message}</span>
+        <span class="settings-row__desc">${formatUiError(message)}</span>
       </div>
     </div>
   `;

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -24,6 +24,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveChannelAccounts } from "../../lib/channels/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import { renderChannelDetail } from "./view.detail.ts";
 import { renderChannelPairingPrompt, renderChannelPairingQueue } from "./view.pairing.ts";
@@ -38,7 +39,10 @@ export function renderChannels(props: ChannelsProps) {
   const connected = channelOrder.filter((key) => channelEnabled(key, props));
   const available = channelOrder.filter((key) => !channelEnabled(key, props));
   const showingStaleSnapshot = Boolean(props.loading && props.snapshot && props.lastSuccessAt);
-  const partialWarnings = props.snapshot?.warnings?.filter((warning) => warning.trim()) ?? [];
+  const partialWarnings =
+    props.snapshot?.warnings
+      ?.filter((warning) => warning.trim())
+      .map((warning) => formatUiExternalText(warning)) ?? [];
   const data = buildChannelData(props);
   const selected = props.selectedChannel;
 

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -363,7 +363,7 @@ describe("ChannelWizardController", () => {
     expect(controller.state).toEqual({
       phase: "error",
       channel: "telegram",
-      message: "Error: wizard unavailable",
+      message: "wizard unavailable",
     });
 
     await controller.cancel();
@@ -449,7 +449,7 @@ describe("ChannelWizardController", () => {
       await timedOutStart;
       expect(controller.state).toMatchObject({
         phase: "error",
-        message: "Error: wizard request timed out: wizard.start",
+        message: "wizard request timed out: wizard.start",
       });
 
       resolveFirstStart({

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -2,6 +2,7 @@
 // as a step/answer state machine for the Control UI wizard modal.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { WizardStep } from "../../api/types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 
 type WizardGatewayClient = Pick<GatewayBrowserClient, "request">;
@@ -138,7 +139,7 @@ export class ChannelWizardController {
       if (this.generation !== generation) {
         return;
       }
-      this.setState({ phase: "error", channel, message: String(err) });
+      this.setState({ phase: "error", channel, message: formatUiError(err) });
     }
   }
 
@@ -198,7 +199,7 @@ export class ChannelWizardController {
         });
         return;
       }
-      this.setState({ phase: "error", channel: this.channel, message: String(err) });
+      this.setState({ phase: "error", channel: this.channel, message: formatUiError(err) });
     }
   }
 

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -2,7 +2,7 @@
 // as a step/answer state machine for the Control UI wizard modal.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { WizardStep } from "../../api/types.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 
 type WizardGatewayClient = Pick<GatewayBrowserClient, "request">;
@@ -231,7 +231,7 @@ export class ChannelWizardController {
         step: result.step,
         stepIndex: this.stepIndex,
         busy: gatewayOwned,
-        validationError: result.error ?? null,
+        validationError: result.error ? formatUiExternalText(result.error) : null,
       });
       if (gatewayOwned) {
         // Gateway-owned steps cannot consume an answer; next long-polls for
@@ -266,7 +266,7 @@ export class ChannelWizardController {
     this.setState({
       phase: "error",
       channel: this.channel,
-      message: result.error ?? "Wizard failed.",
+      message: formatUiExternalText(result.error, "Wizard failed."),
     });
   }
 

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -1984,7 +1984,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     );
 
     expect(result.content).toBe(
-      t("chat.commandResults.steer.requestFailed", { error: "Error: connection lost" }),
+      t("chat.commandResults.steer.requestFailed", { error: "connection lost" }),
     );
   });
 });
@@ -2135,7 +2135,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     );
 
     expect(result.content).toBe(
-      t("chat.commandResults.redirect.requestFailed", { error: "Error: connection lost" }),
+      t("chat.commandResults.redirect.requestFailed", { error: "connection lost" }),
     );
   });
 });

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -35,7 +35,7 @@ import {
   resolveCurrentThinkingLevel,
   resolveThinkingLevelInput,
 } from "../../lib/chat/thinking.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
@@ -220,7 +220,7 @@ async function executeCompact(
     });
     const result = await context.sessions.compact(sessionKey, options);
     if (result?.ok !== true) {
-      const reason = typeof result?.reason === "string" ? result.reason.trim() : "";
+      const reason = typeof result?.reason === "string" ? formatUiExternalText(result.reason) : "";
       return {
         content: reason
           ? t("chat.commandResults.compaction.failedWithReason", { reason })
@@ -246,7 +246,7 @@ async function executeCompact(
     if (typeof result?.reason === "string" && result.reason.trim()) {
       return {
         content: t("chat.commandResults.compaction.skippedWithReason", {
-          reason: result.reason,
+          reason: formatUiExternalText(result.reason),
         }),
         action: "refresh",
       };

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -1,12 +1,11 @@
-/**
- * Client-side execution engine for slash commands.
- * Calls gateway RPC methods and returns formatted results.
- */
-
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
+/**
+ * Client-side execution engine for slash commands.
+ * Calls gateway RPC methods and returns formatted results.
+ */
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsListResult,
@@ -36,6 +35,7 @@ import {
   resolveCurrentThinkingLevel,
   resolveThinkingLevelInput,
 } from "../../lib/chat/thinking.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
@@ -254,7 +254,7 @@ async function executeCompact(
     return { content: t("chat.commandResults.compaction.skipped"), action: "refresh" };
   } catch (err) {
     return {
-      content: t("chat.commandResults.compaction.failedWithReason", { reason: String(err) }),
+      content: t("chat.commandResults.compaction.failedWithReason", { reason: formatUiError(err) }),
       failed: true,
     };
   }
@@ -297,7 +297,7 @@ async function executeModel(
       return { content: lines.join("\n") };
     } catch (err) {
       return {
-        content: t("chat.commandResults.model.getFailed", { error: String(err) }),
+        content: t("chat.commandResults.model.getFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -350,7 +350,7 @@ async function executeModel(
     };
   } catch (err) {
     return {
-      content: t("chat.commandResults.model.setFailed", { error: String(err) }),
+      content: t("chat.commandResults.model.setFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -381,7 +381,7 @@ async function executeThink(
       };
     } catch (err) {
       return {
-        content: t("chat.commandResults.thinking.getFailed", { error: String(err) }),
+        content: t("chat.commandResults.thinking.getFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -398,7 +398,7 @@ async function executeThink(
       };
     } catch (err) {
       return {
-        content: t("chat.commandResults.thinking.resetFailed", { error: String(err) }),
+        content: t("chat.commandResults.thinking.resetFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -432,7 +432,7 @@ async function executeThink(
     };
   } catch (err) {
     return {
-      content: t("chat.commandResults.thinking.setFailed", { error: String(err) }),
+      content: t("chat.commandResults.thinking.setFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -459,7 +459,7 @@ async function executeVerbose(
       };
     } catch (err) {
       return {
-        content: t("chat.commandResults.verbose.getFailed", { error: String(err) }),
+        content: t("chat.commandResults.verbose.getFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -482,7 +482,7 @@ async function executeVerbose(
     };
   } catch (err) {
     return {
-      content: t("chat.commandResults.verbose.setFailed", { error: String(err) }),
+      content: t("chat.commandResults.verbose.setFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -513,7 +513,7 @@ async function executeFast(
       };
     } catch (err) {
       return {
-        content: t("chat.commandResults.fast.getFailed", { error: String(err) }),
+        content: t("chat.commandResults.fast.getFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -530,7 +530,7 @@ async function executeFast(
       };
     } catch (err) {
       return {
-        content: t("chat.commandResults.fast.resetFailed", { error: String(err) }),
+        content: t("chat.commandResults.fast.resetFailed", { error: formatUiError(err) }),
         failed: true,
       };
     }
@@ -556,7 +556,7 @@ async function executeFast(
     };
   } catch (err) {
     return {
-      content: t("chat.commandResults.fast.setFailed", { error: String(err) }),
+      content: t("chat.commandResults.fast.setFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -615,7 +615,7 @@ async function executeUsage(
     return { content: lines.join("\n") };
   } catch (err) {
     return {
-      content: t("chat.commandResults.usage.failed", { error: String(err) }),
+      content: t("chat.commandResults.usage.failed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -641,7 +641,7 @@ async function executeAgents(client: GatewayBrowserClient): Promise<SlashCommand
     return { content: lines.join("\n") };
   } catch (err) {
     return {
-      content: t("chat.commandResults.agents.failed", { error: String(err) }),
+      content: t("chat.commandResults.agents.failed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -912,7 +912,7 @@ async function executeSteer(
     return result;
   } catch (err) {
     return {
-      content: t("chat.commandResults.steer.requestFailed", { error: String(err) }),
+      content: t("chat.commandResults.steer.requestFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }
@@ -951,7 +951,7 @@ async function executeRedirect(
     };
   } catch (err) {
     return {
-      content: t("chat.commandResults.redirect.requestFailed", { error: String(err) }),
+      content: t("chat.commandResults.redirect.requestFailed", { error: formatUiError(err) }),
       failed: true,
     };
   }

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -12,6 +12,7 @@ import {
   type SlashCommandDef,
 } from "../../lib/chat/commands.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import {
   scopedAgentIdForSession,
@@ -84,8 +85,9 @@ function setChatCommandError(
   host: { lastError?: string | null; chatError?: string | null },
   error: string | null,
 ) {
-  host.lastError = error;
-  host.chatError = error;
+  const message = error === null ? null : formatUiError(error);
+  host.lastError = message;
+  host.chatError = message;
 }
 
 function currentSessionAccessSnapshot(
@@ -429,7 +431,7 @@ export async function dispatchChatSlashCommand(
     });
   } catch (err) {
     if (targetIsCurrent()) {
-      setChatCommandError(host, String(err));
+      setChatCommandError(host, formatUiError(err));
       injectCommandResult(host, `Command \`/${name}\` failed unexpectedly.`);
       scheduleChatScroll(host, false, false, {
         contentChanged: true,

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -24,7 +24,7 @@ import {
   patchMcpServers,
   summarizeMcpServers,
 } from "../../lib/config/mcp-servers.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import {
@@ -467,10 +467,9 @@ export class ChatComposerCapabilityHost {
       this.addBusy = false;
     }
     if (!result.ok) {
+      const error = formatUiExternalText(result.error);
       this.addError =
-        result.stage === "session"
-          ? t("mcpServers.sessionEnableFailed", { error: result.error })
-          : result.error;
+        result.stage === "session" ? t("mcpServers.sessionEnableFailed", { error }) : error;
       this.notify();
       return;
     }

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -324,7 +324,7 @@ export class ChatComposerCapabilityHost {
       }
       return { ok: true };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatUiError(error);
       if (isCurrentPatch()) {
         try {
           await refreshCurrentChatSessionList(state);

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -5,6 +5,7 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isAssistantHeartbeatAckForDisplay } from "../../lib/chat/heartbeat-display.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 // Control UI page module reconciles Chat Gateway events into Chat state.
 import { isUiGlobalSessionKey, resolveUiDefaultAgentId } from "../../lib/sessions/session-key.ts";
 import {
@@ -50,7 +51,7 @@ type AssistantMessageNormalizationOptions = {
 };
 
 function setChatRunError(state: ChatState, summary: string) {
-  state.chatRunError = { summary };
+  state.chatRunError = { summary: formatUiExternalText(summary) };
 }
 
 function chatEventSessionMatches(state: ChatState, payload: ChatEventPayload): boolean {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,4 +1,3 @@
-// Control UI page module owns Chat transcript loading and selected-session message subscription.
 import {
   readSessionMessageIdentity,
   readSessionMessageSequence,
@@ -19,6 +18,8 @@ import {
   stripHeartbeatTokenForDisplay,
 } from "../../lib/chat/heartbeat-display.ts";
 import { extractText, isEmptyUserTextOnlyMessage } from "../../lib/chat/message-extract.ts";
+// Control UI page module owns Chat transcript loading and selected-session message subscription.
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -591,8 +592,9 @@ export type ChatEventPayload = {
 };
 
 function setChatError(state: ChatState, error: string | null) {
-  state.lastError = error;
-  state.chatError = error;
+  const message = error === null ? null : formatUiError(error);
+  state.lastError = message;
+  state.chatError = message;
 }
 
 function chatScopedEventAgentScopeMatches(
@@ -812,7 +814,7 @@ export async function syncSelectedSessionMessageSubscription(
             }
             state.chatSessionMessageSubscriptionRequestedKey = nextKey;
             state.chatSessionMessageSubscription = subscribeResult.value;
-            state.sessionsError = `${String(unsubscribeResult.reason)}; replacement release failed: ${String(replacementReleaseError)}`;
+            state.sessionsError = `${formatUiError(unsubscribeResult.reason)}; replacement release failed: ${formatUiError(replacementReleaseError)}`;
           } else {
             paneRequests.pendingSubscriptionReleases.add(subscribeResult.value);
           }
@@ -820,7 +822,7 @@ export async function syncSelectedSessionMessageSubscription(
         }
       }
       if (isCurrent()) {
-        state.sessionsError = String(unsubscribeResult.reason);
+        state.sessionsError = formatUiError(unsubscribeResult.reason);
       }
       return;
     }
@@ -854,7 +856,7 @@ export async function syncSelectedSessionMessageSubscription(
     state.chatSessionMessageSubscription = subscribed;
   } catch (err) {
     if (isCurrent()) {
-      state.sessionsError = String(err);
+      state.sessionsError = formatUiError(err);
     }
   }
 }
@@ -1201,7 +1203,7 @@ export async function clearChatHistory(
     }
   } catch (err) {
     if (ownsClearChatView(state, originalViewOwner)) {
-      setChatError(state, String(err));
+      setChatError(state, formatUiError(err));
       scheduleChatScroll(state);
     }
     return "failed";
@@ -1273,7 +1275,7 @@ export async function rewindChatHistory(
     state.handleChatDraftChange(editorText);
     return result;
   } catch (error) {
-    setChatError(state, error instanceof Error ? error.message : String(error));
+    setChatError(state, formatUiError(error));
     scheduleChatScroll(state);
     return null;
   }
@@ -1303,7 +1305,7 @@ export async function switchChatHistoryBranch(
     await Promise.all([loadChatHistory(state), loadChatBranches(state)]);
     return visibleSessionMatches(state, sessionKey, agentParams.agentId);
   } catch (error) {
-    setChatError(state, error instanceof Error ? error.message : String(error));
+    setChatError(state, formatUiError(error));
     scheduleChatScroll(state);
     return false;
   }
@@ -1794,7 +1796,7 @@ async function loadChatHistoryUncached(
       state.chatVerboseLevel = null;
       setChatError(state, formatMissingOperatorReadScopeMessage("existing chat history"));
     } else {
-      setChatError(state, String(err));
+      setChatError(state, formatUiError(err));
     }
   } finally {
     if (ownsChatHistoryRequest(state, ownership)) {

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -1,5 +1,6 @@
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
 import {
@@ -523,7 +524,7 @@ async function drainStoredChatOutbox(
           dependencies.setChatError(host, null);
         }
       } catch (err) {
-        return failCommand(String(err), true);
+        return failCommand(formatUiError(err), true);
       }
       continue;
     }

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -7,6 +7,7 @@ import {
   type CommandPaletteTargetDetail,
 } from "../../components/command-palette-contract.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   announceCatalogSessionContinued,
   parseCatalogSessionKey,
@@ -519,7 +520,7 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
       }
     } catch (error) {
       if (generation === this.olderLoadGeneration) {
-        state.lastError = error instanceof Error ? error.message : String(error);
+        state.lastError = formatUiError(error);
       }
     } finally {
       if (generation === this.olderLoadGeneration) {
@@ -620,7 +621,7 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
         return;
       }
       this.activeCatalogContinuation = null;
-      state.lastError = error instanceof Error ? error.message : String(error);
+      state.lastError = formatUiError(error);
       state.chatSending = false;
       state.requestUpdate();
     }
@@ -665,7 +666,7 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
         draft: editorText,
       });
     } catch (error) {
-      state.lastError = error instanceof Error ? error.message : String(error);
+      state.lastError = formatUiError(error);
       state.chatError = state.lastError;
       state.requestUpdate?.();
     }

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -21,6 +21,7 @@ import {
   TERMINAL_PANEL_TOGGLE_EVENT,
 } from "../../components/panel-toggle-contract.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { resolveAsciiShortcutKey } from "../../lib/keyboard-shortcuts.ts";
 import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
@@ -275,7 +276,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
         },
       })
       .catch((error: unknown) => {
-        setChatError(state, error instanceof Error ? error.message : String(error));
+        setChatError(state, formatUiError(error));
         state.requestUpdate?.();
       });
   }

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -1,3 +1,4 @@
+import { formatUiError } from "../../lib/format-error.ts";
 import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.ts";
 import { storeChatComposerMemoryFallback } from "./chat-composer-memory-fallback.ts";
 import { ChatPaneBoard } from "./chat-pane-board.ts";
@@ -150,7 +151,7 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
         }
         void state.handleSendChat().catch((error: unknown) => {
           if (this.state === state && state.sessionKey === sessionKey) {
-            setChatError(state, error instanceof Error ? error.message : String(error));
+            setChatError(state, formatUiError(error));
             state.requestUpdate?.();
           }
         });

--- a/ui/src/pages/chat/chat-pane-session-creation.ts
+++ b/ui/src/pages/chat/chat-pane-session-creation.ts
@@ -1,4 +1,5 @@
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   readSessionMethodAccess,
   type SessionMethodAccess,
@@ -154,7 +155,7 @@ export abstract class ChatPaneSessionCreation extends ChatPaneRetainedPresentati
         return false;
       }
       if (recovery.continuation.status === "rejected") {
-        setChatError(state, recovery.continuation.error.message);
+        setChatError(state, formatUiError(recovery.continuation.error));
         state.requestUpdate?.();
         return false;
       }

--- a/ui/src/pages/chat/chat-pane-session-creation.ts
+++ b/ui/src/pages/chat/chat-pane-session-creation.ts
@@ -155,7 +155,7 @@ export abstract class ChatPaneSessionCreation extends ChatPaneRetainedPresentati
         return false;
       }
       if (recovery.continuation.status === "rejected") {
-        setChatError(state, formatUiError(recovery.continuation.error));
+        setChatError(state, formatUiError(recovery.continuation.error.message));
         state.requestUpdate?.();
         return false;
       }

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -14,6 +14,7 @@ import { isCloudWorkerPlacementState } from "../../components/session-row-badges
 import { t } from "../../i18n/index.ts";
 import { copyToClipboard } from "../../lib/clipboard.ts";
 import { openEditor } from "../../lib/editor-links.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
@@ -411,8 +412,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     if (!this.state || !this.ownsHeaderOutcome(owner)) {
       return;
     }
-    this.state.chatError = this.state.lastError =
-      error instanceof Error ? error.message : String(error);
+    this.state.chatError = this.state.lastError = formatUiError(error);
     this.state.requestUpdate?.();
   }
 

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -6,6 +6,7 @@ import type {
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
@@ -234,7 +235,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
         failure = scope.sessions.state.error;
       }
     } catch (error) {
-      failure = error instanceof Error ? error.message : String(error);
+      failure = formatUiError(error);
     }
     if (failure && this.isConnectionScopeCurrent(scope) && scope.state.sessionKey === sessionKey) {
       scope.state.lastError = failure;
@@ -451,7 +452,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       return older ? !olderExhausted : true;
     } catch (error) {
       if (isCurrent()) {
-        (this.state ?? state).lastError = error instanceof Error ? error.message : String(error);
+        (this.state ?? state).lastError = formatUiError(error);
       }
       return false;
     } finally {

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -481,7 +481,7 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
 
     expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(previous.key))).toMatchObject({
       loading: false,
-      error: `Error: ${mutation.name} failed after session switch`,
+      error: `${mutation.name} failed after session switch`,
     });
     expect(state.lastError).toBeNull();
     expect(state.chatError).toBeNull();
@@ -539,7 +539,7 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
 
     expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))).toMatchObject({
       loading: false,
-      error: `Error: ${mutation.name} failed`,
+      error: `${mutation.name} failed`,
     });
     expect(state.lastError).toBe(`${mutation.name} failed`);
     expect(state.chatError).toBe(state.lastError);

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../api/types.ts";
 import { hasMultiplePresenceIdentities } from "../../components/viewer-facepile.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
@@ -155,7 +156,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
         }
         return;
       }
-      this.setSessionSharingState(cacheKey, { loading: false, error: String(error) });
+      this.setSessionSharingState(cacheKey, { loading: false, error: formatUiError(error) });
     }
   }
 
@@ -166,7 +167,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     this.setSessionSharingState(key, {
       ...(this.sessionSharingStates.get(key) ?? { loading: false }),
       loading: false,
-      error: String(error),
+      error: formatUiError(error),
     });
     // Sharing errors stay with their session; the visible slot belongs only to the selected session.
     if (areUiSessionKeysEquivalent(this.state?.sessionKey, session)) {
@@ -528,7 +529,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
         this.sessionSuggestionAddOperation === operation &&
         this.isConnectionScopeCurrent(scope)
       ) {
-        scope.state.chatError = error instanceof Error ? error.message : String(error);
+        scope.state.chatError = formatUiError(error);
         scope.state.lastError = scope.state.chatError;
       }
     } finally {
@@ -611,7 +612,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
         ) {
           scope.state.handleChatDraftChange(previousEditDraft);
         }
-        scope.state.chatError = error instanceof Error ? error.message : String(error);
+        scope.state.chatError = formatUiError(error);
         scope.state.lastError = scope.state.chatError;
       }
     } finally {

--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -7,6 +7,7 @@ import type {
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { t } from "../../i18n/index.ts";
 import { copyToClipboard } from "../../lib/clipboard.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import {
@@ -201,7 +202,7 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       if (!isCurrent()) {
         return;
       }
-      scope.state.lastError = error instanceof Error ? error.message : String(error);
+      scope.state.lastError = formatUiError(error);
       scope.state.chatError = scope.state.lastError;
     } finally {
       if (this.taskSuggestionOperations.get(suggestion.id) === operation) {

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { loadSettings, patchSettings, type UiSettings } from "../../app/settings.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   createRealtimeTalkConversationState,
   updateRealtimeTalkConversation,
@@ -92,7 +93,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
     state.settings = patchSettings({ talkCameraAutoEnable: enabled });
   };
   const showCameraError = (error: unknown) => {
-    state.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
+    state.realtimeTalkDetail = formatUiError(error);
     state.realtimeTalkCameraError = true;
     state.requestUpdate();
   };
@@ -261,7 +262,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       if (state.realtimeTalkSession !== session) {
         return;
       }
-      const detail = error instanceof Error ? error.message : String(error);
+      const detail = formatUiError(error);
       stopChatRealtimeTalk(state);
       state.realtimeTalkStatus = "error";
       state.realtimeTalkDetail = detail;

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -1,6 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { loadSettings, patchSettings, type UiSettings } from "../../app/settings.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import {
   createRealtimeTalkConversationState,
   updateRealtimeTalkConversation,
@@ -185,7 +185,8 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
             return;
           }
           state.realtimeTalkStatus = status;
-          state.realtimeTalkDetail = detail ?? null;
+          state.realtimeTalkDetail =
+            status === "error" && detail ? formatUiExternalText(detail) : (detail ?? null);
           state.realtimeTalkCameraError = false;
           state.realtimeTalkActive = status !== "idle";
           if (status === "idle" || status === "error") {

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -1,5 +1,6 @@
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import type {
@@ -29,8 +30,9 @@ export function setChatError(
   host: { lastError?: string | null; chatError?: string | null },
   error: string | null,
 ) {
-  host.lastError = error;
-  host.chatError = error;
+  const message = error === null ? null : formatUiError(error);
+  host.lastError = message;
+  host.chatError = message;
 }
 
 export function enqueuePendingSendMessage(

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3269,7 +3269,7 @@ describe("handleSendChat", () => {
 
     expect(executeSlashCommandMock).toHaveBeenCalledTimes(1);
     expect(host.chatMessage).toBe("");
-    expect(host.lastError).toBe("Error: dispatch failed");
+    expect(host.lastError).toBe("dispatch failed");
     expect(host.chatMessages).toHaveLength(1);
     const feedback = requireRecord(host.chatMessages[0], "feedback message");
     expect(feedback.role).toBe("system");

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeThinkLevel } from "../../../../src/auto-reply/thinking.shared.js";
 import type { FastMode, GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { resolveChatModelOverrideValue } from "../../lib/chat/model-select-state.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   DEFAULT_SESSION_LIST_QUERY,
@@ -275,8 +276,9 @@ export function flushChatQueueAfterIdleSessionReconciliation(
 }
 
 function setChatError(host: ChatModelSettingsHost, error: string | null, requestUpdate = false) {
-  host.lastError = error;
-  host.chatError = error;
+  const message = error === null ? null : formatUiError(error);
+  host.lastError = message;
+  host.chatError = message;
   if (requestUpdate) {
     host.requestUpdate?.();
   }
@@ -390,7 +392,7 @@ export function switchChatFastMode(
       return true;
     } catch (err) {
       rollback();
-      setChatError(host, `Failed to set speed: ${String(err)}`, true);
+      setChatError(host, `Failed to set speed: ${formatUiError(err)}`, true);
       return false;
     }
   })();
@@ -455,7 +457,7 @@ export async function switchChatModel(
       return true;
     } catch (err) {
       if (ownsModelOverride()) {
-        setChatError(host, `Failed to set model: ${String(err)}`, true);
+        setChatError(host, `Failed to set model: ${formatUiError(err)}`, true);
       }
       return false;
     } finally {
@@ -533,7 +535,7 @@ export function switchChatThinkingLevel(
       return true;
     } catch (err) {
       rollback();
-      setChatError(host, `Failed to set thinking level: ${String(err)}`, true);
+      setChatError(host, `Failed to set thinking level: ${formatUiError(err)}`, true);
       return false;
     }
   })();

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
@@ -288,7 +289,7 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
       return;
     }
     host.modelAuthStatusResult = { ts: 0, providers: [] };
-    host.modelAuthStatusError = err instanceof Error ? err.message : String(err);
+    host.modelAuthStatusError = formatUiError(err);
   }
 }
 
@@ -320,7 +321,7 @@ export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promi
     if (ownsRequest()) {
       // Keep the startup/prepared snapshot usable while making the failed
       // discovery and its retry path visible in the open picker.
-      host.chatModelCatalogError = error instanceof Error ? error.message : String(error);
+      host.chatModelCatalogError = formatUiError(error);
     }
   } finally {
     if (ownsRequest()) {

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -139,6 +139,17 @@ afterEach(() => {
 });
 
 describe("background tasks rail state", () => {
+  it("redacts secrets in task list failures", async () => {
+    const { host } = createHost({
+      request: () => Promise.reject(new Error("OPENAI_API_KEY=sk-1234567890abcdef")),
+    });
+
+    createBackgroundTasksProps(host);
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(host).error).toBe("OPENAI_API_KEY=sk-123...cdef");
+  });
+
   it("loads session-scoped tasks eagerly while the rail is collapsed", async () => {
     const { host, request } = createHost({
       request: (method, params) => {
@@ -245,6 +256,28 @@ describe("background tasks rail state", () => {
     expect(props.cancellingTaskIds.has("task-1")).toBe(false);
   });
 
+  it("redacts secrets in cancellation failures", async () => {
+    const running = makeTask({ id: "task-1" });
+    const { host } = createHost({
+      request: (method) =>
+        method === "tasks.list"
+          ? Promise.resolve({ tasks: [running] })
+          : Promise.reject(new Error("OPENAI_API_KEY=sk-1234567890abcdef")),
+    });
+    host.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: ["operator.write"] },
+    };
+    createBackgroundTasksProps(host);
+    await flushAsync();
+
+    createBackgroundTasksProps(host).onCancel("task-1");
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(host).error).toBe("OPENAI_API_KEY=sk-123...cdef");
+  });
+
   it("routes row selection to the task panel and loads its bounded prompt on demand", async () => {
     const running = makeTask({
       id: "task-1",
@@ -287,7 +320,7 @@ describe("background tasks rail state", () => {
           return Promise.resolve({ tasks: [running] });
         }
         return failLookup
-          ? Promise.reject(new Error("lookup blew up"))
+          ? Promise.reject(new Error("lookup blew up: OPENAI_API_KEY=sk-1234567890abcdef"))
           : Promise.resolve({ task: { ...running, prompt: "Recovered prompt" } });
       },
     });
@@ -296,7 +329,9 @@ describe("background tasks rail state", () => {
 
     createBackgroundTasksProps(host, { onOpenTaskDetail: () => {} }).onLoadDetail?.(running);
     await flushAsync();
-    expect(createBackgroundTasksProps(host).taskDetailErrors.get("task-1")).toBe("lookup blew up");
+    expect(createBackgroundTasksProps(host).taskDetailErrors.get("task-1")).toBe(
+      "lookup blew up: OPENAI_API_KEY=sk-123...cdef",
+    );
 
     // Selection clears the recorded error so the panel's render-driven load
     // (which must skip errored tasks to avoid a retry loop) can run again.

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -147,7 +147,11 @@ describe("background tasks rail state", () => {
     createBackgroundTasksProps(host);
     await flushAsync();
 
-    expect(createBackgroundTasksProps(host).error).toBe("OPENAI_API_KEY=sk-123...cdef");
+    const props = createBackgroundTasksProps(host);
+    expect(props.error).toBe("OPENAI_API_KEY=sk-123...cdef");
+    const rail = renderTaskRail({ ...props, collapsed: false });
+    expect(rail.textContent).toContain("OPENAI_API_KEY=sk-123...cdef");
+    expect(rail.textContent).not.toContain("sk-1234567890abcdef");
   });
 
   it("loads session-scoped tasks eagerly while the rail is collapsed", async () => {
@@ -241,7 +245,11 @@ describe("background tasks rail state", () => {
       request: (method) =>
         method === "tasks.list"
           ? Promise.resolve({ tasks: [running] })
-          : Promise.resolve({ found: true, cancelled: false, reason: "already finished" }),
+          : Promise.resolve({
+              found: true,
+              cancelled: false,
+              reason: "already finished: OPENAI_API_KEY=sk-1234567890abcdef",
+            }),
     });
     const auth = { role: "operator" as const, scopes: ["operator.write"] };
     host.hello = { type: "hello-ok", protocol: 4, auth };
@@ -252,7 +260,7 @@ describe("background tasks rail state", () => {
     await flushAsync();
 
     const props = createBackgroundTasksProps(host);
-    expect(props.error).toBe("already finished");
+    expect(props.error).toBe("already finished: OPENAI_API_KEY=sk-123...cdef");
     expect(props.cancellingTaskIds.has("task-1")).toBe(false);
   });
 

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -511,7 +511,8 @@ async function cancelBackgroundTask(
     // Refusals (already terminal, stale id, no cancellation handle) are
     // successful responses with cancelled=false; surface them like errors.
     if (!result?.cancelled) {
-      state.error = result?.reason?.trim() || t("tasksPage.cancelFailed");
+      const reason = result?.reason?.trim();
+      state.error = reason ? formatUiError(reason) : t("tasksPage.cancelFailed");
     }
   } catch (error) {
     if (getBackgroundTasksState(host) === state) {

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../../api/gateway.ts";
 import { hasOperatorWriteAccess } from "../../../app/operator-access.ts";
 import { t } from "../../../i18n/index.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import type { SessionScopeHost } from "../../../lib/sessions/index.ts";
 import { canonicalUiSessionKeyForPersistence } from "../../../lib/sessions/session-key.ts";
 import {
@@ -286,10 +287,7 @@ function loadBackgroundTasks(
             observeTaskTerminal(current, task, "event");
           }
         }
-        current.error =
-          error instanceof Error && error.message.trim()
-            ? error.message.trim()
-            : t("tasksPage.loadFailed");
+        current.error = formatUiError(error, t("tasksPage.loadFailed"));
       }
     } finally {
       const current = getBackgroundTasksState(host);
@@ -465,10 +463,7 @@ async function loadBackgroundTaskDetail(
     }
   } catch (error) {
     if (getBackgroundTasksState(host) === state) {
-      const message =
-        error instanceof Error && error.message.trim()
-          ? error.message.trim()
-          : t("chat.backgroundTasks.detailFailed");
+      const message = formatUiError(error, t("chat.backgroundTasks.detailFailed"));
       state.taskDetailErrors = new Map(state.taskDetailErrors).set(rowId, message);
     }
   } finally {
@@ -520,10 +515,7 @@ async function cancelBackgroundTask(
     }
   } catch (error) {
     if (getBackgroundTasksState(host) === state) {
-      state.error =
-        error instanceof Error && error.message.trim()
-          ? error.message.trim()
-          : t("tasksPage.cancelFailed");
+      state.error = formatUiError(error, t("tasksPage.cancelFailed"));
     }
   } finally {
     if (getBackgroundTasksState(host) === state) {

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -8,6 +8,7 @@ import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import type { McpServerSummary } from "../../../lib/config/mcp-servers.ts";
+import { formatUiExternalText } from "../../../lib/format-error.ts";
 import type { SessionToolOverrides } from "../../../lib/sessions/patch.ts";
 import {
   nextBooleanToolOverrides,
@@ -358,7 +359,7 @@ function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: stri
         </div>`
       : discoveryNotice
         ? html`<div class="agent-chat__capability-menu-state" role="status">
-            ${discoveryNotice.message}
+            ${formatUiExternalText(discoveryNotice.message)}
           </div>`
         : tools.length === 0
           ? html`<div class="agent-chat__capability-menu-state">

--- a/ui/src/pages/chat/components/chat-message-attachment-availability.ts
+++ b/ui/src/pages/chat/components/chat-message-attachment-availability.ts
@@ -1,4 +1,5 @@
 import { t } from "../../../i18n/index.ts";
+import { formatUiExternalText } from "../../../lib/format-error.ts";
 import {
   buildAssistantAttachmentUrl,
   isLocalAssistantAttachmentSource,
@@ -204,7 +205,7 @@ export function resolveAssistantAttachmentAvailability(
           return availability;
         }
         const unavailable = createUnavailableAssistantAttachment(
-          payload?.reason?.trim() || t("chat.attachments.unavailable"),
+          formatUiExternalText(payload?.reason, t("chat.attachments.unavailable")),
           resource.retryAttempted,
         );
         setAssistantAttachmentAvailability(resource, unavailable);

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -20,9 +20,10 @@ import {
 } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
-import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
+import "../../../components/tooltip.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import { formatByteSize } from "../../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../../lib/gateway-methods.ts";
 import {
@@ -355,7 +356,7 @@ function loadWorkspace(
     } catch (error) {
       const current = currentWorkspaceState(state);
       if (current === workspace && current.requestId === requestId) {
-        current.error = String(error);
+        current.error = formatUiError(error);
       }
     } finally {
       const current = currentWorkspaceState(state);
@@ -444,7 +445,7 @@ function openWorkspaceItem<T>(
       }
     } catch (error) {
       if (isCurrentOpenRequest(state, request)) {
-        workspace.error = String(error);
+        workspace.error = formatUiError(error);
       }
     } finally {
       requestUpdate(state);
@@ -550,7 +551,7 @@ function openFile(
                 return {
                   ok: false as const,
                   code: "error" as const,
-                  message: error instanceof Error ? error.message : String(error),
+                  message: formatUiError(error),
                 };
               }
             },

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -9,11 +9,11 @@ import {
   markdownFileLinkFromEvent,
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
-import "../../../components/web-awesome.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
+import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
-import "../../../components/tooltip.ts";
 import { extractRawText } from "../../../lib/chat/message-extract.ts";
+import "../../../components/tooltip.ts";
 import {
   resolveCanvasIframeUrl,
   resolveEmbedSandbox,
@@ -21,6 +21,7 @@ import {
 } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { openInlineChatImage } from "./chat-image-lightbox.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
@@ -1127,7 +1128,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         if (version === this.fileOperationVersion) {
           this.fileSaveNotice = {
             kind: "error",
-            message: error instanceof Error ? error.message : String(error),
+            message: formatUiError(error),
           };
         }
       })
@@ -1177,7 +1178,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         if (version === this.fileOperationVersion) {
           this.fileSaveNotice = {
             kind: "error",
-            message: error instanceof Error ? error.message : String(error),
+            message: formatUiError(error),
           };
         }
       })
@@ -1220,7 +1221,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         if (version === this.fileOperationVersion) {
           this.fileSaveNotice = {
             kind: "error",
-            message: error instanceof Error ? error.message : String(error),
+            message: formatUiError(error),
           };
         }
       })
@@ -1276,7 +1277,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         return;
       }
       this.error = t("chat.detailPanel.fullContentLoadFailed", {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatUiError(error),
       });
     }
   }

--- a/ui/src/pages/chat/components/session-diff-panel.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.ts
@@ -8,8 +8,8 @@ import type {
   SessionsDiffResult,
 } from "../../../../../packages/gateway-protocol/src/index.js";
 import { icons } from "../../../components/icons.ts";
-import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
+import "../../../components/tooltip.ts";
 import {
   expandSessionDiffGap,
   splitSessionDiffFileText,
@@ -23,6 +23,7 @@ import { parseSessionDiffPatch, type ParsedFilePatch } from "../../../lib/chat/s
 import type { DiffLine } from "../../../lib/chat/tool-call-diff.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { openEditor } from "../../../lib/editor-links.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
@@ -576,9 +577,7 @@ class SessionDiffPanel extends OpenClawLightDomElement {
   private renderBody(): TemplateResult {
     if (this.diffTask.status === TaskStatus.ERROR) {
       const error = this.diffTask.error;
-      return html`<div class="callout danger">
-        ${error instanceof Error ? error.message : String(error)}
-      </div>`;
+      return html`<div class="callout danger">${formatUiError(error)}</div>`;
     }
     const value = this.diffTask.value;
     if (!value) {

--- a/ui/src/pages/chat/components/session-discussion-panel.ts
+++ b/ui/src/pages/chat/components/session-discussion-panel.ts
@@ -8,6 +8,7 @@ import type {
 import { icons } from "../../../components/icons.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
 import { t } from "../../../i18n/index.ts";
+import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { buildWidgetThemeMessage, postWidgetTheme } from "./widget-theme.ts";
 
@@ -240,7 +241,7 @@ class SessionDiscussionPanel extends OpenClawLightDomElement {
     if (this.discussionTask.status === TaskStatus.ERROR) {
       const error = this.discussionTask.error;
       return html`<div class="session-discussion__empty">
-        <div class="callout danger">${error instanceof Error ? error.message : String(error)}</div>
+        <div class="callout danger">${formatUiError(error)}</div>
       </div>`;
     }
     const value = this.discussionTask.value;

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -2,6 +2,7 @@ import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import { loadSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   bytesToBase64,
   floatToG711Ulaw,
@@ -70,7 +71,7 @@ function messageFromError(error: unknown): string {
   if (error instanceof DOMException) {
     return describeRealtimeTalkInputError(error);
   }
-  return error instanceof Error ? error.message : String(error);
+  return formatUiError(error);
 }
 
 function isAbortError(error: unknown): boolean {

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -305,7 +305,12 @@ class ComposerDictationSession {
       return;
     }
     if (payload.type === "error") {
-      this.reportFailure(formatUiExternalText(payload.message, t("chat.composer.dictationFailed")));
+      this.reportFailure(
+        formatUiExternalText(
+          typeof payload.message === "string" ? payload.message : undefined,
+          t("chat.composer.dictationFailed"),
+        ),
+      );
       return;
     }
     if (payload.type === "close" && payload.reason === "error") {

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -2,7 +2,7 @@ import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import { loadSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import {
   bytesToBase64,
   floatToG711Ulaw,
@@ -305,11 +305,7 @@ class ComposerDictationSession {
       return;
     }
     if (payload.type === "error") {
-      this.reportFailure(
-        typeof payload.message === "string" && payload.message.trim()
-          ? payload.message.trim()
-          : t("chat.composer.dictationFailed"),
-      );
+      this.reportFailure(formatUiExternalText(payload.message, t("chat.composer.dictationFailed")));
       return;
     }
     if (payload.type === "close" && payload.reason === "error") {

--- a/ui/src/pages/chat/connect-error.ts
+++ b/ui/src/pages/chat/connect-error.ts
@@ -8,6 +8,7 @@ import {
   readPairingConnectErrorDetails,
 } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "../../api/gateway.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 
 type ErrorWithMessageAndDetails = {
   message?: unknown;
@@ -94,8 +95,9 @@ function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): st
 }
 
 export function formatConnectError(error: unknown): string {
-  if (error && typeof error === "object") {
-    return formatErrorFromMessageAndDetails(error as ErrorWithMessageAndDetails);
-  }
-  return normalizeErrorMessage(error);
+  const message =
+    error && typeof error === "object"
+      ? formatErrorFromMessageAndDetails(error as ErrorWithMessageAndDetails)
+      : normalizeErrorMessage(error);
+  return formatUiError(message);
 }

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -1,3 +1,4 @@
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   bytesToBase64,
   floatToPcm16,
@@ -255,7 +256,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     if (this.closed) {
       return;
     }
-    this.ctx.callbacks.onStatus?.("error", error instanceof Error ? error.message : String(error));
+    this.ctx.callbacks.onStatus?.("error", formatUiError(error));
     this.stop();
   }
 
@@ -272,7 +273,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
       return;
     }
     if (event.type === "error") {
-      this.lastRelayError = event.message ?? "Realtime relay failed";
+      this.lastRelayError = event.message ? formatUiError(event.message) : "Realtime relay failed";
     }
     if (event.type === "close") {
       this.startupError = new Error(
@@ -359,7 +360,9 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
           }
           return;
         case "error":
-          this.lastRelayError = event.message ?? "Realtime relay failed";
+          this.lastRelayError = event.message
+            ? formatUiError(event.message)
+            : "Realtime relay failed";
           this.ctx.callbacks.onStatus?.("error", this.lastRelayError);
           return;
         case "close":
@@ -602,7 +605,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     if (this.closed) {
       return;
     }
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatUiError(error);
     this.lastRelayError = message;
     this.ctx.callbacks.onStatus?.("error", message);
   }

--- a/ui/src/pages/chat/realtime-talk-google-live-tools.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-tools.ts
@@ -1,4 +1,5 @@
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -226,7 +227,7 @@ export class GoogleLiveToolOwner {
     try {
       this.options.sendResult(callId, call.name, result);
     } catch (error) {
-      this.options.failConnection(error instanceof Error ? error.message : String(error));
+      this.options.failConnection(formatUiError(error));
       return false;
     }
     this.pendingCalls.delete(callId);

--- a/ui/src/pages/chat/realtime-talk-google-live.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements realtime talk google live behavior.
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   bytesToBase64,
   estimateBase64DecodedByteLength,
@@ -529,7 +530,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     if (this.closed) {
       return;
     }
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatUiError(error);
     this.ctx.callbacks.onStatus?.("error", message);
   }
 

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -1,4 +1,3 @@
-// Control UI chat module implements realtime talk shared behavior.
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../../../src/talk/agent-consult-tool.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
@@ -10,6 +9,8 @@ import {
 import type { RealtimeVoiceAgentControlMode } from "../../../../src/talk/agent-run-control-shared.js";
 import type { TalkEvent } from "../../../../src/talk/talk-events.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+// Control UI chat module implements realtime talk shared behavior.
+import { formatUiError } from "../../lib/format-error.ts";
 
 export type RealtimeTalkStatus = "idle" | "connecting" | "listening" | "thinking" | "error";
 export type RealtimeTalkEvent = TalkEvent;
@@ -458,7 +459,7 @@ export async function steerRealtimeTalkActiveConsult(params: {
   } catch (error) {
     params.emitTalkEvent?.({
       type: "tool.error",
-      payload: { message: error instanceof Error ? error.message : String(error) },
+      payload: { message: formatUiError(error) },
       final: true,
     });
   }
@@ -509,7 +510,7 @@ export async function submitRealtimeTalkAgentControl(params: {
           : undefined,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatUiError(error);
     talkEvent = {
       type: "tool.error",
       callId: params.callId,
@@ -638,7 +639,7 @@ export async function submitRealtimeTalkConsult(params: {
       return;
     }
     await submitOnce({
-      error: error instanceof Error ? error.message : String(error),
+      error: formatUiError(error),
     });
   } finally {
     params.signal?.removeEventListener("abort", abortRun);

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -1,6 +1,7 @@
-// Control UI chat module implements realtime talk webrtc behavior.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
+// Control UI chat module implements realtime talk webrtc behavior.
+import { formatUiError } from "../../lib/format-error.ts";
 import { RealtimeTalkMediaStreamMeter } from "./realtime-talk-audio.ts";
 import { RealtimeTalkCameraController } from "./realtime-talk-camera-controller.ts";
 import { openRealtimeTalkCamera, openRealtimeTalkInput } from "./realtime-talk-input.ts";
@@ -105,7 +106,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
             if (reportError && this.audio === audio && !this.closed) {
               this.ctx.callbacks.onStatus?.(
                 "error",
-                `Realtime audio playback failed: ${error instanceof Error ? error.message : String(error)}`,
+                `Realtime audio playback failed: ${formatUiError(error)}`,
               );
             }
           });
@@ -644,7 +645,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, frameAttached: true },
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatUiError(error);
       this.submitToolResult(callId, { ok: false, error: message });
       this.emitTalkEvent({
         type: "tool.error",
@@ -675,7 +676,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     if (this.closed) {
       return;
     }
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatUiError(error);
     this.ctx.callbacks.onStatus?.("error", message);
   }
 

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -7,6 +7,7 @@ import {
   VOICE_TRANSCRIPT_QUEUE_POLICY,
 } from "../../../../src/talk/voice-transcript.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
 import type {
@@ -534,7 +535,7 @@ export class RealtimeTalkSession {
               // The utterance exists only in client memory; after retries and surfacing the error,
               // keeping the record open cannot recover it, while server entryId dedupe preserves order.
               // Deferring close would only shift the identical loss to the 6h stale sweep.
-              const detail = `Voice transcript could not be saved: ${error instanceof Error ? error.message : String(error)}`;
+              const detail = `Voice transcript could not be saved: ${formatUiError(error)}`;
               console.warn(detail, error);
               // Only surface to the user if this transport is still the active one; a
               // retired call's late failure must not error a healthy replacement call.

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -4,6 +4,7 @@ import type { SessionsListResult } from "../../api/types.ts";
 import { setLastActiveSessionKey } from "../../app/settings.ts";
 import { compareChatQueueOrder } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
 import {
@@ -316,8 +317,9 @@ export function retirePersistedSteeredChips(state: SteerLifecycleHost): void {
 }
 
 function setChatError(host: SteerLifecycleHost, error: string | null): void {
-  host.lastError = error;
-  host.chatError = error;
+  const message = error === null ? null : formatUiError(error);
+  host.lastError = message;
+  host.chatError = message;
 }
 
 type ChatDeliveryFailureHost = Parameters<typeof visibleSessionMatches>[0] & {
@@ -339,9 +341,10 @@ export function surfaceChatDeliveryFailure(
   agentId: string | undefined,
   error: string,
 ): void {
+  const message = formatUiError(error);
   if (visibleSessionMatches(host, sessionKey, agentId)) {
-    host.lastError = error;
-    host.chatError = error;
+    host.lastError = message;
+    host.chatError = message;
     return;
   }
   // Global rows are agent-scoped while sharing one "global" key, so an
@@ -354,7 +357,7 @@ export function surfaceChatDeliveryFailure(
         !scopedAgentId ||
         (session.agentId !== undefined && normalizeAgentId(session.agentId) === scopedAgentId)),
   );
-  showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${error}` });
+  showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${message}` });
 }
 
 export async function sendQueuedChatMessageWithQueueMode(

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -6,7 +6,7 @@ import { stripInlineDirectiveTagsForDelivery } from "../../../../src/utils/direc
 import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../lib/chat/chat-types.ts";
 import type { DiffStat } from "../../lib/chat/tool-call-diff.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { uiSessionEventMatches } from "../../lib/sessions/session-key.ts";
@@ -763,7 +763,7 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
     }
     return parseFallbackAttempts(data.attempts).map((attempt) => {
       const modelRef = resolveModelLabel(attempt.provider, attempt.model);
-      return `${modelRef ?? `${attempt.provider}/${attempt.model}`}: ${attempt.reason}`;
+      return `${modelRef ?? `${attempt.provider}/${attempt.model}`}: ${formatUiExternalText(attempt.reason)}`;
     });
   })();
 

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -6,6 +6,7 @@ import { stripInlineDirectiveTagsForDelivery } from "../../../../src/utils/direc
 import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../lib/chat/chat-types.ts";
 import type { DiffStat } from "../../lib/chat/tool-call-diff.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { uiSessionEventMatches } from "../../lib/sessions/session-key.ts";
@@ -123,7 +124,8 @@ function parseFallbackAttemptSummaries(value: unknown): string[] {
   }
   return value
     .map((entry) => toTrimmedString(entry))
-    .filter((entry): entry is string => Boolean(entry));
+    .filter((entry): entry is string => Boolean(entry))
+    .map((entry) => formatUiError(entry));
 }
 
 function parseFallbackAttempts(value: unknown): FallbackAttempt[] {
@@ -141,12 +143,13 @@ function parseFallbackAttempts(value: unknown): FallbackAttempt[] {
     if (!provider || !model) {
       continue;
     }
-    const reason =
+    const reason = formatUiError(
       toTrimmedString(item.reason)?.replace(/_/g, " ") ??
-      toTrimmedString(item.code) ??
-      (typeof item.status === "number" ? `HTTP ${item.status}` : null) ??
-      toTrimmedString(item.error) ??
-      "error";
+        toTrimmedString(item.code) ??
+        (typeof item.status === "number" ? `HTTP ${item.status}` : null) ??
+        toTrimmedString(item.error) ??
+        "error",
+    );
     out.push({ provider, model, reason });
   }
   return out;
@@ -751,7 +754,8 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
     return;
   }
 
-  const reason = toTrimmedString(data.reasonSummary) ?? toTrimmedString(data.reason);
+  const rawReason = toTrimmedString(data.reasonSummary) ?? toTrimmedString(data.reason);
+  const reason = rawReason ? formatUiError(rawReason) : null;
   const attempts = (() => {
     const summaries = parseFallbackAttemptSummaries(data.attemptSummaries);
     if (summaries.length > 0) {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -48,6 +48,7 @@ import {
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, isSupportedLocale, t, type Locale } from "../../i18n/index.ts";
 import { resolveControlUiServerQueueMode } from "../../lib/chat/follow-up-mode.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -526,7 +527,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     } catch (error) {
       // Discovery is best-effort in blocked/inactive contexts; a rejection
       // must not wedge the picker in its loading state.
-      this.microphoneError = error instanceof Error ? error.message : String(error);
+      this.microphoneError = formatUiError(error);
     } finally {
       this.microphoneLoading = false;
       this.microphoneRefreshRequestsPermission = false;
@@ -555,7 +556,7 @@ export class ConfigPage extends OpenClawLightDomElement {
         ? realtimeTalkDeviceIssueMessage(result.issue, "videoinput")
         : null;
     } catch (error) {
-      this.cameraError = error instanceof Error ? error.message : String(error);
+      this.cameraError = formatUiError(error);
     } finally {
       this.cameraLoading = false;
       this.cameraRefreshRequestsPermission = false;
@@ -1015,7 +1016,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       });
     } catch (error) {
       if (request === this.cameraSelectionRequest) {
-        this.cameraError = error instanceof Error ? error.message : String(error);
+        this.cameraError = formatUiError(error);
       }
     }
   }

--- a/ui/src/pages/config/custom-theme-import-owner.ts
+++ b/ui/src/pages/config/custom-theme-import-owner.ts
@@ -1,6 +1,7 @@
 import type { ApplicationThemeServerSelection } from "../../app/context.ts";
 import type { ImportedCustomTheme } from "../../app/custom-theme.ts";
 import type { ThemeName } from "../../app/theme.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 
 type ThemeSettingsSnapshot = {
   theme: ThemeName;
@@ -160,7 +161,7 @@ export class CustomThemeImportOwner {
       this.update({
         message: {
           kind: "error",
-          text: error instanceof Error ? error.message : String(error),
+          text: formatUiError(error),
         },
       });
     } finally {

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -8,6 +8,7 @@ import {
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { COMMUNICATION_SETTINGS_TARGET_IDS } from "./settings-targets.ts";
 
 const NOTIFICATIONS_DOCS_URL = "https://docs.openclaw.ai/web/notifications";
@@ -263,7 +264,7 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
             ? html`
                 <div class="settings-row">
                   <div class="settings-row__text">
-                    <span class="cfg-field__error">${push.error}</span>
+                    <span class="cfg-field__error">${formatUiExternalText(push.error)}</span>
                   </div>
                 </div>
               `

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -9,6 +9,7 @@ import { icon } from "../../components/icons.ts";
 import "../../components/web-awesome.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { i18n, t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import {
   formatDurationCompact,
   formatDurationHuman,
@@ -323,7 +324,8 @@ function renderRun(
       : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
         ? `${formatCompactTokenCount(usage.input_tokens)} in / ${formatCompactTokenCount(usage.output_tokens)} out`
         : null;
-  const bodySource = entry.summary || entry.error || t("cron.runEntry.noSummary");
+  const bodySource =
+    entry.summary || formatUiExternalText(entry.error) || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
   const facts = [delivery, entry.model, entry.provider, usageSummary].filter(Boolean);
   return html`
@@ -368,8 +370,12 @@ function renderRun(
                 >
               </div>`
             : nothing}
-          ${showErrorInMeta ? html`<div class="muted">${entry.error}</div>` : nothing}
-          ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
+          ${showErrorInMeta
+            ? html`<div class="muted">${formatUiExternalText(entry.error)}</div>`
+            : nothing}
+          ${entry.deliveryError
+            ? html`<div class="muted">${formatUiExternalText(entry.deliveryError)}</div>`
+            : nothing}
         </div>
       </div>
       <div class="cron-run-entry__body chat-text">

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -49,6 +49,7 @@ import type {
   CronJobsLastStatusFilter,
   CronJobsScheduleKindFilter,
 } from "../../lib/cron/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";
 import { formatCronSchedule } from "../../lib/presenter.ts";
 import { renderSegmented } from "./segmented-control.ts";
@@ -812,7 +813,7 @@ function renderDisabledNote(job: CronJob) {
   return html`<span
     class="cron-table__paused-note cron-table__auto-disabled"
     data-test-id=${`cron-row-auto-disabled-${job.id}`}
-    title=${lastError ?? label}
+    title=${lastError ? formatUiExternalText(lastError) : label}
     >${label}</span
   >`;
 }

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -5,10 +5,17 @@ import { GatewayRequestError } from "../../api/gateway.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext } from "./custodian-page.test-harness.ts";
 import { CustodianSessionStore } from "./custodian-session-store.ts";
+import { custodianErrorMessage } from "./transcript.ts";
 
 describe("CustodianSessionStore", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("redacts secrets in displayed request failures", () => {
+    expect(custodianErrorMessage(new Error("OPENAI_API_KEY=sk-1234567890abcdef"))).toBe(
+      "OPENAI_API_KEY=sk-123...cdef",
+    );
   });
 
   it("shares one live session across repeated surface connections", async () => {

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -8,6 +8,7 @@ import type { WizardStep } from "../../api/types.ts";
 import { renderWizardStepControls } from "../../components/wizard-step-controls.ts";
 import { t } from "../../i18n/index.ts";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { renderChatDivider } from "../chat/components/chat-divider.ts";
 import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { renderCustodianQuestionCard } from "./custodian-question-card.ts";
@@ -67,9 +68,7 @@ export function createCustodianSessionId(): string {
 }
 
 export function custodianErrorMessage(error: unknown): string {
-  return error instanceof Error && error.message.trim()
-    ? error.message
-    : t("custodian.requestFailed");
+  return formatUiError(error, t("custodian.requestFailed"));
 }
 
 function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -8,7 +8,7 @@ import type { WizardStep } from "../../api/types.ts";
 import { renderWizardStepControls } from "../../components/wizard-step-controls.ts";
 import { t } from "../../i18n/index.ts";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { renderChatDivider } from "../chat/components/chat-divider.ts";
 import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { renderCustodianQuestionCard } from "./custodian-question-card.ts";
@@ -180,10 +180,12 @@ export function renderCustodianTranscriptEntry(params: {
     ${params.showWizardStep && step
       ? html`<section
           class="custodian__wizard-step"
-          aria-label=${step.title ?? step.message ?? "Setup"}
+          aria-label=${formatUiExternalText(step.title ?? step.message, "Setup")}
         >
           ${step.title
-            ? html`<strong class="custodian__wizard-title">${step.title}</strong>`
+            ? html`<strong class="custodian__wizard-title"
+                >${formatUiExternalText(step.title)}</strong
+              >`
             : nothing}
           ${renderWizardStepControls({
             step,

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -2,6 +2,7 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { DEFAULT_SESSION_LIST_QUERY } from "../../lib/sessions/index.ts";
 import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-navigation.ts";
 import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
@@ -22,7 +23,7 @@ export async function loadDashboardsRoute(
         : {}),
     });
   } catch (cause) {
-    error = String(cause);
+    error = formatUiError(cause);
   }
   return {
     result: value,

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -8,6 +8,7 @@ import type { HealthSnapshot, StatusSummary } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { loadGatewayDiagnostics } from "../../lib/gateway-diagnostics.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -62,7 +63,7 @@ class DebugPage extends OpenClawLightDomElement {
     },
     onError: (error) => {
       this.diagnosticsTaskActiveClient = null;
-      this.debugDiagnosticsError = String(error);
+      this.debugDiagnosticsError = formatUiError(error);
     },
   });
   private readonly gateway = new GatewayPageController(this, {
@@ -173,7 +174,7 @@ class DebugPage extends OpenClawLightDomElement {
       }
     } catch (err) {
       if (isCurrent()) {
-        this.debugCallError = String(err);
+        this.debugCallError = formatUiError(err);
       }
     }
   }

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -14,8 +14,8 @@ import { renderSettingsWorkspace } from "../../components/settings-workspace.ts"
 import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
-import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -15,6 +15,7 @@ import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
@@ -104,7 +105,7 @@ class LabsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (isCurrent()) {
-        this.saveError = String(error);
+        this.saveError = formatUiError(error);
       }
     } finally {
       if (isCurrent()) {

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -266,7 +266,7 @@ describe("LogsPage lifecycle", () => {
     await page.loadLogs({ reset: true });
     expect(page.logsEntries).toHaveLength(1);
     expect(page.logsStatus).toEqual({
-      error: "Error: logs unavailable",
+      error: "logs unavailable",
       hasLoaded: true,
       stale: true,
     });

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -12,6 +12,7 @@ import {
   failPanelRefresh,
 } from "../../components/panel-refresh-status.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -108,7 +109,7 @@ class LogsPage extends OpenClawLightDomElement {
             formatMissingOperatorReadScopeMessage("logs"),
           );
         } else {
-          this.logsStatus = failPanelRefresh(this.logsStatus, String(result.error));
+          this.logsStatus = failPanelRefresh(this.logsStatus, formatUiError(result.error));
         }
         return;
       }

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -111,7 +111,7 @@ afterEach(() => {
 describe("MemoryImportPage", () => {
   it("keeps a failed plan stable until the operator explicitly refreshes", async () => {
     const request = vi.fn(async () => {
-      throw new Error("planning unavailable");
+      throw new Error("planning unavailable: OPENAI_API_KEY=sk-1234567890abcdef");
     });
     const page = await mountPage(createContext(request));
 
@@ -120,7 +120,8 @@ describe("MemoryImportPage", () => {
     await Promise.resolve();
     await page.updateComplete;
     expect(request).toHaveBeenCalledTimes(1);
-    expect(page.textContent).toContain("planning unavailable");
+    expect(page.textContent).toContain("planning unavailable: OPENAI_API_KEY=sk-123...cdef");
+    expect(page.textContent).not.toContain("sk-1234567890abcdef");
 
     const refresh = [...page.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent?.trim() === "Refresh",

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -12,6 +12,7 @@ import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -36,11 +37,7 @@ type PendingMemoryImport = {
 };
 
 function toErrorMessage(error: unknown): string {
-  return error instanceof Error && error.message.trim()
-    ? error.message
-    : typeof error === "string"
-      ? error
-      : "request failed";
+  return formatUiError(error, "request failed");
 }
 
 function createIdempotencyKey(): string {

--- a/ui/src/pages/memory-import/view.ts
+++ b/ui/src/pages/memory-import/view.ts
@@ -21,6 +21,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { normalizeAgentLabel } from "../../lib/agents/display.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import "../../styles/memory-import.css";
 
 type MemoryCollection = {
@@ -271,7 +272,7 @@ function renderResult(result: MigrationsMemoryApplyResult | undefined) {
                 );
                 return html`<li>
                   <strong>${artifactLabel(item)}</strong>
-                  <span>${item.reason ?? item.message ?? item.status}</span>
+                  <span>${formatUiExternalText(item.reason ?? item.message, item.status)}</span>
                   ${recoveryArtifacts.map(
                     (artifact) => html`<span class="memory-import__result-artifact">
                       <span>${artifact.label}</span>
@@ -296,7 +297,7 @@ function renderProvider(props: MemoryImportViewProps, provider: MemoryMigrationP
     props.backfillBusy === "rollback" ||
     props.backfillRollbackPending;
   const rows = provider.error
-    ? html`<div class="callout danger" role="alert">${provider.error}</div>`
+    ? html`<div class="callout danger" role="alert">${formatUiExternalText(provider.error)}</div>`
     : !provider.found
       ? renderSettingsEmpty(provider.message ?? t("memoryImport.noMemoryFound"))
       : html`

--- a/ui/src/pages/model-providers/config-mutation.ts
+++ b/ui/src/pages/model-providers/config-mutation.ts
@@ -1,5 +1,6 @@
 import { t } from "../../i18n/index.ts";
 import type { RuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type { ModelProviderRowMessage } from "./view.ts";
 
 export type ModelProviderConfigMutation = {
@@ -25,10 +26,7 @@ type ModelProviderConfigMutationOwner = {
 };
 
 export function modelProviderErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" && error.trim() ? error : t("modelProviders.requestFailed");
+  return formatUiError(error, t("modelProviders.requestFailed"));
 }
 
 /**

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -111,7 +111,7 @@ describe("loadModelProvidersData", () => {
   it("surfaces an explicit catalog refresh failure while retaining cached configured models", async () => {
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "models.list" && (params as { view?: string } | undefined)?.view === "all") {
-        throw new Error("catalog refresh failed");
+        throw new Error("catalog refresh failed: OPENAI_API_KEY=sk-1234567890abcdef");
       }
       switch (method) {
         case "models.authStatus":
@@ -139,7 +139,7 @@ describe("loadModelProvidersData", () => {
 
     const result = await loadModelProvidersData(client, { refresh: true, agentId: "writer" });
 
-    expect(result.catalogError).toBe("catalog refresh failed");
+    expect(result.catalogError).toBe("catalog refresh failed: OPENAI_API_KEY=sk-123...cdef");
     expect(result.models).toEqual([{ id: "cached", name: "Cached", provider: "openai" }]);
     expect(
       request.mock.calls.filter(

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -11,6 +11,7 @@ import type {
   ModelCatalogProviderOutcome,
 } from "../../api/types.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -60,10 +61,7 @@ function errorMessage(error: unknown): string {
   if (isMissingOperatorReadScopeError(error)) {
     return formatMissingOperatorReadScopeMessage("model providers");
   }
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" ? error : "request failed";
+  return formatUiError(error, "request failed");
 }
 
 export async function loadModelProvidersData(

--- a/ui/src/pages/model-providers/mutations.test.ts
+++ b/ui/src/pages/model-providers/mutations.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
+import { modelProviderErrorMessage } from "./config-mutation.ts";
 import {
   buildDefaultModelsPatch,
   buildProviderApiKeyPatch,
@@ -7,6 +8,12 @@ import {
 } from "./mutations.ts";
 
 describe("model provider config patches", () => {
+  it("redacts secrets in displayed mutation failures", () => {
+    expect(modelProviderErrorMessage(new Error("OPENAI_API_KEY=sk-1234567890abcdef"))).toBe(
+      "OPENAI_API_KEY=sk-123...cdef",
+    );
+  });
+
   it("sets and removes provider API keys with minimal merge patches", () => {
     expect(buildProviderApiKeyPatch("openai", "new-key")).toEqual({
       models: { providers: { openai: { apiKey: "new-key" } } },

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -18,6 +18,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatThinkingOverrideLabel } from "../../lib/chat/thinking.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatCompactTokenCount, formatCost, formatTimeMs } from "../../lib/format.ts";
 import { MODEL_SETTINGS_TARGET_IDS } from "../config/settings-targets.ts";
 import "../../styles/model-providers.css";
@@ -283,7 +284,7 @@ function renderProbeResult(result: ModelsProbeResult | undefined) {
             >`
           : nothing}
       </div>
-      ${result.error ? html`<div>${result.error}</div>` : nothing}
+      ${result.error ? html`<div>${formatUiExternalText(result.error)}</div>` : nothing}
       ${result.results.map(
         (target) => html`
           <div class="model-providers__probe-target">
@@ -293,7 +294,7 @@ function renderProbeResult(result: ModelsProbeResult | undefined) {
                 ? ` · ${t("modelProviders.probe.latency", { ms: String(target.latencyMs) })}`
                 : ""}
             </span>
-            ${target.error ? html`<small>${target.error}</small>` : nothing}
+            ${target.error ? html`<small>${formatUiExternalText(target.error)}</small>` : nothing}
           </div>
         `,
       )}

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -172,6 +172,22 @@ describe("ModelSetupPage catalog icons", () => {
     expect(page.innerHTML).not.toContain(recommendedIconUrl);
   });
 
+  it("redacts secrets in displayed detection failures", async () => {
+    const { context, client, request, runtimeConfig } = createContext();
+    request.mockRejectedValue(new Error("OPENAI_API_KEY=sk-1234567890abcdef"));
+    const { page } = await mountPage(context, {
+      state: { phase: "ready", result: detection },
+      client,
+      firstRun: false,
+    });
+
+    await (page as unknown as { detect: () => Promise<unknown> }).detect();
+
+    expect(page.textContent).toContain("OPENAI_API_KEY=sk-123...cdef");
+    expect(page.textContent).not.toContain("sk-1234567890abcdef");
+    runtimeConfig.dispose();
+  });
+
   it("loads unknown wire icons through the authenticated same-origin catalog proxy", async () => {
     const NativeUrl = URL;
     const createObjectURL = vi.fn(() => "blob:acme-icon");

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -14,6 +14,7 @@ import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -52,10 +53,7 @@ export type ModelSetupRouteData = {
 };
 
 function errorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" && error.trim() ? error : t("modelSetup.errors.requestFailed");
+  return formatUiError(error, t("modelSetup.errors.requestFailed"));
 }
 
 type BoundModelResult<T> =

--- a/ui/src/pages/model-setup/route.test.ts
+++ b/ui/src/pages/model-setup/route.test.ts
@@ -86,4 +86,26 @@ describe("model setup route", () => {
     });
     expect(request).toHaveBeenCalledTimes(2);
   });
+
+  it("redacts secrets in initial detection failures", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("OPENAI_API_KEY=sk-1234567890abcdef"));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const hello = {
+      type: "hello-ok" as const,
+      protocol: 1,
+      auth: { role: "operator", scopes: ["operator.admin"] },
+      features: { methods: ["openclaw.setup.detect"] },
+    };
+    const context = {
+      gateway: { snapshot: { client, phase: "connected", hello } },
+      agentSelection: { state: { selectedId: "main" } },
+    } as unknown as ApplicationContext;
+
+    await expect(page.loader?.(context, loaderOptions())).resolves.toMatchObject({
+      state: {
+        phase: "detect-error",
+        message: "OPENAI_API_KEY=sk-123...cdef",
+      },
+    });
+  });
 });

--- a/ui/src/pages/model-setup/route.ts
+++ b/ui/src/pages/model-setup/route.ts
@@ -5,6 +5,7 @@ import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { consumeCachedModelSetupDetection } from "./detect-cache.ts";
 import type { ModelSetupRouteData } from "./model-setup-page.ts";
@@ -38,11 +39,10 @@ async function loadModelSetupRouteData(
       result: await detectModelSetup(client, agentId ?? undefined),
     };
   } catch (error) {
-    const message =
-      error instanceof Error && error.message.trim()
-        ? error.message
-        : t("modelSetup.errors.requestFailed");
-    state = { phase: "detect-error", message };
+    state = {
+      phase: "detect-error",
+      message: formatUiError(error, t("modelSetup.errors.requestFailed")),
+    };
   }
 
   const current = context.gateway.snapshot;

--- a/ui/src/pages/model-setup/state.ts
+++ b/ui/src/pages/model-setup/state.ts
@@ -5,6 +5,7 @@ import type {
   WizardNextResult,
   WizardStep,
 } from "../../api/types.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 
 export const MODEL_SETUP_DETECT_TIMEOUT_MS = 20_000;
 export const MODEL_SETUP_VERIFY_TIMEOUT_MS = 30_000;
@@ -78,7 +79,7 @@ export function mapActivationResult(params: {
     phase: "failure",
     targetId: params.targetId,
     status: result.status && result.status !== "ok" ? result.status : "unknown",
-    error: result.error?.trim() || params.fallbackError,
+    error: formatUiExternalText(result.error, params.fallbackError),
   };
 }
 
@@ -90,7 +91,7 @@ export function mapVerifyResult(result: SystemAgentSetupVerifyResult): ModelSetu
       ...(typeof result.latencyMs === "number" ? { latencyMs: result.latencyMs } : {}),
     };
   }
-  return { phase: "failed", status: result.status, error: result.error };
+  return { phase: "failed", status: result.status, error: formatUiExternalText(result.error) };
 }
 
 export function wizardStateFromResult(
@@ -104,7 +105,7 @@ export function wizardStateFromResult(
       authChoice,
       step: result.step,
       busy: false,
-      validationError: result.error?.trim() || null,
+      validationError: result.error?.trim() ? formatUiExternalText(result.error) : null,
     };
   }
   if (result.status === "done") {
@@ -115,9 +116,9 @@ export function wizardStateFromResult(
     };
   }
   if (result.status === "cancelled") {
-    return { phase: "cancelled", message: result.error?.trim() || fallbackError };
+    return { phase: "cancelled", message: formatUiExternalText(result.error, fallbackError) };
   }
-  return { phase: "error", message: result.error?.trim() || fallbackError };
+  return { phase: "error", message: formatUiExternalText(result.error, fallbackError) };
 }
 
 export function initialWizardValue(step: WizardStep): unknown {

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -9,6 +9,7 @@ import {
 } from "../../components/provider-icon.ts";
 import { syncDropdownItemRadio } from "../../components/web-awesome.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import "../../styles/model-setup.css";
 import {
   failureLabel,
@@ -160,7 +161,9 @@ function renderCandidateRows(props: ModelSetupViewProps, result: SystemAgentSetu
                   <strong>${candidate.label}</strong>
                   <span class="model-setup__chip">${candidateStatus(candidate)}</span>
                 </div>
-                <div class="muted">${candidate.modelRef} · ${candidate.detail}</div>
+                <div class="muted">
+                  ${candidate.modelRef} · ${formatUiExternalText(candidate.detail)}
+                </div>
                 ${testing
                   ? html`<div class="model-setup__testing" role="status">
                       ${t("modelSetup.candidates.testing", { modelRef: candidate.modelRef })}
@@ -250,8 +253,10 @@ function renderUnavailable(props: ModelSetupViewProps, result: SystemAgentSetupD
               <div class="model-setup__provider-copy">
                 ${renderProviderIcon(props, candidate)}
                 <div>
-                  <div><strong>${candidate.label}</strong> — ${candidate.detail}</div>
-                  <div class="muted">${candidate.reason}</div>
+                  <div>
+                    <strong>${candidate.label}</strong> — ${formatUiExternalText(candidate.detail)}
+                  </div>
+                  <div class="muted">${formatUiExternalText(candidate.reason)}</div>
                 </div>
               </div>
               <div class="model-setup__row-actions">

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -64,7 +64,7 @@ describe("ModelSetupWizardRunner", () => {
         return Promise.resolve({ sessionId: "session-1", done: false, status: "running" });
       }
       if (method === "wizard.next") {
-        return Promise.reject(new Error("wizard unavailable"));
+        return Promise.reject(new Error("wizard unavailable: OPENAI_API_KEY=sk-1234567890abcdef"));
       }
       return Promise.resolve({ ok: true });
     });
@@ -79,7 +79,10 @@ describe("ModelSetupWizardRunner", () => {
     });
 
     await runner.start("openai-oauth");
-    expect(runner.state).toEqual({ phase: "error", message: "wizard unavailable" });
+    expect(runner.state).toEqual({
+      phase: "error",
+      message: "wizard unavailable: OPENAI_API_KEY=sk-123...cdef",
+    });
     expect(request).toHaveBeenCalledWith(
       "wizard.cancel",
       { sessionId: expect.any(String) },

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SystemAgentSetupAuthStartResult, WizardNextResult } from "../../api/types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 import {
   MODEL_SETUP_AUTH_START_TIMEOUT_MS,
@@ -209,9 +210,7 @@ export class ModelSetupWizardRunner {
     }
     const message = sessionExpired
       ? this.options.sessionExpiredMessage()
-      : error instanceof Error && error.message.trim()
-        ? error.message
-        : this.options.requestFailedMessage();
+      : formatUiError(error, this.options.requestFailedMessage());
     this.setState({ phase: "error", message });
   }
 

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -2,9 +2,10 @@ import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
-import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
+import "../../components/tooltip.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   createChatAttachmentDropHandlers,
   handleChatAttachmentPaste,
@@ -172,7 +173,9 @@ export function renderDraftError(message: string) {
   return html`
     <div class="callout danger new-session-page__error new-session-page__alert" role="alert">
       <span class="new-session-page__alert-icon" aria-hidden="true">${icons.alertTriangle}</span>
-      <span class="callout__content new-session-page__alert-message">${message}</span>
+      <span class="callout__content new-session-page__alert-message"
+        >${formatUiError(message)}</span
+      >
     </div>
   `;
 }

--- a/ui/src/pages/new-session/draft-place-browser.ts
+++ b/ui/src/pages/new-session/draft-place-browser.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import type { BrowserTarget, DraftNode } from "./discovery.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
@@ -184,7 +185,7 @@ export class DraftPlaceBrowser {
       return null;
     }
     const error = this.projectSearchTask.error;
-    return error instanceof Error ? error.message : String(error);
+    return formatUiError(error);
   }
 
   get browserLoading(): boolean {
@@ -489,7 +490,7 @@ export class DraftPlaceBrowser {
       this.close();
     } catch (error) {
       if (requestId === this.browserRequestToken && client === this.gateway.client) {
-        this.browserErrorValue = error instanceof Error ? error.message : String(error);
+        this.browserErrorValue = formatUiError(error);
       }
     } finally {
       if (requestId === this.browserRequestToken) {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -6,10 +6,11 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { beginNativeWindowDragFromTopInset } from "../../app/native-window-drag.ts";
 import { loadSettings } from "../../app/settings.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
-import "../../components/web-awesome-popover.ts";
 import { t } from "../../i18n/index.ts";
+import "../../components/web-awesome-popover.ts";
 import { normalizeAgentTargetLabel } from "../../lib/agents/display.ts";
 import { requestDevicePairJoinSetup, type DevicePairSetup } from "../../lib/device-pair-setup.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
@@ -551,7 +552,7 @@ class NewSessionPage extends OpenClawLightDomElement {
         this.gateway.connected &&
         this.connectMachineOpen
       ) {
-        this.connectMachineError = error instanceof Error ? error.message : String(error);
+        this.connectMachineError = formatUiError(error);
       }
     } finally {
       if (requestId === this.connectMachineRequestId) {

--- a/ui/src/pages/plugin/logbook-controller.ts
+++ b/ui/src/pages/plugin/logbook-controller.ts
@@ -1,5 +1,6 @@
 // Control UI controller for the Logbook tab: state, gateway calls, polling.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type {
   LogbookDaysPayload,
   LogbookStatusPayload,
@@ -181,7 +182,7 @@ export async function loadLogbook(
     state.error = null;
   } catch (err) {
     if (ownsClient(state, client, clientGeneration) && generation === state.loadGeneration) {
-      state.error = err instanceof Error ? err.message : String(err);
+      state.error = formatUiError(err);
     }
   } finally {
     let shouldNotify =
@@ -344,7 +345,7 @@ export async function setLogbookCapturePaused(
     }
   } catch (err) {
     if (ownsClient(state, client, clientGeneration)) {
-      state.error = err instanceof Error ? err.message : String(err);
+      state.error = formatUiError(err);
     }
   } finally {
     if (ownsClient(state, client, clientGeneration)) {
@@ -374,7 +375,7 @@ export async function runLogbookAnalysisNow(
     }
   } catch (err) {
     if (ownsClient(state, client, clientGeneration)) {
-      state.error = err instanceof Error ? err.message : String(err);
+      state.error = formatUiError(err);
     }
   } finally {
     if (ownsClient(state, client, clientGeneration)) {
@@ -407,7 +408,7 @@ export async function loadLogbookStandup(
     }
   } catch (err) {
     if (ownsClient(state, client, clientGeneration)) {
-      state.error = err instanceof Error ? err.message : String(err);
+      state.error = formatUiError(err);
     }
   } finally {
     if (ownsClient(state, client, clientGeneration)) {
@@ -440,7 +441,7 @@ export async function askLogbook(
     }
   } catch (err) {
     if (ownsClient(state, client, clientGeneration)) {
-      state.error = err instanceof Error ? err.message : String(err);
+      state.error = formatUiError(err);
     }
   } finally {
     if (ownsClient(state, client, clientGeneration)) {

--- a/ui/src/pages/plugin/logbook-controller.ts
+++ b/ui/src/pages/plugin/logbook-controller.ts
@@ -1,6 +1,6 @@
 // Control UI controller for the Logbook tab: state, gateway calls, polling.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import type {
   LogbookDaysPayload,
   LogbookStatusPayload,
@@ -371,7 +371,7 @@ export async function runLogbookAnalysisNow(
       {},
     );
     if (ownsClient(state, client, clientGeneration) && !result.started && result.reason) {
-      state.error = result.reason;
+      state.error = formatUiExternalText(result.reason);
     }
   } catch (err) {
     if (ownsClient(state, client, clientGeneration)) {

--- a/ui/src/pages/plugin/logbook-view.ts
+++ b/ui/src/pages/plugin/logbook-view.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { icons } from "../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatDurationCompact, formatTimeMs } from "../../lib/format.ts";
 import "../../styles/logbook.css";
 import {
@@ -72,14 +73,17 @@ function renderStatusChips(status: LogbookStatusPayload): TemplateResult {
           >`
         : nothing}
       ${status.lastCaptureError
-        ? html`<span class="logbook__chip logbook__chip--error" title=${status.lastCaptureError}>
+        ? html`<span
+            class="logbook__chip logbook__chip--error"
+            title=${formatUiExternalText(status.lastCaptureError)}
+          >
             ${t("logbook.status.captureError")}
           </span>`
         : nothing}
       ${status.lastBatch?.status === "error"
         ? html`<span
             class="logbook__chip logbook__chip--error"
-            title=${status.lastBatch.error ?? ""}
+            title=${formatUiExternalText(status.lastBatch.error)}
           >
             ${t("logbook.status.batchError")}
           </span>`
@@ -166,7 +170,9 @@ function renderCard(
                       ${t("common.loading")}
                     </div>`
                   : nothing}
-              ${card.detail ? html`<p class="logbook-card__detail">${card.detail}</p>` : nothing}
+              ${card.detail
+                ? html`<p class="logbook-card__detail">${formatUiExternalText(card.detail)}</p>`
+                : nothing}
               ${card.distractions.length > 0
                 ? html`
                     <div class="logbook-card__distractions">

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -30,7 +30,7 @@ import {
   type McpServerSummary,
   type McpServersPatchBuildResult,
 } from "../../lib/config/mcp-servers.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import {
   installPlugin,
   pluginInstallNeedsRiskAcknowledgement,
@@ -112,7 +112,10 @@ function mutationSuccessMessage(
     ? `pluginsPage.${action}Restart`
     : `pluginsPage.${action}Success`;
   const warnings = "warnings" in result ? (result.warnings ?? []) : [];
-  const lines = [t(key, { name: result.plugin.name }), ...warnings];
+  const lines = [
+    t(key, { name: result.plugin.name }),
+    ...warnings.map((warning) => formatUiExternalText(warning)),
+  ];
   return lines.filter(Boolean).join("\n");
 }
 
@@ -863,7 +866,7 @@ class PluginsPage extends OpenClawLightDomElement {
           kind: "success",
           text: [
             t("pluginsPage.removedRestart", { name: result.pluginId }),
-            ...(result.warnings ?? []),
+            ...(result.warnings ?? []).map((warning) => formatUiExternalText(warning)),
             refreshError ? t("pluginsPage.configRefreshFailed", { error: refreshError }) : null,
           ]
             .filter(Boolean)

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -20,6 +20,7 @@ import {
 import { t } from "../../i18n/index.ts";
 import type { McpServerSummary } from "../../lib/config/mcp-servers.ts";
 import { EXTERNAL_LINK_TARGET, buildExternalLinkRel } from "../../lib/external-link.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import "../../styles/plugins.css";
 import {
   CLAWHUB_BROWSE_URL,
@@ -433,7 +434,9 @@ function renderRowMessage(
     const findings = details.findings ?? [];
     const reviewBody =
       findings.length === 0
-        ? t("pluginsPage.policyReviewBodyReason", { reason: details.reason })
+        ? t("pluginsPage.policyReviewBodyReason", {
+            reason: formatUiExternalText(details.reason),
+          })
         : t("pluginsPage.policyReviewBodyKnown", { count: String(findings.length) });
     return html`
       <div
@@ -447,7 +450,9 @@ function renderRowMessage(
           <div>
             <strong>${t("pluginsPage.policyReviewTitle")}</strong>
             ${findings.length > 0
-              ? html`<span class="plugins-policy-review__reason">${details.reason}</span>`
+              ? html`<span class="plugins-policy-review__reason"
+                  >${formatUiExternalText(details.reason)}</span
+                >`
               : nothing}
             <span>${reviewBody}</span>
           </div>
@@ -467,7 +472,7 @@ function renderRowMessage(
                             class="plugins-policy-review__severity plugins-policy-review__severity--${finding.severity}"
                             >${policyFindingSeverityLabel(finding.severity)}</span
                           >
-                          <span>${finding.message}</span>
+                          <span>${formatUiExternalText(finding.message)}</span>
                         </span>
                       </li>
                     `,
@@ -831,7 +836,7 @@ function renderPluginRow(
       </div>
       ${plugin.error
         ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
-            ${plugin.error}
+            ${formatUiExternalText(plugin.error)}
           </div>`
         : nothing}
       ${renderRowMessage(key, props.messages[key], busy, props, installIdentity)}
@@ -1307,7 +1312,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
           </div>
           ${plugin.error
             ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
-                ${plugin.error}
+                ${formatUiExternalText(plugin.error)}
               </div>`
             : nothing}
           ${renderRowMessage(key, props.messages[key], busy, props, installIdentity)}

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -461,10 +461,11 @@ it("keeps identity refresh single-flight and allows retry after settlement", asy
   await Promise.all([pageWithIdentity.loadIdentity(), pageWithIdentity.loadIdentity()]);
   expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(1);
 
-  rejectIdentity?.(new Error("identity unavailable"));
+  rejectIdentity?.(new Error("identity unavailable: OPENAI_API_KEY=sk-1234567890abcdef"));
   await waitForFast(() => expect(refresh.disabled).toBe(false));
   expect(refresh.textContent?.trim()).toBe(t("common.refresh"));
-  expect(page.textContent).toContain("identity unavailable");
+  expect(page.textContent).toContain("identity unavailable: OPENAI_API_KEY=sk-123...cdef");
+  expect(page.textContent).not.toContain("sk-1234567890abcdef");
 
   refresh.click();
   await waitForFast(() =>

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -30,6 +30,7 @@ import { renderSettingsWorkspace } from "../../components/settings-workspace.ts"
 import { t } from "../../i18n/index.ts";
 import { AuthenticatedAvatarRouteLoader } from "../../lib/authenticated-avatar-route.ts";
 import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../../lib/avatar.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PROFILE_SETTINGS_TARGET_IDS } from "../config/settings-targets.ts";
 import "../../styles/profile.css";
@@ -39,12 +40,7 @@ import { renderIdentitySection } from "./identity-section.ts";
 const PROFILE_DOCS_URL = "https://docs.openclaw.ai/concepts/user-model";
 
 function toIdentityErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" && error.trim()
-    ? error
-    : t("profilePage.identity.profileUnavailable");
+  return formatUiError(error, t("profilePage.identity.profileUnavailable"));
 }
 
 export class ProfilePage extends OpenClawLightDomElement {

--- a/ui/src/pages/sessions/custom-groups.ts
+++ b/ui/src/pages/sessions/custom-groups.ts
@@ -1,4 +1,5 @@
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 
 export function sessionCategoryNames(
@@ -39,7 +40,7 @@ export async function rememberSessionCustomGroup(options: {
     if (!options.isCurrent()) {
       return "stale";
     }
-    options.onError(String(error));
+    options.onError(formatUiError(error));
     return "failed";
   }
 }

--- a/ui/src/pages/sessions/route.ts
+++ b/ui/src/pages/sessions/route.ts
@@ -3,6 +3,7 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   DEFAULT_SESSION_LIST_QUERY,
   type SessionArchivedFilter,
@@ -42,7 +43,7 @@ async function loadSessionsRoute(
       })
       .then(
         (result) => ({ result, error: null }),
-        (error: unknown) => ({ result: null, error: String(error) }),
+        (error: unknown) => ({ result: null, error: formatUiError(error) }),
       ),
     context.runtimeConfig.ensureLoaded().catch(() => undefined),
   ]);

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -851,7 +851,7 @@ describe("sessions page lifecycle", () => {
     await page.rememberCustomGroup(name);
 
     expect(groupsPut).toHaveBeenCalledWith([name]);
-    expect(page.error).toBe("Error: group name exceeds 512 characters");
+    expect(page.error).toBe("group name exceeds 512 characters");
   });
 
   it("drops stale mutation state, errors, and navigation after disconnect", async () => {

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -22,14 +22,15 @@ import {
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
 import { fetchSessionMenuWork } from "../../components/session-menu-work.ts";
-import "../../components/session-menu.ts";
 import type { SessionMenuAction, SessionMenuWork } from "../../components/session-menu.ts";
+import "../../components/session-menu.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
 import { openEditor } from "../../lib/editor-links.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { openExternalUrlSafe } from "../../lib/open-external-url.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../../lib/plugin-activation.ts";
@@ -274,7 +275,7 @@ class SessionsPage extends OpenClawLightDomElement {
       this.transcriptSearch = result ? { status: "results", ...result } : { status: "idle" };
     },
     onError: (error) => {
-      this.transcriptSearch = { status: "error", message: String(error) };
+      this.transcriptSearch = { status: "error", message: formatUiError(error) };
     },
   });
 
@@ -298,7 +299,7 @@ class SessionsPage extends OpenClawLightDomElement {
       if (sessionKey) {
         this.checkpointErrorByKey = {
           ...this.checkpointErrorByKey,
-          [sessionKey]: String(error),
+          [sessionKey]: formatUiError(error),
         };
       }
     },
@@ -608,7 +609,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (requestId === this.sessionRequestId && this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (requestId === this.sessionRequestId && this.isRequestScopeCurrent(scope)) {
@@ -852,7 +853,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.isRequestScopeCurrent(scope)) {
@@ -895,7 +896,7 @@ class SessionsPage extends OpenClawLightDomElement {
       rows = listed;
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
       return;
     }
@@ -974,7 +975,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.isRequestScopeCurrent(scope)) {
@@ -1064,7 +1065,7 @@ class SessionsPage extends OpenClawLightDomElement {
     try {
       return (await import("../../components/input-dialog.ts")).showInputDialog;
     } catch (error) {
-      this.error = String(error);
+      this.error = formatUiError(error);
       return null;
     }
   }
@@ -1181,7 +1182,7 @@ class SessionsPage extends OpenClawLightDomElement {
       return "completed";
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
         return "failed";
       }
       return "stale";
@@ -1250,7 +1251,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     }
   }
@@ -1345,7 +1346,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.isRequestScopeCurrent(scope) && this.checkpointBusyKey === checkpointId) {
@@ -1382,7 +1383,7 @@ class SessionsPage extends OpenClawLightDomElement {
       });
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.isRequestScopeCurrent(scope) && this.checkpointBusyKey === checkpointId) {
@@ -1760,7 +1761,7 @@ class SessionsPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     }
   }

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -30,7 +30,7 @@ import { renderSettingsWorkspace } from "../../components/settings-workspace.ts"
 import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
 import { openEditor } from "../../lib/editor-links.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { openExternalUrlSafe } from "../../lib/open-external-url.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../../lib/plugin-activation.ts";
@@ -849,7 +849,7 @@ class SessionsPage extends OpenClawLightDomElement {
         }
       }
       if (result.errors.length > 0) {
-        this.error = result.errors.join("; ");
+        this.error = formatUiExternalText(result.errors.join("; "));
       }
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -7,6 +7,7 @@ import "../../components/file-preview-modal-registration.ts";
 import "../../components/modal-dialog.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import "../../styles/plugins.css";
 import "../../styles/skill-workshop.css";
@@ -760,9 +761,11 @@ function renderEvaluationOutcome(outcome: SkillWorkshopEvaluationOutcome) {
       </div>
       ${result?.summary ? html`<p class="sw-evaluation__summary">${result.summary}</p>` : nothing}
       ${result?.decisionReason
-        ? html`<p class="sw-evaluation__reason">${result.decisionReason}</p>`
+        ? html`<p class="sw-evaluation__reason">${formatUiExternalText(result.decisionReason)}</p>`
         : nothing}
-      ${outcome.error ? html`<p class="sw-evaluation__error">${outcome.error}</p>` : nothing}
+      ${outcome.error
+        ? html`<p class="sw-evaluation__error">${formatUiExternalText(outcome.error)}</p>`
+        : nothing}
       ${result?.findings?.length ? renderEvaluationFindings(result.findings) : nothing}
       ${result?.metrics && Object.keys(result.metrics).length > 0
         ? renderEvaluationMetrics(result.metrics)
@@ -808,7 +811,8 @@ function renderEvaluationFindings(findings: SkillWorkshopEvaluationFinding[]) {
               </span>
               <span>
                 <code class="sw-evaluation__rule">${finding.ruleId}</code>
-                ${finding.message} ${location ? html`<small>${location}</small>` : nothing}
+                ${formatUiExternalText(finding.message)}
+                ${location ? html`<small>${location}</small>` : nothing}
               </span>
             </li>
           `;

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -13,6 +13,7 @@ import {
 import { renderHubTabs } from "../../components/hub-tabs.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { searchClawHub, type ClawHubSearchResult } from "../../lib/skills/clawhub-search.ts";
 import {
@@ -322,7 +323,7 @@ class SkillsPage extends OpenClawLightDomElement {
       return null;
     }
     const error = this.clawhubSearchTask.error;
-    return error instanceof Error ? error.message : String(error);
+    return formatUiError(error);
   }
 
   private changeDetailTab(tab: SkillDetailTab) {

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -24,6 +24,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { listSelectableAgents, normalizeAgentLabel } from "../../lib/agents/display.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
 import "../../styles/plugins.css";
@@ -767,7 +768,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
 
           ${message
             ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
-                ${message.message}
+                ${formatUiExternalText(message.message)}
               </div>`
             : nothing}
           ${skill.primaryEnv
@@ -847,11 +848,13 @@ function renderInstalledClawHubOverview(
   if (link.status === "invalid") {
     return html`<div class="callout danger">
       <div style="font-weight: 600; margin-bottom: 4px;">${t("skillsPage.invalidLink")}</div>
-      <div>${link.reason}</div>
+      <div>${formatUiExternalText(link.reason)}</div>
     </div>`;
   }
   const auditHref = safeExternalHref(verdict?.securityAuditUrl ?? undefined);
-  const reasonText = verdict?.reasons?.length ? verdict.reasons.join(", ") : null;
+  const reasonText = verdict?.reasons?.length
+    ? formatUiExternalText(verdict.reasons.join(", "))
+    : null;
   const installedRef = `${link.ownerHandle ? `@${link.ownerHandle}/` : ""}${link.slug}@${link.installedVersion}`;
   return html`
     <div

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -305,6 +305,16 @@ describe("TasksPage concurrent refresh events", () => {
 });
 
 describe("TasksPage active pagination", () => {
+  it("redacts secrets in displayed list failures", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("OPENAI_API_KEY=sk-1234567890abcdef"));
+    const source = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+    page.context = createContext(source.gateway);
+    document.body.append(page);
+
+    await vi.waitFor(() => expect(page.error).toBe("OPENAI_API_KEY=sk-123...cdef"));
+  });
+
   it("drains active pages with the selected scope and merges each task once", async () => {
     const sharedPageOne = createTask("task-shared", "running", {
       progressSummary: "Page one progress",

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -9,7 +9,7 @@ import { hasOperatorReadAccess, hasOperatorWriteAccess } from "../../app/operato
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
-import { formatUiError } from "../../lib/format-error.ts";
+import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import {
   findUiSessionRow,
   resolveSessionPreferredFaceForKey,
@@ -282,7 +282,7 @@ class TasksPage extends OpenClawLightDomElement {
       // Refusals (already terminal, stale id, no cancellation handle) are
       // successful responses with cancelled=false; surface them like errors.
       if (!result?.cancelled) {
-        this.error = result?.reason?.trim() || t("tasksPage.cancelFailed");
+        this.error = formatUiExternalText(result?.reason, t("tasksPage.cancelFailed"));
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
@@ -320,7 +320,7 @@ class TasksPage extends OpenClawLightDomElement {
       }
       const result = normalizeTasksRecoveryResult(payload)?.results[0];
       if (!result?.ok) {
-        this.error = result?.reason?.trim() || t("tasksPage.recoveryFailed");
+        this.error = formatUiExternalText(result?.reason, t("tasksPage.recoveryFailed"));
         return;
       }
       if (result.task) {

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -9,6 +9,7 @@ import { hasOperatorReadAccess, hasOperatorWriteAccess } from "../../app/operato
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   findUiSessionRow,
   resolveSessionPreferredFaceForKey,
@@ -33,13 +34,6 @@ import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderTasks } from "./view.ts";
-
-function formatTaskError(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message.trim();
-  }
-  return typeof error === "string" && error.trim() ? error.trim() : fallback;
-}
 
 function taskMatchesAgentScope(task: TaskSummary, agentId: string | null): boolean {
   if (!agentId) {
@@ -191,7 +185,7 @@ class TasksPage extends OpenClawLightDomElement {
     },
     onError: (error) => {
       this.taskRefreshEvents = null;
-      this.error = formatTaskError(error, t("tasksPage.loadFailed"));
+      this.error = formatUiError(error, t("tasksPage.loadFailed"));
     },
   });
   private readonly subscriptions = new SubscriptionsController(this)
@@ -292,7 +286,7 @@ class TasksPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = formatTaskError(error, t("tasksPage.cancelFailed"));
+        this.error = formatUiError(error, t("tasksPage.cancelFailed"));
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {
@@ -339,7 +333,7 @@ class TasksPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = formatTaskError(error, t("tasksPage.recoveryFailed"));
+        this.error = formatUiError(error, t("tasksPage.recoveryFailed"));
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {
@@ -369,7 +363,7 @@ class TasksPage extends OpenClawLightDomElement {
       await navigator.clipboard.writeText(result);
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = formatTaskError(error, t("tasksPage.recoveryFailed"));
+        this.error = formatUiError(error, t("tasksPage.recoveryFailed"));
       }
     }
   }

--- a/ui/src/pages/usage/helpers.node.test.ts
+++ b/ui/src/pages/usage/helpers.node.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { extractQueryTerms, filterSessionsByQuery, parseToolSummary } from "./helpers.ts";
+import {
+  extractQueryTerms,
+  filterSessionsByQuery,
+  parseToolSummary,
+  toUsageErrorMessage,
+} from "./helpers.ts";
 
 function requireFirstTool(tools: Array<[string, number]>): [string, number] {
   const tool = tools[0];
@@ -11,6 +16,12 @@ function requireFirstTool(tools: Array<[string, number]>): [string, number] {
 }
 
 describe("usage-helpers", () => {
+  it("redacts secrets in displayed usage failures", () => {
+    expect(toUsageErrorMessage(new Error("OPENAI_API_KEY=sk-1234567890abcdef"))).toBe(
+      "OPENAI_API_KEY=sk-123...cdef",
+    );
+  });
+
   it("tokenizes query terms including quoted strings", () => {
     const terms = extractQueryTerms('agent:main "model:gpt-5.2" has:errors');
     expect(terms.map((t) => t.raw)).toEqual(["agent:main", "model:gpt-5.2", "has:errors"]);

--- a/ui/src/pages/usage/helpers.ts
+++ b/ui/src/pages/usage/helpers.ts
@@ -1,5 +1,6 @@
 // Control UI module implements usage helpers behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { formatUiError } from "../../lib/format-error.ts";
 
 type UsageQueryTerm = {
   key?: string;
@@ -40,20 +41,7 @@ export function currentLocalDate(): string {
 }
 
 export function toUsageErrorMessage(error: unknown): string {
-  if (typeof error === "string") {
-    return error;
-  }
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  if (error && typeof error === "object") {
-    try {
-      return JSON.stringify(error) || "request failed";
-    } catch {
-      // Fall through to the stable generic message.
-    }
-  }
-  return "request failed";
+  return formatUiError(error, "request failed");
 }
 
 export function toggleUsageRangeSelection<T>(

--- a/ui/src/pages/usage/route.test.ts
+++ b/ui/src/pages/usage/route.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import type { RouteLoaderOptions } from "@openclaw/uirouter";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { page } from "./route.ts";
+import type { UsageRouteData } from "./usage-page.ts";
+
+describe("usage route", () => {
+  it("redacts secrets in displayed loader failures", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage") {
+        throw new Error("OPENAI_API_KEY=sk-1234567890abcdef");
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = { snapshot: { phase: "connected", client } };
+    const context = {
+      gateway,
+      agentSelection: { state: { scopeId: "main" } },
+    } as unknown as ApplicationContext;
+    const options = {
+      signal: new AbortController().signal,
+      shouldRun: () => true,
+      revalidating: false,
+      location: { pathname: "/usage", search: "", hash: "" },
+      deps: "",
+      cause: "navigation",
+    } satisfies RouteLoaderOptions;
+
+    const result = (await page.loader?.(context, options)) as UsageRouteData;
+
+    expect(result.error).toBe("OPENAI_API_KEY=sk-123...cdef");
+  });
+});

--- a/ui/src/pages/usage/route.ts
+++ b/ui/src/pages/usage/route.ts
@@ -2,6 +2,7 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -18,10 +19,7 @@ function errorMessage(error: unknown): string {
   if (isMissingOperatorReadScopeError(error)) {
     return formatMissingOperatorReadScopeMessage("usage");
   }
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" ? error : "request failed";
+  return formatUiError(error, "request failed");
 }
 
 async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRouteData> {

--- a/ui/src/pages/workboard/view-card-details.ts
+++ b/ui/src/pages/workboard/view-card-details.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { ensureCustomElementDefined } from "../../app/lazy-custom-element.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import {
   addWorkboardCardComment,
@@ -174,7 +175,14 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
     [t("workboard.fieldLabels"), card.labels],
     [
       t("workboard.badgeAttempts", { count: String(attempts.length) }),
-      detailValues(attempts, "status", "model", "sessionKey", "error"),
+      attempts.map((entry) =>
+        joinDetailParts(
+          entry.status,
+          entry.model,
+          entry.sessionKey,
+          formatUiExternalText(entry.error),
+        ),
+      ),
     ],
     [
       t("workboard.badgeLinks", { count: String(links.length) }),
@@ -195,14 +203,14 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
     ],
     [
       t("workboard.detailWorkerLogs"),
-      workerLogs.map((entry) => `${entry.level}: ${entry.message}`),
+      workerLogs.map((entry) => `${entry.level}: ${formatUiExternalText(entry.message)}`),
     ],
     [
       t("workboard.detailWorkerProtocol"),
       workerProtocol
         ? [
             workerProtocol.state,
-            workerProtocol.detail ?? "",
+            formatUiExternalText(workerProtocol.detail),
             workerProtocol.updatedAt
               ? t("workboard.detailUpdatedValue", {
                   time: formatUpdatedTime(workerProtocol.updatedAt),

--- a/ui/src/pages/workboard/view-card.ts
+++ b/ui/src/pages/workboard/view-card.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import {
   isActiveWorkboardCard,
@@ -115,15 +116,21 @@ function renderCompactBadges(card: WorkboardCard, task?: WorkboardTaskSummary) {
   }
   if (latestDiagnostic) {
     badges.push(
-      html`<span class="workboard-card__badge--warning" title=${latestDiagnostic.detail}>
+      html`<span
+        class="workboard-card__badge--warning"
+        title=${formatUiExternalText(latestDiagnostic.detail)}
+      >
         ${icons.alertTriangle}${clampText(latestDiagnostic.title.trim(), 64)}
       </span>`,
     );
   }
   if (blockedReason) {
     badges.push(
-      html`<span class="workboard-card__badge--warning" title=${blockedReason}>
-        ${icons.alertTriangle}${clampText(blockedReason.trim(), 64)}
+      html`<span
+        class="workboard-card__badge--warning"
+        title=${formatUiExternalText(blockedReason)}
+      >
+        ${icons.alertTriangle}${clampText(formatUiExternalText(blockedReason), 64)}
       </span>`,
     );
   }

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -419,7 +419,7 @@ describe("WorktreesPage lifecycle", () => {
         return Promise.resolve({ worktrees: [record] });
       }
       if (method === "worktrees.restore") {
-        return Promise.reject(new Error("restore failed"));
+        return Promise.reject(new Error("restore failed: OPENAI_API_KEY=sk-1234567890abcdef"));
       }
       return Promise.resolve({});
     });
@@ -434,7 +434,7 @@ describe("WorktreesPage lifecycle", () => {
     await page.restore(record);
 
     expect(listRequests).toBe(2);
-    expect(page.error).toBe("Error: restore failed");
+    expect(page.error).toBe("restore failed: OPENAI_API_KEY=sk-123...cdef");
     expect(page.busyId).toBeNull();
   });
 
@@ -464,7 +464,7 @@ describe("WorktreesPage lifecycle", () => {
     await page.restore(record);
 
     expect(listRequests).toBe(2);
-    expect(page.error).toBe("Error: list failed");
+    expect(page.error).toBe("list failed");
     expect(page.busyId).toBeNull();
   });
 
@@ -487,11 +487,11 @@ describe("WorktreesPage lifecycle", () => {
       gatewayWithClient({ request } as unknown as GatewayBrowserClient),
     );
     document.body.append(page);
-    await waitForFast(() => expect(page.error).toBe("Error: stale list failure"));
+    await waitForFast(() => expect(page.error).toBe("stale list failure"));
 
     await page.restore(worktree());
 
-    expect(page.error).toBe("Error: restore failed");
+    expect(page.error).toBe("restore failed");
   });
 
   it("clears pending create state across a same-client reconnect", async () => {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -21,6 +21,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
 import { repoName } from "../../lib/session-display.ts";
@@ -82,7 +83,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       this.records = result.worktrees.toSorted((a, b) => b.lastActiveAt - a.lastActiveAt);
     },
     onError: (error) => {
-      this.error = String(error);
+      this.error = formatUiError(error);
     },
   });
 
@@ -195,12 +196,12 @@ class WorktreesPage extends OpenClawLightDomElement {
         }
       } catch (forceError) {
         if (this.gateway.isCurrent(scope)) {
-          this.error = String(forceError);
+          this.error = formatUiError(forceError);
         }
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {
@@ -221,7 +222,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       await scope.client.request("worktrees.restore", { id: record.id });
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {
@@ -242,7 +243,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       await scope.client.request("worktrees.gc", {});
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {
@@ -296,7 +297,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       }
     } catch (error) {
       if (this.gateway.isCurrent(scope)) {
-        this.error = String(error);
+        this.error = formatUiError(error);
       }
     } finally {
       if (this.gateway.isCurrent(scope)) {


### PR DESCRIPTION
## What Problem This Solves

Control UI rendered externally sourced failure text through several non-canonical paths. A thrown error, Gateway/RPC result string, WebSocket close reason, HTTP response diagnostic, or event payload could therefore expose secret-shaped values even when neighboring catches used the canonical formatter.

This PR closes that class: externally sourced diagnostic strings cross `formatUiError` or the browser redactor before display, while internal literals, translated copy, classifiers, and intentional primary content remain unchanged.

## Canonical Boundary

- `formatUiError(error, fallback)` remains the canonical unknown/thrown-error formatter.
- `formatUiExternalText(value, fallback)` is the one narrow string helper added beside it. It trims a nullable external string, applies `redactToolDetail`, and otherwise returns the caller's translated fallback.
- The Gateway close fallback now redacts `CloseEvent.reason` and uses `common.unknown` when the reason is empty.

## User Impact

Operators retain useful failure context, but credential-shaped substrings from remote failures are shortened to the standard redacted hint before they reach visible state, callouts, tooltips, status rails, or toasts.

Before:

![Before: full synthetic token displayed](https://github.com/user-attachments/assets/4e902e6b-578e-4416-aed5-9b9bef019caa)

After:

![After: synthetic token redacted](https://github.com/user-attachments/assets/3a52469f-24d9-42cf-a610-35c21fd68f83)

## External-string invariant enumeration

Search scope: production `ui/src`, excluding tests/test-support, for string-typed state/props named `error`, `reason`, `message`, `detail`, or `failure`; direct render interpolations of those names; and render paths fed by Gateway/RPC, fetch, WebSocket, or event payloads. `statusText` had zero production hits.

Result: **240 production files enumerated: 42 migrated, 198 checked-ok.** The helper and WS regression test are listed separately from the 240 production candidates.

### Migrated (42)

- `ui/src/app/gateway-store.ts` — redacts the no-structured-error WebSocket close reason and supplies translated unknown-reason copy.
- `ui/src/app/update-overlay-helpers.ts` — redacts captured updater stderr/stdout detail before banner composition.
- `ui/src/components/desktop/desktop-panel.ts` — redacts noVNC security and WebSocket disconnect reasons.
- `ui/src/components/onboarding-memory-import.ts` — redacts provider apply-result messages.
- `ui/src/components/provider-usage.ts` — redacts provider snapshot errors at render.
- `ui/src/components/terminal/terminal-panel-session-controller.ts` — redacts terminal-exit payload errors before panel state.
- `ui/src/components/wizard-step-controls.ts` — redacts Gateway wizard message fields before visible/accessibility output.
- `ui/src/lib/config/config-gateway-operations.ts` — redacts `config.openFile` result errors before composing paths.
- `ui/src/lib/skills/index.ts` — redacts skill-install result messages and warnings.
- `ui/src/lib/toast.ts` — redacts string toast messages at the shared render boundary.
- `ui/src/pages/agents/panels-tools-skills.ts` — redacts effective-tool notice messages.
- `ui/src/pages/channels/channels-page.ts` — redacts Nostr HTTP payload errors.
- `ui/src/pages/channels/nostr-profile-ops.ts` — redacts Nostr validation detail strings.
- `ui/src/pages/channels/view.shared.ts` — redacts channel probe and account error detail.
- `ui/src/pages/channels/view.ts` — redacts partial-snapshot warning strings.
- `ui/src/pages/channels/wizard-controller.ts` — redacts wizard RPC validation and terminal errors.
- `ui/src/pages/chat/chat-command-executor.ts` — redacts compaction result reasons.
- `ui/src/pages/chat/chat-composer-capability-host.ts` — redacts connector mutation result errors.
- `ui/src/pages/chat/chat-gateway.ts` — redacts Gateway chat-event error summaries before run state.
- `ui/src/pages/chat/chat-realtime.ts` — redacts external realtime error detail at the shared status boundary.
- `ui/src/pages/chat/components/chat-composer-plus-menu.ts` — redacts Gateway tool-discovery notice messages.
- `ui/src/pages/chat/components/chat-message-attachment-availability.ts` — redacts fetched attachment-unavailability reasons.
- `ui/src/pages/chat/composer-dictation.ts` — redacts transcription event error messages.
- `ui/src/pages/chat/tool-stream.ts` — redacts fallback-attempt reasons from agent events.
- `ui/src/pages/config/notifications-section.ts` — redacts push lifecycle errors at render.
- `ui/src/pages/cron/view-runs.ts` — redacts run and delivery error fields before text/Markdown rendering.
- `ui/src/pages/cron/view.ts` — redacts recorded cron last-error tooltip text.
- `ui/src/pages/custodian/transcript.ts` — redacts Gateway wizard title/message accessibility output.
- `ui/src/pages/memory-import/view.ts` — redacts migration item reasons/messages and provider errors.
- `ui/src/pages/model-providers/view.ts` — redacts model probe and target errors.
- `ui/src/pages/model-setup/state.ts` — redacts activation, verification, cancellation, and wizard result strings.
- `ui/src/pages/model-setup/view.ts` — redacts candidate diagnostic detail/reason strings.
- `ui/src/pages/plugin/logbook-controller.ts` — redacts analysis refusal reasons.
- `ui/src/pages/plugin/logbook-view.ts` — redacts logbook capture/batch errors and external detail text.
- `ui/src/pages/plugins/plugins-page.ts` — redacts plugin mutation warnings.
- `ui/src/pages/plugins/view.ts` — redacts catalog errors and policy-review reason/message fields.
- `ui/src/pages/sessions/sessions-page.ts` — redacts batch mutation error arrays before page state.
- `ui/src/pages/skill-workshop/view.ts` — redacts evaluator decision reasons, errors, and finding messages.
- `ui/src/pages/skills/view.ts` — redacts result messages, invalid-link reasons, and audit reasons.
- `ui/src/pages/tasks/tasks-page.ts` — redacts cancel/recovery refusal reasons.
- `ui/src/pages/workboard/view-card-details.ts` — redacts attempt errors, worker-log messages, and protocol detail.
- `ui/src/pages/workboard/view-card.ts` — redacts diagnostic/blocked detail in badges and tooltips.

### Checked-ok (198)

The following are complete hits from the same enumeration. The one-line decision reason precedes each full group.

<details>
<summary>Type, carrier, and non-render owners</summary>

Reason: these files declare/transport the fields, classify exact slugs, or hand structured values to a separately listed render owner; they do not themselves display raw external diagnostic text.

- `ui/src/api/gateway-connect-errors.ts`
- `ui/src/api/gateway.ts`
- `ui/src/api/types.ts`
- `ui/src/app/chat-attachment-handoff.ts`
- `ui/src/app/context.ts`
- `ui/src/app/notifications-auto-prompt.ts`
- `ui/src/components/app-sidebar-session-types.ts`
- `ui/src/components/desktop/desktop-client.ts`
- `ui/src/components/desktop/desktop-panel-state.ts`
- `ui/src/components/terminal/terminal-connection.ts`
- `ui/src/lib/board/view-types.ts`
- `ui/src/lib/chat/chat-types.ts`
- `ui/src/lib/chat/companion-question.ts`
- `ui/src/lib/chat/tool-display.ts`
- `ui/src/lib/session-method-access.ts`
- `ui/src/lib/sessions/cloud-recovery.ts`
- `ui/src/lib/sessions/cloud-submit.ts`
- `ui/src/lib/sessions/reconcile.ts`
- `ui/src/lib/sessions/session-capability.ts`
- `ui/src/lib/sessions/session-requests.ts`
- `ui/src/lib/sessions/session-scoped-operations.ts`
- `ui/src/lib/skill-workshop/index.ts`
- `ui/src/lib/workboard/types.ts`
- `ui/src/pages/chat/chat-avatar.ts`
- `ui/src/pages/chat/chat-view.ts`
- `ui/src/pages/chat/components/chat-background-tasks.types.ts`
- `ui/src/pages/chat/components/chat-composer-types.ts`
- `ui/src/pages/chat/components/chat-message-media.ts`
- `ui/src/pages/chat/realtime-talk-gateway-relay-types.ts`
- `ui/src/pages/config/view-types.ts`
- `ui/src/pages/plugin/logbook-types.ts`
- `ui/src/pages/skill-workshop/state.ts`
- `ui/src/pages/skill-workshop/view-types.ts`
- `ui/src/pages/usage/types.ts`

</details>

<details>
<summary>Already canonicalized by the producer or shared display owner</summary>

Reason: visible failure strings in these files already originate from `formatUiError`, a migrated owner above, or an existing shared redacting render helper; no additional raw external string crosses the display boundary here.

- `ui/src/app/app-shell-view.ts`
- `ui/src/app/cloud-session-startup.runtime.ts`
- `ui/src/app/cloud-session-startup.ts`
- `ui/src/app/device-auth-migration.ts`
- `ui/src/app/device-scope-upgrade.ts`
- `ui/src/app/overlays.ts`
- `ui/src/app/question-prompt.ts`
- `ui/src/app/update-confirmation.runtime.ts`
- `ui/src/app/update-confirmation.ts`
- `ui/src/app/web-push.ts`
- `ui/src/components/app-sidebar-session-catalog-live.ts`
- `ui/src/components/app-sidebar-session-catalog-render.ts`
- `ui/src/components/board/board-view.ts`
- `ui/src/components/board/board-widget-cell-render.ts`
- `ui/src/components/board/board-widget-frame.ts`
- `ui/src/components/device-auth-migration-banner.ts`
- `ui/src/components/input-dialog.ts`
- `ui/src/components/lazy-view-error.ts`
- `ui/src/components/login-gate.ts`
- `ui/src/components/mcp-app-view.ts`
- `ui/src/components/mcp-servers-card.ts`
- `ui/src/components/panel-refresh-status.ts`
- `ui/src/components/session-group-defaults-dialog.ts`
- `ui/src/components/session-organizer-batch-mutations.ts`
- `ui/src/components/terminal/terminal-panel-chrome.ts`
- `ui/src/components/terminal/terminal-panel-upload.ts`
- `ui/src/lib/agents/index.ts`
- `ui/src/lib/board/widget-sandbox-host.ts`
- `ui/src/lib/board/widgets/workboard-card.ts`
- `ui/src/lib/board/widgets/workboard-mini.ts`
- `ui/src/lib/channels/index.ts`
- `ui/src/lib/config/config-draft-model.ts`
- `ui/src/lib/config/mcp-servers.ts`
- `ui/src/lib/device-pair-setup.ts`
- `ui/src/lib/nodes/index.ts`
- `ui/src/lib/secrets-store/index.ts`
- `ui/src/lib/sessions/cloud-startup.ts`
- `ui/src/lib/sessions/create.ts`
- `ui/src/lib/sessions/session-event-subscription.ts`
- `ui/src/lib/skills/config-mutations.ts`
- `ui/src/lib/workboard/task-links.ts`
- `ui/src/pages/agents/identity-actions.ts`
- `ui/src/pages/agents/panels-status-files.ts`
- `ui/src/pages/agents/route.ts`
- `ui/src/pages/agents/view.ts`
- `ui/src/pages/approvals/approvals-page.ts`
- `ui/src/pages/channels/view.nostr-profile-form.ts`
- `ui/src/pages/channels/wizard-view.ts`
- `ui/src/pages/chat/chat-commands.ts`
- `ui/src/pages/chat/chat-composer-memory-fallback.ts`
- `ui/src/pages/chat/chat-outbox-drain.ts`
- `ui/src/pages/chat/chat-pane-render.ts`
- `ui/src/pages/chat/chat-pane-session-controls.ts`
- `ui/src/pages/chat/chat-pane-session-creation.ts`
- `ui/src/pages/chat/chat-pane-session.ts`
- `ui/src/pages/chat/chat-pane-shared.ts`
- `ui/src/pages/chat/chat-reset-delivery.ts`
- `ui/src/pages/chat/chat-send-actions.ts`
- `ui/src/pages/chat/chat-send-queue-state.ts`
- `ui/src/pages/chat/chat-send-request.ts`
- `ui/src/pages/chat/chat-send-submit.ts`
- `ui/src/pages/chat/chat-session.ts`
- `ui/src/pages/chat/chat-view-notices.ts`
- `ui/src/pages/chat/components/chat-background-task-row.ts`
- `ui/src/pages/chat/components/chat-background-tasks-render.ts`
- `ui/src/pages/chat/components/chat-background-tasks.ts`
- `ui/src/pages/chat/components/chat-composer-status.ts`
- `ui/src/pages/chat/components/chat-composer.ts`
- `ui/src/pages/chat/components/chat-header-session-menu.ts`
- `ui/src/pages/chat/components/chat-message-attachment-status.ts`
- `ui/src/pages/chat/components/chat-model-controls.ts`
- `ui/src/pages/chat/components/chat-question-card.ts`
- `ui/src/pages/chat/components/chat-session-sharing.ts`
- `ui/src/pages/chat/components/chat-session-workspace.ts`
- `ui/src/pages/chat/components/chat-sidebar.ts`
- `ui/src/pages/chat/components/chat-voice-activity.ts`
- `ui/src/pages/chat/components/session-diff-panel.ts`
- `ui/src/pages/chat/components/session-discussion-panel.ts`
- `ui/src/pages/chat/realtime-talk-gateway-relay.ts`
- `ui/src/pages/chat/realtime-talk-google-live-tools.ts`
- `ui/src/pages/chat/realtime-talk-google-live.ts`
- `ui/src/pages/chat/realtime-talk-shared.ts`
- `ui/src/pages/chat/realtime-talk-webrtc.ts`
- `ui/src/pages/chat/realtime-talk.ts`
- `ui/src/pages/chat/run-lifecycle.ts`
- `ui/src/pages/chat/steer-lifecycle.ts`
- `ui/src/pages/config/custom-theme-import-owner.ts`
- `ui/src/pages/config/memory-memories.ts`
- `ui/src/pages/config/memory-overview.ts`
- `ui/src/pages/config/memory-page.ts`
- `ui/src/pages/config/memory.ts`
- `ui/src/pages/config/view-appearance-preferences.ts`
- `ui/src/pages/custodian/custodian-history.ts`
- `ui/src/pages/custodian/custodian-session-store.ts`
- `ui/src/pages/custodian/custodian-surface.ts`
- `ui/src/pages/custodian/session-lifecycle.ts`
- `ui/src/pages/dashboards/route.ts`
- `ui/src/pages/dashboards/view.ts`
- `ui/src/pages/debug/view.ts`
- `ui/src/pages/devices/view-pairing.runtime.ts`
- `ui/src/pages/model-providers/default-models-view.ts`
- `ui/src/pages/model-providers/load.ts`
- `ui/src/pages/model-providers/view-status.ts`
- `ui/src/pages/model-setup/configured-model.ts`
- `ui/src/pages/model-setup/wizard-runner.ts`
- `ui/src/pages/model-setup/wizard-view.ts`
- `ui/src/pages/new-session/cloud-recovery-state.ts`
- `ui/src/pages/new-session/composer.ts`
- `ui/src/pages/new-session/connect-machine-dialog.ts`
- `ui/src/pages/new-session/create-params.ts`
- `ui/src/pages/new-session/draft-gateway-state.ts`
- `ui/src/pages/new-session/draft-place-state.ts`
- `ui/src/pages/new-session/draft-submission-flow.ts`
- `ui/src/pages/new-session/new-session-page.ts`
- `ui/src/pages/new-session/place-browser.ts`
- `ui/src/pages/new-session/rejected-initial-turn.ts`
- `ui/src/pages/plugin/plugin-page.ts`
- `ui/src/pages/portals/portals-page.ts`
- `ui/src/pages/profile/identity-section.ts`
- `ui/src/pages/secrets/view.ts`
- `ui/src/pages/sessions/custom-groups.ts`
- `ui/src/pages/sessions/view.ts`
- `ui/src/pages/skill-workshop/history-scan.ts`
- `ui/src/pages/skill-workshop/self-learning.ts`
- `ui/src/pages/skills/route.ts`
- `ui/src/pages/skills/skills-page.ts`
- `ui/src/pages/tasks/view.ts`
- `ui/src/pages/usage/usage-page.ts`
- `ui/src/pages/usage/view.ts`
- `ui/src/pages/worktrees/worktrees-page.ts`

</details>

<details>
<summary>Internal literals, validation, access, and presentation classifiers</summary>

Reason: these hits are UI-authored validation/i18n copy, enum/reason comparisons, counts, labels, or layout/accessibility detail—not externally supplied diagnostic strings.

- `ui/src/components/app-sidebar-session-row-render.ts`
- `ui/src/components/board/board-widget-capabilities.ts`
- `ui/src/components/config-form-collection-draft.ts`
- `ui/src/components/config-form-structured-draft.ts`
- `ui/src/components/config-form.node.scalar.ts`
- `ui/src/components/config-form.node.shared.ts`
- `ui/src/components/model-picker.ts`
- `ui/src/components/settings-ui.ts`
- `ui/src/components/sidebar-attention-items.ts`
- `ui/src/components/sidebar-attention.ts`
- `ui/src/lib/browser-redact.ts`
- `ui/src/lib/cron/index.ts`
- `ui/src/pages/activity/run-inspector-view.ts`
- `ui/src/pages/agents/memory/toggle-confirmation.ts`
- `ui/src/pages/connection/system-section.ts`
- `ui/src/pages/custodian/event-nudge.ts`
- `ui/src/pages/new-session/detail-chip.ts`
- `ui/src/pages/usage/view-overview.ts`
- `ui/src/pages/workboard/view-helpers.ts`

</details>

<details>
<summary>Intentional primary content or exact operator decision input</summary>

Reason: these fields are the product content being viewed/edited (chat transcript, user-authored cron/task text, logs, or approval command detail), not failure metadata; redacting them would alter the operator's requested content or hide what an approval authorizes.

- `ui/src/components/confirm-dialog.ts`
- `ui/src/components/exec-approval-card.ts`
- `ui/src/components/lobster-pet-look.ts`
- `ui/src/components/secret-reveal-dialog.ts`
- `ui/src/lib/presenter.ts`
- `ui/src/pages/approval/approval-page.ts`
- `ui/src/pages/chat/chat-history.ts`
- `ui/src/pages/chat/chat-thread-items.ts`
- `ui/src/pages/chat/components/chat-composer-context.ts`
- `ui/src/pages/chat/components/chat-message-bubble.ts`
- `ui/src/pages/chat/components/chat-model-picker.ts`
- `ui/src/pages/chat/components/chat-tool-cards.ts`
- `ui/src/pages/chat/user-message-content.ts`
- `ui/src/pages/logs/log-lines.ts`
- `ui/src/pages/logs/view.ts`

</details>

## Regression proof

- New owner-boundary test closes the Gateway with `error` absent and a secret-shaped `CloseEvent.reason`; `lastError` contains the canonical shortened hint and omits the raw token.
- The same test failed against the pre-fix fallback because the full synthetic token survived.
- Empty close reasons now assert translated `Unknown` fallback copy.
- Existing chat background-task rail regression rejects `tasks.list` with a secret-shaped message, opens the rail, and asserts the rendered output omits the raw token.

## Verification

- Focused Control UI: 22 files across 2 Vitest shards, 668 tests passed.
- Earlier full Control UI lane on this PR: 667 files passed, 9,584 tests passed, 1 skipped.
- Local changed gate selected `coreTests, ui`; it stopped on the known assertion-safety baseline shrink in `src/gateway/server-methods/__mocks__/tools-effective.runtime.ts` (`1 > 0`). This did not reproduce in exact CI on the prior head; exact-head CI is authoritative for the final head.
- Follow-up failure proof: targeted oxlint plus 3 files/71 tests passed after the type/max-lines repair.
- Exact-head CI: [run 31954041380](https://github.com/openclaw/openclaw/actions/runs/31954041380) completed green at `a39a19ab8b2fc0f6abefab329daa9b93ab831901`; 119 CI jobs (108 passed, 11 scope-skipped), final `openclaw/ci-gate` passed, and the PR rollup is 121 passed / 20 skipped / 0 failed or pending.
- Autoreview: clean before both commits; no accepted/actionable findings.

## LOC classification for this pass

- Production: +196/-103 (net +93), including one five-line canonical external-string helper and 42 owner/render-boundary migrations. The growth is the explicit security invariant coverage across previously independent display owners.
- Tests: +23/-0, covering the raw WS close reason and translated empty-reason fallback.
