### PR TITLE
fix(ui): prevent stale Labs errors after reconnect

### DIFF
--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ApplicationContext } from "../../app/context.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
 import {
   createApplicationContextProvider,
@@ -21,6 +22,37 @@ type RuntimeConfigState = {
   } | null;
   lastError: string | null;
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function createGateway() {
+  const client = {} as GatewayBrowserClient;
+  let snapshot = { client, phase: "connected" } as ApplicationGatewaySnapshot;
+  const listeners = new Set<(snapshot: ApplicationGatewaySnapshot) => void>();
+  return {
+    gateway: {
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener: (snapshot: ApplicationGatewaySnapshot) => void) {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    } as unknown as ApplicationContext["gateway"],
+    setPhase(phase: ApplicationGatewaySnapshot["phase"]) {
+      snapshot = { ...snapshot, phase };
+      listeners.forEach((listener) => listener(snapshot));
+    },
+  };
+}
 
 function createRuntimeConfig(sourceConfig: Record<string, unknown>) {
   const state: RuntimeConfigState = {
@@ -46,10 +78,13 @@ async function mountPage(sourceConfig: Record<string, unknown>): Promise<{
   page: LabsPageElement;
   provider: ApplicationContextProvider;
   runtimeConfig: ReturnType<typeof createRuntimeConfig>;
+  gateway: ReturnType<typeof createGateway>;
 }> {
   const runtimeConfig = createRuntimeConfig(sourceConfig);
+  const gateway = createGateway();
   const context = {
     basePath: "",
+    gateway: gateway.gateway,
     runtimeConfig,
   } as unknown as ApplicationContext;
   const provider = createApplicationContextProvider(context);
@@ -57,7 +92,7 @@ async function mountPage(sourceConfig: Record<string, unknown>): Promise<{
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;
-  return { page, provider, runtimeConfig };
+  return { page, provider, runtimeConfig, gateway };
 }
 
 function labRow(page: LabsPageElement, title: string) {
@@ -149,6 +184,28 @@ describe("LabsPage", () => {
       note: "labs: update codeMode",
     });
     expect(runtimeConfig.refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not publish a retired save failure after a same-client reconnect", async () => {
+    const pendingPatch = deferred<boolean>();
+    const { gateway, page, runtimeConfig } = await mountPage({
+      tools: { codeMode: { enabled: false } },
+    });
+    runtimeConfig.patch.mockImplementationOnce(() => pendingPatch.promise);
+    const toggle = codeModeToggle(page);
+
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+    await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
+
+    gateway.setPhase("reconnecting");
+    gateway.setPhase("connected");
+    pendingPatch.resolve(false);
+    await pendingPatch.promise;
+    await page.updateComplete;
+
+    expect(page.querySelector('[role="alert"]')).toBeNull();
+    expect(toggle.checked).toBe(false);
   });
 
   it.each([

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -14,6 +14,7 @@ import { renderSettingsWorkspace } from "../../components/settings-workspace.ts"
 import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
+import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
@@ -32,6 +33,14 @@ class LabsPage extends OpenClawLightDomElement {
   @state() private pendingValues: Readonly<Record<string, boolean>> = {};
   @state() private saveError: string | null = null;
 
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    invalidateRequests: () => {
+      this.busyFeatureId = null;
+      this.pendingValues = {};
+      this.saveError = null;
+    },
+  });
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.runtimeConfig,
     (runtimeConfig) => {
@@ -75,10 +84,13 @@ class LabsPage extends OpenClawLightDomElement {
   }
 
   private async updateFeature(feature: LabFeature, enabled: boolean, raw: Record<string, unknown>) {
-    if (!this.canToggle()) {
+    const scope = this.gateway.capture();
+    const runtimeConfig = this.context.runtimeConfig;
+    if (!scope || !this.canToggle()) {
       return;
     }
-    const runtimeConfig = this.context.runtimeConfig;
+    const isCurrent = () =>
+      this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
     this.busyFeatureId = feature.id;
     this.pendingValues = { ...this.pendingValues, [feature.id]: enabled };
     this.saveError = null;
@@ -87,15 +99,19 @@ class LabsPage extends OpenClawLightDomElement {
         raw,
         note: `labs: update ${feature.id}`,
       });
-      if (!patched) {
+      if (isCurrent() && !patched) {
         this.saveError = runtimeConfig.state.lastError ?? t("labsPage.saveFailed");
       }
     } catch (error) {
-      this.saveError = String(error);
+      if (isCurrent()) {
+        this.saveError = String(error);
+      }
     } finally {
-      this.clearPendingValue(feature.id);
-      if (this.busyFeatureId === feature.id) {
-        this.busyFeatureId = null;
+      if (isCurrent()) {
+        this.clearPendingValue(feature.id);
+        if (this.busyFeatureId === feature.id) {
+          this.busyFeatureId = null;
+        }
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users changing a Labs toggle could see a stale “Could not update feature” error after the Gateway reconnected with the same browser client while the original config patch was still pending. The retired completion could also clear newer optimistic state or release a newer busy owner after the reconnected page had loaded authoritative config.

No matching open issue or pull request was found in Gitcrawl or live GitHub title/body searches for the Labs/runtime-config same-client reconnect failure.

## Why This Change Was Made

Labs now captures the canonical `GatewayPageController` connection scope together with the initiating runtime-config source. Result, error, and cleanup publication requires both owners to remain current, while the controller’s invalidation callback clears Labs-owned busy, optimistic, and error state on disconnect, reconnect, source/client replacement, or teardown.

The runtime-config coordinator remains the sole write/refresh owner. This adds no page-local generation counter, timer, fallback, config/default change, protocol change, persistence change, or compatibility path.

Production LOC is +23/-7 (net +16); tests are +59/-2. The production growth is the explicit connection-and-source ownership boundary plus immediate invalidation. Reusing the shared controller is the smallest coherent repair: a downstream result-only guard would leave catch/finally and optimistic/busy cleanup stale, while another local epoch would duplicate canonical lifecycle policy.

AI-assisted implementation and validation; the final patch received direct maintainer review and a clean structured autoreview.

## User Impact

After a reconnect, Labs reflects the current Gateway generation’s authoritative configuration without showing an error from a retired patch or letting retired cleanup disturb a newer interaction.

## Evidence

The authentic pre-fix regression failed for the intended stale post-reconnect publication. Final proof passed 109 tests: 48 Labs/controller tests and 61 runtime-config/coordinator sibling tests.

The final changed gate selected `coreTests, ui` and passed formatting, Control UI i18n, core-test and UI types, lint/style selection, dead-export checks, and dependency/patch/coercion/ratchet guards. Fresh structured autoreview reported no accepted/actionable findings with 0.99 correctness confidence.

The rebase from candidate `adbbec565bb250f987f02ec1481c61477c00826e` to head `b4c3ac07e7e0f9a49fc9c6dd9d3a9f6fdd28edb8` preserved both changed file blobs and the stable patch ID exactly, so the accepted source proof remains exact.

Real built Chromium exercised: generation-A `config.patch` pending → same browser client reconnect → generation-B authoritative `config.get` → retired patch settles `false`.

- Exact traffic in each run: two `config.get` requests, one retired `config.patch`, three WebSocket instances.
- Pre-fix: the stale red error appeared after generation B loaded.
- Post-fix: zero Labs alerts; the authoritative generation-B switch remained unchecked and enabled.

Before:

![Labs showing a stale error after reconnect](https://github.com/user-attachments/assets/be0c33b9-1bc7-4d07-8b1f-ed2cde50340f)

https://github.com/user-attachments/assets/d3424054-77b8-4212-a4bb-92ec5be8a9ef

After:

![Labs remaining clean after reconnect](https://github.com/user-attachments/assets/bf53831e-2ccb-4983-beac-3a636ab43423)

https://github.com/user-attachments/assets/d841f544-fbc2-4372-9bb5-32a7ee7525cf

Remote proof routing was attempted first. Blacksmith Testbox `tbx_01m056xwvct1d9wcv3detc614m` (Actions run 31945731682) and direct AWS Crabbox `cbx_225b86c70f6f` / run `run_eb3c0aad800c` both stalled before executing a runtime preflight; both owned leases were stopped. Per the trusted-source fallback policy, the dependency-ready local checkout then ran the same selected proof successfully.
