### PR TITLE
fix(gateway): retire ownerless requested placements

### DIFF
--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -175,8 +175,8 @@ describe("placement session retirement", () => {
     const forceDestroyEnvironment = vi.fn();
     const retirement = createPlacementSessionRetirement({
       placements: {
-        get: placements.get,
-        list: placements.list,
+        get: (sessionId) => placements.get(sessionId),
+        list: () => placements.list(),
         retireSessionPlacement,
       },
       environments: { get: () => undefined },

--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -1,7 +1,17 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import { createPlacementSessionRetirement } from "./placement-session-retirement.js";
-import type { WorkerSessionPlacementRetirement } from "./placement-store.js";
+import {
+  createWorkerSessionPlacementStore,
+  type WorkerSessionPlacementRetirement,
+} from "./placement-store.js";
 
 function localPlacement(
   sessionId: string,
@@ -146,6 +156,49 @@ describe("placement session retirement", () => {
       },
     ]);
     expect(harness.forceDestroyEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("retires an exact ownerless requested placement after its session disappears", async () => {
+    const root = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "openclaw-placement-retirement-"),
+    );
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    const placements = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const requested = placements.startDispatch({
+      sessionId: "session-requested",
+      sessionKey: "agent:main:session-requested",
+      agentId: "main",
+    });
+    const retireSessionPlacement = vi.fn((input: WorkerSessionPlacementRetirement) =>
+      placements.retireSessionPlacement(input),
+    );
+    const forceDestroyEnvironment = vi.fn();
+    const retirement = createPlacementSessionRetirement({
+      placements: {
+        get: placements.get,
+        list: placements.list,
+        retireSessionPlacement,
+      },
+      environments: { get: () => undefined },
+      forceDestroyEnvironment,
+      createSessionEvidenceResolver: async () => async () => "absent",
+      warn: vi.fn(),
+    });
+
+    try {
+      await retirement.reconcile();
+
+      expect(retireSessionPlacement).toHaveBeenCalledWith({
+        sessionId: requested.sessionId,
+        expectedState: "requested",
+        expectedGeneration: requested.generation,
+      });
+      expect(placements.get(requested.sessionId)).toBeUndefined();
+      expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("fences a live environment before retiring its failed placement", async () => {

--- a/src/gateway/worker-environments/placement-session-retirement.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.ts
@@ -26,28 +26,26 @@ export function createPlacementSessionRetirement(deps: PlacementSessionRetiremen
     if (placement.turnClaim) {
       return false;
     }
-    const retirement =
-      placement.state === "local" || placement.state === "reclaimed"
-        ? {
-            sessionId: placement.sessionId,
-            expectedState: placement.state,
-            expectedGeneration: placement.generation,
-          }
-        : placement.state === "failed" &&
-            isFailedWorkerPlacementEnvironmentGone({
-              environmentService: deps.environments,
-              placement,
-            })
-          ? {
-              sessionId: placement.sessionId,
-              expectedState: placement.state,
-              expectedGeneration: placement.generation,
-            }
-          : undefined;
-    if (!retirement) {
+    if (
+      placement.environmentId !== null &&
+      placement.state !== "reclaimed" &&
+      (placement.state !== "failed" ||
+        !isFailedWorkerPlacementEnvironmentGone({
+          environmentService: deps.environments,
+          placement,
+        }))
+    ) {
       return false;
     }
-    deps.placements.retireSessionPlacement(retirement);
+    // Dispatch binds environment intent before entering provisioning.
+    if (placement.state === "provisioning") {
+      return false;
+    }
+    deps.placements.retireSessionPlacement({
+      sessionId: placement.sessionId,
+      expectedState: placement.state,
+      expectedGeneration: placement.generation,
+    });
     return true;
   };
 

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -54,7 +54,7 @@ import {
 import { boundedWorkerError } from "./worker-error.js";
 import { projectWorkspaceResultConflict } from "./workspace-conflicts.js";
 
-const RETIRABLE_PLACEMENT_STATES = ["local", "reclaimed", "failed"] as const;
+const RETIRABLE_PLACEMENT_STATES = ["local", "requested", "reclaimed", "failed"] as const;
 
 export type WorkerSessionPlacementRetirement = {
   sessionId: string;


### PR DESCRIPTION
## What Problem This Solves

Periodic placement retirement skipped requested placement rows forever when their session was absent and they had neither a turn claim nor an environment assignment. Those ownerless rows could therefore remain in the placement store indefinitely.

## Why This Change Was Made

The canonical retirement path now retires no-environment ownerless records. The placement store allowlist admits only requested placements plus the existing safe terminal and local states, preserving environment teardown requirements and the exact compare-and-swap checks on state and generation.

## User Impact

Stale requested placements whose sessions have disappeared are now cleaned up by periodic reconciliation instead of accumulating indefinitely. Placements with live environment ownership continue through the existing teardown path.

## Evidence

- Focused and sibling proof: 24/24 tests passed.
- Production LOC: +19/-21 (net -2); tests: +54/-1.
- Fresh autoreview completed with no actionable findings.
- Diff check is clean.
