### PR TITLE
fix(ui): show snapshot warning after forced worktree removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI forced worktree removal:** surface snapshot failures when forced removal continues without a recovery snapshot, including preserved-worktree cleanup after session deletion.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI forced worktree removal:** surface snapshot failures when forced removal continues without a recovery snapshot, including preserved-worktree cleanup after session deletion.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -583,6 +583,35 @@ describe("session organizer destructive confirmations", () => {
     });
   });
 
+  it("surfaces a forced worktree removal that could not create a snapshot", async () => {
+    const harness = createHarness({
+      ...destructiveHarness,
+      methods: [...destructiveHarness.methods, "worktrees.remove"],
+    });
+    harness.deleteOne.mockResolvedValueOnce({
+      deleted: true,
+      worktreePreserved: { id: "wt-1", branch: "feature", path: "/tmp/worktree" },
+    } as never);
+    harness.request.mockResolvedValueOnce({
+      removed: true,
+      snapshotError: "nested gitlink",
+    } as never);
+
+    const pending = deleteSession(harness.host, sessionRow(0), harness.scope);
+    answerConfirmDialog(await waitForConfirmDialogActions(), "confirm");
+    answerConfirmDialog(await waitForConfirmDialogActions(), "confirm");
+    await pending;
+
+    expect(harness.request).toHaveBeenCalledWith("worktrees.remove", {
+      id: "wt-1",
+      force: true,
+    });
+    expect(harness.publishSessionMutationError).toHaveBeenCalledWith(
+      harness.scope,
+      "nested gitlink",
+    );
+  });
+
   it("skips the delete confirm entirely once the operator opted out", async () => {
     patchSettings({ sessionDeleteConfirm: false });
     const harness = createHarness(destructiveHarness);

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { WorktreesRemoveResult } from "../../../packages/gateway-protocol/src/index.js";
 import { loadSettings, patchSettings } from "../app/settings.ts";
 import { t } from "../i18n/index.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
@@ -640,10 +641,13 @@ export async function deleteSession(
         }
         if (removeWorktree) {
           try {
-            await scope.client.request("worktrees.remove", {
+            const result = await scope.client.request<WorktreesRemoveResult>("worktrees.remove", {
               id: preserved.id,
               force: true,
             });
+            if (result.snapshotError) {
+              host.sessionData.publishSessionMutationError(scope, result.snapshotError);
+            }
           } catch (error) {
             host.sessionData.publishSessionMutationError(scope, error);
           }

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -343,11 +343,11 @@ describe("WorktreesPage lifecycle", () => {
     expect(secondRequest).not.toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" });
   });
 
-  it("offers force removal when the gateway reports a snapshot failure", async () => {
+  it("surfaces the snapshot failure after a forced removal", async () => {
     const request = vi.fn((method: string, params?: Record<string, unknown>) => {
       if (method === "worktrees.remove") {
         return params?.force
-          ? Promise.resolve({ removed: true })
+          ? Promise.resolve({ removed: true, snapshotError: "nested gitlink" })
           : Promise.resolve({ removed: false, snapshotError: "nested gitlink" });
       }
       return Promise.resolve({ worktrees: [] });
@@ -371,7 +371,9 @@ describe("WorktreesPage lifecycle", () => {
     expect(request).toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" });
     expect(request).toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1", force: true });
     expect(showConfirmDialog).toHaveBeenCalledTimes(2);
-    expect(page.error).toBeNull();
+    expect(page.error).toBe("nested gitlink");
+    await page.updateComplete;
+    expect(page.querySelector(".callout.danger")?.textContent).toContain("nested gitlink");
   });
 
   it("discards a restore error across a same-client reconnect", async () => {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -2,7 +2,10 @@ import { consume } from "@lit/context";
 import { initialState, Task, TaskStatus } from "@lit/task";
 import { html, nothing } from "lit";
 import { state } from "lit/decorators.js";
-import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
+import type {
+  WorktreeRecord,
+  WorktreesRemoveResult,
+} from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
@@ -32,7 +35,6 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 const WORKTREES_DOCS_URL = "https://docs.openclaw.ai/concepts/managed-worktrees";
 
 type WorktreesListResult = { worktrees: WorktreeRecord[] };
-type WorktreesRemoveResult = { removed: boolean; snapshotError?: string };
 type WorktreeBranchesResult = {
   branches: Array<{ name: string }>;
   defaultBranch?: string;
@@ -184,7 +186,13 @@ class WorktreesPage extends OpenClawLightDomElement {
         return;
       }
       try {
-        await scope.client.request("worktrees.remove", { id: record.id, force: true });
+        const forced = await scope.client.request<WorktreesRemoveResult>("worktrees.remove", {
+          id: record.id,
+          force: true,
+        });
+        if (this.gateway.isCurrent(scope)) {
+          this.error = forced.snapshotError ?? null;
+        }
       } catch (forceError) {
         if (this.gateway.isCurrent(scope)) {
           this.error = String(forceError);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators forcing removal of a managed worktree after snapshot creation failed would see an unqualified success, even though no recovery snapshot existed. The same silent outcome affected preserved-worktree cleanup after deleting a session.

## Why This Change Was Made

The Gateway already returns the typed `WorktreesRemoveResult` with `removed: true` and `snapshotError` for this explicit-force outcome. Both Control UI consumers now retain that result and route `snapshotError` through their existing visible, scope-fenced error owners. No Gateway, protocol, or worktree-service behavior changes.

## User Impact

Operators still get the requested forced removal, but now also see why the recovery snapshot was not created instead of being told only that the removal succeeded.

## Evidence

- Focused regressions: 47/47 passing across the Worktrees page and session-organizer deletion flows.
- Full Control UI gate: 9,580 tests passing across 666 files, with one pre-existing skip.
- UI typecheck, stylelint, i18n verification, changed-file formatting/lint/type gates, import/dead-export guards, and `git diff --check` all pass.
- Exact-head Control UI build changed the served asset from `index-CkH47Swx.js` on local `origin/main` to `index-D-CN21K_.js` on this branch.
- Source-blind Chromium contract: 5/5 clauses pass against an isolated mocked Gateway, including ordered `{id}` then `{id, force: true}` requests and a visible `nested gitlink` warning after the worktree disappears.
- Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31949443727
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31950301690 passed on attempt 2. Attempt 1 had one unrelated `config-safe-write.e2e.test.ts` timeout in shard 8/12; the targeted rerun and aggregate `openclaw/ci-gate` are green at the unchanged head.
- Fresh Codex autoreview: clean, no accepted/actionable findings, 0.99.
- Production LOC: +16/-4 (net +12). Tests: +34/-3 (net +31).

### Visual proof

![Forced removal preserves the snapshot warning](https://github.com/user-attachments/assets/c02f8a05-f9f1-424a-a71d-f7cab2a1fba8)

https://github.com/user-attachments/assets/1edbcc9f-d57d-4af8-9bab-047a0bed5216

AI-assisted: yes. The implementation and proof were directly reviewed and independently revalidated.
