### PR TITLE
fix(sessions): missing configured store must not poison readable siblings

### DIFF
--- a/src/config/sessions/targets-read-availability.test.ts
+++ b/src/config/sessions/targets-read-availability.test.ts
@@ -41,6 +41,46 @@ describe("session store availability", () => {
     });
   });
 
+  it("does not let a missing configured store poison readable discovered siblings", async () => {
+    await withTempHome(async (home) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
+      // Sessions live in the discovered default per-agent store...
+      await replaceSessionEntry(
+        { agentId: "main", env, sessionKey: "agent:main:main" },
+        { sessionId: "live-session", updatedAt: 1 },
+      );
+      // ...while the configured per-agent template points at a path that has
+      // not been created yet (fresh config / store migration window).
+      const cfg: OpenClawConfig = {
+        session: { store: path.join(home, "custom", "{agentId}", "sessions.sqlite") },
+      };
+
+      const result = resolveExistingAgentSessionStoreTargetsReadOnlyResult(cfg, "main", { env });
+
+      // The missing configured candidate must be skipped, not returned as
+      // whole-agent unavailability: evidence consumers map database-missing
+      // to "absent" and destroy live worker placements.
+      expect(result.available).toBe(true);
+      if (result.available) {
+        expect(result.targets.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  it("reports database-missing only when no candidate store exists", async () => {
+    await withTempHome(async (home) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
+      const cfg: OpenClawConfig = {
+        session: { store: path.join(home, "custom", "{agentId}", "sessions.sqlite") },
+      };
+
+      expect(resolveExistingAgentSessionStoreTargetsReadOnlyResult(cfg, "main", { env })).toEqual({
+        available: false,
+        reason: "database-missing",
+      });
+    });
+  });
+
   it("reads ownerless fixed-store rows under the requested agent", async () => {
     await withTempHome(async (home) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };

--- a/src/config/sessions/targets-read-availability.ts
+++ b/src/config/sessions/targets-read-availability.ts
@@ -149,11 +149,12 @@ export function resolveExistingAgentSessionStoreTargetsReadOnlyResult(
     agentId: requested,
     storePath: resolveSessionStorePathCore(cfg.session?.store, { agentId: requested, env }),
   };
-  const targets = dedupeTargetsByStorePath([
+  const candidates = dedupeTargetsByStorePath([
     configuredTarget,
     ...resolveExistingAgentSessionStoreTargetsSync(cfg, requested, { env }),
   ]);
-  for (const target of targets) {
+  const targets: SessionStoreTarget[] = [];
+  for (const target of candidates) {
     const defaultAgentId = resolveReadDefaultAgentId(cfg, target.agentId);
     const resolved = resolveSqliteTargetFromSessionStorePath(target.storePath, {
       agentId: target.agentId,
@@ -167,8 +168,22 @@ export function resolveExistingAgentSessionStoreTargetsReadOnlyResult(
       sqlitePath: resolved.path,
     });
     if (!snapshot.available) {
+      // The configured template may point at a store that has not been
+      // created yet (fresh config, store migration window) while the agent's
+      // real sessions live in a discovered store. A missing candidate must
+      // not poison the readable siblings — treating it as whole-agent
+      // unavailability made session-evidence consumers report "absent" and
+      // destroy live worker placements. Broken-but-present stores still fail
+      // the whole agent: partial visibility must never prove absence.
+      if (snapshot.reason === "database-missing") {
+        continue;
+      }
       return snapshot;
     }
+    targets.push(target);
+  }
+  if (targets.length === 0) {
+    return { available: false, reason: "database-missing" };
   }
   return { available: true, targets };
 }


### PR DESCRIPTION
## What Problem This Solves

`resolveExistingAgentSessionStoreTargetsReadOnlyResult` (the per-agent branch) added the configured store-template target unconditionally and early-returned on the **first** unavailable candidate. A configured per-agent store path that has not been created yet — fresh config or a store-migration window — reported `database-missing` for the whole agent even when the agent's real sessions live in a readable discovered store.

The blast radius is worker placements: `server-worker-placement-session-evidence` maps `database-missing` to the default `"absent"` (no probes issued at all), and `placement-session-retirement` retires + **force-destroys environments** for absent sessions. So after a gateway restart during a store-template migration, live placements referencing sessions in the discovered store were destroyed — partial visibility proving absence, which the evidence doctrine forbids ("unreadable state must never be treated as absence"). Introduced by the #124372 evidence-batching cutover; the pre-cutover resolver scanned all candidate stores and would have found the row.

## Why This Change Was Made

Skip `database-missing` candidates and keep collecting readable ones; report `database-missing` only when **no** candidate store exists. Broken-but-present stores (`schema-missing`/`table-missing`/`read-failed`) still fail the whole agent, so degraded state keeps mapping to `"unknown"` downstream — never `"absent"`. The sibling consumer (`managed-image-attachments`) inherits the same repair for free.

## User Impact

Worker environments referencing live sessions survive gateway restarts during a session-store path migration instead of being silently destroyed.

## Evidence

- New regression `does not let a missing configured store poison readable discovered siblings` fails pre-fix (stash proof); companion pins `database-missing` when no candidate exists.
- Consumer suites green: `server-worker-placement-session-evidence.test.ts` (99) + `managed-image-attachments.test.ts` (41), plus the availability suite (4/4).
- tsgo core + core-test shards clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.98.
- Prod LOC: +17 −2 (the skip logic + doctrine comment); tests +40.
