### PR TITLE
fix(plugins): avoid lifecycle lease startup flake

### DIFF
--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -8,22 +8,24 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 
-afterEach(() => {
+const activeLeaseChildren = new Set<ChildProcessWithoutNullStreams>();
+
+afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
+  await Promise.all(Array.from(activeLeaseChildren, terminateLeaseChild));
 });
 
-async function waitForPath(filePath: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    try {
-      await fs.access(filePath);
+async function terminateLeaseChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const onClose = () => resolve();
+    child.once("close", onClose);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      child.off("close", onClose);
+      resolve();
       return;
-    } catch {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 25);
-      });
     }
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
+    child.kill("SIGKILL");
+  });
 }
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
@@ -34,22 +36,72 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
-function runLeaseChild(scriptPath: string, args: string[]): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--import", "tsx", scriptPath, ...args], {
-      stdio: ["ignore", "pipe", "pipe"],
+function runLeaseChild(
+  scriptPath: string,
+  args: string[],
+): { ready: Promise<void>; completed: Promise<void> } {
+  const child = spawn(process.execPath, ["--import", "tsx", scriptPath, ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  activeLeaseChildren.add(child);
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+
+  let stdout = "";
+  let stderr = "";
+  let pendingLine = "";
+  let readySettled = false;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    pendingLine += chunk;
+    const lines = pendingLine.split("\n");
+    pendingLine = lines.pop() ?? "";
+    if (!readySettled && lines.includes("ready")) {
+      readySettled = true;
+      resolveReady();
+    }
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const completed = new Promise<void>((resolve, reject) => {
+    child.once("error", (error) => {
+      activeLeaseChildren.delete(child);
+      const failure = new Error(`failed to start lease child: ${error.message}`, {
+        cause: error,
+      });
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(failure);
+      }
+      reject(failure);
     });
-    let output = "";
-    child.stdout.on("data", (chunk) => (output += chunk));
-    child.stderr.on("data", (chunk) => (output += chunk));
-    child.on("close", (code) => {
+    child.once("close", (code, signal) => {
+      activeLeaseChildren.delete(child);
+      const output = `stdout:\n${stdout}\nstderr:\n${stderr}`;
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(
+          new Error(`lease child exited before readiness (${code ?? signal})\n${output}`),
+        );
+      }
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`lease child exited ${code}: ${output}`));
+        reject(new Error(`lease child exited ${code ?? signal}\n${output}`));
       }
     });
   });
