### PR TITLE
refactor: dedupe session-catalog cursor paging and sleep helper clones

### DIFF
--- a/extensions/acpx/src/pi-session-catalog.ts
+++ b/extensions/acpx/src/pi-session-catalog.ts
@@ -5,6 +5,14 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import {
+  boundSessionCatalogTranscriptPage,
+  boundedSessionCatalogLimit,
+  decodeSessionCatalogCursor,
+  encodeSessionCatalogCursor,
+  isExactSessionCatalogCursor,
+  optionalSessionCatalogCursor,
+} from "openclaw/plugin-sdk/session-catalog-runtime";
+import {
   isRecord,
   normalizeBoundedOptionalString as optionalPiString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -14,124 +22,12 @@ import { parsePiSessionTimestampMs } from "./pi-session-timestamp.js";
 
 const LOCAL_HOST_ID = "gateway";
 const DEFAULT_PAGE_LIMIT = 20;
-const MAX_PAGE_LIMIT = 100;
 const MAX_SEARCH_LENGTH = 500;
-const MAX_CURSOR_LENGTH = 128;
-const MAX_TRANSCRIPT_ITEM_BYTES = 512 * 1024;
-const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
 const SESSION_ID_PATTERN = /^(?!-)[A-Za-z0-9._:-]{1,256}$/u;
 
 export type PiSessionPage = { sessions: SessionCatalogSession[]; nextCursor?: string };
 
-function boundedLimit(value: unknown, fallback = DEFAULT_PAGE_LIMIT): number {
-  if (value === undefined) {
-    return fallback;
-  }
-  if (!Number.isInteger(value) || Number(value) < 1 || Number(value) > MAX_PAGE_LIMIT) {
-    throw new Error(`limit must be an integer between 1 and ${String(MAX_PAGE_LIMIT)}`);
-  }
-  return Number(value);
-}
-
-function encodeCursor(offset: number): string {
-  return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
-}
-
-function optionalRawCursor(value: unknown): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string" || value.length === 0 || value.length > MAX_CURSOR_LENGTH) {
-    throw new Error("cursor is invalid");
-  }
-  return value;
-}
-
-function decodeCursor(value: unknown): number {
-  const cursor = optionalRawCursor(value);
-  if (cursor === undefined) {
-    return 0;
-  }
-  try {
-    const bytes = Buffer.from(cursor, "base64url");
-    if (bytes.toString("base64url") !== cursor) {
-      throw new Error("non-canonical base64url");
-    }
-    const parsed = JSON.parse(bytes.toString("utf8")) as unknown;
-    if (!isRecord(parsed) || !Number.isSafeInteger(parsed.offset) || Number(parsed.offset) < 0) {
-      throw new Error("invalid offset");
-    }
-    const offset = Number(parsed.offset);
-    if (encodeCursor(offset) !== cursor) {
-      throw new Error("non-canonical cursor payload");
-    }
-    return offset;
-  } catch (error) {
-    throw new Error("cursor is invalid", { cause: error });
-  }
-}
-
-export function isExactPiSessionCursor(value: unknown): value is string {
-  if (typeof value !== "string") {
-    return false;
-  }
-  try {
-    decodeCursor(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function truncateUtf8(text: string, maxBytes: number): string {
-  if (Buffer.byteLength(text, "utf8") <= maxBytes) {
-    return text;
-  }
-  let low = 0;
-  let high = text.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (Buffer.byteLength(text.slice(0, middle), "utf8") <= maxBytes - 3) {
-      low = middle;
-    } else {
-      high = middle - 1;
-    }
-  }
-  const end = low > 0 && /[\uD800-\uDBFF]/u.test(text.charAt(low - 1)) ? low - 1 : low;
-  return `${text.slice(0, end)}…`;
-}
-
-function transcriptPage(
-  items: SessionCatalogTranscriptItem[],
-  limit: number,
-  offset: number,
-): { items: SessionCatalogTranscriptItem[]; nextCursor?: string } {
-  const end = Math.max(0, items.length - offset);
-  const start = Math.max(0, end - limit);
-  const page: SessionCatalogTranscriptItem[] = [];
-  let pageBytes = 2;
-  for (let index = end - 1; index >= start; index -= 1) {
-    const item = items[index];
-    if (!item) {
-      continue;
-    }
-    const bounded: SessionCatalogTranscriptItem = {
-      ...item,
-      text: truncateUtf8(item.text ?? "", MAX_TRANSCRIPT_ITEM_BYTES),
-    };
-    const itemBytes = Buffer.byteLength(JSON.stringify(bounded), "utf8") + 1;
-    if (page.length > 0 && pageBytes + itemBytes > MAX_TRANSCRIPT_PAGE_BYTES) {
-      break;
-    }
-    page.unshift(bounded);
-    pageBytes += itemBytes;
-  }
-  const consumed = offset + page.length;
-  return {
-    items: page,
-    ...(consumed < items.length ? { nextCursor: encodeCursor(consumed) } : {}),
-  };
-}
+export const isExactPiSessionCursor = isExactSessionCatalogCursor;
 
 function textFromContent(content: unknown): string {
   if (typeof content === "string") {
@@ -174,9 +70,9 @@ function parseListParams(value: unknown): { searchTerm?: string; limit: number; 
   if (value.searchTerm !== undefined && !searchTerm) {
     throw new Error("searchTerm is invalid");
   }
-  const cursor = optionalRawCursor(value.cursor);
+  const cursor = optionalSessionCatalogCursor(value.cursor);
   return {
-    limit: boundedLimit(value.limit),
+    limit: boundedSessionCatalogLimit(value.limit),
     ...(searchTerm ? { searchTerm } : {}),
     ...(cursor ? { cursor } : {}),
   };
@@ -194,17 +90,17 @@ function parseReadParams(value: unknown): { threadId: string; limit: number; cur
   if (!threadId || !SESSION_ID_PATTERN.test(threadId)) {
     throw new Error("threadId is invalid");
   }
-  const cursor = optionalRawCursor(value.cursor);
+  const cursor = optionalSessionCatalogCursor(value.cursor);
   return {
     threadId,
-    limit: boundedLimit(value.limit),
+    limit: boundedSessionCatalogLimit(value.limit),
     ...(cursor ? { cursor } : {}),
   };
 }
 
 export async function listLocalPiSessionPage(value?: unknown): Promise<PiSessionPage> {
   const params = parseListParams(value);
-  const offset = decodeCursor(params.cursor);
+  const offset = decodeSessionCatalogCursor(params.cursor);
   const { summaries, hasMore } = await listPiSummaryPage(process.env, {
     offset,
     limit: params.limit,
@@ -213,7 +109,7 @@ export async function listLocalPiSessionPage(value?: unknown): Promise<PiSession
   const page = summaries.map(({ file: _file, version: _version, ...session }) => session);
   return {
     sessions: page,
-    ...(hasMore ? { nextCursor: encodeCursor(offset + page.length) } : {}),
+    ...(hasMore ? { nextCursor: encodeSessionCatalogCursor(offset + page.length) } : {}),
   };
 }
 
@@ -369,9 +265,9 @@ export async function readLocalPiTranscriptPage(
   value: unknown,
 ): Promise<SessionsCatalogReadResult> {
   const params = parseReadParams(value);
-  const offset = decodeCursor(params.cursor);
+  const offset = decodeSessionCatalogCursor(params.cursor);
   const items = piTranscriptItems(await readPiSessionById(params.threadId, process.env));
-  const page = transcriptPage(items, params.limit, offset);
+  const page = boundSessionCatalogTranscriptPage(items, params.limit, offset);
   return {
     hostId: LOCAL_HOST_ID,
     label: "Local Pi",

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -6,6 +6,14 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import {
+  boundSessionCatalogTranscriptPage,
+  boundedSessionCatalogLimit,
+  decodeSessionCatalogCursor,
+  encodeSessionCatalogCursor,
+  isExactSessionCatalogCursor,
+  optionalSessionCatalogCursor,
+} from "openclaw/plugin-sdk/session-catalog-runtime";
+import {
   isRecord,
   normalizeBoundedOptionalString as optionalOpenCodeString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -17,13 +25,9 @@ import {
 
 const LOCAL_HOST_ID = "gateway";
 const DEFAULT_PAGE_LIMIT = 20;
-const MAX_PAGE_LIMIT = 100;
 const MAX_SEARCH_LENGTH = 500;
-const MAX_CURSOR_LENGTH = 128;
 const MAX_CLI_LIST_SESSIONS = 10_000;
 const MAX_CLI_OUTPUT_BYTES = 32 * 1024 * 1024;
-const MAX_TRANSCRIPT_ITEM_BYTES = 512 * 1024;
-const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
 const CLI_TIMEOUT_MS = 30_000;
 const OPENCODE_QUERY_CACHE_TTL_MS = 32_000;
 const OPENCODE_QUERY_CACHE_MAX_ENTRIES = 32;
@@ -96,115 +100,7 @@ type OpenCodeReadParams = {
   cursor?: string;
 };
 
-function boundedLimit(value: unknown, fallback = DEFAULT_PAGE_LIMIT): number {
-  if (value === undefined) {
-    return fallback;
-  }
-  if (!Number.isInteger(value) || Number(value) < 1 || Number(value) > MAX_PAGE_LIMIT) {
-    throw new Error(`limit must be an integer between 1 and ${String(MAX_PAGE_LIMIT)}`);
-  }
-  return Number(value);
-}
-
-function encodeCursor(offset: number): string {
-  return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
-}
-
-function optionalRawCursor(value: unknown): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string" || value.length === 0 || value.length > MAX_CURSOR_LENGTH) {
-    throw new Error("cursor is invalid");
-  }
-  return value;
-}
-
-function decodeCursor(value: unknown): number {
-  const cursor = optionalRawCursor(value);
-  if (cursor === undefined) {
-    return 0;
-  }
-  try {
-    const bytes = Buffer.from(cursor, "base64url");
-    if (bytes.toString("base64url") !== cursor) {
-      throw new Error("non-canonical base64url");
-    }
-    const parsed = JSON.parse(bytes.toString("utf8")) as unknown;
-    if (!isRecord(parsed) || !Number.isSafeInteger(parsed.offset) || Number(parsed.offset) < 0) {
-      throw new Error("invalid offset");
-    }
-    const offset = Number(parsed.offset);
-    if (encodeCursor(offset) !== cursor) {
-      throw new Error("non-canonical cursor payload");
-    }
-    return offset;
-  } catch (error) {
-    throw new Error("cursor is invalid", { cause: error });
-  }
-}
-
-export function isExactOpenCodeSessionCursor(value: unknown): value is string {
-  if (typeof value !== "string") {
-    return false;
-  }
-  try {
-    decodeCursor(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function truncateUtf8(text: string, maxBytes: number): string {
-  if (Buffer.byteLength(text, "utf8") <= maxBytes) {
-    return text;
-  }
-  let low = 0;
-  let high = text.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (Buffer.byteLength(text.slice(0, middle), "utf8") <= maxBytes - 3) {
-      low = middle;
-    } else {
-      high = middle - 1;
-    }
-  }
-  const end = low > 0 && /[\uD800-\uDBFF]/u.test(text.charAt(low - 1)) ? low - 1 : low;
-  return `${text.slice(0, end)}…`;
-}
-
-function transcriptPage(
-  items: SessionCatalogTranscriptItem[],
-  limit: number,
-  offset: number,
-): { items: SessionCatalogTranscriptItem[]; nextCursor?: string } {
-  const end = Math.max(0, items.length - offset);
-  const start = Math.max(0, end - limit);
-  const page: SessionCatalogTranscriptItem[] = [];
-  let pageBytes = 2;
-  for (let index = end - 1; index >= start; index -= 1) {
-    const item = items[index];
-    if (!item) {
-      continue;
-    }
-    const bounded: SessionCatalogTranscriptItem = {
-      ...item,
-      text: truncateUtf8(item.text ?? "", MAX_TRANSCRIPT_ITEM_BYTES),
-    };
-    const itemBytes = Buffer.byteLength(JSON.stringify(bounded), "utf8") + 1;
-    if (page.length > 0 && pageBytes + itemBytes > MAX_TRANSCRIPT_PAGE_BYTES) {
-      break;
-    }
-    page.unshift(bounded);
-    pageBytes += itemBytes;
-  }
-  const consumed = offset + page.length;
-  return {
-    items: page,
-    ...(consumed < items.length ? { nextCursor: encodeCursor(consumed) } : {}),
-  };
-}
+export const isExactOpenCodeSessionCursor = isExactSessionCatalogCursor;
 
 function parseListParams(
   value: unknown,
@@ -225,9 +121,9 @@ function parseListParams(
   if (value.searchTerm !== undefined && !searchTerm) {
     throw new Error("searchTerm is invalid");
   }
-  const cursor = optionalRawCursor(value.cursor);
+  const cursor = optionalSessionCatalogCursor(value.cursor);
   return {
-    limit: boundedLimit(value.limit),
+    limit: boundedSessionCatalogLimit(value.limit),
     ...(searchTerm ? { searchTerm } : {}),
     ...(cursor ? { cursor } : {}),
   };
@@ -247,10 +143,10 @@ function parseReadParams(
   if (!threadId || !SESSION_ID_PATTERN.test(threadId)) {
     throw new Error("threadId is invalid");
   }
-  const cursor = optionalRawCursor(value.cursor);
+  const cursor = optionalSessionCatalogCursor(value.cursor);
   return {
     threadId,
-    limit: boundedLimit(value.limit),
+    limit: boundedSessionCatalogLimit(value.limit),
     ...(cursor ? { cursor } : {}),
   };
 }
@@ -414,7 +310,7 @@ export async function listLocalOpenCodeSessionPage(
   options: OpenCodeQueryCacheOptions = {},
 ): Promise<OpenCodeSessionPage> {
   const params = parseListParams(value);
-  const offset = decodeCursor(params.cursor);
+  const offset = decodeSessionCatalogCursor(params.cursor);
   const requestedCount = params.searchTerm
     ? MAX_CLI_LIST_SESSIONS
     : Math.min(MAX_CLI_LIST_SESSIONS, offset + params.limit + 1);
@@ -446,7 +342,7 @@ export async function listLocalOpenCodeSessionPage(
   return {
     sessions: page,
     ...(offset + page.length < sessions.length
-      ? { nextCursor: encodeCursor(offset + page.length) }
+      ? { nextCursor: encodeSessionCatalogCursor(offset + page.length) }
       : {}),
   };
 }
@@ -557,9 +453,9 @@ export async function readLocalOpenCodeTranscriptPage(
   value: unknown,
 ): Promise<SessionsCatalogReadResult> {
   const params = parseReadParams(value);
-  const offset = decodeCursor(params.cursor);
+  const offset = decodeSessionCatalogCursor(params.cursor);
   const items = openCodeTranscriptItems(await exportOpenCodeSession(params.threadId));
-  const page = transcriptPage(items, params.limit, offset);
+  const page = boundSessionCatalogTranscriptPage(items, params.limit, offset);
   return {
     hostId: LOCAL_HOST_ID,
     label: "Local OpenCode",

--- a/src/agents/embedded-agent-runner/run/attempt-async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-async-tasks.ts
@@ -11,6 +11,7 @@ import {
   findTaskByRunIdForStatus,
   listTasksForOwnerOrRequesterSessionKeyForStatus,
 } from "../../../tasks/task-status-access.js";
+import { sleep } from "../../../utils/sleep.js";
 
 export type AsyncStartedToolMeta = {
   toolName?: string;
@@ -35,12 +36,6 @@ const COMPLETION_REQUIRED_TASK_KINDS = new Set([
 
 function resolveAsyncTaskPollIntervalMs(): number {
   return isFastTestRuntimeEnv() ? 10 : DEFAULT_ASYNC_TASK_POLL_INTERVAL_MS;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, Math.max(1, ms));
-  });
 }
 
 function createAbortError(signal: AbortSignal): Error {

--- a/src/gateway/desktop/managed-linux.ts
+++ b/src/gateway/desktop/managed-linux.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { sleepWithAbort } from "@openclaw/retry";
 import { tryListenOnPort } from "../../infra/ports-probe.js";
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
 import { runCommandBuffered } from "../../process/exec.js";
@@ -114,13 +115,6 @@ function lastStderrLine(stderr: string): string | undefined {
   return undefined;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    timer.unref?.();
-  });
-}
-
 async function readDisplaySocketNames(socketDir: string): Promise<string[]> {
   try {
     return await fs.readdir(socketDir);
@@ -169,7 +163,9 @@ export function createManagedLinuxDesktop(
   const readinessPollMs = params.runtime?.readinessPollMs ?? MANAGED_READINESS_POLL_MS;
   const readinessTimeoutMs = params.runtime?.readinessTimeoutMs ?? MANAGED_READINESS_TIMEOUT_MS;
   const runPasswordTool = params.runtime?.runPasswordTool ?? runCommandBuffered;
-  const wait = params.runtime?.sleep ?? sleep;
+  // ref:false keeps readiness polling from pinning an otherwise idle process alive.
+  const wait =
+    params.runtime?.sleep ?? ((ms: number) => sleepWithAbort(ms, undefined, { ref: false }));
   const tempRoot = params.runtime?.tempRoot ?? os.tmpdir();
   const pickPort = params.runtime?.tryListenOnPort ?? tryListenOnPort;
   const x11SocketDir = params.runtime?.x11SocketDir ?? "/tmp/.X11-unix";

--- a/src/plugin-sdk/session-catalog-runtime.ts
+++ b/src/plugin-sdk/session-catalog-runtime.ts
@@ -1,6 +1,127 @@
 // Private runtime helpers for registered session catalogs.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { SessionCatalogTranscriptItem } from "../../packages/gateway-protocol/src/schema/sessions-catalog.js";
+
 export { buildControlUiCatalogSessionUrl } from "../../packages/session-url-contract/src/index.js";
 export {
   listActiveSessionCatalogs,
   type ActiveSessionCatalog,
 } from "../plugins/session-catalog-active.js";
+
+// Offset-cursor paging scaffolding shared by local session catalog providers.
+const DEFAULT_PAGE_LIMIT = 20;
+const MAX_PAGE_LIMIT = 100;
+const MAX_CURSOR_LENGTH = 128;
+const MAX_TRANSCRIPT_ITEM_BYTES = 512 * 1024;
+const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
+
+export function boundedSessionCatalogLimit(value: unknown, fallback = DEFAULT_PAGE_LIMIT): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!Number.isInteger(value) || Number(value) < 1 || Number(value) > MAX_PAGE_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${String(MAX_PAGE_LIMIT)}`);
+  }
+  return Number(value);
+}
+
+export function encodeSessionCatalogCursor(offset: number): string {
+  return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
+}
+
+export function optionalSessionCatalogCursor(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.length === 0 || value.length > MAX_CURSOR_LENGTH) {
+    throw new Error("cursor is invalid");
+  }
+  return value;
+}
+
+export function decodeSessionCatalogCursor(value: unknown): number {
+  const cursor = optionalSessionCatalogCursor(value);
+  if (cursor === undefined) {
+    return 0;
+  }
+  try {
+    const bytes = Buffer.from(cursor, "base64url");
+    if (bytes.toString("base64url") !== cursor) {
+      throw new Error("non-canonical base64url");
+    }
+    const parsed = JSON.parse(bytes.toString("utf8")) as unknown;
+    if (!isRecord(parsed) || !Number.isSafeInteger(parsed.offset) || Number(parsed.offset) < 0) {
+      throw new Error("invalid offset");
+    }
+    const offset = Number(parsed.offset);
+    if (encodeSessionCatalogCursor(offset) !== cursor) {
+      throw new Error("non-canonical cursor payload");
+    }
+    return offset;
+  } catch (error) {
+    throw new Error("cursor is invalid", { cause: error });
+  }
+}
+
+export function isExactSessionCatalogCursor(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    decodeSessionCatalogCursor(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function truncateUtf8(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) {
+    return text;
+  }
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, middle), "utf8") <= maxBytes - 3) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  const end = low > 0 && /[\uD800-\uDBFF]/u.test(text.charAt(low - 1)) ? low - 1 : low;
+  return `${text.slice(0, end)}…`;
+}
+
+/** Page transcript items from the tail, bounding per-item and per-page byte budgets. */
+export function boundSessionCatalogTranscriptPage(
+  items: SessionCatalogTranscriptItem[],
+  limit: number,
+  offset: number,
+): { items: SessionCatalogTranscriptItem[]; nextCursor?: string } {
+  const end = Math.max(0, items.length - offset);
+  const start = Math.max(0, end - limit);
+  const page: SessionCatalogTranscriptItem[] = [];
+  let pageBytes = 2;
+  for (let index = end - 1; index >= start; index -= 1) {
+    const item = items[index];
+    if (!item) {
+      continue;
+    }
+    const bounded: SessionCatalogTranscriptItem = {
+      ...item,
+      text: truncateUtf8(item.text ?? "", MAX_TRANSCRIPT_ITEM_BYTES),
+    };
+    const itemBytes = Buffer.byteLength(JSON.stringify(bounded), "utf8") + 1;
+    if (page.length > 0 && pageBytes + itemBytes > MAX_TRANSCRIPT_PAGE_BYTES) {
+      break;
+    }
+    page.unshift(bounded);
+    pageBytes += itemBytes;
+  }
+  const consumed = offset + page.length;
+  return {
+    items: page,
+    ...(consumed < items.length ? { nextCursor: encodeSessionCatalogCursor(consumed) } : {}),
+  };
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Two clusters of copy-pasted code were drifting hazards:

1. `extensions/acpx/src/pi-session-catalog.ts` and `extensions/opencode/session-catalog.ts` each carried ~114 byte-identical lines of session-catalog cursor paging scaffolding (`boundedLimit` / `encodeCursor` / `decodeCursor` / `optionalRawCursor` / `transcriptPage`). Any future paging fix would have to be applied twice, and the copies could silently diverge.
2. `src/gateway/desktop/managed-linux.ts` and `src/agents/embedded-agent-runner/run/attempt-async-tasks.ts` each had a private `sleep()` clone duplicating canonical helpers that already exist in the repo.

## Why This Change Was Made

The cursor-paging scaffolding moves into the existing private-local SDK subpath `src/plugin-sdk/session-catalog-runtime.ts` (already listed in `plugin-sdk-private-local-only-subpaths.json` and already consumed by beam — no new public surface). Both plugins keep their plugin-named cursor guards as direct aliases, so error strings, cursor canonical form, and byte budgets are unchanged.

The managed-linux readiness poll now uses `@openclaw/retry` `sleepWithAbort` with `ref: false` (preserving the clone's `timer.unref()` behavior), and the embedded agent runner's async-task wait uses `src/utils/sleep.ts`. A third `sleep` copy in the update-managed-service handoff script is intentionally kept: it lives inside a serialized standalone script (`String.raw` template) that cannot import repo modules; noted in the commit body.

## User Impact

No user-visible behavior change. Behavior-neutral refactor: one canonical owner for session-catalog cursor paging and sleep semantics, net -96 production LOC, zero test lines touched.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx/src/pi-session-catalog extensions/opencode/session-catalog src/gateway/desktop/managed-linux.test.ts src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts` — 4 shards passed post-rebase (7 + 20 + 18 tests plus managed-linux suite, all green).
- `plugin-sdk:surface:check` (via `node --import tsx scripts/plugin-sdk-surface-report.mts --check`) — clean, `package-exported forbidden subpaths: 0`.
- tsgo core + extensions typecheck lanes — clean.
- Autoreview clean (0.99), no accepted/actionable findings.
- `git diff --numstat` vs `origin/main`: production delta net -96 LOC (extensions -208/+34, core sleep sites -14/+5, +121 relocated canonical copy in `src/plugin-sdk/session-catalog-runtime.ts`); no test files changed.
