### PR TITLE
fix(cron): stop warning forever for deleted agents

### DIFF
--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -333,6 +333,72 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     });
   });
 
+  it.each([
+    { name: "deleted persisted owner", includeStaleJob: false },
+    { name: "blocked-delete owner with unfinished job cleanup", includeStaleJob: true },
+  ])("skips an unavailable $name without hiding a live owner", async ({ includeStaleJob }) => {
+    const store = await makeStorePath();
+    const now = Date.parse("2026-02-10T10:00:00.000Z");
+    const liveAgentId = "live";
+    const unavailableAgentId = includeStaleJob ? "blocked" : "deleted";
+    const sessionStorePath = path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+    const jobs = includeStaleJob
+      ? [
+          {
+            ...createDueIsolatedJob({ id: "unfinished-cleanup", nowMs: now }),
+            agentId: unavailableAgentId,
+            enabled: false,
+          },
+        ]
+      : [];
+    await saveCronStore(store.storePath, { version: 1, jobs });
+    await replaceSessionEntry(
+      {
+        agentId: liveAgentId,
+        storePath: sessionStorePath,
+        sessionKey: `agent:${liveAgentId}:cron:old-job:run:expired`,
+      },
+      { sessionId: "live-expired", updatedAt: now - 25 * 3_600_000 },
+    );
+    const resolveSessionStorePath = vi.fn((agentId?: string) => {
+      if (agentId === unavailableAgentId) {
+        throw new Error(
+          `OpenClaw agent database is unavailable while agent ${unavailableAgentId} is deleted.`,
+        );
+      }
+      return sessionStorePath;
+    });
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+      resolveDefaultAgentId: () => undefined,
+      resolveSessionStoreAgentIds: () => [liveAgentId, unavailableAgentId],
+      isAgentAvailable: (agentId) => agentId === liveAgentId,
+      resolveSessionStorePath,
+    });
+
+    await withCronServiceStateForTest(state, async () => {
+      await onTimer(state);
+      await onTimer(state);
+
+      expect(resolveSessionStorePath.mock.calls).toEqual([[liveAgentId], [liveAgentId]]);
+      expect(listSessionEntriesCore({ agentId: liveAgentId, storePath: sessionStorePath })).toEqual(
+        [],
+      );
+      expect(noopLogger.warn).not.toHaveBeenCalled();
+      expect(
+        noopLogger.debug.mock.calls.filter(
+          ([, message]) => message === "cron-reaper: skipped unavailable agent",
+        ),
+      ).toEqual([[{ agentId: unavailableAgentId }, "cron-reaper: skipped unavailable agent"]]);
+    });
+  });
+
   it("sweeps a persisted owner after it leaves the roster and cron store", async () => {
     const store = await makeStorePath();
     const now = Date.parse("2026-02-10T10:00:00.000Z");

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -259,6 +259,7 @@ export function createMockCronStateForJobs(params: {
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedInvalidPersistedJobKeys: new Set<string>(),
+    reportedUnavailableReaperAgentIds: new Set<string>(),
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
     deps: {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -295,6 +295,8 @@ export type CronServiceState = {
    * until the runtime can quarantine and sanitize the active store.
    */
   warnedInvalidPersistedJobKeys: Set<string>;
+  /** Availability is rechecked every tick; this set only bounds skip diagnostics. */
+  reportedUnavailableReaperAgentIds: Set<string>;
   pendingQuarantineConfigJobs: QuarantinedCronConfigJob[];
   lastQuarantineFailureWarnKey: string | null;
   storeLoadedAtMs: number | null;
@@ -323,6 +325,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedInvalidPersistedJobKeys: new Set<string>(),
+    reportedUnavailableReaperAgentIds: new Set<string>(),
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
     storeLoadedAtMs: null,

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -466,6 +466,14 @@ async function onAdmittedTimer(state: CronServiceState) {
         if (reaperAgentIds.size > 0) {
           const nowMs = state.deps.nowMs();
           for (const agentId of reaperAgentIds) {
+            if (state.deps.isAgentAvailable?.(agentId) === false) {
+              if (!state.reportedUnavailableReaperAgentIds.has(agentId)) {
+                state.reportedUnavailableReaperAgentIds.add(agentId);
+                state.deps.log.debug({ agentId }, "cron-reaper: skipped unavailable agent");
+              }
+              continue;
+            }
+            state.reportedUnavailableReaperAgentIds.delete(agentId);
             const storePath = state.deps.resolveSessionStorePath
               ? state.deps.resolveSessionStorePath(agentId)
               : state.deps.sessionStorePath;

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -83,7 +83,7 @@ function createLocalGatewayRequestContext(
         storePath,
         cronEnabled: cfg.cron?.enabled !== false,
         cronConfig: cfg.cron,
-        log: getChildLogger({ module: "cron", storePath }),
+        log: getChildLogger({ module: "cron", storeKey: storePath }),
         defaultAgentId: tryResolveLegacyCompatibilityAgentId(cfg),
         legacyDefaultAgentId: tryGetLegacyDefaultAgentId(cfg),
         resolveDefaultAgentId: () =>

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1022,7 +1022,7 @@ export function buildGatewayCronService(params: {
         webhookToken: params.cfg.cron?.webhookToken,
         ssrfPolicy: webhookSsrfPolicy,
       }),
-    log: getChildLogger({ module: "cron", storePath }),
+    log: getChildLogger({ module: "cron", storeKey: storePath }),
     onEvent: (evt) => {
       // Any job/store change can alter session automation bindings, including
       // in-place enable flips during runs; run/schedule events bump too (cheap).


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who deleted agents accumulated a permanent cron warning loop. The observed gateway emitted 715 `cron-reaper: failed to sweep session store` warnings in one day: 13 deleted agents multiplied by 55 sweep attempts each. Every attempt tried to open a database that the deletion journal correctly fences, so no expired session was pruned and the warning could not resolve without code changes.

The target set was seeded from every persisted session-store owner in `timer-scheduler.ts`, but unlike cron mutations and run receipts, the reaper never consulted the existing `isAgentAvailable` owner before resolving and opening the store.

## Why This Change Was Made

The reaper now applies `isAgentAvailable` to the complete, normalized target set after persisted owners, cron-job owners, and the default owner have been combined. This is the owning boundary: filtering `listKnownSessionStoreAgentIds` would break its other caller, the combined Gateway session view, and filtering only the discovery callback would let stale job/default owners re-add the unavailable agent.

Unavailable targets are re-evaluated on every tick and recorded once per unavailable transition at debug level. The diagnostic Set only bounds emission; it is not an agent-existence or deletion cache. The database fence and five-minute reaper throttle are unchanged.

Agent deletion remains the cleanup owner. Shared-store session rows are purged during deletion; per-agent rows disappear with the deleted database. An interrupted cleanup retains its journal and database fence for an explicit delete retry. Completed `deleteFiles:false` tombstones intentionally retain the database behind the fence until identity recreation, so the cron reaper must not access it.

The JSON-looking cron path still selects a logical SQLite partition, but it is not a file. Cron logger bindings now call it `storeKey` instead of the misleading `storePath`.

AI-assisted change; the implementation, ownership boundaries, and evidence below were reviewed before publication.

## User Impact

Deleted and blocked-delete agents no longer cause a failed database open and WARN every five minutes. Live agents—including agents with no cron jobs—continue to have expired cron-run sessions pruned. Operators debugging cron logs see the logical SQLite partition labeled as `storeKey`, not as a nonexistent JSON file.

## Evidence

### Before / regression

- Production log, 2026-08-16: 715 warnings/day = 13 deleted agents x 55 attempts. Several tombstones dated back to 2026-08-14 and did not decay.
- The regression failed before the production change for both a deleted persisted owner and a blocked-delete owner re-added by an unfinished stale job. Across two timer ticks, each unavailable owner reached store resolution twice; the live no-job owner was also swept.

### After

- `node scripts/run-vitest.mjs src/cron/service.session-reaper-in-finally.test.ts src/cron/service/state.test.ts src/config/sessions/targets-known-owners.test.ts src/gateway/server-cron.test.ts src/gateway/local-request-context.test.ts`
  - 87 tests passed across three Vitest shards.
  - Deleted and blocked targets never reached store resolution.
  - The live persisted owner with no cron jobs was still swept.
  - WARN count was zero; the skip debug record appeared once across two ticks.
- Blacksmith Testbox build: `tbx_01m056bs44sm009704ppmmknf3`, Actions run https://github.com/openclaw/openclaw/actions/runs/31945286828
  - `pnpm build` passed.
- Live scratch gateway on port 19888 with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_SKIP_CHANNELS=1`:
  - Created agent `victim` and an expired cron-run session.
  - Deleted the roster entry with `deleteFiles:false`, leaving `cleanupCompleted:true` and the database intentionally retained behind its tombstone.
  - Kept the gateway running from 11:55:51Z to 12:06:16Z, crossing two full five-minute reaper intervals while enabled cron jobs kept the timer active.
  - After: `reaper_warning_count=0`, `reaper_skip_debug_count=1`.
  - Logger proof: zero stale `storePath` bindings for the cron partition; 39 `storeKey` bindings. The one skip record carried `agentId=victim` and `storeKey=/tmp/openclaw-cron-reaper-r18/cron/jobs.json`.
- `node scripts/check-changed.mjs`
  - Passed on Blacksmith Testbox `tbx_01m057nbdds0tz18mq2m6pwjr8`, Actions run https://github.com/openclaw/openclaw/actions/runs/31946320495.
  - Formatting, core/core-test/extension/script/root-test typechecks, lint, dead-code, database-first, and import-cycle guards passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`
  - Clean: no accepted/actionable findings; patch judged correct with 0.99 confidence.

Production LOC: +13/-2 (net +11) | Tests/test support: +67/-0

Sweep result: `listKnownSessionStoreAgentIds` remains intentionally broad for combined session views. Gateway startup temp cleanup may encounter a tombstone once per startup, and explicit task/plugin maintenance may report one visible failure, but no other recurring maintenance loop derives a forever-retried target set from persisted owners. Transcript-index startup and memory/index maintenance are configured/active-agent scoped.
