### PR TITLE
fix(slack): stop sniffing the NO_REPLY product token in the transport

### DIFF
--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -95,50 +95,16 @@ function slackDnsRequestError(): Error {
   });
 }
 
-describe("sendMessageSlack NO_REPLY guard", () => {
-  it("suppresses NO_REPLY text before any Slack API call", async () => {
+describe("sendMessageSlack NO_REPLY literal", () => {
+  // Silent-reply stripping is owned by core auto-reply normalization before
+  // payloads reach outbound; a literal NO_REPLY sent through the message tool
+  // must deliver on Slack exactly like every sibling channel.
+  it("delivers a literal NO_REPLY text like sibling channels", async () => {
     const client = createSlackSendTestClient();
     const result = await sendMessageSlack("channel:C123", "NO_REPLY", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
-    });
-
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-    expect(result.messageId).toBe("suppressed");
-    expect(result.receipt.platformMessageIds).toStrictEqual([]);
-  });
-
-  it("suppresses NO_REPLY with surrounding whitespace", async () => {
-    const client = createSlackSendTestClient();
-    const result = await sendMessageSlack("channel:C123", "  NO_REPLY  ", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
-
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-    expect(result.messageId).toBe("suppressed");
-  });
-
-  it("does not suppress substantive text containing NO_REPLY", async () => {
-    const client = createSlackSendTestClient();
-    await sendMessageSlack("channel:C123", "This is not a NO_REPLY situation", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalled();
-  });
-
-  it("does not suppress NO_REPLY when blocks are attached", async () => {
-    const client = createSlackSendTestClient();
-    const result = await sendMessageSlack("channel:C123", "NO_REPLY", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks: [{ type: "section", text: { type: "mrkdwn", text: "content" } }],
     });
 
     expect(client.chat.postMessage).toHaveBeenCalled();

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -16,7 +16,6 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-run
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
   chunkMarkdownTextWithMode,
-  isSilentReplyText,
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "openclaw/plugin-sdk/reply-chunking";
@@ -325,7 +324,7 @@ function createSlackSendReceipt(params: {
 }): MessageReceipt {
   const platformMessageIds = params.platformMessageIds
     .map((messageId) => messageId.trim())
-    .filter((messageId) => messageId && messageId !== "unknown" && messageId !== "suppressed");
+    .filter((messageId) => messageId && messageId !== "unknown");
   return createMessageReceiptFromOutboundResults({
     results: platformMessageIds.map((messageId) => {
       const result: MessageReceiptSourceResult = {
@@ -1077,14 +1076,6 @@ export async function sendMessageSlack(
   const recipient = eventScope ? parseEnterpriseEventRecipient(to) : parseRecipient(to);
   if (!eventScope) {
     assertSlackDetachedTargetAllowed(account.accountId, recipient.teamId);
-  }
-  if (isSilentReplyText(normalizedMessage) && !opts.mediaUrl && !opts.blocks) {
-    logVerbose("slack send: suppressed NO_REPLY token before API call");
-    return {
-      messageId: "suppressed",
-      channelId: "",
-      receipt: createSlackSendReceipt({ platformMessageIds: [], kind: "unknown" }),
-    };
   }
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   if (!normalizedMessage && !opts.mediaUrl && !blocks) {

--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -287,9 +287,9 @@ function resolveConversationKind(
 function firstIdentifier(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     const normalized = value?.trim();
-    // "unknown"/"suppressed" are adapter sentinel messageIds (telegram/slack
-    // outbound adapters), not platform identifiers; treating them as real ids
-    // would pseudonymize a constant and corrupt correlation refs.
+    // "unknown"/"suppressed" are adapter sentinel messageIds, not platform
+    // identifiers; treating them as real ids would pseudonymize a constant
+    // and corrupt correlation refs.
     if (normalized && normalized !== "unknown" && normalized !== "suppressed") {
       return normalized;
     }


### PR DESCRIPTION
## What Problem This Solves

`sendMessageSlack` special-cased core's `NO_REPLY` silent-reply token inside the transport: any outbound text that trimmed to the token was suppressed before the API call, returning a fabricated `"suppressed"` messageId. Silent-reply stripping is owned by core auto-reply normalization (`normalize-reply.ts` / `reply-dispatcher.ts`) before payloads ever reach outbound — no sibling channel transport (Telegram, Discord, Signal, WhatsApp) has this check. Net effect: a literal `NO_REPLY` sent through the message tool delivered on every channel except Slack, a transport-only violation ("never special-case product strings in adapters") plus a cross-channel behavior asymmetry.

## Why This Change Was Made

`git log -S` shows the check moved verbatim in the extension extraction (8746362f5ebf) — it predates core ownership of silent-reply normalization and is duplicate policy. Deleted: the check, its `"suppressed"` sentinel mint (the only one left in the repo), the local receipt filter for it, and the sentinel-list comment in outbound-audit trimmed to match. The audit/deliver-results sentinel filters stay (they also cover `"unknown"`).

## User Impact

Sending text containing exactly `NO_REPLY` via the message tool now behaves identically on Slack and every sibling channel. No change to agent replies — core normalization already strips genuine silent replies before delivery.

## Evidence

- New sibling-parity regression `delivers a literal NO_REPLY text like sibling channels` fails pre-fix (stash proof) and passes post-fix; the four suppression-pinning tests are deleted with the behavior per test-audit policy.
- Full Slack extension suite: 2411/2411 green.
- tsgo core + extensions clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +4 −13 (net −9); tests +5 −39.
