### PR TITLE
fix(gateway): omit JavaScript class names from proven RPC failures

### DIFF
--- a/src/gateway/agent-turn/agent-delivery-phase.test.ts
+++ b/src/gateway/agent-turn/agent-delivery-phase.test.ts
@@ -31,7 +31,11 @@ describe("resolveAgentDeliveryPhase", () => {
     const respond = vi.fn();
 
     await resolveAgentDeliveryPhase({
-      request: { message: "strict delivery", deliver: true },
+      request: {
+        message: "strict delivery",
+        deliver: true,
+        idempotencyKey: "strict-target-resolution",
+      },
       cfg: {},
       agentId: "main",
       replyTo: "",

--- a/src/gateway/agent-turn/agent-delivery-phase.test.ts
+++ b/src/gateway/agent-turn/agent-delivery-phase.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveAgentDeliveryPlanWithSessionRoute: vi.fn(),
+}));
+
+vi.mock("../../infra/outbound/agent-delivery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/outbound/agent-delivery.js")>()),
+  resolveAgentDeliveryPlanWithSessionRoute: mocks.resolveAgentDeliveryPlanWithSessionRoute,
+}));
+
+const { resolveAgentDeliveryPhase } = await import("./agent-delivery-phase.js");
+
+describe("resolveAgentDeliveryPhase", () => {
+  beforeEach(() => {
+    mocks.resolveAgentDeliveryPlanWithSessionRoute.mockReset();
+  });
+
+  it("renders a strict target-resolution failure without its Error class", async () => {
+    const targetError = Object.assign(new Error('Reserved target "current" for Telegram'), {
+      code: "INVALID_TARGET",
+    });
+    mocks.resolveAgentDeliveryPlanWithSessionRoute.mockResolvedValue({
+      baseDelivery: {},
+      resolvedChannel: "telegram",
+      resolvedTo: "current",
+      deliveryTargetMode: "explicit",
+      targetResolutionError: targetError,
+    });
+    const respond = vi.fn();
+
+    await resolveAgentDeliveryPhase({
+      request: { message: "strict delivery", deliver: true },
+      cfg: {},
+      agentId: "main",
+      replyTo: "",
+      to: "current",
+      bestEffortDeliver: false,
+      runId: "strict-target-resolution",
+      client: null,
+      context: { chatAbortControllers: new Map() } as never,
+      respond,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'Reserved target "current" for Telegram | INVALID_TARGET',
+    });
+  });
+});

--- a/src/gateway/agent-turn/agent-delivery-phase.ts
+++ b/src/gateway/agent-turn/agent-delivery-phase.ts
@@ -16,10 +16,10 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveChatRunOwnerAgentId } from "../chat-run-owner.js";
+import { errorShapeFromError } from "../error-shape.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import type { GatewayRequestHandlerOptions } from "../server-methods/types.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
-import { formatForLog } from "../ws-log.js";
 import type { AgentTurnContext, AgentTurnPrincipal } from "./types.js";
 
 type DeliveryPlan = Awaited<ReturnType<typeof resolveAgentDeliveryPlanWithSessionRoute>>;
@@ -141,7 +141,7 @@ export async function resolveAgentDeliveryPhase(params: {
           resolvedChannel,
         })
       ) {
-        params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
+        params.respond(false, undefined, errorShapeFromError(ErrorCodes.INVALID_REQUEST, err));
         return undefined;
       }
       deliveryResolutionError = String(err);
@@ -152,7 +152,7 @@ export async function resolveAgentDeliveryPhase(params: {
     params.respond(
       false,
       undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, String(deliveryTargetResolutionError)),
+      errorShapeFromError(ErrorCodes.INVALID_REQUEST, deliveryTargetResolutionError),
     );
     return undefined;
   }
@@ -176,12 +176,12 @@ export async function resolveAgentDeliveryPhase(params: {
       params.respond(
         false,
         undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          deliveryTargetResolutionError
-            ? String(deliveryTargetResolutionError)
-            : `delivery target is required for ${resolvedChannel}: pass --to/--reply-to or configure a default target`,
-        ),
+        deliveryTargetResolutionError
+          ? errorShapeFromError(ErrorCodes.INVALID_REQUEST, deliveryTargetResolutionError)
+          : errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `delivery target is required for ${resolvedChannel}: pass --to/--reply-to or configure a default target`,
+            ),
       );
       return undefined;
     }

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -27,6 +27,7 @@ import { claimAgentRunContext } from "../../infra/agent-run-registry.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SessionWorkAdmissionLease } from "../../sessions/session-lifecycle-admission.js";
 import { registerChatAbortController, resolveAgentRunExpiresAtMs } from "../chat-abort.js";
