### PR TITLE
refactor(macos): name computer-use executors for their scope

### DIFF
--- a/apps/macos/Sources/OpenClaw/ComputerActionService.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionService.swift
@@ -1,11 +1,7 @@
-import AppKit
 import ApplicationServices
 import CoreGraphics
 import Foundation
 import OpenClawKit
-import PeekabooAutomationKit
-import PeekabooFoundation
-@preconcurrency import ScreenCaptureKit
 
 /// Linearizes caller cancellation against action completion outside MainActor.
 /// The cancellation handler must record authority loss synchronously; its actor
@@ -403,28 +399,13 @@ struct ComputerControlPermissionSnapshot: Equatable, Sendable {
     }
 }
 
-/// Fulfills `computer.act` on this Mac by driving the embedded Peekaboo
-/// automation engine in-process. Peekaboo covers single/right/double click,
-/// move, drag, scroll, and key/hold. A narrow CoreGraphics path handles
-/// grapheme-atomic typing plus computer_20251124 primitives Peekaboo cannot
-/// express: middle/triple click, separate mouse down/up, and modified input.
+/// Routes one `computer.act` request to the executor that owns it: screen
+/// coordinates go to `ComputerScreenActionExecutor`, window- and element-scoped
+/// requests to `ComputerWindowActionExecutor`. This type owns everything the two
+/// executors share — the serializing execution queue, the input-permission
+/// probe, and the `ComputerActionError` vocabulary both of them throw.
 @MainActor
 final class ComputerActionService {
-    typealias MouseButtonEventPoster = @MainActor (
-        _ down: Bool,
-        _ point: CGPoint,
-        _ flags: CGEventFlags) throws -> Void
-    typealias MouseEventFactory = @MainActor (
-        _ type: CGEventType,
-        _ point: CGPoint,
-        _ button: CGMouseButton,
-        _ clickState: Int,
-        _ flags: CGEventFlags) throws -> CGEvent
-    typealias MouseEventPoster = @MainActor (_ event: CGEvent) throws -> Void
-    /// Posts one Swift grapheme as an atomic key-down/key-up pair. Cancellation
-    /// checkpoints live between calls so authority loss cannot strand a key.
-    typealias TextGraphemePoster = @MainActor (_ grapheme: Character) async throws -> Void
-
     enum ComputerActionError: LocalizedError {
         case accessibilityNotTrusted
         case accessibilityGrantMayBeStale
@@ -444,7 +425,7 @@ final class ComputerActionService {
         case buttonNotHeld
         case eventCreationFailed
         case lifecycleChanged
-        case invalidV2Request(String)
+        case invalidRequest(String)
         case staleObservation
         case unsupportedAction(OpenClawComputerAction)
         case refused(String)
@@ -487,7 +468,7 @@ final class ComputerActionService {
                 "Failed to synthesize input event"
             case .lifecycleChanged:
                 "COMPUTER_STALE_OBSERVATION: provider generation changed; take a fresh observation and retry"
-            case let .invalidV2Request(message):
+            case let .invalidRequest(message):
                 "COMPUTER_INVALID_REQUEST: \(message)"
             case .staleObservation:
                 "COMPUTER_STALE_OBSERVATION: take a fresh observation and retry"
@@ -499,81 +480,19 @@ final class ComputerActionService {
         }
     }
 
-    private let automation: UIAutomationService
-    private let mouseButtonEventPoster: MouseButtonEventPoster
-    private let mouseEventFactory: MouseEventFactory
-    private let mouseEventPoster: MouseEventPoster
-    private let textGraphemePoster: TextGraphemePoster
-    private lazy var v2 = ComputerActionServiceV2()
-    /// Tracks whether a left_mouse_down is outstanding so mouse_move emits
-    /// drag events (state persists across invokes on the shared instance).
-    private var leftButtonDown = false
-    /// Bounded watchdog that releases a stuck left button if the matching
-    /// left_mouse_up never arrives (arm expiry, disconnect, or a failed turn).
-    private var buttonReleaseTask: Task<Void, Never>?
-    /// Modifier flags held since the outstanding left_mouse_down, reapplied to
-    /// drag and release events so a modifier-held split drag keeps Cmd/Opt/Shift
-    /// for the whole gesture even when later turns omit the modifier.
-    private var heldButtonFlags: CGEventFlags = []
+    private let screen: ComputerScreenActionExecutor
+    private lazy var window = ComputerWindowActionExecutor()
     private lazy var executionQueue = ComputerActionExecutionQueue { [weak self] in
-        self?.releaseCurrentHeldButton() ?? true
+        self?.screen.releaseCurrentHeldButton() ?? true
     }
 
-    // Drag pacing: fast enough to feel responsive, slow enough that dropped
-    // targets (AppKit hit-testing mid-drag) do not misfire.
-    private static let dragDurationMs = 400
-    private static let dragSteps = 24
-    private static let clickInterEventDelay: useconds_t = 12000
-    /// Cap wheel ticks at the node so a direct armed caller cannot overflow the
-    /// Int32 wheel delta (line count = ticks * 5) and crash the app.
-    private static let maxScrollTicks = 100
-    /// Cap hold_key at the node: computer.act is directly invocable once armed,
-    /// so an unbounded durationMs must not pin a key down for minutes.
-    private static let maxHoldMs = 10000
-    /// Allow slightly-past-edge coordinates so clicks on the last row/column of
-    /// the reported frame still land instead of erroring on rounding.
-    private static let coordinateBoundsEpsilon: Double = 2
-    /// Idle timeout for an outstanding left button. Refreshed by each drag move,
-    /// so a legitimate multi-turn drag (every turn adds a screenshot plus a model
-    /// inference) is not force-released mid-gesture. Only a truly abandoned button
-    /// (arm expiry, disconnect, or a failed turn with no further activity) hits
-    /// this bounded cleanup.
-    private static let buttonHoldIdleTimeoutNanoseconds: UInt64 = 120 * 1_000_000_000
-
     init() {
-        self.automation = UIAutomationService()
-        self.mouseButtonEventPoster = Self.postMouseButtonEvent
-        self.mouseEventFactory = Self.makeMouseEvent
-        self.mouseEventPoster = Self.postMouseEvent
-        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
+        self.screen = ComputerScreenActionExecutor()
     }
 
     #if DEBUG
-    init(mouseButtonEventPoster: @escaping MouseButtonEventPoster) {
-        self.automation = UIAutomationService()
-        self.mouseButtonEventPoster = mouseButtonEventPoster
-        self.mouseEventFactory = Self.makeMouseEvent
-        self.mouseEventPoster = Self.postMouseEvent
-        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
-    }
-
-    init(
-        mouseEventFactory: @escaping MouseEventFactory,
-        mouseEventPoster: @escaping MouseEventPoster)
-    {
-        self.automation = UIAutomationService()
-        self.mouseButtonEventPoster = Self.postMouseButtonEvent
-        self.mouseEventFactory = mouseEventFactory
-        self.mouseEventPoster = mouseEventPoster
-        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
-    }
-
-    init(textGraphemePoster: @escaping TextGraphemePoster) {
-        self.automation = UIAutomationService()
-        self.mouseButtonEventPoster = Self.postMouseButtonEvent
-        self.mouseEventFactory = Self.makeMouseEvent
-        self.mouseEventPoster = Self.postMouseEvent
-        self.textGraphemePoster = textGraphemePoster
+    init(screen: ComputerScreenActionExecutor) {
+        self.screen = screen
     }
     #endif
 
@@ -599,7 +518,7 @@ final class ComputerActionService {
         try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
         if params.deliveryMode == .background,
            params.windowRef == nil,
-           !params.action.isComputerActV2Only
+           !params.action.isWindowScopedOnly
         {
             return OpenClawComputerActResult(
                 ok: false,
@@ -608,26 +527,20 @@ final class ComputerActionService {
                     recommended: "window-pixel",
                     reasonCode: "no_window_target"))
         }
-        if params.isV2Request {
-            return try await self.v2.perform(
+        let checkExecutionAllowed: @MainActor () throws -> Void = { [weak self] in
+            guard let self else { throw CancellationError() }
+            try self.executionQueue.checkExecutionAllowed(
+                lifecycleGeneration: lifecycleGeneration)
+        }
+        if params.isWindowScopedRequest {
+            return try await self.window.perform(
                 params,
                 lifecycleGeneration: lifecycleGeneration,
-                checkExecutionAllowed: { [weak self] in
-                    guard let self else { throw CancellationError() }
-                    try self.executionQueue.checkExecutionAllowed(
-                        lifecycleGeneration: lifecycleGeneration)
-                })
+                checkExecutionAllowed: checkExecutionAllowed)
         }
-        try Self.validateInputPermissions(ComputerControlPermissionSnapshot.probe())
-        let display = try await resolveDisplay(params: params)
-        try executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-        try await self.dispatch(
+        return try await self.screen.perform(
             params,
-            display: display,
-            lifecycleGeneration: lifecycleGeneration)
-        try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-        let cursor = self.automation.currentMouseLocation() ?? CGPoint.zero
-        return OpenClawComputerActResult(ok: true, cursorX: cursor.x, cursorY: cursor.y)
+            checkExecutionAllowed: checkExecutionAllowed)
     }
 
     static func validateInputPermissions(_ permissions: ComputerControlPermissionSnapshot) throws {
@@ -643,277 +556,6 @@ final class ComputerActionService {
         }
     }
 
-    // MARK: - Dispatch
-
-    private func dispatch(
-        _ params: OpenClawComputerActParams,
-        display: ResolvedDisplay,
-        lifecycleGeneration: UInt64) async throws
-    {
-        try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-        let modifiers = try ComputerModifiers.parse(params.modifiers)
-        try Self.validateHeldButtonTransition(action: params.action, leftButtonDown: self.leftButtonDown)
-        switch params.action {
-        case .leftClick, .rightClick, .doubleClick:
-            let point = try requiredPoint(params, display: display)
-            let button: ComputerMouseButton = params.action == .rightClick ? .right : .left
-            let count = params.action == .doubleClick ? 2 : 1
-            if modifiers.isEmpty {
-                try await self.peekabooClick(at: point, action: params.action)
-            } else {
-                try self.rawClick(at: point, button: button, count: count, flags: modifiers.flags)
-            }
-        case .middleClick:
-            let point = try requiredPoint(params, display: display)
-            try rawClick(at: point, button: .middle, count: 1, flags: modifiers.flags)
-        case .tripleClick:
-            let point = try requiredPoint(params, display: display)
-            try rawClick(at: point, button: .left, count: 3, flags: modifiers.flags)
-        case .mouseMove:
-            let point = try requiredPoint(params, display: display)
-            if self.leftButtonDown {
-                // A drag is in progress; ordinary moveMouse would post
-                // mouseMoved and break drag targets, so emit dragged events
-                // carrying the modifiers held since left_mouse_down.
-                let event = try self.mouseEventFactory(
-                    .leftMouseDragged,
-                    point,
-                    .left,
-                    1,
-                    self.heldButtonFlags)
-                try self.mouseEventPoster(event)
-                // Refresh the release watchdog: an active drag must not be
-                // auto-released mid-gesture during normal tool-loop latency.
-                self.armButtonWatchdog()
-            } else {
-                try await self.automation.moveMouse(to: point, duration: 0, steps: 1, profile: .linear)
-            }
-        case .leftClickDrag:
-            let to = try requiredPoint(params, display: display)
-            let from = try point(params.fromX, params.fromY, params: params, display: display)
-                ?? to
-            try await self.rawDrag(from: from, to: to, flags: modifiers.flags)
-        case .leftMouseDown, .leftMouseUp:
-            // Coordinate is optional: press/release at the current cursor when omitted.
-            let mappedPoint = try self.point(params.x, params.y, params: params, display: display)
-            let point = if let mappedPoint {
-                mappedPoint
-            } else if params.action == .leftMouseDown {
-                try Self.validatedCurrentCursorPoint(
-                    self.automation.currentMouseLocation(),
-                    display: display.geometry)
-            } else {
-                self.automation.currentMouseLocation() ?? CGPoint.zero
-            }
-            if params.action == .leftMouseDown {
-                try self.rawMouseButton(down: true, at: point, flags: modifiers.flags)
-                self.setLeftButtonDown(true, flags: modifiers.flags)
-            } else {
-                // Release with the modifiers held since left_mouse_down (unioned
-                // with any the release turn resends) so modifier-held drops keep
-                // their copy/move semantics.
-                try self.releaseHeldButton(at: point, additionalFlags: modifiers.flags)
-            }
-        case .scroll:
-            try await self.performScroll(
-                params,
-                display: display,
-                modifiers: modifiers,
-                lifecycleGeneration: lifecycleGeneration)
-        case .type:
-            guard let text = params.text, !text.isEmpty else { throw ComputerActionError.emptyText }
-            try await self.typeText(text, lifecycleGeneration: lifecycleGeneration)
-        case .key:
-            let keys = try requireKeys(params.keys)
-            try await self.automation.hotkey(keys: keys, holdDuration: 0)
-        case .holdKey:
-            let keys = try requireKeys(params.keys)
-            let holdMs = min(Self.maxHoldMs, max(0, params.durationMs ?? 1000))
-            try await self.automation.hotkey(keys: keys, holdDuration: holdMs)
-        default:
-            throw ComputerActionError.unsupportedAction(params.action)
-        }
-    }
-
-    private func peekabooClick(at point: CGPoint, action: OpenClawComputerAction) async throws {
-        let clickType: ClickType = switch action {
-        case .rightClick: .right
-        case .doubleClick: .double
-        default: .single
-        }
-        try await self.automation.click(target: .coordinates(point), clickType: clickType, snapshotId: nil)
-    }
-
-    private func typeText(_ text: String, lifecycleGeneration: UInt64) async throws {
-        for grapheme in text {
-            // Caller cancellation is recorded synchronously by the execution
-            // queue, so this check remains authoritative even before its actor
-            // cancellation hop runs.
-            try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-            try await self.textGraphemePoster(grapheme)
-            // The default poster is synchronous. Yield explicitly so disconnect,
-            // pause, disable, and endpoint-replacement lifecycle hops can revoke
-            // authority before the next synthetic key pair.
-            await Task.yield()
-        }
-        try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-    }
-
-    private func performScroll(
-        _ params: OpenClawComputerActParams,
-        display: ResolvedDisplay,
-        modifiers: ComputerModifiers,
-        lifecycleGeneration: UInt64) async throws
-    {
-        guard let direction = params.scrollDirection else { throw ComputerActionError.invalidScroll }
-        let amount = min(Self.maxScrollTicks, max(1, params.scrollAmount ?? 3))
-        // Position the pointer over the requested region first; both Peekaboo
-        // and the raw wheel event scroll at the current mouse location.
-        if let point = try point(params.x, params.y, params: params, display: display) {
-            try await self.automation.moveMouse(to: point, duration: 0, steps: 1, profile: .linear)
-        } else {
-            _ = try Self.validatedCurrentCursorPoint(
-                self.automation.currentMouseLocation(),
-                display: display.geometry)
-        }
-        try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: lifecycleGeneration)
-        if modifiers.isEmpty {
-            try await self.automation.scroll(ScrollRequest(
-                direction: Self.scrollDirection(direction),
-                amount: amount))
-        } else {
-            try self.rawScroll(direction: direction, amount: amount, flags: modifiers.flags)
-        }
-    }
-
-    // MARK: - Coordinate mapping
-
-    /// The target display in global points plus the capture source width used to
-    /// derive the captured screenshot pixel width for coordinate scaling.
-    private struct ResolvedDisplay {
-        var geometry: OpenClawComputerDisplayGeometry
-        var sourceWidth: Double
-        var sourceHeight: Double
-    }
-
-    private func requiredPoint(
-        _ params: OpenClawComputerActParams,
-        display: ResolvedDisplay) throws -> CGPoint
-    {
-        guard let point = try point(params.x, params.y, params: params, display: display) else {
-            throw ComputerActionError.missingCoordinate
-        }
-        return point
-    }
-
-    private func point(
-        _ x: Double?,
-        _ y: Double?,
-        params: OpenClawComputerActParams,
-        display: ResolvedDisplay) throws -> CGPoint?
-    {
-        if x == nil, y == nil {
-            return nil
-        }
-        // A partial coordinate (only x or only y) is malformed: optional-coordinate
-        // actions (scroll, mouse down/up) must fail rather than silently acting at
-        // the current cursor, and a partial drag origin must not fall back to the
-        // destination.
-        guard let x, let y else { throw ComputerActionError.missingCoordinate }
-        // Coordinates are meaningful only in the exact reference frame bound into
-        // displayFrameId. Missing or non-positive widths must never fall back to
-        // the native source width, which could turn valid screenshot pixels into a
-        // deterministic misclick.
-        let refWidth = try Self.requiredReferenceWidth(params)
-        let capturedWidth = OpenClawComputerInputGeometry.capturedWidth(
-            refWidth: refWidth,
-            sourceWidth: display.sourceWidth,
-            sourceHeight: display.sourceHeight)
-        let mapped = OpenClawComputerInputGeometry.mapReferencePointToGlobal(
-            x: x,
-            y: y,
-            capturedWidthPixels: capturedWidth,
-            display: display.geometry)
-        // Reject coordinates well outside the captured display: on a multi-display
-        // Mac an out-of-frame coordinate could otherwise map onto an adjacent
-        // screen and click content the model never saw.
-        let geometry = display.geometry
-        let epsilon = Self.coordinateBoundsEpsilon
-        let withinX = mapped.x >= geometry.originX - epsilon
-            && mapped.x <= geometry.originX + geometry.widthPoints + epsilon
-        let withinY = mapped.y >= geometry.originY - epsilon
-            && mapped.y <= geometry.originY + geometry.heightPoints + epsilon
-        guard withinX, withinY else { throw ComputerActionError.coordinateOutOfBounds }
-        // Clamp the epsilon-tolerated rounding to strictly inside the selected
-        // display so a far-edge coordinate cannot post onto an adjacent screen.
-        let clamped = OpenClawComputerInputGeometry.clampToDisplay(
-            x: mapped.x,
-            y: mapped.y,
-            display: geometry)
-        return CGPoint(x: clamped.x, y: clamped.y)
-    }
-
-    static func validatedCurrentCursorPoint(
-        _ point: CGPoint?,
-        display: OpenClawComputerDisplayGeometry) throws -> CGPoint
-    {
-        guard let point,
-              point.x >= display.originX,
-              point.x < display.originX + display.widthPoints,
-              point.y >= display.originY,
-              point.y < display.originY + display.heightPoints
-        else { throw ComputerActionError.coordinateOutOfBounds }
-        return point
-    }
-
-    static func validateHeldButtonTransition(
-        action: OpenClawComputerAction,
-        leftButtonDown: Bool) throws
-    {
-        if action == .leftMouseUp, !leftButtonDown {
-            // Never synthesize an unmatched up: it could terminate a physical
-            // user drag that this service did not start.
-            throw ComputerActionError.buttonNotHeld
-        }
-        guard leftButtonDown else { return }
-        switch action {
-        case .leftClick, .doubleClick, .tripleClick, .leftClickDrag, .leftMouseDown:
-            throw ComputerActionError.buttonAlreadyHeld
-        default:
-            return
-        }
-    }
-
-    // MARK: - Button-hold watchdog
-
-    private func setLeftButtonDown(_ down: Bool, flags: CGEventFlags = []) {
-        self.buttonReleaseTask?.cancel()
-        self.buttonReleaseTask = nil
-        self.leftButtonDown = down
-        self.heldButtonFlags = down ? flags : []
-        guard down else { return }
-        self.armButtonWatchdog()
-    }
-
-    /// Arms or re-arms the bounded idle watchdog for an outstanding left button.
-    /// Re-armed on each drag move so a live multi-turn gesture is never cut off,
-    /// while an abandoned button still gets released after the idle timeout.
-    private func armButtonWatchdog() {
-        self.buttonReleaseTask?.cancel()
-        self.buttonReleaseTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.buttonHoldIdleTimeoutNanoseconds)
-            guard !Task.isCancelled else { return }
-            self?.autoReleaseLeftButton()
-        }
-    }
-
-    private func autoReleaseLeftButton() {
-        // This task has fired and cannot serve as a future retry. Clear its handle
-        // before attempting release; a failure must install a new watchdog below.
-        self.buttonReleaseTask = nil
-        self.releaseCurrentHeldButton()
-    }
-
     /// Releases any outstanding synthetic left button immediately. Called on
     /// lifecycle transitions (node disconnect, node stop, Computer Control
     /// disabled) so a stranded left_mouse_down is not held until the idle
@@ -922,68 +564,7 @@ final class ComputerActionService {
         await self.executionQueue.releaseHeldInput(lifecycleGeneration: lifecycleGeneration)
     }
 
-    /// Releases the current button without advancing the lifecycle epoch. The
-    /// execution queue owns epoch changes so a reordered duplicate release cannot
-    /// cancel a fresh action that already adopted the same epoch.
-    @discardableResult
-    private func releaseCurrentHeldButton() -> Bool {
-        guard self.leftButtonDown else {
-            self.buttonReleaseTask?.cancel()
-            self.buttonReleaseTask = nil
-            return true
-        }
-        let point = self.automation.currentMouseLocation() ?? CGPoint.zero
-        try? self.releaseHeldButton(at: point)
-        return !self.leftButtonDown
-    }
-
-    /// Posts the service-owned mouse-up and commits the state transition only
-    /// after synthesis succeeds. A failed explicit up carries its modifiers into
-    /// watchdog/lifecycle retries so the eventual drop preserves its semantics.
-    private func releaseHeldButton(
-        at point: CGPoint,
-        additionalFlags: CGEventFlags = []) throws
-    {
-        let releaseFlags = self.heldButtonFlags.union(additionalFlags)
-        do {
-            try self.rawMouseButton(down: false, at: point, flags: releaseFlags)
-        } catch {
-            // Ownership authorizes the only safe follow-up mouse-up. Keep it and
-            // its modifiers until synthesis succeeds, with a live watchdog retry.
-            self.heldButtonFlags = releaseFlags
-            self.armButtonWatchdog()
-            throw error
-        }
-        self.setLeftButtonDown(false)
-    }
-
     #if DEBUG
-    var isLeftButtonDownForTesting: Bool {
-        self.leftButtonDown
-    }
-
-    var heldButtonFlagsForTesting: CGEventFlags {
-        self.heldButtonFlags
-    }
-
-    var buttonWatchdogArmedForTesting: Bool {
-        self.buttonReleaseTask != nil
-    }
-
-    func holdLeftButtonForTesting(flags: CGEventFlags) {
-        self.setLeftButtonDown(true, flags: flags)
-    }
-
-    func fireButtonWatchdogForTesting() {
-        self.buttonReleaseTask?.cancel()
-        self.autoReleaseLeftButton()
-    }
-
-    func releaseHeldButtonForTesting(additionalFlags: CGEventFlags) throws {
-        let point = self.automation.currentMouseLocation() ?? CGPoint.zero
-        try self.releaseHeldButton(at: point, additionalFlags: additionalFlags)
-    }
-
     var lifecycleGenerationForTesting: UInt64 {
         self.executionQueue.lifecycleGenerationForTesting
     }
@@ -998,337 +579,12 @@ final class ComputerActionService {
             lifecycleGeneration: lifecycleGeneration)
         { [weak self] _, generation in
             guard let self else { throw CancellationError() }
-            try await self.typeText(text, lifecycleGeneration: generation)
+            try await self.screen.typeText(text) { [weak self] in
+                guard let self else { throw CancellationError() }
+                try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: generation)
+            }
             return OpenClawComputerActResult(ok: true, cursorX: 0, cursorY: 0)
         }
     }
     #endif