+  void completed.catch(() => {});
+  return { ready, completed };
 }
 
 describe("plugin lifecycle lease", () => {
@@ -130,10 +182,8 @@ describe("plugin lifecycle lease", () => {
 
   it("serializes lifecycle work across processes", async () => {
     await withOpenClawTestState({ label: "plugin-lifecycle-processes" }, async (state) => {
-      const firstMarker = state.path("first-entered");
       const releaseMarker = state.path("release-first");
       const secondMarker = state.path("second-entered");
-      const secondReady = state.path("second-ready");
       const secondResult = state.path("second-result");
       const leaseModuleUrl = pathToFileURL(
         path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
@@ -143,10 +193,10 @@ describe("plugin lifecycle lease", () => {
         `
           import fs from "node:fs/promises";
           import { withPluginLifecycleLease } from ${JSON.stringify(leaseModuleUrl)};
-          const [role, stateDir, firstMarker, releaseMarker, secondMarker, secondReady, secondResult] = process.argv.slice(2);
+          const [role, stateDir, releaseMarker, secondMarker, secondResult] = process.argv.slice(2);
           const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
           if (role === "second") {
-            await fs.writeFile(secondReady, "ready");
+            process.stdout.write("ready\\n");
             try {
               await withPluginLifecycleLease({ env, leaseMs: 1_000, waitMs: 0 }, async () => {
                 await fs.writeFile(secondMarker, "entered");
@@ -157,7 +207,7 @@ describe("plugin lifecycle lease", () => {
             }
           } else {
             await withPluginLifecycleLease({ env, leaseMs: 1_000, waitMs: 5_000 }, async () => {
-              await fs.writeFile(firstMarker, "entered");
+              process.stdout.write("ready\\n");
               while (true) {
                 try {
                   await fs.access(releaseMarker);
@@ -173,21 +223,14 @@ describe("plugin lifecycle lease", () => {
         `,
       );
 
-      const childArgs = [
-        state.stateDir,
-        firstMarker,
-        releaseMarker,
-        secondMarker,
-        secondReady,
-        secondResult,
-      ];
+      const childArgs = [state.stateDir, releaseMarker, secondMarker, secondResult];
       const first = runLeaseChild(childScript, ["first", ...childArgs]);
-      await waitForPath(firstMarker);
+      await first.ready;
       const second = runLeaseChild(childScript, ["second", ...childArgs]);
-      await waitForPath(secondReady);
+      await second.ready;
       // Wait for the child to close so its result write is fully flushed before
       // reading; file existence alone can race with the write after open().
-      await second;
+      await second.completed;
 
       let assertionError: unknown;
       try {
@@ -200,7 +243,7 @@ describe("plugin lifecycle lease", () => {
       } finally {
         await fs.writeFile(releaseMarker, "release");
       }
-      await Promise.all([first, second]);
+      await Promise.all([first.completed, second.completed]);
       if (assertionError) {
         throw assertionError instanceof Error
           ? assertionError
@@ -218,8 +261,6 @@ describe("plugin lifecycle lease", () => {
         path.resolve("src/plugins/installed-plugin-index-records.ts"),
       ).href;
       const goMarker = state.path("go");
-      const readyAlpha = state.path("ready-alpha");
-      const readyBeta = state.path("ready-beta");
       const childScript = await state.writeText(
         "record-cache-child.mts",
         `
@@ -229,11 +270,11 @@ describe("plugin lifecycle lease", () => {
             loadInstalledPluginIndexInstallRecords,
             writePersistedInstalledPluginIndexInstallRecords,
           } from ${JSON.stringify(recordsModuleUrl)};
-          const [pluginId, stateDir, readyMarker, goMarker] = process.argv.slice(2);
+          const [pluginId, stateDir, goMarker] = process.argv.slice(2);
           process.env.OPENCLAW_STATE_DIR = stateDir;
           const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
           await loadInstalledPluginIndexInstallRecords();
-          await fs.writeFile(readyMarker, "ready");
+          process.stdout.write("ready\\n");
           while (true) {
             try {
               await fs.access(goMarker);
@@ -257,11 +298,11 @@ describe("plugin lifecycle lease", () => {
         `,
       );
 
-      const alpha = runLeaseChild(childScript, ["alpha", state.stateDir, readyAlpha, goMarker]);
-      const beta = runLeaseChild(childScript, ["beta", state.stateDir, readyBeta, goMarker]);
-      await Promise.all([waitForPath(readyAlpha), waitForPath(readyBeta)]);
+      const alpha = runLeaseChild(childScript, ["alpha", state.stateDir, goMarker]);
+      const beta = runLeaseChild(childScript, ["beta", state.stateDir, goMarker]);
+      await Promise.all([alpha.ready, beta.ready]);
       await fs.writeFile(goMarker, "go");
-      await Promise.all([alpha, beta]);
+      await Promise.all([alpha.completed, beta.completed]);
 
       closeOpenClawStateDatabaseForTest();
       const persisted = await readPersistedInstalledPluginIndex({ env: state.env });

--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -1,6 +1,7 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -8,14 +9,16 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 
-const activeLeaseChildren = new Set<ChildProcessWithoutNullStreams>();
+type LeaseChild = ChildProcessByStdio<null, Readable, Readable>;
+
+const activeLeaseChildren = new Set<LeaseChild>();
 
 afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
   await Promise.all(Array.from(activeLeaseChildren, terminateLeaseChild));
 });
 
-async function terminateLeaseChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+async function terminateLeaseChild(child: LeaseChild): Promise<void> {
   await new Promise<void>((resolve) => {
     const onClose = () => resolve();
     child.once("close", onClose);

--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -11,11 +11,8 @@ import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 
 type LeaseChild = ChildProcessByStdio<null, Readable, Readable>;
 
-const activeLeaseChildren = new Set<LeaseChild>();
-
-afterEach(async () => {
+afterEach(() => {
   closeOpenClawStateDatabaseForTest();
-  await Promise.all(Array.from(activeLeaseChildren, terminateLeaseChild));
 });
 
 async function terminateLeaseChild(child: LeaseChild): Promise<void> {
@@ -31,6 +28,15 @@ async function terminateLeaseChild(child: LeaseChild): Promise<void> {
   });
 }
 
+async function withLeaseChildren<T>(fn: (children: Set<LeaseChild>) => Promise<T>): Promise<T> {
+  const children = new Set<LeaseChild>();
+  try {
+    return await fn(children);
+  } finally {
+    await Promise.all(Array.from(children, terminateLeaseChild));
+  }
+}
+
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
   const promise = new Promise<void>((resolvePromise) => {
@@ -40,13 +46,14 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 function runLeaseChild(
+  children: Set<LeaseChild>,
   scriptPath: string,
   args: string[],
 ): { ready: Promise<void>; completed: Promise<void> } {
   const child = spawn(process.execPath, ["--import", "tsx", scriptPath, ...args], {
     stdio: ["ignore", "pipe", "pipe"],
   });
-  activeLeaseChildren.add(child);
+  children.add(child);
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
 
@@ -77,7 +84,7 @@ function runLeaseChild(
 
   const completed = new Promise<void>((resolve, reject) => {
     child.once("error", (error) => {
-      activeLeaseChildren.delete(child);
+      children.delete(child);
       const failure = new Error(`failed to start lease child: ${error.message}`, {
         cause: error,
       });
@@ -88,7 +95,7 @@ function runLeaseChild(
       reject(failure);
     });
     child.once("close", (code, signal) => {
-      activeLeaseChildren.delete(child);
+      children.delete(child);
       const output = `stdout:\n${stdout}\nstderr:\n${stderr}`;
       if (!readySettled) {
         readySettled = true;
@@ -185,15 +192,16 @@ describe("plugin lifecycle lease", () => {
 
   it("serializes lifecycle work across processes", async () => {
     await withOpenClawTestState({ label: "plugin-lifecycle-processes" }, async (state) => {
-      const releaseMarker = state.path("release-first");
-      const secondMarker = state.path("second-entered");
-      const secondResult = state.path("second-result");
-      const leaseModuleUrl = pathToFileURL(
-        path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
-      ).href;
-      const childScript = await state.writeText(
-        "lease-child.mts",
-        `
+      await withLeaseChildren(async (children) => {
+        const releaseMarker = state.path("release-first");
+        const secondMarker = state.path("second-entered");
+        const secondResult = state.path("second-result");
+        const leaseModuleUrl = pathToFileURL(
+          path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
+        ).href;
+        const childScript = await state.writeText(
+          "lease-child.mts",
+          `
           import fs from "node:fs/promises";
           import { withPluginLifecycleLease } from ${JSON.stringify(leaseModuleUrl)};
           const [role, stateDir, releaseMarker, secondMarker, secondResult] = process.argv.slice(2);
@@ -224,49 +232,51 @@ describe("plugin lifecycle lease", () => {
             });
           }
         `,
-      );
-
-      const childArgs = [state.stateDir, releaseMarker, secondMarker, secondResult];
-      const first = runLeaseChild(childScript, ["first", ...childArgs]);
-      await first.ready;
-      const second = runLeaseChild(childScript, ["second", ...childArgs]);
-      await second.ready;
-      // Wait for the child to close so its result write is fully flushed before
-      // reading; file existence alone can race with the write after open().
-      await second.completed;
-
-      let assertionError: unknown;
-      try {
-        await expect(fs.readFile(secondResult, "utf8")).resolves.toBe(
-          "OPENCLAW_STATE_LEASE_TIMEOUT",
         );
-        await expect(fs.access(secondMarker)).rejects.toMatchObject({ code: "ENOENT" });
-      } catch (error) {
-        assertionError = error;
-      } finally {
-        await fs.writeFile(releaseMarker, "release");
-      }
-      await Promise.all([first.completed, second.completed]);
-      if (assertionError) {
-        throw assertionError instanceof Error
-          ? assertionError
-          : new Error("cross-process lease assertion failed", { cause: assertionError });
-      }
+
+        const childArgs = [state.stateDir, releaseMarker, secondMarker, secondResult];
+        const first = runLeaseChild(children, childScript, ["first", ...childArgs]);
+        await first.ready;
+        const second = runLeaseChild(children, childScript, ["second", ...childArgs]);
+        await second.ready;
+        // Wait for the child to close so its result write is fully flushed before
+        // reading; file existence alone can race with the write after open().
+        await second.completed;
+
+        let assertionError: unknown;
+        try {
+          await expect(fs.readFile(secondResult, "utf8")).resolves.toBe(
+            "OPENCLAW_STATE_LEASE_TIMEOUT",
+          );
+          await expect(fs.access(secondMarker)).rejects.toMatchObject({ code: "ENOENT" });
+        } catch (error) {
+          assertionError = error;
+        } finally {
+          await fs.writeFile(releaseMarker, "release");
+        }
+        await Promise.all([first.completed, second.completed]);
+        if (assertionError) {
+          throw assertionError instanceof Error
+            ? assertionError
+            : new Error("cross-process lease assertion failed", { cause: assertionError });
+        }
+      });
     });
   });
 
   it("reloads install records after waiting for another process", async () => {
     await withOpenClawTestState({ label: "plugin-lifecycle-record-cache" }, async (state) => {
-      const leaseModuleUrl = pathToFileURL(
-        path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
-      ).href;
-      const recordsModuleUrl = pathToFileURL(
-        path.resolve("src/plugins/installed-plugin-index-records.ts"),
-      ).href;
-      const goMarker = state.path("go");
-      const childScript = await state.writeText(
-        "record-cache-child.mts",
-        `
+      await withLeaseChildren(async (children) => {
+        const leaseModuleUrl = pathToFileURL(
+          path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
+        ).href;
+        const recordsModuleUrl = pathToFileURL(
+          path.resolve("src/plugins/installed-plugin-index-records.ts"),
+        ).href;
+        const goMarker = state.path("go");
+        const childScript = await state.writeText(
+          "record-cache-child.mts",
+          `
           import fs from "node:fs/promises";
           import { withPluginLifecycleLease } from ${JSON.stringify(leaseModuleUrl)};
           import {
@@ -299,17 +309,18 @@ describe("plugin lifecycle lease", () => {
             });
           });
         `,
-      );
+        );
 
-      const alpha = runLeaseChild(childScript, ["alpha", state.stateDir, goMarker]);
-      const beta = runLeaseChild(childScript, ["beta", state.stateDir, goMarker]);
-      await Promise.all([alpha.ready, beta.ready]);
-      await fs.writeFile(goMarker, "go");
-      await Promise.all([alpha.completed, beta.completed]);
+        const alpha = runLeaseChild(children, childScript, ["alpha", state.stateDir, goMarker]);
+        const beta = runLeaseChild(children, childScript, ["beta", state.stateDir, goMarker]);
+        await Promise.all([alpha.ready, beta.ready]);
+        await fs.writeFile(goMarker, "go");
+        await Promise.all([alpha.completed, beta.completed]);
 
-      closeOpenClawStateDatabaseForTest();
-      const persisted = await readPersistedInstalledPluginIndex({ env: state.env });
-      expect(Object.keys(persisted?.installRecords ?? {}).toSorted()).toEqual(["alpha", "beta"]);
+        closeOpenClawStateDatabaseForTest();
+        const persisted = await readPersistedInstalledPluginIndex({ env: state.env });
+        expect(Object.keys(persisted?.installRecords ?? {}).toSorted()).toEqual(["alpha", "beta"]);
+      });
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the plugin lifecycle lease suite could fail on loaded macOS hosts before a child process finished cold TypeScript startup, even though the cross-process lease behavior was correct.

## Why This Change Was Made

The generated lease children now report observable readiness on their already-piped stdout after reaching the boundary the parent needs. The parent waits for that exact signal, reports child startup/exit diagnostics, and lets Vitest's assertion deadline own genuinely stuck startup instead of adding a second short polling timeout.

ClawSweeper found that file-global child cleanup in `afterEach` ran after `withOpenClawTestState` removed the fixture root when a callback failed. Both fixture callbacks that spawn children now use callback-scoped `withLeaseChildren` ownership. `runLeaseChild` registers and removes each child in that callback's `Set`, and the wrapper's `finally` kills and awaits any remaining children before the fixture callback returns, so state cleanup cannot delete the root first. `afterEach` is synchronous again and only closes the database.

The first exact-head CI run also correctly caught a test-only typing mismatch: `ChildProcessWithoutNullStreams` required non-null stdin even though the child is spawned with `stdio: ["ignore", "pipe", "pipe"]`. The follow-up uses `ChildProcessByStdio<null, Readable, Readable>`, which exactly models ignore/pipe/pipe and changes no runtime behavior.

## User Impact

No runtime behavior changes. Maintainers get reliable coverage that still proves a second process waits on the lifecycle lease and reloads install records before writing, with child cleanup ordered before fixture deletion on every callback exit.

## Evidence

- Final diff: tests +144/-89; production +0/-0.
- Before: the unmodified construction failed 1/5 after 2.594s while waiting for `ready-alpha`.
- Original readiness fix: five consecutive loaded runs of `node scripts/run-vitest.mjs src/plugins/plugin-lifecycle-lease.test.ts`, each with two concurrent CPU consumers, passed 5/5. Total run durations, including heavy-check lock waits: 23.76s, 17.45s, 16.34s, 20.90s, and 45.90s.
- Callback-scoped cleanup correction: three consecutive focused runs under two CPU consumers passed 5/5. Wrapper totals, including heavy-check lock waits: 159.24s, 17.71s, and 121.74s; Vitest durations: 13.96s, 12.54s, and 12.82s.
- Independent focused proof: three additional focused passes, including one loaded pass, all passed 5/5.
- Prior changed gate passed: `node scripts/check-changed.mjs -- src/plugins/plugin-lifecycle-lease.test.ts` completed on Azure Crabbox run `run_5a0557a834a4`, lease `cbx_c45db092e22e` (`brisk-shrimp`), exit 0. It passed core test tsgo, changed-file lint, formatting, guards, dependency/deadcode, and plugin-boundary checks. Portal: https://crabbox.openclaw.ai/portal/runs/run_5a0557a834a4
- `node_modules/.bin/oxfmt --check src/plugins/plugin-lifecycle-lease.test.ts` and `git diff --check` passed on the final tree.
- The first exact-head CI run failed only `check-test-types-core-2` because `ChildProcessWithoutNullStreams` incorrectly modeled ignored stdin as non-null: https://github.com/openclaw/openclaw/actions/runs/31950509712/job/95173188397. The exact correction is `ChildProcessByStdio<null, Readable, Readable>`.
- The predecessor exact head `f211c3355065c419095c001e30f5f5a8d6e52787` passed CI: https://github.com/openclaw/openclaw/actions/runs/31951542298.
- The latest Codex-backed autoreview covered the callback-scoped cleanup and full PR context and exited clean with no accepted or actionable findings, confirming child cleanup completes before fixture deletion.
- ClawSweeper's review was on predecessor head `f211c3355065c419095c001e30f5f5a8d6e52787`. Its concrete P2 and rank-up move requested callback-scoped child termination before fixture cleanup; this head implements exactly that correction. Under repository policy, no re-review is requested because the review is under 12 hours old and the post-review push only addresses its finding plus mechanical corrections.
- Exact-head CI and native Testbox/landing evidence for `aace4af41470989fedc7cdd5d848143e388b91ef` will be recorded in the land-ready proof comment.

AI-assisted: yes
