### PR TITLE
fix: surface hidden-pane steer failures and demote per-turn gateway log noise

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -137,7 +137,9 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     }
     state.sharedCodexClientRetiredForOneShotCleanup = true;
     const retired = clearSharedCodexAppServerClientIfCurrentAndUnclaimed(state.client);
-    embeddedAgentLog.info("codex app-server one-shot cleanup checked shared client retirement", {
+    // Runs on every one-shot attempt teardown; routine retirement checks are
+    // diagnostic detail, not operator-facing info.
+    embeddedAgentLog.debug("codex app-server one-shot cleanup checked shared client retirement", {
       runId: params.runId,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -117,8 +117,8 @@ function createSqliteHostTrajectoryRecorder(params: {
 }
 
 describe("Codex trajectory recorder", () => {
-  it("warns once per process when the SQLite host recorder is unavailable", async () => {
-    // Import a fresh module instance so the process-wide warn-once flag starts
+  it("warns once per session when the SQLite host recorder is unavailable", async () => {
+    // Import a fresh module instance so the process-wide dedupe set starts
     // clean without a test-only reset export in production code.
     vi.resetModules();
     const { createCodexTrajectoryRecorder: createFreshRecorder } = await import("./trajectory.js");
@@ -136,13 +136,21 @@ describe("Codex trajectory recorder", () => {
       });
 
     expect(makeRecorder("session-1")).toBeNull();
-    // Static config condition: repeated attempts must not repeat the warn.
-    expect(makeRecorder("session-2")).toBeNull();
-
+    // Retried attempts for the same session must not repeat the warn.
+    expect(makeRecorder("session-1")).toBeNull();
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "codex trajectory capture requires the SQLite host recorder",
       { sessionId: "session-1", reason: "sqlite-recorder-unavailable" },
+    );
+
+    // A later distinct session's recorder loss stays visible: the host can
+    // reject per-session (target-mapping conflicts), not only per-process.
+    expect(makeRecorder("session-2")).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenLastCalledWith(
+      "codex trajectory capture requires the SQLite host recorder",
+      { sessionId: "session-2", reason: "sqlite-recorder-unavailable" },
     );
   });
 

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -18,7 +18,6 @@ import {
   createCodexTrajectoryRecorder,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
-  resetCodexTrajectoryRecorderWarningForTest,
 } from "./trajectory.js";
 
 type CodexTrajectoryRecorder = NonNullable<ReturnType<typeof createCodexTrajectoryRecorder>>;
@@ -118,11 +117,14 @@ function createSqliteHostTrajectoryRecorder(params: {
 }
 
 describe("Codex trajectory recorder", () => {
-  it("warns once per process when the SQLite host recorder is unavailable", () => {
-    resetCodexTrajectoryRecorderWarningForTest();
+  it("warns once per process when the SQLite host recorder is unavailable", async () => {
+    // Import a fresh module instance so the process-wide warn-once flag starts
+    // clean without a test-only reset export in production code.
+    vi.resetModules();
+    const { createCodexTrajectoryRecorder: createFreshRecorder } = await import("./trajectory.js");
     const warn = vi.fn();
     const makeRecorder = (sessionId: string) =>
-      createCodexTrajectoryRecorder({
+      createFreshRecorder({
         cwd: testWorkspace.dir,
         attempt: {
           sessionFile: `agent:main:${sessionId}`,

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -18,6 +18,7 @@ import {
   createCodexTrajectoryRecorder,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
+  resetCodexTrajectoryRecorderWarningForTest,
 } from "./trajectory.js";
 
 type CodexTrajectoryRecorder = NonNullable<ReturnType<typeof createCodexTrajectoryRecorder>>;
@@ -117,20 +118,26 @@ function createSqliteHostTrajectoryRecorder(params: {
 }
 
 describe("Codex trajectory recorder", () => {
-  it("warns when the SQLite host recorder is unavailable", () => {
+  it("warns once per process when the SQLite host recorder is unavailable", () => {
+    resetCodexTrajectoryRecorderWarningForTest();
     const warn = vi.fn();
-    const recorder = createCodexTrajectoryRecorder({
-      cwd: testWorkspace.dir,
-      attempt: {
-        sessionFile: "agent:main:session-1",
-        sessionId: "session-1",
-        model: { api: "responses" },
-      } as never,
-      env: {},
-      warn,
-    });
+    const makeRecorder = (sessionId: string) =>
+      createCodexTrajectoryRecorder({
+        cwd: testWorkspace.dir,
+        attempt: {
+          sessionFile: `agent:main:${sessionId}`,
+          sessionId,
+          model: { api: "responses" },
+        } as never,
+        env: {},
+        warn,
+      });
 
-    expect(recorder).toBeNull();
+    expect(makeRecorder("session-1")).toBeNull();
+    // Static config condition: repeated attempts must not repeat the warn.
+    expect(makeRecorder("session-2")).toBeNull();
+
+    expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "codex trajectory capture requires the SQLite host recorder",
       { sessionId: "session-1", reason: "sqlite-recorder-unavailable" },

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -121,7 +121,12 @@ function createCodexHostTrajectorySink(params: {
   };
 }
 
-let warnedSqliteRecorderUnavailable = false;
+// The host recorder can be absent per session (target-mapping conflicts), not
+// only per process, so dedupe the warn by session: repeated attempts for one
+// session stay quiet while a later distinct session still records its loss.
+// Bounded: cleared past the cap so a pathological session churn cannot grow it.
+const warnedRecorderUnavailableSessions = new Set<string>();
+const WARNED_RECORDER_SESSIONS_CAP = 64;
 
 /** Creates a trajectory recorder when trajectory capture is enabled for the environment. */
 export function createCodexTrajectoryRecorder(
@@ -138,10 +143,13 @@ export function createCodexTrajectoryRecorder(
   // from a session-file string silently drops every capture once the host
   // stops emitting the legacy `sqlite:` marker.
   if (!params.trajectoryRecorder) {
-    // A missing host recorder is a static config condition; repeating the warn
-    // on every attempt buries real diagnostics, so emit it once per process.
-    if (!warnedSqliteRecorderUnavailable) {
-      warnedSqliteRecorderUnavailable = true;
+    // Per-attempt repeats for one session bury real diagnostics; warn once per
+    // session so retries stay quiet but each newly affected session is visible.
+    if (!warnedRecorderUnavailableSessions.has(params.attempt.sessionId)) {
+      if (warnedRecorderUnavailableSessions.size >= WARNED_RECORDER_SESSIONS_CAP) {
+        warnedRecorderUnavailableSessions.clear();
+      }
+      warnedRecorderUnavailableSessions.add(params.attempt.sessionId);
       params.warn?.("codex trajectory capture requires the SQLite host recorder", {
         sessionId: params.attempt.sessionId,
         reason: "sqlite-recorder-unavailable",

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -121,6 +121,13 @@ function createCodexHostTrajectorySink(params: {
   };
 }
 
+let warnedSqliteRecorderUnavailable = false;
+
+/** Clears the process-wide missing-recorder warn-once flag between tests. */
+export function resetCodexTrajectoryRecorderWarningForTest(): void {
+  warnedSqliteRecorderUnavailable = false;
+}
+
 /** Creates a trajectory recorder when trajectory capture is enabled for the environment. */
 export function createCodexTrajectoryRecorder(
   params: CodexTrajectoryInit,
@@ -136,10 +143,15 @@ export function createCodexTrajectoryRecorder(
   // from a session-file string silently drops every capture once the host
   // stops emitting the legacy `sqlite:` marker.
   if (!params.trajectoryRecorder) {
-    params.warn?.("codex trajectory capture requires the SQLite host recorder", {
-      sessionId: params.attempt.sessionId,
-      reason: "sqlite-recorder-unavailable",
-    });
+    // A missing host recorder is a static config condition; repeating the warn
+    // on every attempt buries real diagnostics, so emit it once per process.
+    if (!warnedSqliteRecorderUnavailable) {
+      warnedSqliteRecorderUnavailable = true;
+      params.warn?.("codex trajectory capture requires the SQLite host recorder", {
+        sessionId: params.attempt.sessionId,
+        reason: "sqlite-recorder-unavailable",
+      });
+    }
     return null;
   }
   const sink = createCodexHostTrajectorySink({ recorder: params.trajectoryRecorder });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -123,11 +123,6 @@ function createCodexHostTrajectorySink(params: {
 
 let warnedSqliteRecorderUnavailable = false;
 
-/** Clears the process-wide missing-recorder warn-once flag between tests. */
-export function resetCodexTrajectoryRecorderWarningForTest(): void {
-  warnedSqliteRecorderUnavailable = false;
-}
-
 /** Creates a trajectory recorder when trajectory capture is enabled for the environment. */
 export function createCodexTrajectoryRecorder(
   params: CodexTrajectoryInit,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -349,8 +349,6 @@ type OpenClawCodingToolsOptions = {
   onYield?: (message: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
-  /** Lower routine policy-removal audits for diagnostic-only tool probes. */
-  toolPolicyAuditLogLevel?: "info" | "debug";
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
   /** Reads the sticky untrusted-content flag for the current user turn. */
@@ -907,7 +905,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       includeRuntimeToolPolicy: true,
       unavailableCoreToolReason,
     }),
-    auditLogLevel: options?.toolPolicyAuditLogLevel,
     declaredToolAllowlist: buildDeclaredToolAllowlistContext({
       config: options?.config,
       metadataSnapshot: options?.preparedModelRuntime?.metadataSnapshot,

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -38,7 +38,6 @@ type FinalEffectiveToolPolicyParams = {
   metadataSnapshot?: PluginMetadataSnapshot;
   conversationCapabilityProfile: ResolvedConversationCapabilityProfile;
   warn: (message: string) => void;
-  toolPolicyAuditLogLevel?: "info" | "debug";
   onFilter?: (event: ToolPolicyFilterEvent) => void;
 };
 
@@ -78,7 +77,6 @@ export function applyFinalEffectiveToolPolicy(
     toolMeta: (tool) => getPluginToolMeta(tool),
     warn: params.warn,
     steps: pipelineSteps,
-    auditLogLevel: params.toolPolicyAuditLogLevel,
     onFilter: params.onFilter,
     declaredToolAllowlist: buildDeclaredToolAllowlistContext({
       config: params.config,

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -15,9 +15,6 @@ const MAX_AUDIT_TOOL_NAMES = 50;
 const MAX_AUDIT_FIELD_LENGTH = 160;
 const toolPolicyAuditLogger = createSubsystemLogger("agents/tool-policy");
 
-/** Log level used for tool-policy audit events. */
-export type ToolPolicyAuditLogLevel = "info" | "debug";
-
 type ToolPolicyRuleKind = "allow" | "deny" | "allow+deny" | "unknown";
 
 function toolPolicyRuleKind(policy: ToolPolicyLike): ToolPolicyRuleKind {
@@ -174,7 +171,6 @@ export function auditToolPolicyFilter(params: {
   policy: ToolPolicyLike;
   before: readonly { name: string }[];
   after: readonly { name: string }[];
-  logLevel?: ToolPolicyAuditLogLevel;
 }): void {
   const removedByRule = removedToolNamesByRule({
     policy: params.policy,
@@ -208,11 +204,9 @@ export function auditToolPolicyFilter(params: {
       removedTools: toolNames,
       removedToolsTruncated: truncated,
     };
-    if (params.logLevel === "debug") {
-      toolPolicyAuditLogger.debug(message, metadata);
-    } else {
-      toolPolicyAuditLogger.info(message, metadata);
-    }
+    // Routine policy filtering runs on every turn; per-turn removal detail is
+    // diagnostic, not operator-facing, so it stays out of info-level logs.
+    toolPolicyAuditLogger.debug(message, metadata);
   }
 }
 

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -629,42 +629,13 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 2 tool(s) via agent tools.allow: browser, write",
       {
         rule: "agent tools.allow",
         ruleKind: "allow",
         removedToolCount: 2,
         removedTools: ["browser", "write"],
-        removedToolsTruncated: false,
-      },
-    );
-    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
-  });
-
-  test("can lower removal audits for diagnostic-only policy probes", () => {
-    const tools = [{ name: "exec" }, { name: "browser" }] as unknown as DummyTool[];
-
-    applyToolPolicyPipeline({
-      tools: asPolicyTools(tools),
-      toolMeta: () => undefined,
-      warn: () => {},
-      auditLogLevel: "debug",
-      steps: [
-        {
-          policy: { allow: ["exec"] },
-          label: "doctor tools.profile (coding)",
-        },
-      ],
-    });
-
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
-      "tool policy removed 1 tool(s) via doctor tools.profile (coding): browser",
-      {
-        rule: "doctor tools.profile (coding)",
-        ruleKind: "allow",
-        removedToolCount: 1,
-        removedTools: ["browser"],
         removedToolsTruncated: false,
       },
     );
@@ -686,7 +657,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via tools.deny: browser; matched browser",
       {
         rule: "tools.deny",
@@ -697,7 +668,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("splits mixed allow and deny policy audit entries by cause", () => {
@@ -719,7 +690,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser; matched browser",
       {
         rule: "agents.worker.tools.deny",
@@ -730,7 +701,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.allow: write",
       {
         rule: "agents.worker.tools.allow",
@@ -740,7 +711,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("does not audit policy steps that leave the tool surface unchanged", () => {
@@ -777,7 +748,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker\\nbad.tools.allow: exec\\nbad",
       {
         rule: "agents.worker\\nbad.tools.allow",
@@ -787,7 +758,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("truncates audit fields without splitting surrogate pairs", () => {
@@ -807,7 +778,7 @@ describe("tool-policy-pipeline", () => {
     });
 
     const rule = `${labelPrefix}...`;
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       `tool policy removed 1 tool(s) via ${rule}: exec`,
       {
         rule,

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -7,7 +7,7 @@ import { isFrozenClawToolAllowPolicy } from "../claws/tool-policy-runtime.js";
 import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isKnownCoreToolId } from "./tool-catalog.js";
-import { auditToolPolicyFilter, type ToolPolicyAuditLogLevel } from "./tool-policy-audit.js";
+import { auditToolPolicyFilter } from "./tool-policy-audit.js";
 import {
   analyzeAllowlistByToolType,
   buildPluginToolGroups,
@@ -138,7 +138,6 @@ export function applyToolPolicyPipeline<TTool extends { name: string }>(params: 
   toolMeta: (tool: TTool) => { pluginId: string } | undefined;
   warn: (message: string) => void;
   steps: ToolPolicyPipelineStep[];
-  auditLogLevel?: ToolPolicyAuditLogLevel;
   declaredToolAllowlist?: DeclaredToolAllowlistContext;
   onFilter?: (event: ToolPolicyFilterEvent<TTool>) => void;
 }): TTool[] {
@@ -226,7 +225,6 @@ export function applyToolPolicyPipeline<TTool extends { name: string }>(params: 
       policy: expanded,
       before,
       after: filtered,
-      logLevel: params.auditLogLevel,
     });
   }
   return filtered;

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -104,9 +104,6 @@ describe("active tool schema doctor warnings", () => {
     ).toEqual([
       '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema (fuzzplugin_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
-    expect(toolState.createTools).toHaveBeenCalledWith(
-      expect.objectContaining({ toolPolicyAuditLogLevel: "debug" }),
-    );
   });
 
   it("warns about unreadable active tool entries without crashing", async () => {

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -142,7 +142,6 @@ export async function collectActiveToolSchemaProjectionWarnings(params: {
           modelCompat: runtimeModelContext.modelCompat,
           modelContextWindowTokens: runtimeModelContext.modelContextWindowTokens,
           allowGatewaySubagentBinding: true,
-          toolPolicyAuditLogLevel: "debug",
         });
       } catch (error) {
         agentWarnings.push(

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -375,10 +375,10 @@ describe("doctor runtime tool schema checks", () => {
         "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
     expect(mocks.createOpenClawCodingTools).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "main", toolPolicyAuditLogLevel: "debug" }),
+      expect.objectContaining({ agentId: "main" }),
     );
     expect(mocks.createOpenClawCodingTools).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "worker", toolPolicyAuditLogLevel: "debug" }),
+      expect.objectContaining({ agentId: "worker" }),
     );
     expect(mocks.loadModelCatalog).toHaveBeenCalledTimes(2);
     expect(mocks.loadModelCatalog).toHaveBeenNthCalledWith(

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -841,7 +841,6 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
       modelId: params.modelRef.model,
     }),
     warn: () => {},
-    toolPolicyAuditLogLevel: "debug",
   });
   return collectNormalizedToolSchemaFindings({
     agentId: params.agentId,
@@ -904,7 +903,6 @@ function collectAgentRuntimeToolSchemaFindings(params: {
       modelContextWindowTokens: params.model.contextWindow,
       allowGatewaySubagentBinding: true,
       emitBeforeToolCallDiagnostics: false,
-      toolPolicyAuditLogLevel: "debug",
     });
   } catch (error) {
     return [agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error })];
@@ -1054,7 +1052,6 @@ function shouldReportBundleMcpRuntimeDiagnostic(params: {
         modelId: params.modelRef.model,
       }),
       warn: () => {},
-      toolPolicyAuditLogLevel: "debug",
     }).length > 0
   );
 }

--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -238,10 +238,10 @@ describe("createCronExitWatchers", () => {
       expect.objectContaining({ consecutiveErrors: 1 }),
     );
     expect(w.activeJobIds()).toEqual(["job-a"]);
-    // The backoff timer re-arms without an external reconcile.
-    await delay(5);
-    await flush();
-    expect(supervisor.spawn).toHaveBeenCalledTimes(2);
+    // The backoff timer re-arms without an external reconcile. The 0ms retry
+    // timer is armed only after async state persistence, so a fixed sleep races
+    // it on loaded CI workers — wait for the re-arm instead.
+    await vi.waitFor(() => expect(supervisor.spawn).toHaveBeenCalledTimes(2));
     expect(w.activeJobIds()).toEqual(["job-a"]);
   });
 
@@ -264,10 +264,9 @@ describe("createCronExitWatchers", () => {
       expect.objectContaining({ id: "job-a" }),
       expect.objectContaining({ consecutiveErrors: 1 }),
     );
-    // Backoff re-arm succeeds on the second spawn.
-    await delay(5);
-    await flush();
-    expect(supervisor.spawn).toHaveBeenCalledTimes(2);
+    // Backoff re-arm succeeds on the second spawn. Same async-persist race as
+    // the wait-rejection case above: wait for the re-arm, not a fixed sleep.
+    await vi.waitFor(() => expect(supervisor.spawn).toHaveBeenCalledTimes(2));
     expect(w.activeJobIds()).toEqual(["job-a"]);
 
     // Cancelling clears any pending retry timer; once the cancelled child

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -414,7 +414,6 @@ export function resolveGatewayScopedTools(params: {
           },
           // The MCP dispatcher is the shared hook and abort boundary for these tools.
           wrapBeforeToolCallHook: false,
-          toolPolicyAuditLogLevel: "debug",
         })
       : [];
   // CLI backends already own their local shell. This extra surface is deliberately

--- a/src/skills/workshop/tool-policy-diagnostic.ts
+++ b/src/skills/workshop/tool-policy-diagnostic.ts
@@ -205,7 +205,6 @@ export function resolveSkillWorkshopToolPolicyAvailability(params: {
     config: params.config,
     conversationCapabilityProfile: params.conversationCapabilityProfile,
     warn: () => {},
-    toolPolicyAuditLogLevel: "debug",
     onFilter: (event) => {
       if (
         !exclusion &&

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -9303,6 +9303,38 @@ describe("handleSendChat", () => {
     expect(host.applySettings).not.toHaveBeenCalled();
   });
 
+  it("surfaces an unconfirmed steer failure globally when the pane is no longer visible", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.send": () => {
+          // The operator navigates away before transport fails, so the stale
+          // visibility gate used to swallow the terminal outcome entirely.
+          host.sessionKey = "agent:main:second";
+          throw new Error("network dropped");
+        },
+      },
+      chatRunId: "run-1",
+      chatDisplayedLeafEntryId: "leaf-active",
+      chatQueue: [original],
+      sessionKey: "agent:main:main",
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    await steerQueuedChatMessage(host, "queued-1");
+
+    // Pre-fix: the failure was parked on the queue row with no visible outcome.
+    expect(host.lastError).toBeNull();
+    await waitForFast(() =>
+      expect(document.body.textContent).toContain(
+        "Steer delivery could not be confirmed. Check the active run before retrying.",
+      ),
+    );
+    document.body.replaceChildren();
+  });
+
   it("removes pending steer indicators when the run finishes", () => {
     const host = makeChatHost({
       chatQueue: [

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -479,9 +479,7 @@ export async function sendQueuedChatMessageWithQueueMode(
   if (!result) {
     // A transport failure does not prove active-run admission was rejected. Keep the
     // durable row parked so reconnect cannot replay it as a separate turn.
-    if (itemStillVisible) {
-      setChatError(host, unconfirmedError);
-    }
+    surfaceChatDeliveryFailure(host, itemSessionKey, item.agentId, unconfirmedError);
     return;
   }
   if (isRejectedSteerChatSend(result)) {
@@ -505,9 +503,7 @@ export async function sendQueuedChatMessageWithQueueMode(
       ...(entry.attachments?.length ? { attachments: entry.attachments } : {}),
     }));
     if (!restored) {
-      if (itemStillVisible) {
-        setChatError(host, unconfirmedError);
-      }
+      surfaceChatDeliveryFailure(host, itemSessionKey, item.agentId, unconfirmedError);
     } else {
       surfaceChatDeliveryFailure(
         host,
@@ -521,9 +517,7 @@ export async function sendQueuedChatMessageWithQueueMode(
   }
   const removed = removeQueuedMessageWithoutReleasing(host, id, itemSessionKey, item.agentId);
   if (!removed) {
-    if (itemStillVisible) {
-      setChatError(host, unconfirmedError);
-    }
+    surfaceChatDeliveryFailure(host, itemSessionKey, item.agentId, unconfirmedError);
     return;
   }
   const userTurnAlreadyVisible = chatMessagesContainQueuedSend(host.chatMessages, claimed, true);


### PR DESCRIPTION
Related: #124473

## What Problem This Solves

Fixes an issue where operators who steered a queued chat message and then navigated to another session would see no outcome at all when the steer failed: three terminal failure branches in the chat steer lifecycle (null transport result, failed queue-row restore, failed queue-row removal) still gated their error surfacing on the pane being visible, parking the error on a queue row nobody was looking at. This is the exact silent-failure invariant #124473 introduced `surfaceChatDeliveryFailure()` to protect — these three pre-existing branches never got routed through it.

Separately, resolves a problem where three per-turn gateway log lines dominated operator logs at info/warn level with no per-turn diagnostic value (one repeated 42x in a single observed session).

## Why This Change Was Made

The steer fix routes all three terminal branches through the canonical `surfaceChatDeliveryFailure()` helper and deletes the divergent visibility-only branches, so every steer failure ends in a visible outcome (inline when the pane is visible, session-named global toast when not). The logging change demotes the per-turn `tool policy removed N tool(s)` audit line to debug and deletes the now-dead `toolPolicyAuditLogLevel`/`auditLogLevel` plumbing end-to-end (it only existed to lower diagnostic probes to what is now the default), demotes the codex one-shot cleanup teardown line to debug, and makes the static codex trajectory recorder warning fire once per process instead of per attempt. The `[model-fetch]` info carve-out is intentionally kept — it is a named always-info contract (docs/logging.md, #89648).

## User Impact

Operators always get a visible outcome for a failed steer, even after switching sessions — no more silently swallowed terminal failures. Gateway logs at default level lose three lines of per-turn noise while keeping every signal available at debug.

## Evidence

- Regression test (mocked-gateway harness, real-behavior proof for the channel-visible toast path): `ui/src/pages/chat/chat-send.test.ts` — "surfaces an unconfirmed steer failure globally when the pane is no longer visible". Stash-verified failing pre-fix for the intended reason (visibility gate swallowed the terminal outcome); passes post-fix.
- Post-rebase focused proof on this head: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts extensions/codex/src/app-server/trajectory.test.ts` — 297 + 6 tests, all green.
- Trajectory warn-once behavior covered in `extensions/codex/src/app-server/trajectory.test.ts`; tool-policy plumbing deletion covered by the updated `src/agents/tool-policy-pipeline.test.ts`.
- Production LOC delta: net -11 (steer fix -6, logging refactor -5); test LOC +~40 (regression coverage).
- UI screenshot: infeasible without new harness work — no existing `dev:ui:mock` scenario simulates a steer transport failure combined with pane navigation, and repo policy accepts the mock-gateway regression test as real-behavior proof for this channel-visible path.

## Opportunistic fixes (called out per Pathfinder rule)

- `check-dependencies` flagged the warn-once reset (`resetCodexTrajectoryRecorderWarningForTest`) as a production unused export — it was a test-only seam. Removed it; the test now gets clean module state via `vi.resetModules()` + fresh dynamic import.
- `checks-node-compact-large-2` flaked on `src/gateway/cron-exit-watchers.test.ts` (unrelated to this diff): the 0ms retry timer arms only after async watcher-state persistence, so `await delay(5)` races it on loaded CI workers. Replaced both fixed-sleep re-arm waits with `vi.waitFor` on the spawn count; the remaining `delay(5)` guards a negative assertion where a bounded sleep is the correct shape.
- ClawSweeper P2 (accepted): the trajectory-recorder warn suppression was process-wide, but the host factory returns null for per-session target-mapping conflicts too — a later distinct session's recorder loss would be silenced. Now dedupes per session (bounded set), with regression coverage for a later distinct session still warning.

## ClawSweeper rank-up moves

- "Tighten the PR description" — applied: Evidence above lists exact validation commands, the stash-verified pre-fix failure, and the LOC delta. Remaining risk: the toast path is proven at the DOM level via the mocked-gateway harness rather than a live served dashboard; the helper it routes through (`surfaceChatDeliveryFailure`, #124473) is already live-proven, so residual risk is limited to wiring, which the regression test covers.
- "Live Control UI proof" — skipped per repo policy: channel-visible chat behavior may satisfy the real-behavior-proof gate via the mock-gateway harness regression test covering the changed path (the review's own proof gate marks live proof not applicable for maintainer-authored PRs). No existing `dev:ui:mock` scenario simulates steer transport failure plus pane navigation; building one is named follow-up work, not a blocker.
