### PR TITLE
fix(plugins): restrict npm project cleanup to owned roots

### DIFF
--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -1,5 +1,6 @@
 // Resolves plugin install paths for local and package sources.
 import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import {
   resolveSafeInstallDir,
@@ -140,8 +141,19 @@ export function isPluginNpmProjectDir(params: {
   projectDir: string;
   npmDir?: string;
 }): boolean {
+  const npmDir = path.resolve(params.npmDir ?? resolveDefaultPluginNpmDir());
   const projectDir = path.resolve(params.projectDir);
-  if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(params.npmDir))) {
+  if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(npmDir))) {
+    return false;
+  }
+  try {
+    if (
+      path.relative(npmDir, projectDir) !==
+      path.relative(realpathSync(npmDir), realpathSync(projectDir))
+    ) {
+      return false;
+    }
+  } catch {
     return false;
   }
   if (projectDir === path.resolve(resolvePluginNpmProjectDir(params))) {

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -135,6 +135,21 @@ export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string):
   return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
 }
 
+/** Checks that an existing managed path preserves its npm-root-relative real path. */
+export function isPluginNpmManagedPath(params: { managedPath: string; npmDir?: string }): boolean {
+  const npmDir = path.resolve(params.npmDir ?? resolveDefaultPluginNpmDir());
+  const managedPath = path.resolve(params.managedPath);
+  try {
+    return (
+      lstatSync(npmDir).isDirectory() &&
+      path.relative(npmDir, managedPath) ===
+        path.relative(realpathSync(npmDir), realpathSync(managedPath))
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Checks whether a project directory has the exact managed shape owned by a package. */
 export function isPluginNpmProjectDir(params: {
   packageName: string;
@@ -146,17 +161,7 @@ export function isPluginNpmProjectDir(params: {
   if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(npmDir))) {
     return false;
   }
-  try {
-    if (!lstatSync(npmDir).isDirectory()) {
-      return false;
-    }
-    if (
-      path.relative(npmDir, projectDir) !==
-      path.relative(realpathSync(npmDir), realpathSync(projectDir))
-    ) {
-      return false;
-    }
-  } catch {
+  if (!isPluginNpmManagedPath({ managedPath: projectDir, npmDir })) {
     return false;
   }
   if (projectDir === path.resolve(resolvePluginNpmProjectDir(params))) {

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -124,10 +124,35 @@ export function resolvePluginNpmProjectDir(params: {
 
 const PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR = "__openclaw-generation__";
 const PLUGIN_NPM_GENERATION_KEY_HASH_CHARS = 16;
+const PLUGIN_NPM_GENERATION_KEY_DIR_NAME_PATTERN = new RegExp(
+  `^g-[a-f0-9]{${PLUGIN_NPM_GENERATION_KEY_HASH_CHARS}}$`,
+  "u",
+);
 
 /** Resolves the managed npm artifact-generation project directory prefix for a package. */
 export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string): string {
   return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
+}
+
+/** Checks whether a project directory has the exact managed shape owned by a package. */
+export function isPluginNpmProjectDir(params: {
+  packageName: string;
+  projectDir: string;
+  npmDir?: string;
+}): boolean {
+  const projectDir = path.resolve(params.projectDir);
+  if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(params.npmDir))) {
+    return false;
+  }
+  if (projectDir === path.resolve(resolvePluginNpmProjectDir(params))) {
+    return true;
+  }
+  const projectName = path.basename(projectDir);
+  const generationPrefix = resolvePluginNpmGenerationProjectDirPrefix(params.packageName);
+  return (
+    projectName.startsWith(generationPrefix) &&
+    PLUGIN_NPM_GENERATION_KEY_DIR_NAME_PATTERN.test(projectName.slice(generationPrefix.length))
+  );
 }
 
 /** Encodes a package generation fingerprint into a compact project directory suffix. */

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -1,6 +1,6 @@
 // Resolves plugin install paths for local and package sources.
 import { createHash } from "node:crypto";
-import { realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import path from "node:path";
 import {
   resolveSafeInstallDir,
@@ -147,6 +147,9 @@ export function isPluginNpmProjectDir(params: {
     return false;
   }
   try {
+    if (!lstatSync(npmDir).isDirectory()) {
+      return false;
+    }
     if (
       path.relative(npmDir, projectDir) !==
       path.relative(realpathSync(npmDir), realpathSync(projectDir))

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { lstatSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import {
   resolveSafeInstallDir,
   safeDirName,
@@ -135,15 +136,24 @@ export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string):
   return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
 }
 
-/** Checks that an existing managed path preserves its npm-root-relative real path. */
-export function isPluginNpmManagedPath(params: { managedPath: string; npmDir?: string }): boolean {
+/** Checks that a managed path preserves its npm-root-relative real path. */
+export function isPluginNpmManagedPath(params: {
+  managedPath: string;
+  npmDir?: string;
+  allowMissing?: boolean;
+}): boolean {
   const npmDir = path.resolve(params.npmDir ?? resolveDefaultPluginNpmDir());
   const managedPath = path.resolve(params.managedPath);
   try {
     return (
       lstatSync(npmDir).isDirectory() &&
       path.relative(npmDir, managedPath) ===
-        path.relative(realpathSync(npmDir), realpathSync(managedPath))
+        path.relative(
+          realpathSync(npmDir),
+          params.allowMissing
+            ? resolvePathViaExistingAncestorSync(managedPath)
+            : realpathSync(managedPath),
+        )
     );
   } catch {
     return false;
@@ -162,6 +172,10 @@ export function isPluginNpmProjectDir(params: {
     return false;
   }
   if (!isPluginNpmManagedPath({ managedPath: projectDir, npmDir })) {
+    return false;
+  }
+  const packageDir = path.join(projectDir, "node_modules", ...params.packageName.split("/"));
+  if (!isPluginNpmManagedPath({ managedPath: packageDir, npmDir, allowMissing: true })) {
     return false;
   }
   if (projectDir === path.resolve(resolvePluginNpmProjectDir(params))) {

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -403,6 +403,7 @@ describe("persistPluginInstall", () => {
           kind: "npm",
           npmRoot: previousProjectRoot,
           packageName: "@openclaw/codex",
+          rootKind: "isolated-project",
         },
       },
     });

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { resolvePluginNpmGenerationProjectDir } from "./install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
 
 const retentionTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -14,44 +17,50 @@ import {
 } from "./managed-npm-retention.js";
 
 describe("managed npm retention", () => {
-  it("cleans retired generations while preserving the active install root", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
-    const npmDir = path.join(stateDir, "npm");
-    const packageName = "@openclaw/codex";
-    const oldProjectRoot = resolvePluginNpmGenerationProjectDir({
-      npmDir,
-      packageName,
-      generationKey: "codex-v1",
-    });
-    const activeProjectRoot = resolvePluginNpmGenerationProjectDir({
-      npmDir,
-      packageName,
-      generationKey: "codex-v2",
-    });
-    const oldPackageDir = path.join(oldProjectRoot, "node_modules", "@openclaw", "codex");
-    const activePackageDir = path.join(activeProjectRoot, "node_modules", "@openclaw", "codex");
-    fs.mkdirSync(oldPackageDir, { recursive: true });
-    fs.mkdirSync(activePackageDir, { recursive: true });
-    await markRetainedManagedNpmInstall({
-      packageDir: oldPackageDir,
-      pluginId: "codex",
-      reason: "test-retired-generation",
-    });
+  it.each(["ordinary", "generation"] as const)(
+    "cleans a retired %s project while preserving the active install root",
+    async (layout) => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+      const npmDir = path.join(stateDir, "npm");
+      const packageName = "@openclaw/codex";
+      const oldProjectRoot =
+        layout === "ordinary"
+          ? resolvePluginNpmProjectDir({ npmDir, packageName })
+          : resolvePluginNpmGenerationProjectDir({
+              npmDir,
+              packageName,
+              generationKey: "codex-v1",
+            });
+      const activeProjectRoot = resolvePluginNpmGenerationProjectDir({
+        npmDir,
+        packageName,
+        generationKey: "codex-v2",
+      });
+      const oldPackageDir = path.join(oldProjectRoot, "node_modules", "@openclaw", "codex");
+      const activePackageDir = path.join(activeProjectRoot, "node_modules", "@openclaw", "codex");
+      fs.mkdirSync(oldPackageDir, { recursive: true });
+      fs.mkdirSync(activePackageDir, { recursive: true });
+      await markRetainedManagedNpmInstall({
+        packageDir: oldPackageDir,
+        pluginId: "codex",
+        reason: "test-retired-generation",
+      });
 
-    try {
-      await expect(
-        cleanupRetainedManagedNpmInstallGenerations({
-          npmDir,
-          activeInstallPaths: [activePackageDir],
-        }),
-      ).resolves.toBe(1);
-      expect(fs.existsSync(oldProjectRoot)).toBe(false);
-      expect(fs.existsSync(activeProjectRoot)).toBe(true);
-      expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
-    } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-    }
-  });
+      try {
+        await expect(
+          cleanupRetainedManagedNpmInstallGenerations({
+            npmDir,
+            activeInstallPaths: [activePackageDir],
+          }),
+        ).resolves.toBe(1);
+        expect(fs.existsSync(oldProjectRoot)).toBe(false);
+        expect(fs.existsSync(activeProjectRoot)).toBe(true);
+        expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
+      } finally {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("cleans retained packages from the legacy shared npm root", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
@@ -75,6 +84,24 @@ describe("managed npm retention", () => {
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
+  });
+
+  it("preserves a noncanonical project root even when it has a retained marker", async () => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-noncanonical-");
+    const npmDir = path.join(stateDir, "npm");
+    const projectRoot = path.join(npmDir, "projects", "noncanonical-sibling");
+    const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+    const siblingFile = path.join(projectRoot, "must-remain.txt");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(siblingFile, "preserve me", "utf8");
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: "test-retired-generation",
+    });
+
+    await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+    expect(fs.readFileSync(siblingFile, "utf8")).toBe("preserve me");
   });
 
   it.each(["project", "legacy"] as const)(

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -8,19 +7,19 @@ import {
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
 import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
-
-const retentionTempDirs = useAutoCleanupTempDirTracker(afterEach);
 import {
   cleanupRetainedManagedNpmInstallGenerations,
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
 } from "./managed-npm-retention.js";
 
+const retentionTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("managed npm retention", () => {
   it.each(["ordinary", "generation"] as const)(
     "cleans a retired %s project while preserving the active install root",
     async (layout) => {
-      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+      const stateDir = retentionTempDirs.make("openclaw-retention-");
       const npmDir = path.join(stateDir, "npm");
       const packageName = "@openclaw/codex";
       const oldProjectRoot =
@@ -46,24 +45,20 @@ describe("managed npm retention", () => {
         reason: "test-retired-generation",
       });
 
-      try {
-        await expect(
-          cleanupRetainedManagedNpmInstallGenerations({
-            npmDir,
-            activeInstallPaths: [activePackageDir],
-          }),
-        ).resolves.toBe(1);
-        expect(fs.existsSync(oldProjectRoot)).toBe(false);
-        expect(fs.existsSync(activeProjectRoot)).toBe(true);
-        expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
-      } finally {
-        fs.rmSync(stateDir, { recursive: true, force: true });
-      }
+      await expect(
+        cleanupRetainedManagedNpmInstallGenerations({
+          npmDir,
+          activeInstallPaths: [activePackageDir],
+        }),
+      ).resolves.toBe(1);
+      expect(fs.existsSync(oldProjectRoot)).toBe(false);
+      expect(fs.existsSync(activeProjectRoot)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
     },
   );
 
   it("cleans retained packages from the legacy shared npm root", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+    const stateDir = retentionTempDirs.make("openclaw-retention-");
     const npmDir = path.join(stateDir, "npm");
     const packageDir = path.join(npmDir, "node_modules", "@openclaw", "codex");
     fs.mkdirSync(packageDir, { recursive: true });
@@ -73,17 +68,13 @@ describe("managed npm retention", () => {
       reason: "test-legacy-generation",
     });
 
-    try {
-      await expect(
-        cleanupRetainedManagedNpmInstallGenerations({
-          npmDir,
-        }),
-      ).resolves.toBe(1);
-      expect(fs.existsSync(packageDir)).toBe(false);
-      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
-    } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-    }
+    await expect(
+      cleanupRetainedManagedNpmInstallGenerations({
+        npmDir,
+      }),
+    ).resolves.toBe(1);
+    expect(fs.existsSync(packageDir)).toBe(false);
+    expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
   });
 
   it("preserves a noncanonical project root even when it has a retained marker", async () => {
@@ -102,6 +93,30 @@ describe("managed npm retention", () => {
 
     await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
     expect(fs.readFileSync(siblingFile, "utf8")).toBe("preserve me");
+  });
+
+  it("does not follow a substituted managed projects directory", async () => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-symlink-");
+    const npmDir = path.join(stateDir, "npm");
+    const outsideProjectsDir = retentionTempDirs.make("openclaw-retention-outside-");
+    fs.mkdirSync(npmDir, { recursive: true });
+    fs.symlinkSync(outsideProjectsDir, path.join(npmDir, "projects"), "dir");
+    const projectRoot = resolvePluginNpmProjectDir({
+      npmDir,
+      packageName: "@openclaw/codex",
+    });
+    const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+    const sentinel = path.join(projectRoot, "must-remain.txt");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(sentinel, "preserve me", "utf8");
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: "test-retired-generation",
+    });
+
+    await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+    expect(fs.readFileSync(sentinel, "utf8")).toBe("preserve me");
   });
 
   it.each(["project", "legacy"] as const)(
@@ -125,13 +140,9 @@ describe("managed npm retention", () => {
         reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
       });
 
-      try {
-        await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
-        expect(fs.existsSync(packageDir)).toBe(true);
-        expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
-      } finally {
-        fs.rmSync(stateDir, { recursive: true, force: true });
-      }
+      await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
     },
   );
 });

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
-import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
+import {
+  isPluginNpmProjectDir,
+  resolveDefaultPluginNpmDir,
+  resolvePluginNpmProjectsDir,
+} from "./install-paths.js";
 import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
 import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
@@ -152,6 +156,25 @@ function listManagedNpmPackageDirs(npmRoot: string): string[] {
   });
 }
 
+function isOwnedManagedNpmProject(params: {
+  markerNames: ReadonlySet<string>;
+  npmDir: string;
+  projectRoot: string;
+}): boolean {
+  return listManagedNpmPackageDirs(params.projectRoot).some((packageDir) => {
+    const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+    return Boolean(
+      info &&
+      params.markerNames.has(path.basename(info.markerPath)) &&
+      isPluginNpmProjectDir({
+        npmDir: params.npmDir,
+        packageName: info.packageName,
+        projectDir: params.projectRoot,
+      }),
+    );
+  });
+}
+
 async function cleanupRetainedLegacyNpmPackages(params: {
   npmRoot: string;
   activeInstallPaths: string[];
@@ -221,6 +244,11 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
         markerPreservesPackageFiles(path.join(markerDir, entry.name)),
       ) ||
       !isPathEqualOrInside(projectsDir, projectRoot) ||
+      !isOwnedManagedNpmProject({
+        markerNames: new Set(markerEntries.map((entry) => entry.name)),
+        npmDir,
+        projectRoot,
+      }) ||
       activeInstallPaths.some((installPath) => isPathEqualOrInside(projectRoot, installPath))
     ) {
       continue;

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -162,7 +162,7 @@ describe("managed plugin install compensation", () => {
 
       expect(mocks.applyUninstall).toHaveBeenCalledWith({
         target: npmRoot,
-        cleanup: { kind: "npm", npmRoot, packageName },
+        cleanup: { kind: "npm", npmRoot, packageName, rootKind: "isolated-project" },
       });
       await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
     },

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectDir } from "./install-paths.js";
+import {
+  resolveDefaultPluginNpmDir,
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 
 const mocks = vi.hoisted(() => ({
   applyUninstall: vi.fn(),
@@ -104,57 +108,67 @@ describe("managed plugin install compensation", () => {
     expect(mocks.applyUninstall).toHaveBeenCalledWith({ target: targetDir });
   });
 
-  it("removes a planner-validated isolated npm project after persistence conflicts", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-npm-conflict-"));
-    const env = { HOME: home };
-    const packageName = "@openclaw/demo";
-    const npmRoot = resolvePluginNpmProjectDir({
-      npmDir: resolveDefaultPluginNpmDir(env),
-      packageName,
-    });
-    const targetDir = path.join(npmRoot, "node_modules", "@openclaw", "demo");
-    const packArchive = path.join(npmRoot, "_openclaw-pack-archives", "demo.tgz");
-    const conflict = new Error("config changed during npm plugin install");
+  it.each([
+    { name: "ordinary", generationKey: undefined },
+    { name: "generation", generationKey: "demo-v2" },
+  ])(
+    "removes a planner-validated $name npm project after persistence conflicts",
+    async (fixture) => {
+      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-npm-conflict-"));
+      const env = { HOME: home };
+      const packageName = "@openclaw/demo";
+      const npmDir = resolveDefaultPluginNpmDir(env);
+      const npmRoot = fixture.generationKey
+        ? resolvePluginNpmGenerationProjectDir({
+            npmDir,
+            packageName,
+            generationKey: fixture.generationKey,
+          })
+        : resolvePluginNpmProjectDir({ npmDir, packageName });
+      const targetDir = path.join(npmRoot, "node_modules", "@openclaw", "demo");
+      const packArchive = path.join(npmRoot, "_openclaw-pack-archives", "demo.tgz");
+      const conflict = new Error("config changed during npm plugin install");
 
-    try {
-      await fs.mkdir(targetDir, { recursive: true });
-      await fs.mkdir(path.dirname(packArchive), { recursive: true });
-      await fs.writeFile(packArchive, "packed plugin");
-      mocks.npmInstall.mockResolvedValue({
-        ok: true,
-        pluginId: "demo",
-        targetDir,
-        extensions: ["index.js"],
-        manifestName: packageName,
-      });
-      mocks.persistInstall.mockRejectedValue(conflict);
-      mocks.planUninstall.mockImplementation((params) =>
-        actualUninstall.planPluginUninstall(
-          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-        ),
-      );
-      mocks.applyUninstall.mockImplementation(async (removal: { target: string }) => {
-        await fs.rm(removal.target, { recursive: true, force: true });
-        return { directoryRemoved: true, warnings: [] };
-      });
+      try {
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.mkdir(path.dirname(packArchive), { recursive: true });
+        await fs.writeFile(packArchive, "packed plugin");
+        mocks.npmInstall.mockResolvedValue({
+          ok: true,
+          pluginId: "demo",
+          targetDir,
+          extensions: ["index.js"],
+          manifestName: packageName,
+        });
+        mocks.persistInstall.mockRejectedValue(conflict);
+        mocks.planUninstall.mockImplementation((params) =>
+          actualUninstall.planPluginUninstall(
+            params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+          ),
+        );
+        mocks.applyUninstall.mockImplementation(async (removal: { target: string }) => {
+          await fs.rm(removal.target, { recursive: true, force: true });
+          return { directoryRemoved: true, warnings: [] };
+        });
 
-      await expect(
-        installManagedPluginSource({
-          request: { source: "npm", spec: packageName, mode: "install" },
-          snapshot: installPersistSnapshot(),
-          env,
-        }),
-      ).rejects.toBe(conflict);
+        await expect(
+          installManagedPluginSource({
+            request: { source: "npm", spec: packageName, mode: "install" },
+            snapshot: installPersistSnapshot(),
+            env,
+          }),
+        ).rejects.toBe(conflict);
 
-      expect(mocks.applyUninstall).toHaveBeenCalledWith({
-        target: npmRoot,
-        cleanup: { kind: "npm", npmRoot, packageName },
-      });
-      await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
-    } finally {
-      await fs.rm(home, { recursive: true, force: true });
-    }
-  });
+        expect(mocks.applyUninstall).toHaveBeenCalledWith({
+          target: npmRoot,
+          cleanup: { kind: "npm", npmRoot, packageName },
+        });
+        await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await fs.rm(home, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("never deletes an operator-owned source when link persistence fails", async () => {
     const env = { HOME: "/tmp/openclaw-managed-link-conflict-home" };

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   resolveDefaultPluginNpmDir,
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
+
+const compensationTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const mocks = vi.hoisted(() => ({
   applyUninstall: vi.fn(),
@@ -114,7 +116,7 @@ describe("managed plugin install compensation", () => {
   ])(
     "removes a planner-validated $name npm project after persistence conflicts",
     async (fixture) => {
-      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-npm-conflict-"));
+      const home = compensationTempDirs.make("openclaw-managed-npm-conflict-");
       const env = { HOME: home };
       const packageName = "@openclaw/demo";
       const npmDir = resolveDefaultPluginNpmDir(env);
@@ -129,44 +131,40 @@ describe("managed plugin install compensation", () => {
       const packArchive = path.join(npmRoot, "_openclaw-pack-archives", "demo.tgz");
       const conflict = new Error("config changed during npm plugin install");
 
-      try {
-        await fs.mkdir(targetDir, { recursive: true });
-        await fs.mkdir(path.dirname(packArchive), { recursive: true });
-        await fs.writeFile(packArchive, "packed plugin");
-        mocks.npmInstall.mockResolvedValue({
-          ok: true,
-          pluginId: "demo",
-          targetDir,
-          extensions: ["index.js"],
-          manifestName: packageName,
-        });
-        mocks.persistInstall.mockRejectedValue(conflict);
-        mocks.planUninstall.mockImplementation((params) =>
-          actualUninstall.planPluginUninstall(
-            params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-          ),
-        );
-        mocks.applyUninstall.mockImplementation(async (removal: { target: string }) => {
-          await fs.rm(removal.target, { recursive: true, force: true });
-          return { directoryRemoved: true, warnings: [] };
-        });
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.mkdir(path.dirname(packArchive), { recursive: true });
+      await fs.writeFile(packArchive, "packed plugin");
+      mocks.npmInstall.mockResolvedValue({
+        ok: true,
+        pluginId: "demo",
+        targetDir,
+        extensions: ["index.js"],
+        manifestName: packageName,
+      });
+      mocks.persistInstall.mockRejectedValue(conflict);
+      mocks.planUninstall.mockImplementation((params) =>
+        actualUninstall.planPluginUninstall(
+          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+        ),
+      );
+      mocks.applyUninstall.mockImplementation(async (removal: { target: string }) => {
+        await fs.rm(removal.target, { recursive: true, force: true });
+        return { directoryRemoved: true, warnings: [] };
+      });
 
-        await expect(
-          installManagedPluginSource({
-            request: { source: "npm", spec: packageName, mode: "install" },
-            snapshot: installPersistSnapshot(),
-            env,
-          }),
-        ).rejects.toBe(conflict);
+      await expect(
+        installManagedPluginSource({
+          request: { source: "npm", spec: packageName, mode: "install" },
+          snapshot: installPersistSnapshot(),
+          env,
+        }),
+      ).rejects.toBe(conflict);
 
-        expect(mocks.applyUninstall).toHaveBeenCalledWith({
-          target: npmRoot,
-          cleanup: { kind: "npm", npmRoot, packageName },
-        });
-        await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
-      } finally {
-        await fs.rm(home, { recursive: true, force: true });
-      }
+      expect(mocks.applyUninstall).toHaveBeenCalledWith({
+        target: npmRoot,
+        cleanup: { kind: "npm", npmRoot, packageName },
+      });
+      await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
 

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1230,6 +1230,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "@openclaw/kitchen-sink",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1309,6 +1310,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "@openclaw/kitchen-sink",
+        rootKind: "isolated-project",
       },
     });
 
@@ -1406,12 +1408,14 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "@openclaw/kitchen-sink",
+        rootKind: "isolated-project",
       },
     });
 
     const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 
     expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
     await expectPathAccessState(pluginDir, "missing");
     await expect(fs.readFile(siblingFile, "utf8")).resolves.toBe("preserve me");
   });
@@ -1736,6 +1740,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "removed-plugin",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1844,6 +1849,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "removed-plugin",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -2095,6 +2101,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "missing-plugin",
+        rootKind: "legacy-shared",
       },
     });
 

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1458,6 +1458,105 @@ describe("uninstallPlugin", () => {
     await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
   });
 
+  it("does not follow a substituted canonical npm project directory", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const projectRoot = resolvePluginNpmProjectDir({
+      npmDir,
+      packageName: "@openclaw/kitchen-sink",
+    });
+    const outsideProjectRoot = path.join(tempDir, "outside-project");
+    const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const outsidePluginDir = path.join(
+      outsideProjectRoot,
+      "node_modules",
+      "@openclaw",
+      "kitchen-sink",
+    );
+    const sentinel = path.join(outsideProjectRoot, "must-remain.txt");
+    await fs.mkdir(path.dirname(projectRoot), { recursive: true });
+    await fs.mkdir(outsidePluginDir, { recursive: true });
+    await fs.writeFile(sentinel, "preserve me");
+    await fs.symlink(outsideProjectRoot, projectRoot, "dir");
+
+    const result = await uninstallPlugin({
+      config: createPluginConfig({
+        entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+        installs: {
+          "openclaw-kitchen-sink-fixture": {
+            source: "npm",
+            spec: "@openclaw/kitchen-sink@1.0.0",
+            installPath: pluginDir,
+          },
+        },
+      }),
+      pluginId: "openclaw-kitchen-sink-fixture",
+      deleteFiles: true,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.warnings).toEqual([]);
+    expect(result.actions.directory).toBe(false);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+  });
+
+  it("rejects a symlinked package inside a canonical npm project", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const projectRoot = resolvePluginNpmProjectDir({
+      npmDir,
+      packageName: "@openclaw/kitchen-sink",
+    });
+    const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const packageTarget = path.join(projectRoot, "node_modules", "package-target");
+    const sentinel = path.join(projectRoot, "must-remain.txt");
+    await fs.mkdir(path.dirname(pluginDir), { recursive: true });
+    await fs.mkdir(packageTarget, { recursive: true });
+    await fs.writeFile(path.join(projectRoot, "package.json"), "{}\n");
+    await fs.writeFile(sentinel, "preserve me");
+    await fs.symlink(packageTarget, pluginDir, "dir");
+
+    const plan = planPluginUninstall(
+      recordPluginPackageUninstallPlan(
+        {
+          config: createPluginConfig({
+            installs: {
+              "openclaw-kitchen-sink-fixture": {
+                source: "npm",
+                spec: "@openclaw/kitchen-sink@1.0.0",
+                installPath: pluginDir,
+              },
+            },
+          }),
+          pluginId: "openclaw-kitchen-sink-fixture",
+          deleteFiles: true,
+          extensionsDir,
+        },
+        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+      ),
+    );
+    expect(plan.ok).toBe(true);
+    if (!plan.ok || !plan.directoryRemoval) {
+      throw new Error(plan.ok ? "missing removal" : plan.error);
+    }
+    expect(plan.directoryRemoval.target).toBe(pluginDir);
+
+    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+
+    expect(applied).toEqual({
+      directoryRemoved: false,
+      warnings: [`Refused to remove npm path without canonical package ownership: ${pluginDir}`],
+    });
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+    await expect(fs.lstat(pluginDir).then((stat) => stat.isSymbolicLink())).resolves.toBe(true);
+  });
+
   it.each(["canonical", "noncanonical"] as const)(
     "revalidates %s npm project ownership after the removal plan is created",
     async (layout) => {
@@ -1520,53 +1619,65 @@ describe("uninstallPlugin", () => {
     },
   );
 
-  it("refuses package cleanup through a substituted npm manifest", async () => {
-    const stateDir = path.join(tempDir, "state");
-    const extensionsDir = path.join(stateDir, "extensions");
-    const npmRoot = path.join(stateDir, "npm", "projects", "noncanonical-manifest");
-    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
-    const manifestPath = path.join(npmRoot, "package.json");
-    await fs.mkdir(pluginDir, { recursive: true });
-    await fs.writeFile(manifestPath, "{}\n");
-    const plan = planPluginUninstall(
-      recordPluginPackageUninstallPlan(
-        {
-          config: createPluginConfig({
-            installs: {
-              "openclaw-kitchen-sink-fixture": {
-                source: "npm",
-                spec: "@openclaw/kitchen-sink@1.0.0",
-                installPath: pluginDir,
+  it.each(["canonical", "noncanonical"] as const)(
+    "refuses $layout npm cleanup through a substituted manifest",
+    async (layout) => {
+      const stateDir = path.join(tempDir, "state");
+      const extensionsDir = path.join(stateDir, "extensions");
+      const npmDir = path.join(stateDir, "npm");
+      const npmRoot =
+        layout === "canonical"
+          ? resolvePluginNpmProjectDir({
+              npmDir,
+              packageName: "@openclaw/kitchen-sink",
+            })
+          : path.join(npmDir, "projects", "noncanonical-manifest");
+      const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+      const manifestPath = path.join(npmRoot, "package.json");
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(manifestPath, "{}\n");
+      const plan = planPluginUninstall(
+        recordPluginPackageUninstallPlan(
+          {
+            config: createPluginConfig({
+              installs: {
+                "openclaw-kitchen-sink-fixture": {
+                  source: "npm",
+                  spec: "@openclaw/kitchen-sink@1.0.0",
+                  installPath: pluginDir,
+                },
               },
-            },
-          }),
-          pluginId: "openclaw-kitchen-sink-fixture",
-          deleteFiles: true,
-          extensionsDir,
-        },
-        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
-      ),
-    );
-    expect(plan.ok).toBe(true);
-    if (!plan.ok || !plan.directoryRemoval) {
-      throw new Error(plan.ok ? "missing removal" : plan.error);
-    }
+            }),
+            pluginId: "openclaw-kitchen-sink-fixture",
+            deleteFiles: true,
+            extensionsDir,
+          },
+          { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+        ),
+      );
+      expect(plan.ok).toBe(true);
+      if (!plan.ok || !plan.directoryRemoval) {
+        throw new Error(plan.ok ? "missing removal" : plan.error);
+      }
+      const expectedTarget = layout === "canonical" ? npmRoot : pluginDir;
+      expect(plan.directoryRemoval.target).toBe(expectedTarget);
 
-    const outsideManifest = path.join(tempDir, "outside-package.json");
-    await fs.writeFile(outsideManifest, '{"preserve":true}\n');
-    await fs.rm(manifestPath);
-    await fs.symlink(outsideManifest, manifestPath);
+      const outsideManifest = path.join(tempDir, "outside-package.json");
+      await fs.writeFile(outsideManifest, '{"preserve":true}\n');
+      await fs.rm(manifestPath);
+      await fs.symlink(outsideManifest, manifestPath);
 
-    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+      const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 
-    expect(applied.directoryRemoved).toBe(false);
-    expect(applied.warnings).toEqual([
-      `Refused to remove npm path without canonical package ownership: ${pluginDir}`,
-    ]);
-    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
-    await expect(fs.readFile(outsideManifest, "utf8")).resolves.toBe('{"preserve":true}\n');
-    await expectPathAccessState(pluginDir, "exists");
-  });
+      expect(applied.directoryRemoved).toBe(false);
+      expect(applied.warnings).toEqual([
+        `Refused to remove npm path without canonical package ownership: ${expectedTarget}`,
+      ]);
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      await expect(fs.readFile(outsideManifest, "utf8")).resolves.toBe('{"preserve":true}\n');
+      await expectPathAccessState(pluginDir, "exists");
+    },
+  );
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {
     const stateDir = path.join(tempDir, "state");

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1416,6 +1416,101 @@ describe("uninstallPlugin", () => {
     await expect(fs.readFile(siblingFile, "utf8")).resolves.toBe("preserve me");
   });
 
+  it("does not follow a substituted npm projects directory", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const outsideProjectsDir = path.join(tempDir, "outside-projects");
+    await fs.mkdir(npmDir, { recursive: true });
+    await fs.mkdir(outsideProjectsDir, { recursive: true });
+    await fs.symlink(outsideProjectsDir, path.join(npmDir, "projects"), "dir");
+    const projectRoot = resolvePluginNpmProjectDir({
+      npmDir,
+      packageName: "@openclaw/kitchen-sink",
+    });
+    const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const sentinel = path.join(projectRoot, "must-remain.txt");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(sentinel, "preserve me");
+
+    const result = await uninstallPlugin({
+      config: createPluginConfig({
+        entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+        installs: {
+          "openclaw-kitchen-sink-fixture": {
+            source: "npm",
+            spec: "@openclaw/kitchen-sink@1.0.0",
+            installPath: pluginDir,
+          },
+        },
+      }),
+      pluginId: "openclaw-kitchen-sink-fixture",
+      deleteFiles: true,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.warnings).toEqual([]);
+    expect(result.actions.directory).toBe(false);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+  });
+
+  it("revalidates npm project ownership after the removal plan is created", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const projectsDir = path.join(npmDir, "projects");
+    const projectRoot = resolvePluginNpmProjectDir({
+      npmDir,
+      packageName: "@openclaw/kitchen-sink",
+    });
+    const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
+    await fs.mkdir(pluginDir, { recursive: true });
+    const plan = planPluginUninstall(
+      recordPluginPackageUninstallPlan(
+        {
+          config: createPluginConfig({
+            installs: {
+              "openclaw-kitchen-sink-fixture": {
+                source: "npm",
+                spec: "@openclaw/kitchen-sink@1.0.0",
+                installPath: pluginDir,
+              },
+            },
+          }),
+          pluginId: "openclaw-kitchen-sink-fixture",
+          deleteFiles: true,
+          extensionsDir,
+        },
+        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+      ),
+    );
+    expect(plan.ok).toBe(true);
+    if (!plan.ok || !plan.directoryRemoval) {
+      throw new Error(plan.ok ? "missing removal" : plan.error);
+    }
+    expect(plan.directoryRemoval.target).toBe(projectRoot);
+
+    const outsideProjectsDir = path.join(tempDir, "outside-projects-race");
+    const outsideProjectRoot = path.join(outsideProjectsDir, path.basename(projectRoot));
+    const sentinel = path.join(outsideProjectRoot, "must-remain.txt");
+    await fs.mkdir(outsideProjectRoot, { recursive: true });
+    await fs.writeFile(sentinel, "preserve me");
+    await fs.rename(projectsDir, `${projectsDir}-original`);
+    await fs.symlink(outsideProjectsDir, projectsDir, "dir");
+
+    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+
+    expect(applied.directoryRemoved).toBe(false);
+    expect(applied.warnings).toEqual([
+      `Refused to remove npm project without canonical package ownership: ${projectRoot}`,
+    ]);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+  });
+
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {
     const stateDir = path.join(tempDir, "state");
     const npmRoot = path.join(stateDir, "npm");

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { runCommandWithTimeout } from "../process/exec.js";
 import { toRepoRelativePath } from "../test-utils/repo-files.js";
-import { resolvePluginNpmProjectDir } from "./install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmGenerationProjectDirPrefix,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 import { resolvePluginInstallDir } from "./install.js";
 import {
   cleanupTrackedTempDirsAsync,
@@ -1236,14 +1240,23 @@ describe("uninstallPlugin", () => {
     await expectPathAccessState(pluginDir, "missing");
   });
 
-  it("uninstalls per-plugin npm project packages through their project root", async () => {
+  it.each([
+    { name: "ordinary", generationKey: undefined },
+    { name: "generation", generationKey: "kitchen-sink-v2" },
+  ])("uninstalls $name per-plugin npm projects through their project root", async (fixture) => {
     const stateDir = path.join(tempDir, "state");
     const extensionsDir = path.join(stateDir, "extensions");
     const npmBaseDir = path.join(stateDir, "npm");
-    const npmRoot = resolvePluginNpmProjectDir({
-      npmDir: npmBaseDir,
-      packageName: "@openclaw/kitchen-sink",
-    });
+    const npmRoot = fixture.generationKey
+      ? resolvePluginNpmGenerationProjectDir({
+          npmDir: npmBaseDir,
+          packageName: "@openclaw/kitchen-sink",
+          generationKey: fixture.generationKey,
+        })
+      : resolvePluginNpmProjectDir({
+          npmDir: npmBaseDir,
+          packageName: "@openclaw/kitchen-sink",
+        });
     const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
     const hoistedDir = path.join(npmRoot, "node_modules", "is-number");
     await fs.mkdir(pluginDir, { recursive: true });
@@ -1305,6 +1318,102 @@ describe("uninstallPlugin", () => {
     expectNpmUninstallCommand({ packageName: "@openclaw/kitchen-sink", npmRoot });
     await expectPathAccessState(pluginDir, "missing");
     await expectPathAccessState(npmRoot, "missing");
+  });
+
+  it.each([
+    ["unrelated sibling", "noncanonical-sibling"],
+    [
+      "ordinary-name lookalike",
+      `${path.basename(
+        resolvePluginNpmProjectDir({
+          npmDir: "/managed/npm",
+          packageName: "@openclaw/kitchen-sink",
+        }),
+      )}-lookalike`,
+    ],
+    [
+      "malformed generation prefix",
+      `${path.basename(
+        resolvePluginNpmProjectDir({
+          npmDir: "/managed/npm",
+          packageName: "@openclaw/kitchen-sink",
+        }),
+      )}__openclaw-generation_g-0123456789abcdef`,
+    ],
+    [
+      "short generation suffix",
+      `${resolvePluginNpmGenerationProjectDirPrefix("@openclaw/kitchen-sink")}g-0123456789abcde`,
+    ],
+    [
+      "uppercase generation suffix",
+      `${resolvePluginNpmGenerationProjectDirPrefix("@openclaw/kitchen-sink")}g-0123456789abcdeF`,
+    ],
+    [
+      "generation suffix lookalike",
+      `${resolvePluginNpmGenerationProjectDirPrefix("@openclaw/kitchen-sink")}g-0123456789abcdef-extra`,
+    ],
+  ])("preserves a noncanonical npm project root ($name)", async (_name, projectName) => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmRoot = path.join(stateDir, "npm", "projects", projectName);
+    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const siblingFile = path.join(npmRoot, "must-remain.txt");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "@openclaw/kitchen-sink": "1.0.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.writeFile(path.join(pluginDir, "package.json"), "{}");
+    await fs.writeFile(siblingFile, "preserve me");
+
+    const plan = planPluginUninstall(
+      recordPluginPackageUninstallPlan(
+        {
+          config: createPluginConfig({
+            entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+            installs: {
+              "openclaw-kitchen-sink-fixture": {
+                source: "npm",
+                spec: "@openclaw/kitchen-sink@1.0.0",
+                installPath: pluginDir,
+              },
+            },
+          }),
+          pluginId: "openclaw-kitchen-sink-fixture",
+          deleteFiles: true,
+          extensionsDir,
+        },
+        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+      ),
+    );
+
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) {
+      throw new Error(plan.error);
+    }
+    expect(plan.directoryRemoval).toEqual({
+      target: pluginDir,
+      cleanup: {
+        kind: "npm",
+        npmRoot,
+        packageName: "@openclaw/kitchen-sink",
+      },
+    });
+
+    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+
+    expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
+    await expectPathAccessState(pluginDir, "missing");
+    await expect(fs.readFile(siblingFile, "utf8")).resolves.toBe("preserve me");
   });
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1458,57 +1458,67 @@ describe("uninstallPlugin", () => {
     await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
   });
 
-  it("revalidates npm project ownership after the removal plan is created", async () => {
-    const stateDir = path.join(tempDir, "state");
-    const extensionsDir = path.join(stateDir, "extensions");
-    const npmDir = path.join(stateDir, "npm");
-    const projectRoot = resolvePluginNpmProjectDir({
-      npmDir,
-      packageName: "@openclaw/kitchen-sink",
-    });
-    const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
-    await fs.mkdir(pluginDir, { recursive: true });
-    const plan = planPluginUninstall(
-      recordPluginPackageUninstallPlan(
-        {
-          config: createPluginConfig({
-            installs: {
-              "openclaw-kitchen-sink-fixture": {
-                source: "npm",
-                spec: "@openclaw/kitchen-sink@1.0.0",
-                installPath: pluginDir,
+  it.each(["canonical", "noncanonical"] as const)(
+    "revalidates %s npm project ownership after the removal plan is created",
+    async (layout) => {
+      const stateDir = path.join(tempDir, "state");
+      const extensionsDir = path.join(stateDir, "extensions");
+      const npmDir = path.join(stateDir, "npm");
+      const projectRoot =
+        layout === "canonical"
+          ? resolvePluginNpmProjectDir({
+              npmDir,
+              packageName: "@openclaw/kitchen-sink",
+            })
+          : path.join(npmDir, "projects", "noncanonical-race");
+      const pluginDir = path.join(projectRoot, "node_modules", "@openclaw", "kitchen-sink");
+      await fs.mkdir(pluginDir, { recursive: true });
+      const plan = planPluginUninstall(
+        recordPluginPackageUninstallPlan(
+          {
+            config: createPluginConfig({
+              installs: {
+                "openclaw-kitchen-sink-fixture": {
+                  source: "npm",
+                  spec: "@openclaw/kitchen-sink@1.0.0",
+                  installPath: pluginDir,
+                },
               },
-            },
-          }),
-          pluginId: "openclaw-kitchen-sink-fixture",
-          deleteFiles: true,
-          extensionsDir,
-        },
-        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
-      ),
-    );
-    expect(plan.ok).toBe(true);
-    if (!plan.ok || !plan.directoryRemoval) {
-      throw new Error(plan.ok ? "missing removal" : plan.error);
-    }
-    expect(plan.directoryRemoval.target).toBe(projectRoot);
+            }),
+            pluginId: "openclaw-kitchen-sink-fixture",
+            deleteFiles: true,
+            extensionsDir,
+          },
+          { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+        ),
+      );
+      expect(plan.ok).toBe(true);
+      if (!plan.ok || !plan.directoryRemoval) {
+        throw new Error(plan.ok ? "missing removal" : plan.error);
+      }
+      expect(plan.directoryRemoval.target).toBe(layout === "canonical" ? projectRoot : pluginDir);
 
-    const outsideNpmDir = path.join(tempDir, "outside-npm-race");
-    const outsideProjectRoot = path.join(outsideNpmDir, "projects", path.basename(projectRoot));
-    const sentinel = path.join(outsideProjectRoot, "must-remain.txt");
-    await fs.mkdir(outsideProjectRoot, { recursive: true });
-    await fs.writeFile(sentinel, "preserve me");
-    await fs.rename(npmDir, `${npmDir}-original`);
-    await fs.symlink(outsideNpmDir, npmDir, "dir");
+      const outsideNpmDir = path.join(tempDir, "outside-npm-race");
+      const outsideProjectRoot = path.join(outsideNpmDir, "projects", path.basename(projectRoot));
+      const outsideTarget =
+        layout === "canonical"
+          ? outsideProjectRoot
+          : path.join(outsideProjectRoot, "node_modules", "@openclaw", "kitchen-sink");
+      const sentinel = path.join(outsideTarget, "must-remain.txt");
+      await fs.mkdir(outsideTarget, { recursive: true });
+      await fs.writeFile(sentinel, "preserve me");
+      await fs.rename(npmDir, `${npmDir}-original`);
+      await fs.symlink(outsideNpmDir, npmDir, "dir");
 
-    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+      const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 
-    expect(applied.directoryRemoved).toBe(false);
-    expect(applied.warnings).toEqual([
-      `Refused to remove npm project without canonical package ownership: ${projectRoot}`,
-    ]);
-    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
-  });
+      expect(applied.directoryRemoved).toBe(false);
+      expect(applied.warnings).toEqual([
+        `Refused to remove npm path without canonical package ownership: ${plan.directoryRemoval.target}`,
+      ]);
+      await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+    },
+  );
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {
     const stateDir = path.join(tempDir, "state");

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1462,7 +1462,6 @@ describe("uninstallPlugin", () => {
     const stateDir = path.join(tempDir, "state");
     const extensionsDir = path.join(stateDir, "extensions");
     const npmDir = path.join(stateDir, "npm");
-    const projectsDir = path.join(npmDir, "projects");
     const projectRoot = resolvePluginNpmProjectDir({
       npmDir,
       packageName: "@openclaw/kitchen-sink",
@@ -1494,13 +1493,13 @@ describe("uninstallPlugin", () => {
     }
     expect(plan.directoryRemoval.target).toBe(projectRoot);
 
-    const outsideProjectsDir = path.join(tempDir, "outside-projects-race");
-    const outsideProjectRoot = path.join(outsideProjectsDir, path.basename(projectRoot));
+    const outsideNpmDir = path.join(tempDir, "outside-npm-race");
+    const outsideProjectRoot = path.join(outsideNpmDir, "projects", path.basename(projectRoot));
     const sentinel = path.join(outsideProjectRoot, "must-remain.txt");
     await fs.mkdir(outsideProjectRoot, { recursive: true });
     await fs.writeFile(sentinel, "preserve me");
-    await fs.rename(projectsDir, `${projectsDir}-original`);
-    await fs.symlink(outsideProjectsDir, projectsDir, "dir");
+    await fs.rename(npmDir, `${npmDir}-original`);
+    await fs.symlink(outsideNpmDir, npmDir, "dir");
 
     const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1315,7 +1315,7 @@ describe("uninstallPlugin", () => {
     const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 
     expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
-    expectNpmUninstallCommand({ packageName: "@openclaw/kitchen-sink", npmRoot });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
     await expectPathAccessState(pluginDir, "missing");
     await expectPathAccessState(npmRoot, "missing");
   });
@@ -1519,6 +1519,54 @@ describe("uninstallPlugin", () => {
       await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
     },
   );
+
+  it("refuses package cleanup through a substituted npm manifest", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmRoot = path.join(stateDir, "npm", "projects", "noncanonical-manifest");
+    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const manifestPath = path.join(npmRoot, "package.json");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(manifestPath, "{}\n");
+    const plan = planPluginUninstall(
+      recordPluginPackageUninstallPlan(
+        {
+          config: createPluginConfig({
+            installs: {
+              "openclaw-kitchen-sink-fixture": {
+                source: "npm",
+                spec: "@openclaw/kitchen-sink@1.0.0",
+                installPath: pluginDir,
+              },
+            },
+          }),
+          pluginId: "openclaw-kitchen-sink-fixture",
+          deleteFiles: true,
+          extensionsDir,
+        },
+        { runtimePluginIds: ["openclaw-kitchen-sink-fixture"] },
+      ),
+    );
+    expect(plan.ok).toBe(true);
+    if (!plan.ok || !plan.directoryRemoval) {
+      throw new Error(plan.ok ? "missing removal" : plan.error);
+    }
+
+    const outsideManifest = path.join(tempDir, "outside-package.json");
+    await fs.writeFile(outsideManifest, '{"preserve":true}\n');
+    await fs.rm(manifestPath);
+    await fs.symlink(outsideManifest, manifestPath);
+
+    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+
+    expect(applied.directoryRemoved).toBe(false);
+    expect(applied.warnings).toEqual([
+      `Refused to remove npm path without canonical package ownership: ${pluginDir}`,
+    ]);
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    await expect(fs.readFile(outsideManifest, "utf8")).resolves.toBe('{"preserve":true}\n');
+    await expectPathAccessState(pluginDir, "exists");
+  });
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {
     const stateDir = path.join(tempDir, "state");

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -9,6 +9,7 @@ import { readOpenClawManagedNpmRootOverrides } from "../infra/npm-managed-root.j
 import { createSafeNpmInstallEnv } from "../infra/safe-package-install.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
+  isPluginNpmManagedPath,
   isPluginNpmProjectDir,
   resolveDefaultPluginGitDir,
   resolveDefaultPluginNpmDir,
@@ -446,18 +447,45 @@ export function pluginUninstallTargetExists(target: string): boolean {
   }
 }
 
-function isOwnedNpmProjectRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
+function isOwnedNpmRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
   const cleanup = removal.cleanup;
-  if (cleanup?.kind !== "npm" || path.resolve(removal.target) !== path.resolve(cleanup.npmRoot)) {
+  if (cleanup?.kind !== "npm") {
     return true;
   }
   const projectsDir = path.dirname(cleanup.npmRoot);
+  const projectRoot = path.basename(projectsDir) === "projects";
+  const npmDir = projectRoot ? path.dirname(projectsDir) : cleanup.npmRoot;
+  if (
+    projectRoot
+      ? !isPluginNpmManagedPath({ managedPath: cleanup.npmRoot, npmDir })
+      : !pluginUninstallTargetExists(npmDir) ||
+        !isPluginNpmManagedPath({ managedPath: npmDir, npmDir })
+  ) {
+    return false;
+  }
+  if (path.resolve(removal.target) === path.resolve(cleanup.npmRoot)) {
+    return (
+      projectRoot &&
+      isPluginNpmProjectDir({
+        npmDir,
+        packageName: cleanup.packageName,
+        projectDir: cleanup.npmRoot,
+      })
+    );
+  }
+  const expectedPackageDir = path.join(
+    cleanup.npmRoot,
+    "node_modules",
+    ...cleanup.packageName.split("/"),
+  );
+  if (path.resolve(removal.target) !== path.resolve(expectedPackageDir)) {
+    return false;
+  }
   return (
-    path.basename(projectsDir) === "projects" &&
-    isPluginNpmProjectDir({
-      npmDir: path.dirname(projectsDir),
-      packageName: cleanup.packageName,
-      projectDir: cleanup.npmRoot,
+    !pluginUninstallTargetExists(removal.target) ||
+    isPluginNpmManagedPath({
+      managedPath: removal.target,
+      npmDir,
     })
   );
 }
@@ -487,8 +515,8 @@ export async function applyPluginUninstallDirectoryRemoval(
     return { directoryRemoved: false, warnings };
   }
 
-  const ownershipWarning = `Refused to remove npm project without canonical package ownership: ${removal.target}`;
-  if (!isOwnedNpmProjectRemoval(removal)) {
+  const ownershipWarning = `Refused to remove npm path without canonical package ownership: ${removal.target}`;
+  if (!isOwnedNpmRemoval(removal)) {
     return { directoryRemoved: false, warnings: [ownershipWarning] };
   }
 
@@ -552,7 +580,7 @@ export async function applyPluginUninstallDirectoryRemoval(
       );
     }
   }
-  if (!isOwnedNpmProjectRemoval(removal) && pluginUninstallTargetExists(removal.target)) {
+  if (!isOwnedNpmRemoval(removal) && pluginUninstallTargetExists(removal.target)) {
     return { directoryRemoved: false, warnings: [...warnings, ownershipWarning] };
   }
   try {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -503,10 +503,15 @@ export async function applyPluginUninstallDirectoryRemoval(
     return { directoryRemoved: false, warnings };
   }
 
+  const removesNpmProject =
+    removal.cleanup?.kind === "npm" &&
+    path.resolve(removal.target) === path.resolve(removal.cleanup.npmRoot);
+  const npmCleanupManifestPath =
+    removal.cleanup?.kind === "npm" ? path.join(removal.cleanup.npmRoot, "package.json") : "";
   const npmCleanupManifestExists =
     removal.cleanup?.kind === "npm"
       ? await fs
-          .access(path.join(removal.cleanup.npmRoot, "package.json"))
+          .access(npmCleanupManifestPath)
           .then(() => true)
           .catch(() => false)
       : false;
@@ -519,8 +524,22 @@ export async function applyPluginUninstallDirectoryRemoval(
   if (!isOwnedNpmRemoval(removal)) {
     return { directoryRemoved: false, warnings: [ownershipWarning] };
   }
+  if (
+    removal.cleanup?.kind === "npm" &&
+    !removesNpmProject &&
+    npmCleanupManifestExists &&
+    !isPluginNpmManagedPath({
+      managedPath: npmCleanupManifestPath,
+      npmDir:
+        path.basename(path.dirname(removal.cleanup.npmRoot)) === "projects"
+          ? path.dirname(path.dirname(removal.cleanup.npmRoot))
+          : removal.cleanup.npmRoot,
+    })
+  ) {
+    return { directoryRemoved: false, warnings: [ownershipWarning] };
+  }
 
-  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists) {
+  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists && !removesNpmProject) {
     const uninstall = await runCommandWithTimeout(
       [
         "npm",

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -9,6 +9,7 @@ import { readOpenClawManagedNpmRootOverrides } from "../infra/npm-managed-root.j
 import { createSafeNpmInstallEnv } from "../infra/safe-package-install.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
+  isPluginNpmProjectDir,
   resolveDefaultPluginGitDir,
   resolveDefaultPluginNpmDir,
   resolvePluginInstallDir,
@@ -227,7 +228,12 @@ function resolveNpmManagedProjectInstall(params: {
   ) {
     return null;
   }
-  return { installPath: npmRoot, npmRoot, packageName };
+  const ownsProjectRoot = isPluginNpmProjectDir({
+    packageName,
+    projectDir: npmRoot,
+    npmDir: path.dirname(params.projectsDir),
+  });
+  return { installPath: ownsProjectRoot ? npmRoot : params.installPath, npmRoot, packageName };
 }
 
 function resolveNpmPackageNameFromInstallPath(params: {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -82,6 +82,7 @@ export type PluginUninstallDirectoryRemoval = {
         kind: "npm";
         npmRoot: string;
         packageName: string;
+        rootKind: "legacy-shared" | "isolated-project";
       }
     | {
         kind: "git";
@@ -164,7 +165,12 @@ function resolveUninstallDirectoryTarget(params: {
 function resolveNpmManagedInstall(params: {
   installRecord?: PluginInstallRecord;
   extensionsDir?: string;
-}): { installPath: string; npmRoot: string; packageName: string } | null {
+}): {
+  installPath: string;
+  npmRoot: string;
+  packageName: string;
+  rootKind: "legacy-shared" | "isolated-project";
+} | null {
   const installPath = params.installRecord?.installPath?.trim();
   if (params.installRecord?.source !== "npm" || !installPath) {
     return null;
@@ -184,7 +190,7 @@ function resolveNpmManagedInstall(params: {
         resolveComparableUninstallPath(installPath)
     ) {
       const packageName = resolveNpmPackageNameFromInstallPath({ installPath, nodeModulesRoot });
-      return packageName ? { installPath, npmRoot, packageName } : null;
+      return packageName ? { installPath, npmRoot, packageName, rootKind: "legacy-shared" } : null;
     }
     const projectMatch = resolveNpmManagedProjectInstall({
       installPath,
@@ -197,10 +203,12 @@ function resolveNpmManagedInstall(params: {
   return null;
 }
 
-function resolveNpmManagedProjectInstall(params: {
+function resolveNpmManagedProjectInstall(params: { installPath: string; projectsDir: string }): {
   installPath: string;
-  projectsDir: string;
-}): { installPath: string; npmRoot: string; packageName: string } | null {
+  npmRoot: string;
+  packageName: string;
+  rootKind: "isolated-project";
+} | null {
   if (
     !isUninstallPathInsideOrEqual(params.projectsDir, params.installPath) ||
     resolveComparableUninstallPath(params.projectsDir) ===
@@ -238,7 +246,12 @@ function resolveNpmManagedProjectInstall(params: {
     projectDir: npmRoot,
     npmDir,
   });
-  return { installPath: ownsProjectRoot ? npmRoot : params.installPath, npmRoot, packageName };
+  return {
+    installPath: ownsProjectRoot ? npmRoot : params.installPath,
+    npmRoot,
+    packageName,
+    rootKind: "isolated-project",
+  };
 }
 
 function resolveNpmPackageNameFromInstallPath(params: {
@@ -423,6 +436,7 @@ export function planPluginUninstall(params: UninstallPluginParams): PluginUninst
                   kind: "npm",
                   npmRoot: npmManagedInstall.npmRoot,
                   packageName: npmManagedInstall.packageName,
+                  rootKind: npmManagedInstall.rootKind,
                 },
               }
             : gitManagedInstall && deleteTarget === gitManagedInstall.installPath
@@ -453,7 +467,10 @@ function isOwnedNpmRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
     return true;
   }
   const projectsDir = path.dirname(cleanup.npmRoot);
-  const projectRoot = path.basename(projectsDir) === "projects";
+  const projectRoot = cleanup.rootKind === "isolated-project";
+  if (projectRoot !== (path.basename(projectsDir) === "projects")) {
+    return false;
+  }
   const npmDir = projectRoot ? path.dirname(projectsDir) : cleanup.npmRoot;
   if (
     projectRoot
@@ -510,9 +527,8 @@ export async function applyPluginUninstallDirectoryRemoval(
     return { directoryRemoved: false, warnings };
   }
 
-  const removesNpmProject =
-    removal.cleanup?.kind === "npm" &&
-    path.resolve(removal.target) === path.resolve(removal.cleanup.npmRoot);
+  const usesLegacySharedNpmRoot =
+    removal.cleanup?.kind === "npm" && removal.cleanup.rootKind === "legacy-shared";
   const npmCleanupManifestPath =
     removal.cleanup?.kind === "npm" ? path.join(removal.cleanup.npmRoot, "package.json") : "";
   const npmCleanupManifestExists =
@@ -531,7 +547,7 @@ export async function applyPluginUninstallDirectoryRemoval(
   if (!isOwnedNpmRemoval(removal)) {
     return { directoryRemoved: false, warnings: [ownershipWarning] };
   }
-  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists && !removesNpmProject) {
+  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists && usesLegacySharedNpmRoot) {
     const uninstall = await runCommandWithTimeout(
       [
         "npm",

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -463,6 +463,13 @@ function isOwnedNpmRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
   ) {
     return false;
   }
+  const manifestPath = path.join(cleanup.npmRoot, "package.json");
+  if (
+    pluginUninstallTargetExists(manifestPath) &&
+    !isPluginNpmManagedPath({ managedPath: manifestPath, npmDir })
+  ) {
+    return false;
+  }
   if (path.resolve(removal.target) === path.resolve(cleanup.npmRoot)) {
     return (
       projectRoot &&
@@ -524,21 +531,6 @@ export async function applyPluginUninstallDirectoryRemoval(
   if (!isOwnedNpmRemoval(removal)) {
     return { directoryRemoved: false, warnings: [ownershipWarning] };
   }
-  if (
-    removal.cleanup?.kind === "npm" &&
-    !removesNpmProject &&
-    npmCleanupManifestExists &&
-    !isPluginNpmManagedPath({
-      managedPath: npmCleanupManifestPath,
-      npmDir:
-        path.basename(path.dirname(removal.cleanup.npmRoot)) === "projects"
-          ? path.dirname(path.dirname(removal.cleanup.npmRoot))
-          : removal.cleanup.npmRoot,
-    })
-  ) {
-    return { directoryRemoved: false, warnings: [ownershipWarning] };
-  }
-
   if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists && !removesNpmProject) {
     const uninstall = await runCommandWithTimeout(
       [

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -216,6 +216,10 @@ function resolveNpmManagedProjectInstall(params: {
     return null;
   }
   const npmRoot = path.join(params.projectsDir, segments[0] ?? "");
+  const npmDir = path.dirname(params.projectsDir);
+  if (!isUninstallPathInsideOrEqual(npmDir, params.installPath)) {
+    return null;
+  }
   const nodeModulesRoot = path.join(npmRoot, "node_modules");
   const packageName = resolveNpmPackageNameFromInstallPath({
     installPath: params.installPath,
@@ -231,7 +235,7 @@ function resolveNpmManagedProjectInstall(params: {
   const ownsProjectRoot = isPluginNpmProjectDir({
     packageName,
     projectDir: npmRoot,
-    npmDir: path.dirname(params.projectsDir),
+    npmDir,
   });
   return { installPath: ownsProjectRoot ? npmRoot : params.installPath, npmRoot, packageName };
 }
@@ -442,6 +446,22 @@ export function pluginUninstallTargetExists(target: string): boolean {
   }
 }
 
+function isOwnedNpmProjectRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
+  const cleanup = removal.cleanup;
+  if (cleanup?.kind !== "npm" || path.resolve(removal.target) !== path.resolve(cleanup.npmRoot)) {
+    return true;
+  }
+  const projectsDir = path.dirname(cleanup.npmRoot);
+  return (
+    path.basename(projectsDir) === "projects" &&
+    isPluginNpmProjectDir({
+      npmDir: path.dirname(projectsDir),
+      packageName: cleanup.packageName,
+      projectDir: cleanup.npmRoot,
+    })
+  );
+}
+
 export async function applyPluginUninstallDirectoryRemoval(
   removal: PluginUninstallDirectoryRemoval | null,
 ): Promise<{ directoryRemoved: boolean; warnings: string[] }> {
@@ -465,6 +485,11 @@ export async function applyPluginUninstallDirectoryRemoval(
 
   if (!existed && removal.cleanup?.kind === "npm" && !npmCleanupManifestExists) {
     return { directoryRemoved: false, warnings };
+  }
+
+  const ownershipWarning = `Refused to remove npm project without canonical package ownership: ${removal.target}`;
+  if (!isOwnedNpmProjectRemoval(removal)) {
+    return { directoryRemoved: false, warnings: [ownershipWarning] };
   }
 
   if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists) {
@@ -526,6 +551,9 @@ export async function applyPluginUninstallDirectoryRemoval(
         `Failed to repair managed npm peer links after uninstalling ${removal.cleanup.packageName}: ${formatErrorMessage(error)}`,
       );
     }
+  }
+  if (!isOwnedNpmProjectRemoval(removal) && pluginUninstallTargetExists(removal.target)) {
+    return { directoryRemoved: false, warnings: [...warnings, ownershipWarning] };
   }
   try {
     await fs.rm(removal.target, { recursive: true, force: true });


### PR DESCRIPTION
Closes #123972
Related: #123973

## What Problem This Solves

Fixes an issue where uninstalling an npm-managed plugin could either leave its isolated OpenClaw npm project behind or, after the partial repair in #123973, widen recursive cleanup without proving that the selected project root was owned by that package.

## Why This Change Was Made

The plugin lifecycle owner now records whether an npm match came from the exact legacy shared root or the isolated projects topology, and validates that fact again before filesystem or npm mutation. Whole-project deletion is limited to the package's exact ordinary root or an exact lowercase-hex generation root. Every noncanonical project falls back to exact package-leaf removal without running npm in the enclosing project.

The accepted ownership matrix is:

| Root/path state | Result |
| --- | --- |
| Exact ordinary package project root | Remove the complete owned project |
| Exact `<package-prefix>__openclaw-generation__g-[a-f0-9]{16}` root | Remove the complete owned generation |
| Legacy shared npm root | Run shared-root npm cleanup, then remove only the exact package |
| Arbitrary sibling, lookalike, malformed generation, or cross-package root | Remove only the exact validated package leaf; never mutate the enclosing project |
| Traversal or outside managed topology | Refuse removal |
| Symlinked npm root, projects directory, project root, package leaf, or project manifest | Refuse removal |
| Active or explicit `--keep-files` retained generation | Preserve it |
| Missing package target | Keep cleanup retryable through the canonical existing ancestor |
| Bundled plugin | Reject uninstall; disable instead |
| git, path, ClawHub, and marketplace installs | Existing behavior unchanged |

Peter explicitly approved the reviewed +154 production baseline. Fresh security review found three additional ownership gaps in that form: package/manifest symlink acceptance, npm mutation inside noncanonical fallback projects, and inference of legacy-root ownership from directory shape. The final patch is +185/-9 production (net +176); the extra net +22 records the planner-owned root kind, validates missing leaves through canonical existing ancestors, and applies universal manifest/package checks. Removing those paths reproduces the accepted P1 findings.

Alternatives tried and rejected:

- The earlier +59 form validated names but not the full real-path ownership chain.
- Always deleting only the package leaf avoids widening deletion but preserves the original project-level archive/lockfile/dependency leak.
- Inferring a legacy shared root from “parent is not named `projects`” remained forgeable; ownership is now recorded at the exact planner match site and cross-checked against topology.
- Node's recursive `rm` is path-based and does not expose descriptor-anchored recursive deletion. Hostile same-user swaps between adjacent filesystem syscalls remain outside the documented single-user trusted-host threat model; every stable pre-plan and post-plan substitution we can revalidate is covered.

No config, schema, protocol, Plugin SDK, dependency, release, or migration contract changes.

## User Impact

Ordinary uninstall removes all files in an OpenClaw-owned isolated npm project. Shared and noncanonical projects keep unrelated manifests, lockfiles, dependencies, and sibling packages intact. Retained update generations and `--keep-files` continue to work, and failed or missing cleanup targets remain retryable.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/plugins/management-service.test.ts src/plugins/management-service.install-compensation.test.ts src/plugins/uninstall.test.ts src/plugins/install-record-commit.test.ts src/plugins/install-record-commit.retention.test.ts src/plugins/managed-npm-retention.test.ts src/plugins/install-persistence.test.ts` — 167/167 passed. This includes the requested 135-test owner/sibling set plus retention, compensation, rollback/failure/retry, missing-target, and hostile symlink/root matrices.
- Blacksmith Testbox `tbx_01m05atf16x2w15abd90c82jch`, [run 31948837818](https://github.com/openclaw/openclaw/actions/runs/31948837818) — exact-head source-absent packed Docker lifecycle passed: full build and tarball integrity, tgz/local/file/npm/git/marketplace install and update, malformed npm rejection, explicit restart visibility, retained reinstall, and uninstall. Hermetic ClawHub block was intentionally offline.
- Blacksmith Testbox `tbx_01m05b7wcfetgp6x0ke1h0f29m`, [run 31949170366](https://github.com/openclaw/openclaw/actions/runs/31949170366) — `check:changed`, full `pnpm check`, test types, full format, core/extensions/scripts lint, both cycle guards, plugin boundary and SDK surface checks, dead-code/dependency checks, high-severity production dependency audit, OpenGrep rule metadata, and diff hygiene passed. The OpenGrep binary was unavailable on the runner, so no binary OpenGrep scan is claimed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — final whole-branch general review clean; no accepted/actionable P0 finding (0.98 confidence).
- Dedicated whole-branch P1 filesystem-security autoreview — clean; no accepted/actionable P0/P1 finding (0.91 confidence).
- TruffleHog exact-bundle scan — clean in both final reviews.
- Direct sibling Codex source inspection confirmed this plugin lifecycle path does not change Codex CLI/app-server protocol or runtime contracts (`../codex/codex-rs/cli/src/main.rs`, `../codex/codex-rs/core/src/lib.rs`).

Tests and test support: +508/-78 (net +430).

No `CHANGELOG.md` edit. AI-assisted, maintainer-owned, and explicitly approved for full repair landing.
