### PR TITLE
fix(cli): keep approvals JSON failures parseable

### DIFF
--- a/src/cli/exec-approvals-cli.pending-resolve.test.ts
+++ b/src/cli/exec-approvals-cli.pending-resolve.test.ts
@@ -273,6 +273,19 @@ describe("exec approvals pending and resolve CLI", () => {
     });
   });
 
+  it("writes pending approval failures as JSON", async () => {
+    callGatewayFromCli.mockRejectedValue(new Error("gateway unavailable"));
+
+    await expect(runApprovalsCommand(["approvals", "pending", "--json"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledOnce();
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({ error: "gateway unavailable" }, 0);
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("preserves whitespace-bearing ids verbatim and keeps them distinct", async () => {
     const now = Date.now();
     callGatewayFromCli.mockImplementation(async (method: string) => {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -945,7 +945,8 @@ describe("exec approvals CLI", () => {
 
     await expect(runNativeApprovalsFileCommand(filePath)).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors[0]).toContain("File exceeds 1048576 bytes");
+    expect(writtenJson().error).toContain("File exceeds 1048576 bytes");
+    expect(runtimeErrors).toHaveLength(0);
     expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
   });
 
@@ -954,7 +955,8 @@ describe("exec approvals CLI", () => {
 
     await expect(runNativeApprovalsFileCommand(dir)).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors[0]).toMatch(/EISDIR|directory/i);
+    expect(writtenJson().error).toMatch(/EISDIR|directory/i);
+    expect(runtimeErrors).toHaveLength(0);
     expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
   });
 
@@ -990,7 +992,8 @@ describe("exec approvals CLI", () => {
       openSpy.mockRestore();
     }
 
-    expect(runtimeErrors[0]).toContain("File exceeds 1048576 bytes");
+    expect(writtenJson().error).toContain("File exceeds 1048576 bytes");
+    expect(runtimeErrors).toHaveLength(0);
     expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -302,8 +302,6 @@ async function loadSnapshotTarget(opts: ExecApprovalsCliOpts): Promise<{
 }
 
 function exitWithError(message: string): never {
-  defaultRuntime.error(message);
-  defaultRuntime.exit(1);
   throw new Error(message);
 }
 
@@ -380,6 +378,16 @@ function formatCliError(err: unknown): string {
   const firstLine = msg.includes("\n") ? msg.split("\n")[0] : msg;
   const safe = sanitizeForLog(expectDefined(firstLine, "exec approvals cli first line"));
   return safe.length > 300 ? `${truncateUtf16Safe(safe, 300)}...` : safe;
+}
+
+function failApprovalsCommand(err: unknown, opts: ExecApprovalsCliOpts): void {
+  const message = formatCliError(err);
+  if (opts.json) {
+    defaultRuntime.writeJson({ error: message }, 0);
+  } else {
+    defaultRuntime.error(message);
+  }
+  defaultRuntime.exit(1);
 }
 
 function isApprovalDecision(value: string): value is ApprovalDecision {
@@ -1082,8 +1090,7 @@ async function runAllowlistMutation(
       targetLabel: context.targetLabel,
     });
   } catch (err) {
-    defaultRuntime.error(formatCliError(err));
-    defaultRuntime.exit(1);
+    failApprovalsCommand(err, opts);
   }
 }
 
@@ -1132,8 +1139,7 @@ export function registerExecApprovalsCli(program: Command) {
         }
         renderPendingApprovals(entries);
       } catch (err) {
-        defaultRuntime.error(formatCliError(err));
-        defaultRuntime.exit(1);
+        failApprovalsCommand(err, opts);
       }
     });
   nodesCallOpts(pendingCmd);
@@ -1146,8 +1152,7 @@ export function registerExecApprovalsCli(program: Command) {
       try {
         await resolvePendingApproval(id, decision, opts);
       } catch (err) {
-        defaultRuntime.error(formatCliError(err));
-        defaultRuntime.exit(1);
+        failApprovalsCommand(err, opts);
       }
     });
   nodesCallOpts(resolveCmd);
@@ -1187,8 +1192,7 @@ export function registerExecApprovalsCli(program: Command) {
         renderApprovalsSnapshot(snapshot, targetLabel);
         renderEffectivePolicy({ report: effectivePolicy });
       } catch (err) {
-        defaultRuntime.error(formatCliError(err));
-        defaultRuntime.exit(1);
+        failApprovalsCommand(err, opts);
       }
     });
   nodesCallOpts(getCmd, { timeoutMs: APPROVALS_GET_DEFAULT_TIMEOUT_MS });
