### PR TITLE
perf(agents): skip dead restart session lookups

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -129,7 +129,7 @@ export async function markRestartAbortedMainSessions(params: {
         `failed to resolve configured session stores for restart marker: ${String(err)}`,
       );
     }
-    for (const sessionKey of sessionKeys) {
+    for (const sessionKey of preferSessionIdMatch ? [] : sessionKeys) {
       try {
         const target = resolveGatewaySessionStoreTarget({
           cfg,

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { callGateway } from "../../gateway/call.js";
 import type { GatewayRecoveryRuntime } from "../../gateway/server-instance-runtime.types.js";
+import * as gatewaySessionUtils from "../../gateway/session-utils.js";
 import {
   getAgentEventLifecycleGeneration,
   resetAgentEventsForTest,
@@ -904,6 +905,37 @@ describe("main-session-restart-recovery", () => {
     expect(result).toEqual({ marked: 1, skipped: 0 });
     expect(defaultStore["agent:main:issue-82433"]?.abortedLastRun).toBeUndefined();
     expect(customStore["agent:main:issue-82433"]?.abortedLastRun).toBe(true);
+  });
+
+  it("does not resolve session keys when session ids are authoritative", async () => {
+    const candidates = Array.from({ length: 24 }, (_, index) => ({
+      sessionId: `active-session-${index}`,
+      sessionKey: `agent:main:active-${index}`,
+    }));
+    const storePath = path.join(tmpDir, "custom-many-active", "sessions.json");
+    await writeStorePath(
+      storePath,
+      Object.fromEntries(
+        candidates.map(({ sessionId, sessionKey }) => [sessionKey, runningSessionEntry(sessionId)]),
+      ),
+    );
+    const resolveTarget = vi.spyOn(gatewaySessionUtils, "resolveGatewaySessionStoreTarget");
+
+    try {
+      const result = await markRestartAbortedMainSessions({
+        cfg: { session: { store: storePath } },
+        stateDir: tmpDir,
+        sessionIds: candidates.map(({ sessionId }) => sessionId),
+        sessionKeys: candidates.map(({ sessionKey }) => sessionKey),
+      });
+
+      const store = readStore(storePath);
+      expect(result).toEqual({ marked: candidates.length, skipped: 0 });
+      expect(candidates.every(({ sessionKey }) => store[sessionKey]?.abortedLastRun)).toBe(true);
+      expect(resolveTarget).not.toHaveBeenCalled();
+    } finally {
+      resolveTarget.mockRestore();
+    }
   });
 
   it("marks custom-store sessions by session id when no session key is available", async () => {


### PR DESCRIPTION
## What Problem This Solves

Restart recovery could do unnecessary work during shutdown when active main sessions were already identified by authoritative session IDs. The marker still resolved every accompanying session key, repeatedly materializing session-store targets and path identities even though those keys could not affect matching.

## Why This Change Was Made

When session IDs are present, restart marking now skips the dead session-key resolution loop and matches from the configured and on-disk session stores that recovery already discovers. Key-only recovery remains unchanged for cases where no authoritative IDs are available.

## User Impact

Gateway shutdown and restart recovery avoid repeated session-store lookup work for active sessions, while preserving the same restart-aborted marking behavior and recovery coverage.

## Evidence

- Focused restart-recovery suite: 155/155 tests passed.
- Scoped macOS benchmark: Node v26.7.0, three alternating runs per revision of only `main-session-restart-recovery.test.ts` test `does not resolve session keys when session ids are authoritative`, using the repo wrapper under `/usr/bin/time -l` and distinct Vitest caches.

| Revision | Elapsed runs | Median elapsed | Peak-RSS runs (bytes) | Median peak RSS |
|---|---:|---:|---:|---:|
| Base `d8e7ec5345b6` + test-only hunk | 16.19s, 8.80s, 9.04s | 9.04s | 909,312,000; 675,135,488; 667,172,864 | 675,135,488 bytes (643.9 MiB) |
| PR `19e51f99388f` | 15.46s, 8.39s, 7.64s | 8.39s | 789,643,264; 663,076,864; 667,746,304 | 667,746,304 bytes (636.8 MiB) |

- The identical test observed the exact resolver-call change: base 24/24/24 and expected failure of the zero-call assertion; PR 0/0/0 and 3/3 passes. Elapsed time and RSS are startup-dominated and noisy, so the small median differences are not claimed as a material performance benefit; the deterministic proof is removal of 24 redundant resolver calls.
- [CI rerun 31951007173](https://github.com/openclaw/openclaw/actions/runs/31951007173) is green on the exact PR head. Its unrelated first-attempt QA harness timing failure (`bounds a stalled versions probe by the remaining discovery deadline`) passed on rerun.
- Production LOC: +1/-1 (net 0); tests: +32/-0.
- `git diff --check`: clean.
- Fresh structured autoreview: clean, with no accepted/actionable findings.
