### PR TITLE
fix(compaction): bound the ratcheting file-operations summary lists

### DIFF
--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -5,6 +5,8 @@ import {
   computeFileLists,
   createFileOps,
   extractFileOpsFromMessage,
+  formatFileOperations,
+  MAX_FILE_OPS_SECTION_CHARS,
   mergeSummaryFileOperations,
   serializeConversation,
 } from "./utils.js";
@@ -277,5 +279,25 @@ describe("serializeConversation", () => {
 
     expect(serialized.split("ERROR: early failure")).toHaveLength(2);
     expect(serialized).toContain(`[... ${output.length - 2000} more characters truncated]`);
+  });
+});
+
+describe("formatFileOperations bounds", () => {
+  it("caps ratcheting file lists with an overflow line instead of growing unbounded", () => {
+    const files = Array.from({ length: 5_000 }, (_, i) => `src/deep/nested/path/file-${i}.ts`);
+
+    const section = formatFileOperations(files, files);
+
+    // File lists ratchet across compactions; the model-visible section must
+    // stay bounded no matter how many paths accumulated.
+    expect(section.length).toBeLessThanOrEqual(MAX_FILE_OPS_SECTION_CHARS);
+    expect(section).toContain("more");
+  });
+
+  it("emits full lists untouched when they fit the budget", () => {
+    const section = formatFileOperations(["a.ts"], ["b.ts"]);
+    expect(section).toBe(
+      "\n\n<read-files>\na.ts\n</read-files>\n\n<modified-files>\nb.ts\n</modified-files>",
+    );
   });
 });

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -90,13 +90,54 @@ export function computeFileLists(fileOps: FileOperations): {
   return { readFiles: readOnly, modifiedFiles };
 }
 
-/** Format file lists as summary metadata tags. */
+// File lists ratchet across compactions (prior summary entries merge into the
+// next accumulation), so an unbounded join grows without limit in long
+// sessions. Hard caps keep the model-visible section bounded per the
+// context-budget invariant; overflow collapses to a "...and N more" line.
+export const MAX_FILE_OPS_SECTION_CHARS = 2_000;
+export const MAX_FILE_OPS_LIST_CHARS = 900;
+
+function formatBoundedFileList(tag: string, files: string[], maxChars: number): string {
+  if (files.length === 0 || maxChars <= 0) {
+    return "";
+  }
+  const openTag = `<${tag}>\n`;
+  const closeTag = `\n</${tag}>`;
+  const lines: string[] = [];
+  let usedChars = openTag.length + closeTag.length;
+
+  for (let i = 0; i < files.length; i++) {
+    const line = `${files[i]}\n`;
+    const remaining = files.length - i - 1;
+    const overflowLine = remaining > 0 ? `...and ${remaining} more\n` : "";
+    const projected = usedChars + line.length + overflowLine.length;
+    if (projected > maxChars) {
+      const overflow = `...and ${files.length - i} more\n`;
+      if (usedChars + overflow.length <= maxChars) {
+        lines.push(overflow);
+      }
+      break;
+    }
+    lines.push(line);
+    usedChars += line.length;
+  }
+
+  return lines.length > 0 ? `${openTag}${lines.join("").trimEnd()}${closeTag}` : "";
+}
+
+/** Format file lists as bounded summary metadata tags. */
 export function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
   const sections = [
-    readFiles.length ? `<read-files>\n${readFiles.join("\n")}\n</read-files>` : "",
-    modifiedFiles.length ? `<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>` : "",
+    formatBoundedFileList("read-files", readFiles, MAX_FILE_OPS_LIST_CHARS),
+    formatBoundedFileList("modified-files", modifiedFiles, MAX_FILE_OPS_LIST_CHARS),
   ].filter(Boolean);
-  return sections.length ? `\n\n${sections.join("\n\n")}` : "";
+  if (sections.length === 0) {
+    return "";
+  }
+  const joined = `\n\n${sections.join("\n\n")}`;
+  return joined.length > MAX_FILE_OPS_SECTION_CHARS
+    ? joined.slice(0, MAX_FILE_OPS_SECTION_CHARS)
+    : joined;
 }
 
 /** Extract visible summary text without normalizing valid model output. */

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -4,6 +4,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  computeFileLists,
+  formatFileOperations,
+  MAX_FILE_OPS_LIST_CHARS,
+  MAX_FILE_OPS_SECTION_CHARS,
+} from "../../../packages/agent-core/src/harness/compaction/utils.js";
 import { classifyToolUseResultPairing } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { isAbortError } from "../../infra/abort-signal.js";
