### PR TITLE
perf(cli): skip plugin preflight for audit

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -218,6 +218,15 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     route: { id: "health" },
   },
   {
+    commandPath: ["audit"],
+    policy: {
+      configGuard: "skip",
+      loadPlugins: "never",
+      ensureCliPath: false,
+      networkProxy: "bypass",
+    },
+  },
+  {
     commandPath: ["gateway"],
     policy: {
       networkProxy: ({ commandPath }) =>

--- a/src/cli/program/preaction.test-helpers.ts
+++ b/src/cli/program/preaction.test-helpers.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 export const COLD_READ_COMMAND_PATHS: string[][] = [
+  ["audit"],
   ["skills", "info"],
   ["skills", "search"],
   ["hooks"],
@@ -11,6 +12,10 @@ export const COLD_READ_COMMAND_PATHS: string[][] = [
 ];
 
 export function registerColdReadCommandFixtures(program: Command, skills: Command): void {
+  program
+    .command("audit")
+    .option("--json")
+    .action(() => {});
   for (const skillCommand of ["info", "search"]) {
     skills
       .command(skillCommand)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw audit` evaluated configured plugin doctor modules before making its read-only Gateway RPC. After #124562 removed plugin CLI evaluation from root help, `audit --limit 5` still took a reported 9,503 ms median on a configured profile even though routed/cold-policy commands were near 1,300 ms.

The trigger was not plugin CLI registration. `audit` is a known core command, so runtime plugin registrars were already skipped. It had no command-catalog startup policy, however, and therefore inherited the generic config guard. The resulting chain was:

`run-main.ts` → Commander pre-action → `command-bootstrap.ts` → `config-guard.ts` → `doctor-config-preflight.ts` → plugin doctor legacy/state migration discovery → `doctor-contract-registry.ts` → `plugin-module-loader-cache.ts` → Jiti.

## Why This Change Was Made

The core command catalog now marks `audit` as a cold read: skip the observing/migrating config guard, never preload plugins, skip CLI PATH setup, and bypass the operator network proxy for the loopback Gateway read.

This deliberately keeps the existing Commander registration and action instead of adding a second parser for eleven audit options. `cron list --json` demonstrates that route-first dispatch is not required to reach the cold-command floor: a catalog policy plus lazy builtin registration is sufficient. Manifest `cliCommands` from #124562 remains the canonical owner signal for plugin roots, while `audit` continues to resolve from the core descriptor catalog. Plugin-owned command selection and execution are unchanged.

AI-assisted: implemented and reviewed with Codex; the trace, tests, runtime behavior, and benchmark were inspected directly.

## User Impact

`openclaw audit` reaches the Gateway without evaluating unrelated plugin modules or running local state migrations. Argument parsing, output, errors, and exit codes remain owned by the same Commander command and `auditListCommand` action.

## Evidence

Reported post-#124562 profile that motivated this follow-up:

| Command | Median |
| --- | ---: |
| `audit --limit 5` | 9,503 ms |
| `status` | 6,540 ms |
| `--help` | 2,213 ms |
| `skills list` | 1,664 ms |
| `plugins list` | 1,531 ms |
| `tasks list --json` | ~1,300 ms |

Same Blacksmith Testbox `tbx_01m05a77hrfphsnsnbatp0x15e`, Node 24.19.0, built `dist`, same isolated state/profile, scratch Gateway on port 19847, `OPENCLAW_SKIP_CHANNELS=1`, three measured cold processes per cell. The profile allowlisted 149 bundled plugins and explicitly configured 38 doctor-contract owners. Before was `4e652f9fac92ac7a7e83787a3bc7a44c8c720e43`; after used the patch-identical working tree later committed as `079f7ead72752c3db4398a1f90c2707fb6d6b102`.

| Command | Classification | Before samples, ms | Before median | After samples, ms | After median |
| --- | --- | ---: | ---: | ---: | ---: |
| `audit --limit 5` | Full Commander, now cold policy | 1779 / 1591 / 1592 | 1592 | 1162 / 460 / 448 | 460 |
| `health --json` | Routed | 940 / 929 / 961 | 940 | 942 / 944 / 924 | 942 |
| `models list --json` | Routed | 1474 / 1471 / 1376 | 1471 | 1402 / 1399 / 1491 | 1402 |
| `sessions list --json` | Full Commander; sessions exclude migration preflight | 1142 / 1153 / 1140 | 1142 | 1137 / 1137 / 1130 | 1137 |
| `logs --limit 5 --json` | Full Commander; logs skip migrations and plugin validation | 837 / 827 / 834 | 834 | 836 / 830 / 821 | 830 |
| `doctor --json` | Full Commander; plugin-aware work is intentional | 9485 / 8857 / 8854 | 8857 | 8752 / 8671 / 8717 | 8717 |
| `status` | Routed; overview scan is real work | 2412 / 2453 / 2428 | 2428 | 2431 / 2474 / 2459 | 2459 |
| `tasks list --json` | Routed | 576 / 599 / 577 | 577 | 565 / 579 / 571 | 571 |
| `cron list --json` | Full Commander, cold parent policy | 512 / 504 / 513 | 512 | 511 / 490 / 481 | 490 |
| `channels status --json` | Routed | 398 / 389 / 375 | 389 | 385 / 391 / 375 | 385 |
| `memory status --json` | Plugin-owned execution | 3139 / 3142 / 3176 | 3142 | 3113 / 3125 / 3121 | 3121 |

All 66 measured command executions exited 0. `audit` output was byte-identical before/after. The plugin-owned `memory status --json` output was also byte-identical, proving the first real plugin command still loads and runs normally rather than paying the optimization elsewhere.

Regression provenance: the audit CLI landed in #98704 (`f53346944db`, July 6, 2026) with invalid-config allowance but no cold startup policy. The later cold-read policy infrastructure did not include `audit`; #124562 addressed root-help/plugin-CLI ownership, not this pre-action guard.

Validation:

- Pre-fix regression: `node scripts/run-vitest.mjs src/cli/program/preaction.test.ts` failed because `audit` called the injected `ensureConfigReady` spy once. Post-fix it calls neither config readiness nor the plugin registry loader.
- `node scripts/run-vitest.mjs src/cli/program/preaction.test.ts src/cli/command-startup-policy.test.ts src/cli/command-path-policy.test.ts src/plugins/cli.test.ts src/commands/audit.test.ts src/cli/cold-command-plugin-imports.process.test.ts`: 156 tests passed after rebase.
- Existing plugin execution regression scopes loading to the selected `memory-core` owner, registers `memory`, parses `memory list`, and confirms the action runs.
- `node scripts/check-changed.mjs`: passed core/test typechecks, lint, formatting, dead code, import cycles, database-first, plugin-boundary, and repository guard lanes on Testbox `tbx_01m05b5794z381s88yee821gxy` ([run](https://github.com/openclaw/openclaw/actions/runs/31949104312)).
- Exact-head `pnpm build`: passed on Testbox `tbx_01m05bs51d0p65jfdz7f78sft9` ([run](https://github.com/openclaw/openclaw/actions/runs/31949616428)); CLI bootstrap guard passed and the log contained no `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings (`patch is correct`, confidence 0.99).

LOC: production +9/-0; tests +5/-0. No descriptors, plugin metadata, persistence, compatibility path, or runtime branch were added.
