### PR TITLE
fix(macos): keep embedded CUA unavailable when PID tracking fails

### DIFF
--- a/apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift
@@ -371,15 +371,20 @@ final class CuaDriverHostCoordinator {
                     self?.processExited(generation: generation, status: status)
                 }
             }
-            // Record the pid we spawned so startup/teardown reaping can attribute and
-            // terminate exactly this daemon; without it a reaper can only delete the
-            // directory and would leave an orphaned privileged process running.
-            Self.writeProcessIdentifier(process.processIdentifier, to: socketDirectory)
             self.runningChild = RunningChild(
                 generation: generation,
                 process: process,
                 socketDirectory: socketDirectory,
                 executableURL: executableURL)
+            // Record the pid we spawned so startup/teardown reaping can attribute and
+            // terminate exactly this daemon; without it a reaper can only delete the
+            // directory and would leave an orphaned privileged process running.
+            guard Self.writeProcessIdentifier(process.processIdentifier, to: socketDirectory) else {
+                self.logger.error("embedded CUA could not record the spawned daemon pid")
+                await self.ensureStopped()
+                self.scheduleRestartIfNeeded()
+                return
+            }
         } catch {
             Self.cleanupSocketDirectory(socketDirectory)
             self.logger.error("embedded CUA launch failed: \(error.localizedDescription, privacy: .public)")

--- a/apps/macos/Sources/OpenClaw/CuaDriverHostLifecycle.swift
+++ b/apps/macos/Sources/OpenClaw/CuaDriverHostLifecycle.swift
@@ -112,9 +112,12 @@ extension CuaDriverHostCoordinator {
             0o600)
         guard descriptor >= 0 else { return false }
         defer { close(descriptor) }
-        let contents = Array("\(processIdentifier)".utf8)
-        return contents.withUnsafeBytes { bytes in
-            Darwin.write(descriptor, bytes.baseAddress, bytes.count) == bytes.count
+        do {
+            let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+            try handle.write(contentsOf: Data("\(processIdentifier)".utf8))
+            return true
+        } catch {
+            return false
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
@@ -217,6 +217,38 @@ struct CuaDriverHostCoordinatorTests {
         await coordinator.setEnabled(false)
     }
 
+    @Test func `launch without an authoritative pid record never becomes ready`() async throws {
+        let root = self.shortTemporaryDirectory("launch-pidfile-failure")
+        let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let launcher = CuaProcessLauncherProbe()
+        let coordinator = CuaDriverHostCoordinator(
+            artifactURL: { executable },
+            applicationSupportURL: { root },
+            bundleIdentifier: { "ai.openclaw.test" },
+            processLauncher: { launch, onTermination in
+                let socketIndex = try #require(launch.arguments.firstIndex(of: "--socket"))
+                let socketPath = try #require(launch.arguments.indices.contains(socketIndex + 1)
+                    ? launch.arguments[socketIndex + 1]
+                    : nil)
+                let pidFile = URL(fileURLWithPath: socketPath)
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("cua.pid")
+                try Data("incomplete".utf8).write(to: pidFile)
+                return launcher.launch(launch, onTermination: onTermination)
+            },
+            readinessProbe: { _ in true })
+
+        await coordinator.setEnabled(true)
+
+        #expect(coordinator.workerEndpoint == nil)
+        #expect(launcher.processes.count == 1)
+        #expect(launcher.processes.allSatisfy { !$0.isRunning })
+        await coordinator.setEnabled(false)
+        let cuaRoot = root.appendingPathComponent("OpenClaw/cua", isDirectory: true)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: cuaRoot.path).isEmpty)
+    }
+
     @Test func `startup refuses to signal a pid owned by another executable`() async throws {
         let root = self.shortTemporaryDirectory("startup-pid-reuse")
         let expectedExecutable = try self.expectedExecutable(in: root, target: "/bin/cat")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users enabling the embedded CUA computer provider could have it advertised as ready after a legal positive short write truncated its authoritative PID record. Later lifecycle cleanup could then be unable to attribute and reap the exact privileged daemon that OpenClaw spawned.

## Why This Change Was Made

The PID publication owner now uses Foundation's throwing full-write operation on the existing securely opened, non-owning descriptor. Startup records the exact child before publication and, if publication fails, reuses the existing stop/kill, directory cleanup, and bounded restart lifecycle instead of advancing to readiness.

Successful launches keep the same path, ownership checks, file mode, readiness flow, and teardown behavior. This changes no config, protocol, persistence schema, public API, or permission policy.

## User Impact

Embedded CUA will no longer become available with a truncated or missing authoritative PID record. On the rare publication failure path, OpenClaw leaves no endpoint, process, or owned socket directory behind and retries only through the existing bounded restart policy.

## Evidence

- A real local DYLD_INTERPOSE probe shortened the first write(2) targeting cua.pid; pre-fix code published only 424 instead of 424242.
- Under the same injected positive short write, Foundation FileHandle.write(contentsOf:) persisted the complete 424242 payload. Public Swift Foundation source confirms its remaining-byte loop, EINTR retry, and zero/error failure behavior.
- The owner-boundary regression proves failed PID publication leaves no ready endpoint, no live child, and no owned-directory residue.
- Reviewed candidate 731bce49fe5a6ec1d29608b2f4f4e737527619d2: 17/17 focused Swift tests passed; six routed macOS Vitest shards passed 356 tests; native schema guard v8, strict Swift lint/format, TruffleHog, and exact-diff checks passed.
- Fresh Codex autoreview reported no accepted/actionable findings, correctness 0.96.
- After rebasing onto local origin/main at d437a4a4b49c43b4104299f14bdc0550e631e424, the stable patch ID and all three resulting source/test blobs remained byte-identical to the reviewed candidate, so the completed exact-candidate proof remains applicable.
- Production LOC: +15/-7, net +8. The growth establishes the fail-closed readiness invariant and routes publication failure through existing lifecycle ownership; it adds no fallback or parallel cleanup path. Tests: +32/-0.
- No changelog entry, release, or deployment is part of this PR.

AI-assisted maintainer repair; the implementation and proof were directly reviewed.