-
-    private func resolveDisplay(params: OpenClawComputerActParams) async throws -> ResolvedDisplay {
-        // Match ScreenSnapshotService display ordering so a computer.act
-        // screenIndex targets the same display the model saw in screen.snapshot.
-        let content = try await SCShareableContent.current
-        let displays = content.displays.sorted { $0.displayID < $1.displayID }
-        guard !displays.isEmpty else { throw ComputerActionError.noDisplays }
-        let idx = params.screenIndex ?? 0
-        guard idx >= 0, idx < displays.count else { throw ComputerActionError.invalidScreenIndex(idx) }
-        // CGDisplayBounds is the global top-left point space CGEvent uses;
-        // SCDisplay.width/height is the capture source size ScreenSnapshotService
-        // caps to refWidth, so together they recover the captured pixel scale and
-        // the source aspect ratio needed for portrait longest-edge scaling.
-        let bounds = CGDisplayBounds(displays[idx].displayID)
-        let geometry = OpenClawComputerDisplayGeometry(
-            originX: bounds.origin.x,
-            originY: bounds.origin.y,
-            widthPoints: bounds.width,
-            heightPoints: bounds.height)
-        let sourceWidth = Double(displays[idx].width)
-        let sourceHeight = Double(displays[idx].height)
-        // A display can disappear between the ScreenCaptureKit snapshot and
-        // CGDisplayBounds, which returns a zero rectangle for a stale id. Reject
-        // all degenerate geometry here; mapping it would collapse input to (0, 0).
-        guard OpenClawComputerInputGeometry.isValidMappingGeometry(
-            sourceWidth: sourceWidth,
-            sourceHeight: sourceHeight,
-            display: geometry)
-        else {
-            throw ComputerActionError.noDisplays
-        }
-        if Self.usesScreenshotCoordinates(params) {
-            let refWidth = try Self.requiredReferenceWidth(params)
-            let currentFrameId = OpenClawComputerInputGeometry.displayFrameId(
-                displayID: displays[idx].displayID,
-                sourceWidth: sourceWidth,
-                sourceHeight: sourceHeight,
-                referenceWidth: refWidth,
-                display: geometry)
-            try Self.validateDisplayFrame(params, currentFrameId: currentFrameId)
-        }
-        return ResolvedDisplay(
-            geometry: geometry,
-            sourceWidth: sourceWidth,
-            sourceHeight: sourceHeight)
-    }
-
-    private static func usesScreenshotCoordinates(_ params: OpenClawComputerActParams) -> Bool {
-        params.x != nil || params.y != nil || params.fromX != nil || params.fromY != nil
-    }
-
-    private static func requiredReferenceWidth(_ params: OpenClawComputerActParams) throws -> Int {
-        guard let refWidth = params.refWidth, refWidth > 0 else {
-            throw ComputerActionError.invalidReferenceWidth
-        }
-        return refWidth
-    }
-
-    static func validateDisplayFrame(
-        _ params: OpenClawComputerActParams,
-        currentFrameId: String) throws
-    {
-        guard self.usesScreenshotCoordinates(params) else { return }
-        _ = try self.requiredReferenceWidth(params)
-        guard let expectedFrameId = params.displayFrameId, !expectedFrameId.isEmpty else {
-            throw ComputerActionError.missingDisplayFrameId
-        }
-        guard expectedFrameId == currentFrameId else {
-            throw ComputerActionError.displayFrameChanged
-        }
-    }
-
-    private func requireKeys(_ keys: String?) throws -> String {
-        guard let keys, !keys.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw ComputerActionError.missingKeys
-        }
-        return keys
-    }
-
-    private static func scrollDirection(
-        _ direction: OpenClawComputerScrollDirection) -> PeekabooFoundation.ScrollDirection
-    {
-        switch direction {
-        case .up: .up
-        case .down: .down
-        case .left: .left
-        case .right: .right
-        }
-    }
-
-    // MARK: - Raw CoreGraphics primitives
-
-    private func rawClick(at point: CGPoint, button: ComputerMouseButton, count: Int, flags: CGEventFlags) throws {
-        // Build every down/up pair before posting the first down. Event creation
-        // failure can then never strand a button between a successfully created
-        // down and a missing up.
-        let pairs = try (1...max(1, count)).map { click in
-            let down = try self.mouseEventFactory(
-                button.downType,
-                point,
-                button.cgButton,
-                click,
-                flags)
-            let up = try self.mouseEventFactory(
-                button.upType,
-                point,
-                button.cgButton,
-                click,
-                flags)
-            return (down: down, up: up)
-        }
-        for pair in pairs {
-            try self.mouseEventPoster(pair.down)
-            try self.mouseEventPoster(pair.up)
-            usleep(Self.clickInterEventDelay)
-        }
-    }
-
-    private func rawDrag(from: CGPoint, to: CGPoint, flags: CGEventFlags) async throws {
-        let down = try self.mouseEventFactory(.leftMouseDown, from, .left, 1, flags)
-        let moves = try (1...Self.dragSteps).map { step in
-            let fraction = Double(step) / Double(Self.dragSteps)
-            let point = CGPoint(
-                x: from.x + (to.x - from.x) * fraction,
-                y: from.y + (to.y - from.y) * fraction)
-            return try self.mouseEventFactory(.leftMouseDragged, point, .left, 1, flags)
-        }
-        let up = try self.mouseEventFactory(.leftMouseUp, to, .left, 1, flags)
-
-        try self.mouseEventPoster(down)
-        var needsRelease = true
-        defer {
-            if needsRelease {
-                try? self.mouseEventPoster(up)
-            }
-        }
-        let stepDelay = UInt64(Self.dragDurationMs) * 1_000_000 / UInt64(Self.dragSteps)
-        for move in moves {
-            try Task.checkCancellation()
-            try self.mouseEventPoster(move)
-            try await Task.sleep(nanoseconds: stepDelay)
-        }
-        try self.mouseEventPoster(up)
-        needsRelease = false
-    }
-
-    private func rawMouseButton(down: Bool, at point: CGPoint, flags: CGEventFlags) throws {
-        try self.mouseButtonEventPoster(down, point, flags)
-    }
-
-    private static func postMouseButtonEvent(
-        _ down: Bool,
-        _ point: CGPoint,
-        _ flags: CGEventFlags) throws
-    {
-        let type: CGEventType = down ? .leftMouseDown : .leftMouseUp
-        let event = try Self.makeMouseEvent(type, point, .left, 1, flags)
-        try Self.postMouseEvent(event)
-    }
-
-    private static func makeMouseEvent(
-        _ type: CGEventType,
-        _ point: CGPoint,
-        _ button: CGMouseButton,
-        _ clickState: Int,
-        _ flags: CGEventFlags) throws -> CGEvent
-    {
-        guard let event = CGEvent(
-            mouseEventSource: nil,
-            mouseType: type,
-            mouseCursorPosition: point,
-            mouseButton: button)
-        else {
-            throw ComputerActionError.eventCreationFailed
-        }
-        if clickState > 1 {
-            event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
-        }
-        if !flags.isEmpty {
-            event.flags = flags
-        }
-        return event
-    }
-
-    private static func postMouseEvent(_ event: CGEvent) throws {
-        event.post(tap: .cghidEventTap)
-    }
-
-    /// Mirrors the pinned Peekaboo/AXorcist typing contract: iterate Swift
-    /// graphemes, map newline/tab to their physical keys, and post Unicode for
-    /// everything else. Both events are built before the first is posted.
-    private static func postTextGrapheme(_ grapheme: Character) throws {
-        let keyCode: CGKeyCode = switch grapheme {
-        case "\n": 0x24
-        case "\t": 0x30
-        default: 0
-        }
-        guard let keyDown = CGEvent(
-            keyboardEventSource: nil,
-            virtualKey: keyCode,
-            keyDown: true),
-            let keyUp = CGEvent(
-                keyboardEventSource: nil,
-                virtualKey: keyCode,
-                keyDown: false)
-        else { throw ComputerActionError.eventCreationFailed }
-
-        if grapheme != "\n", grapheme != "\t" {
-            let utf16 = Array(String(grapheme).utf16)
-            utf16.withUnsafeBufferPointer { buffer in
-                guard let baseAddress = buffer.baseAddress else { return }
-                keyDown.keyboardSetUnicodeString(
-                    stringLength: buffer.count,
-                    unicodeString: baseAddress)
-                keyUp.keyboardSetUnicodeString(
-                    stringLength: buffer.count,
-                    unicodeString: baseAddress)
-            }
-        }
-
-        keyDown.post(tap: .cghidEventTap)
-        usleep(1000)
-        keyUp.post(tap: .cghidEventTap)
-    }
-
-    #if DEBUG
-    func rawClickForTesting(count: Int = 1) throws {
-        try self.rawClick(at: .zero, button: .left, count: count, flags: [])
-    }
-
-    func rawDragForTesting() async throws {
-        try await self.rawDrag(
-            from: .zero,
-            to: CGPoint(x: 24, y: 24),
-            flags: [])
-    }
-    #endif
-
-    private func rawScroll(direction: OpenClawComputerScrollDirection, amount: Int, flags: CGEventFlags) throws {
-        // Line units per tick match Peekaboo's non-smooth scroll (~5 lines).
-        let lines = Int32(amount * 5)
-        let (wheel1, wheel2): (Int32, Int32) = switch direction {
-        case .up: (lines, 0)
-        case .down: (-lines, 0)
-        case .left: (0, lines)
-        case .right: (0, -lines)
-        }
-        guard let event = CGEvent(
-            scrollWheelEvent2Source: nil,
-            units: .line,
-            wheelCount: 2,
-            wheel1: wheel1,
-            wheel2: wheel2,
-            wheel3: 0)
-        else {
-            throw ComputerActionError.eventCreationFailed
-        }
-        if !flags.isEmpty {
-            event.flags = flags
-        }
-        event.post(tap: .cghidEventTap)
-    }
-}
-
-/// Mouse button plus the CoreGraphics event types for the raw click path.
-private enum ComputerMouseButton {
-    case left
-    case right
-    case middle
-
-    var cgButton: CGMouseButton {
-        switch self {
-        case .left: .left
-        case .right: .right
-        case .middle: .center
-        }
-    }
-
-    var downType: CGEventType {
-        switch self {
-        case .left: .leftMouseDown
-        case .right: .rightMouseDown
-        case .middle: .otherMouseDown
-        }
-    }
-
-    var upType: CGEventType {
-        switch self {
-        case .left: .leftMouseUp
-        case .right: .rightMouseUp
-        case .middle: .otherMouseUp
-        }
-    }
-}
-
-/// Parses a portable modifier string ("shift", "cmd+alt") into CGEvent flags.
-struct ComputerModifiers {
-    var flags: CGEventFlags
-
-    var isEmpty: Bool {
-        self.flags.isEmpty
-    }
-
-    static func parse(_ raw: String?) throws -> ComputerModifiers {
-        guard let raw, !raw.isEmpty else { return ComputerModifiers(flags: []) }
-        var flags: CGEventFlags = []
-        for piece in raw.split(whereSeparator: { $0 == "+" || $0 == "," || $0 == " " }) {
-            let key = piece.lowercased()
-            switch key {
-            case "cmd", "command", "meta", "super", "win", "windows":
-                flags.insert(.maskCommand)
-            case "shift":
-                flags.insert(.maskShift)
-            case "ctrl", "control":
-                flags.insert(.maskControl)
-            case "alt", "opt", "option":
-                flags.insert(.maskAlternate)
-            case "fn", "function":
-                flags.insert(.maskSecondaryFn)
-            default:
-                // A typo like "shfit" would otherwise silently drop the modifier
-                // and perform a materially different high-risk gesture (a plain
-                // click instead of a modifier-click); reject it instead.
-                throw ComputerActionService.ComputerActionError.invalidModifier(key)
-            }
-        }
-        return ComputerModifiers(flags: flags)
-    }
 }

