### PR TITLE
fix(macos): keep the app near-zero CPU while idle

### DIFF
--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -201,7 +201,7 @@ enum CLIInstaller {
                 expectedVersion: GatewayEnvironment.expectedGatewayVersionString(),
                 preferredPaths: preferredPaths)
             if status.isReady {
-                self.rememberValidated(status)
+                self.rememberValidated(status, defaults: AppDefaults.standard)
                 return status
             }
             fallbackStatus = fallbackStatus ?? status
@@ -225,7 +225,7 @@ enum CLIInstaller {
             expectedVersion: expectedVersion,
             preferredPaths: preferredPaths)
         if status.isReady {
-            self.rememberValidated(status)
+            self.rememberValidated(status, defaults: AppDefaults.standard)
         }
         return status
     }
@@ -316,10 +316,14 @@ enum CLIInstaller {
         return environment
     }
 
-    private static func rememberValidated(_ status: Status) {
+    static func rememberValidated(_ status: Status, defaults: UserDefaults) {
         guard case let .ready(location, version) = status else { return }
-        AppDefaults.standard.set(location, forKey: cliValidatedExecutableKey)
-        AppDefaults.standard.set(version, forKey: cliValidatedVersionKey)
+        if defaults.string(forKey: cliValidatedExecutableKey) != location {
+            defaults.set(location, forKey: cliValidatedExecutableKey)
+        }
+        if defaults.string(forKey: cliValidatedVersionKey) != version {
+            defaults.set(version, forKey: cliValidatedVersionKey)
+        }
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -936,6 +936,12 @@ extension MacNodeModeCoordinator {
         guard self.nodeHostWorkerRetryTask == nil else {
             throw MacNodeHostWorkerRetryPolicy.RetryBackoffPending()
         }
+        if let activeInput = self.activeNodeHostWorkerInput {
+            // Worker launch metadata is startup-scoped. Route retries reuse it instead of
+            // repeating CLI and runtime discovery until an explicit restart resets state.
+            try self.nodeHostWorkerRetryPolicy.prepareForStart(activeInput)
+            return try await nodeHostWorker.start(launch: activeInput.launch)
+        }
         let launch: MacNodeHostWorkerLaunch
         do {
             if let projectLaunch = try await CommandResolver.projectNodeHostWorkerLaunch() {

--- a/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import OpenClaw
 
@@ -289,6 +290,46 @@ struct CLIInstallerTests {
             appVersion: "2026.7.2",
             isDebug: false,
             defaults: defaults) == "2026.7.2")
+    }
+
+    @Test func `validated CLI cache changes only when the ready tuple changes`() throws {
+        let suite = "CLIInstallerTests.validated-cache.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let notificationCount = OSAllocatedUnfairLock(initialState: 0)
+        let initialLocation = "/Users/test/.local/bin/openclaw"
+        defaults.set(initialLocation, forKey: cliValidatedExecutableKey)
+        defaults.set("2026.8.1", forKey: cliValidatedVersionKey)
+        let observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: defaults,
+            queue: nil)
+        { _ in
+            notificationCount.withLock { $0 += 1 }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        CLIInstaller.rememberValidated(
+            .ready(location: initialLocation, version: "2026.8.1"),
+            defaults: defaults)
+
+        #expect(notificationCount.withLock { $0 } == 0)
+
+        let updatedLocation = "/opt/homebrew/bin/openclaw"
+        CLIInstaller.rememberValidated(
+            .ready(location: updatedLocation, version: "2026.8.1"),
+            defaults: defaults)
+
+        #expect(notificationCount.withLock { $0 } == 1)
+        #expect(defaults.string(forKey: cliValidatedExecutableKey) == updatedLocation)
+        #expect(defaults.string(forKey: cliValidatedVersionKey) == "2026.8.1")
+
+        CLIInstaller.rememberValidated(
+            .ready(location: updatedLocation, version: "2026.8.2"),
+            defaults: defaults)
+
+        #expect(notificationCount.withLock { $0 } == 2)
+        #expect(defaults.string(forKey: cliValidatedVersionKey) == "2026.8.2")
     }
 
     @Test func `managed setup requires a parseable compatible version`() {


### PR DESCRIPTION
Closes #124592
Related: #100451

## What Problem This Solves

Fixes an issue where users leaving the signed macOS menu-bar app idle would see the app consume about 20–22% CPU after node-host startup became part of node connection preparation.

## Why This Change Was Made

Validated CLI cache persistence is now idempotent, so a successful validation only mutates the fields that actually changed instead of generating a `UserDefaults` notification for an identical tuple. Ordinary route retries also reuse the active startup-scoped node worker launch rather than rediscovering the CLI and Node runtime.

This preserves real config, install, permission, endpoint, and worker-restart refreshes. It does not add polling, delays, compatibility paths, or weaker lifecycle invalidation.

Production LOC: +15/-5 (net +10) | Tests: +41/-0. The production growth makes the cache-write and startup-scoped lifecycle boundaries explicit; the prior implementation had no place to express either invariant without repeating work.

## User Impact

The resident macOS app returns to near-zero idle CPU, reducing battery use, heat, and background process/config/TCC work. CLI installation changes and node worker restarts still take effect through their existing explicit lifecycle events.

AI-assisted; the final implementation and proof were reviewed against the full owner path.

## Evidence

- **Observed baseline:** signed OpenClaw 2026.8.1 app at 20–22% idle CPU.
- **60-second baseline Time Profiler:** 3,118 node-coordinator start samples; 2,169 `_subprocess_spawn`; 1,311 `CLIInstaller.status`.
- **15-second baseline process sample:** 299 `__fork` samples and 65 `CLClientIsLocationServicesEnabled` samples.
- **Regression proof before the fix:** `validated CLI cache changes only when the ready tuple changes` expected zero notifications and observed two; the other 21 focused tests passed.
- **Focused Swift proof after the fix:** `swift test --package-path apps/macos --no-parallel --filter 'CLIInstallerTests|MacNodeModeCoordinatorTests'` — 59 tests passed. Xcode 27 beta required a generated local `PackageFrameworks/Sparkle.framework` link for SwiftPM test loading; no workaround or build artifact is committed.
- **Signed app rebuild:** deep/strict `codesign` verification passed with `Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)` and Team ID `FWJYW4S8P8`.
- **Observed result:** rebuilt signed app held at 0.0–0.4% CPU in repeated `top` samples.
- **Final 15-second sample:** no `CLIInstaller`, runtime-version, permission, or recurring subprocess frames; node coordinator appeared twice while reading the endpoint/config state.
- **Final 60-second Time Profiler:** no `CLIInstaller` hotspot; remaining subprocess samples were the bounded initial worker launch rather than repeated validation.
- **Changed gate:** Crabbox Azure run `run_d5a5b950f813` / lease `cbx_b6aeacfdf2df` passed all selected guards and six macOS-related Vitest shards (317 tests passed, 39 skipped).
- **Autoreview:** Codex review completed with no accepted/actionable findings.
- `swiftformat --lint` on all changed Swift files — clean.
- `git diff --check` — clean.

Known proof gap: the isolated loopback Gateway exercised auth-none device metadata reapproval churn, so the final capture stressed the disconnected retry path rather than a sustained fully registered node route. That is the path that previously amplified the CPU loop; the app stayed near-zero CPU throughout repeated reconnects.
