### PR TITLE
fix(auto-reply): preserve complete startup memory after short reads

### DIFF
--- a/src/auto-reply/reply/startup-context.test.ts
+++ b/src/auto-reply/reply/startup-context.test.ts
@@ -50,6 +50,35 @@ describe("buildSessionStartupContextPrelude", () => {
     expect(prelude).toContain("yesterday notes");
   });
 
+  it("loads the complete bounded daily memory after positive short reads", async () => {
+    const workspaceDir = await makeWorkspace();
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-11.md"),
+      "alpha beta gamma delta",
+      "utf-8",
+    );
+    const originalRead = fsCore.read.bind(fsCore);
+    vi.spyOn(fsCore, "read").mockImplementation(((...args: unknown[]) => {
+      args[3] = Math.min(args[3] as number, 5);
+      (originalRead as (...forwarded: unknown[]) => void)(...args);
+    }) as typeof fsCore.read);
+
+    const prelude = await buildSessionStartupContextPrelude({
+      workspaceDir,
+      cfg: {
+        agents: {
+          defaults: {
+            userTimezone: "UTC",
+            startupContext: { dailyMemoryDays: 1 },
+          },
+        },
+      } as OpenClawConfig,
+      nowMs: Date.UTC(2026, 3, 11, 18, 0, 0),
+    });
+
+    expect(prelude).toContain("alpha beta gamma delta");
+  });
+
   it("loads date-prefixed session-memory artifacts saved with friendly suffixes", async () => {
     const workspaceDir = await makeWorkspace();
     await fs.writeFile(

--- a/src/auto-reply/reply/startup-context.ts
+++ b/src/auto-reply/reply/startup-context.ts
@@ -6,7 +6,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatDateStamp, resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { openRootFile } from "../../infra/boundary-file-read.js";
+import { openRootFile, readFileDescriptorBounded } from "../../infra/boundary-file-read.js";
 
 const STARTUP_MEMORY_FILE_MAX_BYTES = 16_384;
 const STARTUP_MEMORY_FILE_MAX_CHARS = 1_200;
@@ -153,20 +153,6 @@ function fitStartupMemoryBlock(params: {
   return best;
 }
 
-async function readFromFd(params: { fd: number; maxFileBytes: number }): Promise<string> {
-  const buf = Buffer.alloc(params.maxFileBytes);
-  const bytesRead = await new Promise<number>((resolve, reject) => {
-    fs.read(params.fd, buf, 0, params.maxFileBytes, 0, (error, read) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve(read);
-    });
-  });
-  return buf.subarray(0, bytesRead).toString("utf-8");
-}
-
 async function closeFd(fd: number): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     fs.close(fd, (error) => {
@@ -195,7 +181,7 @@ async function readStartupMemoryFile(params: {
     return null;
   }
   try {
-    return await readFromFd({ fd: opened.fd, maxFileBytes: params.maxFileBytes });
+    return (await readFileDescriptorBounded(opened.fd, params.maxFileBytes)).toString("utf-8");
   } finally {
     await closeFd(opened.fd);
   }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users starting a new or reset session could receive silently incomplete daily-memory context when the operating system completed a file read with a positive short byte count. In the fault-injected reproduction, a 23-byte daily-memory file returned 5 bytes and the remaining 18 bytes were incorrectly treated as if they were past EOF.

## Why This Change Was Made

Startup context now uses the existing bounded descriptor reader, which continues reading the already root-pinned descriptor until EOF and preserves the existing overflow contract. This deletes the local one-read helper while retaining the 16 KiB byte cap, descriptor cleanup, UTF-8 decoding, and 1,200-character prompt projection.

## User Impact

New and reset sessions now receive the complete bounded daily-memory content even when the filesystem returns a legal positive short read, instead of silently losing the unread suffix.

## Evidence

- Authentic pre-fix fault injection capped each successful `fs.read` at 5 bytes: 5/23 bytes appeared in startup context and 18/23 were silently omitted.
- The original candidate passed 31/31 focused startup and sibling tests, plus lint, production/test types, import cycles, formatting, and diff checks.
- The rebased exact head passed 20/20 cases in `src/auto-reply/reply/startup-context.test.ts`; the regression asserts the complete `alpha beta gamma delta` content across repeated 5-byte reads.
- Direct inspection of pinned `@openclaw/fs-safe` 0.5.5 confirms that `readFileDescriptorBounded` loops until a zero-byte EOF, advances the descriptor offset between reads, reads at most the cap plus one byte for overflow detection, and leaves descriptor cleanup to the caller.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/31949869160 completed successfully for `6185f91b5e0006e588c8cfe1a9a3f5dd94002022`.
- Final formatting and `git diff --check` passed on the two changed files.
- Final structured autoreview reported no accepted/actionable findings and rated the patch correct at 0.99.
- Production is +2/-16 (net -14); tests are +29/-0. The change replaces duplicate policy with the canonical owner.
- A source-blind operator reproduction is not available because startup context exposes no supported surface for forcing kernel-level partial reads. The fault-injected owner-boundary regression exercises the real `fs.read` callback behavior instead.

