### PR TITLE
fix(macos): stop Talk MLX helpers after shutdown or replacement

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -3,6 +3,7 @@ import Foundation
 import OpenClawKit
 import OpenClawMLXTTSProtocol
 import OSLog
+import Subprocess
 
 protocol MLXTTSTransport: AnyObject, Sendable {
     func send(_ request: MLXTTSRequest) async throws
@@ -44,7 +45,7 @@ actor TalkMLXSpeechSynthesizer {
 
     private init() {
         self.transportFactory = {
-            try ProcessMLXTTSTransport.launch(invocation: TalkMLXSpeechSynthesizer.helperInvocation())
+            try await ProcessMLXTTSTransport.launch(invocation: TalkMLXSpeechSynthesizer.helperInvocation())
         }
         self.idleDuration = .seconds(300)
         self.cancelGraceDuration = .seconds(1)
@@ -114,8 +115,10 @@ actor TalkMLXSpeechSynthesizer {
                 }
                 throw error
             } catch is CancellationError {
-                try? await self.transport?.send(.cancel(id: id))
-                await self.discardTransport()
+                if self.activeID == id {
+                    try? await self.transport?.send(.cancel(id: id))
+                }
+                await self.discardTransport(forRequest: id)
                 self.finishRequest(id: id)
                 throw SynthesizeError.canceled
             } catch {
@@ -124,7 +127,7 @@ actor TalkMLXSpeechSynthesizer {
                     talk mlx helper transport failed attempt=\(attempt + 1, privacy: .public): \
                     \(error.localizedDescription, privacy: .public)
                     """)
-                await self.discardTransport()
+                await self.discardTransport(forRequest: id)
                 if self.fallbackRequiredID == id {
                     self.finishRequest(id: id)
                     throw SynthesizeError.audioGenerationFailed
@@ -221,15 +224,17 @@ actor TalkMLXSpeechSynthesizer {
                 }
                 throw error
             } catch is CancellationError {
-                try? await self.transport?.send(.cancel(id: id))
-                await self.discardTransport()
+                if self.activeID == id {
+                    try? await self.transport?.send(.cancel(id: id))
+                }
+                await self.discardTransport(forRequest: id)
                 self.finishRequest(id: id)
                 throw SynthesizeError.canceled
             } catch {
                 self.logger.error(
                     "talk mlx helper stream failed attempt=\(attempt + 1, privacy: .public): " +
                         "\(error.localizedDescription, privacy: .public)")
-                await self.discardTransport()
+                await self.discardTransport(forRequest: id)
                 if self.fallbackRequiredID == id {
                     self.finishRequest(id: id)
                     throw SynthesizeError.audioGenerationFailed
@@ -295,7 +300,11 @@ actor TalkMLXSpeechSynthesizer {
             self.logger.info("talk mlx helper ready")
             return transport
         } catch {
-            self.transport = nil
+            // Shutdown can admit a replacement while this startup is unwinding.
+            // Only the exact failed transport may surrender current ownership.
+            if self.transport === transport {
+                self.transport = nil
+            }
             await transport.close()
             throw error
         }
@@ -514,7 +523,9 @@ actor TalkMLXSpeechSynthesizer {
         await self.shutdown()
     }
 
-    private func discardTransport() async {
+    private func discardTransport(forRequest id: String? = nil) async {
+        // A stale request may finish after shutdown admitted a replacement.
+        guard id == nil || self.activeID == id else { return }
         let transport = self.transport
         self.transport = nil
         await transport?.close()
@@ -599,7 +610,7 @@ private enum MLXTTSTransportError: Error {
 }
 
 private actor ProcessMLXTTSTransport: MLXTTSTransport {
-    private let process: Process
+    private let process: ManagedProcess
     private let input: FileHandle
     private let output: FileHandle
     private let chunkContinuation: AsyncStream<Data>.Continuation
@@ -609,7 +620,7 @@ private actor ProcessMLXTTSTransport: MLXTTSTransport {
     private var isClosed = false
 
     private init(
-        process: Process,
+        process: ManagedProcess,
         input: FileHandle,
         output: FileHandle,
         chunks: AsyncStream<Data>,
@@ -622,15 +633,11 @@ private actor ProcessMLXTTSTransport: MLXTTSTransport {
         self.chunkContinuation = chunkContinuation
     }
 
-    static func launch(invocation: TalkMLXSpeechSynthesizer.HelperInvocation) throws -> ProcessMLXTTSTransport {
-        let process = Process()
+    static func launch(invocation: TalkMLXSpeechSynthesizer.HelperInvocation) async throws
+        -> ProcessMLXTTSTransport
+    {
         let inputPipe = Pipe()
         let outputPipe = Pipe()
-        process.executableURL = invocation.executableURL
-        process.arguments = invocation.argumentPrefix
-        process.standardInput = inputPipe
-        process.standardOutput = outputPipe
-        process.standardError = FileHandle.standardError
 
         let output = outputPipe.fileHandleForReading
         let (stream, continuation) = AsyncStream<Data>.makeStream()
@@ -646,15 +653,29 @@ private actor ProcessMLXTTSTransport: MLXTTSTransport {
             }
         }
 
+        let configuration = Subprocess.Configuration(
+            .path(.init(invocation.executableURL.path)),
+            arguments: Arguments(invocation.argumentPrefix))
+        let process = ManagedProcess.launch(
+            configuration: configuration,
+            input: .fileDescriptor(
+                .init(rawValue: inputPipe.fileHandleForReading.fileDescriptor),
+                closeAfterSpawningProcess: false),
+            output: .fileDescriptor(
+                .init(rawValue: outputPipe.fileHandleForWriting.fileDescriptor),
+                closeAfterSpawningProcess: false),
+            error: .currentStandardError,
+            closeAfterSpawn: [
+                inputPipe.fileHandleForReading,
+                outputPipe.fileHandleForWriting,
+            ])
         do {
-            try process.run()
+            _ = try await process.waitUntilStarted()
         } catch {
             output.readabilityHandler = nil
             continuation.finish()
             throw error
         }
-        inputPipe.fileHandleForReading.closeFile()
-        outputPipe.fileHandleForWriting.closeFile()
 
         return ProcessMLXTTSTransport(
             process: process,
@@ -688,9 +709,7 @@ private actor ProcessMLXTTSTransport: MLXTTSTransport {
         self.chunkContinuation.finish()
         self.input.closeFile()
         self.output.closeFile()
-        if self.process.isRunning {
-            self.process.terminate()
-        }
+        await self.process.terminate()
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -100,7 +100,7 @@ actor TalkMLXSpeechSynthesizer {
             do {
                 let transport = try await ensureTransport()
                 guard self.activeID == id, self.cancelRequestedID != id else {
-                    await self.discardTransport()
+                    await self.discardTransport(forRequest: id)
                     throw SynthesizeError.canceled
                 }
                 try await transport.send(request)
@@ -194,7 +194,7 @@ actor TalkMLXSpeechSynthesizer {
             do {
                 let transport = try await ensureTransport()
                 guard self.activeID == id, self.cancelRequestedID != id else {
-                    await self.discardTransport()
+                    await self.discardTransport(forRequest: id)
                     throw SynthesizeError.canceled
                 }
                 try await transport.send(request)
@@ -265,7 +265,7 @@ actor TalkMLXSpeechSynthesizer {
         do {
             try await self.transport?.send(.cancel(id: activeID))
         } catch {
-            await self.discardTransport()
+            await self.discardTransport(forRequest: activeID)
         }
         self.scheduleCancelEscalation(id: activeID)
     }
@@ -394,7 +394,7 @@ actor TalkMLXSpeechSynthesizer {
         do {
             try await transport.send(.cancel(id: id))
         } catch {
-            await self.discardTransport()
+            await self.discardTransport(forRequest: id)
             return
         }
         self.scheduleCancelEscalation(id: id)
@@ -437,7 +437,7 @@ actor TalkMLXSpeechSynthesizer {
                 }
             }
         } catch SynthesizeError.timedOut {
-            await self.discardTransport()
+            await self.discardTransport(forRequest: id)
             self.finishRequest(id: id)
             continuation.finish(throwing: SynthesizeError.timedOut)
         } catch {
@@ -488,7 +488,7 @@ actor TalkMLXSpeechSynthesizer {
         // Soprano checks cancellation while producing tokens, but its final
         // decoder has no cancellation contract. Bound that phase with a kill.
         self.logger.info("talk mlx cancel grace expired; terminating helper")
-        await self.discardTransport()
+        await self.discardTransport(forRequest: id)
     }
 
     private func scheduleIdleShutdown() {
@@ -523,9 +523,13 @@ actor TalkMLXSpeechSynthesizer {
         await self.shutdown()
     }
 
-    private func discardTransport(forRequest id: String? = nil) async {
+    private func discardTransport(forRequest id: String) async {
         // A stale request may finish after shutdown admitted a replacement.
-        guard id == nil || self.activeID == id else { return }
+        guard self.activeID == id else { return }
+        await self.discardTransport()
+    }
+
+    private func discardTransport() async {
         let transport = self.transport
         self.transport = nil
         await transport?.close()

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import OpenClawMLXTTSProtocol
 import Testing
@@ -6,6 +7,92 @@ import Testing
 #if arch(arm64)
 @Suite(.serialized)
 struct TalkMLXSpeechSynthesizerTests {
+    @Test @MainActor
+    func `shutdown reaps a TERM-resistant helper before returning`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-mlx-tts-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let helper = directory.appendingPathComponent("openclaw-mlx-tts-test-helper")
+        let pidFile = directory.appendingPathComponent("helper.pid")
+        let readyFrame = directory.appendingPathComponent("ready.frame")
+        defer { TestProcessSupport.killLeakedProcesses(in: [pidFile]) }
+        try MLXTTSFrameCodec.encode(MLXTTSEvent.ready).write(to: readyFrame)
+        try Data("""
+        #!/bin/sh
+        trap '' TERM
+        printf '%s\\n' "$$" > "$OPENCLAW_MLX_TTS_PID_FILE"
+        /bin/cat "$OPENCLAW_MLX_TTS_READY_FILE"
+        exec /bin/sleep 30
+        """.utf8).write(to: helper)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_MLX_TTS_BIN": helper.path,
+            "OPENCLAW_MLX_TTS_PID_FILE": pidFile.path,
+            "OPENCLAW_MLX_TTS_READY_FILE": readyFrame.path,
+        ]) {
+            let synthesizer = TalkMLXSpeechSynthesizer.shared
+            await synthesizer.shutdown()
+            let synthesis = Task {
+                try await synthesizer.synthesize(
+                    text: "hold transport open",
+                    modelRepo: nil,
+                    language: nil,
+                    voicePreset: nil)
+            }
+            let pid = try await TestProcessSupport.waitForPID(in: pidFile)
+
+            await synthesizer.shutdown()
+            let helperWasReaped = await TestProcessSupport.waitUntilGone(
+                pid,
+                timeout: .milliseconds(100))
+            if !helperWasReaped {
+                _ = kill(pid, SIGKILL)
+            }
+            synthesis.cancel()
+            _ = try? await synthesis.value
+
+            #expect(await TestProcessSupport.waitUntilGone(pid))
+            #expect(helperWasReaped)
+        }
+    }
+
+    @Test
+    func `stale startup exit cannot discard the replacement helper`() async throws {
+        let stale = TestMLXTransport(mode: .staleStartupClose)
+        let replacement = TestMLXTransport(mode: .audio)
+        let factory = TestMLXTransportFactory([stale, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let staleSynthesis = Task {
+            try await synthesizer.synthesize(
+                text: "stale startup",
+                modelRepo: nil,
+                language: nil,
+                voicePreset: nil)
+        }
+        await factory.waitForCall()
+        await synthesizer.shutdown()
+
+        _ = try await synthesizer.synthesize(
+            text: "replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+        await stale.finishStaleClose()
+        _ = try? await staleSynthesis.value
+        _ = try await synthesizer.synthesize(
+            text: "reuse replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+
+        #expect(await factory.callCount == 2)
+        await synthesizer.shutdown()
+    }
+
     @Test
     func `reuses resident helper across utterances`() async throws {
         let transport = TestMLXTransport(mode: .audio)
@@ -355,6 +442,7 @@ private actor TestMLXTransport: MLXTTSTransport {
         case audioAfterCancel
         case crash
         case ignoreCancel
+        case staleStartupClose
         case startupHang
         case stream
         case streamWaitForCancel
@@ -369,7 +457,7 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     init(mode: Mode) {
         self.mode = mode
-        if mode == .startupHang {
+        if mode == .startupHang || mode == .staleStartupClose {
             self.events = []
         }
     }
@@ -398,7 +486,7 @@ private actor TestMLXTransport: MLXTTSTransport {
                     sampleRate: 32000)))
             case .crash:
                 self.closed = true
-            case .audioAfterCancel, .ignoreCancel, .startupHang, .waitForCancel:
+            case .audioAfterCancel, .ignoreCancel, .staleStartupClose, .startupHang, .waitForCancel:
                 break
             }
         case let .cancel(id):
@@ -411,7 +499,9 @@ private actor TestMLXTransport: MLXTTSTransport {
                 self.events.append(.canceled(id: id))
             }
         case .shutdown:
-            self.closed = true
+            if self.mode != .staleStartupClose {
+                self.closed = true
+            }
         }
     }
 
@@ -427,6 +517,12 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     func close() {
         self.closeCount += 1
+        if self.mode != .staleStartupClose {
+            self.closed = true
+        }
+    }
+
+    func finishStaleClose() {
         self.closed = true
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkMLXSpeechSynthesizerTests.swift
@@ -94,6 +94,79 @@ struct TalkMLXSpeechSynthesizerTests {
     }
 
     @Test
+    func `stale startup ready cannot discard the replacement helper`() async throws {
+        let stale = TestMLXTransport(mode: .staleStartupReady)
+        let replacement = TestMLXTransport(mode: .audio)
+        let factory = TestMLXTransportFactory([stale, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let staleSynthesis = Task {
+            try await synthesizer.synthesize(
+                text: "stale startup",
+                modelRepo: nil,
+                language: nil,
+                voicePreset: nil)
+        }
+        await factory.waitForCall()
+        await synthesizer.shutdown()
+
+        _ = try await synthesizer.synthesize(
+            text: "replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+        await stale.finishStaleReady()
+        _ = try? await staleSynthesis.value
+        _ = try await synthesizer.synthesize(
+            text: "reuse replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+
+        #expect(await factory.callCount == 2)
+        await synthesizer.shutdown()
+    }
+
+    @Test
+    func `stale stream timeout cannot discard the replacement helper`() async throws {
+        let stale = TestMLXTransport(mode: .staleStreamTimeout)
+        let replacement = TestMLXTransport(mode: .audio)
+        let factory = TestMLXTransportFactory([stale, replacement])
+        let synthesizer = TalkMLXSpeechSynthesizer(
+            transportFactory: { try await factory.make() },
+            idleDuration: .seconds(60))
+        let playback = try await synthesizer.synthesizeStream(
+            text: "stale stream",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil,
+            referenceAudioPath: nil,
+            referenceText: nil,
+            stallTimeoutSeconds: 0.25)
+        let staleConsumption = Task {
+            for try await _ in playback.chunks {}
+        }
+        await stale.waitForBlockedEvent()
+        await synthesizer.shutdown()
+
+        _ = try await synthesizer.synthesize(
+            text: "replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+        _ = try? await staleConsumption.value
+        _ = try await synthesizer.synthesize(
+            text: "reuse replacement",
+            modelRepo: nil,
+            language: nil,
+            voicePreset: nil)
+
+        #expect(await factory.callCount == 2)
+        await synthesizer.shutdown()
+    }
+
+    @Test
     func `reuses resident helper across utterances`() async throws {
         let transport = TestMLXTransport(mode: .audio)
         let factory = TestMLXTransportFactory([transport])
@@ -443,6 +516,8 @@ private actor TestMLXTransport: MLXTTSTransport {
         case crash
         case ignoreCancel
         case staleStartupClose
+        case staleStartupReady
+        case staleStreamTimeout
         case startupHang
         case stream
         case streamWaitForCancel
@@ -457,7 +532,7 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     init(mode: Mode) {
         self.mode = mode
-        if mode == .startupHang || mode == .staleStartupClose {
+        if mode == .startupHang || mode == .staleStartupClose || mode == .staleStartupReady {
             self.events = []
         }
     }
@@ -480,13 +555,14 @@ private actor TestMLXTransport: MLXTTSTransport {
                     id: synthesize.id,
                     pcm: Data([0x00, 0x00, 0xFF, 0x7F]))))
                 self.events.append(.completed(id: synthesize.id))
-            case .streamWaitForCancel:
+            case .staleStreamTimeout, .streamWaitForCancel:
                 self.events.append(.streamStarted(MLXTTSStreamStart(
                     id: synthesize.id,
                     sampleRate: 32000)))
             case .crash:
                 self.closed = true
-            case .audioAfterCancel, .ignoreCancel, .staleStartupClose, .startupHang, .waitForCancel:
+            case .audioAfterCancel, .ignoreCancel, .staleStartupClose, .staleStartupReady,
+                 .startupHang, .waitForCancel:
                 break
             }
         case let .cancel(id):
@@ -495,11 +571,18 @@ private actor TestMLXTransport: MLXTTSTransport {
                     id: id,
                     sampleRate: 32000,
                     pcm: Data([0x00, 0x00, 0xFF, 0x7F]))))
-            } else if self.mode != .ignoreCancel, self.mode != .startupHang {
+            } else if self.mode != .ignoreCancel,
+                      self.mode != .staleStartupReady,
+                      self.mode != .staleStreamTimeout,
+                      self.mode != .startupHang
+            {
                 self.events.append(.canceled(id: id))
             }
         case .shutdown:
-            if self.mode != .staleStartupClose {
+            if self.mode != .staleStartupClose,
+               self.mode != .staleStartupReady,
+               self.mode != .staleStreamTimeout
+            {
                 self.closed = true
             }
         }
@@ -517,13 +600,26 @@ private actor TestMLXTransport: MLXTTSTransport {
 
     func close() {
         self.closeCount += 1
-        if self.mode != .staleStartupClose {
+        if self.mode != .staleStartupClose,
+           self.mode != .staleStartupReady,
+           self.mode != .staleStreamTimeout
+        {
             self.closed = true
         }
     }
 
     func finishStaleClose() {
         self.closed = true
+    }
+
+    func finishStaleReady() {
+        self.events.append(.ready)
+    }
+
+    func waitForBlockedEvent() async {
+        while !self.events.isEmpty {
+            await Task.yield()
+        }
     }
 
     func waitForSynthesisRequest() async {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS Talk users could leave the MLX speech helper running after app shutdown, helper replacement, or a failed startup when the helper ignored `SIGTERM`. A retired startup or request could also clear or close a newer replacement transport.

## Why This Change Was Made

The MLX transport now uses the existing `ManagedProcess` lifecycle owner, including start settlement and process-group TERM/KILL/reap/descendant cleanup. Transport replacement is guarded by exact transport identity during startup failure and by the active request ID during request cleanup, so retired work cannot mutate a replacement generation.

The production change is +52/-29 (net +23). That growth is justified by moving the helper onto the canonical process owner, explicitly settling startup/descriptor ownership, and separating authoritative shutdown from request-scoped cleanup so callers cannot accidentally bypass identity checks. It removes the Foundation `Process` path instead of adding a second termination policy or a downstream workaround.

## User Impact

Talk's local MLX helper now stops deterministically when the app shuts down or replaces a failed helper, including TERM-resistant descendants. Replacement speech requests keep their live transport even when an older startup or request finishes late.

No UI, permissions, signing, configuration, protocol, persistence, release, or deployment surface changes.

## Evidence

- Before: a real helper emitted `ready`, ignored TERM, then `exec`'d `sleep`; shutdown returned while that process survived.
- After: the same lifecycle reproduction proves exact process termination, reap completion, descendant cleanup, and temporary artifact cleanup before shutdown returns.
- Replacement generation regressions: forced stale-startup close, delayed startup `ready`, and a stale stream timeout cannot discard the replacement transport; the replacement is reused for the following request.
- Red/green proof: delayed `ready` and stale stream timeout both failed on the prior unscoped cleanup rule by closing the replacement, then passed with request-scoped disposal.
- Direct-review proof on the original candidate: 19 macOS tests and 6 helper tests passed.
- Fresh post-review focused proof: all 17 `TalkMLXSpeechSynthesizerTests` and all 4 `ManagedProcessTests` passed.
- Changed checks, Swift lint, and formatting passed.
- Fresh autoreview on the final patch was clean (0.98 confidence).
- Rebase proof: reviewed candidate `a2aa7bde613f2db2921288c257876e85264c58da` rebased to `da8c50f114eea34084f359329f2539c23c3baea4` with unchanged blobs; the verified ClawSweeper finding was then resolved at final head `7a3bdf204961dcbd34182efd918910a73760aa4a`.
- Tests: +197/-5 (net +192), protecting real process cleanup plus stale close, delayed-ready, timeout, cancellation, and replacement ownership.

AI-assisted: yes.
