### PR TITLE
[AI-assisted] fix(config): include overridden plugin path in duplicate-id warning

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1636,6 +1636,89 @@ describe("config plugin validation", () => {
     ).toBe(false);
   });
 
+  it("appends overridden copy path to duplicate plugin id warnings", () => {
+    const loserPath = path.join(suiteHome, "extensions", "loser-plugin", "openclaw.plugin.json");
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          entries: { "ekho-adapter": { enabled: true } },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [
+              {
+                level: "warn",
+                pluginId: "ekho-adapter",
+                source: loserPath,
+                message:
+                  "duplicate plugin id detected; global plugin will be overridden by global plugin (/winner/path/index.js)",
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    const dupWarning = res.warnings.find((w) => w.message.includes("duplicate plugin id"));
+    expect(dupWarning).toBeDefined();
+    expect(dupWarning!.message).toContain(`overridden copy at ${loserPath}`);
+  });
+
+  it("does not append source hint for non-duplicate diagnostics with source", () => {
+    const blockedPath = path.join(
+      suiteHome,
+      "extensions",
+      "blocked-plugin",
+      "openclaw.plugin.json",
+    );
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          enabled: true,
+          load: { paths: [suiteHome] },
+          entries: { "blocked-plugin": { enabled: true } },
+          allow: ["blocked-plugin"],
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [
+              {
+                level: "warn",
+                pluginId: "blocked-plugin",
+                source: blockedPath,
+                message: `blocked plugin candidate: world-writable path (${suiteHome}, mode=0777)`,
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    const blockedWarning = res.warnings.find(
+      (w) => w.message.includes("blocked plugin") && w.message.includes("world-writable"),
+    );
+    expect(blockedWarning).toBeDefined();
+    expect(blockedWarning!.message).not.toContain("overridden copy at");
+  });
+
   it("warns instead of failing for stale channel config backed by missing plugin refs", () => {
     const res = validateInSuite({
       agents: { list: [{ id: "openclaw" }] },

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { resolveConfigWidePluginManifestRegistry } from "./io.plugin-metadata.js";
 import { validateConfigObjectWithPlugins as validateConfigObjectWithPluginsRaw } from "./validation.js";
@@ -1672,6 +1674,63 @@ describe("config plugin validation", () => {
     const dupWarning = res.warnings.find((w) => w.message.includes("duplicate plugin id"));
     expect(dupWarning).toBeDefined();
     expect(dupWarning!.message).toContain(`overridden copy at ${loserPath}`);
+  });
+
+  it("counts config-selected duplicate diagnostics as overridden in validation consumers", () => {
+    const bundledGoogleRecord: PluginManifestRecord = {
+      id: "google",
+      origin: "bundled",
+      channels: [],
+      providers: [],
+      contracts: { webSearchProviders: ["google"] },
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      rootDir: "/plugin-fixtures/bundled-google",
+      source: "test",
+      manifestPath: "/plugin-fixtures/bundled-google/openclaw.plugin.json",
+      schemaCacheKey: "test:google",
+      configSchema: {
+        type: "object",
+        properties: { apiKey: { type: "string" } },
+      },
+    };
+
+    const configSelectedDuplicate: PluginDiagnostic = {
+      level: "warn",
+      pluginId: "google",
+      source: "/plugin-fixtures/overridden-copy/openclaw.plugin.json",
+      code: "duplicate-plugin-id",
+      message:
+        "duplicate plugin id resolved by explicit config-selected plugin; bundled plugin will be overridden by config plugin (/plugin-fixtures/config-copy/index.js)",
+    };
+
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          allow: ["imessage"],
+          entries: {
+            google: { config: { apiKey: "test-google-key" } },
+          },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [bundledGoogleRecord],
+            diagnostics: [configSelectedDuplicate],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expectPathMessageIncludes(res.warnings, "plugins.entries.google", "but config is present");
   });
 
   it("does not append source hint for non-duplicate diagnostics with source", () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1655,6 +1655,7 @@ describe("config plugin validation", () => {
                 level: "warn",
                 pluginId: "ekho-adapter",
                 source: loserPath,
+                code: "duplicate-plugin-id",
                 message:
                   "duplicate plugin id detected; global plugin will be overridden by global plugin (/winner/path/index.js)",
               },

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
-import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import {
+  parseInstalledPluginIndex,
+  writePersistedInstalledPluginIndex,
+} from "../plugins/installed-plugin-index-store.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
@@ -1676,6 +1679,56 @@ describe("config plugin validation", () => {
     expect(dupWarning!.message).toContain(`overridden copy at ${loserPath}`);
   });
 
+  it("appends overridden copy path after migrating a legacy persisted duplicate diagnostic", () => {
+    const loserPath = path.join(suiteHome, "extensions", "loser-plugin", "openclaw.plugin.json");
+    const parsed = parseInstalledPluginIndex({
+      version: 1,
+      hostContractVersion: "2026.4.25",
+      compatRegistryVersion: "compat-v1",
+      migrationVersion: 1,
+      policyHash: "policy-v1",
+      generatedAtMs: 1,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "ekho-adapter",
+          source: loserPath,
+          message:
+            "duplicate plugin id detected; global plugin will be overridden by global plugin (/winner/path/index.js)",
+        },
+      ],
+    });
+    expect(parsed?.diagnostics[0]?.code).toBe("duplicate-plugin-id");
+
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          entries: { "ekho-adapter": { enabled: true } },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: parsed!.diagnostics,
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    const dupWarning = res.warnings.find((w) => w.message.includes("duplicate plugin id"));
+    expect(dupWarning).toBeDefined();
+    expect(dupWarning!.message).toContain(`overridden copy at ${loserPath}`);
+  });
+
   it("counts config-selected duplicate diagnostics as overridden in validation consumers", () => {
     const bundledGoogleRecord: PluginManifestRecord = {
       id: "google",
@@ -1721,6 +1774,74 @@ describe("config plugin validation", () => {
           manifestRegistry: {
             plugins: [bundledGoogleRecord],
             diagnostics: [configSelectedDuplicate],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expectPathMessageIncludes(res.warnings, "plugins.entries.google", "but config is present");
+  });
+
+  it("counts a legacy persisted config-selected duplicate as overridden after index parse", () => {
+    const bundledGoogleRecord: PluginManifestRecord = {
+      id: "google",
+      origin: "bundled",
+      channels: [],
+      providers: [],
+      contracts: { webSearchProviders: ["google"] },
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      rootDir: "/plugin-fixtures/bundled-google",
+      source: "test",
+      manifestPath: "/plugin-fixtures/bundled-google/openclaw.plugin.json",
+      schemaCacheKey: "test:google",
+      configSchema: {
+        type: "object",
+        properties: { apiKey: { type: "string" } },
+      },
+    };
+    const parsed = parseInstalledPluginIndex({
+      version: 1,
+      hostContractVersion: "2026.4.25",
+      compatRegistryVersion: "compat-v1",
+      migrationVersion: 1,
+      policyHash: "policy-v1",
+      generatedAtMs: 1,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "google",
+          source: "/plugin-fixtures/overridden-copy/openclaw.plugin.json",
+          message:
+            "duplicate plugin id resolved by explicit config-selected plugin; bundled plugin will be overridden by config plugin (/plugin-fixtures/config-copy/index.js)",
+        },
+      ],
+    });
+    expect(parsed?.diagnostics[0]?.code).toBe("duplicate-plugin-id");
+
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          allow: ["imessage"],
+          entries: {
+            google: { config: { apiKey: "test-google-key" } },
+          },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [bundledGoogleRecord],
+            diagnostics: parsed!.diagnostics,
           },
         },
       },

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1714,7 +1714,7 @@ describe("config plugin validation", () => {
         pluginMetadataSnapshot: {
           manifestRegistry: {
             plugins: [],
-            diagnostics: parsed!.diagnostics,
+            diagnostics: [...parsed!.diagnostics],
           },
         },
       },
@@ -1841,7 +1841,7 @@ describe("config plugin validation", () => {
         pluginMetadataSnapshot: {
           manifestRegistry: {
             plugins: [bundledGoogleRecord],
-            diagnostics: parsed!.diagnostics,
+            diagnostics: [...parsed!.diagnostics],
           },
         },
       },

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -258,7 +258,11 @@ function validateConfigObjectWithPluginsBase(
         issuePath = "plugins.load.paths";
       }
       const pluginLabel = diag.pluginId ? `plugin ${diag.pluginId}` : "plugin";
-      const issue = { path: issuePath, message: `${pluginLabel}: ${diag.message}` };
+      const sourceHint =
+        diag.source && diag.message.includes("duplicate plugin id")
+          ? ` — overridden copy at ${diag.source}`
+          : "";
+      const issue = { path: issuePath, message: `${pluginLabel}: ${diag.message}${sourceHint}` };
       if (diag.level === "error" && (explicitPath || !diag.pluginId)) {
         issues.push(issue);
       } else {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -327,7 +327,7 @@ function validateConfigObjectWithPluginsBase(
     const info = ensureRegistry();
     info.overriddenPluginIds ??= new Set(
       info.registry.diagnostics
-        .filter((diag) => diag.message.includes("duplicate plugin id detected"))
+        .filter((diag) => diag.code === "duplicate-plugin-id")
         .map((diag) => diag.pluginId)
         .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
     );

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -259,7 +259,7 @@ function validateConfigObjectWithPluginsBase(
       }
       const pluginLabel = diag.pluginId ? `plugin ${diag.pluginId}` : "plugin";
       const sourceHint =
-        diag.source && diag.message.includes("duplicate plugin id")
+        diag.code === "duplicate-plugin-id" && diag.source
           ? ` — overridden copy at ${diag.source}`
           : "";
       const issue = { path: issuePath, message: `${pluginLabel}: ${diag.message}${sourceHint}` };

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -753,6 +753,45 @@ describe("installed plugin index persistence", () => {
     await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toBeNull();
   });
 
+  it("migrates duplicate-id diagnostics persisted before the closed code existed", async () => {
+    const stateDir = makeTempDir();
+    const duplicate = {
+      level: "warn",
+      pluginId: "demo",
+      source: "/plugins/demo-loser/index.ts",
+      message:
+        "duplicate plugin id detected; global plugin will be overridden by global plugin (/plugins/demo-winner/index.ts)",
+    };
+    const configSelected = {
+      level: "warn",
+      pluginId: "demo",
+      source: "/plugins/demo-loser/index.ts",
+      message:
+        "duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (/plugins/demo-winner/index.ts)",
+    };
+    const coded = {
+      level: "warn",
+      pluginId: "demo",
+      code: "plugin-verification",
+      message: "plugin demo failed verification",
+    };
+    const unrelated = {
+      level: "error",
+      message: "plugin path not found: /gone",
+    };
+    insertPersistedIndexRow(stateDir, {
+      diagnosticsJson: JSON.stringify([duplicate, configSelected, coded, unrelated]),
+    });
+
+    const persisted = requirePersisted(await readPersistedInstalledPluginIndex({ stateDir }));
+    expect(persisted.diagnostics).toEqual([
+      { ...duplicate, code: "duplicate-plugin-id" },
+      { ...configSelected, code: "duplicate-plugin-id" },
+      coded,
+      unrelated,
+    ]);
+  });
+
   it("refreshes and persists a rebuilt index without loading plugin runtime", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "demo");

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -758,16 +758,12 @@ describe("installed plugin index persistence", () => {
     const duplicate = {
       level: "warn",
       pluginId: "demo",
-      source: "/plugins/demo-loser/index.ts",
-      message:
-        "duplicate plugin id detected; global plugin will be overridden by global plugin (/plugins/demo-winner/index.ts)",
+      message: "duplicate plugin id: overridden by global plugin (/plugins/demo-winner/index.ts)",
     };
     const configSelected = {
       level: "warn",
       pluginId: "demo",
-      source: "/plugins/demo-loser/index.ts",
-      message:
-        "duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (/plugins/demo-winner/index.ts)",
+      message: "duplicate plugin id: overridden by config plugin (/plugins/demo-winner/index.ts)",
     };
     const coded = {
       level: "warn",
@@ -775,10 +771,7 @@ describe("installed plugin index persistence", () => {
       code: "plugin-verification",
       message: "plugin demo failed verification",
     };
-    const unrelated = {
-      level: "error",
-      message: "plugin path not found: /gone",
-    };
+    const unrelated = { level: "error", message: "plugin path not found: /gone" };
     insertPersistedIndexRow(stateDir, {
       diagnosticsJson: JSON.stringify([duplicate, configSelected, coded, unrelated]),
     });

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -47,6 +47,7 @@ import {
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
 import { hasMissingInstalledPluginOwnerMetadata } from "./installed-plugin-package-ownership.js";
+import type { PluginDiagnostic } from "./manifest-types.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 export {
   resolveInstalledPluginIndexStorePath,
@@ -156,6 +157,13 @@ const InstalledPluginIndexSchema = z.object({
   diagnostics: z.array(PluginDiagnosticSchema),
 });
 
+/** Backfills the closed duplicate-id code on diagnostics persisted by earlier releases. */
+function migrateLegacyDuplicateDiagnostic(diagnostic: PluginDiagnostic): PluginDiagnostic {
+  return diagnostic.code === undefined && diagnostic.message.startsWith("duplicate plugin id")
+    ? { ...diagnostic, code: "duplicate-plugin-id" }
+    : diagnostic;
+}
+
 export function parseInstalledPluginIndex(value: unknown): InstalledPluginIndex | null {
   const parsed = safeParseWithSchema(InstalledPluginIndexSchema, value) as
     | (Omit<InstalledPluginIndex, "installRecords" | "plugins"> & {
@@ -191,7 +199,7 @@ export function parseInstalledPluginIndex(value: unknown): InstalledPluginIndex 
     plugins: parsed.plugins.map(({ installOwner, installOwnerAmbiguous, ...plugin }) =>
       recordInstalledPluginIndexInstallOwner(plugin, installOwner, installOwnerAmbiguous === true),
     ),
-    diagnostics: parsed.diagnostics,
+    diagnostics: parsed.diagnostics.map(migrateLegacyDuplicateDiagnostic),
   };
 }
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -652,6 +652,11 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(registry)).toBe(1);
     expect(registry.plugins).toHaveLength(1);
     expect(registry.plugins[0]?.origin).toBe("bundled");
+    const duplicateWarning = registry.diagnostics.find(
+      (diag) => diag.pluginId === "test-plugin" && diag.level === "warn",
+    );
+    expect(duplicateWarning?.code).toBe("duplicate-plugin-id");
+    expect(duplicateWarning?.source).toBe(path.join(dirB, "index.ts"));
     expectRegistryDiagnosticContains(
       registry,
       "global plugin will be overridden by bundled plugin",
@@ -752,6 +757,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins).toHaveLength(1);
     expect(registry.plugins[0]?.origin).toBe("config");
     const warning = registry.diagnostics.find((diag) => diag.pluginId === "config-shadow");
+    expect(warning?.code).toBe("duplicate-plugin-id");
     expect(warning?.source).toBe(path.join(bundledDir, "index.ts"));
     expect(warning?.message).toContain(path.join(configDir, "index.ts"));
   });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1289,6 +1289,7 @@ export function loadPluginManifestRegistryCore(
         level: "warn",
         pluginId: effectivePluginId,
         source: overriddenCandidate.source,
+        code: "duplicate-plugin-id",
         message:
           winnerCandidate.origin === "config"
             ? `duplicate plugin id resolved by explicit config-selected plugin; ${overriddenCandidate.origin} plugin will be overridden by config plugin (${winnerCandidate.source})`

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -31,6 +31,7 @@ export type PluginDiagnosticCode =
   | "backup-resource-declaration-invalid"
   | "channel-setup-failure"
   | "dashboard-declaration-invalid"
+  | "duplicate-plugin-id"
   | "plugin-verification"
   | "workspace-scope-omitted";
 


### PR DESCRIPTION
## What Problem This Solves

When two copies of the same plugin id are discovered during registry resolution, the `duplicate plugin id detected` config warning names only the winning copy and omits the overridden (losing) copy path. When both origins are `global`, the warning reads `global plugin will be overridden by global plugin (/path/to/winner)` — the only actionable path is the winner itself, which must be kept.

The `PluginDiagnostic.source` field already carries the overridden copy path (`overriddenCandidate.source`), but `pushRegistryDiagnostics` in `src/config/validation.ts` discards it when rendering the config warning, using only `diag.message`.

## Why This Change Was Made

Append the overridden copy path to the warning message when `diag.source` is present and the diagnostic is a duplicate plugin id warning. The registry producer stamps those diagnostics with the closed `code: "duplicate-plugin-id"`, and **both** validation consumers classify duplicates by that typed code instead of parsing the mutable message text.

Upgrade path (head `4debace07f3` after the 2026-08-26 rebase onto main `54db7d4f99`; code unchanged by the test-only follow-ups): released v1 installed-plugin indexes still persist duplicate diagnostics *without* that code. `parseInstalledPluginIndex` now backfills `code: "duplicate-plugin-id"` on uncoded diagnostics whose message starts with `duplicate plugin id`, so a valid persisted index is not left hiding the overridden path or misclassifying config-selected duplicates after upgrade. Seeded legacy-index regressions cover the store parse and both validation consumers.

## User Impact

Operators will now see which file to remove directly in the config warning:
```
plugin ekho-adapter: duplicate plugin id detected; global plugin will be overridden by global plugin (/path/to/winner) — overridden copy at /path/to/loser
```

## Terminal proof (real CLI, before/after)

Reproduced on real binaries with a temp `HOME` containing a duplicate plugin `demo-dup-7f3a`: one config-selected copy registered via `plugins.entries` under `~/config-copy/`, and a discarded global copy under `~/.openclaw/extensions/demo-dup-7f3a/`. Command: `node --import tsx src/entry.ts config validate`.

**BEFORE — current `main` `248966d3`:**
```
Config valid: ~/.openclaw/openclaw.json
1 warning(s):
  ! plugins.entries.demo-dup-7f3a: plugin demo-dup-7f3a: duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (~/.config-copy/demo-dup-7f3a/index.js)
```

**AFTER — this PR branch (`03d2322cf745`):**
```
Config valid: ~/.openclaw/openclaw.json
1 warning(s):
  ! plugins.entries.demo-dup-7f3a: plugin demo-dup-7f3a: duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (~/.config-copy/demo-dup-7f3a/index.js) — overridden copy at ~/.openclaw/extensions/demo-dup-7f3a/index.js
```

Difference: `— overridden copy at <discarded copy path>` is appended, naming the file an operator can actually delete.


## Terminal proof (persisted-index upgrade, end-to-end CLI)

Upgrade-path proof observed through the real CLI, not just the parser. A temp `HOME` was seeded by running the **pre-fix base** `5e438e9d0b` (merge-base with main) with two copies of plugin id `demo-dup-7f3a`: a config-selected copy under `~/config-copy/demo-dup-7f3a/` and a discarded global copy under `~/.openclaw/extensions/demo-dup-7f3a/`. `openclaw plugins registry --refresh` on the pre-fix build persisted the installed-plugin index to `~/.openclaw/state/openclaw.sqlite` with the **released v1 diagnostic shape** (raw `diagnostics_json` row, no `code` field):

```json
[{"level":"warn","pluginId":"demo-dup-7f3a","source":"~/.openclaw/extensions/demo-dup-7f3a/index.js","message":"duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (~/config-copy/demo-dup-7f3a/index.js)"}]
```

**BEFORE — `config validate` on pre-fix base `5e438e9d0b`, same seeded state:**

```
Config valid: ~/.openclaw/openclaw.json
2 warning(s):
  ! plugins.entries.demo-dup-7f3a: plugin demo-dup-7f3a: duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (~/config-copy/demo-dup-7f3a/index.js)
  ! agents.entries: Moved agents.list to keyed agents.entries.
```

**AFTER — `config validate` on head `8fa2bfb79b` / unchanged tree at `4debace07f3` (rebase did not touch these files' code), same seeded state (no re-refresh, files untouched):**

```
Config valid: ~/.openclaw/openclaw.json
2 warning(s):
  ! plugins.entries.demo-dup-7f3a: plugin demo-dup-7f3a: duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (~/config-copy/demo-dup-7f3a/index.js) — overridden copy at ~/.openclaw/extensions/demo-dup-7f3a/index.js
  ! agents.entries: Moved agents.list to keyed agents.entries.
```

The persisted-index read path is confirmed, not assumed:

- `openclaw plugins registry --json` on the head reports `state: "fresh"`, `refreshReasons: []` (persisted read, no re-derivation), and its read-time `diagnostics` entry shows the closed code backfilled from the legacy row: `"code": "duplicate-plugin-id"` with `source` naming the discarded copy.
- Re-dumping the raw SQLite `diagnostics_json` after the head-side runs shows the row is byte-identical (still no `code`) — the upgrade happens at read time via `parseInstalledPluginIndex`; nothing is rewritten behind the user's back.
- Negative control: after deleting the discarded copy from disk, `config validate` on the head drops the duplicate warning entirely (staleness re-derivation works; the persisted diagnostic is not blindly trusted) and the store row is again unchanged.

Commands (paths redacted; `~` was a scratch `HOME` for the run): `node --import tsx src/entry.ts plugins registry --refresh` (seed, pre-fix base), `node --import tsx src/entry.ts config validate` (both builds), `node --import tsx src/entry.ts plugins registry --json` (head), plus a read-only `node:sqlite` dump of `installed_plugin_index.diagnostics_json` before/after.

## Evidence

- **Root cause**: `pushRegistryDiagnostics` constructs the warning via `${pluginLabel}: ${diag.message}` without using `diag.source` (line 216 of `validation.ts`).
- **Fix verification**: The diagnostic object at `manifest-registry.ts:1283` already stores `source: overriddenCandidate.source`. The change in `pushRegistryDiagnostics` reads it and appends it.
- **Closed-code migration**: both validation consumers in `src/config/validation.ts` (compat set ~line 260, overridden-ID set ~line 302) now filter on `diag.code === "duplicate-plugin-id"` instead of `diag.message.includes(...)`. Regression test: "counts config-selected duplicate diagnostics as overridden in validation consumers" in `src/config/config.plugin-validation.test.ts`.
- **Regression gate**: No non-duplicate diagnostics carry `source` with a "duplicate plugin id" message, so the `message.includes` guard is safe. The `diag.source` guard prevents appending to diagnostics that lack a source.
- **Focused regression test**: Two new test cases added:
  - Verifies the overridden copy path appears in the warning message for duplicate-id diagnostics with a source.
  - Verifies non-duplicate diagnostics with a source (e.g. blocked plugin) do not get the "overridden copy at" hint.
- **After-fix behavior**: see the fenced before/after CLI traces under "Terminal proof" above.
- **Tests** (head `4debace07f3`, re-run after the rebase): `node scripts/run-vitest.mjs run src/plugins/installed-plugin-index-store.test.ts src/config/config.plugin-validation.test.ts` — 90 + 32 passing (main's #130031 added store tests; all green), including `migrates duplicate-id diagnostics persisted before the closed code existed`, `appends overridden copy path after migrating a legacy persisted duplicate diagnostic`, and `counts a legacy persisted config-selected duplicate as overridden after index parse`.

**Note**: This PR addresses warning rendering plus the persisted-index upgrade classification. The broader registry recovery behavior described in #124468 (stale index state preventing recovery) is a separate concern not covered by this diff.

Related: #124468 (warning rendering only; does not close the broader report)

[AI-assisted] Evidence and diff produced with AI assistance. Change rationale and terminal verification verified by author.
- **Test types** (head `4debace07f3`, re-run after the rebase): `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.config-cli.json --builders 1` — exit 0. Reproduced the CI `check-test-types-core-3` TS4104 failures (readonly `parsed!.diagnostics` assigned into the mutable `PluginManifestRegistry.diagnostics`) on `8fa2bfb79b`, fixed by spreading into a fresh array at both seeded-test sites; production types untouched.

- **Lint (max-lines) (head `5fdad32876f`)**: `check-lint-core-4` failed on the merge ref because main grew `installed-plugin-index-store.test.ts` by +63 lines in #130031; combined with this branch's migration test the merged file hit 1004 counted lines (test-file limit 1000, `skipBlankLines`/`skipComments`). Reproduced locally on the exact merge-tree file with the pinned oxlint 1.78.0 (`1094:4 File has too many lines (1004)`), compacted the seeded fixtures (single-line messages kept to the matcher-relevant `duplicate plugin id` prefix, dropped the unused `source` field, collapsed the unrelated fixture; 7 counted lines saved, merged file now 997), and re-verified the compacted merge tree passes oxlint exit 0. Re-ran `vitest run src/plugins/installed-plugin-index-store.test.ts` — 26/26 passed; `oxfmt --check` clean. Migration semantics unchanged: the backfill only keys on `code === undefined && message.startsWith("duplicate plugin id")`. Re-verified on the rebased head `4debace07f3`: `installed-plugin-index-store.test.ts` counts 997 non-blank/non-comment lines (limit 1000), pinned `oxlint@1.78.0` exit 0 on all 7 changed files, `oxfmt@0.60.0 --check` clean.

- **Rebase (2026-08-26, per review P1/P2)**: branch rebased onto main `54db7d4f99` (was 1132 commits ahead of the merge-base); replay was conflict-free and the tree diff vs the pre-rebase head `5fdad32876f` is empty for all 7 changed files. All 7 commits are authored by Santhi Prakash and SSH-signed (GitHub **Verified** on the new head). Required checks re-running on `4debace07f3`.

