### PR TITLE
fix(ci): cover core-driven extension impact in PR fallback

### DIFF
--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -9,6 +9,7 @@ import {
   isTestSupportFileTarget,
   resolveChangedTestTargetPlan,
 } from "../test-projects.test-support.mts";
+import { listAvailableExtensionIds } from "./changed-extensions.mts";
 import {
   createNodeTestShards,
   isPolicyTestOwnedPath,
@@ -118,6 +119,11 @@ const PROMPT_SNAPSHOT_SURFACE_RE =
 // is the snapshot helper's import graph (auto-reply prompts, channel typing,
 // plugin-sdk agent harness, codex catalog fixtures).
 const PROMPT_SNAPSHOT_ENTRY = "test/helpers/agents/happy-path-prompt-snapshots.ts";
+
+// The fallback planner and chunk-policy owner are part of the gate surface; changes to the
+// gate must not be able to skip the gated lane (#124412).
+const CORE_EXTENSION_IMPACT_SURFACE_RE =
+  /^scripts\/lib\/(?:ci-changed-node-test-plan|extension-test-plan)\.mts$/u;
 
 /**
  * True when a changed path can influence generated prompt snapshots: it
@@ -351,14 +357,41 @@ function createChangedExtensionConfigShardsForPaths(changedPaths: string[], cwd:
 }
 
 /**
- * The fail-safe cause leaves the non-extension diff's extension impact unbounded,
- * so whole extension configs are required; precise targets would under-cover.
+ * True when core or fallback-gate changes can affect extension consumers beyond
+ * the changed extension paths.
+ */
+export function hasCoreExtensionImpact(changedPaths: string[], options: CwdOptions = {}) {
+  if (changedPaths.some((changedPath) => CORE_EXTENSION_IMPACT_SURFACE_RE.test(changedPath))) {
+    return true;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const regularLivePaths = changedPaths.filter(
+    (changedPath) =>
+      existsSync(path.join(cwd, changedPath)) &&
+      !changedPath.startsWith("extensions/") &&
+      !isPolicyTestOwnedPath(changedPath),
+  );
+  return (
+    detectChangedLanes(changedPaths).extensionImpactFromCore ||
+    (regularLivePaths.some((changedPath) => changedPath.startsWith("src/")) &&
+      hasImportGraphImpactOnTargets(regularLivePaths, publicPluginSdkEntrySources, cwd))
+  );
+}
+
+/**
+ * Covers changed extensions plus the full core-impact blast radius when precise
+ * planning falls back. See #124412.
  */
 export function createChangedExtensionFallbackShards(
   changedPaths: string[],
   options: CwdOptions = {},
 ): ChangedNodeTestShard[] {
   const cwd = options.cwd ?? process.cwd();
+  if (hasCoreExtensionImpact(changedPaths, { cwd })) {
+    return createChangedExtensionConfigShards(
+      listAvailableExtensionIds().map((extensionId) => `extensions/${extensionId}`),
+    );
+  }
   return createChangedExtensionConfigShardsForPaths(changedPaths, cwd);
 }
 
@@ -405,11 +438,7 @@ export function createChangedNodeTestShards(
 
   // Package-specifier consumers are invisible to the relative import graph.
   // Fail safe when a core change reaches a public SDK entrypoint indirectly.
-  if (
-    detectChangedLanes(changedPaths).extensionImpactFromCore ||
-    (regularLivePaths.some((changedPath) => changedPath.startsWith("src/")) &&
-      hasImportGraphImpactOnTargets(regularLivePaths, publicPluginSdkEntrySources, cwd))
-  ) {
+  if (hasCoreExtensionImpact(changedPaths, { cwd })) {
     return null;
   }
 

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -123,7 +123,7 @@ const PROMPT_SNAPSHOT_ENTRY = "test/helpers/agents/happy-path-prompt-snapshots.t
 // The fallback planner and chunk-policy owner are part of the gate surface; changes to the
 // gate must not be able to skip the gated lane (#124412).
 const CORE_EXTENSION_IMPACT_SURFACE_RE =
-  /^scripts\/lib\/(?:ci-changed-node-test-plan|extension-test-plan)\.mts$/u;
+  /^scripts\/lib\/(?:changed-extensions|ci-changed-node-test-plan|extension-test-plan)\.mts$/u;
 
 /**
  * True when a changed path can influence generated prompt snapshots: it

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -333,8 +333,15 @@ describe("CI changed Node test plan", () => {
     );
   });
 
+  it("covers every extension config when the extension inventory changes", () => {
+    expectAllExtensionConfigs(
+      createChangedExtensionFallbackShards(["scripts/lib/changed-extensions.mts"]),
+    );
+  });
+
   it("classifies core and fallback-gate extension impact", () => {
     expect(hasCoreExtensionImpact(["src/agents/openclaw-tools.ts"])).toBe(true);
+    expect(hasCoreExtensionImpact(["scripts/lib/changed-extensions.mts"])).toBe(true);
     expect(hasCoreExtensionImpact(["scripts/lib/ci-changed-node-test-plan.mts"])).toBe(true);
     expect(hasCoreExtensionImpact(["scripts/lib/extension-test-plan.mts"])).toBe(true);
     expect(hasCoreExtensionImpact(["extensions/discord/src/channel.ts"])).toBe(false);

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -2,15 +2,20 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { listAvailableExtensionIds } from "../../scripts/lib/changed-extensions.mts";
 import {
   createChangedExtensionFallbackShards,
   createChangedNodeTestShards,
   hasBuildArtifactAffectingChange,
+  hasCoreExtensionImpact,
   hasPromptSnapshotAffectingChange,
   hasQaSmokeAffectingChange,
   hasSqliteSessionLifecycleAffectingChange,
 } from "../../scripts/lib/ci-changed-node-test-plan.mts";
-import { listExtensionTestFilesForRoots } from "../../scripts/lib/extension-test-plan.mts";
+import {
+  listExtensionTestFilesForRoots,
+  resolveExtensionTestConfig,
+} from "../../scripts/lib/extension-test-plan.mts";
 import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-support.mts";
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
@@ -33,6 +38,20 @@ function expectBoundedCodexFallback(
   ).toBe(true);
   expect(targets).toEqual(listExtensionTestFilesForRoots(["extensions/codex"]));
   expect(new Set(targets).size).toBe(targets.length);
+}
+
+function expectAllExtensionConfigs(
+  shards: ReturnType<typeof createChangedExtensionFallbackShards>,
+) {
+  const configs = new Set(shards.flatMap((shard) => shard.configs));
+  const expectedConfigs = new Set(
+    listAvailableExtensionIds().map((extensionId) =>
+      resolveExtensionTestConfig(`extensions/${extensionId}`),
+    ),
+  );
+
+  expect(configs).toEqual(expectedConfigs);
+  expect(configs).toContain("test/vitest/vitest.extension-codex.config.ts");
 }
 
 describe("CI changed Node test plan", () => {
@@ -298,6 +317,46 @@ describe("CI changed Node test plan", () => {
     expectBoundedCodexFallback(createChangedExtensionFallbackShards(changedPaths));
   });
 
+  it("covers every extension config when core changes can impact extension consumers", () => {
+    const shards = createChangedExtensionFallbackShards([
+      "src/gateway/tool-resolution.ts",
+      "src/agents/openclaw-tools.ts",
+      "extensions/discord/src/channel.ts",
+    ]);
+
+    expectAllExtensionConfigs(shards);
+  });
+
+  it("covers every extension config when the fallback planner itself changes", () => {
+    expectAllExtensionConfigs(
+      createChangedExtensionFallbackShards(["scripts/lib/ci-changed-node-test-plan.mts"]),
+    );
+  });
+
+  it("classifies core and fallback-gate extension impact", () => {
+    expect(hasCoreExtensionImpact(["src/agents/openclaw-tools.ts"])).toBe(true);
+    expect(hasCoreExtensionImpact(["scripts/lib/ci-changed-node-test-plan.mts"])).toBe(true);
+    expect(hasCoreExtensionImpact(["scripts/lib/extension-test-plan.mts"])).toBe(true);
+    expect(hasCoreExtensionImpact(["extensions/discord/src/channel.ts"])).toBe(false);
+    expect(hasCoreExtensionImpact(["docs/ci.md"])).toBe(false);
+  });
+
+  it("keeps extension-only fallbacks scoped to the changed extension config", () => {
+    expect(createChangedExtensionFallbackShards(["extensions/discord/src/channel.ts"])).toEqual([
+      {
+        checkName: "checks-node-changed-extensions-config",
+        configs: ["test/vitest/vitest.extension-discord.config.ts"],
+        requiresDist: false,
+        runner: "blacksmith-8vcpu-ubuntu-2404",
+        shardName: "changed-extensions-config",
+      },
+    ]);
+  });
+
+  it("does not create extension fallback shards for docs-only diffs", () => {
+    expect(createChangedExtensionFallbackShards(["docs/ci.md"])).toEqual([]);
+  });
+
   it.each([
     {
       changedPath: "extensions/browser/src/browser/cdp.helpers.test.ts",
@@ -352,13 +411,8 @@ describe("CI changed Node test plan", () => {
     expect(new Set(targets).size).toBe(targets.length);
   });
 
-  it("skips extension fallback when no extension paths changed", () => {
-    expect(
-      createChangedExtensionFallbackShards([
-        "packages/gateway-protocol/src/frame-guards.ts",
-        "src/agents/live-model-filter.ts",
-      ]),
-    ).toEqual([]);
+  it("skips extension fallback when the core-impact predicate does not fire", () => {
+    expect(createChangedExtensionFallbackShards(["src/agents/live-model-filter.ts"])).toEqual([]);
   });
 
   it("falls back to bounded Codex config shards for deleted sources", () => {


### PR DESCRIPTION
Fixes #124412

## What Problem This Solves

Fixes an issue where pull requests with core changes that can affect plugin tests could pass the changed-test planner without scheduling the affected plugin configurations. PR #118579 demonstrated the gap: its 89-file diff triggered the precise-plan fail-safe, but PR fallback coverage included only configurations for directly changed plugins and omitted Codex.

Maintainer sampling found the core-to-plugin impact predicate fires on only 2 of 25 recent `origin/main` first-parent merges, and it also fires on #118579 itself, so this broader coverage remains concentrated on the PRs that need it.

## Why This Change Was Made

The planner now gives the existing core-impact predicate one named owner and reuses it for both precise-plan fallback and plugin fallback expansion. When it fires, fallback planning routes every canonical plugin root through the existing configuration resolver and preserves the existing config grouping, naming, and process bounds. Direct plugin-only changes retain their current scoped behavior, and docs-only changes still schedule nothing.

The fallback planner, extension inventory owner, and chunk-policy owner self-select the gated lane, matching the existing QA and prompt-snapshot gate precedent. `ci.yml` is intentionally unchanged because it already appends the fallback shards returned by this planner. PR #124553 (merge `d437a4a4b49`) already bounded the Codex lane that these shards exercise.

## User Impact

No end-user behavior changes. Pull requests whose core changes can affect plugin consumers now receive the missing plugin regression coverage before merge.

## Evidence

- Pre-fix regression: the culprit-shaped fixture expected 26 plugin configs but received only Discord; the planner-only fixture received none.
- Focused suite: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts` — 38/38 passed.
- #118579 real-diff probe (`git diff-tree 8668aeb9698`): 89 files, core impact `true`, 54 bounded shards, 26 configs, Codex present in 5 shards.
- Planner-only diffs intentionally match `NODE_FAST_CI_ROUTING_SCOPE_RE`; this PR's exact-head CI ran the extended planner suites through the green `checks-fast-ci-routing` lane.
- The all-extension fallback is unit-proven: the culprit fixture creates 54 shards across all 26 configs with Codex present in 5 bounded shards, the planner-only fixture covers the self-gating path, and the shard names, grouping, and shape are identical to the changed-extension shards production CI already runs.
- The first live materialization will occur on the next core-impact PR. The predicate fired on 2 of 25 recent first-parent merges, keeping the rollout narrow and trivially revertible if a shard-shape issue surfaces.
- `CI=1 node scripts/check-changed.mjs` — passed.
- Touched-file oxlint and oxfmt checks — passed.
- Autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings.
