### PR TITLE
fix(ui): surface the blocking reason when Enter cannot start a new session

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -514,10 +514,14 @@ suite.define(() => {
         await expect.poll(() => message.inputValue()).toBe("retry this draft after reconnect");
         await expect.poll(() => message.isEnabled()).toBe(true);
         await expect.poll(() => start.isDisabled()).toBe(true);
+        // The gate table also surfaces this reason in the Start tooltip, so
+        // scope to the page callout instead of a bare text match.
         await page
-          .getByText(
-            "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
-          )
+          .getByRole("alert")
+          .filter({
+            hasText:
+              "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
+          })
           .waitFor();
         expect(new URL(page.url()).pathname).toBe("/new");
         expect(await gateway.getRequests("sessions.create")).toHaveLength(1);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -810,6 +810,12 @@ export const en: TranslationMap = {
     cloudSetupInterrupted:
       "This cloud session's setup was interrupted. Check recent sessions before starting this task again.",
     catalogUnavailable: "This session target is unavailable.",
+    restoringPreferences: "Restoring your last session setup…",
+    checkingPlace: "Checking the selected place…",
+    cloudNotReady: "The cloud worker isn't ready yet. Try again in a moment.",
+    agentsUnavailable: "No agents are available on this Gateway yet.",
+    nodeUnavailable: "The selected device is unavailable. Pick another place.",
+    terminalNeedsFolder: "Pick a folder before starting in a terminal.",
     what: "What",
     detail: "Detail",
     local: "Local",

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -17,6 +17,7 @@ function renderComposer(
     canSubmit?: boolean;
     requiresModifier?: boolean;
     submitDisabledReason?: string;
+    blockedSubmitNotice?: string;
     terminalAction?: {
       canStart: boolean;
       disabledReason?: string;
@@ -54,6 +55,7 @@ function renderComposer(
       modelControl: new NewSessionModelControl(() => undefined),
       requiresModifier: overrides.requiresModifier ?? false,
       submitDisabledReason: overrides.submitDisabledReason,
+      blockedSubmitNotice: overrides.blockedSubmitNotice,
       terminalAction: overrides.terminalAction,
       submitting: overrides.submitting ?? false,
       textareaController,
@@ -97,7 +99,7 @@ describe("new-session composer keyboard submission", () => {
     { label: "Enter", requiresModifier: false, ctrlKey: false, metaKey: false },
     { label: "Ctrl+Enter", requiresModifier: true, ctrlKey: true, metaKey: false },
     { label: "Meta+Enter", requiresModifier: true, ctrlKey: false, metaKey: true },
-  ])("keeps $label native when starting a session is disabled", (testCase) => {
+  ])("keeps $label native when submission is silently gated", (testCase) => {
     const onSubmit = vi.fn();
     const { composer } = renderComposer({
       canSubmit: false,
@@ -149,6 +151,39 @@ describe("new-session composer keyboard submission", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("forwards Enter to onSubmit while a reasoned gate blocks submission", () => {
+    // Silent-swallow regression: an Enter press during a transient gate
+    // (preference restore, reconnect) must reach the submission flow so it
+    // can surface the blocking reason, not die in the keydown handler.
+    const onSubmit = vi.fn();
+    const { composer } = renderComposer({
+      canSubmit: false,
+      submitDisabledReason: "Restoring your last session setup…",
+      onSubmit,
+    });
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+    const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" });
+
+    textarea.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("renders the blocked-submit notice near the composer", () => {
+    const { composer } = renderComposer({
+      canSubmit: false,
+      blockedSubmitNotice: "Restoring your last session setup…",
+    });
+    const notice = composer.querySelector<HTMLElement>(".new-session-page__blocked-submit");
+
+    expect(notice?.getAttribute("role")).toBe("status");
+    expect(notice?.textContent?.trim()).toBe("Restoring your last session setup…");
   });
 });
 

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -33,6 +33,7 @@ type NewSessionComposerOptions = {
   readSignal: AbortSignal;
   requiresModifier: boolean;
   submitDisabledReason?: string;
+  blockedSubmitNotice?: string;
   terminalAction?: {
     canStart: boolean;
     disabledReason?: string;
@@ -178,17 +179,16 @@ export function renderDraftError(message: string) {
 }
 
 function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposerOptions) {
-  if (
-    !options.canSubmit ||
-    options.submitting ||
-    event.key !== "Enter" ||
-    event.shiftKey ||
-    event.isComposing ||
-    event.keyCode === 229
-  ) {
+  if (event.key !== "Enter" || event.shiftKey || event.isComposing || event.keyCode === 229) {
     return;
   }
-  if (!options.requiresModifier || event.metaKey || event.ctrlKey) {
+  if (options.requiresModifier && !event.metaKey && !event.ctrlKey) {
+    return;
+  }
+  // A reasoned gate still consumes the press: the submission flow records the
+  // attempt and surfaces the reason instead of silently inserting a newline.
+  // Only silent gates (busy button, empty draft) keep Enter native.
+  if (options.canSubmit || options.submitDisabledReason !== undefined) {
     event.preventDefault();
     options.onSubmit();
   }
@@ -265,6 +265,11 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
               : nothing}
           </div>
         </div>
+        ${options.blockedSubmitNotice
+          ? html`<div class="new-session-page__blocked-submit" role="status">
+              ${options.blockedSubmitNotice}
+            </div>`
+          : nothing}
         ${options.pendingAttachmentReads > 0
           ? html`<span class="sr-only" role="status">${t("newSession.readingAttachment")}</span>`
           : nothing}
@@ -287,6 +292,7 @@ export function renderNewSessionDraftComposer(options: {
   textareaController: NewSessionComposerTextareaController;
   requiresModifier: boolean;
   submitDisabledReason?: string;
+  blockedSubmitNotice?: string;
   terminalAction?: {
     canStart: boolean;
     disabledReason?: string;
@@ -320,6 +326,7 @@ export function renderNewSessionDraftComposer(options: {
     readSignal,
     requiresModifier: options.requiresModifier,
     submitDisabledReason: options.submitDisabledReason,
+    blockedSubmitNotice: options.blockedSubmitNotice,
     terminalAction: options.terminalAction,
     submitting: options.submitting,
     textareaController: options.textareaController,

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -7,6 +7,12 @@ import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+import { patchNewSessionPreference } from "./preferences.ts";
+
+// The closed list of gates allowed to block without a visible reason: the busy
+// Start button and an empty draft explain themselves. Growing it is a product
+// decision — edit this list and the matching one in submit-gates.ts together.
+const SILENT_SUBMIT_GATES = ["submitting", "empty-draft"];
 
 class ControllerHost implements ReactiveControllerHost {
   readonly updateComplete = Promise.resolve(true);
@@ -17,6 +23,259 @@ class ControllerHost implements ReactiveControllerHost {
 
 afterEach(() => {
   sessionStorage.clear();
+  localStorage.clear();
+});
+
+type FixtureOptions = {
+  phase?: "connected" | "connecting";
+  agents?: unknown[];
+  methods?: string[];
+  scopes?: string[];
+  selfUser?: { id: string };
+  request?: (method: string) => Promise<unknown>;
+};
+
+function createDraftFixture(options: FixtureOptions = {}) {
+  const request = vi.fn((method: string) => {
+    if (method === "node.list") {
+      return Promise.resolve({ nodes: [] });
+    }
+    if (options.request) {
+      return options.request(method);
+    }
+    return Promise.resolve({});
+  });
+  const client = { recoveryScope: "principal-a", recoveryScopeReady: true, request };
+  const phase = options.phase ?? "connected";
+  const context = {
+    gateway: {
+      connection: { gatewayUrl: "ws://gateway.example" },
+      snapshot: {
+        phase,
+        client: phase === "connected" ? client : null,
+        ...(options.selfUser ? { selfUser: options.selfUser } : {}),
+        hello:
+          phase === "connected"
+            ? {
+                auth: {
+                  role: "operator",
+                  scopes: options.scopes ?? ["operator.read", "operator.write"],
+                },
+                features: { methods: options.methods ?? ["sessions.create"] },
+              }
+            : null,
+      },
+    },
+    agents: {
+      state: {
+        agentsList: {
+          defaultId: "main",
+          agents: options.agents ?? [
+            {
+              id: "main",
+              workspace: "/workspace",
+              workspaceGit: false,
+              model: { primary: "openai/gpt-5.6-luna" },
+            },
+          ],
+        },
+      },
+    },
+    sessions: { state: { result: null }, createResult: vi.fn() },
+    config: { current: {} },
+  } as unknown as ApplicationContext;
+  const host = new ControllerHost();
+  const gateway = new DraftGatewayState(
+    host,
+    () => ({
+      context,
+      data: undefined,
+      isConnected: phase === "connected",
+      isAdmin: place?.isAdmin() ?? false,
+      canStartAsDraft: flow?.canStartAsDraft() ?? false,
+      visibility: flow?.visibility ?? "normal",
+      cloudProfileId: place?.cloudProfileId ?? "",
+      pendingCloud: flow?.pendingCloud ?? { sessionKey: "", gatewayUrl: "", recoveryScope: "" },
+      agentsHydrated: place?.agentsHydrated ?? false,
+    }),
+    {
+      requestUpdate: vi.fn(),
+      updateComplete: () => Promise.resolve(),
+      onInvalidate: vi.fn(),
+      onVisibilityRetired: () => flow?.setVisibility("normal"),
+      onCloudProfileCleared: () => place?.clearCloudProfile(),
+      onCloudState: (error) => flow?.setError(error),
+      onPendingCloudReset: () => flow?.resetPendingCloudWithoutClearingStorage(),
+      onRecoveryReady: (gatewayUrl, recoveryScope) =>
+        flow?.restorePendingCloudRecovery(gatewayUrl, recoveryScope),
+      onAdoptAgentDefaults: () => place?.adoptAgentDefaults(),
+    },
+  );
+  const browser = new DraftPlaceBrowser(
+    host,
+    gateway,
+    () => ({
+      context,
+      nodes: place?.nodes ?? [],
+      folder: place?.folder ?? "",
+      execNode: place?.execNode ?? "",
+      isAdmin: place?.isAdmin() ?? false,
+    }),
+    {
+      requestUpdate: vi.fn(),
+      onProjectMissing: () => place?.clearProjectSelection(),
+      onSelectProject: (projectId) => place?.selectProjectId(projectId),
+      onApprovedListing: (listing) => place?.recordGatewayApprovedListing(listing),
+      querySelector: () => null,
+      activeElement: () => null,
+      body: () => null,
+    },
+  );
+  const place = new DraftPlaceState(
+    gateway,
+    browser,
+    () => ({
+      context,
+      data: undefined,
+      submitting: flow?.submitting ?? false,
+      pendingCloudSessionKey: flow?.pendingCloud.sessionKey ?? "",
+    }),
+    {
+      requestUpdate: vi.fn(),
+      onError: (error) => flow?.setError(error),
+      onClearError: (error) => flow?.clearErrorIf(error),
+    },
+  );
+  const flow = new DraftSubmissionFlow(
+    gateway,
+    place,
+    () => ({ context, data: undefined, isConnected: phase === "connected" }),
+    { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
+  );
+  gateway.synchronize(context.gateway);
+  place.setAgentsHydrated(true);
+  place.adoptAgentDefaults();
+  return { context, flow, gateway, place, request };
+}
+
+describe("DraftSubmissionFlow submit gates", () => {
+  it("keeps every blocking gate visible: canSubmit and the reason derive from one table", () => {
+    const scenarios: Array<{ name: string; build: () => ReturnType<typeof createDraftFixture> }> = [
+      { name: "empty draft", build: () => createDraftFixture() },
+      {
+        name: "gateway disconnected",
+        build: () => {
+          const fixture = createDraftFixture({ phase: "connecting" });
+          fixture.flow.setMessage("hello");
+          return fixture;
+        },
+      },
+      {
+        name: "attachment reads pending",
+        build: () => {
+          const fixture = createDraftFixture();
+          fixture.flow.setMessage("hello");
+          fixture.flow.attachmentDraft.updatePending(fixture.flow.attachmentDraft.readSignal, 1);
+          return fixture;
+        },
+      },
+      {
+        name: "no agents on the gateway",
+        build: () => {
+          const fixture = createDraftFixture({ agents: [] });
+          fixture.flow.setMessage("hello");
+          return fixture;
+        },
+      },
+      {
+        name: "sessions.create not advertised",
+        build: () => {
+          const fixture = createDraftFixture({ methods: [] });
+          fixture.flow.setMessage("hello");
+          return fixture;
+        },
+      },
+      {
+        name: "submission outcome unknown",
+        build: () => {
+          const fixture = createDraftFixture();
+          fixture.flow.setMessage("hello");
+          fixture.flow.markPendingCloudUnavailable("gateway-changed");
+          return fixture;
+        },
+      },
+    ];
+    for (const scenario of scenarios) {
+      const { flow } = scenario.build();
+      const block = flow.submitBlock();
+      expect(block, scenario.name).toBeDefined();
+      expect(flow.canSubmit(), scenario.name).toBe(false);
+      if (!(SILENT_SUBMIT_GATES as readonly string[]).includes(block?.gate ?? "")) {
+        // A reasoned gate must explain itself, and the Start tooltip must
+        // report the same first-gate reason canSubmit blocks on.
+        expect(block?.reason, scenario.name).toBeTruthy();
+        expect(flow.submitDisabledReason(), scenario.name).toBe(block?.reason);
+      }
+    }
+
+    const ready = createDraftFixture();
+    ready.flow.setMessage("hello");
+    expect(ready.flow.submitBlock()).toBeUndefined();
+    expect(ready.flow.canSubmit()).toBe(true);
+    expect(ready.flow.submitDisabledReason()).toBeUndefined();
+  });
+
+  it("surfaces a reason for Enter during worktree preference restore, then clears it", async () => {
+    patchNewSessionPreference("ws://gateway.example", "main", {
+      folder: "/workspace",
+      worktree: true,
+    });
+    let resolveBranches!: (value: unknown) => void;
+    const fixture = createDraftFixture({
+      agents: [
+        {
+          id: "main",
+          workspace: "/workspace",
+          workspaceGit: true,
+          model: { primary: "openai/gpt-5.6-luna" },
+        },
+      ],
+      request: (method) => {
+        if (method === "worktrees.branches") {
+          return new Promise((resolve) => {
+            resolveBranches = resolve;
+          });
+        }
+        return Promise.resolve({});
+      },
+    });
+    const { context, flow } = fixture;
+    flow.setMessage("start something");
+
+    // The async preference restore is still in flight: submission is gated,
+    // but the gate must be visible, not a silent no-op.
+    expect(flow.canSubmit()).toBe(false);
+    expect(flow.submitDisabledReason()).toBeTruthy();
+    expect(flow.blockedSubmitNotice()).toBeUndefined();
+
+    await flow.submit();
+    expect(context.sessions.createResult).not.toHaveBeenCalled();
+    expect(flow.blockedSubmitNotice()).toBe(flow.submitDisabledReason());
+
+    resolveBranches({ repositoryStatus: "git", branches: ["main"], defaultBranch: "main" });
+    await vi.waitFor(() => expect(flow.canSubmit()).toBe(true));
+    // The transient gate lifted; the notice retires itself.
+    expect(flow.blockedSubmitNotice()).toBeUndefined();
+    expect(flow.submitDisabledReason()).toBeUndefined();
+  });
+
+  it("does not raise a notice for the silent empty-draft gate", async () => {
+    const fixture = createDraftFixture();
+    await fixture.flow.submit();
+    expect(fixture.flow.canSubmit()).toBe(false);
+    expect(fixture.flow.submitBlock()?.gate).toBe("empty-draft");
+    expect(fixture.flow.blockedSubmitNotice()).toBeUndefined();
+  });
 });
 
 describe("DraftSubmissionFlow", () => {

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -27,7 +27,6 @@ import { NewSessionComposerTextareaController } from "./composer.ts";
 import {
   buildDraftSessionCreateParams as assembleDraftSessionCreateParams,
   canStartSessionAsDraft,
-  isWorktreeNameValid,
   type NewSessionVisibility,
 } from "./create-params.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
@@ -37,11 +36,17 @@ import type {
   DraftSubmissionSnapshot,
 } from "./draft-submission-contract.ts";
 import { retainRejectedInitialTurn } from "./rejected-initial-turn.ts";
+import {
+  PAGE_RENDERED_GATES,
+  resolveNewSessionSubmitBlock,
+  type NewSessionSubmitBlock,
+} from "./submit-gates.ts";
 
 export class DraftSubmissionFlow {
   private visibilityValue: NewSessionVisibility = "normal";
   private messageValue = "";
   private submittingValue = false;
+  private blockedSubmitGate: string | null = null;
   private submissionOutcomeUnknownValue: SubmissionOutcomeReason | null = null;
   private errorValue: string | null = null;
   private submitRequestToken = 0;
@@ -113,6 +118,26 @@ export class DraftSubmissionFlow {
     this.pendingCloud.retryAllowed = false;
     this.submissionOutcomeUnknownValue = outcome;
     this.callbacks.requestUpdate();
+  }
+
+  /** A submit was attempted (Enter or Start click) while a gate blocked it. */
+  noteBlockedSubmitAttempt(kind: "session" | "terminal" = "session") {
+    this.blockedSubmitGate = this.submitBlock(kind)?.gate ?? null;
+    this.callbacks.requestUpdate();
+  }
+
+  /**
+   * Reason to surface near the composer after a blocked submit attempt. Bound
+   * to the gate captured at attempt time, so it disappears on its own once a
+   * transient gate (preference restore, reconnect) lifts and never shows for
+   * gates the user did not trip.
+   */
+  blockedSubmitNotice(): string | undefined {
+    const block = this.blockedSubmitGate ? this.submitBlock() : undefined;
+    if (!block?.reason || block.gate !== this.blockedSubmitGate) {
+      return undefined;
+    }
+    return PAGE_RENDERED_GATES.has(block.gate) ? undefined : block.reason;
   }
 
   canStartAsDraft(): boolean {
@@ -194,19 +219,11 @@ export class DraftSubmissionFlow {
   }
 
   submitDisabledReason(): string | undefined {
-    if (catalog.isRoutePending(this.read().data, this.read().context?.sessions)) {
-      return t("newSession.catalogUnavailable");
-    }
-    if (this.place.modelControl.isModelUnavailable(this.place.selectedAgent())) {
-      return `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`;
-    }
-    const access = this.submissionAccess();
-    return access.allowed ? undefined : access.reason;
+    return this.submitBlock()?.reason;
   }
 
   terminalStartDisabledReason(): string | undefined {
-    const access = this.terminalStartAccess();
-    return access.allowed ? undefined : access.reason;
+    return this.submitBlock("terminal")?.reason;
   }
 
   incognitoDisabledReason(): string | undefined {
@@ -218,80 +235,35 @@ export class DraftSubmissionFlow {
   }
 
   canSubmit(kind: "session" | "terminal" = "session"): boolean {
-    const pendingCloud = Boolean(this.pendingCloud.sessionKey);
-    const cloudProfileId = this.cloudProfileForSubmission();
-    const message = pendingCloud ? this.pendingCloud.message : this.messageValue.trim();
-    const hasAttachments = pendingCloud
-      ? Boolean(this.pendingCloud.attachments?.length)
-      : this.attachmentDraft.attachments.length > 0;
-    const gateway = this.read().context?.gateway;
-    if (
-      this.submittingValue ||
-      this.gateway.preferenceLoading ||
-      this.requiresModelSetup() ||
-      catalog.isRoutePending(this.read().data, this.read().context?.sessions) ||
-      this.place.modelControl.isModelUnavailable(this.place.selectedAgent()) ||
-      this.attachmentDraft.pendingReads > 0 ||
-      (!pendingCloud && this.submissionOutcomeUnknownValue) ||
-      (kind === "session" && !message && !hasAttachments) ||
-      gateway?.snapshot.phase !== "connected" ||
-      !gateway.snapshot.client
-    ) {
-      return false;
-    }
-    const access = kind === "terminal" ? this.terminalStartAccess() : this.submissionAccess();
-    if (!access.allowed || this.place.folderSubmissionBlocked()) {
-      return false;
-    }
-    if (this.place.modelControl.isRestoringPreference() || !this.place.worktreePreferenceReady) {
-      return false;
-    }
-    if (pendingCloud) {
-      return Boolean(
-        this.pendingCloud.retryAllowed &&
-        gateway.snapshot.client.recoveryScopeReady &&
-        cloudProfileId &&
-        this.pendingCloud.agentId &&
-        this.pendingCloud.gatewayUrl === gateway.connection.gatewayUrl &&
-        this.pendingCloud.recoveryScope === gateway.snapshot.client?.recoveryScope &&
-        this.place.isAdmin(),
-      );
-    }
-    if (this.place.agents().length === 0) {
-      return false;
-    }
-    if (!catalog.allowsSelectedAgent(this.read().data, this.place.selectedAgent())) {
-      return false;
-    }
-    if (!this.place.execNodeReady()) {
-      return false;
-    }
-    if (
-      cloudProfileId &&
-      (!this.place.isAdmin() ||
-        !gateway.snapshot.client.recoveryScope ||
-        !gateway.snapshot.client.recoveryScopeReady ||
-        !this.gateway.cloudProfilesReady ||
-        this.gateway.cloudProfilesPending ||
-        !this.place.worktree ||
-        !this.gateway.cloudProfiles.some((profile) => profile.id === cloudProfileId) ||
-        Boolean(this.cloudRuntimeUnsupportedReason()))
-    ) {
-      return false;
-    }
-    if (this.place.execNode && this.place.worktree) {
-      return false;
-    }
-    if (this.place.worktree && !this.place.worktreeAvailable()) {
-      return false;
-    }
-    if (this.place.worktree && !isWorktreeNameValid(this.place.worktreeName)) {
-      return false;
-    }
-    if (kind === "terminal" && !(this.place.folder.trim() || this.place.workspacePath())) {
-      return false;
-    }
-    return true;
+    return this.submitBlock(kind) === undefined;
+  }
+
+  /**
+   * The single owner of every submit gate (`submit-gates.ts`). `canSubmit`,
+   * the disabled-reason tooltips, and blocked Enter notices all derive from
+   * that one walk, so a gate cannot block without a user-visible reason.
+   */
+  submitBlock(kind: "session" | "terminal" = "session"): NewSessionSubmitBlock | undefined {
+    return resolveNewSessionSubmitBlock(
+      {
+        gatewayState: this.gateway,
+        placeState: this.place,
+        pendingCloud: this.pendingCloud,
+        submitting: this.submittingValue,
+        message: this.messageValue,
+        submissionOutcomeUnknown: this.submissionOutcomeUnknownValue,
+        pendingAttachmentReads: this.attachmentDraft.pendingReads,
+        hasDraftAttachments: this.attachmentDraft.attachments.length > 0,
+        submissionSnapshot: () => this.read(),
+        requiresModelSetup: () => this.requiresModelSetup(),
+        submissionAccess: () => this.submissionAccess(),
+        terminalStartAccess: () => this.terminalStartAccess(),
+        cloudProfileForSubmission: () => this.cloudProfileForSubmission(),
+        cloudDisabledReason: () => this.cloudDisabledReason(),
+        cloudRuntimeUnsupportedReason: () => this.cloudRuntimeUnsupportedReason(),
+      },
+      kind,
+    );
   }
 
   requiresModelSetup(): boolean {
@@ -333,6 +305,7 @@ export class DraftSubmissionFlow {
 
   resetDraft() {
     const preservePendingCloud = Boolean(this.pendingCloud.sessionKey);
+    this.blockedSubmitGate = null;
     this.invalidate();
     this.submissionOutcomeUnknownValue = preservePendingCloud
       ? (this.submissionOutcomeUnknownValue ?? "cloud-interrupted")
@@ -396,8 +369,10 @@ export class DraftSubmissionFlow {
   async submit() {
     const context = this.read().context;
     if (!context || !this.canSubmit()) {
+      this.noteBlockedSubmitAttempt();
       return;
     }
+    this.blockedSubmitGate = null;
     const pendingCloud = Boolean(this.pendingCloud.sessionKey);
     const message = pendingCloud ? this.pendingCloud.message : this.messageValue.trim();
     const attachments = this.attachmentDraft.attachments;
@@ -641,8 +616,10 @@ export class DraftSubmissionFlow {
     const catalogId = data?.catalogId.trim() ?? "";
     const agentId = normalizeAgentId(this.place.agentId);
     if (!context || !client || !catalogId || !agentId || !this.canSubmit("terminal")) {
+      this.noteBlockedSubmitAttempt("terminal");
       return;
     }
+    this.blockedSubmitGate = null;
     const requestId = ++this.submitRequestToken;
     const initialMessage = this.messageValue.trim();
     this.submittingValue = true;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -592,6 +592,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           attachmentDraft: this.submission.attachmentDraft,
           canSubmit: this.submission.canSubmit(),
           submitDisabledReason: this.submission.submitDisabledReason(),
+          blockedSubmitNotice: this.submission.blockedSubmitNotice(),
           context: this.context,
           isCatalogTarget: catalog.isTarget(this.data),
           message: this.submission.message,

--- a/ui/src/pages/new-session/submit-gates.ts
+++ b/ui/src/pages/new-session/submit-gates.ts
@@ -1,0 +1,200 @@
+// New-session submit gate table: the single owner of every reason submission
+// can be blocked. canSubmit, the Start tooltip, and blocked-Enter notices all
+// derive from this walk, so a gate cannot block silently.
+import { t } from "../../i18n/index.ts";
+import type { SessionMethodAccess } from "../../lib/session-method-access.ts";
+import * as catalog from "./catalog-target.ts";
+import type { PendingCloudRecoveryState, SubmissionOutcomeReason } from "./cloud-recovery-state.ts";
+import { isWorktreeNameValid } from "./create-params.ts";
+import type { DraftGatewayState } from "./draft-gateway-state.ts";
+import type { DraftPlaceState } from "./draft-place-state.ts";
+import type { DraftSubmissionSnapshot } from "./draft-submission-contract.ts";
+
+// Silent gates are the only submit blocks allowed to omit a visible reason:
+// the busy Start button and an empty draft already explain themselves. Every
+// other gate must carry a reason at the type level, so a new gate cannot
+// silently eat an Enter press again.
+type SilentSubmitGate = "submitting" | "empty-draft";
+type ReasonedSubmitGate =
+  | "preference-restore"
+  | "model-setup"
+  | "route-pending"
+  | "model-unavailable"
+  | "attachment-reads"
+  | "outcome-unknown"
+  | "disconnected"
+  | "access"
+  | "folder"
+  | "cloud-recovery"
+  | "agents"
+  | "agent-not-allowed"
+  | "node"
+  | "cloud"
+  | "worktree-unavailable"
+  | "worktree-name"
+  | "terminal-folder";
+export type NewSessionSubmitBlock =
+  | { gate: SilentSubmitGate; reason?: undefined }
+  | { gate: ReasonedSubmitGate; reason: string };
+
+// These gates already render a persistent callout on the page; a blocked
+// submit attempt must not duplicate that text as a second notice.
+export const PAGE_RENDERED_GATES: ReadonlySet<string> = new Set([
+  "outcome-unknown",
+  "worktree-name",
+]);
+
+/** Facts the gate walk reads from DraftSubmissionFlow, kept read-only. */
+type SubmitGateHost = {
+  readonly gatewayState: DraftGatewayState;
+  readonly placeState: DraftPlaceState;
+  readonly pendingCloud: PendingCloudRecoveryState;
+  readonly submitting: boolean;
+  readonly message: string;
+  readonly submissionOutcomeUnknown: SubmissionOutcomeReason | null;
+  readonly pendingAttachmentReads: number;
+  readonly hasDraftAttachments: boolean;
+  submissionSnapshot(): DraftSubmissionSnapshot;
+  requiresModelSetup(): boolean;
+  submissionAccess(): SessionMethodAccess;
+  terminalStartAccess(): SessionMethodAccess;
+  cloudProfileForSubmission(): string;
+  cloudDisabledReason(): string | undefined;
+  cloudRuntimeUnsupportedReason(): string | undefined;
+};
+
+export function resolveNewSessionSubmitBlock(
+  host: SubmitGateHost,
+  kind: "session" | "terminal",
+): NewSessionSubmitBlock | undefined {
+  const gateway = host.gatewayState;
+  const place = host.placeState;
+  const snapshot = host.submissionSnapshot();
+  const pendingCloudActive = Boolean(host.pendingCloud.sessionKey);
+  if (host.submitting) {
+    return { gate: "submitting" };
+  }
+  if (
+    gateway.preferenceLoading ||
+    place.modelControl.isRestoringPreference() ||
+    !place.worktreePreferenceReady
+  ) {
+    return { gate: "preference-restore", reason: t("newSession.restoringPreferences") };
+  }
+  if (host.requiresModelSetup()) {
+    return { gate: "model-setup", reason: t("modelSetup.required.title") };
+  }
+  if (catalog.isRoutePending(snapshot.data, snapshot.context?.sessions)) {
+    return { gate: "route-pending", reason: t("newSession.catalogUnavailable") };
+  }
+  if (place.modelControl.isModelUnavailable(place.selectedAgent())) {
+    return {
+      gate: "model-unavailable",
+      reason: `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`,
+    };
+  }
+  if (host.pendingAttachmentReads > 0) {
+    return { gate: "attachment-reads", reason: t("newSession.readingAttachment") };
+  }
+  if (!pendingCloudActive && host.submissionOutcomeUnknown) {
+    return {
+      gate: "outcome-unknown",
+      reason: t(
+        host.submissionOutcomeUnknown === "gateway-changed"
+          ? "newSession.createOutcomeUnknown"
+          : "newSession.cloudSetupInterrupted",
+      ),
+    };
+  }
+  const connection = snapshot.context?.gateway;
+  const client =
+    connection?.snapshot.phase === "connected" ? (connection.snapshot.client ?? null) : null;
+  if (!connection || !client) {
+    // Same string readSessionMethodAccess reports for its disconnected
+    // cause; checked here so the gates below can rely on a live client.
+    return { gate: "disconnected", reason: t("sessionsView.actionRequiresConnection") };
+  }
+  const access = kind === "terminal" ? host.terminalStartAccess() : host.submissionAccess();
+  if (!access.allowed) {
+    return { gate: "access", reason: access.reason };
+  }
+  if (place.folderSubmissionBlocked()) {
+    return { gate: "folder", reason: t("newSession.checkingPlace") };
+  }
+  if (pendingCloudActive) {
+    const retryReady = Boolean(
+      host.pendingCloud.retryAllowed &&
+      client.recoveryScopeReady &&
+      host.cloudProfileForSubmission() &&
+      host.pendingCloud.agentId &&
+      host.pendingCloud.gatewayUrl === connection.connection.gatewayUrl &&
+      host.pendingCloud.recoveryScope === client.recoveryScope &&
+      place.isAdmin(),
+    );
+    // Recovery retries own the remaining draft state; the place gates
+    // below intentionally do not apply to a restored cloud draft.
+    return retryReady
+      ? emptyDraftBlock(host, kind, pendingCloudActive)
+      : { gate: "cloud-recovery", reason: t("newSession.cloudNotReady") };
+  }
+  if (place.agents().length === 0) {
+    return { gate: "agents", reason: t("newSession.agentsUnavailable") };
+  }
+  if (!catalog.allowsSelectedAgent(snapshot.data, place.selectedAgent())) {
+    return { gate: "agent-not-allowed", reason: t("newSession.catalogUnavailable") };
+  }
+  if (!place.execNodeReady()) {
+    return { gate: "node", reason: t("newSession.nodeUnavailable") };
+  }
+  const cloudProfileId = host.cloudProfileForSubmission();
+  if (
+    cloudProfileId &&
+    (!place.isAdmin() ||
+      !client.recoveryScope ||
+      !client.recoveryScopeReady ||
+      !gateway.cloudProfilesReady ||
+      gateway.cloudProfilesPending ||
+      !place.worktree ||
+      !gateway.cloudProfiles.some((profile) => profile.id === cloudProfileId) ||
+      Boolean(host.cloudRuntimeUnsupportedReason()))
+  ) {
+    const reason =
+      host.cloudDisabledReason() ??
+      (place.worktree ? t("newSession.cloudNotReady") : t("newSession.cloudRequiresWorktree"));
+    return { gate: "cloud", reason };
+  }
+  // worktreeAvailable() is already false when an exec node is selected, so
+  // this single gate also covers the node+worktree combination.
+  if (place.worktree && !place.worktreeAvailable()) {
+    return {
+      gate: "worktree-unavailable",
+      reason:
+        place.repository.kind === "checking"
+          ? t("newSession.checkingGit")
+          : t("newSession.worktreeUnavailable"),
+    };
+  }
+  if (place.worktree && !isWorktreeNameValid(place.worktreeName)) {
+    return { gate: "worktree-name", reason: t("newSession.worktreeNameInvalid") };
+  }
+  if (kind === "terminal" && !(place.folder.trim() || place.workspacePath())) {
+    return { gate: "terminal-folder", reason: t("newSession.terminalNeedsFolder") };
+  }
+  return emptyDraftBlock(host, kind, pendingCloudActive);
+}
+
+// Last so an empty draft never masks a reasoned gate in the tooltip.
+function emptyDraftBlock(
+  host: SubmitGateHost,
+  kind: "session" | "terminal",
+  pendingCloudActive: boolean,
+): NewSessionSubmitBlock | undefined {
+  if (kind !== "session") {
+    return undefined;
+  }
+  const message = pendingCloudActive ? host.pendingCloud.message : host.message.trim();
+  const hasAttachments = pendingCloudActive
+    ? Boolean(host.pendingCloud.attachments?.length)
+    : host.hasDraftAttachments;
+  return message || hasAttachments ? undefined : { gate: "empty-draft" };
+}

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -539,6 +539,13 @@ wa-dropdown.new-session-page__start-menu {
   opacity: 0.5;
 }
 
+/* Reason shown after Enter/Start is pressed while a submit gate blocks it. */
+.new-session-page__blocked-submit {
+  padding: 4px var(--chat-box-inset) 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .new-session-page__start-submit[aria-busy="true"] svg {
     animation: none;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits by maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users pressing Enter on the New Session page during a transient gate (preference restore, roster hydration, gateway reconnect, catalog route pending, attachment reads still in flight) would see nothing happen at all: no session, no error, no notice. Clicking Start a few seconds later worked, so the failure looked random. Reproduced live twice; it is a textbook silent-failure — the worst bug class per repo doctrine.

## Why This Change Was Made

The root cause was divergence between two hand-maintained lists: `canSubmit()` checked ~14 gates while `submitDisabledReason()` only knew 3 of them, so 11 blocking states had no reason string, no identity, and no UI surface. The fix consolidates all submit gates into one ordered, typed gate table (`ui/src/pages/new-session/submit-gates.ts`) where every block is a `{gate, reason}` entry. Only a closed two-member silent list (busy Start button, empty draft) may omit a reason — enforced at the type level, so adding a gate without a reason is a compile error. `canSubmit`, `submitDisabledReason`, and `terminalStartDisabledReason` become one-line derivations of the same walk; the divergent 3-gate copy is deleted.

Enter during a reasoned gate now records a blocked submit attempt: the composer renders the gate's reason as a `role=status` notice bound to the gate identity, and the notice retires itself as soon as the gate lifts (no queue, no timers). Gates that already render a persistent page callout (`outcome-unknown`, invalid worktree name) are excluded to avoid duplicate text.

## User Impact

Pressing Enter on the New Session page always produces a visible outcome: either the session starts, or a status notice states exactly why it cannot yet (e.g. "Restoring preferences…", "Reading attachment…", "Reconnecting…") and disappears on its own when the blocker clears. The Start-button tooltip now covers every blocking state instead of 3 of 14. Net +198 production LOC, justified as missing capability: 11 gates previously had no reason surface at all, and the type-level invariant prevents the bug class from recurring.

## Evidence

- Regression tests verified failing pre-fix via stash: 3 draft-submission-flow tests (gate-table completeness sweep asserting every blocking scenario yields `canSubmit=false` plus a visible reason; Enter-while-restoring surfaces then clears the notice) and 2 composer tests (reasoned gates consume Enter, silent gates keep it native).
- Post-rebase on latest `origin/main`: `node scripts/run-vitest.mjs ui/src/pages/new-session` — 231 tests, 23 files, all pass.
- Wider sweep pre-rebase: 9098 tests green; tsgo, oxlint, stylelint, and i18n lanes green.
- Autoreview (Codex) clean at 0.99.
- Real-behavior proof: the mocked-gateway regression tests above exercise the changed Enter path end-to-end (composer keydown -> flow gate walk -> rendered notice), and the mocked-UI (`pnpm dev:ui:mock`) before/after capture below shows the shipped rendering. Live-gateway proof gap: the transient gates are timing-dependent races and not reliably reproducible on demand against a live instance, and no operator gateway may be touched from this environment.

### Before/after (mocked UI, `preference-restore` gate active)

Before pressing Enter (and identical to what a pre-fix Enter press left behind — draft typed, gate active, zero feedback):

![Gate active, no feedback](https://github.com/user-attachments/assets/11b3bf4e-60d8-4a30-bf9a-c8d0d1bb4c80)

After pressing Enter with the fix: the gate's reason renders as a `role=status` notice below the composer ("Restoring your last session setup…"):

![Blocked-Enter notice rendered](https://github.com/user-attachments/assets/368f9719-ab0f-436f-b0a1-6b7002f2935a)

After the gate lifts, the notice retires itself with no timer or user action:

![Notice retired after gate lift](https://github.com/user-attachments/assets/8ed18f12-1a22-44f2-9c40-285c129907b0)

Capture method: mocked dev server, the `preference-restore` gate forced via the page's own flow state (the same transient state the live bug hit), Enter dispatched into the composer textarea; the notice text and its retirement were also asserted programmatically in the capture script.
