### PR TITLE
docs(gateway): correct node pairing storage description

### DIFF
--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -198,10 +198,10 @@ can approve, reject, rotate, revoke, or remove only its own device entry.
 
 ## Node pairing approvals
 
-Legacy `node.pair.*` methods use a separate Gateway-owned node pairing store.
-WS nodes use device pairing (`role: node`) instead, but the same approval
-vocabulary applies. See [Gateway pairing](/gateway/pairing) for how the two
-stores relate.
+`node.pair.*` capability approvals are stored on the paired device record in
+the shared SQLite pairing store. Gateways migrate any remaining entries from
+the retired standalone `nodes/paired.json` store into those records once at
+startup. See [Gateway pairing](/gateway/pairing) for details.
 
 `node.pair.approve` derives extra required scopes from the pending request's
 command list:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reading the scope reference were told that `node.pair.*` approvals used a separate node pairing store, contradicting the current shared SQLite pairing model and the dedicated pairing guide.

## Why This Change Was Made

The operator-scope reference now states that node capability approvals are stored on paired-device records in the shared SQLite pairing store. It also documents that any remaining `nodes/paired.json` entries are migrated once at Gateway startup.

## User Impact

Operators now get a consistent and accurate explanation of node pairing storage across the Gateway documentation.

## Evidence

- Verified against `docs/gateway/pairing.md` and `src/infra/node-pairing-migration.ts`.
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- `git diff --check`
- Autoreview: no accepted/actionable findings.

AI-assisted: yes.
