### PR TITLE
fix(telegram): keep canceled requests health-neutral

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -930,6 +931,54 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
+  it("keeps a late canceled fallback response out of sticky transport health", async () => {
+    const lateResponse = createDeferred<Response>();
+    undiciFetch.mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"));
+    for (let i = 0; i < 4; i += 1) {
+      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    }
+    undiciFetch.mockReturnValueOnce(lateResponse.promise);
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+    const transport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+    const controller = new AbortController();
+    const reason = new Error("telegram fetch canceled after response headers");
+
+    try {
+      await transport.fetch("https://api.telegram.org/botx/sendMessage");
+      for (let i = 0; i < 3; i += 1) {
+        await transport.fetch(`https://api.telegram.org/botx/sendChatAction?healthy=${i}`);
+      }
+
+      const canceled = transport.fetch("https://api.telegram.org/botx/getMe", {
+        signal: controller.signal,
+      });
+      lateResponse.resolve({ ok: true } as Response);
+      controller.abort(reason);
+
+      await expect(canceled).rejects.toBe(reason);
+      await expect(transport.fetch("https://api.telegram.org/botx/getMe?retry=1")).resolves.toEqual(
+        { ok: true },
+      );
+      await expect(transport.fetch("https://api.telegram.org/botx/getMe?probe=1")).resolves.toEqual(
+        { ok: true },
+      );
+
+      const primaryDispatcher = getDispatcherFromUndiciCall(1);
+      const fallbackDispatcher = getDispatcherFromUndiciCall(2);
+      expect(getDispatcherFromUndiciCall(6)).toBe(fallbackDispatcher);
+      expect(getDispatcherFromUndiciCall(7)).toBe(fallbackDispatcher);
+      expect(getDispatcherFromUndiciCall(8)).toBe(primaryDispatcher);
+    } finally {
+      await transport.close();
+    }
+  });
+
   it("escalates from IPv4 fallback to pinned Telegram IP and recovers to primary", async () => {
     undiciFetch
       .mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"))
@@ -1159,6 +1208,42 @@ describe("resolveTelegramFetch", () => {
 
     expect(undiciFetch).toHaveBeenCalledTimes(2);
     expectCallerDispatcherPreserved([1, 2], callerDispatcher);
+  });
+
+  it("lets caller cancellation beat a late retryable dispatcher failure", async () => {
+    const lateFailure = createDeferred<Response>();
+    undiciFetch.mockReturnValueOnce(lateFailure.promise);
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+    const transport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+    const callerDispatcher = { name: "caller" };
+    const controller = new AbortController();
+    const reason = new Error("telegram fetch canceled before retry classification");
+
+    try {
+      const canceled = transport.fetch("https://api.telegram.org/botx/sendMessage", {
+        dispatcher: callerDispatcher,
+        signal: controller.signal,
+      } as RequestInit);
+      lateFailure.reject(buildFetchFallbackError("EHOSTUNREACH"));
+      controller.abort(reason);
+
+      await expect(canceled).rejects.toBe(reason);
+      expect(undiciFetch).toHaveBeenCalledTimes(1);
+
+      await expect(
+        transport.fetch("https://api.telegram.org/botx/sendMessage?retry=1", {
+          dispatcher: callerDispatcher,
+        } as RequestInit),
+      ).resolves.toEqual({ ok: true });
+      expectCallerDispatcherPreserved([1, 2], callerDispatcher);
+    } finally {
+      await transport.close();
+    }
   });
 
   it("does not arm sticky fallback from caller-provided dispatcher failures", async () => {

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -931,53 +931,60 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
-  it("keeps a late canceled fallback response out of sticky transport health", async () => {
-    const lateResponse = createDeferred<Response>();
-    undiciFetch.mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"));
-    for (let i = 0; i < 4; i += 1) {
-      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
-    }
-    undiciFetch.mockReturnValueOnce(lateResponse.promise);
-    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
-    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
-
-    const transport = resolveTelegramTransport(undefined, {
-      network: {
-        autoSelectFamily: true,
-      },
-    });
-    const controller = new AbortController();
-    const reason = new Error("telegram fetch canceled after response headers");
-
-    try {
-      await transport.fetch("https://api.telegram.org/botx/sendMessage");
-      for (let i = 0; i < 3; i += 1) {
-        await transport.fetch(`https://api.telegram.org/botx/sendChatAction?healthy=${i}`);
+  it.each(["init", "request"] as const)(
+    "keeps a late canceled fallback response out of sticky transport health with signal on %s",
+    async (signalSource) => {
+      const lateResponse = createDeferred<Response>();
+      undiciFetch.mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"));
+      for (let i = 0; i < 4; i += 1) {
+        undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
       }
+      undiciFetch.mockReturnValueOnce(lateResponse.promise);
+      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
 
-      const canceled = transport.fetch("https://api.telegram.org/botx/getMe", {
-        signal: controller.signal,
+      const transport = resolveTelegramTransport(undefined, {
+        network: {
+          autoSelectFamily: true,
+        },
       });
-      lateResponse.resolve({ ok: true } as Response);
-      controller.abort(reason);
+      const controller = new AbortController();
+      const reason = new Error("telegram fetch canceled after response headers");
 
-      await expect(canceled).rejects.toBe(reason);
-      await expect(transport.fetch("https://api.telegram.org/botx/getMe?retry=1")).resolves.toEqual(
-        { ok: true },
-      );
-      await expect(transport.fetch("https://api.telegram.org/botx/getMe?probe=1")).resolves.toEqual(
-        { ok: true },
-      );
+      try {
+        await transport.fetch("https://api.telegram.org/botx/sendMessage");
+        for (let i = 0; i < 3; i += 1) {
+          await transport.fetch(`https://api.telegram.org/botx/sendChatAction?healthy=${i}`);
+        }
 
-      const primaryDispatcher = getDispatcherFromUndiciCall(1);
-      const fallbackDispatcher = getDispatcherFromUndiciCall(2);
-      expect(getDispatcherFromUndiciCall(6)).toBe(fallbackDispatcher);
-      expect(getDispatcherFromUndiciCall(7)).toBe(fallbackDispatcher);
-      expect(getDispatcherFromUndiciCall(8)).toBe(primaryDispatcher);
-    } finally {
-      await transport.close();
-    }
-  });
+        const requestUrl = "https://api.telegram.org/botx/getMe";
+        const input =
+          signalSource === "request"
+            ? new Request(requestUrl, { signal: controller.signal })
+            : requestUrl;
+        const init = signalSource === "init" ? { signal: controller.signal } : undefined;
+        const canceled = transport.fetch(input, init);
+        lateResponse.resolve({ ok: true } as Response);
+        controller.abort(reason);
+
+        await expect(canceled).rejects.toBe(reason);
+        await expect(
+          transport.fetch("https://api.telegram.org/botx/getMe?retry=1"),
+        ).resolves.toEqual({ ok: true });
+        await expect(
+          transport.fetch("https://api.telegram.org/botx/getMe?probe=1"),
+        ).resolves.toEqual({ ok: true });
+
+        const primaryDispatcher = getDispatcherFromUndiciCall(1);
+        const fallbackDispatcher = getDispatcherFromUndiciCall(2);
+        expect(getDispatcherFromUndiciCall(6)).toBe(fallbackDispatcher);
+        expect(getDispatcherFromUndiciCall(7)).toBe(fallbackDispatcher);
+        expect(getDispatcherFromUndiciCall(8)).toBe(primaryDispatcher);
+      } finally {
+        await transport.close();
+      }
+    },
+  );
 
   it("escalates from IPv4 fallback to pinned Telegram IP and recovers to primary", async () => {
     undiciFetch
@@ -1210,41 +1217,49 @@ describe("resolveTelegramFetch", () => {
     expectCallerDispatcherPreserved([1, 2], callerDispatcher);
   });
 
-  it("lets caller cancellation beat a late retryable dispatcher failure", async () => {
-    const lateFailure = createDeferred<Response>();
-    undiciFetch.mockReturnValueOnce(lateFailure.promise);
-    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+  it.each(["init", "request"] as const)(
+    "lets caller cancellation beat a late retryable dispatcher failure with signal on %s",
+    async (signalSource) => {
+      const lateFailure = createDeferred<Response>();
+      undiciFetch.mockReturnValueOnce(lateFailure.promise);
+      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
 
-    const transport = resolveTelegramTransport(undefined, {
-      network: {
-        autoSelectFamily: true,
-      },
-    });
-    const callerDispatcher = { name: "caller" };
-    const controller = new AbortController();
-    const reason = new Error("telegram fetch canceled before retry classification");
+      const transport = resolveTelegramTransport(undefined, {
+        network: {
+          autoSelectFamily: true,
+        },
+      });
+      const callerDispatcher = { name: "caller" };
+      const controller = new AbortController();
+      const reason = new Error("telegram fetch canceled before retry classification");
 
-    try {
-      const canceled = transport.fetch("https://api.telegram.org/botx/sendMessage", {
-        dispatcher: callerDispatcher,
-        signal: controller.signal,
-      } as RequestInit);
-      lateFailure.reject(buildFetchFallbackError("EHOSTUNREACH"));
-      controller.abort(reason);
-
-      await expect(canceled).rejects.toBe(reason);
-      expect(undiciFetch).toHaveBeenCalledTimes(1);
-
-      await expect(
-        transport.fetch("https://api.telegram.org/botx/sendMessage?retry=1", {
+      try {
+        const requestUrl = "https://api.telegram.org/botx/sendMessage";
+        const input =
+          signalSource === "request"
+            ? new Request(requestUrl, { signal: controller.signal })
+            : requestUrl;
+        const canceled = transport.fetch(input, {
           dispatcher: callerDispatcher,
-        } as RequestInit),
-      ).resolves.toEqual({ ok: true });
-      expectCallerDispatcherPreserved([1, 2], callerDispatcher);
-    } finally {
-      await transport.close();
-    }
-  });
+          ...(signalSource === "init" ? { signal: controller.signal } : {}),
+        } as RequestInit);
+        lateFailure.reject(buildFetchFallbackError("EHOSTUNREACH"));
+        controller.abort(reason);
+
+        await expect(canceled).rejects.toBe(reason);
+        expect(undiciFetch).toHaveBeenCalledTimes(1);
+
+        await expect(
+          transport.fetch("https://api.telegram.org/botx/sendMessage?retry=1", {
+            dispatcher: callerDispatcher,
+          } as RequestInit),
+        ).resolves.toEqual({ ok: true });
+        expectCallerDispatcherPreserved([1, 2], callerDispatcher);
+      } finally {
+        await transport.close();
+      }
+    },
+  );
 
   it("does not arm sticky fallback from caller-provided dispatcher failures", async () => {
     primeStickyFallbackRetry();

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -728,6 +728,7 @@ export function resolveTelegramTransport(
   };
 
   const resolvedFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
     const callerProvidedDispatcher = Boolean(
       (init as RequestInitWithDispatcher | undefined)?.dispatcher,
     );
@@ -753,7 +754,7 @@ export function resolveTelegramTransport(
     if (callerProvidedDispatcher) {
       try {
         const response = await sourceFetch(input, init);
-        init?.signal?.throwIfAborted();
+        signal?.throwIfAborted();
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -765,12 +766,12 @@ export function resolveTelegramTransport(
         });
         return response;
       } catch (caught) {
-        init?.signal?.throwIfAborted();
+        signal?.throwIfAborted();
         if (!shouldUseTelegramTransportFallback(caught)) {
           throw caught;
         }
         const response = await sourceFetch(input, init ?? {});
-        init?.signal?.throwIfAborted();
+        signal?.throwIfAborted();
         return response;
       }
     }
@@ -797,7 +798,7 @@ export function resolveTelegramTransport(
           input,
           withDispatcherIfMissing(init, attempt.createDispatcher()),
         );
-        init?.signal?.throwIfAborted();
+        signal?.throwIfAborted();
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -813,7 +814,7 @@ export function resolveTelegramTransport(
         recordSuccessfulAttempt(attemptIndex);
         return response;
       } catch (caught) {
-        init?.signal?.throwIfAborted();
+        signal?.throwIfAborted();
         err = caught;
         if (!shouldUseTelegramTransportFallback(err)) {
           throw err;

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -368,6 +368,12 @@ function resolveWrappedFetch(fetchImpl: typeof fetch): typeof fetch {
   return resolveFetch(fetchImpl) ?? fetchImpl;
 }
 
+function throwIfTelegramFetchAborted(signal: AbortSignal | null | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Telegram fetch aborted");
+  }
+}
+
 function logResolverNetworkDecisions(params: {
   autoSelectDecision: ReturnType<typeof resolveTelegramAutoSelectFamilyDecision>;
   dnsDecision: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
@@ -753,6 +759,7 @@ export function resolveTelegramTransport(
     if (callerProvidedDispatcher) {
       try {
         const response = await sourceFetch(input, init);
+        throwIfTelegramFetchAborted(init?.signal);
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -764,10 +771,13 @@ export function resolveTelegramTransport(
         });
         return response;
       } catch (caught) {
+        throwIfTelegramFetchAborted(init?.signal);
         if (!shouldUseTelegramTransportFallback(caught)) {
           throw caught;
         }
-        return sourceFetch(input, init ?? {});
+        const response = await sourceFetch(input, init ?? {});
+        throwIfTelegramFetchAborted(init?.signal);
+        return response;
       }
     }
 
@@ -793,6 +803,7 @@ export function resolveTelegramTransport(
           input,
           withDispatcherIfMissing(init, attempt.createDispatcher()),
         );
+        throwIfTelegramFetchAborted(init?.signal);
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -808,6 +819,7 @@ export function resolveTelegramTransport(
         recordSuccessfulAttempt(attemptIndex);
         return response;
       } catch (caught) {
+        throwIfTelegramFetchAborted(init?.signal);
         err = caught;
         if (!shouldUseTelegramTransportFallback(err)) {
           throw err;

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -368,12 +368,6 @@ function resolveWrappedFetch(fetchImpl: typeof fetch): typeof fetch {
   return resolveFetch(fetchImpl) ?? fetchImpl;
 }
 
-function throwIfTelegramFetchAborted(signal: AbortSignal | null | undefined): void {
-  if (signal?.aborted) {
-    throw signal.reason ?? new Error("Telegram fetch aborted");
-  }
-}
-
 function logResolverNetworkDecisions(params: {
   autoSelectDecision: ReturnType<typeof resolveTelegramAutoSelectFamilyDecision>;
   dnsDecision: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
@@ -759,7 +753,7 @@ export function resolveTelegramTransport(
     if (callerProvidedDispatcher) {
       try {
         const response = await sourceFetch(input, init);
-        throwIfTelegramFetchAborted(init?.signal);
+        init?.signal?.throwIfAborted();
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -771,12 +765,12 @@ export function resolveTelegramTransport(
         });
         return response;
       } catch (caught) {
-        throwIfTelegramFetchAborted(init?.signal);
+        init?.signal?.throwIfAborted();
         if (!shouldUseTelegramTransportFallback(caught)) {
           throw caught;
         }
         const response = await sourceFetch(input, init ?? {});
-        throwIfTelegramFetchAborted(init?.signal);
+        init?.signal?.throwIfAborted();
         return response;
       }
     }
@@ -803,7 +797,7 @@ export function resolveTelegramTransport(
           input,
           withDispatcherIfMissing(init, attempt.createDispatcher()),
         );
-        throwIfTelegramFetchAborted(init?.signal);
+        init?.signal?.throwIfAborted();
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -819,7 +813,7 @@ export function resolveTelegramTransport(
         recordSuccessfulAttempt(attemptIndex);
         return response;
       } catch (caught) {
-        throwIfTelegramFetchAborted(init?.signal);
+        init?.signal?.throwIfAborted();
         err = caught;
         if (!shouldUseTelegramTransportFallback(err)) {
           throw err;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a canceled Telegram request could still be treated as successful or retryable when Undici fulfilled or rejected its fetch after the caller had already aborted. That could publish a canceled response, mutate transport health, advance sticky recovery, or perform an extra fallback retry.

## Why This Change Was Made

Telegram's transport now derives the effective signal from either `init.signal` or a `Request` input, then applies native `AbortSignal.throwIfAborted()` immediately after every source-fetch await and before response capture, health mutation, retry classification, or return in both owned-dispatcher and caller-dispatcher paths. The caller's exact abort reason wins, canceled work stays health-neutral, and the next identical request uses the unchanged healthy transport state.

This is the transport owner's canonical boundary: no downstream guard, alternate retry path, compatibility shim, config change, release, or deployment is included.

## User Impact

Canceling Telegram work can no longer leak a late success or failure into request delivery or transport recovery. Operators should see no extra retry and no degraded transport selection on the next healthy request.

## Evidence

- Regression provenance: the original authentic pre-fix replay produced 2 failures / 44 passes. After ClawSweeper identified the supported `Request.signal` form, the table-driven regression produced 2 failures / 46 passes on the prior PR code. The repaired owner suite now passes 48 / 48 across both signal locations.
- Local proof: source-blind Undici process proof passed; the full changed gate, extension and test types, lint, formatting, database-first guard, dead-code scan, runtime loaders, import cycles, and `git diff --check` passed. The remote changed-gate backend was unavailable, so trusted-source checks completed locally. A fresh structured autoreview on the final repair reported no accepted/actionable findings.
- Exact-candidate build: `pnpm build` passed for final candidate `96402768ecdc7130fa16f8ba13b620623630cf21`; the exact production and test blob IDs are `e0d782362631d52758b90e6217dea056777b15b7` and `17fbf24213a53fe7a2a8ead7acf60ce7a2f0cf52`.
- Live Telegram proof: the exact built candidate ran a task-owned Gateway on isolated port `59703` with copied state/config and channel autostart suppressed. The copied config resolved the existing personal Telegram credential through OpenClaw's normal resolver. Two sequential authenticated, read-only `getMe` calls through the exact Telegram runtime were healthy in 512 ms and 454 ms; bot ID, `is_bot`, username, and first-name fields were present, with values redacted. No message, polling, webhook mutation, or uncertain write occurred. The Gateway stopped cleanly, the port was free, and the copied credential/state root was permanently removed.
- LOC: production `+8/-1` (net `+7`); tests `+100/-0`. The production growth is the single effective-signal owner plus the minimum post-await fences needed across owned and caller-dispatcher continuations; it uses the native signal API and adds no parallel abstraction or policy.
- Test audit: two table-driven regressions protect observable cancellation precedence, retry count, transport-health neutrality, and next-request dispatcher behavior across `init.signal` and `Request.signal`; the new Request rows fail on the prior PR code for the intended race and require no test-only production seam.
- Duplicate search: Gitcrawl (fresh through 2026-08-16 12:33 UTC) plus live issue/PR title/body searches found no matching report or repair. Closed #89954 concerns polling 409 rebuilds; closed #114880 concerns post-adoption tool cancellation, so neither shares this invariant.
- AI-assisted: yes; the final change was directly reviewed and independently autoreviewed.