+import { errorShapeFromError } from "../error-shape.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import {
   isConfirmedAcpManualSpawnTaskOwner,
@@ -352,9 +353,11 @@ export async function prepareAgentRunDispatch(params: {
       params.io.emitAcceptance([
         false,
         undefined,
-        errorShape(
+        errorShapeFromError(
           ErrorCodes.UNAVAILABLE,
-          `plugin subagent registry persistence failed; run was not started: ${formatForLog(err)}`,
+          new Error("plugin subagent registry persistence failed; run was not started", {
+            cause: err,
+          }),
         ),
       ]);
       return undefined;

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -27,6 +27,7 @@ import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { recordSessionCreated } from "../../sessions/session-state-events.js";
 import { getGeneratedMediaTaskIdsForSessionKey } from "../../tasks/task-status-access.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
+import { errorShapeFromError } from "../error-shape.js";
 import {
   assertExpectedExistingSession,
   ExpectedExistingSessionChangedError,
@@ -35,7 +36,6 @@ import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import type { AgentSessionPatchBuild } from "../server-methods/agent-session-patch.js";
 import type { TrustedSessionCreation } from "../server-methods/session-creation-provenance.js";
 import type { GatewayRequestHandlerOptions } from "../server-methods/types.js";
-import { formatForLog } from "../ws-log.js";
 import {
   cronContinuationHasReusableRuntime,
   emitAgentSendSessionLifecycleTransition,
@@ -372,7 +372,7 @@ export async function persistAgentSessionPhase(params: {
         return undefined;
       }
       if (deletedDuringStoreUpdateError) {
-        params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
+        params.respond(false, undefined, errorShapeFromError(ErrorCodes.INVALID_REQUEST, err));
         return undefined;
       }
       if (err instanceof ExpectedExistingSessionChangedError) {
@@ -430,7 +430,7 @@ export async function persistAgentSessionPhase(params: {
     try {
       params.assertGatewayWorkAdmissionAllowed();
     } catch (err) {
-      params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
+      params.respond(false, undefined, errorShapeFromError(ErrorCodes.INVALID_REQUEST, err));
       return undefined;
     }
     if (

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -1,9 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  ErrorCodes,
-  errorShape,
-  type AgentWaitParams,
-} from "../../../packages/gateway-protocol/src/index.js";
+import { ErrorCodes, type AgentWaitParams } from "../../../packages/gateway-protocol/src/index.js";
 import { scheduleMainSessionRecoveryPendingTarget } from "../../agents/main-session-recovery/main-session-recovery-owner-release.js";
 import {
   releaseMainSessionRecoveryOwner,
@@ -13,6 +9,7 @@ import { mergeSessionEntry, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import { errorShapeFromError } from "../error-shape.js";
 import { createCronContinuationController } from "../server-methods/agent-cron-continuation.js";
 import { runAgentResetPhase } from "../server-methods/agent-reset-phase.js";
 import { buildAgentSessionPatch } from "../server-methods/agent-session-patch.js";
@@ -21,7 +18,6 @@ import { handleChatAbortRequest } from "../server-methods/chat-abort-handler.js"
 import { resolveAgentRunSessionCreation } from "../server-methods/session-creation-provenance.js";
 import type { GatewayRequestHandlerOptions, RespondFn } from "../server-methods/shared-types.js";
 import { authorizeResolvedSessionMutation } from "../session-sharing.js";
-import { formatForLog } from "../ws-log.js";
 import { createAgentAdmissionController } from "./agent-admission-controller.js";
 import { prepareAgentContentPhase } from "./agent-content-phase.js";
 import { createAgentDedupeLifecycle } from "./agent-dedupe-lifecycle.js";
@@ -413,7 +409,7 @@ export function createAgentTurnService({
           io.emitAcceptance([
             false,
             undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)),
+            errorShapeFromError(ErrorCodes.INVALID_REQUEST, err),
           ]);
           return;
         }

--- a/src/gateway/error-shape.ts
+++ b/src/gateway/error-shape.ts
@@ -1,0 +1,11 @@
+import { errorShape } from "../../packages/gateway-protocol/src/index.js";
+import { formatErrorMessageWithCode } from "../infra/errors.js";
+
+/** Builds a wire error from an unknown failure without diagnostic class names. */
+export function errorShapeFromError(
+  code: Parameters<typeof errorShape>[0],
+  error: unknown,
+  opts?: Parameters<typeof errorShape>[2],
+) {
+  return errorShape(code, formatErrorMessageWithCode(error), opts);
+}

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -695,7 +695,7 @@ describe("gateway agent handler", () => {
     );
 
     expectRespondError(respond, {
-      message: `Error: Session "${sessionKey}" was deleted while starting work. Retry.`,
+      message: `Session "${sessionKey}" was deleted while starting work. Retry.`,
     });
     expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
@@ -723,7 +723,7 @@ describe("gateway agent handler", () => {
     );
 
     expectRespondError(respond, {
-      message: `Error: Session "${sessionKey}" was deleted while starting work. Retry.`,
+      message: `Session "${sessionKey}" was deleted while starting work. Retry.`,
     });
     expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
@@ -756,7 +756,7 @@ describe("gateway agent handler", () => {
     );
 
     expectRespondError(respond, {
-      message: `Error: Session "${sessionKey}" was deleted while starting work. Retry.`,
+      message: `Session "${sessionKey}" was deleted while starting work. Retry.`,
     });
     expect(mocks.agentCommand).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -654,7 +654,11 @@ describe("gateway agent handler", () => {
 
     expect(mocks.agentCommand).not.toHaveBeenCalled();
     const error = expectRespondError(respond, {});
-    expectStringFieldContains(error, "message", "requires target");
+    expect(error).toMatchObject({
+      code: ErrorCodes.INVALID_REQUEST,
+      message: expect.stringContaining("requires target"),
+    });
+    expect(error.message).not.toMatch(/^Error:/u);
   });
 
   it("preserves requested delivery when best effort has no external channel", async () => {

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -523,8 +523,9 @@ describe("gateway agent handler", () => {
         resetAgentTaskRegistryForTests();
         resetSubagentRegistryForTests({ persist: false });
         const persistSubagentRunsToDiskOrThrow = vi.fn();
+        const persistenceError = Object.assign(new Error("disk full"), { code: "SQLITE_FULL" });
         persistSubagentRunsToDiskOrThrow.mockImplementationOnce(() => {
-          throw new Error("disk full");
+          throw persistenceError;
         });
         applyGatewaySubagentRegistryTestDeps({
           persistSubagentRunsToDiskOrThrow,
@@ -586,8 +587,11 @@ describe("gateway agent handler", () => {
         expect(persistSubagentRunsToDiskOrThrow).toHaveBeenCalledTimes(1);
         expect(mocks.agentCommand).toHaveBeenCalledTimes(commandCallCount);
         expect(findTaskByRunId(runId)).toBeUndefined();
-        const error = expectRespondError(respond, { code: ErrorCodes.UNAVAILABLE });
-        expectStringFieldContains(error, "message", "run was not started");
+        expectRespondError(respond, {
+          code: ErrorCodes.UNAVAILABLE,
+          message:
+            "plugin subagent registry persistence failed; run was not started | disk full | SQLITE_FULL",
+        });
         expect(context.logGateway.warn).toHaveBeenCalledWith(
           expect.stringContaining("rejecting untracked dispatch"),
         );
@@ -636,8 +640,11 @@ describe("gateway agent handler", () => {
           pauseReason: "sessions_yield",
         });
         expect(getSubagentRunByChildSessionKey(childSessionKey)?.runId).not.toBe(adoptionRunId);
-        const adoptionError = expectRespondError(adoptionRespond, { code: ErrorCodes.UNAVAILABLE });
-        expectStringFieldContains(adoptionError, "message", "run was not started");
+        expectRespondError(adoptionRespond, {
+          code: ErrorCodes.UNAVAILABLE,
+          message:
+            "plugin subagent registry persistence failed; run was not started | disk full during paused-run adoption",
+        });
 
         resetSubagentRegistryForTests({ persist: false });
         const retryRunId = "plugin-subagent-registry-retry";

--- a/src/gateway/server-methods/fs.test.ts
+++ b/src/gateway/server-methods/fs.test.ts
@@ -101,12 +101,16 @@ describe("fs.listDir", () => {
 
   it("reports missing directories as request errors", async () => {
     const root = tempDirs.make("openclaw-fs-listdir-");
+    const missing = path.join(root, "does-not-exist");
     const [ok, , error] = expectDefined(
-      await call({ path: path.join(root, "does-not-exist") }),
-      'await call({ path: path.join(root, "does-not-exist") }) test invariant',
+      await call({ path: missing }),
+      "missing directory response",
     );
     expect(ok).toBe(false);
-    expect((error as { message?: string })?.message).toContain("ENOENT");
+    const message = (error as { message?: string })?.message ?? "";
+    expect(message).toContain(`ENOENT: no such file or directory, scandir '${missing}'`);
+    expect(message).toMatch(/ \| ENOENT$/u);
+    expect(message).not.toMatch(/^Error:/u);
   });
 
   it("allows write-scoped browsing inside a configured workspace", async () => {
@@ -174,7 +178,10 @@ describe("fs.listDir", () => {
     );
 
     expect(ok).toBe(false);
-    expect(error).toMatchObject({ message: expect.stringContaining("ENOENT") });
+    const message = (error as { message?: string })?.message ?? "";
+    expect(message).toContain(`ENOENT: no such file or directory, scandir '${missing}'`);
+    expect(message).toMatch(/ \| ENOENT$/u);
+    expect(message).not.toMatch(/^Error:/u);
   });
 
   it("routes node listings through the connected node capability", async () => {

--- a/src/gateway/server-methods/fs.ts
+++ b/src/gateway/server-methods/fs.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listHostDirectories } from "../../infra/host-directory-listing.js";
 import { NODE_FS_LIST_DIR_COMMAND } from "../../infra/node-commands.js";
+import { errorShapeFromError } from "../error-shape.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -118,7 +119,7 @@ export const fsHandlers: GatewayRequestHandlers = {
       }
       respond(true, listing, undefined);
     } catch (error) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(error)));
+      respond(false, undefined, errorShapeFromError(ErrorCodes.INVALID_REQUEST, error));
     }
   },
 };

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -786,6 +786,7 @@ describe("gateway server agent", () => {
       expect(res.ok).toBe(false);
       expect(res.error?.code).toBe("INVALID_REQUEST");
       expect(res.error?.message).toContain("Channel is required");
+      expect(res.error?.message).not.toMatch(/^Error:/u);
       expect(vi.mocked(agentCommandMock)).not.toHaveBeenCalled();
     } finally {
       testState.allowFrom = undefined;

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -506,6 +506,7 @@ describe("gateway server agent", () => {
     expect(errorMessage).toMatch(/ACP_TURN_FAILED/);
     expect(errorMessage).toMatch(/Internal error/);
     expect(errorMessage).toMatch(/upstream rejected/);
+    expect(errorMessage).not.toContain("AcpRuntimeError");
     expect(JSON.stringify(final)).not.toContain(token);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could receive JavaScript error class names in Gateway RPC failures when a handler passed a diagnostic formatter or raw `String(error)` into `ErrorShape.message`.

The concrete live reproduction was `fs.listDir` on a missing workspace descendant. The CLI rendered `Gateway call failed: Error: ENOENT: ...`, even though `ErrorShape.message` is the user-facing wire contract shared by the CLI, Control UI, plugins, and ACP.

## Why This Change Was Made

Adds one Gateway-owned `errorShapeFromError` constructor that uses the canonical redacting `formatErrorMessageWithCode` renderer, then adopts it at eight producers with proven handler/client reachability:

| Producer | Reachability and observed behavior |
| --- | --- |
| `src/gateway/server-methods/fs.ts:119` | A schema-valid absolute path reaches `fs.readdir`; `ENOENT` previously became `Error: ENOENT...`. Live CLI proof is below. |
| `src/gateway/agent-turn/agent-delivery-phase.ts:142` | Strict delivery without an unambiguous configured channel reaches `resolveMessageChannelSelection`, whose ordinary `Error` previously leaked `Error:`. |
| `src/gateway/agent-turn/agent-delivery-phase.ts:153` | A strict explicit target can carry a plugin target-resolution `Error`; the new owner-boundary test proves the message omits the class and retains `INVALID_TARGET`. |
| `src/gateway/agent-turn/agent-delivery-phase.ts:177` | Strict fallback target resolution returns the same typed `Error` family; an existing handler test reproduced `Error: Delivering to Telegram requires target`. |
| `src/gateway/agent-turn/agent-turn-service.ts:414` | A session deleted between persistence and lifecycle admission produced `Error: Session ... was deleted...`; the existing handler test already asserted the old prefix exactly. |
| `src/gateway/agent-turn/agent-session-persist.ts:373` | A session deleted before its initial authoritative store touch produced the same prefixed wire error; existing handler coverage reproduced it. |
| `src/gateway/agent-turn/agent-session-persist.ts:431` | A newly touched session deleted before admission revalidation produced the same prefixed wire error; existing handler coverage reproduced it. |
| `src/gateway/agent-turn/agent-run-admission-phase.ts:353` | Plugin-subagent registry persistence can throw SQLite errors. The handler test now proves `disk full | SQLITE_FULL`, rather than `Error: disk full: code=SQLITE_FULL`. |

This deliberately does not change `formatForLog`; diagnostic logs keep error names and diagnostic formatting.

### Inventory and guard decision

The task's 55-site grep count was incomplete on current `main`: a balanced AST inventory found 67 message expressions across 34 files because 12 multiline calls were missed. Of those, 60 can receive an `Error`, six are already behavior-neutral because their `Error` branch uses `.message`, and one stringifies a schema-validated identifier rather than an error.

This PR changes 8 proven sites and deliberately leaves 59:

- 52 reachable candidates in web, health, TTS, send, talk, pairing, auth status, nodes, attachments, board/worktrees, and remaining agent/WS fallback paths. Each needs its own handler-level wire proof before behavior changes.
- 6 already class-safe expressions in portals, conversations, and schema-validated channel formatting.
- 1 non-error `secrets.resolve` target identifier coercion.

I did not add the proposed AST guard. Making it pass now would require either 52 additional untested behavior changes or roughly 59 allow comments that normalize known debt. The single canonical constructor makes the correct new path obvious without institutionalizing that baseline; a future guard is worthwhile once the remaining handlers have focused wire tests.

## User Impact

For the repaired RPC paths, clients now render the actionable operator message and structured error code without a JavaScript class prefix. Structured primary and cause-chain codes still survive, and sensitive text still goes through the canonical redactor.

No protocol shape, `ErrorShape`, outer Gateway error codes, or diagnostic log formatting changed. No changelog entry was added, per task instructions.

Production LOC: +33/-22 (net +11). Tests/test support: +89/-13 (net +76).

## Evidence

Live isolated scratch Gateway on port 19789 with channels skipped:

```text
before: Gateway call failed: Error: ENOENT: no such file or directory, scandir '<scratch>/workspace-dev/does-not-exist'
after:  Gateway call failed: ENOENT: no such file or directory, scandir '<scratch>/workspace-dev/does-not-exist' | ENOENT
```

The JSON response retained outer `code: INVALID_REQUEST`; only the wire message changed, and it now retains the filesystem's structured `ENOENT`.

Validation:

- Regression-first proof: 7 existing handler tests failed against the old producers for the expected class-prefix/code-loss reason, then passed after the repair.
- The new strict target-resolution test was also run with the old `String(Error)` producer restored temporarily; it failed with `Error: Reserved target...` and missing `INVALID_TARGET`, then passed with the canonical helper.
- `node scripts/run-vitest.mjs src/gateway/server-methods/fs.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts` — 335 passed.
- `node scripts/run-vitest.mjs src/gateway/agent-turn/agent-delivery-phase.test.ts` — 1 passed.
- `pnpm build` — passed.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01m057vte4va102gpfnt62v78r`; exact successful run: https://github.com/openclaw/openclaw/actions/runs/31946483691
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings. Follow-up test-only reviews were also clean.
