### PR TITLE
fix(test): route extension roots through bounded planner

### DIFF
--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -89,10 +89,17 @@ const EXTENSION_TEST_COST_MULTIPLIERS: Record<string, number> = {
   // overstates its real wall-clock cost during CI shard planning.
   "test/vitest/vitest.extensions.config.ts": 1.1,
 };
+const CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
 const MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT = 1;
 const TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT = 10;
 const EXTENSION_TEST_PROCESS_FILE_LIMITS = new Map<string, number>([
+  [
+    "test/vitest/vitest.extension-codex.config.ts",
+    // This non-isolated fileParallelism:false lane accumulates every mocked module graph.
+    // At ~166 files, one worker exhausted its heap during teardown (#124413).
+    CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+  ],
   // The non-isolated Matrix suite intentionally shares module state within a process.
   // Bound its lifetime so Vite's transformed module graph cannot grow across the whole suite.
   ["test/vitest/vitest.extension-matrix.config.ts", MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT],

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -13,6 +13,7 @@ import { toolingIsolatedTestFiles } from "../test/vitest/vitest.tooling-isolated
 import { isUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
 import { boundaryTestFiles } from "../test/vitest/vitest.unit-paths.mjs";
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
+import { resolveExtensionTestConfig } from "./lib/extension-test-plan.mts";
 import { runWithFailedTrailer, writeFailedTrailer } from "./lib/failed-trailer.mts";
 import { createGatewayServerTestTargetChunks } from "./lib/gateway-server-test-plan.mts";
 import { signalExitCode } from "./lib/managed-child-process.mts";
@@ -699,6 +700,22 @@ function isOwnedAgentDirectoryTarget(arg: string, cwd: string, fsImpl: VitestPat
   );
 }
 
+function isOwnedExtensionRootTarget(arg: string, cwd: string, fsImpl: VitestPathFs): boolean {
+  const relative = toRepoRelativeArg(arg, cwd).replace(/\/+$/u, "");
+  const [root, extensionId, ...remainder] = relative.split("/");
+  if (
+    root !== "extensions" ||
+    !extensionId ||
+    remainder.length > 0 ||
+    !isExplicitDirectoryTargetArg(arg, cwd, fsImpl)
+  ) {
+    return false;
+  }
+  // Extension roots delegate so the bounded planner owns process lifetime (#124413).
+  // Raw Vitest would run the workspace config as one process.
+  return resolveExtensionTestConfig(relative).length > 0;
+}
+
 function isExplicitProjectRouterTargetArg(
   arg: string,
   cwd = process.cwd(),
@@ -715,7 +732,9 @@ function isExplicitProjectRouterTargetArg(
   }
   const filePath = path.isAbsolute(arg) ? arg : path.resolve(cwd, arg);
   return fsImpl.existsSync(filePath)
-    ? isDelegableBroadProjectRouterTarget(arg, cwd) || isOwnedAgentDirectoryTarget(arg, cwd, fsImpl)
+    ? isDelegableBroadProjectRouterTarget(arg, cwd) ||
+        isOwnedAgentDirectoryTarget(arg, cwd, fsImpl) ||
+        isOwnedExtensionRootTarget(arg, cwd, fsImpl)
     : path.extname(arg) === "" &&
         /^(?:src|test|extensions|ui|packages|apps)\//u.test(toRepoRelativeArg(arg, cwd));
 }

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -31,7 +31,10 @@ import { isAcpxExtensionRoot } from "../test/vitest/vitest.extension-acpx-paths.
 import { isActiveMemoryExtensionRoot } from "../test/vitest/vitest.extension-active-memory-paths.mjs";
 import { isBrowserExtensionRoot } from "../test/vitest/vitest.extension-browser-paths.mjs";
 import { resolveSplitChannelExtensionShard } from "../test/vitest/vitest.extension-channel-split-paths.mjs";
-import { isCodexExtensionRoot } from "../test/vitest/vitest.extension-codex-paths.mjs";
+import {
+  codexExtensionTestRoots,
+  isCodexExtensionRoot,
+} from "../test/vitest/vitest.extension-codex-paths.mjs";
 import { isDiffsExtensionRoot } from "../test/vitest/vitest.extension-diffs-paths.mjs";
 import { isFeishuExtensionRoot } from "../test/vitest/vitest.extension-feishu-paths.mjs";
 import { isIrcExtensionRoot } from "../test/vitest/vitest.extension-irc-paths.mjs";
@@ -261,6 +264,7 @@ const UNIT_SECURITY_VITEST_CONFIG = "test/vitest/vitest.unit-security.config.ts"
 const UNIT_SRC_VITEST_CONFIG = "test/vitest/vitest.unit-src.config.ts";
 const UNIT_SUPPORT_VITEST_CONFIG = "test/vitest/vitest.unit-support.config.ts";
 const EXTENSION_TEST_PROCESS_ROOTS = new Map([
+  [EXTENSION_CODEX_VITEST_CONFIG, codexExtensionTestRoots],
   [EXTENSION_MATRIX_VITEST_CONFIG, matrixExtensionTestRoots],
   [EXTENSION_TELEGRAM_VITEST_CONFIG, telegramExtensionTestRoots],
 ]);

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -10,9 +10,30 @@ import {
   hasQaSmokeAffectingChange,
   hasSqliteSessionLifecycleAffectingChange,
 } from "../../scripts/lib/ci-changed-node-test-plan.mts";
+import { listExtensionTestFilesForRoots } from "../../scripts/lib/extension-test-plan.mts";
 import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-support.mts";
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
+
+const CODEX_TEST_PROCESS_FILE_LIMIT = 40;
+
+function expectBoundedCodexFallback(
+  shards: ReturnType<typeof createChangedExtensionFallbackShards>,
+) {
+  const targets = shards.flatMap((shard) => shard.includePatterns ?? []);
+
+  expect(shards.length).toBeGreaterThan(1);
+  expect(
+    shards.every(
+      (shard) =>
+        shard.configs[0] === "test/vitest/vitest.extension-codex.config.ts" &&
+        (shard.includePatterns?.length ?? 0) > 0 &&
+        (shard.includePatterns?.length ?? 0) <= CODEX_TEST_PROCESS_FILE_LIMIT,
+    ),
+  ).toBe(true);
+  expect(targets).toEqual(listExtensionTestFilesForRoots(["extensions/codex"]));
+  expect(new Set(targets).size).toBe(targets.length);
+}
 
 describe("CI changed Node test plan", () => {
   it("routes Control UI style changes through source-scanning policy tests", () => {
@@ -274,15 +295,7 @@ describe("CI changed Node test plan", () => {
     ];
 
     expect(createChangedNodeTestShards(changedPaths)).toBeNull();
-    expect(createChangedExtensionFallbackShards(changedPaths)).toEqual([
-      {
-        checkName: "checks-node-changed-extensions-config",
-        configs: ["test/vitest/vitest.extension-codex.config.ts"],
-        requiresDist: false,
-        runner: "blacksmith-8vcpu-ubuntu-2404",
-        shardName: "changed-extensions-config",
-      },
-    ]);
+    expectBoundedCodexFallback(createChangedExtensionFallbackShards(changedPaths));
   });
 
   it.each([
@@ -348,22 +361,14 @@ describe("CI changed Node test plan", () => {
     ).toEqual([]);
   });
 
-  it("falls back to the affected extension config for deleted sources", () => {
+  it("falls back to bounded Codex config shards for deleted sources", () => {
     const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-ci-extension-fallback-"));
     try {
-      expect(
+      expectBoundedCodexFallback(
         createChangedExtensionFallbackShards(["extensions/codex/src/deleted-session-runtime.ts"], {
           cwd,
         }),
-      ).toEqual([
-        {
-          checkName: "checks-node-changed-extensions-config",
-          configs: ["test/vitest/vitest.extension-codex.config.ts"],
-          requiresDist: false,
-          runner: "blacksmith-8vcpu-ubuntu-2404",
-          shardName: "changed-extensions-config",
-        },
-      ]);
+      );
       expect(
         createChangedExtensionFallbackShards(
           ["extensions/codex/src/deleted-session-runtime.test.ts"],

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -391,6 +391,31 @@ describe("scripts/run-vitest", () => {
     expect(resolveTestProjectsDelegationArgs([prefix])).toEqual([prefix]);
   });
 
+  it("delegates an existing extension root to the project router", () => {
+    const directory = "extensions/codex";
+
+    expect(resolveTestProjectsDelegationArgs([directory])).toEqual([directory]);
+    expect(resolveTestProjectsDelegationArgs(["run", directory, "--reporter=verbose"])).toEqual([
+      directory,
+      "--",
+      "--reporter=verbose",
+    ]);
+  });
+
+  it("keeps extension subdirectories and direct-mode root runs on Vitest", () => {
+    const directory = "extensions/codex";
+
+    expect(resolveTestProjectsDelegationArgs([`${directory}/src`])).toBeNull();
+    expect(
+      resolveTestProjectsDelegationArgs([
+        "--config",
+        "test/vitest/vitest.extension-codex.config.ts",
+        directory,
+      ]),
+    ).toBeNull();
+    expect(resolveTestProjectsDelegationArgs(["--watch", directory])).toBeNull();
+  });
+
   it("delegates owned agent directories with separate Vitest option values", () => {
     const directory = "src/agents/embedded-agent-runner/run";
 

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -40,8 +40,14 @@ import {
 } from "../vitest/vitest.contracts-shared.ts";
 
 const normalizeRepoPath = toRepoPath;
+const CODEX_TEST_PROCESS_FILE_LIMIT = 40;
 const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_TEST_PROCESS_FILE_LIMIT = 1;
+
+function expectedCodexTestProcessCount() {
+  const testFileCount = listExtensionTestFilesForRoots(["extensions/codex"]).length;
+  return Math.max(1, Math.ceil(testFileCount / CODEX_TEST_PROCESS_FILE_LIMIT));
+}
 
 function expectedMatrixTestProcessCount() {
   const testFileCount = listExtensionTestFilesForRoots(["extensions/matrix"]).length;
@@ -54,9 +60,11 @@ function expectedTelegramTestProcessCount() {
 }
 
 function listExpectedFullExtensionRunPlans() {
+  const codexConfig = "test/vitest/vitest.extension-codex.config.ts";
   const matrixConfig = "test/vitest/vitest.extension-matrix.config.ts";
   const telegramConfig = "test/vitest/vitest.extension-telegram.config.ts";
   const boundedPlansByConfig = new Map([
+    [codexConfig, buildVitestRunPlans(["extensions/codex"], process.cwd())],
     [matrixConfig, buildVitestRunPlans(["extensions/matrix"], process.cwd())],
     [telegramConfig, buildVitestRunPlans(["extensions/telegram"], process.cwd())],
   ]);
@@ -2105,12 +2113,13 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes the top-level extensions target to every extension shard", () => {
+    const codexConfig = "test/vitest/vitest.extension-codex.config.ts";
     const matrixConfig = "test/vitest/vitest.extension-matrix.config.ts";
     const telegramConfig = "test/vitest/vitest.extension-telegram.config.ts";
     const plans = buildVitestRunPlans(["extensions"], process.cwd());
     const matrixPlans = plans.filter((plan) => plan.config === matrixConfig);
     const telegramPlans = plans.filter((plan) => plan.config === telegramConfig);
-    const boundedConfigs = new Set([matrixConfig, telegramConfig]);
+    const boundedConfigs = new Set([codexConfig, matrixConfig, telegramConfig]);
 
     expect(plans.filter((plan) => !boundedConfigs.has(plan.config))).toEqual(
       listFullExtensionVitestProjectConfigs()
@@ -2251,6 +2260,37 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(plans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(
       listExtensionTestFilesForRoots(["extensions/matrix"]),
     );
+  });
+
+  it("bounds an explicit Codex directory target across process lifetimes", () => {
+    const config = "test/vitest/vitest.extension-codex.config.ts";
+    const plans = buildVitestRunPlans(["extensions/codex"], process.cwd());
+
+    expect(plans.length).toBeGreaterThan(1);
+    expect(plans).toHaveLength(expectedCodexTestProcessCount());
+    expect(plans.every((plan) => plan.config === config)).toBe(true);
+    expect(
+      plans.every((plan) => (plan.includePatterns?.length ?? 0) <= CODEX_TEST_PROCESS_FILE_LIMIT),
+    ).toBe(true);
+    expect(plans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(
+      listExtensionTestFilesForRoots(["extensions/codex"]),
+    );
+  });
+
+  it("keeps an explicit Codex file target in one process", () => {
+    const testFile = listExtensionTestFilesForRoots(["extensions/codex"])[0];
+    if (!testFile) {
+      throw new Error("expected a Codex test fixture");
+    }
+
+    expect(buildVitestRunPlans([testFile], process.cwd())).toEqual([
+      {
+        config: "test/vitest/vitest.extension-codex.config.ts",
+        forwardedArgs: [],
+        includePatterns: [testFile],
+        watchMode: false,
+      },
+    ]);
   });
 
   it("keeps grouped Matrix targets covered when bounding the directory", () => {


### PR DESCRIPTION
Fixes #124413

## What Problem This Solves

Fixes an issue where maintainers running either `pnpm test extensions/codex` or `node scripts/run-vitest.mjs extensions/codex` could finish the Codex tests and then lose the run to `Worker exited unexpectedly` during teardown. The issue's clean Linux/macOS A/B evidence isolated this to the one-shot lane itself (Crabbox leases `cbx_d0045e753f72` and `cbx_e4c804319801`).

## Why This Change Was Made

Codex is enrolled in the existing bounded-extension planner with the Matrix-precedent limit of 40 files, producing five fresh processes for the current 165-file lane. Exact existing `extensions/<id>` directory targets now delegate from the direct Vitest wrapper to that same canonical project router, so both documented entrypoints share one process-lifetime owner. Explicit files, extension subdirectories, watch/project/config modes, and the direct `--config` path remain unchanged; affected Codex CI fallback shards consume the same bounded file sets.

## User Impact

`pnpm test extensions/codex` and `node scripts/run-vitest.mjs extensions/codex` now complete with real summaries instead of dying during worker teardown. Product behavior is unchanged. Codex fallback CI plans preserve complete, duplicate-free test coverage while bounding each descriptor to 40 files.

## Evidence

Pre-fix planner regression:

```text
FAIL ... bounds an explicit Codex directory target across process lifetimes
AssertionError: expected 1 to be greater than 1
Tests 1 failed | 273 passed (274)
```

Pre-fix wrapper-routing regression:

```text
FAIL ... delegates an existing extension root to the project router
AssertionError: expected null to deeply equal [ 'extensions/codex' ]
Tests 1 failed | 96 passed (97)
```

Post-fix proof:

- `node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts` — 2 files, 371 tests passed.
- `node scripts/run-vitest.mjs extensions/codex` — emitted five `[test] starting test/vitest/vitest.extension-codex.config.ts` invocations; `[test] passed 5 Vitest shards in 276.52s`.
- `pnpm test extensions/codex` — `[test] passed 5 Vitest shards in 273.42s`.
- Stability repeat, `pnpm test extensions/codex` — `[test] passed 5 Vitest shards in 265.59s`.
- `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts` — 32 tests passed; bounded Codex fallback descriptors are complete and duplicate-free.
- `CI=1 node scripts/check-changed.mjs` — passed on the final six-file diff.
- `node_modules/.bin/oxfmt` on all six touched files — clean.
- Changed-file oxlint — clean. The requested broad `node scripts/run-oxlint.mjs scripts test/scripts` also surfaced 17 pre-existing findings in untouched current-main test files; none are in this diff or selected by `check-changed`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean after the final test update, no accepted/actionable findings.

AI-assisted: yes. The change was reviewed against the owning router/planner boundaries and verified through both real entrypoints.