--- a/apps/macos/Sources/OpenClaw/ComputerScreenActionExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerScreenActionExecutor.swift
@@ -1,0 +1,787 @@
+import CoreGraphics
+import Foundation
+import OpenClawKit
+import PeekabooAutomationKit
+import PeekabooFoundation
+@preconcurrency import ScreenCaptureKit
+
+/// Fulfills `computer.act` on this Mac by driving the embedded Peekaboo
+/// automation engine in-process. Peekaboo covers single/right/double click,
+/// move, drag, scroll, and key/hold. A narrow CoreGraphics path handles
+/// grapheme-atomic typing plus computer_20251124 primitives Peekaboo cannot
+/// express: middle/triple click, separate mouse down/up, and modified input.
+@MainActor
+final class ComputerScreenActionExecutor {
+    private typealias ComputerActionError = ComputerActionService.ComputerActionError
+
+    typealias MouseButtonEventPoster = @MainActor (
+        _ down: Bool,
+        _ point: CGPoint,
+        _ flags: CGEventFlags) throws -> Void
+    typealias MouseEventFactory = @MainActor (
+        _ type: CGEventType,
+        _ point: CGPoint,
+        _ button: CGMouseButton,
+        _ clickState: Int,
+        _ flags: CGEventFlags) throws -> CGEvent
+    typealias MouseEventPoster = @MainActor (_ event: CGEvent) throws -> Void
+    /// Posts one Swift grapheme as an atomic key-down/key-up pair. Cancellation
+    /// checkpoints live between calls so authority loss cannot strand a key.
+    typealias TextGraphemePoster = @MainActor (_ grapheme: Character) async throws -> Void
+
+    private let automation: UIAutomationService
+    private let mouseButtonEventPoster: MouseButtonEventPoster
+    private let mouseEventFactory: MouseEventFactory
+    private let mouseEventPoster: MouseEventPoster
+    private let textGraphemePoster: TextGraphemePoster
+    /// Tracks whether a left_mouse_down is outstanding so mouse_move emits
+    /// drag events (state persists across invokes on the shared instance).
+    private var leftButtonDown = false
+    /// Bounded watchdog that releases a stuck left button if the matching
+    /// left_mouse_up never arrives (arm expiry, disconnect, or a failed turn).
+    private var buttonReleaseTask: Task<Void, Never>?
+    /// Modifier flags held since the outstanding left_mouse_down, reapplied to
+    /// drag and release events so a modifier-held split drag keeps Cmd/Opt/Shift
+    /// for the whole gesture even when later turns omit the modifier.
+    private var heldButtonFlags: CGEventFlags = []
+
+    // Drag pacing: fast enough to feel responsive, slow enough that dropped
+    // targets (AppKit hit-testing mid-drag) do not misfire.
+    private static let dragDurationMs = 400
+    private static let dragSteps = 24
+    private static let clickInterEventDelay: useconds_t = 12000
+    /// Cap wheel ticks at the node so a direct armed caller cannot overflow the
+    /// Int32 wheel delta (line count = ticks * 5) and crash the app.
+    private static let maxScrollTicks = 100
+    /// Cap hold_key at the node: computer.act is directly invocable once armed,
+    /// so an unbounded durationMs must not pin a key down for minutes.
+    private static let maxHoldMs = 10000
+    /// Allow slightly-past-edge coordinates so clicks on the last row/column of
+    /// the reported frame still land instead of erroring on rounding.
+    private static let coordinateBoundsEpsilon: Double = 2
+    /// Idle timeout for an outstanding left button. Refreshed by each drag move,
+    /// so a legitimate multi-turn drag (every turn adds a screenshot plus a model
+    /// inference) is not force-released mid-gesture. Only a truly abandoned button
+    /// (arm expiry, disconnect, or a failed turn with no further activity) hits
+    /// this bounded cleanup.
+    private static let buttonHoldIdleTimeoutNanoseconds: UInt64 = 120 * 1_000_000_000
+
+    init() {
+        self.automation = UIAutomationService()
+        self.mouseButtonEventPoster = Self.postMouseButtonEvent
+        self.mouseEventFactory = Self.makeMouseEvent
+        self.mouseEventPoster = Self.postMouseEvent
+        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
+    }
+
+    #if DEBUG
+    init(mouseButtonEventPoster: @escaping MouseButtonEventPoster) {
+        self.automation = UIAutomationService()
+        self.mouseButtonEventPoster = mouseButtonEventPoster
+        self.mouseEventFactory = Self.makeMouseEvent
+        self.mouseEventPoster = Self.postMouseEvent
+        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
+    }
+
+    init(
+        mouseEventFactory: @escaping MouseEventFactory,
+        mouseEventPoster: @escaping MouseEventPoster)
+    {
+        self.automation = UIAutomationService()
+        self.mouseButtonEventPoster = Self.postMouseButtonEvent
+        self.mouseEventFactory = mouseEventFactory
+        self.mouseEventPoster = mouseEventPoster
+        self.textGraphemePoster = { try Self.postTextGrapheme($0) }
+    }
+
+    init(textGraphemePoster: @escaping TextGraphemePoster) {
+        self.automation = UIAutomationService()
+        self.mouseButtonEventPoster = Self.postMouseButtonEvent
+        self.mouseEventFactory = Self.makeMouseEvent
+        self.mouseEventPoster = Self.postMouseEvent
+        self.textGraphemePoster = textGraphemePoster
+    }
+    #endif
+
+    func perform(
+        _ params: OpenClawComputerActParams,
+        checkExecutionAllowed: @MainActor () throws -> Void) async throws
+        -> OpenClawComputerActResult
+    {
+        try ComputerActionService.validateInputPermissions(ComputerControlPermissionSnapshot.probe())
+        let display = try await resolveDisplay(params: params)
+        try checkExecutionAllowed()
+        try await self.dispatch(
+            params,
+            display: display,
+            checkExecutionAllowed: checkExecutionAllowed)
+        try checkExecutionAllowed()
+        let cursor = self.automation.currentMouseLocation() ?? CGPoint.zero
+        return OpenClawComputerActResult(ok: true, cursorX: cursor.x, cursorY: cursor.y)
+    }
+
+    // MARK: - Dispatch
+
+    private func dispatch(
+        _ params: OpenClawComputerActParams,
+        display: ResolvedDisplay,
+        checkExecutionAllowed: @MainActor () throws -> Void) async throws
+    {
+        try checkExecutionAllowed()
+        let modifiers = try ComputerModifiers.parse(params.modifiers)
+        try Self.validateHeldButtonTransition(action: params.action, leftButtonDown: self.leftButtonDown)
+        switch params.action {
+        case .leftClick, .rightClick, .doubleClick:
+            let point = try requiredPoint(params, display: display)
+            let button: ComputerMouseButton = params.action == .rightClick ? .right : .left
+            let count = params.action == .doubleClick ? 2 : 1
+            if modifiers.isEmpty {
+                try await self.peekabooClick(at: point, action: params.action)
+            } else {
+                try self.rawClick(at: point, button: button, count: count, flags: modifiers.flags)
+            }
+        case .middleClick:
+            let point = try requiredPoint(params, display: display)
+            try rawClick(at: point, button: .middle, count: 1, flags: modifiers.flags)
+        case .tripleClick:
+            let point = try requiredPoint(params, display: display)
+            try rawClick(at: point, button: .left, count: 3, flags: modifiers.flags)
+        case .mouseMove:
+            let point = try requiredPoint(params, display: display)
+            if self.leftButtonDown {
+                // A drag is in progress; ordinary moveMouse would post
+                // mouseMoved and break drag targets, so emit dragged events
+                // carrying the modifiers held since left_mouse_down.
+                let event = try self.mouseEventFactory(
+                    .leftMouseDragged,
+                    point,
+                    .left,
+                    1,
+                    self.heldButtonFlags)
+                try self.mouseEventPoster(event)
+                // Refresh the release watchdog: an active drag must not be
+                // auto-released mid-gesture during normal tool-loop latency.
+                self.armButtonWatchdog()
+            } else {
+                try await self.automation.moveMouse(to: point, duration: 0, steps: 1, profile: .linear)
+            }
+        case .leftClickDrag:
+            let to = try requiredPoint(params, display: display)
+            let from = try point(params.fromX, params.fromY, params: params, display: display)
+                ?? to
+            try await self.rawDrag(from: from, to: to, flags: modifiers.flags)
+        case .leftMouseDown, .leftMouseUp:
+            // Coordinate is optional: press/release at the current cursor when omitted.
+            let mappedPoint = try self.point(params.x, params.y, params: params, display: display)
+            let point = if let mappedPoint {
+                mappedPoint
+            } else if params.action == .leftMouseDown {
+                try Self.validatedCurrentCursorPoint(
+                    self.automation.currentMouseLocation(),
+                    display: display.geometry)
+            } else {
+                self.automation.currentMouseLocation() ?? CGPoint.zero
+            }
+            if params.action == .leftMouseDown {
+                try self.rawMouseButton(down: true, at: point, flags: modifiers.flags)
+                self.setLeftButtonDown(true, flags: modifiers.flags)
+            } else {
+                // Release with the modifiers held since left_mouse_down (unioned
+                // with any the release turn resends) so modifier-held drops keep
+                // their copy/move semantics.
+                try self.releaseHeldButton(at: point, additionalFlags: modifiers.flags)
+            }
+        case .scroll:
+            try await self.performScroll(
+                params,
+                display: display,
+                modifiers: modifiers,
+                checkExecutionAllowed: checkExecutionAllowed)
+        case .type:
+            guard let text = params.text, !text.isEmpty else { throw ComputerActionError.emptyText }
+            try await self.typeText(text, checkExecutionAllowed: checkExecutionAllowed)
+        case .key:
+            let keys = try requireKeys(params.keys)
+            try await self.automation.hotkey(keys: keys, holdDuration: 0)
+        case .holdKey:
+            let keys = try requireKeys(params.keys)
+            let holdMs = min(Self.maxHoldMs, max(0, params.durationMs ?? 1000))
+            try await self.automation.hotkey(keys: keys, holdDuration: holdMs)
+        default:
+            throw ComputerActionError.unsupportedAction(params.action)
+        }
+    }
+
+    private func peekabooClick(at point: CGPoint, action: OpenClawComputerAction) async throws {
+        let clickType: ClickType = switch action {
+        case .rightClick: .right
+        case .doubleClick: .double
+        default: .single
+        }
+        try await self.automation.click(target: .coordinates(point), clickType: clickType, snapshotId: nil)
+    }
+
+    func typeText(
+        _ text: String,
+        checkExecutionAllowed: @MainActor () throws -> Void) async throws
+    {
+        for grapheme in text {
+            // Caller cancellation is recorded synchronously by the execution
+            // queue, so this check remains authoritative even before its actor
+            // cancellation hop runs.
+            try checkExecutionAllowed()
+            try await self.textGraphemePoster(grapheme)
+            // The default poster is synchronous. Yield explicitly so disconnect,
+            // pause, disable, and endpoint-replacement lifecycle hops can revoke
+            // authority before the next synthetic key pair.
+            await Task.yield()
+        }
+        try checkExecutionAllowed()
+    }
+
+    private func performScroll(
+        _ params: OpenClawComputerActParams,
+        display: ResolvedDisplay,
+        modifiers: ComputerModifiers,
+        checkExecutionAllowed: @MainActor () throws -> Void) async throws
+    {
+        guard let direction = params.scrollDirection else { throw ComputerActionError.invalidScroll }
+        let amount = min(Self.maxScrollTicks, max(1, params.scrollAmount ?? 3))
+        // Position the pointer over the requested region first; both Peekaboo
+        // and the raw wheel event scroll at the current mouse location.
+        if let point = try point(params.x, params.y, params: params, display: display) {
+            try await self.automation.moveMouse(to: point, duration: 0, steps: 1, profile: .linear)
+        } else {
+            _ = try Self.validatedCurrentCursorPoint(
+                self.automation.currentMouseLocation(),
+                display: display.geometry)
+        }
+        try checkExecutionAllowed()
+        if modifiers.isEmpty {
+            try await self.automation.scroll(ScrollRequest(
+                direction: Self.scrollDirection(direction),
+                amount: amount))
+        } else {
+            try self.rawScroll(direction: direction, amount: amount, flags: modifiers.flags)
+        }
+    }
+
+    // MARK: - Coordinate mapping
+
+    /// The target display in global points plus the capture source width used to
+    /// derive the captured screenshot pixel width for coordinate scaling.
+    private struct ResolvedDisplay {
+        var geometry: OpenClawComputerDisplayGeometry
+        var sourceWidth: Double
+        var sourceHeight: Double
+    }
+
+    private func requiredPoint(
+        _ params: OpenClawComputerActParams,
+        display: ResolvedDisplay) throws -> CGPoint
+    {
+        guard let point = try point(params.x, params.y, params: params, display: display) else {
+            throw ComputerActionError.missingCoordinate
+        }
+        return point
+    }
+
+    private func point(
+        _ x: Double?,
+        _ y: Double?,
+        params: OpenClawComputerActParams,
+        display: ResolvedDisplay) throws -> CGPoint?
+    {
+        if x == nil, y == nil {
+            return nil
+        }
+        // A partial coordinate (only x or only y) is malformed: optional-coordinate
+        // actions (scroll, mouse down/up) must fail rather than silently acting at
+        // the current cursor, and a partial drag origin must not fall back to the
+        // destination.
+        guard let x, let y else { throw ComputerActionError.missingCoordinate }
+        // Coordinates are meaningful only in the exact reference frame bound into
+        // displayFrameId. Missing or non-positive widths must never fall back to
+        // the native source width, which could turn valid screenshot pixels into a
+        // deterministic misclick.
+        let refWidth = try Self.requiredReferenceWidth(params)
+        let capturedWidth = OpenClawComputerInputGeometry.capturedWidth(
+            refWidth: refWidth,
+            sourceWidth: display.sourceWidth,
+            sourceHeight: display.sourceHeight)
+        let mapped = OpenClawComputerInputGeometry.mapReferencePointToGlobal(
+            x: x,
+            y: y,
+            capturedWidthPixels: capturedWidth,
+            display: display.geometry)
+        // Reject coordinates well outside the captured display: on a multi-display
+        // Mac an out-of-frame coordinate could otherwise map onto an adjacent
+        // screen and click content the model never saw.
+        let geometry = display.geometry
+        let epsilon = Self.coordinateBoundsEpsilon
+        let withinX = mapped.x >= geometry.originX - epsilon
+            && mapped.x <= geometry.originX + geometry.widthPoints + epsilon
+        let withinY = mapped.y >= geometry.originY - epsilon
+            && mapped.y <= geometry.originY + geometry.heightPoints + epsilon
+        guard withinX, withinY else { throw ComputerActionError.coordinateOutOfBounds }
+        // Clamp the epsilon-tolerated rounding to strictly inside the selected
+        // display so a far-edge coordinate cannot post onto an adjacent screen.
+        let clamped = OpenClawComputerInputGeometry.clampToDisplay(
+            x: mapped.x,
+            y: mapped.y,
+            display: geometry)
+        return CGPoint(x: clamped.x, y: clamped.y)
+    }
+
+    static func validatedCurrentCursorPoint(
+        _ point: CGPoint?,
+        display: OpenClawComputerDisplayGeometry) throws -> CGPoint
+    {
+        guard let point,
+              point.x >= display.originX,
+              point.x < display.originX + display.widthPoints,
+              point.y >= display.originY,
+              point.y < display.originY + display.heightPoints
+        else { throw ComputerActionError.coordinateOutOfBounds }
+        return point
+    }
+
+    static func validateHeldButtonTransition(
+        action: OpenClawComputerAction,
+        leftButtonDown: Bool) throws
+    {
+        if action == .leftMouseUp, !leftButtonDown {
+            // Never synthesize an unmatched up: it could terminate a physical
+            // user drag that this service did not start.
+            throw ComputerActionError.buttonNotHeld
+        }
+        guard leftButtonDown else { return }
+        switch action {
+        case .leftClick, .doubleClick, .tripleClick, .leftClickDrag, .leftMouseDown:
+            throw ComputerActionError.buttonAlreadyHeld
+        default:
+            return
+        }
+    }
+
+    // MARK: - Button-hold watchdog
+
+    private func setLeftButtonDown(_ down: Bool, flags: CGEventFlags = []) {
+        self.buttonReleaseTask?.cancel()
+        self.buttonReleaseTask = nil
+        self.leftButtonDown = down
+        self.heldButtonFlags = down ? flags : []
+        guard down else { return }
+        self.armButtonWatchdog()
+    }
+
+    /// Arms or re-arms the bounded idle watchdog for an outstanding left button.
+    /// Re-armed on each drag move so a live multi-turn gesture is never cut off,
+    /// while an abandoned button still gets released after the idle timeout.
+    private func armButtonWatchdog() {
+        self.buttonReleaseTask?.cancel()
+        self.buttonReleaseTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.buttonHoldIdleTimeoutNanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.autoReleaseLeftButton()
+        }
+    }
+
+    private func autoReleaseLeftButton() {
+        // This task has fired and cannot serve as a future retry. Clear its handle
+        // before attempting release; a failure must install a new watchdog below.
+        self.buttonReleaseTask = nil
+        self.releaseCurrentHeldButton()
+    }
+
+    /// Releases the current button without advancing the lifecycle epoch. The
+    /// execution queue owns epoch changes so a reordered duplicate release cannot
+    /// cancel a fresh action that already adopted the same epoch.
+    @discardableResult
+    func releaseCurrentHeldButton() -> Bool {
+        guard self.leftButtonDown else {
+            self.buttonReleaseTask?.cancel()
+            self.buttonReleaseTask = nil
+            return true
+        }
+        let point = self.automation.currentMouseLocation() ?? CGPoint.zero
+        try? self.releaseHeldButton(at: point)
+        return !self.leftButtonDown
+    }
+
+    /// Posts the service-owned mouse-up and commits the state transition only
+    /// after synthesis succeeds. A failed explicit up carries its modifiers into
+    /// watchdog/lifecycle retries so the eventual drop preserves its semantics.
+    private func releaseHeldButton(
+        at point: CGPoint,
+        additionalFlags: CGEventFlags = []) throws
+    {
+        let releaseFlags = self.heldButtonFlags.union(additionalFlags)
+        do {
+            try self.rawMouseButton(down: false, at: point, flags: releaseFlags)
+        } catch {
+            // Ownership authorizes the only safe follow-up mouse-up. Keep it and
+            // its modifiers until synthesis succeeds, with a live watchdog retry.
+            self.heldButtonFlags = releaseFlags
+            self.armButtonWatchdog()
+            throw error
+        }
+        self.setLeftButtonDown(false)
+    }
+
+    #if DEBUG
+    var isLeftButtonDownForTesting: Bool {
+        self.leftButtonDown
+    }
+
+    var heldButtonFlagsForTesting: CGEventFlags {
+        self.heldButtonFlags
+    }
+
+    var buttonWatchdogArmedForTesting: Bool {
+        self.buttonReleaseTask != nil
+    }
+
+    func holdLeftButtonForTesting(flags: CGEventFlags) {
+        self.setLeftButtonDown(true, flags: flags)
+    }
+
+    func fireButtonWatchdogForTesting() {
+        self.buttonReleaseTask?.cancel()
+        self.autoReleaseLeftButton()
+    }
+
+    func releaseHeldButtonForTesting(additionalFlags: CGEventFlags) throws {
+        let point = self.automation.currentMouseLocation() ?? CGPoint.zero
+        try self.releaseHeldButton(at: point, additionalFlags: additionalFlags)
+    }
+    #endif
+
+    private func resolveDisplay(params: OpenClawComputerActParams) async throws -> ResolvedDisplay {
+        // Match ScreenSnapshotService display ordering so a computer.act
+        // screenIndex targets the same display the model saw in screen.snapshot.
+        let content = try await SCShareableContent.current
+        let displays = content.displays.sorted { $0.displayID < $1.displayID }
+        guard !displays.isEmpty else { throw ComputerActionError.noDisplays }
+        let idx = params.screenIndex ?? 0
+        guard idx >= 0, idx < displays.count else { throw ComputerActionError.invalidScreenIndex(idx) }
+        // CGDisplayBounds is the global top-left point space CGEvent uses;
+        // SCDisplay.width/height is the capture source size ScreenSnapshotService
+        // caps to refWidth, so together they recover the captured pixel scale and
+        // the source aspect ratio needed for portrait longest-edge scaling.
+        let bounds = CGDisplayBounds(displays[idx].displayID)
+        let geometry = OpenClawComputerDisplayGeometry(
+            originX: bounds.origin.x,
+            originY: bounds.origin.y,
+            widthPoints: bounds.width,
+            heightPoints: bounds.height)
+        let sourceWidth = Double(displays[idx].width)
+        let sourceHeight = Double(displays[idx].height)
+        // A display can disappear between the ScreenCaptureKit snapshot and
+        // CGDisplayBounds, which returns a zero rectangle for a stale id. Reject
+        // all degenerate geometry here; mapping it would collapse input to (0, 0).
+        guard OpenClawComputerInputGeometry.isValidMappingGeometry(
+            sourceWidth: sourceWidth,
+            sourceHeight: sourceHeight,
+            display: geometry)
+        else {
+            throw ComputerActionError.noDisplays
+        }
+        if Self.usesScreenshotCoordinates(params) {
+            let refWidth = try Self.requiredReferenceWidth(params)
+            let currentFrameId = OpenClawComputerInputGeometry.displayFrameId(
+                displayID: displays[idx].displayID,
+                sourceWidth: sourceWidth,
+                sourceHeight: sourceHeight,
+                referenceWidth: refWidth,
+                display: geometry)
+            try Self.validateDisplayFrame(params, currentFrameId: currentFrameId)
+        }
+        return ResolvedDisplay(
+            geometry: geometry,
+            sourceWidth: sourceWidth,
+            sourceHeight: sourceHeight)
+    }
+
+    private static func usesScreenshotCoordinates(_ params: OpenClawComputerActParams) -> Bool {
+        params.x != nil || params.y != nil || params.fromX != nil || params.fromY != nil
+    }
+
+    private static func requiredReferenceWidth(_ params: OpenClawComputerActParams) throws -> Int {
+        guard let refWidth = params.refWidth, refWidth > 0 else {
+            throw ComputerActionError.invalidReferenceWidth
+        }
+        return refWidth
+    }
+
+    static func validateDisplayFrame(
+        _ params: OpenClawComputerActParams,
+        currentFrameId: String) throws
+    {
+        guard self.usesScreenshotCoordinates(params) else { return }
+        _ = try self.requiredReferenceWidth(params)
+        guard let expectedFrameId = params.displayFrameId, !expectedFrameId.isEmpty else {
+            throw ComputerActionError.missingDisplayFrameId
+        }
+        guard expectedFrameId == currentFrameId else {
+            throw ComputerActionError.displayFrameChanged
+        }
+    }
+
+    private func requireKeys(_ keys: String?) throws -> String {
+        guard let keys, !keys.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ComputerActionError.missingKeys
+        }
+        return keys
+    }
+
+    private static func scrollDirection(
+        _ direction: OpenClawComputerScrollDirection) -> PeekabooFoundation.ScrollDirection
+    {
+        switch direction {
+        case .up: .up
+        case .down: .down
+        case .left: .left
+        case .right: .right
+        }
+    }
+
+    // MARK: - Raw CoreGraphics primitives
+
+    private func rawClick(at point: CGPoint, button: ComputerMouseButton, count: Int, flags: CGEventFlags) throws {
+        // Build every down/up pair before posting the first down. Event creation
+        // failure can then never strand a button between a successfully created
+        // down and a missing up.
+        let pairs = try (1...max(1, count)).map { click in
+            let down = try self.mouseEventFactory(
+                button.downType,
+                point,
+                button.cgButton,
+                click,
+                flags)
+            let up = try self.mouseEventFactory(
+                button.upType,
+                point,
+                button.cgButton,
+                click,
+                flags)
+            return (down: down, up: up)
+        }
+        for pair in pairs {
+            try self.mouseEventPoster(pair.down)
+            try self.mouseEventPoster(pair.up)
+            usleep(Self.clickInterEventDelay)
+        }
+    }
+
+    private func rawDrag(from: CGPoint, to: CGPoint, flags: CGEventFlags) async throws {
+        let down = try self.mouseEventFactory(.leftMouseDown, from, .left, 1, flags)
+        let moves = try (1...Self.dragSteps).map { step in
+            let fraction = Double(step) / Double(Self.dragSteps)
+            let point = CGPoint(
+                x: from.x + (to.x - from.x) * fraction,
+                y: from.y + (to.y - from.y) * fraction)
+            return try self.mouseEventFactory(.leftMouseDragged, point, .left, 1, flags)
+        }
+        let up = try self.mouseEventFactory(.leftMouseUp, to, .left, 1, flags)
+
+        try self.mouseEventPoster(down)
+        var needsRelease = true
+        defer {
+            if needsRelease {
+                try? self.mouseEventPoster(up)
+            }
+        }
+        let stepDelay = UInt64(Self.dragDurationMs) * 1_000_000 / UInt64(Self.dragSteps)
+        for move in moves {
+            try Task.checkCancellation()
+            try self.mouseEventPoster(move)
+            try await Task.sleep(nanoseconds: stepDelay)
+        }
+        try self.mouseEventPoster(up)
+        needsRelease = false
+    }
+
+    private func rawMouseButton(down: Bool, at point: CGPoint, flags: CGEventFlags) throws {
+        try self.mouseButtonEventPoster(down, point, flags)
+    }
+
+    private static func postMouseButtonEvent(
+        _ down: Bool,
+        _ point: CGPoint,
+        _ flags: CGEventFlags) throws
+    {
+        let type: CGEventType = down ? .leftMouseDown : .leftMouseUp
+        let event = try Self.makeMouseEvent(type, point, .left, 1, flags)
+        try Self.postMouseEvent(event)
+    }
+
+    private static func makeMouseEvent(
+        _ type: CGEventType,
+        _ point: CGPoint,
+        _ button: CGMouseButton,
+        _ clickState: Int,
+        _ flags: CGEventFlags) throws -> CGEvent
+    {
+        guard let event = CGEvent(
+            mouseEventSource: nil,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: button)
+        else {
+            throw ComputerActionError.eventCreationFailed
+        }
+        if clickState > 1 {
+            event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
+        }
+        if !flags.isEmpty {
+            event.flags = flags
+        }
+        return event
+    }
+
+    private static func postMouseEvent(_ event: CGEvent) throws {
+        event.post(tap: .cghidEventTap)
+    }
+
+    /// Mirrors the pinned Peekaboo/AXorcist typing contract: iterate Swift
+    /// graphemes, map newline/tab to their physical keys, and post Unicode for
+    /// everything else. Both events are built before the first is posted.
+    private static func postTextGrapheme(_ grapheme: Character) throws {
+        let keyCode: CGKeyCode = switch grapheme {
+        case "\n": 0x24
+        case "\t": 0x30
+        default: 0
+        }
+        guard let keyDown = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: keyCode,
+            keyDown: true),
+            let keyUp = CGEvent(
+                keyboardEventSource: nil,
+                virtualKey: keyCode,
+                keyDown: false)
+        else { throw ComputerActionError.eventCreationFailed }
+
+        if grapheme != "\n", grapheme != "\t" {
+            let utf16 = Array(String(grapheme).utf16)
+            utf16.withUnsafeBufferPointer { buffer in
+                guard let baseAddress = buffer.baseAddress else { return }
+                keyDown.keyboardSetUnicodeString(
+                    stringLength: buffer.count,
+                    unicodeString: baseAddress)
+                keyUp.keyboardSetUnicodeString(
+                    stringLength: buffer.count,
+                    unicodeString: baseAddress)
+            }
+        }
+
+        keyDown.post(tap: .cghidEventTap)
+        usleep(1000)
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    #if DEBUG
+    func rawClickForTesting(count: Int = 1) throws {
+        try self.rawClick(at: .zero, button: .left, count: count, flags: [])
+    }
+
+    func rawDragForTesting() async throws {
+        try await self.rawDrag(
+            from: .zero,
+            to: CGPoint(x: 24, y: 24),
+            flags: [])
+    }
+    #endif
+
+    private func rawScroll(direction: OpenClawComputerScrollDirection, amount: Int, flags: CGEventFlags) throws {
+        // Line units per tick match Peekaboo's non-smooth scroll (~5 lines).
+        let lines = Int32(amount * 5)
+        let (wheel1, wheel2): (Int32, Int32) = switch direction {
+        case .up: (lines, 0)
+        case .down: (-lines, 0)
+        case .left: (0, lines)
+        case .right: (0, -lines)
+        }
+        guard let event = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: wheel1,
+            wheel2: wheel2,
+            wheel3: 0)
+        else {
+            throw ComputerActionError.eventCreationFailed
+        }
+        if !flags.isEmpty {
+            event.flags = flags
+        }
+        event.post(tap: .cghidEventTap)
+    }
+}
+
+/// Mouse button plus the CoreGraphics event types for the raw click path.
+private enum ComputerMouseButton {
+    case left
+    case right
+    case middle
+
+    var cgButton: CGMouseButton {
+        switch self {
+        case .left: .left
+        case .right: .right
+        case .middle: .center
+        }
+    }
+
+    var downType: CGEventType {
+        switch self {
+        case .left: .leftMouseDown
+        case .right: .rightMouseDown
+        case .middle: .otherMouseDown
+        }
+    }
+
+    var upType: CGEventType {
+        switch self {
+        case .left: .leftMouseUp
+        case .right: .rightMouseUp
+        case .middle: .otherMouseUp
+        }
+    }
+}
+
+/// Parses a portable modifier string ("shift", "cmd+alt") into CGEvent flags.
+struct ComputerModifiers {
+    var flags: CGEventFlags
+
+    var isEmpty: Bool {
+        self.flags.isEmpty
+    }
+
+    static func parse(_ raw: String?) throws -> ComputerModifiers {
+        guard let raw, !raw.isEmpty else { return ComputerModifiers(flags: []) }
+        var flags: CGEventFlags = []
+        for piece in raw.split(whereSeparator: { $0 == "+" || $0 == "," || $0 == " " }) {
+            let key = piece.lowercased()
+            switch key {
+            case "cmd", "command", "meta", "super", "win", "windows":
+                flags.insert(.maskCommand)
+            case "shift":
+                flags.insert(.maskShift)
+            case "ctrl", "control":
+                flags.insert(.maskControl)
+            case "alt", "opt", "option":
+                flags.insert(.maskAlternate)
+            case "fn", "function":
+                flags.insert(.maskSecondaryFn)
+            default:
+                // A typo like "shfit" would otherwise silently drop the modifier
+                // and perform a materially different high-risk gesture (a plain
+                // click instead of a modifier-click); reject it instead.
+                throw ComputerActionService.ComputerActionError.invalidModifier(key)
+            }
+        }
+        return ComputerModifiers(flags: flags)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/ComputerWindowActionExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerWindowActionExecutor.swift
@@ -12,14 +12,19 @@ extension CGRect {
 }
 
 extension OpenClawComputerActParams {
-    var isV2Request: Bool {
-        self.action.isComputerActV2Only || self.windowRef != nil || self.elementRef != nil ||
+    /// True when the request names a window, element, or observation, or asks for
+    /// an action that has no screen-coordinate form. Such requests must run on
+    /// `ComputerWindowActionExecutor`; everything else is screen-coordinate work.
+    var isWindowScopedRequest: Bool {
+        self.action.isWindowScopedOnly || self.windowRef != nil || self.elementRef != nil ||
             self.observationId != nil
     }
 }
 
 extension OpenClawComputerAction {
-    var isComputerActV2Only: Bool {
+    /// True for actions that cannot be expressed as screen-coordinate input and
+    /// therefore always need a window/element target.
+    var isWindowScopedOnly: Bool {
         switch self {
         case .leftClick, .rightClick, .middleClick, .doubleClick, .tripleClick, .mouseMove,
              .leftClickDrag, .leftMouseDown, .leftMouseUp, .scroll, .type, .key, .holdKey:
@@ -42,11 +47,14 @@ struct ComputerActionExecutionAuthority {
     }
 }
 
-/// Implements the additive computer.act v2 surface without changing the v1
-/// coordinate path. All authority-bearing references are process-local,
-/// execution-local, and invalidated when the native lifecycle generation moves.
+/// Executes the window- and element-scoped half of `computer.act`: discovery,
+/// app/window lifecycle, and accessibility-targeted input. Its peer
+/// `ComputerScreenActionExecutor` owns the screen-coordinate half; both are
+/// routed by `ComputerActionService`. All authority-bearing references are
+/// process-local, execution-local, and invalidated when the native lifecycle
+/// generation moves.
 @MainActor
-final class ComputerActionServiceV2 {
+final class ComputerWindowActionExecutor {
     struct WindowTarget {
         let app: ServiceApplicationInfo
         let window: ServiceWindowInfo
@@ -365,7 +373,7 @@ final class ComputerActionServiceV2 {
     private func killApp(_ params: OpenClawComputerActParams) async throws -> OpenClawComputerActResult {
         let appRef = try Self.require(params.app, field: "app")
         guard let app = self.appRefs[appRef], let identity = app.processIdentity else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "kill_app requires a running app reference from list_apps")
         }
         let quit = try await self.withExecutionAuthority {
@@ -406,7 +414,7 @@ final class ComputerActionServiceV2 {
         if mode == .foreground {
             try await self.focus(target)
             guard target.window.bounds.contains(resolved.point) else {
-                throw ComputerActionService.ComputerActionError.invalidV2Request(
+                throw ComputerActionService.ComputerActionError.invalidRequest(
                     "foreground click target is outside the selected window")
             }
             try Self.postForegroundClick(
@@ -549,7 +557,7 @@ final class ComputerActionServiceV2 {
         guard let path = params.path, !path.isEmpty, path.count <= 16,
               path.allSatisfy({ !$0.isEmpty && $0.count <= 200 })
         else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "path must contain 1 to 16 non-empty menu components")
         }
         try await self.withExecutionAuthority {
@@ -567,7 +575,7 @@ final class ComputerActionServiceV2 {
         let windowRef = try Self.require(params.windowRef, field: "windowRef")
         let target = try self.resolveWindow(windowRef)
         guard let direction = params.scrollDirection else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "scrollDirection is required for scroll")
         }
         let mode = params.deliveryMode ?? .background
@@ -691,11 +699,11 @@ final class ComputerActionServiceV2 {
             return (.elementId(element.id), element.bounds.centerPoint, observation.snapshotId)
         }
         guard let x = params.x, let y = params.y else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "coordinates or elementRef are required for \(params.action.rawValue)")
         }
         guard x >= 0, y >= 0 else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "coordinates must be nonnegative")
         }
         let point = CGPoint(x: x, y: y)
@@ -711,11 +719,11 @@ final class ComputerActionServiceV2 {
         }
         if params.x == nil, params.y == nil { return nil }
         guard let x = params.x, let y = params.y else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "both x and y are required")
         }
         guard x >= 0, y >= 0 else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "coordinates must be nonnegative")
         }
         _ = try self.resolveObservation(params.observationId, windowRef: windowRef)
@@ -763,7 +771,7 @@ final class ComputerActionServiceV2 {
 
 // MARK: - Projection and outcomes
 
-extension ComputerActionServiceV2 {
+extension ComputerWindowActionExecutor {
     private static func result(
         from outcome: DesktopActionOutcome?,
         background: Bool) -> OpenClawComputerActResult
@@ -888,7 +896,7 @@ extension ComputerActionServiceV2 {
         let depth = params.depth ?? AXTraversalBudget.defaultMaxDepth
         let maxElements = params.maxElements ?? AXTraversalBudget.defaultMaxElementCount
         guard (0...64).contains(depth), (1...2000).contains(maxElements) else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "depth must be 0...64 and maxElements must be 1...2000")
         }
         return (depth, maxElements)
@@ -900,7 +908,7 @@ extension ComputerActionServiceV2 {
         allowEmpty: Bool = false) throws -> String
     {
         guard let value, allowEmpty || !value.isEmpty else {
-            throw ComputerActionService.ComputerActionError.invalidV2Request(
+            throw ComputerActionService.ComputerActionError.invalidRequest(
                 "\(field) is required")
         }
         return value
@@ -985,7 +993,7 @@ extension ComputerActionServiceV2 {
             case "alt", "option": flags.insert(.maskAlternate)
             case "fn", "function": flags.insert(.maskSecondaryFn)
             default:
-                throw ComputerActionService.ComputerActionError.invalidV2Request(
+                throw ComputerActionService.ComputerActionError.invalidRequest(
                     "unsupported modifier '\(token)'")
             }
         }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -632,7 +632,7 @@ extension MacNodeRuntime {
             case .noDisplays, .invalidScreenIndex, .missingDisplayFrameId, .displayFrameChanged,
                  .missingCoordinate, .coordinateOutOfBounds, .invalidReferenceWidth, .missingKeys,
                  .emptyText, .invalidScroll, .invalidModifier, .buttonAlreadyHeld, .buttonNotHeld,
-                 .invalidV2Request, .staleObservation, .unsupportedAction:
+                 .invalidRequest, .staleObservation, .unsupportedAction:
                 return Self.errorResponse(
                     req,
                     code: .invalidRequest,

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerActionServiceTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerActionServiceTests.swift
@@ -197,7 +197,7 @@ struct ComputerActionServiceTests {
             y: 2,
             refWidth: 1280)
         let missingError = self.validationError {
-            try ComputerActionService.validateDisplayFrame(missing, currentFrameId: currentFrameId)
+            try ComputerScreenActionExecutor.validateDisplayFrame(missing, currentFrameId: currentFrameId)
         }
         if case .some(.missingDisplayFrameId) = missingError {} else {
             Issue.record("expected missingDisplayFrameId")
@@ -210,7 +210,7 @@ struct ComputerActionServiceTests {
             y: 2,
             refWidth: 1280)
         let staleError = self.validationError {
-            try ComputerActionService.validateDisplayFrame(stale, currentFrameId: currentFrameId)
+            try ComputerScreenActionExecutor.validateDisplayFrame(stale, currentFrameId: currentFrameId)
         }
         if case .some(.displayFrameChanged) = staleError {} else {
             Issue.record("expected displayFrameChanged")
@@ -222,7 +222,7 @@ struct ComputerActionServiceTests {
             x: 1,
             y: 2,
             refWidth: 1280)
-        try ComputerActionService.validateDisplayFrame(current, currentFrameId: currentFrameId)
+        try ComputerScreenActionExecutor.validateDisplayFrame(current, currentFrameId: currentFrameId)
 
         let missingScale = OpenClawComputerActParams(
             action: .leftClick,
@@ -230,7 +230,7 @@ struct ComputerActionServiceTests {
             x: 1,
             y: 2)
         let missingScaleError = self.validationError {
-            try ComputerActionService.validateDisplayFrame(
+            try ComputerScreenActionExecutor.validateDisplayFrame(
                 missingScale,
                 currentFrameId: currentFrameId)
         }
@@ -262,7 +262,7 @@ struct ComputerActionServiceTests {
             y: 2,
             refWidth: 640)
         let mismatchedScaleError = self.validationError {
-            try ComputerActionService.validateDisplayFrame(
+            try ComputerScreenActionExecutor.validateDisplayFrame(
                 mismatchedScale,
                 currentFrameId: mismatchedScaleFrameId)
         }
@@ -272,7 +272,7 @@ struct ComputerActionServiceTests {
 
         // Cursor-relative/keyboard actions do not consume screenshot coordinates.
         let keyboard = OpenClawComputerActParams(action: .type, text: "hello")
-        try ComputerActionService.validateDisplayFrame(keyboard, currentFrameId: currentFrameId)
+        try ComputerScreenActionExecutor.validateDisplayFrame(keyboard, currentFrameId: currentFrameId)
     }
 
     @Test func `cursor-relative input stays inside the selected display`() throws {
@@ -281,50 +281,50 @@ struct ComputerActionServiceTests {
             originY: -50,
             widthPoints: 800,
             heightPoints: 600)
-        #expect(try ComputerActionService.validatedCurrentCursorPoint(
+        #expect(try ComputerScreenActionExecutor.validatedCurrentCursorPoint(
             CGPoint(x: 100, y: -50),
             display: display) == CGPoint(x: 100, y: -50))
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validatedCurrentCursorPoint(
+            try ComputerScreenActionExecutor.validatedCurrentCursorPoint(
                 CGPoint(x: 99, y: 0),
                 display: display)
         }
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validatedCurrentCursorPoint(nil, display: display)
+            try ComputerScreenActionExecutor.validatedCurrentCursorPoint(nil, display: display)
         }
     }
 
     @Test func `integrated drag and duplicate down are rejected during a split hold`() throws {
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validateHeldButtonTransition(
+            try ComputerScreenActionExecutor.validateHeldButtonTransition(
                 action: .leftClickDrag,
                 leftButtonDown: true)
         }
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validateHeldButtonTransition(
+            try ComputerScreenActionExecutor.validateHeldButtonTransition(
                 action: .leftMouseDown,
                 leftButtonDown: true)
         }
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validateHeldButtonTransition(
+            try ComputerScreenActionExecutor.validateHeldButtonTransition(
                 action: .doubleClick,
                 leftButtonDown: true)
         }
-        try ComputerActionService.validateHeldButtonTransition(
+        try ComputerScreenActionExecutor.validateHeldButtonTransition(
             action: .leftMouseUp,
             leftButtonDown: true)
     }
 
     @Test func `left mouse up requires a service owned split hold`() throws {
         #expect(throws: ComputerActionService.ComputerActionError.self) {
-            try ComputerActionService.validateHeldButtonTransition(
+            try ComputerScreenActionExecutor.validateHeldButtonTransition(
                 action: .leftMouseUp,
                 leftButtonDown: false)
         }
-        try ComputerActionService.validateHeldButtonTransition(
+        try ComputerScreenActionExecutor.validateHeldButtonTransition(
             action: .leftMouseDown,
             leftButtonDown: false)
-        try ComputerActionService.validateHeldButtonTransition(
+        try ComputerScreenActionExecutor.validateHeldButtonTransition(
             action: .leftMouseUp,
             leftButtonDown: true)
     }
@@ -333,7 +333,7 @@ struct ComputerActionServiceTests {
         let flags: CGEventFlags = [.maskCommand, .maskShift]
         var attempts = 0
         var postedFlags: [CGEventFlags] = []
-        let service = ComputerActionService { down, _, eventFlags in
+        let screen = ComputerScreenActionExecutor { down, _, eventFlags in
             #expect(!down)
             attempts += 1
             postedFlags.append(eventFlags)
@@ -341,13 +341,14 @@ struct ComputerActionServiceTests {
                 throw ComputerActionService.ComputerActionError.eventCreationFailed
             }
         }
-        service.holdLeftButtonForTesting(flags: flags)
+        let service = ComputerActionService(screen: screen)
+        screen.holdLeftButtonForTesting(flags: flags)
 
         await service.releaseHeldInput(lifecycleGeneration: 1)
 
-        #expect(!service.isLeftButtonDownForTesting)
-        #expect(service.heldButtonFlagsForTesting.isEmpty)
-        #expect(!service.buttonWatchdogArmedForTesting)
+        #expect(!screen.isLeftButtonDownForTesting)
+        #expect(screen.heldButtonFlagsForTesting.isEmpty)
+        #expect(!screen.buttonWatchdogArmedForTesting)
         #expect(attempts == 2)
         #expect(postedFlags == [flags, flags])
     }
@@ -355,7 +356,7 @@ struct ComputerActionServiceTests {
     @Test func `watchdog release retains ownership and rearms after post failure`() {
         let flags: CGEventFlags = [.maskAlternate]
         var attempts = 0
-        let service = ComputerActionService { down, _, eventFlags in
+        let screen = ComputerScreenActionExecutor { down, _, eventFlags in
             #expect(!down)
             #expect(eventFlags == flags)
             attempts += 1
@@ -363,19 +364,19 @@ struct ComputerActionServiceTests {
                 throw SyntheticPostError.failed
             }
         }
-        service.holdLeftButtonForTesting(flags: flags)
+        screen.holdLeftButtonForTesting(flags: flags)
 
-        service.fireButtonWatchdogForTesting()
+        screen.fireButtonWatchdogForTesting()
 
-        #expect(service.isLeftButtonDownForTesting)
-        #expect(service.heldButtonFlagsForTesting == flags)
-        #expect(service.buttonWatchdogArmedForTesting)
+        #expect(screen.isLeftButtonDownForTesting)
+        #expect(screen.heldButtonFlagsForTesting == flags)
+        #expect(screen.buttonWatchdogArmedForTesting)
 
-        service.fireButtonWatchdogForTesting()
+        screen.fireButtonWatchdogForTesting()
 
-        #expect(!service.isLeftButtonDownForTesting)
-        #expect(service.heldButtonFlagsForTesting.isEmpty)
-        #expect(!service.buttonWatchdogArmedForTesting)
+        #expect(!screen.isLeftButtonDownForTesting)
+        #expect(screen.heldButtonFlagsForTesting.isEmpty)
+        #expect(!screen.buttonWatchdogArmedForTesting)
         #expect(attempts == 2)
     }
 
@@ -385,7 +386,7 @@ struct ComputerActionServiceTests {
         let expectedFlags = heldFlags.union(releaseFlags)
         var attempts = 0
         var postedFlags: [CGEventFlags] = []
-        let service = ComputerActionService { down, _, eventFlags in
+        let screen = ComputerScreenActionExecutor { down, _, eventFlags in
             #expect(!down)
             attempts += 1
             postedFlags.append(eventFlags)
@@ -393,21 +394,21 @@ struct ComputerActionServiceTests {
                 throw SyntheticPostError.failed
             }
         }
-        service.holdLeftButtonForTesting(flags: heldFlags)
+        screen.holdLeftButtonForTesting(flags: heldFlags)
 
         #expect(throws: SyntheticPostError.self) {
-            try service.releaseHeldButtonForTesting(additionalFlags: releaseFlags)
+            try screen.releaseHeldButtonForTesting(additionalFlags: releaseFlags)
         }
 
-        #expect(service.isLeftButtonDownForTesting)
-        #expect(service.heldButtonFlagsForTesting == expectedFlags)
-        #expect(service.buttonWatchdogArmedForTesting)
+        #expect(screen.isLeftButtonDownForTesting)
+        #expect(screen.heldButtonFlagsForTesting == expectedFlags)
+        #expect(screen.buttonWatchdogArmedForTesting)
 
-        service.fireButtonWatchdogForTesting()
+        screen.fireButtonWatchdogForTesting()
 
-        #expect(!service.isLeftButtonDownForTesting)
-        #expect(service.heldButtonFlagsForTesting.isEmpty)
-        #expect(!service.buttonWatchdogArmedForTesting)
+        #expect(!screen.isLeftButtonDownForTesting)
+        #expect(screen.heldButtonFlagsForTesting.isEmpty)
+        #expect(!screen.buttonWatchdogArmedForTesting)
         #expect(attempts == 2)
         #expect(postedFlags == [expectedFlags, expectedFlags])
     }
@@ -439,8 +440,8 @@ struct ComputerActionServiceTests {
         #expect(probe.maximumActiveActionCount == 1)
     }
 
-    @Test func `v2 authority rejects a result after lifecycle revocation`() async {
-        let service = ComputerActionServiceV2()
+    @Test func `window authority rejects a result after lifecycle revocation`() async {
+        let service = ComputerWindowActionExecutor()
         var checks = 0
         let outcomeError: Error?
         do {
@@ -492,8 +493,8 @@ struct ComputerActionServiceTests {
         #expect(self.isLifecycleChanged(outcomeError))
     }
 
-    @Test func `v2 rejects foreground accessibility-only actions`() async {
-        let service = ComputerActionServiceV2()
+    @Test func `window executor rejects foreground accessibility-only actions`() async {
+        let service = ComputerWindowActionExecutor()
         for action in [OpenClawComputerAction.setValue, .invokeMenu] {
             let outcomeError: Error?
             do {
@@ -603,7 +604,8 @@ struct ComputerActionServiceTests {
 
     @Test func `typing posts exactly one event pair per Swift grapheme`() async throws {
         var posted: [Character] = []
-        let service = ComputerActionService(textGraphemePoster: { posted.append($0) })
+        let service = ComputerActionService(
+            screen: ComputerScreenActionExecutor(textGraphemePoster: { posted.append($0) }))
         let text = "A👨‍👩‍👧‍👦e\u{301}\n\t"
 
         _ = try await service.typeTextForTesting(text)
@@ -615,12 +617,13 @@ struct ComputerActionServiceTests {
         let firstPosted = AsyncSignal()
         let resumePoster = AsyncSignal()
         var posted: [Character] = []
-        let service = ComputerActionService(textGraphemePoster: { grapheme in
-            posted.append(grapheme)
-            guard posted.count == 1 else { return }
-            await firstPosted.signal()
-            await resumePoster.wait()
-        })
+        let service = ComputerActionService(screen: ComputerScreenActionExecutor(
+            textGraphemePoster: { grapheme in
+                posted.append(grapheme)
+                guard posted.count == 1 else { return }
+                await firstPosted.signal()
+                await resumePoster.wait()
+            }))
         let action = Task { @MainActor in
             try await service.typeTextForTesting("A👨‍👩‍👧‍👦B")
         }
@@ -644,12 +647,13 @@ struct ComputerActionServiceTests {
         let firstPosted = AsyncSignal()
         let resumePoster = AsyncSignal()
         var posted: [Character] = []
-        let service = ComputerActionService(textGraphemePoster: { grapheme in
-            posted.append(grapheme)
-            guard posted.count == 1 else { return }
-            await firstPosted.signal()
-            await resumePoster.wait()
-        })
+        let service = ComputerActionService(screen: ComputerScreenActionExecutor(
+            textGraphemePoster: { grapheme in
+                posted.append(grapheme)
+                guard posted.count == 1 else { return }
+                await firstPosted.signal()
+                await resumePoster.wait()
+            }))
         let action = Task { @MainActor in
             try await service.typeTextForTesting("A👨‍👩‍👧‍👦B")
         }
@@ -751,7 +755,7 @@ struct ComputerActionServiceTests {
     @Test func `raw click preconstructs up before posting down`() throws {
         var factoryCalls = 0
         var postCount = 0
-        let service = ComputerActionService(
+        let screen = ComputerScreenActionExecutor(
             mouseEventFactory: { type, point, button, _, _ in
                 factoryCalls += 1
                 if factoryCalls == 2 {
@@ -768,7 +772,7 @@ struct ComputerActionServiceTests {
             mouseEventPoster: { _ in postCount += 1 })
 
         #expect(throws: SyntheticPostError.self) {
-            try service.rawClickForTesting()
+            try screen.rawClickForTesting()
         }
         #expect(factoryCalls == 2)
         #expect(postCount == 0)
@@ -778,7 +782,7 @@ struct ComputerActionServiceTests {
         var eventTypes: [ObjectIdentifier: CGEventType] = [:]
         var postedTypes: [CGEventType] = []
         var failedMove = false
-        let service = ComputerActionService(
+        let screen = ComputerScreenActionExecutor(
             mouseEventFactory: { type, point, button, _, _ in
                 guard let event = CGEvent(
                     mouseEventSource: nil,
@@ -799,7 +803,7 @@ struct ComputerActionServiceTests {
             })
 
         do {
-            try await service.rawDragForTesting()
+            try await screen.rawDragForTesting()
             Issue.record("raw drag unexpectedly succeeded")
         } catch is SyntheticPostError {
             // Expected injected move failure.
@@ -815,7 +819,7 @@ struct ComputerActionServiceTests {
     @Test func `raw drag posts release when cancelled between moves`() async {
         var eventTypes: [ObjectIdentifier: CGEventType] = [:]
         var postedTypes: [CGEventType] = []
-        let service = ComputerActionService(
+        let screen = ComputerScreenActionExecutor(
             mouseEventFactory: { type, point, button, _, _ in
                 guard let event = CGEvent(
                     mouseEventSource: nil,
@@ -833,7 +837,7 @@ struct ComputerActionServiceTests {
             })
 
         let drag = Task { @MainActor in
-            try await service.rawDragForTesting()
+            try await screen.rawDragForTesting()
         }
         while !postedTypes.contains(.leftMouseDragged) {
             await Task.yield()

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerRefLifecycleContractTests.swift
@@ -5,7 +5,7 @@ import PeekabooAutomationKit
 import Testing
 @testable import OpenClaw
 
-/// Drives the real `ComputerActionServiceV2` reference lifecycle through the same
+/// Drives the real `ComputerWindowActionExecutor` reference lifecycle through the same
 /// case table the CUA provider runs in `ref-lifecycle.contract.test.ts`, so the two
 /// providers cannot drift apart on what an opaque ref means.
 @MainActor
@@ -64,7 +64,7 @@ struct ComputerRefLifecycleContractTests {
     }
 
     private func run(_ testCase: Case) async -> Error? {
-        let service = ComputerActionServiceV2()
+        let service = ComputerWindowActionExecutor()
         service.adoptLifecycleGeneration(1)
         let windowRef = service.issueWindowRef(
             app: Self.app,
@@ -72,7 +72,7 @@ struct ComputerRefLifecycleContractTests {
         let observation = service.issueObservation(
             windowRef: windowRef,
             snapshotId: "snapshot-1",
-            elements: [ComputerActionServiceV2.ElementTarget(id: "button", bounds: .zero)])
+            elements: [ComputerWindowActionExecutor.ElementTarget(id: "button", bounds: .zero)])
 
         do {
             switch testCase.scenario {
@@ -96,7 +96,7 @@ struct ComputerRefLifecycleContractTests {
                 _ = service.issueObservation(
                     windowRef: windowRef,
                     snapshotId: "snapshot-2",
-                    elements: [ComputerActionServiceV2.ElementTarget(id: "button", bounds: .zero)])
+                    elements: [ComputerWindowActionExecutor.ElementTarget(id: "button", bounds: .zero)])
                 _ = try service.resolveObservation(observation.id, windowRef: windowRef)
             case .unrelatedDiscovery:
                 _ = service.issueWindowRef(
@@ -115,7 +115,7 @@ struct ComputerRefLifecycleContractTests {
     /// Runs a real action whose lifecycle generation is revoked after the work
     /// completed but before the result is released, which is the only way the
     /// in-flight change reaches a caller.
-    private static func performWithRevokedLifecycle(_ service: ComputerActionServiceV2) async throws {
+    private static func performWithRevokedLifecycle(_ service: ComputerWindowActionExecutor) async throws {
         var checks = 0
         _ = try await service.perform(
             OpenClawComputerActParams(action: .getCursorPosition),

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -305,7 +305,7 @@ extensions/cua-computer/src/driver-artifacts.ts	1
 extensions/cua-computer/src/driver-client.ts	15
 extensions/cua-computer/src/driver-result.ts	10
 extensions/cua-computer/src/mcp-driver-client.ts	6
-extensions/cua-computer/src/v2-actions.ts	3
+extensions/cua-computer/src/window-actions.ts	3
 extensions/deepinfra/embedding-adapter.ts	1
 extensions/deepinfra/provider-models.ts	3
 extensions/deepinfra/video-generation-provider.ts	2

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -33,7 +33,7 @@ import {
 } from "./frame.js";
 import { createCuaMcpDriver } from "./mcp-driver-client.js";
 import { closeRecordingExecution } from "./recording-actions.js";
-import { handleV2Act, type CuaComputerActParams } from "./v2-actions.js";
+import { handleWindowAct, type CuaComputerActParams } from "./window-actions.js";
 
 const AVAILABILITY_POLL_MS = 5_000;
 const CUA_WIRE_ACTION_NAMES = COMPUTER_USE_V2_ACTION_NAMES.slice(1, 14);
@@ -278,37 +278,37 @@ async function handleDesktopAct(
   if (!(CUA_WIRE_ACTION_NAMES as readonly string[]).includes(params.action)) {
     throw new Error(`COMPUTER_UNSUPPORTED_ACTION: ${params.action}`);
   }
-  const v1Params = params as CuaComputerActParams;
-  assertPrimaryDisplay(v1Params.screenIndex);
+  const desktopParams = params as CuaComputerActParams;
+  assertPrimaryDisplay(desktopParams.screenIndex);
   // `wait` never reaches the wire: core sleeps locally and the Swift wire enum
   // has no wait case, so accepting it here would fork the computer.act contract.
   if (
-    v1Params.action === "hold_key" ||
-    v1Params.action === "left_mouse_down" ||
-    v1Params.action === "left_mouse_up"
+    desktopParams.action === "hold_key" ||
+    desktopParams.action === "left_mouse_down" ||
+    desktopParams.action === "left_mouse_up"
   ) {
     // Upstream has no desktop keyboard-down API, and its Linux mouse hold tools
     // are window-only, so these actions cannot preserve desktop-scope semantics.
-    throw new Error(`COMPUTER_UNSUPPORTED_ACTION: ${v1Params.action}`);
+    throw new Error(`COMPUTER_UNSUPPORTED_ACTION: ${desktopParams.action}`);
   }
 
   // Every action uses scope:"desktop", a global SendInput/XTest/wayland_desktop
   // injection that is inherently foreground and ignores delivery_mode (that
   // background-vs-foreground contract is window-targeted only). We deliberately
   // never send delivery_mode.
-  switch (v1Params.action) {
+  switch (desktopParams.action) {
     case "type": {
-      if (!v1Params.text) {
+      if (!desktopParams.text) {
         throw new Error("COMPUTER_INVALID_REQUEST: text is required for type");
       }
-      assertToolSuccess(await driver.typeText(v1Params.text, signal), "type_text");
+      assertToolSuccess(await driver.typeText(desktopParams.text, signal), "type_text");
       break;
     }
     case "key": {
       // press_key applies the modifier array on every backend: X11 via XTest,
       // and native Wayland by internally promoting a modifier chord to
       // hotkey_focused. No separate hotkey call is needed for chords.
-      const chord = parseKeyChord(v1Params.keys);
+      const chord = parseKeyChord(desktopParams.keys);
       assertToolSuccess(
         await driver.pressKey(
           {
@@ -322,10 +322,10 @@ async function handleDesktopAct(
       break;
     }
     case "scroll": {
-      if (!v1Params.scrollDirection) {
+      if (!desktopParams.scrollDirection) {
         throw new Error("COMPUTER_INVALID_REQUEST: scrollDirection is required for scroll");
       }
-      if (normalizeModifiers(v1Params.modifiers).length > 0) {
+      if (normalizeModifiers(desktopParams.modifiers).length > 0) {
         throw new Error(
           "COMPUTER_UNSUPPORTED_ACTION: modifier-held scroll is unsupported by cua-driver",
         );
@@ -334,20 +334,20 @@ async function handleDesktopAct(
       // frame-authorized like clicks. We deliberately do not synthesize a point
       // from get_cursor_position: that mixes cursor and capture coordinate
       // spaces across X11/Wayland/Windows and would scroll an unverified target.
-      const frame = await currentFrame(driver, frameState, v1Params, signal);
-      const point = scalePoint(frame, v1Params.x, v1Params.y, v1Params.action);
+      const frame = await currentFrame(driver, frameState, desktopParams, signal);
+      const point = scalePoint(frame, desktopParams.x, desktopParams.y, desktopParams.action);
       const direction = {
         up: ScrollDirection.Up,
         down: ScrollDirection.Down,
         left: ScrollDirection.Left,
         right: ScrollDirection.Right,
-      }[v1Params.scrollDirection];
+      }[desktopParams.scrollDirection];
       assertToolSuccess(
         await driver.scroll(
           {
             direction,
             // Schema guarantees a positive amount; cap at the driver's max of 50.
-            amount: BigInt(Math.min(50, v1Params.scrollAmount ?? 3)),
+            amount: BigInt(Math.min(50, desktopParams.scrollAmount ?? 3)),
             ...point,
           },
           signal,
@@ -357,49 +357,49 @@ async function handleDesktopAct(
       break;
     }
     default: {
-      const frame = await currentFrame(driver, frameState, v1Params, signal);
-      switch (v1Params.action) {
+      const frame = await currentFrame(driver, frameState, desktopParams, signal);
+      switch (desktopParams.action) {
         case "left_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, v1Params, ClickButton.Left, 1), signal),
+            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 1), signal),
             "click",
           );
           break;
         case "right_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, v1Params, ClickButton.Right, 1), signal),
+            await driver.click(clickArgs(frame, desktopParams, ClickButton.Right, 1), signal),
             "click",
           );
           break;
         case "middle_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, v1Params, ClickButton.Middle, 1), signal),
+            await driver.click(clickArgs(frame, desktopParams, ClickButton.Middle, 1), signal),
             "click",
           );
           break;
         case "double_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, v1Params, ClickButton.Left, 2), signal),
+            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 2), signal),
             "click",
           );
           break;
         case "triple_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, v1Params, ClickButton.Left, 3), signal),
+            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 3), signal),
             "click",
           );
           break;
         case "mouse_move": {
-          const point = scalePoint(frame, v1Params.x, v1Params.y, v1Params.action);
+          const point = scalePoint(frame, desktopParams.x, desktopParams.y, desktopParams.action);
           assertToolSuccess(await driver.moveCursor(point, signal), "move_cursor");
           break;
         }
         case "left_click_drag": {
-          const from = scalePoint(frame, v1Params.fromX, v1Params.fromY, "drag start");
-          const to = scalePoint(frame, v1Params.x, v1Params.y, "drag end");
+          const from = scalePoint(frame, desktopParams.fromX, desktopParams.fromY, "drag start");
+          const to = scalePoint(frame, desktopParams.x, desktopParams.y, "drag end");
           // The typed desktop drag API has no modifier field. Refuse instead of
           // silently widening a model request into an unmodified drag.
-          if (normalizeModifiers(v1Params.modifiers).length > 0) {
+          if (normalizeModifiers(desktopParams.modifiers).length > 0) {
             throw new Error(
               "COMPUTER_UNSUPPORTED_ACTION: modifier-held drag is unsupported by cua-driver",
             );
@@ -413,9 +413,9 @@ async function handleDesktopAct(
                 toY: to.y,
                 // CUA caps desktop drag duration at 10 seconds; clamp rather than
                 // rejecting a valid computer.act request at the SDK boundary.
-                ...(v1Params.durationMs === undefined
+                ...(desktopParams.durationMs === undefined
                   ? {}
-                  : { durationMs: BigInt(Math.min(10_000, v1Params.durationMs)) }),
+                  : { durationMs: BigInt(Math.min(10_000, desktopParams.durationMs)) }),
               },
               signal,
             ),
@@ -583,7 +583,7 @@ export function createCuaComputerProvider(
                   : "COMPUTER_DRIVER_UNAVAILABLE: cua-computer supports macOS, Windows, and Linux",
               );
             }
-            return await handleV2Act(
+            return await handleWindowAct(
               platform,
               executionDriver,
               frameState,

--- a/extensions/cua-computer/src/window-actions.ts
+++ b/extensions/cua-computer/src/window-actions.ts
@@ -214,7 +214,10 @@ async function handleTargetedAct(
 
 export type { CuaComputerActParams } from "./action-targets.js";
 
-export async function handleV2Act(
+/// Entry point for `computer.act` on the CUA driver. Owns every window- and
+/// element-scoped action (targeted input, discovery, app/window lifecycle) and
+/// hands screen-scoped desktop actions to the injected `handleDesktop`.
+export async function handleWindowAct(
   platform: NodeJS.Platform,
   driver: CuaDriverSession,
   state: CuaFrameState,

--- a/src/agents/tools/computer-tool-node.ts
+++ b/src/agents/tools/computer-tool-node.ts
@@ -142,6 +142,9 @@ function computerActIdempotencyKey(params: { scope?: string; toolCallId: string 
     .createHash("sha256")
     .update(JSON.stringify([stableScope, stableCallId, COMPUTER_ACT_COMMAND]))
     .digest("hex");
+  // `v1` versions this key's composition (scope + call id + command), not the
+  // `computer.act` wire contract. Changing what goes into the digest needs a
+  // new prefix so in-flight keys from an older node cannot collide.
   return `computer.act:v1:${digest}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Computer Use surface on macOS still carried `v1`/`v2` naming from a migration
that finished long ago. The v1 wire contract is gone — there is one
`ComputerActParamsSchema`, one `parseComputerActParamsJSON`, and a typed
`COMPUTER_CONTRACT_MISMATCH`. What survived was naming that actively misdescribes
the real split.

The real split is **screen-coordinate execution vs window/element-scoped
execution**. Both are first-class rungs of the same ladder (`docs/nodes/computer-use.md`:
"Coordinate actions bind to a node-issued reference frame; capable providers can
also address windows and elements"). Calling the window path "V2" and the
coordinate path "v1" tells the next reader that one is legacy and the other is the
replacement, which is false — coordinate actions are live and are what the
`computer` tool uses after a screenshot.

`ComputerActionService.swift` had also grown to 1,334 lines carrying four unrelated
responsibilities: the `perform()` router, the serializing execution queue, the
permission snapshot, and the entire screen-coordinate `dispatch` implementation.

## Why This Change Was Made

Names now describe scope instead of version, and the file that owned four
responsibilities owns one.

- `ComputerActionService` keeps its name and becomes the coordinator: it routes one
  request to the executor that owns it and owns what both share — the execution
  queue, the input-permission probe, and the `ComputerActionError` vocabulary.
- `ComputerScreenActionExecutor` (new file) owns screen-coordinate execution:
  `dispatch`, typing, scroll, coordinate mapping and display-frame validation, the
  button-hold watchdog, and the raw CoreGraphics primitives.
- `ComputerActionServiceV2` becomes `ComputerWindowActionExecutor`, a peer named for
  window/element-scoped execution. Its doc comment described migration history
  ("the additive computer.act v2 surface without changing the v1 coordinate path")
  and now describes the screen-vs-window split and the reference-lifecycle invariant.
- `isV2Request` -> `isWindowScopedRequest`, `isComputerActV2Only` ->
  `isWindowScopedOnly`, `ComputerActionError.invalidV2Request` -> `.invalidRequest`.
  The emitted `COMPUTER_INVALID_REQUEST:` prefix is the closed code on the wire and
  is byte-identical.
- cua-computer: `v2-actions.ts` -> `window-actions.ts`, `handleV2Act` ->
  `handleWindowAct` (matching the sibling `handleBrowserAct` / `handleRecordingAct`
  convention), and the stale `v1Params` local inside `handleDesktopAct` -> `desktopParams`.

Deliberately untouched: `computer.act:v1:<digest>` in `computer-tool-node.ts` is a
dedupe **key-format** namespace, not the wire contract; it keeps its string and
gains a comment saying so. Wire values (`semantic_v2`, `dom_refs_v1`,
`openclaw:computer-resource:v1:`, `cua:v2:` / `peekaboo:v2:` ref prefixes,
`COMPUTER_USE_V2_ACTION_NAMES`) are contract values and are unchanged.
`docs/plan/computer-use.md` is a historical campaign record where "v1" is correct
history, and is not touched.

## User Impact

None. This is behavior-neutral: no logic edits, no new branches, no changed error
strings, no changed wire values. Operators and models see exactly the same
`computer.act` behavior and the same error codes. The benefit is for the next person
to read this code: file and symbol names now say which execution scope they own.

## Evidence

**Behavior neutrality proof.** The extraction is a move, verified two ways:

1. Git rename detection pairs the new file with its source:
   ```
   $ git diff --numstat --find-copies-harder -M origin/main...HEAD
   22  569  apps/macos/Sources/OpenClaw/{ComputerActionService.swift => ComputerScreenActionExecutor.swift}
   27   19  apps/macos/Sources/OpenClaw/{ComputerActionServiceV2.swift => ComputerWindowActionExecutor.swift}
   ```
2. Direct region diff of the moved body against `origin/main`. Everything from
   `// MARK: - Raw CoreGraphics primitives` to end of file (raw click/drag/mouse-button
   plumbing, `postTextGrapheme`, `ComputerMouseButton`, `ComputerModifiers`) is
   **byte-for-byte identical**. The `dispatch` .. coordinate-mapping region diffs to
   exactly one mechanical substitution repeated at each site: the threaded
   `lifecycleGeneration: UInt64` parameter became a `checkExecutionAllowed:` closure
   parameter, so `try self.executionQueue.checkExecutionAllowed(lifecycleGeneration:)`
   became `try checkExecutionAllowed()`. Same checks, same order, same call sites —
   this mirrors the closure the window executor already receives. The only other
   deltas are two `private` -> internal access widenings so the coordinator can reach
   `typeText` and `releaseCurrentHeldButton`.

**Tests and checks** (all local, macOS host):

| Check | Result |
| --- | --- |
| `swift test --package-path apps/macos --parallel` | exit 0, 987 tests passed, 0 failures |
| `pnpm test extensions/cua-computer src/plugins src/agents/tools` | 240/241 files pass; see note below |
| `pnpm check:test-types` | clean |
| `node scripts/run-oxlint.mjs extensions/cua-computer src/agents/tools` | exit 0 |
| `oxfmt --check` on touched TS | clean |
| `swiftlint lint --config config/swiftlint.yml` | 0 violations in 335 files |
| `swiftformat --lint apps/macos/Sources --config config/swiftformat` | 0/333 require formatting |
| `pnpm check:import-cycles` | 0 runtime value cycles |
| `check-deadcode-unused-files` / `check-deadcode-exports` | 0 entries |
| `git diff --check` | clean |
| autoreview (codex, `gpt-5.6-sol`, high) | `autoreview clean: no accepted/actionable findings reported` |

Vitest note: `src/plugins/plugin-lifecycle-lease.test.ts > reloads install records
after waiting for another process` fails on this host. It is **pre-existing and
unrelated** — verified failing identically on a clean `origin/main` checkout. Its
`waitForPath` helper allows a fixed 2.5s (100 x 25ms) for a child spawned via
`node --import tsx`, which a loaded macOS host exceeds during cold tsx compile. Not
touched here; the timeout is flaky by construction and raising the count would mask
the cold-start cost.

**Swift test hooks.** Two `#if DEBUG` initializers on `ComputerActionService`
(`mouseButtonEventPoster:`, `textGraphemePoster:`) and three raw-primitive test hooks
collapsed into a single `init(screen:)` injection point, so tests that only exercise
coordinate execution now construct `ComputerScreenActionExecutor` directly instead of
reaching through the coordinator. Net effect is one seam instead of five.

**LOC delta** (`git diff --numstat origin/main...HEAD`):

- Production: +882 / -825 = **net +57**
- Tests: +73 / -69 = **net +4**

The +57 is entirely the cost of the second file existing: 6 import lines, the type
declaration, its `perform` entry point, the `checkExecutionAllowed` closure the
coordinator now builds once, and the doc comments this PR was asked to add or correct.
Total Swift lines across the three files went 2,328 -> 2,379 while the largest file
dropped from 1,334 to 598. No new branches, no new logic.