@@ -38,7 +44,7 @@ import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
-import type { ExtensionAPI, ExtensionContext, FileOperations } from "../sessions/index.js";
+import type { ExtensionAPI, ExtensionContext } from "../sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
   MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
@@ -68,8 +74,6 @@ const TURN_PREFIX_INSTRUCTIONS =
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
 const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
-const MAX_FILE_OPS_SECTION_CHARS = 2_000;
-const MAX_FILE_OPS_LIST_CHARS = 900;
 const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
 const CONTEXT_TRUNCATED_MARKER = "\n\n[Earlier compaction context truncated to fit budget]\n\n";
 // Split-turn context supplements the generated summary and must not claim its
@@ -560,54 +564,6 @@ function formatToolFailuresSection(failures: ToolFailure[]): string {
     lines.push(`- ...and ${failures.length - MAX_TOOL_FAILURES} more`);
   }
   return `\n\n## Tool Failures\n${lines.join("\n")}`;
-}
-
-function computeFileLists(fileOps: FileOperations): {
-  readFiles: string[];
-  modifiedFiles: string[];
-} {
-  const modified = new Set([...fileOps.edited, ...fileOps.written]);
-  const readFiles = [...fileOps.read].filter((f) => !modified.has(f)).toSorted();
-  const modifiedFiles = [...modified].toSorted();
-  return { readFiles, modifiedFiles };
-}
-
-function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
-  function formatBoundedFileList(tag: string, files: string[], maxChars: number): string {
-    if (files.length === 0 || maxChars <= 0) {
-      return "";
-    }
-    const openTag = `<${tag}>\n`;
-    const closeTag = `\n</${tag}>`;
-    const lines: string[] = [];
-    let usedChars = openTag.length + closeTag.length;
-
-    for (let i = 0; i < files.length; i++) {
-      const line = `${files[i]}\n`;
-      const remaining = files.length - i - 1;
-      const overflowLine = remaining > 0 ? `...and ${remaining} more\n` : "";
-      const projected = usedChars + line.length + overflowLine.length;
-      if (projected > maxChars) {
-        const overflow = `...and ${files.length - i} more\n`;
-        if (usedChars + overflow.length <= maxChars) {
-          lines.push(overflow);
-        }
-        break;
-      }
-      lines.push(line);
-      usedChars += line.length;
-    }
-
-    return lines.length > 0 ? `${openTag}${lines.join("")}${closeTag}` : "";
-  }
-
-  const sections = [
-    formatBoundedFileList("read-files", readFiles, MAX_FILE_OPS_LIST_CHARS),
-    formatBoundedFileList("modified-files", modifiedFiles, MAX_FILE_OPS_LIST_CHARS),
-  ].filter(Boolean);
-  return sections.length > 0
-    ? capCompactionSummary(`\n\n${sections.join("\n\n")}`, MAX_FILE_OPS_SECTION_CHARS)
-    : "";
 }
 
 function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS): string {


### PR DESCRIPTION
## What Problem This Solves

`formatFileOperations` in agent-core joined every accumulated read/modified file path into the compaction summary unbounded — and the lists ratchet: `extractFileOperations` merges the prior compaction entry's `readFiles`/`modifiedFiles` into each new accumulation, so a long session in `compaction.mode: "default"` re-emitted an ever-growing path dump (easily tens of thousands of chars) into every model-visible summary. Branch summarization (`generateBranchSummary`) hits the same unbounded path in **every** mode. This violates the root context-budget invariant: every injected model-visible item is bounded with a hard cap.

## Why This Change Was Made

The safeguard extension already solved exactly this with a bounded formatter (900 chars per list, 2000 chars per section, "...and N more" overflow) — duplicate policy with one bounded and one unbounded copy. The bounded implementation now lives in the agent-core owner (`harness/compaction/utils.ts`), used by `compact()`, `generateBranchSummary`, and the safeguard alike; the safeguard-local duplicate (`formatFileOperations`, `formatBoundedFileList`, `computeFileLists`, and the constant copies) is deleted, with its `testing` exports re-pointing at the canonical constants.

## User Impact

Long default-mode sessions and branch navigation no longer inflate compaction summaries with unbounded file lists — token spend and prompt-cache churn stay bounded.

## Evidence

- New regression `caps ratcheting file lists with an overflow line instead of growing unbounded` (5000-path input) fails pre-fix via stash proof; a fit-within-budget companion pins the unchanged small-list shape.
- Full agent-core compaction suites (70/70) + compaction-safeguard suite (133/133) green — including the safeguard's pre-existing bound assertions now running against the shared implementation.
- tsgo core + core-test shards clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99.
- Prod LOC: +52 −55 (net −3); tests +22.
