### PR TITLE
fix: keep Codex delegation when image generation is denied

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -56,11 +56,13 @@ does not set this flag.
 Harnesses with an independently managed native surface can also declare
 `conversationToolPolicySafeDenyTools` using canonical OpenClaw tool names. Core
 preserves the native surface only when every expanded deny is a known core tool
-in that audited safe list. Finite allowlists, undeclared or unknown tool names,
-wildcards, and groups containing any undeclared name remain native-surface
-restrictions. Omit the list to retain the conservative behavior where every
-explicit restriction isolates the native surface. Because omissions fail
-closed, new tools cannot silently relax the policy boundary.
+in that audited safe list and passes the matching names in
+`params.pluginHarnessToolPolicySafeDeniedTools`. The harness must disable any
+native equivalents for those names. Finite allowlists, undeclared or unknown
+tool names, wildcards, and groups containing any undeclared name remain
+native-surface restrictions. Omit the list to retain the conservative behavior
+where every explicit restriction isolates the native surface. Because omissions
+fail closed, new tools cannot silently relax the policy boundary.
 
 Omit the declaration when any native capability can bypass those layers.
 OpenClaw then visibly rejects explicitly restricted turns before invoking the

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -35,6 +35,7 @@ describe("Codex agent harness supports()", () => {
   });
 
   it("keeps computer-control denies out of the native-surface exemption", () => {
+    expect(harness.conversationToolPolicySafeDenyTools).toContain("image_generate");
     expect(harness.conversationToolPolicySafeDenyTools).not.toEqual(
       expect.arrayContaining(["browser", "computer", "mobile_ui", "nodes", "screen"]),
     );

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -18,8 +18,8 @@ import type { CodexSessionCatalogControlFactory } from "./src/session-catalog-ty
 const DEFAULT_CODEX_HARNESS_PROVIDER_IDS = new Set(["codex", "openai"]);
 const SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER = Symbol.for("openclaw.codexAppServerClientDisposer");
 // Audited against @openai/codex 0.147.0 (rust-v0.147.0). These exact denies
-// target OpenClaw-owned capabilities with no Codex-native equivalent. Keep the
-// list positive and conservative: an omitted tool isolates the native surface.
+// either have no Codex-native equivalent or are enforced by the harness. Keep
+// the list positive and conservative: an omitted tool isolates the native surface.
 const CODEX_TOOL_POLICY_SAFE_DENY_NAMES = [
   "web_fetch",
   "x_search",
@@ -33,6 +33,7 @@ const CODEX_TOOL_POLICY_SAFE_DENY_NAMES = [
   "automations",
   "gateway",
   "skill_workshop",
+  "image_generate",
   "music_generate",
   "video_generate",
   "tts",

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -46,7 +46,7 @@ import {
 } from "./shared-client.js";
 import { buildCodexRuntimeThreadConfig } from "./thread-lifecycle.js";
 import {
-  assertCodexRestrictedToolSurfaceHasNoManagedHooks,
+  assertCodexManagedRequirementsDoNotOverrideToolPolicy,
   attestCodexRestrictedToolSurfaceMcpServersDisabled,
   buildCodexRingZeroThreadConfigPatch,
   readCodexInheritedMcpServerNames,
@@ -250,7 +250,11 @@ async function runBoundedCodexAppServerTurnInWorkspace(
       ? await readCodexInheritedMcpServerNames(client, workspace.cwd, abortController.signal)
       : [];
     if (params.requireNoExternalCapabilities) {
-      await assertCodexRestrictedToolSurfaceHasNoManagedHooks(client, abortController.signal);
+      await assertCodexManagedRequirementsDoNotOverrideToolPolicy(
+        client,
+        { restrictedToolSurface: true },
+        abortController.signal,
+      );
     }
     const threadConfig = buildCodexRuntimeThreadConfig(
       resolveBoundedThreadConfig(params, workspace, inheritedMcpServerNames),

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -24,7 +24,7 @@ import {
 import { createCodexThreadLifecycleTimingTracker } from "./thread-lifecycle-timing.js";
 import type { CodexStartOrResumeThreadParams } from "./thread-lifecycle-types.js";
 import {
-  assertCodexRestrictedToolSurfaceHasNoManagedHooks,
+  assertCodexManagedRequirementsDoNotOverrideToolPolicy,
   buildCodexRingZeroThreadConfigPatch,
   CODEX_RING_ZERO_BASE_INSTRUCTIONS,
   readCodexInheritedMcpServerNames,
@@ -107,6 +107,8 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
     ringZeroActive ||
     messageOnlySourceReply ||
     params.params.pluginHarnessToolPolicyRestricted === true;
+  const imageGenerationDenied =
+    params.params.pluginHarnessToolPolicySafeDeniedTools?.includes("image_generate") === true;
   if (restrictedToolSurface && params.nativeCodeModeEnabled !== false) {
     throw new Error("Codex restricted tool surfaces require native code mode to be disabled");
   }
@@ -115,9 +117,16 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
         readCodexInheritedMcpServerNames(params.client, params.cwd, params.signal),
       )
     : [];
-  if (restrictedToolSurface) {
-    await lifecycleTiming.measure("restricted-tool-surface-config-requirements-read", () =>
-      assertCodexRestrictedToolSurfaceHasNoManagedHooks(params.client, params.signal),
+  if (restrictedToolSurface || imageGenerationDenied) {
+    await lifecycleTiming.measure("tool-policy-config-requirements-read", () =>
+      assertCodexManagedRequirementsDoNotOverrideToolPolicy(
+        params.client,
+        {
+          restrictedToolSurface,
+          additionalDeniedFeatures: imageGenerationDenied ? ["image_generation"] : undefined,
+        },
+        params.signal,
+      ),
     );
   }
   const ringZeroConfigFingerprint = ringZeroActive

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -413,7 +413,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const sessionFile = path.join(tempDir, "warm-image-deny-session.jsonl");
     const workspaceDir = path.join(tempDir, "warm-image-deny-workspace");
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const request = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "configRequirements/read") {
         return { requirements: null };
       }

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -409,6 +409,66 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
   });
 
+  it("cold-resumes a warm thread when final config adds an image-generation deny", async () => {
+    const sessionFile = path.join(tempDir, "warm-image-deny-session.jsonl");
+    const workspaceDir = path.join(tempDir, "warm-image-deny-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const request = vi.fn(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return { requirements: null };
+      }
+      if (method === "thread/start" || method === "thread/resume") {
+        return threadStartResult("thread-warm-image-deny");
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const client = {
+      getInstanceId: () => "client-warm-image-deny",
+      request,
+      addNotificationHandler: () => () => undefined,
+      addRequestHandler: () => () => undefined,
+      addCloseHandler: () => () => undefined,
+    } as never;
+    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const common = {
+      client,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      userMcpServersEnabled: false,
+    };
+
+    const started = await startOrResumeThread(common);
+    await expect(
+      retainCodexAppServerLiveThread(
+        client,
+        started.threadId,
+        undefined,
+        started.liveThreadConfigFingerprint,
+      ),
+    ).resolves.toBe(true);
+    params.pluginHarnessToolPolicySafeDeniedTools = ["image_generate"];
+    const resumed = await startOrResumeThread(common);
+
+    expect(resumed).toMatchObject({
+      threadId: "thread-warm-image-deny",
+      lifecycle: { action: "resumed" },
+    });
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "configRequirements/read",
+      "thread/unsubscribe",
+      "thread/resume",
+    ]);
+    expect(request.mock.calls.find(([method]) => method === "thread/resume")?.[1]).toMatchObject({
+      config: { "features.image_generation": false },
+    });
+  });
+
   it("keeps a warm native session across sticky environment selection changes", async () => {
     const sessionFile = path.join(tempDir, "environment-session.jsonl");
     const workspaceDir = path.join(tempDir, "environment-workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1711,6 +1711,34 @@ describe("Codex app-server thread lifecycle bindings", () => {
     ]);
   });
 
+  it("fails closed when requirements pin denied image generation on", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.pluginHarnessToolPolicySafeDeniedTools = ["image_generate"];
+    const request = vi.fn(async (method: string) => {
+      if (method === "config/read") {
+        return { config: {}, layers: [] };
+      }
+      if (method === "configRequirements/read") {
+        return { requirements: { featureRequirements: { image_generation: true } } };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+      }),
+    ).rejects.toThrow("cannot override required feature image_generation");
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["configRequirements/read"]);
+  });
+
   it.each([
     "apps",
     "artifact",

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -237,6 +237,36 @@ describe("Codex delegation capability", () => {
     }
   });
 
+  it("disables only native image generation for an audited image_generate deny", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.pluginHarnessToolPolicySafeDeniedTools = ["image_generate"];
+    const appServer = createAppServerOptions() as never;
+    const config = {
+      "features.image_generation": true,
+      "features.multi_agent": true,
+      "features.multi_agent_v2": true,
+    };
+    const start = buildThreadStartParams(params, {
+      appServer,
+      cwd: "/repo",
+      dynamicTools: [],
+      config,
+    });
+    const resume = buildThreadResumeParams(params, {
+      appServer,
+      dynamicTools: [],
+      threadId: "thread-1",
+      config,
+    });
+
+    for (const request of [start, resume]) {
+      expect(request.config?.["features.image_generation"]).toBe(false);
+      expect(request.config?.["features.multi_agent"]).toBe(true);
+      expect(request.config?.["features.multi_agent_v2"]).toBe(true);
+      expect(request.config?.["agents.enabled"]).toBeUndefined();
+    }
+  });
+
   it("keeps message-only completion threads and prompts free of native delegation", () => {
     const params = createAttemptParams({ provider: "openai" });
     params.toolsAllow = ["message"];

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -426,6 +426,9 @@ export function buildCodexRuntimeThreadConfigForRun(
     mergeCodexThreadConfigs(
       baseConfig,
       options.appServer?.networkProxy?.configPatch,
+      params.pluginHarnessToolPolicySafeDeniedTools?.includes("image_generate")
+        ? { "features.image_generation": false }
+        : undefined,
       shouldDisableCodexToolSearchForModel(params.modelId)
         ? CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG
         : undefined,
@@ -524,8 +527,12 @@ export async function readCodexInheritedMcpServerNames(
   return Object.keys(configuredServers).toSorted();
 }
 
-export async function assertCodexRestrictedToolSurfaceHasNoManagedHooks(
+export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
   client: Pick<CodexAppServerClient, "request">,
+  options: {
+    restrictedToolSurface: boolean;
+    additionalDeniedFeatures?: readonly string[];
+  },
   signal?: AbortSignal,
 ): Promise<void> {
   const response: CodexConfigRequirementsReadResponse = await client.request(
@@ -542,18 +549,21 @@ export async function assertCodexRestrictedToolSurfaceHasNoManagedHooks(
   if (!isJsonObject(response.requirements)) {
     throw new Error("Codex configRequirements/read returned invalid requirements");
   }
-  for (const key of ["hooks", "managedHooks", "managed_hooks"] as const) {
-    const hooks = response.requirements[key];
-    if (hooks === undefined || hooks === null) {
-      continue;
-    }
-    if (!isJsonObject(hooks)) {
-      throw new Error("Codex configRequirements/read returned invalid managed hooks");
-    }
-    if (hasNonEmptyJsonValue(hooks)) {
-      throw new Error("Codex restricted tool surface cannot override managed hooks");
+  if (options.restrictedToolSurface) {
+    for (const key of ["hooks", "managedHooks", "managed_hooks"] as const) {
+      const hooks = response.requirements[key];
+      if (hooks === undefined || hooks === null) {
+        continue;
+      }
+      if (!isJsonObject(hooks)) {
+        throw new Error("Codex configRequirements/read returned invalid managed hooks");
+      }
+      if (hasNonEmptyJsonValue(hooks)) {
+        throw new Error("Codex restricted tool surface cannot override managed hooks");
+      }
     }
   }
+  const additionalDeniedFeatures = new Set(options.additionalDeniedFeatures);
   for (const key of ["featureRequirements", "feature_requirements"] as const) {
     const requirements = response.requirements[key];
     if (requirements === undefined || requirements === null) {
@@ -567,10 +577,12 @@ export async function assertCodexRestrictedToolSurfaceHasNoManagedHooks(
         throw new Error("Codex configRequirements/read returned invalid feature requirements");
       }
       const canonicalFeature = CODEX_RING_ZERO_RESTRICTED_FEATURE_ALIASES.get(feature) ?? feature;
-      if (enabled && CODEX_RING_ZERO_RESTRICTED_FEATURES.has(canonicalFeature)) {
-        throw new Error(
-          `Codex restricted tool surface cannot override required feature ${feature}`,
-        );
+      const deniedByToolPolicy =
+        (options.restrictedToolSurface &&
+          CODEX_RING_ZERO_RESTRICTED_FEATURES.has(canonicalFeature)) ||
+        additionalDeniedFeatures.has(canonicalFeature);
+      if (enabled && deniedByToolPolicy) {
+        throw new Error(`Codex tool policy cannot override required feature ${feature}`);
       }
     }
   }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -114,6 +114,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   operation?: EmbeddedRunAttemptOperation;
   /** Core-prepared fact that explicit requester/config policy restricts plugin-native tools. */
   pluginHarnessToolPolicyRestricted?: boolean;
+  /** Audited exact denies that the plugin harness must enforce against native equivalents. */
+  pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
   preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   /** Active file-backed artifact target resolved by the run/session target seam. */
   sessionFile: string;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1299,9 +1299,15 @@ describe("runAgentHarnessAttempt", () => {
   });
 
   it("isolates native tools unless every exact deny is explicitly safe", async () => {
-    const received: boolean[] = [];
+    const received: Array<{
+      restricted: boolean;
+      safeDeniedTools?: readonly string[];
+    }> = [];
     const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async (attempt) => {
-      received.push(attempt.pluginHarnessToolPolicyRestricted === true);
+      received.push({
+        restricted: attempt.pluginHarnessToolPolicyRestricted === true,
+        safeDeniedTools: attempt.pluginHarnessToolPolicySafeDeniedTools,
+      });
       return createAttemptResult("codex");
     });
     const harness: AgentHarness = {
@@ -1311,6 +1317,7 @@ describe("runAgentHarnessAttempt", () => {
       conversationToolPolicySafeDenyTools: [
         "tts",
         "music_generate",
+        "image_generate",
         "browser",
         "unknown_native_tool",
       ],
@@ -1321,6 +1328,7 @@ describe("runAgentHarnessAttempt", () => {
     registerAgentHarness(harness, { ownerPluginId: "codex" });
 
     const policies = [
+      { deny: ["image_generate"] },
       { deny: ["tts", "music_generate"] },
       { deny: ["browser"] },
       { deny: ["exec"] },
@@ -1337,7 +1345,18 @@ describe("runAgentHarnessAttempt", () => {
       });
     }
 
-    expect(received).toEqual([false, false, true, true, true, true, true, true]);
+    expect(received.map((attempt) => attempt.restricted)).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(received[0]?.safeDeniedTools).toEqual(["image_generate"]);
   });
 
   it("marks only explicit restrictive policy layers for plugin harness isolation", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -183,6 +183,7 @@ type ResolvedPluginHarnessToolPolicies = {
   senderScopedGroupPolicy?: PluginHarnessToolPolicy;
   groupPolicy?: PluginHarnessToolPolicy;
   runtimePolicies: Array<PluginHarnessToolPolicy | undefined>;
+  safeDeniedToolNames: string[];
   toolPolicyRestricted: boolean;
 };
 
@@ -808,6 +809,8 @@ function preparePluginHarnessParams(
   return applyPluginHarnessDenyAllToolPolicy(
     {
       ...preparedParams,
+      pluginHarnessToolPolicySafeDeniedTools:
+        policies.safeDeniedToolNames.length > 0 ? policies.safeDeniedToolNames : undefined,
       pluginHarnessToolPolicyRestricted: policies.toolPolicyRestricted,
     },
     policies,
@@ -990,10 +993,28 @@ function resolvePluginHarnessToolPolicies(
       policy.inheritedToolPolicy,
       requestedToolPolicy,
     ],
+    safeDeniedToolNames: collectHarnessSafeDeniedToolNames(explicitPolicies, safeDenyToolNameSet),
     toolPolicyRestricted: explicitPolicies.some((explicitPolicy) =>
       toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
     ),
   };
+}
+
+function collectHarnessSafeDeniedToolNames(
+  policies: Array<PluginHarnessToolPolicy | undefined>,
+  safeDenyToolNames: ReadonlySet<string> | undefined,
+): string[] {
+  if (!safeDenyToolNames) {
+    return [];
+  }
+  return [
+    ...new Set(
+      policies
+        .flatMap((policy) => expandToolGroups(policy?.deny ?? []))
+        .map(normalizeToolPolicyName)
+        .filter((name) => isKnownCoreToolId(name) && safeDenyToolNames.has(name)),
+    ),
+  ].toSorted();
 }
 
 function toolPolicyRestrictsHarnessNativeTools(

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -353,8 +353,8 @@ type AgentHarnessRunCapability<
   /** Certifies exact runAttempt enforcement; direct-policy-restricted channel side questions fail in core. */
   conversationToolPolicySupport?: "exact";
   /**
-   * Canonical OpenClaw tool names whose exact denies are fully enforced outside
-   * this harness's native surface. Every other deny remains fail-closed.
+   * Canonical OpenClaw tool names whose exact denies the harness can also enforce
+   * against native equivalents. Every other deny remains fail-closed.
    */
   conversationToolPolicySafeDenyTools?: readonly string[];
   supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -117,8 +117,12 @@ type EmbeddedRunAttemptParamsBase = Omit<
   | "admittedRunContext"
   | "contextEngineLogicalTurnLease"
   | "onContextEngineTurnCandidate"
+  | "pluginHarnessToolPolicySafeDeniedTools"
   | "trajectoryRecorder"
->;
+> & {
+  /** Audited exact denies that the plugin harness must enforce against native equivalents. */
+  pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
+};
 /**
  * @deprecated Use EmbeddedRunAttemptParamsV2. The optional capability keeps
  * existing harness source compatible through 2026-10-12.


### PR DESCRIPTION
Closes #124541

AI-assisted: yes (Codex implementation and review; Claude Opus 5 independent red-team). I reviewed the final diff and understand the behavior and security boundary.

## What Problem This Solves

Fixes an issue where users denying `image_generate` would lose unrelated Codex native tools, including multi-agent delegation.

## Why This Change Was Made

Core now passes audited exact deny names to native harnesses, and the Codex harness maps `image_generate` to the pinned native `features.image_generation=false` override on both thread start and resume. Unknown, wildcard, allowlist, and undeclared denies remain fail-closed; managed Codex requirements that force image generation on are rejected before a thread is created.

## User Impact

Users can deny image generation without disabling Codex delegation or other unrelated native capabilities. The denied OpenClaw tool and its Codex-native equivalent both remain unavailable.

## Evidence

- Regression fail-before: the new managed-policy test reached `thread/start` (`unexpected method: thread/start`), proving `image_generation=true` could bypass the targeted deny. It now passes and rejects the conflict before thread creation.
- Warm-transition regression: a normal retained thread is followed by the real OpenClaw `pluginHarnessToolPolicySafeDeniedTools=["image_generate"]` handoff. The lifecycle reads managed requirements, rejects warm reuse because the final-config fingerprint changed, unsubscribes the loaded thread, and cold-resumes it with `features.image_generation=false`.
- Focused tests: agent harness selection 115/115; Codex harness 32/32; Codex thread requests 143/143; managed-requirement regression 1/1.
- Plugin contracts: 42 files, 1,039 tests passed.
- `node --import tsx scripts/check.mts --timed`: all preflight, production/script/test typecheck, lint, format, and policy lanes passed.
- `node --import tsx scripts/build-all.mts`: complete production and Control UI build passed.
- Plugin SDK surface check passed with all 144 public subpaths verified.
- Final adversarial reviews: Codex GPT-5.6 Sol and Claude Opus 5 both reported no actionable findings.

### Pinned Codex contract

Directly inspected `openai/codex` at the dependency's exact `rust-v0.147.0` commit [`be6e8eac029b`](https://github.com/openai/codex/tree/be6e8eac029b183056b7e4402879f15d2c85f61b):

- [`Feature::ImageGeneration` is the stable `image_generation` key, default enabled](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/features/src/lib.rs#L1267-L1272).
- [`image_generation_available` requires that feature to be enabled](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/tools/spec_plan.rs#L547-L554), and [the tool planner omits the `image_gen` namespace when it is false](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/tools/spec_plan.rs#L1200-L1205).
- [The pinned regression test explicitly proves `features.image_generation=false` removes `image_gen`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/tools/spec_plan_tests.rs#L2550-L2580).
- [App-server config requirements are exposed for the managed-policy preflight](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server/src/request_processors/config_processor.rs#L410-L412).

### Real app-server behavior

Ran a redacted, isolated `codex app-server` 0.147.0 session against the installed pinned package, without changing or restarting the production gateway. The thread used `features.image_generation=false` while leaving native multi-agent enabled. The live app-server event stream showed a real child spawn and wait completion:

```json
{
  "serverVersion": "0.147.0",
  "model": "gpt-5.4",
  "appliedConfig": {
    "features.image_generation": false,
    "features.multi_agent": true,
    "features.multi_agent_v2": false
  },
  "events": [
    { "event": "item/started", "tool": "spawnAgent", "status": "inProgress" },
    { "event": "item/completed", "tool": "spawnAgent", "status": "completed", "receiverCount": 1 },
    { "event": "item/started", "tool": "wait", "status": "inProgress", "receiverCount": 1 },
    { "event": "item/completed", "tool": "wait", "status": "completed", "childStatus": "completed", "childMessage": "PROBE_CHILD_OK" }
  ],
  "final": "DELEGATION_OK=true\nIMAGE_GEN_AVAILABLE=false"
}
```

The exact pinned source and its regression establish the image namespace removal; the real app-server trace establishes that delegation remains operational under the same feature override.

### Warm retained-thread transition

ClawSweeper's second review raised a possible warm-session bypass. The retained-thread contract already fails closed on this transition:

1. `buildThreadResumeParams` includes the current OpenClaw deny handoff in the would-be resume config.
2. `fingerprintCodexThreadConfig` hashes that complete config.
3. `consumeCodexAppServerLiveThread` requires exact equality with the retained fingerprint.
4. Adding the deny changes the fingerprint, so the lifecycle unsubscribes the loaded thread and cold-resumes it with the new config.

Commit `ddff5f64808` adds a regression through the actual safe-deny input—not a synthetic config patch—and asserts the observable request sequence:

```text
thread/start
configRequirements/read
thread/unsubscribe
thread/resume  config.features.image_generation=false
```

Focused verification after adding this coverage: lifecycle bindings 112/112, thread lifecycle 143/143, harness selection 115/115, and Codex harness 32/32. Claude Opus 5 independently audited the fingerprint/ownership flow and found no warm-reuse bypass; it also required the regression to exercise the real safe-deny input, which the final test does.

## Maintainer validation (2026-08-16)

Maintainer decision: approved the narrow optional Plugin SDK handoff. A harness that declares an audited exact safe deny must receive that prepared fact and enforce any native equivalent; all undeclared, unknown, wildcard, finite-allowlist, and mixed unsafe policies remain fail-closed.

Independent exact-head proof:

- Regression provenance: with current tests and pre-fix production restored, the Codex owner-boundary regression failed because features.image_generation remained true.
- Focused exact-head tests: harness selection 115/115; Codex harness/lifecycle/bindings 287/287.
- Full local check: preflight guards, production/scripts/test TypeScript, Oxlint, Oxfmt, and policy guards passed.
- Pinned dependency source: directly inspected openai/codex be6e8eac029b; image_generation is stable/default-on, false removes the image_gen namespace, and configRequirements/read exposes managed feature requirements.
- Exact-head CI: run 31954907753 passed with 143 successful checks, 38 intentional skips, and zero failures.

Per the maintainer fast-lane order, final Telegram user proof ran after the passing local ClawSweeper gate and is attached below.

### Fresh and retained OpenClaw proof

Ran the pushed exact head 2c61c18f4d72540b6d23406e4f62c6c024a279e4 through the real local OpenClaw agent entrypoint with tools.deny: ["image_generate"], openai/gpt-5.6-sol, and the Codex harness. No mock provider or direct app-server override was used.

- Fresh turn: OpenClaw selected agentHarnessId=codex; native rollout called spawn_agent and wait_agent; visible result was FRESH_DELEGATION_OK / IMAGE_GEN_AVAILABLE=false.
- Retained turn: the same OpenClaw session f4850185-f602-4560-99d9-34ded865f23a retained Codex thread 01a00b33-4d81-70c3-b1a5-0af6a70bdb58; its original rollout appended a second spawn_agent and wait_agent sequence; visible result was RETAINED_DELEGATION_OK / IMAGE_GEN_AVAILABLE=false.
- The state DB still bound that same Codex thread after the second turn. The pinned Codex source inspection above independently proves features.image_generation=false removes the image_gen namespace.

This exercises the actual OpenClaw policy-to-plugin-to-Codex path for both a fresh and retained session.


### Final Telegram real-user proof

Ran the canonical Telegram userbot runner last, with a fresh isolated Gateway and no mock provider (`mockRequests=0`).

- Current main `eb174bcaffd`: with `tools.deny: ["image_generate"]`, Telegram returned `MAIN_DELEGATION_UNAVAILABLE` (Bot API message 48849, 13.151s).
- Exact PR head `2c61c18f4d72540b6d23406e4f62c6c024a279e4`: OpenClaw selected `openai/gpt-5.6-sol` through the Codex harness; the parent rollout invoked native `spawn_agent` and `wait_agent`, the child returned `CHILD_PR_OK`, and Telegram returned `PR_DELEGATION_OK IMAGE_GEN_AVAILABLE=false` (Bot API message 48853, 9.188s).
- The Telegram event stream and both parent/child Codex rollouts were retained as evidence. Native Desktop recording was unreachable because the skill prerequisite `scripts/e2e/telegram-desktop-recorder.ts` is absent on both current main and this PR; no PR code was changed for that infrastructure gap.
