### PR TITLE
fix: reject invalid targeted channel setup

### DIFF
--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -540,6 +540,36 @@ describe("channelsAddCommand", () => {
     expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
   });
 
+  it.each(
+    [true, false].flatMap((interactive) => [
+      { label: "empty", channel: "", expectedChannel: "", interactive },
+      { label: "whitespace-only", channel: " \t ", expectedChannel: "", interactive },
+      {
+        label: "unknown",
+        channel: "unknown-channel",
+        expectedChannel: "unknown-channel",
+        interactive,
+      },
+    ]),
+  )(
+    "rejects an explicit $label guided selector when interactive=$interactive",
+    async ({ channel, expectedChannel, interactive }) => {
+      terminalMocks.isTerminalInteractive.mockReturnValue(interactive);
+      configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+      await channelsAddCommand({ channel }, runtime, { hasFlags: false });
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        `Unknown channel "${expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(channelWizardMocks.prompter.intro).not.toHaveBeenCalled();
+      expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     {
       channel: "single-env-chat",
@@ -672,20 +702,44 @@ describe("channelsAddCommand", () => {
     expect(channelWizardMocks.prompter.outro).toHaveBeenCalledWith("Channels updated.");
   });
 
-  it("preselects an installable catalog channel in guided setup", async () => {
-    const config: OpenClawConfig = { channels: {} };
+  it.each(["external-chat", "ext"])(
+    "preselects an installable catalog channel from the %s selector",
+    async (channel) => {
+      const config: OpenClawConfig = { channels: {} };
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        sourceConfig: config,
+        config,
+      });
+      catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+        {
+          ...createExternalChatCatalogEntry(),
+          origin: "bundled",
+          trustedSourceLinkedOfficialInstall: true,
+          meta: { ...createExternalChatCatalogEntry().meta, aliases: ["ext"] },
+        },
+      ]);
+
+      await channelsAddCommand({ channel }, runtime, { hasFlags: false });
+
+      expect(setupOptions().initialSelection).toEqual(["external-chat"]);
+      expect(setupOptions().finishAfterInitialSelection).toBe(true);
+    },
+  );
+
+  it("preselects an inactive known channel in guided setup", async () => {
+    const config: OpenClawConfig = {
+      channels: { "lifecycle-chat": { enabled: false } },
+    };
     configMocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
       sourceConfig: config,
       config,
     });
-    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
-      { ...createExternalChatCatalogEntry(), origin: "workspace" },
-    ]);
 
-    await channelsAddCommand({ channel: "external-chat" }, runtime, { hasFlags: false });
+    await channelsAddCommand({ channel: "lifecycle-chat" }, runtime, { hasFlags: false });
 
-    expect(setupOptions().initialSelection).toEqual(["external-chat"]);
+    expect(setupOptions().initialSelection).toEqual(["lifecycle-chat"]);
     expect(setupOptions().finishAfterInitialSelection).toBe(true);
   });
 

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -24,6 +24,7 @@ import {
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 let channelsAddCommand: typeof import("./channels/add.js").channelsAddCommand;
+let runChannelsSetupWizard: typeof import("./channels/add-wizard.js").runChannelsSetupWizard;
 
 const catalogMocks = vi.hoisted(() => ({
   getChannelPluginCatalogEntry: vi.fn(),
@@ -58,7 +59,9 @@ const channelWizardMocks = vi.hoisted(() => {
     confirm: vi.fn(async () => false),
     note: vi.fn(async () => undefined),
     select: vi.fn(),
+    multiselect: vi.fn(async () => []),
     text: vi.fn(),
+    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
   };
   return {
     prompter,
@@ -462,6 +465,7 @@ async function runSignalAddCommand(
 describe("channelsAddCommand", () => {
   beforeAll(async () => {
     ({ channelsAddCommand } = await import("./channels/add.js"));
+    ({ runChannelsSetupWizard } = await import("./channels/add-wizard.js"));
   });
 
   beforeEach(async () => {
@@ -515,7 +519,9 @@ describe("channelsAddCommand", () => {
     channelWizardMocks.prompter.confirm.mockClear();
     channelWizardMocks.prompter.note.mockClear();
     channelWizardMocks.prompter.select.mockClear();
+    channelWizardMocks.prompter.multiselect.mockClear();
     channelWizardMocks.prompter.text.mockClear();
+    channelWizardMocks.prompter.progress.mockClear();
     channelWizardMocks.setupChannels.mockClear();
     channelWizardMocks.setupChannels.mockImplementation(
       async (...args: unknown[]) => args[0] as OpenClawConfig,
@@ -567,6 +573,73 @@ describe("channelsAddCommand", () => {
       expect(channelWizardMocks.prompter.intro).not.toHaveBeenCalled();
       expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
       expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { label: "empty", channel: "", expectedChannel: "" },
+    { label: "whitespace-only", channel: " \t ", expectedChannel: "" },
+    {
+      label: "unknown",
+      channel: "unknown-channel",
+      expectedChannel: "unknown-channel",
+    },
+  ])(
+    "rejects an explicit $label hosted selector before wizard effects",
+    async ({ channel, expectedChannel }) => {
+      configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+      await expect(
+        runChannelsSetupWizard({ channel }, runtime, channelWizardMocks.prompter),
+      ).rejects.toThrow(
+        `Unknown channel "${expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
+      );
+
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(channelWizardMocks.prompter.intro).not.toHaveBeenCalled();
+      expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps an omitted hosted selector on the shared picker path", async () => {
+    const config: OpenClawConfig = { channels: {} };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+
+    await runChannelsSetupWizard({}, runtime, channelWizardMocks.prompter);
+
+    expect(setupOptions()).not.toHaveProperty("initialSelection");
+    expect(setupOptions()).not.toHaveProperty("finishAfterInitialSelection");
+    expect(setupOptions().deferDeviceLinkToClient).toBe(true);
+  });
+
+  it.each(["external-chat", "ext"])(
+    "preselects a hosted catalog channel from the %s selector",
+    async (channel) => {
+      const config: OpenClawConfig = { channels: {} };
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        sourceConfig: config,
+        config,
+      });
+      catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+        {
+          ...createExternalChatCatalogEntry(),
+          origin: "bundled",
+          trustedSourceLinkedOfficialInstall: true,
+          meta: { ...createExternalChatCatalogEntry().meta, aliases: ["ext"] },
+        },
+      ]);
+
+      await runChannelsSetupWizard({ channel }, runtime, channelWizardMocks.prompter);
+
+      expect(setupOptions().initialSelection).toEqual(["external-chat"]);
+      expect(setupOptions().finishAfterInitialSelection).toBe(true);
+      expect(setupOptions().deferDeviceLinkToClient).toBe(true);
     },
   );
 

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
+import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import { readConfigFileSnapshot, type OpenClawConfig } from "../../config/config.js";
 import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
