### PR TITLE
perf(test): shorten Google Meet reconnect proof

### DIFF
--- a/extensions/google-meet/src/voice-call-gateway.test.ts
+++ b/extensions/google-meet/src/voice-call-gateway.test.ts
@@ -94,16 +94,9 @@ describe("Google Meet voice-call gateway", () => {
 
     const server = createServer();
     let connectionCount = 0;
-    let resolveReconnect: ((observed: boolean) => void) | undefined;
-    const reconnected = new Promise<boolean>((resolve) => {
-      resolveReconnect = resolve;
-    });
     server.on("upgrade", (_request, socket) => {
       connectionCount += 1;
       socket.destroy();
-      if (connectionCount > 1) {
-        resolveReconnect?.(true);
-      }
     });
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
@@ -117,7 +110,6 @@ describe("Google Meet voice-call gateway", () => {
     const stopAndWait = vi.spyOn(actual.GatewayClient.prototype, "stopAndWait");
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
-    let observationTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       const config = resolveGoogleMeetConfig({
         voiceCall: {
@@ -148,33 +140,17 @@ describe("Google Meet voice-call gateway", () => {
         );
       });
 
-      const retryObserved = await Promise.race([
-        reconnected,
-        new Promise<boolean>((resolve) => {
-          observationTimer = setTimeout(() => resolve(false), 1_150);
-        }),
-      ]);
-      if (observationTimer) {
-        clearTimeout(observationTimer);
-        observationTimer = undefined;
-      }
-
       expect({
         stopCalls: stopAndWait.mock.calls.length,
-        reconnected: retryObserved,
         connectionCount,
         referencedRetry,
       }).toEqual({
         stopCalls: 1,
-        reconnected: false,
         connectionCount: 1,
         referencedRetry: false,
       });
       expect(gatewayMocks.runtimeRequest).not.toHaveBeenCalled();
     } finally {
-      if (observationTimer) {
-        clearTimeout(observationTimer);
-      }
       await Promise.all(gatewayMocks.actualClients.map((client) => client.stopAndWait()));
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
## What Problem This Solves

The Google Meet voice-call gateway regression waits 1.15 real seconds after a failed localhost connection to re-prove that `GatewayClient.stopAndWait()` cleared its reconnect timer. The same test already inspects the actual one-second retry timer, and the GatewayClient owner suite independently advances 30 seconds to prove stopped clients never reconnect.

## Why This Change Was Made

Keep the real cross-component proof but remove the duplicate elapsed observation window:

- The Google Meet test still uses a real localhost upgrade server and the actual GatewayClient implementation.
- It still proves the failed client is stopped exactly once, the initial socket connects once, and no live referenced one-second retry timer remains.
- `src/gateway/client.test.ts` remains the owner proof that advancing well past the retry window creates no second socket.

No mocks replace the real connection boundary, and production behavior is unchanged.

## User Impact

Maintainer Google Meet test feedback is about 1.2 seconds faster while retaining the original failed-client teardown regression and its GatewayClient reconnect owner coverage.

## Evidence

Controlled same-Testbox A/B on `tbx_01m05bdf2m3229wy5rj8ncja7d`, with one excluded warmup and two retained samples per state, the same command, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 8.80s | 7.63s | -1.17s (-13.3%) |
| Vitest | 5.94s | 4.74s | -20.2% |
| Test body | 1.65s | 0.51s | -69.1% |
| Imports | 3.67s | 3.62s | effectively flat |

CPU and peak RSS were effectively flat, so this PR makes no resource-usage claim.

Validation:

- 12/12 Google Meet voice-call gateway tests.
- GatewayClient owner test `clears pending reconnect timers on stop` passed.
- Mutation: removing Google Meet's production `stopAndWait()` fails the shortened real integration with `stopCalls: 0` and `referencedRetry: true`; three sibling teardown cases fail too.
- Full extension-test changed gate passed, including typecheck, targeted lint, plugin boundaries, dead exports, and assertion guards.
- Fresh autoreview: no accepted/actionable findings.
- Production LOC: `+0/-0`; test LOC: `+0/-24`.

Testbox benchmark, mutation, and owner proof: https://github.com/openclaw/openclaw/actions/runs/31949314982

Final post-rebase changed gate: https://github.com/openclaw/openclaw/actions/runs/31949786933

AI-assisted: yes. The change and evidence were reviewed by the maintainer agent and fresh autoreview.
