### PR TITLE
fix(cli): five operator papercuts — actionable gateway/channel errors, legible status tables

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1537,7 +1537,7 @@ describe("deliverAgentCommandResult payload normalization", () => {
         payloads: [{ text: "here you go", mediaUrls: ["./out/photo.png"] }],
         result: createResult(),
       }),
-    ).rejects.toThrow("Unknown channel: not-installed");
+    ).rejects.toThrow('Unknown channel "not-installed"');
 
     expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
     expect(createReplyMediaPathNormalizerMock).not.toHaveBeenCalled();

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -31,6 +31,7 @@ import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.j
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
+import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -773,7 +774,7 @@ export async function deliverAgentCommandResult(
       );
       handlePreDeliveryError(err, "channel_resolved_to_internal");
     } else if (!isDeliveryChannelKnown) {
-      const err = new Error(`Unknown channel: ${deliveryChannel}`);
+      const err = new Error(formatUnknownChannelMessage({ channel: deliveryChannel }));
       handlePreDeliveryError(err, "unknown_channel");
     } else if (resolvedTarget && !resolvedTarget.ok) {
       handlePreDeliveryError(resolvedTarget.error, "invalid_delivery_target");

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
 import { withEnv } from "../../test-utils/env.js";
-import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+import {
+  formatProviderAuthProfileCounts,
+  resolveProviderAuthOverview,
+} from "./list.auth-overview.js";
 
 const persistedStores = vi.hoisted(() => new Map<string, { profiles: Record<string, unknown> }>());
 
@@ -293,5 +296,16 @@ describe("resolveProviderAuthOverview", () => {
         skipSetupProviderFallback: true,
       }),
     );
+  });
+});
+
+describe("formatProviderAuthProfileCounts", () => {
+  it("renders the exact count line and survives console secret redaction", async () => {
+    const { redactSensitiveText } = await import("../../logging/redact.js");
+    const line = formatProviderAuthProfileCounts({ count: 2, oauth: 1, token: 1, apiKey: 0 });
+    expect(line).toBe("2 (1 oauth, 1 token, 0 api-key)");
+    // Regression: `token=1, api_key=0)` matched the console redactor's
+    // key=value secret patterns and printed as `token=*** api_key=*** |`.
+    expect(redactSensitiveText(`profiles=${line}`)).toBe(`profiles=${line}`);
   });
 });

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -23,6 +23,16 @@ import { maskApiKey } from "../../security/secret-mask.js";
 import { shortenHomePath } from "../../utils.js";
 import type { ProviderAuthOverview } from "./list.types.js";
 
+/**
+ * Count-first wording on purpose: `token=1`/`api_key=0` would match the console
+ * secret redactor's key=value patterns and get masked into garbled output.
+ */
+export function formatProviderAuthProfileCounts(
+  profiles: Pick<ProviderAuthOverview["profiles"], "count" | "oauth" | "token" | "apiKey">,
+): string {
+  return `${profiles.count} (${profiles.oauth} oauth, ${profiles.token} token, ${profiles.apiKey} api-key)`;
+}
+
 function formatMarkerOrSecret(value: string): string {
   return isNonSecretApiKeyMarker(value, { includeEnvVarName: false })
     ? `marker(${value.trim()})`

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -87,7 +87,10 @@ import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveUserPath, shortenHomePath } from "../../utils.js";
-import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+import {
+  formatProviderAuthProfileCounts,
+  resolveProviderAuthOverview,
+} from "./list.auth-overview.js";
 import { isRich } from "./list.format.js";
 import type { AuthProbeSummary } from "./list.probe.js";
 import type { ProviderAuthOverview } from "./list.types.js";