@@ -24,7 +25,11 @@ async function loadOnboardChannels(): Promise<OnboardChannelsModule> {
 type InitialWizardChannelTarget =
   | { kind: "omitted" }
   | { kind: "resolved"; channel: ChannelChoice }
-  | { kind: "unresolved"; input: string };
+  | { kind: "unresolved"; message: string };
+
+function unresolvedInitialWizardChannelTarget(channel: string): InitialWizardChannelTarget {
+  return { kind: "unresolved", message: formatUnknownChannelMessage({ channel }) };
+}
 
 /** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */
 export async function resolveInitialWizardChannelTarget(
@@ -36,7 +41,7 @@ export async function resolveInitialWizardChannelTarget(
   }
   const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
-    return { kind: "unresolved", input: "" };
+    return unresolvedInitialWizardChannelTarget("");
   }
   const [{ listActiveChannelSetupPlugins }, { resolveChannelSetupEntries }] = await Promise.all([
     import("../../channels/plugins/setup-registry.js"),
@@ -58,7 +63,7 @@ export async function resolveInitialWizardChannelTarget(
     );
   return matchedEntry
     ? { kind: "resolved", channel: matchedEntry.id }
-    : { kind: "unresolved", input: raw.trim() };
+    : unresolvedInitialWizardChannelTarget(raw.trim());
 }
 
 type ChannelsAddWizardFlowParams = {
@@ -284,6 +289,9 @@ export async function runChannelsSetupWizard(
   }
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
+  if (target.kind === "unresolved") {
+    throw new Error(target.message);
+  }
   await runChannelsAddWizardFlow({
     cfg,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -21,14 +21,22 @@ async function loadOnboardChannels(): Promise<OnboardChannelsModule> {
   return await import("../onboard-channels.js");
 }
 
-/** Resolve a raw channel name/alias against the installed setup entries. */
-export async function resolveInitialWizardChannel(
-  raw: string,
+type InitialWizardChannelTarget =
+  | { kind: "omitted" }
+  | { kind: "resolved"; channel: ChannelChoice }
+  | { kind: "unresolved"; input: string };
+
+/** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */
+export async function resolveInitialWizardChannelTarget(
+  raw: string | undefined,
   cfg: OpenClawConfig,
-): Promise<ChannelChoice | undefined> {
+): Promise<InitialWizardChannelTarget> {
+  if (raw === undefined) {
+    return { kind: "omitted" };
+  }
   const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
-    return undefined;
+    return { kind: "unresolved", input: "" };
   }
   const [{ listActiveChannelSetupPlugins }, { resolveChannelSetupEntries }] = await Promise.all([
     import("../../channels/plugins/setup-registry.js"),
@@ -39,14 +47,18 @@ export async function resolveInitialWizardChannel(
     installedPlugins: listActiveChannelSetupPlugins(),
     workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
   });
-  return (
-    resolved.entries.find((entry) => normalizeOptionalLowercaseString(entry.id) === normalized) ??
-    resolved.entries.find((entry) =>
-      (entry.meta.aliases ?? []).some(
+  const matchedEntry =
+    resolved.entries.find(
+      (candidate) => normalizeOptionalLowercaseString(candidate.id) === normalized,
+    ) ??
+    resolved.entries.find((candidate) =>
+      (candidate.meta.aliases ?? []).some(
         (alias) => normalizeOptionalLowercaseString(alias) === normalized,
       ),
-    )
-  )?.id;
+    );
+  return matchedEntry
+    ? { kind: "resolved", channel: matchedEntry.id }
+    : { kind: "unresolved", input: raw.trim() };
 }
 
 type ChannelsAddWizardFlowParams = {
@@ -271,15 +283,13 @@ export async function runChannelsSetupWizard(
     );
   }
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const initialChannel = opts.channel
-    ? await resolveInitialWizardChannel(opts.channel, cfg)
-    : undefined;
+  const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
   await runChannelsAddWizardFlow({
     cfg,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
     runtime,
     prompter,
-    ...(initialChannel ? { initialChannel } : {}),
+    ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
     deferDeviceLinkToClient: true,
     ...(opts.onConfigured ? { onConfigured: opts.onConfigured } : {}),
     ...(opts.beforePersistentEffect ? { beforePersistentEffect: opts.beforePersistentEffect } : {}),

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -159,7 +159,7 @@ async function channelsAddCommandImpl(
       await import("./add-wizard.js");
     const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
     if (target.kind === "unresolved") {
-      runtime.error(formatUnknownChannelMessage({ channel: target.input }));
+      runtime.error(target.message);
       runtime.exit(1);
       return;
     }

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -155,6 +155,14 @@ async function channelsAddCommandImpl(
 
   const useWizard = shouldUseWizard(params);
   if (useWizard) {
+    const { resolveInitialWizardChannelTarget, runChannelsAddWizardFlow } =
+      await import("./add-wizard.js");
+    const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
+    if (target.kind === "unresolved") {
+      runtime.error(formatUnknownChannelMessage({ channel: target.input }));
+      runtime.exit(1);
+      return;
+    }
     if (!isTerminalInteractive()) {
       runtime.error(
         "Interactive channel setup requires a TTY. Use `openclaw channels add --channel <id> --use-env` or pass the channel's credential flags for non-interactive setup.",
@@ -162,15 +170,12 @@ async function channelsAddCommandImpl(
       runtime.exit(1);
       return;
     }
-    const { resolveInitialWizardChannel, runChannelsAddWizardFlow } =
-      await import("./add-wizard.js");
-    const initialChannel = await resolveInitialWizardChannel(opts.channel ?? "", cfg);
     await runChannelsAddWizardFlow({
       cfg,
       ...(baseHash !== undefined ? { baseHash } : {}),
       runtime,
       prompter: createClackPrompter(),
-      ...(initialChannel ? { initialChannel } : {}),
+      ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
       ...(params?.beforePersistentEffect
         ? { beforePersistentEffect: params.beforePersistentEffect }
         : {}),

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -4,6 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  WizardNextResult,
+  WizardStartResult,
+} from "../../packages/gateway-protocol/src/index.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -871,20 +875,14 @@ module.exports = {
       });
 
       try {
-        const start = await client.request<{
-          sessionId: string;
-          done: boolean;
-          status: "running" | "done" | "cancelled" | "error";
-          step?: { id: string };
-        }>("wizard.start", flow === "channels" ? { flow } : { mode: "local" });
+        const start = await client.request<WizardStartResult>(
+          "wizard.start",
+          flow === "channels" ? { flow } : { mode: "local" },
+        );
         expect(start).toMatchObject({ done: false, status: "running" });
         expect(start.step?.id).toBeTruthy();
 
-        const result = await client.request<{
-          done: boolean;
-          status: "running" | "done" | "cancelled" | "error";
-          error?: string;
-        }>("wizard.next", {
+        const result = await client.request<WizardNextResult>("wizard.next", {
           sessionId: start.sessionId,
           answer: { stepId: start.step?.id, value: null },
         });
@@ -946,21 +944,14 @@ module.exports = {
           { label: "canonical", channel: "telegram", expected: "telegram" },
           { label: "alias", channel: "imsg", expected: "imsg" },
         ]) {
-          const start = await client.request<{
-            sessionId?: string;
-            done: boolean;
-            status: "running" | "done" | "cancelled" | "error";
-            step?: { id: string; type: string };
-            channels?: string[];
-            accounts?: Array<{ channel: string; accountId: string }>;
-          }>("wizard.start", {
+          const start = await client.request<WizardStartResult>("wizard.start", {
             flow: "channels",
             ...(testCase.channel === undefined ? {} : { channel: testCase.channel }),
           });
           const sessionId = start.sessionId;
           expect(typeof sessionId, testCase.label).toBe("string");
 
-          let next = start;
+          let next: WizardStartResult | WizardNextResult = start;
           const seenSteps: string[] = [];
           while (!next.done) {
             const step = next.step;
@@ -968,7 +959,7 @@ module.exports = {
               throw new Error("wizard missing step");
             }
             seenSteps.push(step.type);
-            next = await client.request(
+            next = await client.request<WizardNextResult>(
               "wizard.next",
               {
                 sessionId,
@@ -1007,46 +998,29 @@ module.exports = {
         minimalGateway: true,
       });
       const configPath = await createGatewayConfigPath(tempHome);
-      const initialConfig = "{}\n";
-      await fs.writeFile(configPath, initialConfig, "utf8");
-      const wizardToken = nextGatewayId("wiz-channel-target");
-      const port = await getGatewayE2ePortBlock();
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token: wizardToken },
-        controlUiEnabled: false,
-      });
-      const client = await connectGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token: wizardToken,
-        clientDisplayName: "vitest-wizard-channel-target",
+      const { client, server } = await startGatewayWithClient({
+        cfg: {},
+        configPath,
+        token: nextGatewayId("wiz-channel-target"),
       });
 
       try {
-        for (const testCase of [
-          { label: "whitespace", channel: " \t ", expectedChannel: "" },
-          {
-            label: "unknown",
-            channel: "unknown-channel",
-            expectedChannel: "unknown-channel",
-          },
-        ]) {
-          const result = await client.request<{
-            done: boolean;
-            status: "running" | "done" | "cancelled" | "error";
-            error?: string;
-            step?: unknown;
-          }>("wizard.start", { flow: "channels", channel: testCase.channel });
-          expect(result, testCase.label).toMatchObject({
+        for (const channel of [" \t ", "unknown-channel"]) {
+          const expectedChannel = channel.trim();
+          const result = await client.request<WizardStartResult>("wizard.start", {
+            flow: "channels",
+            channel,
+          });
+          expect(result).toMatchObject({
             done: true,
             status: "error",
-            error: `Error: Unknown channel "${testCase.expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
+            error: `Error: Unknown channel "${expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
           });
-          expect(result.step, testCase.label).toBeUndefined();
+          expect(result.step).toBeUndefined();
         }
 
         await expect(client.request("health", {})).resolves.toBeDefined();
-        await expect(fs.readFile(configPath, "utf8")).resolves.toBe(initialConfig);
+        await expect(fs.readFile(configPath, "utf8")).resolves.toBe("{}\n");
       } finally {
         await disconnectGatewayClient(client);
         await server.close({ reason: "wizard channel target validation E2E complete" });

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -941,43 +941,115 @@ module.exports = {
       });
 
       try {
-        const start = await client.request<{
-          sessionId?: string;
-          done: boolean;
-          status: "running" | "done" | "cancelled" | "error";
-          step?: { id: string; type: string };
-          channels?: string[];
-          accounts?: Array<{ channel: string; accountId: string }>;
-        }>("wizard.start", { flow: "channels", channel: "telegram" });
-        const sessionId = start.sessionId;
-        expect(typeof sessionId).toBe("string");
+        for (const testCase of [
+          { label: "omitted", channel: undefined, expected: "none" },
+          { label: "canonical", channel: "telegram", expected: "telegram" },
+          { label: "alias", channel: "imsg", expected: "imsg" },
+        ]) {
+          const start = await client.request<{
+            sessionId?: string;
+            done: boolean;
+            status: "running" | "done" | "cancelled" | "error";
+            step?: { id: string; type: string };
+            channels?: string[];
+            accounts?: Array<{ channel: string; accountId: string }>;
+          }>("wizard.start", {
+            flow: "channels",
+            ...(testCase.channel === undefined ? {} : { channel: testCase.channel }),
+          });
+          const sessionId = start.sessionId;
+          expect(typeof sessionId, testCase.label).toBe("string");
 
-        let next = start;
-        const seenSteps: string[] = [];
-        while (!next.done) {
-          const step = next.step;
-          if (!step) {
-            throw new Error("wizard missing step");
+          let next = start;
+          const seenSteps: string[] = [];
+          while (!next.done) {
+            const step = next.step;
+            if (!step) {
+              throw new Error("wizard missing step");
+            }
+            seenSteps.push(step.type);
+            next = await client.request(
+              "wizard.next",
+              {
+                sessionId,
+                answer: {
+                  stepId: step.id,
+                  value: step.type === "select" ? testCase.expected : null,
+                },
+              },
+              { timeoutMs: 60_000 },
+            );
           }
-          seenSteps.push(step.type);
-          next = await client.request(
-            "wizard.next",
-            {
-              sessionId,
-              answer: { stepId: step.id, value: step.type === "select" ? "telegram" : null },
-            },
-            { timeoutMs: 60_000 },
-          );
-        }
 
-        expect(next.status, `seenSteps=${seenSteps.join(",")}`).toBe("done");
-        expect(seenSteps).toContain("select");
-        expect(channelRuns).toEqual(["telegram"]);
-        expect(next.channels).toEqual(["telegram"]);
-        expect(next.accounts).toEqual([{ channel: "telegram", accountId: "default" }]);
+          expect(next.status, `${testCase.label}: seenSteps=${seenSteps.join(",")}`).toBe("done");
+          expect(seenSteps, testCase.label).toContain("select");
+          expect(next.channels, testCase.label).toEqual([testCase.expected]);
+          expect(next.accounts, testCase.label).toEqual([
+            { channel: testCase.expected, accountId: "default" },
+          ]);
+        }
+        expect(channelRuns).toEqual([undefined, "telegram", "imsg"]);
       } finally {
         await disconnectGatewayClient(client);
         await server.close({ reason: "wizard channels flow complete" });
+        await removeGatewayTempHome(tempHome);
+        envSnapshot.restore();
+      }
+    },
+  );
+
+  it(
+    "returns targeted channel resolution errors without wizard or config effects",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const { envSnapshot, tempHome } = await setupGatewayTempHome({
+        prefix: "openclaw-wizard-channel-target-home-",
+        minimalGateway: true,
+      });
+      const configPath = await createGatewayConfigPath(tempHome);
+      const initialConfig = "{}\n";
+      await fs.writeFile(configPath, initialConfig, "utf8");
+      const wizardToken = nextGatewayId("wiz-channel-target");
+      const port = await getGatewayE2ePortBlock();
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token: wizardToken },
+        controlUiEnabled: false,
+      });
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: wizardToken,
+        clientDisplayName: "vitest-wizard-channel-target",
+      });
+
+      try {
+        for (const testCase of [
+          { label: "whitespace", channel: " \t ", expectedChannel: "" },
+          {
+            label: "unknown",
+            channel: "unknown-channel",
+            expectedChannel: "unknown-channel",
+          },
+        ]) {
+          const result = await client.request<{
+            done: boolean;
+            status: "running" | "done" | "cancelled" | "error";
+            error?: string;
+            step?: unknown;
+          }>("wizard.start", { flow: "channels", channel: testCase.channel });
+          expect(result, testCase.label).toMatchObject({
+            done: true,
+            status: "error",
+            error: `Error: Unknown channel "${testCase.expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
+          });
+          expect(result.step, testCase.label).toBeUndefined();
+        }
+
+        await expect(client.request("health", {})).resolves.toBeDefined();
+        await expect(fs.readFile(configPath, "utf8")).resolves.toBe(initialConfig);
+      } finally {
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard channel target validation E2E complete" });
         await removeGatewayTempHome(tempHome);
         envSnapshot.restore();
       }


### PR DESCRIPTION
Related: #120932

## What Problem This Solves

Fixes an issue where users explicitly targeting a channel through `openclaw channels add --channel` or Gateway `wizard.start` could have an empty, whitespace-only, or unknown selector treated like an omitted selector. Instead of failing visibly, the flow opened the broad channel picker and discarded the operator's targeting intent.

## Why This Change Was Made

Both entry points now consume one shared closed channel-target result: omitted, resolved, or unresolved with the canonical recovery message. Omitted targets still open the picker; canonical IDs, aliases, inactive known channels, and installable catalog channels resolve and preselect. The CLI renders unresolved targets and exits, while the hosted runner throws so `WizardSession` preserves its existing `Error: ...` projection without calling `runtime.exit`.

Maintainer decision: explicit unresolved CLI/Gateway selectors terminate with the standard recovery error. This intentionally supersedes the picker-fallback policy proposed for the overlapping paths in #120932; picker fallback remains the behavior only when the selector is omitted.

## User Impact

Explicit invalid selectors now fail before any prompt or config effect and point users to `openclaw channels list --all`. Hosted failures end only the wizard session and leave the Gateway healthy. Valid targeted setup and the existing omitted-selector picker behavior are unchanged.

## Evidence

- Fail-first proof: six CLI cases (blank/whitespace/unknown across TTY and non-TTY) failed for the reported behavior; three direct hosted cases entered the wizard instead of rejecting.
- Expanded focused baseline: 166/166 passed (37 channel-flow, 65 CLI, 64 command tests) on [Actions 31945058538](https://github.com/openclaw/openclaw/actions/runs/31945058538). The real Gateway WebSocket matrix passed 2/2 in the same run: omitted/canonical/alias completed, whitespace/unknown returned the exact existing terminal error, config bytes stayed unchanged, and health remained available.
- Source-blind built-CLI PTY/non-TTY matrix passed on [Actions 31930197326](https://github.com/openclaw/openclaw/actions/runs/31930197326): omitted opened the picker; canonical, alias, inactive, and installable targets entered targeted setup; blank/whitespace/unknown rejected before a prompt with actionable stderr and no config effect.
- Changed formatting, policy, ratchet, duplicate/dead-code, plugin-boundary, and production-type gates passed on [Actions 31947585203](https://github.com/openclaw/openclaw/actions/runs/31947585203); the corrected core test-type shards passed on [Actions 31947837159](https://github.com/openclaw/openclaw/actions/runs/31947837159).
- The earlier full selector candidate passed build, changed/type/lint/architecture/cycle/docs/diff gates on [Actions 31931378789](https://github.com/openclaw/openclaw/actions/runs/31931378789). Rebase range-diff confirms the two production commits are patch-identical to the directly reviewed candidates.
- Exact-head PR CI passed on [Actions 31949327383](https://github.com/openclaw/openclaw/actions/runs/31949327383). The only first-run failure was the Gateway test file crossing `max-lines`; the final test-only commit replaced repeated local response shapes with canonical protocol types and reused the existing Gateway/client fixture, then the full exact-head matrix passed.
- Final local checks: exact four-file `oxfmt --check`, `git diff --check`, changed-lane dry run, targeted oxlint, and two fresh Codex autoreviews passed with no accepted/actionable findings. A local Gateway rerun could not collect tests because this linked worktree intentionally has no UI dependency tree; hosted exact-head CI is the runtime proof.
- Final LOC: production `+42/-19` (net `+23`); tests `+223/-50` (net `+173`). No docs, changelog, protocol, schema, config, or Plugin SDK changes.

The Gateway protocol already rejects a literal empty string before the runner because that field is non-empty; direct hosted coverage proves the empty resolver case, while the real RPC blank-input case uses whitespace.
