### PR TITLE
perf(test): reuse QA hook routing fixture

### DIFF
--- a/extensions/qa-lab/src/hook-agent-account-routing.e2e.test.ts
+++ b/extensions/qa-lab/src/hook-agent-account-routing.e2e.test.ts
@@ -1,7 +1,7 @@
 // QA Lab product proof exercises hook delivery through a real Gateway child and qa-channel bus.
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { startQaGatewayChild } from "./gateway-child.js";
 import { startQaLabServer } from "./lab-server.js";
 import { startQaProviderServer } from "./providers/server-runtime.js";
@@ -103,50 +103,27 @@ async function startHookAccountFixture() {
 }
 
 describe("hook agent account routing product proof", () => {
+  let fixture: Awaited<ReturnType<typeof startHookAccountFixture>>;
+
+  beforeAll(async () => {
+    fixture = await startHookAccountFixture();
+  }, 180_000);
+
+  afterAll(async () => {
+    await fixture?.stop();
+  });
+
   it(
     "rejects invalid explicit accounts before running the agent",
     { timeout: 180_000 },
     async () => {
-      const fixture = await startHookAccountFixture();
+      const messageCountBefore = fixture.lab.state.getSnapshot().messages.length;
 
-      try {
-        for (const { accountId, expectedError } of [
-          { accountId: "missing", expectedError: 'Unknown account "missing"' },
-          { accountId: "disabled", expectedError: 'Account "disabled"' },
-          { accountId: "__proto__", expectedError: 'Invalid account ID "__proto__"' },
-        ]) {
-          const response = await postJson(
-            `${fixture.gateway.baseUrl}/hooks/agent`,
-            {
-              message: `Reply exactly: ${MARKER}`,
-              deliver: true,
-              channel: "qa-channel",
-              to: "dm:hook-recipient",
-              accountId,
-            },
-            { Authorization: `Bearer ${HOOK_TOKEN}` },
-          );
-
-          expect(response.status, JSON.stringify(response.json)).toBe(400);
-          expect(response.json).toMatchObject({ ok: false, runId: expect.any(String) });
-          expect((response.json as { error?: unknown }).error).toEqual(
-            expect.stringContaining(expectedError),
-          );
-        }
-        expect(fixture.lab.state.getSnapshot().messages).toHaveLength(0);
-      } finally {
-        await fixture.stop();
-      }
-    },
-  );
-
-  it(
-    "delivers exactly once through the selected qa-channel account",
-    { timeout: 180_000 },
-    async () => {
-      const fixture = await startHookAccountFixture();
-
-      try {
+      for (const { accountId, expectedError } of [
+        { accountId: "missing", expectedError: 'Unknown account "missing"' },
+        { accountId: "disabled", expectedError: 'Account "disabled"' },
+        { accountId: "__proto__", expectedError: 'Invalid account ID "__proto__"' },
+      ]) {
         const response = await postJson(
           `${fixture.gateway.baseUrl}/hooks/agent`,
           {
@@ -154,67 +131,95 @@ describe("hook agent account routing product proof", () => {
             deliver: true,
             channel: "qa-channel",
             to: "dm:hook-recipient",
-            accountId: "work",
+            accountId,
           },
           { Authorization: `Bearer ${HOOK_TOKEN}` },
         );
-        expect(response.status, JSON.stringify(response.json)).toBe(200);
 
-        const body = response.json as { ok?: boolean; runId?: string };
-        expect(body.ok).toBe(true);
-        expect(body.runId).toEqual(expect.any(String));
-
-        await vi.waitFor(
-          () => {
-            const outbound = fixture.lab.state
-              .getSnapshot()
-              .messages.filter((message) => message.direction === "outbound");
-            expect(outbound).toHaveLength(1);
-            expect(outbound[0]).toMatchObject({
-              accountId: "work",
-              conversation: { id: "hook-recipient", kind: "direct" },
-              text: MARKER,
-            });
-          },
-          { interval: 50, timeout: 60_000 },
+        expect(response.status, JSON.stringify(response.json)).toBe(400);
+        expect(response.json).toMatchObject({ ok: false, runId: expect.any(String) });
+        expect((response.json as { error?: unknown }).error).toEqual(
+          expect.stringContaining(expectedError),
         );
-        await sleep(500);
-
-        const outbound = fixture.lab.state
-          .getSnapshot()
-          .messages.filter((message) => message.direction === "outbound");
-        expect(outbound).toHaveLength(1);
-        expect(outbound.filter((message) => message.accountId === "default")).toHaveLength(0);
-
-        const defaultResponse = await postJson(
-          `${fixture.gateway.baseUrl}/hooks/agent`,
-          {
-            message: `Reply exactly: ${DEFAULT_MARKER}`,
-            deliver: true,
-            channel: "qa-channel",
-            to: "dm:hook-default-recipient",
-          },
-          { Authorization: `Bearer ${HOOK_TOKEN}` },
-        );
-        expect(defaultResponse.status, JSON.stringify(defaultResponse.json)).toBe(200);
-
-        await vi.waitFor(
-          () => {
-            const currentOutbound = fixture.lab.state
-              .getSnapshot()
-              .messages.filter((message) => message.direction === "outbound");
-            expect(currentOutbound).toHaveLength(2);
-            expect(currentOutbound[1]).toMatchObject({
-              accountId: "default",
-              conversation: { id: "hook-default-recipient", kind: "direct" },
-              text: DEFAULT_MARKER,
-            });
-          },
-          { interval: 50, timeout: 60_000 },
-        );
-      } finally {
-        await fixture.stop();
       }
+      expect(fixture.lab.state.getSnapshot().messages).toHaveLength(messageCountBefore);
+    },
+  );
+
+  it(
+    "delivers exactly once through the selected qa-channel account",
+    { timeout: 180_000 },
+    async () => {
+      const outboundCountBefore = fixture.lab.state
+        .getSnapshot()
+        .messages.filter((message) => message.direction === "outbound").length;
+      const response = await postJson(
+        `${fixture.gateway.baseUrl}/hooks/agent`,
+        {
+          message: `Reply exactly: ${MARKER}`,
+          deliver: true,
+          channel: "qa-channel",
+          to: "dm:hook-recipient",
+          accountId: "work",
+        },
+        { Authorization: `Bearer ${HOOK_TOKEN}` },
+      );
+      expect(response.status, JSON.stringify(response.json)).toBe(200);
+
+      const body = response.json as { ok?: boolean; runId?: string };
+      expect(body.ok).toBe(true);
+      expect(body.runId).toEqual(expect.any(String));
+
+      await vi.waitFor(
+        () => {
+          const outbound = fixture.lab.state
+            .getSnapshot()
+            .messages.filter((message) => message.direction === "outbound");
+          expect(outbound).toHaveLength(outboundCountBefore + 1);
+          expect(outbound.at(-1)).toMatchObject({
+            accountId: "work",
+            conversation: { id: "hook-recipient", kind: "direct" },
+            text: MARKER,
+          });
+        },
+        { interval: 50, timeout: 60_000 },
+      );
+      await sleep(500);
+
+      const outbound = fixture.lab.state
+        .getSnapshot()
+        .messages.filter((message) => message.direction === "outbound");
+      expect(outbound).toHaveLength(outboundCountBefore + 1);
+      expect(
+        outbound.slice(outboundCountBefore).filter((message) => message.accountId === "default"),
+      ).toHaveLength(0);
+
+      const defaultResponse = await postJson(
+        `${fixture.gateway.baseUrl}/hooks/agent`,
+        {
+          message: `Reply exactly: ${DEFAULT_MARKER}`,
+          deliver: true,
+          channel: "qa-channel",
+          to: "dm:hook-default-recipient",
+        },
+        { Authorization: `Bearer ${HOOK_TOKEN}` },
+      );
+      expect(defaultResponse.status, JSON.stringify(defaultResponse.json)).toBe(200);
+
+      await vi.waitFor(
+        () => {
+          const currentOutbound = fixture.lab.state
+            .getSnapshot()
+            .messages.filter((message) => message.direction === "outbound");
+          expect(currentOutbound).toHaveLength(outboundCountBefore + 2);
+          expect(currentOutbound.at(-1)).toMatchObject({
+            accountId: "default",
+            conversation: { id: "hook-default-recipient", kind: "direct" },
+            text: DEFAULT_MARKER,
+          });
+        },
+        { interval: 50, timeout: 60_000 },
+      );
     },
   );
 });

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -315,15 +315,16 @@ describe("matrix harness runtime", () => {
   });
 
   it("bounds a stalled versions probe by the remaining discovery deadline", async () => {
-    let probeSignal: AbortSignal | undefined;
+    const probeSignals: AbortSignal[] = [];
     const fetchImpl = vi.fn(
       async (_input: string, init?: Pick<RequestInit, "signal">) =>
         await new Promise<never>((_resolve, reject) => {
-          probeSignal = init?.signal ?? undefined;
+          const probeSignal = init?.signal ?? undefined;
           if (!probeSignal) {
             reject(new Error("versions probe signal missing"));
             return;
           }
+          probeSignals.push(probeSignal);
           const rejectAborted = () => reject(new Error("versions probe aborted"));
           if (probeSignal.aborted) {
             rejectAborted();
@@ -348,8 +349,9 @@ describe("matrix harness runtime", () => {
     ).rejects.toThrow("did not become healthy");
 
     expect(Date.now() - startedAt).toBeLessThan(500);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(probeSignal?.aborted).toBe(true);
+    expect(probeSignals).not.toHaveLength(0);
+    expect(probeSignals.length).toBeLessThanOrEqual(2);
+    expect(probeSignals.every((signal) => signal.aborted)).toBe(true);
     expect(sleepImpl).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The QA hook account-routing product proof starts and stops the same real Gateway child, QA Lab server, and mock provider independently for its two tests. After the one-time build, each fixture startup costs about ten seconds and dominates the file.

## Why This Change Was Made

Move the fixture to suite ownership while preserving both independent tests:

- `beforeAll` starts one real Gateway/provider/lab stack and `afterAll` always tears it down.
- The invalid-account case records the message count before its requests and proves no new message is admitted.
- The delivery case records the outbound count before its requests and proves exactly one `work` delivery followed by exactly one default-account delivery.

Both tests still pass when selected independently, so the shared lifecycle does not depend on another test preparing state.

## User Impact

Maintainer QA feedback is about ten seconds faster while retaining the real Gateway, provider, channel transport, invalid-account, routing, and exactly-once boundaries.

## Evidence

Controlled same-Testbox A/B on `tbx_01m057wyds5ekmvrxttg9xjfpv`, with one excluded warmup and two retained samples per state, the same command, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 35.33s | 25.65s | -9.68s (-27.4%) |
| Vitest | 34.95s | 25.28s | -27.7% |
| Test body | 21.43s | 11.47s | -46.5% |
| CPU user+sys | 51.14s | 36.46s | -28.7% |
| Imports | 10.19s | 10.42s | effectively flat/noisy |

Peak RSS was noisy across retained samples, so this PR makes no memory claim.

Validation:

- 2/2 real QA hook product tests pass together.
- Each test passes when selected independently with the shared suite fixture.
- Fault injection: putting the valid `work` account into the invalid-account table fails immediately with HTTP 200 versus the required 400.
- Initial exact-head CI exposed a latent Matrix deadline assertion race: the per-request timeout and outer discovery timeout can validly produce one or two aborted probes. The repair asserts bounded attempts, every signal aborted, no poll sleep, and sub-500ms completion.
- The repaired Matrix deadline case passed 20/20 focused repetitions.
- The complete extension-qa shard passed: 202 files and 2,771 tests.
- Full extension-test changed gate passed, including typecheck, targeted lint, plugin boundaries, dead exports, and assertion guards.
- Fresh post-rebase autoreview: no accepted/actionable findings.
- Production LOC: `+0/-0`; test LOC: `+106/-99`.

Controlled benchmark and initial proof: https://github.com/openclaw/openclaw/actions/runs/31946513539

Full extension-qa shard and final changed gate: https://github.com/openclaw/openclaw/actions/runs/31947628671

Post-rebase QA hook proof: https://github.com/openclaw/openclaw/actions/runs/31948131695

AI-assisted: yes. The change and evidence were reviewed by the maintainer agent and fresh autoreview.
