### PR TITLE
fix(line): stop inbound media hangs after response headers

### DIFF
--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -1363,6 +1363,49 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).not.toHaveBeenCalled();
   });
 
+  it("does not materialize or dispatch media after ingress cancellation", async () => {
+    const cancellation = new Error("LINE webhook spool stopped");
+    const abort = new AbortController();
+    const processMessage = vi.fn();
+    downloadLineMediaMock.mockImplementationOnce(
+      async (
+        _messageId: string,
+        _token: string,
+        _maxBytes: number,
+        options?: { signal?: AbortSignal },
+      ) => {
+        options?.signal?.throwIfAborted();
+        throw new Error("download did not receive ingress cancellation");
+      },
+    );
+    const event = createTestMessageEvent({
+      message: {
+        id: "image-cancelled-1",
+        type: "image",
+        contentProvider: { type: "line" },
+        quoteToken: "q-image-cancelled",
+      },
+      source: { type: "user", userId: "user-image-cancelled" },
+      webhookEventId: "evt-image-cancelled",
+    });
+    const context = {
+      ...createLineWebhookTestContext({ processMessage, dmPolicy: "open" }),
+      turnAdoptionLifecycle: {
+        admission: "exclusive" as const,
+        abortSignal: abort.signal,
+        onAdopted: vi.fn(),
+        onDeferred: vi.fn(),
+        onAbandoned: vi.fn(),
+      },
+    };
+    abort.abort(cancellation);
+
+    await expect(handleLineWebhookEvents([event], context)).rejects.toBe(cancellation);
+
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
   it("allows non-text group messages through when requireMention is set (cannot detect mention)", async () => {
     // Image message -- LINE only carries mention metadata on text messages.
     const event = createTestMessageEvent({

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -423,6 +423,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     let mediaUnavailable = false;
 
     if (isDownloadableLineMessageType(message.type)) {
+      const abortSignal = context.turnAdoptionLifecycle?.abortSignal;
       try {
         const originalFilename =
           message.type === "file" ? normalizeOptionalString(message.fileName) : undefined;
@@ -430,13 +431,17 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
           message.id,
           account.channelAccessToken,
           mediaMaxBytes,
-          { originalFilename },
+          { originalFilename, ...(abortSignal ? { signal: abortSignal } : {}) },
         );
+        abortSignal?.throwIfAborted();
         allMedia.push({
           path: media.path,
           contentType: media.contentType,
         });
       } catch (err) {
+        if (abortSignal?.aborted) {
+          throw abortSignal.reason;
+        }
         if (isRetryableLineInboundMediaError(err)) {
           // Preparation-phase failure before turn adoption: reject so the durable
           // ingress drain retries the whole event once LINE finishes preparing the

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -313,7 +313,7 @@ describe("downloadLineMedia", () => {
 
     vi.useFakeTimers();
     const pending = downloadLineMedia("mid-hung", "token");
-    const rejection = expect(pending).rejects.toThrow(/did not become ready within 15 seconds/i);
+    const rejection = expect(pending).rejects.toThrow(/did not download within 15 seconds/i);
     await vi.advanceTimersByTimeAsync(15_000);
     await rejection;
 
@@ -383,23 +383,57 @@ describe("downloadLineMedia", () => {
     expect(isRetryableLineInboundMediaError(err)).toBe(true);
   });
 
-  it("raises a retryable MediaFetchError when the readiness deadline aborts", async () => {
-    fetchMock.mockImplementation(
-      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
-        await new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => reject(new Error("fetch aborted")), {
-            once: true,
-          });
-        }),
+  it("uses one deadline across headers and body, then permits an identical retry", async () => {
+    let stalledBody: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let stalledResponse: Response | undefined;
+    let requestSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce(
+      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        requestSignal = init?.signal ?? undefined;
+        stalledResponse = new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              stalledBody = controller;
+              controller.enqueue(Buffer.from("partial"));
+              init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), {
+                once: true,
+              });
+            },
+          }),
+          { status: 200 },
+        );
+        return stalledResponse;
+      },
     );
 
     vi.useFakeTimers();
-    const pending = downloadLineMedia("mid-hung", "token").catch((e: unknown) => e);
+    let settledAtDeadline = false;
+    const pending = downloadLineMedia("mid-body-stall", "token")
+      .catch((error: unknown) => error)
+      .finally(() => {
+        settledAtDeadline = true;
+      });
+    await vi.waitFor(() => expect(saveMediaStreamMock).toHaveBeenCalledTimes(1));
     await vi.advanceTimersByTimeAsync(15_000);
+    await Promise.resolve();
+    const observedAtDeadline = settledAtDeadline;
+    if (!settledAtDeadline) {
+      stalledBody?.error(new Error("pre-fix test cleanup"));
+    }
     const err = expectMediaFetchError(await pending);
 
+    expect(observedAtDeadline).toBe(true);
     expect(err.code).toBe("fetch_failed");
+    expect(err).toBe(requestSignal?.reason);
+    expect(requestSignal?.aborted).toBe(true);
+    expect(stalledResponse?.body?.locked).toBe(false);
     expect(isRetryableLineInboundMediaError(err)).toBe(true);
+
+    const healthy = Buffer.from("healthy retry");
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [healthy]));
+    await expect(downloadLineMedia("mid-body-stall", "token")).resolves.toMatchObject({
+      size: healthy.length,
+    });
   });
 
   it("raises a non-retryable MediaFetchError for a permanent HTTP error", async () => {

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -16,7 +16,7 @@ interface DownloadResult {
 const CONTENT_READY_MAX_ATTEMPTS = 6;
 const CONTENT_READY_BASE_DELAY_MS = 500;
 const CONTENT_READY_MAX_DELAY_MS = 4000;
-const CONTENT_READY_TIMEOUT_MS = 15_000;
+const CONTENT_DOWNLOAD_TIMEOUT_MS = 15_000;
 const LINE_CONTENT_BASE_URL = "https://api-data.line.me/v2/bot/message";
 
 class RetryableLineMediaFetchError extends MediaFetchError {
@@ -37,6 +37,8 @@ function lineContentUrl(messageId: string): string {
 async function* lineResponseBodyChunks(
   response: Response,
   messageId: string,
+  signal: AbortSignal,
+  onComplete: () => void,
 ): AsyncIterable<Uint8Array> {
   const body = response.body;
   if (!body) {
@@ -52,6 +54,9 @@ async function* lineResponseBodyChunks(
       try {
         chunk = await reader.read();
       } catch (err) {
+        if (signal.aborted) {
+          throw signal.reason;
+        }
         throw new RetryableLineMediaFetchError(
           `LINE media response stream failed for message ${messageId}`,
           { cause: err },
@@ -59,6 +64,7 @@ async function* lineResponseBodyChunks(
       }
       if (chunk.done) {
         completed = true;
+        onComplete();
         return;
       }
       if (chunk.value.byteLength > 0) {
@@ -67,7 +73,7 @@ async function* lineResponseBodyChunks(
     }
   } finally {
     if (!completed) {
-      await reader.cancel().catch(() => undefined);
+      await reader.cancel(signal.aborted ? signal.reason : undefined).catch(() => undefined);
     }
     try {
       reader.releaseLock();
@@ -78,16 +84,14 @@ async function* lineResponseBodyChunks(
 async function fetchLineContentWhenReady(
   messageId: string,
   channelAccessToken: string,
+  signal: AbortSignal,
 ): Promise<Response> {
-  const controller = new AbortController();
-  const deadline = setTimeout(() => controller.abort(), CONTENT_READY_TIMEOUT_MS);
-  deadline.unref();
   try {
     for (let attempt = 0; attempt < CONTENT_READY_MAX_ATTEMPTS; attempt++) {
       const response = await fetchWithRuntimeDispatcherOrMockedGlobal(lineContentUrl(messageId), {
         headers: { Authorization: `Bearer ${channelAccessToken}` },
         redirect: "error",
-        signal: controller.signal,
+        signal,
       });
       if (response.status === 200) {
         if (!response.body) {
@@ -107,15 +111,12 @@ async function fetchLineContentWhenReady(
         );
       }
       if (attempt < CONTENT_READY_MAX_ATTEMPTS - 1) {
-        await delay(contentBackoffDelayMs(attempt), undefined, { signal: controller.signal });
+        await delay(contentBackoffDelayMs(attempt), undefined, { signal });
       }
     }
   } catch (err) {
-    if (controller.signal.aborted) {
-      throw new RetryableLineMediaFetchError(
-        `LINE media for message ${messageId} did not become ready within ${CONTENT_READY_TIMEOUT_MS / 1000} seconds`,
-        { cause: err },
-      );
+    if (signal.aborted) {
+      throw signal.reason;
     }
     if (err instanceof MediaFetchError) {
       throw err;
@@ -123,8 +124,6 @@ async function fetchLineContentWhenReady(
     throw new RetryableLineMediaFetchError(`LINE media download failed for message ${messageId}`, {
       cause: err,
     });
-  } finally {
-    clearTimeout(deadline);
   }
 
   throw new MediaFetchError(
@@ -160,27 +159,49 @@ export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
-  options?: { originalFilename?: string },
+  options?: { originalFilename?: string; signal?: AbortSignal },
 ): Promise<DownloadResult> {
-  const response = await fetchLineContentWhenReady(messageId, channelAccessToken);
-  let saved: Awaited<ReturnType<typeof saveMediaStream>>;
-  try {
-    saved = await saveMediaStream(
-      lineResponseBodyChunks(response, messageId),
-      response.headers.get("content-type") ?? undefined,
-      "inbound",
-      maxBytes,
-      options?.originalFilename,
+  options?.signal?.throwIfAborted();
+  const deadlineAbort = new AbortController();
+  const signal = options?.signal
+    ? AbortSignal.any([options.signal, deadlineAbort.signal])
+    : deadlineAbort.signal;
+  // Header resolution does not finish the request; only EOF retires this deadline.
+  const deadline = setTimeout(() => {
+    deadlineAbort.abort(
+      new RetryableLineMediaFetchError(
+        `LINE media for message ${messageId} did not download within ${CONTENT_DOWNLOAD_TIMEOUT_MS / 1000} seconds`,
+      ),
     );
-  } catch (err) {
-    await response.body?.cancel().catch(() => undefined);
-    throw err;
-  }
-  logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
+  }, CONTENT_DOWNLOAD_TIMEOUT_MS);
+  deadline.unref();
+  try {
+    const response = await fetchLineContentWhenReady(messageId, channelAccessToken, signal);
+    let saved: Awaited<ReturnType<typeof saveMediaStream>>;
+    try {
+      saved = await saveMediaStream(
+        lineResponseBodyChunks(response, messageId, signal, () => clearTimeout(deadline)),
+        response.headers.get("content-type") ?? undefined,
+        "inbound",
+        maxBytes,
+        options?.originalFilename,
+      );
+    } catch (err) {
+      await response.body?.cancel(signal.aborted ? signal.reason : err).catch(() => undefined);
+      if (signal.aborted) {
+        throw signal.reason;
+      }
+      throw err;
+    }
+    options?.signal?.throwIfAborted();
+    logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 
-  return {
-    path: saved.path,
-    contentType: saved.contentType,
-    size: saved.size,
-  };
+    return {
+      path: saved.path,
+      contentType: saved.contentType,
+      size: saved.size,
+    };
+  } finally {
+    clearTimeout(deadline);
+  }
 }


### PR DESCRIPTION
Related: #109165

## What Problem This Solves

Fixes an issue where a LINE inbound media message could leave delivery running indefinitely after LINE returned HTTP 200 headers but stalled the response body. Gateway shutdown also did not cancel that pre-adoption download, so old media work could continue after the durable ingress owner stopped.

## Why This Change Was Made

The LINE download owner now keeps one existing 15-second absolute deadline across readiness polling, 202 backoff, response headers, and body EOF. It composes that deadline with the durable-ingress abort signal, preserves the exact winning abort reason, cancels and releases incomplete response readers, and rechecks ingress cancellation before accepting materialized media. Healthy 202-to-200 retry behavior, byte limits, MIME detection, persistence, and retry classification remain unchanged.

Maintainer decision: accept the 15-second total-transfer policy. A valid transfer that exceeds the single owner-held budget retries through durable ingress instead of holding that ingress claim indefinitely.

A separate post-header timeout was rejected because it would extend work beyond the existing deadline and lifecycle owner. Moving LINE policy into the shared media store was also rejected: the store already owns atomic sibling-temp cleanup, while LINE owns its API-specific readiness and retry contract.

## User Impact

LINE media delivery now either finishes within the existing bounded window or rejects for durable retry; it no longer wedges indefinitely on a stalled body or continues after ingress shutdown. Text messages, outbound LINE sends, configuration, auth, routing, public plugin contracts, persistence schemas, release behavior, and deployment are unchanged.

## Evidence

Exact reviewed candidate: `2dbf2e1bec02e824eb3d41aa16462f6b8e15c7bf`. Rebased exact head: `e0cd3b87953c650d7de6147d8de8e4236fc8acad` on local `origin/main` `eafeeec537a643d1f47459ec617516986b17c514`. The rebase was conflict-free; all four before/after blob IDs and stable patch ID remained identical, so the accepted proof and autoreview still cover the exact change.

- Controlled native loopback before fix: HTTP 200 headers plus one chunk remained pending with its socket open at 15.755 seconds.
- Controlled native loopback after fix: settled at about 15.258 seconds with the exact retryable abort reason, closed the stalled socket, and an identical healthy retry saved four bytes.
- External live gate from exact candidate code: one read-only GET to LINE Get Content with a synthetic invalid bearer and synthetic message ID rejected safely as HTTP 404 in 760 ms. It created no media/temp residue, performed no send or persistent write, closed the dispatcher, left no network resources, and removed its isolated state root. No real credentials or user content were used.
- Focused lifecycle proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/line/src/download.test.ts extensions/line/src/bot-handlers.test.ts extensions/line/src/webhook-spool.test.ts extensions/line/src/monitor.lifecycle.test.ts --reporter=verbose` — 81 tests passed. The body-stall and ingress-cancellation regressions failed on pre-fix code for the intended reasons.
- Production/test types, type-aware extension lint, formatting, media-download ownership guard, database-first guard, import cycles, and diff checks passed. Pinned Undici 8.9.0 source and the official LINE 202/200 content contract were inspected.
- Exact-head CI: [run 31950487996](https://github.com/openclaw/openclaw/actions/runs/31950487996) completed successfully on `e0cd3b87953c650d7de6147d8de8e4236fc8acad` with 41 successful jobs and zero failures.
- Fresh structured autoreview on the reviewed patch reported: `autoreview clean: no accepted/actionable findings reported`.
- Test audit: the added tests protect observable total-deadline, exact-cancellation, resource-release, and healthy-retry behavior at the download/lifecycle boundaries; they add no test-only production seam.

Production LOC: +61/-35 (net +26). Tests: +87/-10 (net +77). The production growth is the minimum owner-held signal/deadline composition and reader cleanup needed to cover headers through EOF and ingress shutdown without adding config, fallback, or parallel policy paths.

Duplicate search found closed #109165 and closed #86873. #109165 used separate 15-second readiness and 120-second body budgets, did not propagate durable-ingress cancellation, exposed a test-only timeout option, and lacked native transport cleanup proof; this change replaces that shape with the single owner deadline and lifecycle invariant above.

AI-assisted: yes. The implementation, dependency behavior, lifecycle ownership, tests, and live/controlled evidence were directly reviewed.