@@ -1236,8 +1240,7 @@ export function registerExecApprovalsCli(program: Command) {
         file.version = 1;
         await saveSnapshotTargeted({ opts, source, nodeId, file, baseHash, targetLabel });
       } catch (err) {
-        defaultRuntime.error(formatCliError(err));
-        defaultRuntime.exit(1);
+        failApprovalsCommand(err, opts);
       }
     });
   nodesCallOpts(setCmd);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators scripting `openclaw approvals ... --json` would receive exit 1 with empty machine-readable stdout when pending, resolve, get, set, or allowlist operations failed. The same commands already returned JSON on success, so callers could not reliably parse the advertised output mode.

## Why This Change Was Made

The approvals CLI now owns failure rendering at each command action boundary. Validation and mutation helpers throw to that boundary, which emits exactly one compact `{ "error": "..." }` JSON value in JSON mode or the existing human-readable stderr message otherwise, then exits 1. Error text remains bounded and terminal-sanitized.

No flags, authentication behavior, Gateway methods, configuration, or protocol shapes change. This PR is AI-assisted and directly maintainer-reviewed.

Maintainer LOC decision: accept the net +3 production lines. The JSON-versus-human output branch is the required machine-output capability, and centralizing it at one owner boundary removes ten repeated failure-rendering lines; a net-neutral alternative would scatter that policy back across five command actions.

## User Impact

Scripts can parse approvals command stdout as one JSON value on both success and failure. Human-mode failures remain on stderr with the same non-zero exit behavior.

## Evidence

- Before, the built CLI returned exit 1 with empty stdout for an approvals JSON-mode failure. After, Gateway, node, file-read, parse, validation, and mutation failures return exit 1 with one parseable `{error}` value on stdout; the human-mode control remains stderr-only.
- `node scripts/run-vitest.mjs src/cli/exec-approvals-cli.test.ts src/cli/exec-approvals-cli.pending-resolve.test.ts` — focused owner-boundary tests passed on the reviewed candidate. No rerun was required after the mechanical rebase because all relevant blobs remained identical.
- Source-blind built-CLI validation on the rebased head passed missing-file JSON and human controls, invalid stdin JSON, and a closed-port Gateway failure. Every JSON failure exited 1 with exactly one parseable `{error}` stdout value and no duplicated error across streams.
- Full `pnpm build`, changed checks, lint, production/test types, import-cycle checks, built-dist controls, and `git diff --check` passed during direct review.
- Exact-head CI run [31948737477](https://github.com/openclaw/openclaw/actions/runs/31948737477) passed on `1599e73baeef5d6547d26f091c1c73e2c5d33c36`, including `openclaw/ci-gate`, build artifacts, compact Node shards, lint, production/test types, dependencies, protocol, and boundary checks.
- Autoreview on candidate `8ed5748a84867fbea4eff11f4335952ba95c5d25` completed clean with no accepted/actionable findings.
- ClawSweeper reviewed the exact head with no actionable findings; its sole rank-up move was to wait for exact-head checks, now complete.
- Rebased head `1599e73baeef5d6547d26f091c1c73e2c5d33c36` has byte-identical changed blobs to the reviewed candidate: production `e3a481ba98779895e8804aa4d39d5b7b1d23af97`, primary tests `96646a695a7237dbd02e836da3b03e81286ce6eb`, pending/resolve tests `02086858b19fa1100718f96be5ba64fe6b255515`.
- Production LOC: +15/-12 (net +3), consolidating five command failure paths behind one bounded/redacted owner. Tests: +19/-3 (net +16).
