### PR TITLE
fix(zalo): report failed HTTP probes as unhealthy

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -4,7 +4,10 @@
  */
 
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { ZALO_DEFAULT_REQUEST_TIMEOUT_MS, ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS } from "./timeouts.js";
 
@@ -155,6 +158,7 @@ export async function callZaloApi<T = unknown>(
       signal: controller.signal,
     });
 
+    await assertOkOrThrowProviderError(response, `zalo.${method}`);
     const data = await readProviderJsonResponse<ZaloApiResponse<T>>(response, `zalo.${method}`);
 
     if (!data.ok) {

--- a/extensions/zalo/src/probe.test.ts
+++ b/extensions/zalo/src/probe.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import type { ZaloFetch } from "./api.js";
 import { probeZalo } from "./probe.js";
@@ -29,6 +30,53 @@ describe("probeZalo", () => {
       error: "invalid token",
       elapsedMs: expect.any(Number),
     });
+  });
+
+  it("rejects a non-ok HTTP response with a success-shaped body", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: "controlled-bot",
+            account_name: "Controlled Bot",
+            account_type: "BOT",
+            can_join_groups: false,
+          },
+        }),
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback Zalo API address");
+    }
+    const originalApiUrl = process.env.ZALO_API_URL;
+    process.env.ZALO_API_URL = `http://127.0.0.1:${String(address.port)}`;
+
+    try {
+      await expect(probeZalo("controlled-token", 1000)).resolves.toMatchObject({
+        ok: false,
+        error: expect.stringContaining("zalo.getMe (401)"),
+      });
+    } finally {
+      if (originalApiUrl === undefined) {
+        delete process.env.ZALO_API_URL;
+      } else {
+        process.env.ZALO_API_URL = originalApiUrl;
+      }
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("preserves timeout errors", async () => {


### PR DESCRIPTION
<!-- No linked issue; focused maintainer-authorized Auto QA bug repair. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where Zalo account probes could report a channel as working when the Bot API returned a failed HTTP status carrying success-shaped JSON. That false-positive status could flow through Gateway status and the human CLI as `works` even though the transport request failed.

## Why This Change Was Made

The shared Zalo API owner now rejects non-2xx responses through the canonical Plugin SDK provider-error helper before parsing success data. This covers every Zalo API operation at the common boundary while preserving the existing body-level error handling for 2xx responses.

## User Impact

Operators now see a failed Zalo probe when the provider transport returns a non-2xx response, rather than a misleading healthy status. Normal successful responses and Zalo's 2xx body-error contract are unchanged.

## Evidence

- **Live public Zalo control:** the exact rebased candidate made one read-only, bodyless `POST getMe` call to the real public Zalo Bot API with a clearly synthetic invalid token. Zalo returned its actual invalid-token contract—HTTP 200 with body-level `Not Found`—and the existing body-error path returned `probe.ok=false`. The error was bounded to 9 characters, contained no token, the response body was consumed, and the request timer was cleared. No credential, message/send operation, or persistent mutation was involved.
- **Controlled non-2xx regression:** a real loopback HTTP server returned HTTP 401 with deliberately success-shaped JSON (`ok:true` plus bot identity). Before the repair, the probe returned `ok:true` and the human projection rendered `works`; on this head, the shared API owner rejects it and the probe reports `ok:false` with `zalo.getMe (401)`. The server closes connections and awaits shutdown.
- **Owner and projection coverage:** 62 focused tests passed; Gateway status and human CLI projection added 36 passing checks; the real plugin/Gateway/manual source-blind projection passed twice.
- **Static and review gates:** formatting, lint, types, import cycles, and focused diff checks passed. Fresh autoreview reported no accepted/actionable findings. The broader changed gate reached only a missing `playwright-core` worktree dependency; all relevant lanes were green.
- **Exact head:** `701776ca2c60828ac9049a61b8b7e56bfaa45a30`. Rebase onto local `origin/main` changed the commit identity but left both patch blobs byte-identical.
- **LOC:** production `+5/-1` (net `+4`); tests `+48/-0`.

## ClawSweeper Rank-up Moves

- **Current-main refresh:** accepted on the existing exact head. GitHub reports the PR mergeable against current `main`, and exact-head hosted CI run `31949697657` is green. Repository landing policy treats behind-main drift as advisory when there is no conflict; lead review explicitly authorized preserving exact candidate `701776ca2c60828ac9049a61b8b7e56bfaa45a30`, so no drift-only rebase is warranted. Native prepare will validate the current merge result.
- **Production growth:** accepted. The net +4 production lines put the HTTP-status decision in the shared Zalo API owner. Moving it into the generic JSON reader would improperly broaden that helper, while a probe-only guard would leave sibling Zalo operations inconsistent.
- **Maintainer handling:** no repair lane is needed. Proceeding through native review artifacts, Testbox prepare, and native merge on the reviewed head.
- **Stored-data note:** ClawSweeper's serialized-state detector matched JSON inside `probe.test.ts`; this PR changes no persistence, schema, migration, config, or stored data model.