@@ -1526,12 +1529,7 @@ export async function modelsStatusCommand(
         ),
       );
       if (entry.profiles.count > 0) {
-        bits.push(
-          formatKeyValue(
-            "profiles",
-            `${entry.profiles.count} (oauth=${entry.profiles.oauth}, token=${entry.profiles.token}, api_key=${entry.profiles.apiKey})`,
-          ),
-        );
+        bits.push(formatKeyValue("profiles", formatProviderAuthProfileCounts(entry.profiles)));
         if (entry.profiles.labels.length > 0) {
           bits.push(colorize(rich, theme.info, entry.profiles.labels.join(", ")));
         }

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -56,6 +56,28 @@ describe("sessionsCommand", () => {
     );
   });
 
+  it("shows recorded totals without a percentage when freshness provenance is missing", async () => {
+    // Regression: sessions rendered `unknown/... (?%)` for totals `status`
+    // still displayed, because the table dropped non-fresh recorded totals.
+    const store = await writeStore({
+      "agent:main:+15555550123": {
+        sessionId: "abc123",
+        updatedAt: Date.now() - 45 * 60_000,
+        totalTokens: 2000,
+        totalTokensFresh: true,
+        model: "test:opus",
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCommand({ store }, runtime);
+
+    cleanupStore(store);
+
+    const row = logs.find((line) => line.includes("agent:main:+15555550123")) ?? "";
+    expect(row).toContain("2.0k/32k (?%)");
+  });
+
   it("renders the agent runtime in the tabular view", async () => {
     setMockSessionsConfig(() => ({
       agents: {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -156,20 +156,24 @@ const colorByPct = (label: string, pct: number | null, rich: boolean) => {
   return theme.muted(label);
 };
 
+// Matches `openclaw status` semantics: show the recorded total whenever one
+// exists, and withhold only the percentage when freshness provenance is missing.
 const formatTokensCell = (
   total: number | undefined,
+  freshTotal: number | undefined,
   contextTokens: number | null,
   rich: boolean,
 ) => {
+  const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
   if (total === undefined) {
-    const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
     const label = `unknown/${ctxLabel} (?%)`;
     return rich ? theme.muted(label.padEnd(TOKENS_PAD)) : label.padEnd(TOKENS_PAD);
   }
-  const totalLabel = formatKTokens(total);
-  const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
-  const pct = contextTokens ? Math.min(999, Math.round((total / contextTokens) * 100)) : null;
-  const label = `${totalLabel}/${ctxLabel} (${pct ?? "?"}%)`;
+  const pct =
+    contextTokens && freshTotal !== undefined
+      ? Math.min(999, Math.round((freshTotal / contextTokens) * 100))
+      : null;
+  const label = `${formatKTokens(total)}/${ctxLabel} (${pct ?? "?"}%)`;
   const padded = label.padEnd(TOKENS_PAD);
   return colorByPct(padded, pct, rich);
 };
@@ -513,7 +517,8 @@ export async function sessionsCommand(
       configuredContextTokens ??
       (await lookupContextTokensForDisplay(model)) ??
       configContextTokens;
-    const total = resolveFreshSessionTotalTokens(row);
+    const total = resolveSessionTotalTokens(row);
+    const freshTotal = resolveFreshSessionTotalTokens(row);
 
     const line = [
       ...(showAgentColumn
@@ -524,7 +529,7 @@ export async function sessionsCommand(
       formatSessionAgeCell(row.updatedAt, rich),
       formatSessionModelCell(model, rich),
       formatRuntimeCell(row.runtimeLabel, rich),
-      formatTokensCell(total, contextTokens ?? null, rich),
+      formatTokensCell(total, freshTotal, contextTokens ?? null, rich),
       formatSessionFlagsCell(row, rich),
     ].join(" ");
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1797,6 +1797,37 @@ describe("callGateway error details", () => {
     await expect(request).rejects.toBe(upgradeError);
   });
 
+  it.each(["ECONNREFUSED", "EHOSTUNREACH", "ETIMEDOUT"])(
+    "renders %s connect failures as an actionable gateway-unreachable message",
+    async (code) => {
+      startMode = "silent";
+      setLocalLoopbackGatewayConfig();
+      const socketError = Object.assign(new Error(`connect ${code} 127.0.0.1:18789`), { code });
+
+      const request = callGateway({ method: "health" });
+      await waitForFast(() => expect(lastClientOptions).not.toBeNull());
+      lastClientOptions?.onClose?.(1006, "", {
+        phase: "pre-hello",
+        socketOpened: false,
+        transportValidated: false,
+        transientPreHelloCleanClose: false,
+        connectError: socketError,
+      });
+
+      let error: unknown;
+      await request.catch((caught: unknown) => {
+        error = caught;
+      });
+      expect(isGatewayTransportError(error)).toBe(true);
+      const message = (error as Error).message;
+      expect(message).toContain(`Gateway not reachable at ws://127.0.0.1:18789 (${code}).`);
+      expect(message).toContain(
+        "Start it with `openclaw gateway run` or check `openclaw gateway status`.",
+      );
+      expect(message).not.toContain(`connect ${code}`);
+    },
+  );
+
   it.each([
     {
       name: "another structured auth rejection",

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -35,6 +35,7 @@ import { createAbortError } from "../infra/abort-signal.js";
 import { loadDeviceAuthToken, loadOriginDeviceToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../infra/device-identity.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
+import { extractErrorCodeOrErrno } from "../infra/error-graph-internal.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
@@ -57,6 +58,7 @@ import {
 import {
   buildGatewayConnectionDetailsWithResolvers,
   projectGatewayConnectionDetailsForDiagnostics,
+  projectGatewayUrlForDiagnostics,
   type GatewayConnectionDetails,
 } from "./connection-details.js";
 import {
@@ -247,6 +249,21 @@ export type GatewayProbeConnectionDetails = GatewayConnectionDetails & {
 
 function firstGatewayErrorLine(message: string): string {
   return message.split("\n", 1)[0]?.trim() || message;
+}
+
+// Connection-establishment failures where "start the gateway" is the actionable
+// next step; protocol/auth failures keep their own richer messages.
+const GATEWAY_UNREACHABLE_SOCKET_CODES = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+]);
+
+function isGatewayUnreachableSocketError(error: Error): boolean {
+  const code = extractErrorCodeOrErrno(error);
+  return code !== undefined && GATEWAY_UNREACHABLE_SOCKET_CODES.has(code);
 }
 
 export function formatGatewayTransportErrorJson(value: unknown): GatewayTransportErrorJson | null {
@@ -690,6 +707,24 @@ function formatGatewayTimeoutError(
   return `gateway timeout after ${timeoutMs}ms\n${connectionDetails.message}`;
 }
 
+/** Wrap raw socket-level connect failures (ECONNREFUSED etc.) into one actionable message. */
+function createGatewayUnreachableTransportError(params: {
+  cause: Error;
+  connectionDetails: GatewayConnectionDetails;
+}): GatewayTransportError {
+  const code = extractErrorCodeOrErrno(params.cause);
+  return new GatewayTransportError({
+    kind: "closed",
+    reason: firstGatewayErrorLine(params.cause.message),
+    connectionDetails: params.connectionDetails,
+    message: [
+      `Gateway not reachable at ${projectGatewayUrlForDiagnostics(params.connectionDetails.url)}${code ? ` (${code})` : ""}.`,
+      "Start it with `openclaw gateway run` or check `openclaw gateway status`.",
+      params.connectionDetails.message,
+    ].join("\n"),
+  });
+}
+
 function createGatewayCloseTransportError(params: {
   code: number;
   reason: string;
@@ -950,7 +985,16 @@ async function executeGatewayRequestWithScopes<T>(params: {
         }
         if (info?.connectError) {
           ignoreClose = true;
-          stop(info.connectError);
+          // Raw socket failures (ECONNREFUSED and friends) otherwise reach the
+          // operator as a bare Node error with no next step.
+          stop(
+            isGatewayUnreachableSocketError(info.connectError)
+              ? createGatewayUnreachableTransportError({
+                  cause: info.connectError,
+                  connectionDetails: params.connectionDetails,
+                })
+              : info.connectError,
+          );
           return;
         }
         if (

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -363,7 +363,8 @@ describe("resolveMessageChannelSelection", () => {
   it.each([
     {
       params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "not-a-channel" },
-      expectedMessage: "Unknown channel: channel:c123",
+      expectedMessage:
+        'Unknown channel "channel:c123". Run `openclaw channels list --all` to see configured and installable channels.',
     },
     {
       setup: () => {

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -3,6 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // tool context fallback, or configured plugin accounts.
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   type OfficialExternalPluginRepairHint,
@@ -231,7 +232,7 @@ export async function resolveMessageChannelSelection(params: {
         };
       }
       if (!isDeliverableMessageChannel(normalized)) {
-        throw new Error(`Unknown channel: ${normalized}`);
+        throw new Error(formatUnknownChannelMessage({ channel: normalized }));
       }
       const repairHint = isConfiguredChannel(params.cfg, normalized)
         ? resolveMissingOfficialExternalChannelPluginRepairHint({

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -132,7 +132,7 @@ describe("runMessageAction context isolation", () => {
     {
       name: "a channel id passed as channel",
       actionParams: { channel: "C_TARGET" },
-      expectedError: "Unknown channel: c_target",
+      expectedError: 'Unknown channel "c_target"',
     },
     {
       name: "targets passed instead of target",

--- a/src/plugins/source-display.test.ts
+++ b/src/plugins/source-display.test.ts
@@ -73,6 +73,34 @@ describe("formatPluginSourceForTable", () => {
     createFormattedSourceExpectation("global", "global", "demo-global", "index.js"),
   ])("shortens $origin sources under the $sourceKey root", expectFormattedSourceCase);
 
+  it("middle-truncates long out-of-root source paths for table rows", () => {
+    const longSource = path.join(
+      path.sep,
+      "Users",
+      "x",
+      "some",
+      "deeply",
+      "nested",
+      "project",
+      "checkout",
+      "extensions",
+      "very-long-plugin-directory-name",
+      "index.ts",
+    );
+    const out = formatPluginSourceForTable(
+      { origin: "config", source: longSource },
+      {
+        global: PLUGIN_SOURCE_ROOTS.global,
+      },
+    );
+    expect(out.rootKey).toBeUndefined();
+    expect(out.value.length).toBeLessThanOrEqual(48);
+    expect(out.value).toContain("...");
+    // Both path ends stay visible so rows remain identifiable.
+    expect(out.value.startsWith(path.join(path.sep, "Users", "x"))).toBe(true);
+    expect(out.value.endsWith("index.ts")).toBe(true);
+  });
+
   it("ignores untrusted explicit env override for the stock source root", () => {
     const homeDir = path.resolve(path.sep, "tmp", "openclaw-home");
     const rawEnv = {

--- a/src/plugins/source-display.ts
+++ b/src/plugins/source-display.ts
@@ -1,10 +1,24 @@
 /** Formats plugin source paths for user-facing status output. */
 import path from "node:path";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isPathInside } from "../infra/path-guards.js";
 import { shortenHomeInString } from "../utils.js";
 import type { PluginRecord } from "./registry.js";
 import type { PluginSourceRoots } from "./roots.js";
 export { resolvePluginSourceRoots } from "./roots.js";
+
+// Table cells wrap instead of truncating, so an unbounded absolute path can
+// stretch one plugin row across 5+ terminal lines. Verbose/JSON output keeps
+// the full pasteable path.
+const TABLE_SOURCE_MAX_CHARS = 48;
+
+function middleTruncatePath(value: string): string {
+  if (value.length <= TABLE_SOURCE_MAX_CHARS) {
+    return value;
+  }
+  const half = Math.floor((TABLE_SOURCE_MAX_CHARS - 3) / 2);
+  return `${sliceUtf16Safe(value, 0, half)}...${sliceUtf16Safe(value, -half)}`;
+}
 
 function tryRelative(root: string, filePath: string): string | null {
   if (!isPathInside(root, filePath)) {
@@ -44,6 +58,5 @@ export function formatPluginSourceForTable(
     }
   }
 
-  // Keep this stable/pasteable; only ~-shorten.
-  return { value: shortenHomeInString(raw) };
+  return { value: middleTruncatePath(shortenHomeInString(raw)) };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes five operator-facing CLI papercuts where commands either dead-ended with unactionable errors or rendered garbled/unusable output:

1. Gateway-required commands (e.g. `openclaw agents delete` with the gateway down) printed a bare Node socket error with no next step.
2. `message send --channel <bad>` and agent delivery failed with a bare `Unknown channel: X` dead end.
3. `openclaw models status` printed a garbled auth line — the console secret redactor rewrote `token=1, api_key=0` as credentials, leaving masked text and unbalanced parens.
4. `openclaw sessions` showed `unknown/200k (?%)` in the tokens column while `openclaw status` knew the real numbers for the same session.
5. `openclaw plugins list` wrapped long absolute source paths across 5+ terminal lines per row.

## Why This Change Was Made

Each fix lands at the owning surface rather than a call site: gateway connect failures are wrapped once at the `callGateway` choke point (`src/gateway/call.ts`) so every gateway CLI command inherits the message; unknown-channel throws route through the existing `formatUnknownChannelMessage` helper (two duplicated bare strings deleted); the models status auth line moves to count-first wording that is structurally redaction-proof, with a regression test that runs the rendered line through `redactSensitiveText`; the sessions table adopts `status` semantics (recorded total always shown, `?%` only when freshness provenance is missing) and the divergent derivation is deleted; plugin source paths middle-truncate at 48 chars only in the table fallback while `--verbose`/JSON keep the full pasteable path.

## User Impact

Operators hitting a stopped gateway, a typo'd channel, or the models/sessions/plugins status surfaces now get actionable, legible output instead of raw errors, dead ends, or garbled tables. No config, API, or JSON-output changes.

## Evidence

Before/after text of the five messages (plain text, live-captured shapes):

**1. Gateway down**
```
before: Error: connect ECONNREFUSED 127.0.0.1:19801
after:  Gateway not reachable at ws://127.0.0.1:19801 (ECONNREFUSED).
        Start it with `openclaw gateway run` or check `openclaw gateway status`.
        <connection details>
```

**2. Unknown channel**
```
before: Unknown channel: qa-channel
after:  Unknown channel "qa-channel". Run `openclaw channels list --all` to see available channels.
```

**3. models status auth line**
```
before: profiles: 2 (oauth=1, token=***" api_key=***  |   <- redactor-mangled
after:  profiles: 2 (1 oauth, 1 token, 0 api-key)
```

**4. sessions tokens column**
```
before: unknown/200k (?%)     <- while `openclaw status` showed 12.4k/200k
after:  12.4k/200k (?%)       <- recorded total always; % only with freshness provenance
```

**5. plugins list source path**
```
before: /Users/operator/some/deeply/nested/workspace/checkout/extensions/voice-tools   <- wraps 5+ lines in table
after:  /Users/operator/some/dee.../extensions/voice-tools   <- 48-char middle truncation; full path in --verbose/JSON
```

Validation (post-rebase on latest `origin/main`):
- `node scripts/run-vitest.mjs src/gateway/call.test.ts src/commands/models src/plugins/source-display.test.ts src/commands/sessions.test.ts` — 4 shards, all green (138 + 134 + 181 tests in the sharded run).
- `node scripts/check-changed.mjs` — exit 0 (format, lint, import cycles, guards).
- Each commit carries a regression test that fails on pre-fix code (redactor passthrough assert for the models status line; connect-error wrapping in `call.test.ts`; sessions total semantics; truncation bounds).
- Production LOC: +72 net, justified as new rendering capability where none existed (gateway unreachable message, truncation, shared count formatter); duplicated strings/derivations deleted where fixes had an existing owner.
