### PR TITLE
fix(gateway): recover remote-exec staged results after restart

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -1,5 +1,5 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { WorkerPlacementExecutionMode } from "./placement-record.js";
+import { placementTurnOwner, type WorkerPlacementExecutionMode } from "./placement-record.js";
 import type {
   createWorkerSessionPlacementStore,
   WorkerSessionPlacementRecord,
@@ -44,6 +44,7 @@ export type WorkerDispatchPlacementStore = Pick<
   | "listPendingWorkspaceResults"
   | "markWorkspaceResultPending"
   | "workspaceResultInstanceId"
+  | "validateWorkspaceResultClaim"
   | "recordStagedWorkspaceResult"
   | "recordWorkspaceResultConflict"
   | "acceptWorkspaceResult"
@@ -235,18 +236,7 @@ export function createPlacementFailureActions(deps: {
         claimId: current.turnClaim.claimId,
         runId: current.turnClaim.runId,
         placementGeneration: current.turnClaim.generation,
-        owner:
-          current.turnClaim.owner === "worker"
-            ? {
-                kind: "worker",
-                environmentId: current.environmentId,
-                ownerEpoch: current.turnClaim.ownerEpoch,
-              }
-            : {
-                kind: "local",
-                environmentId: current.environmentId,
-                ownerEpoch: current.activeOwnerEpoch,
-              },
+        owner: placementTurnOwner(current),
       });
     }
     const reconciling = startReconcile(current);

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -6,6 +6,7 @@ import type {
   WorkerDispatchPlacementStore,
   WorkerDrainingDispatchPlacement,
 } from "./placement-dispatch-failure.js";
+import { placementTurnOwner } from "./placement-record.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
@@ -109,17 +110,19 @@ export async function recoverPendingWorkspaceResults(
       continue;
     }
     try {
-      const claim = placement?.turnClaim;
-      if (
+      const turnClaim =
         (placement?.state !== "active" && placement?.state !== "draining") ||
         placement.environmentId !== pending.environmentId ||
-        placement.activeOwnerEpoch !== pending.ownerEpoch ||
-        claim?.owner !== "worker" ||
-        claim.claimId !== pending.claimId ||
-        claim.runId !== pending.runId ||
-        claim.generation !== pending.placementGeneration ||
-        claim.ownerEpoch !== pending.ownerEpoch
-      ) {
+        placement.activeOwnerEpoch !== pending.ownerEpoch
+          ? undefined
+          : {
+              sessionId: placement.sessionId,
+              claimId: pending.claimId,
+              runId: pending.runId,
+              placementGeneration: pending.placementGeneration,
+              owner: placementTurnOwner(placement),
+            };
+      if (!turnClaim || !placements.validateWorkspaceResultClaim(turnClaim)) {
         if (pending.stagedResultRef && pending.workspaceAcceptedAtMs === null) {
           // A staged unaccepted result outlives stale placement ownership. Only
           // explicit operator abandonment may delete its durable Git ref.
@@ -150,29 +153,9 @@ export async function recoverPendingWorkspaceResults(
         }
         continue;
       }
-      const turnClaim = {
-        sessionId: placement.sessionId,
-        claimId: claim.claimId,
-        runId: claim.runId,
-        placementGeneration: claim.generation,
-        owner: {
-          kind: "worker" as const,
-          environmentId: placement.environmentId,
-          ownerEpoch: placement.activeOwnerEpoch,
-        },
-      };
-      const localPath = await deps.resolveWorkspacePath({
-        sessionId: placement.sessionId,
-        sessionKey: placement.sessionKey,
-        agentId: placement.agentId,
-      });
+      const localPath = await deps.resolveWorkspacePath(placement);
       const priorWorkspaceResultConflict =
-        placement.workspaceResultConflict ??
-        (await deps.resolveWorkspaceResultConflict({
-          sessionId: placement.sessionId,
-          sessionKey: placement.sessionKey,
-          agentId: placement.agentId,
-        }));
+        placement.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(placement));
       const canonicalStagedResultRef = workerWorkspaceResultRef(turnClaim.claimId);
       let stagedResultRef = pending.stagedResultRef;
       if (
@@ -225,7 +208,9 @@ export async function recoverPendingWorkspaceResults(
         }
         // Clean refs are deleted while their accepted fence still exists. A
         // crash after deletion resumes here and can safely finish ownership.
-        await placements.closeWorkerTurnToolState(turnClaim);
+        if (turnClaim.owner.kind === "worker") {
+          await placements.closeWorkerTurnToolState(turnClaim);
+        }
         if (
           environment &&
           environment.state !== "destroyed" &&
@@ -263,17 +248,7 @@ export async function recoverPendingWorkspaceResults(
           abort: () => placements.abortWorkspaceReconciliation(owner),
         };
         await deps.workspaceOperations.run(placement.environmentId, async () => {
-          const owned = placements.get(placement.sessionId);
-          const ownedClaim = owned?.turnClaim;
-          if (
-            (owned?.state !== "active" && owned?.state !== "draining") ||
-            owned.generation !== placement.generation ||
-            owned.environmentId !== placement.environmentId ||
-            owned.activeOwnerEpoch !== placement.activeOwnerEpoch ||
-            ownedClaim?.owner !== "worker" ||
-            ownedClaim.claimId !== claim.claimId ||
-            ownedClaim.runId !== claim.runId
-          ) {
+          if (!placements.validateWorkspaceResultClaim(turnClaim)) {
             throw new Error("Recovered workspace result lost its placement owner");
           }
           const interrupted = journal.load();
@@ -353,11 +328,9 @@ export async function recoverPendingWorkspaceResults(
           continue;
         }
         if (pending.workspaceAcceptedAtMs !== null && environment?.state === "destroyed") {
-          await placements.closeWorkerTurnToolState(turnClaim);
           placements.completeWorkspaceResultAndReleaseTurn(turnClaim, { reclaim: true });
           continue;
         }
-        await placements.closeWorkerTurnToolState(turnClaim);
         const failed = placements.failWorkspaceResultAndReleaseTurn(
           pending,
           pendingWorkerLossError(environment, pending.sessionId),
@@ -386,17 +359,7 @@ export async function recoverPendingWorkspaceResults(
         ownerEpoch: placement.activeOwnerEpoch,
       });
       await deps.workspaceOperations.run(placement.environmentId, async () => {
-        const owned = placements.get(placement.sessionId);
-        const ownedClaim = owned?.turnClaim;
-        if (
-          (owned?.state !== "active" && owned?.state !== "draining") ||
-          owned.generation !== placement.generation ||
-          owned.environmentId !== placement.environmentId ||
-          owned.activeOwnerEpoch !== placement.activeOwnerEpoch ||
-          ownedClaim?.owner !== "worker" ||
-          ownedClaim.claimId !== claim.claimId ||
-          ownedClaim.runId !== claim.runId
-        ) {
+        if (!placements.validateWorkspaceResultClaim(turnClaim)) {
           throw new Error("Recovered workspace result lost its placement owner");
         }
         const quiescence = await tunnel.quiesceWorkspace(placement.remoteWorkspaceDir);

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -110,19 +110,21 @@ export async function recoverPendingWorkspaceResults(
       continue;
     }
     try {
+      const active =
+        placement?.state === "active" || placement?.state === "draining" ? placement : undefined;
       const turnClaim =
-        (placement?.state !== "active" && placement?.state !== "draining") ||
-        placement.environmentId !== pending.environmentId ||
-        placement.activeOwnerEpoch !== pending.ownerEpoch
-          ? undefined
-          : {
-              sessionId: placement.sessionId,
+        active &&
+        active.environmentId === pending.environmentId &&
+        active.activeOwnerEpoch === pending.ownerEpoch
+          ? {
+              sessionId: active.sessionId,
               claimId: pending.claimId,
               runId: pending.runId,
               placementGeneration: pending.placementGeneration,
-              owner: placementTurnOwner(placement),
-            };
-      if (!turnClaim || !placements.validateWorkspaceResultClaim(turnClaim)) {
+              owner: placementTurnOwner(active),
+            }
+          : undefined;
+      if (!active || !turnClaim || !placements.validateWorkspaceResultClaim(turnClaim)) {
         if (pending.stagedResultRef && pending.workspaceAcceptedAtMs === null) {
           // A staged unaccepted result outlives stale placement ownership. Only
           // explicit operator abandonment may delete its durable Git ref.
@@ -153,9 +155,9 @@ export async function recoverPendingWorkspaceResults(
         }
         continue;
       }
-      const localPath = await deps.resolveWorkspacePath(placement);
+      const localPath = await deps.resolveWorkspacePath(active);
       const priorWorkspaceResultConflict =
-        placement.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(placement));
+        active.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(active));
       const canonicalStagedResultRef = workerWorkspaceResultRef(turnClaim.claimId);
       let stagedResultRef = pending.stagedResultRef;
       if (
@@ -187,10 +189,10 @@ export async function recoverPendingWorkspaceResults(
           root: localPath,
           stagedResultRef: preparedWorkerWorkspaceResultRef(canonicalStagedResultRef),
         }));
-      const environment = environments.get(placement.environmentId);
+      const environment = environments.get(active.environmentId);
       if (
         environment?.state === "attached" &&
-        environment.attachedSessionIds.includes(placement.sessionId) &&
+        environment.attachedSessionIds.includes(active.sessionId) &&
         environment.attachedSessionIds.length !== 1
       ) {
         // This result cannot own teardown while another session remains attached.
@@ -214,9 +216,9 @@ export async function recoverPendingWorkspaceResults(
         if (
           environment &&
           environment.state !== "destroyed" &&
-          environment.ownerEpoch === placement.activeOwnerEpoch
+          environment.ownerEpoch === active.activeOwnerEpoch
         ) {
-          await environments.destroy(placement.environmentId);
+          await environments.destroy(active.environmentId);
         }
         const reclaimed = placements.completeWorkspaceResultAndReleaseTurn(turnClaim, {
           reclaim: true,
@@ -225,7 +227,7 @@ export async function recoverPendingWorkspaceResults(
           throw new Error("Recovered cleaned worker result did not reclaim its environment");
         }
         await environments
-          .stopTunnel(placement.environmentId, placement.activeOwnerEpoch)
+          .stopTunnel(active.environmentId, active.activeOwnerEpoch)
           .catch(() => undefined);
         continue;
       }
@@ -234,10 +236,10 @@ export async function recoverPendingWorkspaceResults(
         // A staged result must never be destroyed by environment lifecycle.
         // Keep its fence and placement until the local apply is durably accepted.
         const owner = {
-          sessionId: placement.sessionId,
-          environmentId: placement.environmentId,
-          ownerEpoch: placement.activeOwnerEpoch,
-          placementGeneration: placement.generation,
+          sessionId: active.sessionId,
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          placementGeneration: active.generation,
         };
         const journal = {
           load: () => placements.loadWorkspaceReconciliation(owner),
@@ -247,7 +249,7 @@ export async function recoverPendingWorkspaceResults(
             placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
           abort: () => placements.abortWorkspaceReconciliation(owner),
         };
-        await deps.workspaceOperations.run(placement.environmentId, async () => {
+        await deps.workspaceOperations.run(active.environmentId, async () => {
           if (!placements.validateWorkspaceResultClaim(turnClaim)) {
             throw new Error("Recovered workspace result lost its placement owner");
           }
@@ -260,7 +262,7 @@ export async function recoverPendingWorkspaceResults(
           const reconciliation = await applyStagedWorkerWorkspaceResult({
             root: localPath,
             stagedResultRef: ownedStagedResultRef,
-            expectedBaseManifestRef: placement.workspaceBaseManifestRef,
+            expectedBaseManifestRef: active.workspaceBaseManifestRef,
             alreadyAccepted: pending.workspaceAcceptedAtMs !== null || alreadyApplied,
             journal,
           });
@@ -286,9 +288,9 @@ export async function recoverPendingWorkspaceResults(
             root: localPath,
             report: async (report) =>
               await deps.reportWorkspaceResultConflict({
-                sessionId: placement.sessionId,
-                sessionKey: placement.sessionKey,
-                agentId: placement.agentId,
+                sessionId: active.sessionId,
+                sessionKey: active.sessionKey,
+                agentId: active.agentId,
                 ...report,
               }),
           });
@@ -300,13 +302,13 @@ export async function recoverPendingWorkspaceResults(
             conflictRetained: finalized.conflictRetained,
             reclaim: true,
             beforeComplete: async () => {
-              const currentEnvironment = environments.get(placement.environmentId);
+              const currentEnvironment = environments.get(active.environmentId);
               if (
                 currentEnvironment &&
                 currentEnvironment.state !== "destroyed" &&
-                currentEnvironment.ownerEpoch === placement.activeOwnerEpoch
+                currentEnvironment.ownerEpoch === active.activeOwnerEpoch
               ) {
-                await environments.destroy(placement.environmentId);
+                await environments.destroy(active.environmentId);
               }
             },
             validateCompleted: (completed) => {
@@ -316,12 +318,12 @@ export async function recoverPendingWorkspaceResults(
             },
           });
           await environments
-            .stopTunnel(placement.environmentId, placement.activeOwnerEpoch)
+            .stopTunnel(active.environmentId, active.activeOwnerEpoch)
             .catch(() => undefined);
         });
         continue;
       }
-      if (!sameActiveEnvironment(placement, environment)) {
+      if (!sameActiveEnvironment(active, environment)) {
         if (hasPreparedResult) {
           // Verification did not publish this prepared snapshot before the
           // crash. Preserve the fence for retry or operator inspection.
@@ -341,10 +343,10 @@ export async function recoverPendingWorkspaceResults(
         continue;
       }
       const owner = {
-        sessionId: placement.sessionId,
-        environmentId: placement.environmentId,
-        ownerEpoch: placement.activeOwnerEpoch,
-        placementGeneration: placement.generation,
+        sessionId: active.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        placementGeneration: active.generation,
       };
       const journal = {
         load: () => placements.loadWorkspaceReconciliation(owner),
@@ -355,20 +357,20 @@ export async function recoverPendingWorkspaceResults(
         abort: () => placements.abortWorkspaceReconciliation(owner),
       };
       const tunnel = await environments.startTunnel({
-        environmentId: placement.environmentId,
-        ownerEpoch: placement.activeOwnerEpoch,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
       });
-      await deps.workspaceOperations.run(placement.environmentId, async () => {
+      await deps.workspaceOperations.run(active.environmentId, async () => {
         if (!placements.validateWorkspaceResultClaim(turnClaim)) {
           throw new Error("Recovered workspace result lost its placement owner");
         }
-        const quiescence = await tunnel.quiesceWorkspace(placement.remoteWorkspaceDir);
+        const quiescence = await tunnel.quiesceWorkspace(active.remoteWorkspaceDir);
         let quiescenceHandled = false;
         try {
           const reconciliation = await tunnel.reconcileWorkspace({
             localPath,
-            remoteWorkspaceDir: placement.remoteWorkspaceDir,
-            baseManifestRef: placement.workspaceBaseManifestRef,
+            remoteWorkspaceDir: active.remoteWorkspaceDir,
+            baseManifestRef: active.workspaceBaseManifestRef,
             journal: {
               ...journal,
             },
@@ -400,9 +402,9 @@ export async function recoverPendingWorkspaceResults(
             root: localPath,
             report: async (report) =>
               await deps.reportWorkspaceResultConflict({
-                sessionId: placement.sessionId,
-                sessionKey: placement.sessionKey,
-                agentId: placement.agentId,
+                sessionId: active.sessionId,
+                sessionKey: active.sessionKey,
+                agentId: active.agentId,
                 ...report,
               }),
           });
@@ -417,7 +419,7 @@ export async function recoverPendingWorkspaceResults(
               if (sameGatewayInstance) {
                 await quiescence.resume();
               } else {
-                await environments.destroy(placement.environmentId);
+                await environments.destroy(active.environmentId);
               }
               quiescenceHandled = true;
             },
@@ -429,7 +431,7 @@ export async function recoverPendingWorkspaceResults(
             afterComplete: async () => {
               if (!sameGatewayInstance) {
                 await environments
-                  .stopTunnel(placement.environmentId, placement.activeOwnerEpoch)
+                  .stopTunnel(active.environmentId, active.activeOwnerEpoch)
                   .catch(() => undefined);
               }
             },

--- a/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
@@ -293,6 +293,94 @@ describe("staged worker placement result recovery", () => {
     expect(restartedHarness.log).not.toContain("placement:failed");
   });
 
+  it.each(["active", "draining"] as const)(
+    "recovers a staged remote-exec %s result after restart clears its local claim",
+    async (placementState) => {
+      const workspacePath = path.join(root, `remote-exec-restart-${placementState}-result`);
+      const originalHarness = createHarness(placementStore, { workspacePath });
+      const active = originalHarness.placements.seedActive(2, "remote-exec");
+      if (active.state !== "active") {
+        throw new Error("active placement fixture was not active");
+      }
+      const claimId = `reclaim-remote-exec-restart-${placementState}`;
+      const claimInput = {
+        ...REQUEST,
+        claimId,
+        runId: claimId,
+        owner: {
+          kind: "local" as const,
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      };
+      const claim =
+        placementState === "active"
+          ? placementStore.claimReclaimWorkspaceResult(claimInput)
+          : placementStore.claimTurn(claimInput);
+      if (placementState === "draining") {
+        expect(
+          placementStore.startDrain({
+            sessionId: active.sessionId,
+            environmentId: active.environmentId,
+            ownerEpoch: active.activeOwnerEpoch,
+            expectedGeneration: active.generation,
+          }),
+        ).toMatchObject({ state: "draining" });
+      }
+      const staged = await stagePendingResult({
+        store: placementStore,
+        claim,
+        workspacePath,
+        base: "base\n",
+        current: "remote exec\n",
+      });
+
+      closeOpenClawStateDatabaseForTest();
+      database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+      const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+      expect(restartedStore.clearLocalTurnClaimsAfterRestart()).toBe(1);
+      expect(restartedStore.get(active.sessionId)).toMatchObject({
+        state: placementState,
+        turnClaim: null,
+      });
+      expect(restartedStore.validateTurnClaim(claim)).toBe(false);
+      expect(restartedStore.validateWorkspaceResultClaim(claim)).toBe(true);
+      for (const staleClaim of [
+        { ...claim, claimId: `${claim.claimId}-stale` },
+        { ...claim, runId: `${claim.runId}-stale` },
+        { ...claim, placementGeneration: claim.placementGeneration + 1 },
+        {
+          ...claim,
+          owner: { ...claim.owner, environmentId: `${claim.owner.environmentId}-stale` },
+        },
+        {
+          ...claim,
+          owner: { ...claim.owner, ownerEpoch: (claim.owner.ownerEpoch ?? 0) + 1 },
+        },
+      ]) {
+        expect(restartedStore.validateWorkspaceResultClaim(staleClaim)).toBe(false);
+        expect(() => restartedStore.acceptWorkspaceResult(staleClaim)).toThrow(
+          "Cannot update stale worker workspace result",
+        );
+      }
+      const restartedHarness = createHarness(restartedStore, { workspacePath });
+      restartedHarness.markEnvironmentOwnerEpoch(active.activeOwnerEpoch);
+
+      await restartedHarness.service.reconcile();
+
+      await expect(fs.readFile(path.join(workspacePath, "result.txt"), "utf8")).resolves.toBe(
+        "remote exec\n",
+      );
+      expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+      expect(restartedHarness.placements.current()).toMatchObject({
+        state: "reclaimed",
+        turnClaim: null,
+        workspaceBaseManifestRef: staged.currentManifestRef,
+      });
+      expect(restartedHarness.environments.startTunnel).not.toHaveBeenCalled();
+    },
+  );
+
   it("adopts a published result after a crash before its fence-row update", async () => {
     const workspacePath = path.join(root, "published-unrecorded-result");
     const originalHarness = createHarness(placementStore, { workspacePath });

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -39,8 +39,9 @@ export const REQUEST: WorkerDispatchRequest = {
 export function seedSyncingPlacement(
   store: PlacementStore,
   environmentId: string,
+  executionMode: WorkerDispatchRequest["executionMode"] = REQUEST.executionMode,
 ): WorkerSessionPlacementRecord {
-  let current = store.startDispatch(REQUEST);
+  let current = store.startDispatch({ ...REQUEST, executionMode });
   current = store.transition({
     sessionId: REQUEST.sessionId,
     from: "requested",
@@ -61,8 +62,9 @@ export function seedSyncingPlacement(
 export function seedStartingPlacement(
   store: PlacementStore,
   environmentId: string,
+  executionMode: WorkerDispatchRequest["executionMode"] = REQUEST.executionMode,
 ): WorkerSessionPlacementRecord {
-  let current = seedSyncingPlacement(store, environmentId);
+  let current = seedSyncingPlacement(store, environmentId, executionMode);
   current = store.transition({
     sessionId: REQUEST.sessionId,
     from: "syncing",
@@ -78,9 +80,13 @@ export function seedStartingPlacement(
 
 export function seedActivePlacement(
   store: PlacementStore,
-  params: { environmentId: string; ownerEpoch: number },
+  params: {
+    environmentId: string;
+    ownerEpoch: number;
+    executionMode?: WorkerDispatchRequest["executionMode"];
+  },
 ): WorkerSessionPlacementRecord {
-  const current = seedStartingPlacement(store, params.environmentId);
+  const current = seedStartingPlacement(store, params.environmentId, params.executionMode);
   return store.transition({
     sessionId: REQUEST.sessionId,
     from: "starting",

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -76,6 +76,7 @@ export function createHarness(
     listWorkspaceReconciliationOwners: () => placementStore.listWorkspaceReconciliationOwners(),
     listPendingWorkspaceResults: () => placementStore.listPendingWorkspaceResults(),
     workspaceResultInstanceId: () => placementStore.workspaceResultInstanceId(),
+    validateWorkspaceResultClaim: (claim) => placementStore.validateWorkspaceResultClaim(claim),
     recordStagedWorkspaceResult: (claim, ref) =>
       placementStore.recordStagedWorkspaceResult(claim, ref),
     recordWorkspaceResultConflict: (claim, conflict) =>
@@ -371,8 +372,8 @@ export function createHarness(
     placements: {
       current: () => placementStore.get(REQUEST.sessionId),
       seedStarting: () => seedStartingPlacement(placementStore, environmentId),
-      seedActive: (ownerEpoch: number) =>
-        seedActivePlacement(placementStore, { environmentId, ownerEpoch }),
+      seedActive: (ownerEpoch: number, executionMode?: "worker-turn" | "remote-exec") =>
+        seedActivePlacement(placementStore, { environmentId, ownerEpoch, executionMode }),
       seedDraining: (ownerEpoch: number) => {
         const active = seedActivePlacement(placementStore, { environmentId, ownerEpoch });
         if (active.state !== "active") {

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -12,6 +12,7 @@ import {
 } from "./placement-dispatch-failure.js";
 import { createPlacementRecoveryActions } from "./placement-dispatch-recovery.js";
 import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
+import { placementTurnOwner } from "./placement-record.js";
 import type {
   WorkerPlacementDispatchRequest,
   WorkerPlacementReclaimRequest,
@@ -311,18 +312,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           agentId: current.agentId,
           claimId: reclaimClaimId,
           runId: reclaimClaimId,
-          owner:
-            current.executionMode === "remote-exec"
-              ? {
-                  kind: "local",
-                  environmentId: current.environmentId,
-                  ownerEpoch: current.activeOwnerEpoch,
-                }
-              : {
-                  kind: "worker",
-                  environmentId: current.environmentId,
-                  ownerEpoch: current.activeOwnerEpoch,
-                },
+          owner: placementTurnOwner(current),
         });
         const reclaimResultRef = workerWorkspaceResultRef(reclaimClaim.claimId);
         let manifestAccepted = false;

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,4 +1,5 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
+import { placementTurnOwner } from "./placement-record.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   deleteStagedWorkerWorkspaceResult,
@@ -112,21 +113,13 @@ export async function forceAbandonWorkerEnvironment(params: {
           refs: [finalRef, preparedWorkerWorkspaceResultRef(finalRef)],
         });
         const claim = placement.turnClaim;
-        if (
-          claim?.owner === "worker" &&
-          claim.claimId === pending.claimId &&
-          claim.runId === pending.runId
-        ) {
+        if (claim && claim.claimId === pending.claimId && claim.runId === pending.runId) {
           await placements.closeWorkerTurnToolState({
             sessionId: placement.sessionId,
             claimId: claim.claimId,
             runId: claim.runId,
             placementGeneration: claim.generation,
-            owner: {
-              kind: "worker",
-              environmentId: placement.environmentId,
-              ownerEpoch: claim.ownerEpoch,
-            },
+            owner: placementTurnOwner(placement),
           });
         }
         placements.failWorkspaceResultAndReleaseTurn(pending, recoveryError);
@@ -155,18 +148,7 @@ export async function forceAbandonWorkerEnvironment(params: {
           claimId: current.turnClaim.claimId,
           runId: current.turnClaim.runId,
           placementGeneration: current.turnClaim.generation,
-          owner:
-            current.turnClaim.owner === "worker"
-              ? {
-                  kind: "worker",
-                  environmentId: current.environmentId,
-                  ownerEpoch: current.turnClaim.ownerEpoch,
-                }
-              : {
-                  kind: "local",
-                  environmentId: current.environmentId,
-                  ownerEpoch: current.activeOwnerEpoch,
-                },
+          owner: placementTurnOwner(current),
         });
       }
       current = placements.startReconcile({

--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -2,6 +2,7 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   isCurrentPlacementTurnClaim,
+  placementTurnOwner,
   required,
   type WorkerSessionPlacementRecord,
   type WorkerSessionTurnClaim,
@@ -34,18 +35,11 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
               claimId: persisted.claimId,
               runId: persisted.runId,
               placementGeneration: persisted.generation,
-              owner:
-                persisted.owner === "worker"
-                  ? {
-                      kind: "worker",
-                      environmentId: pending.environmentId,
-                      ownerEpoch: persisted.ownerEpoch,
-                    }
-                  : {
-                      kind: "local",
-                      environmentId: pending.environmentId,
-                      ownerEpoch: pending.ownerEpoch,
-                    },
+              owner: placementTurnOwner({
+                executionMode: current.executionMode,
+                environmentId: pending.environmentId,
+                activeOwnerEpoch: pending.ownerEpoch,
+              }),
             }
           : null;
         const exactClaim =

--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -23,6 +23,18 @@ export type WorkerSessionTurnClaim = {
   owner: WorkerSessionTurnOwner;
 };
 
+export function placementTurnOwner(placement: {
+  executionMode: WorkerPlacementExecutionMode;
+  environmentId: string;
+  activeOwnerEpoch: number;
+}): WorkerSessionTurnOwner {
+  return {
+    kind: placement.executionMode === "remote-exec" ? "local" : "worker",
+    environmentId: placement.environmentId,
+    ownerEpoch: placement.activeOwnerEpoch,
+  };
+}
+
 export type PersistedTurnClaim =
   | {
       owner: "local";

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -49,6 +49,7 @@ import {
 } from "./placement-workspace-journal.js";
 import {
   createPlacementWorkspaceResultOps,
+  hasCurrentWorkspaceResultClaim,
   hasWorkerWorkspacePendingResult,
 } from "./placement-workspace-result.js";
 import { boundedWorkerError } from "./worker-error.js";
@@ -142,8 +143,12 @@ export function createWorkerSessionPlacementStore(
   };
 
   const requireClaimOwner = (claim: WorkerSessionTurnClaim): void => {
-    const current = find(read(), required(claim.sessionId, "session id"));
-    if (!current || !isCurrentPlacementTurnClaim(current, claim)) {
+    const db = read();
+    const current = find(db, required(claim.sessionId, "session id"));
+    if (
+      !current ||
+      (!isCurrentPlacementTurnClaim(current, claim) && !hasCurrentWorkspaceResultClaim(db, claim))
+    ) {
       throw new Error(`Session ${claim.sessionId} workspace result conflict owner changed`);
     }
   };

--- a/src/gateway/worker-environments/placement-turn-claims.ts
+++ b/src/gateway/worker-environments/placement-turn-claims.ts
@@ -33,6 +33,7 @@ export {
 import { clearWorkerWorkspaceReconciliation } from "./placement-workspace-journal.js";
 import {
   clearWorkerWorkspacePendingResult,
+  hasCurrentWorkspaceResultClaim,
   hasAcceptedWorkerWorkspacePendingResult,
   hasWorkerWorkspacePendingResult,
   insertWorkerWorkspacePendingResult,
@@ -212,7 +213,8 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
           throw new Error(`Session ${sessionId} cloud workspace result was not accepted`);
         }
         const current = getRequired(db, sessionId);
-        if (!resolvePlacementTurnEnvironment(current, claim)) {
+        const environment = resolvePlacementTurnEnvironment(current, claim);
+        if (!environment && !hasCurrentWorkspaceResultClaim(db, claim)) {
           throw new Error(`Session ${sessionId} workspace result owner changed before release`);
         }
         assertNoRunningWorkerSessionToolOperations(db, { sessionId, claimId });
@@ -236,8 +238,8 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
             .where("session_id", "=", sessionId)
             .where("state", "=", current.state)
             .where("transition_generation", "=", current.generation)
-            .where("turn_claim_id", "=", claimId)
-            .where("turn_claim_run_id", "=", runId),
+            .where("turn_claim_id", current.turnClaim ? "=" : "is", current.turnClaim && claimId)
+            .where("turn_claim_run_id", current.turnClaim ? "=" : "is", current.turnClaim && runId),
         );
         if (result.numAffectedRows !== 1n) {
           throw new Error(`Session ${sessionId} workspace result changed during release`);
@@ -494,13 +496,11 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
       return write((db) => {
         const current = getRequired(db, sessionId);
         const environment = resolvePlacementTurnEnvironment(current, input.claim);
-        if (!environment) {
+        if (!environment && !hasCurrentWorkspaceResultClaim(db, input.claim)) {
           throw new Error(`Cannot advance stale worker workspace for session ${sessionId}`);
         }
-        const { environmentId, ownerEpoch } = environment;
-        if (!isCurrentPlacementTurnClaim(current, input.claim)) {
-          throw new Error(`Cannot advance stale worker workspace for session ${sessionId}`);
-        }
+        const environmentId = environment?.environmentId ?? current.environmentId!;
+        const ownerEpoch = environment?.ownerEpoch ?? current.activeOwnerEpoch!;
         const reconciliation = executeSqliteQuerySync(
           db,
           workspaceJournalQuery(db)
@@ -528,14 +528,30 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
             .where("transition_generation", "=", current.generation)
             .where("environment_id", "=", environmentId)
             .where("active_owner_epoch", "=", ownerEpoch)
-            .where("turn_claim_owner", "=", input.claim.owner.kind)
-            .where("turn_claim_id", "=", claimId)
-            .where("turn_claim_run_id", "=", runId)
-            .where("turn_claim_generation", "=", placementGeneration)
+            .where(
+              "turn_claim_owner",
+              current.turnClaim ? "=" : "is",
+              current.turnClaim?.owner ?? null,
+            )
+            .where(
+              "turn_claim_id",
+              current.turnClaim ? "=" : "is",
+              current.turnClaim ? claimId : null,
+            )
+            .where(
+              "turn_claim_run_id",
+              current.turnClaim ? "=" : "is",
+              current.turnClaim ? runId : null,
+            )
+            .where(
+              "turn_claim_generation",
+              current.turnClaim ? "=" : "is",
+              current.turnClaim ? placementGeneration : null,
+            )
             .where(
               "turn_claim_owner_epoch",
-              input.claim.owner.kind === "worker" ? "=" : "is",
-              input.claim.owner.kind === "worker" ? ownerEpoch : null,
+              current.turnClaim?.owner === "worker" ? "=" : "is",
+              current.turnClaim?.ownerEpoch ?? null,
             ),
         );
         if (result.numAffectedRows !== 1n) {

--- a/src/gateway/worker-environments/placement-workspace-result.ts
+++ b/src/gateway/worker-environments/placement-workspace-result.ts
@@ -2,7 +2,10 @@ import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
+  isCurrentPlacementTurnClaim,
+  placementTurnOwner,
   resolvePlacementTurnEnvironment,
+  type WorkerSessionPlacementRecord,
   type WorkerSessionTurnClaim,
 } from "./placement-record.js";
 import { getRequired } from "./placement-row-codec.js";
@@ -28,6 +31,52 @@ export type WorkerWorkspacePendingResult = {
   workspaceAcceptedAtMs: number | null;
   stagedResultRef: string | null;
 };
+
+function matchesWorkspaceResultClaim(
+  placement: WorkerSessionPlacementRecord,
+  row: StateDatabase["worker_workspace_pending_results"],
+  claim: WorkerSessionTurnClaim,
+): boolean {
+  const recoveryOwner =
+    placement.state === "active" || placement.state === "draining"
+      ? placementTurnOwner(placement)
+      : undefined;
+  const recoveryGenerationMatches =
+    placement.state === "active"
+      ? placement.generation === claim.placementGeneration
+      : placement.state === "draining" && placement.generation === claim.placementGeneration + 1;
+  return (
+    row.session_id === claim.sessionId &&
+    row.environment_id === placement.environmentId &&
+    row.owner_epoch === placement.activeOwnerEpoch &&
+    row.placement_generation === claim.placementGeneration &&
+    row.claim_id === claim.claimId &&
+    row.run_id === claim.runId &&
+    (isCurrentPlacementTurnClaim(placement, claim) ||
+      // Restart revokes local authority; only the exact durable result may finish.
+      (recoveryGenerationMatches &&
+        placement.turnClaim === null &&
+        recoveryOwner?.kind === "local" &&
+        claim.owner.kind === "local" &&
+        claim.owner.environmentId === recoveryOwner.environmentId &&
+        claim.owner.ownerEpoch === recoveryOwner.ownerEpoch))
+  );
+}
+
+export function hasCurrentWorkspaceResultClaim(
+  db: DatabaseSync,
+  claim: WorkerSessionTurnClaim,
+): boolean {
+  const placement = getRequired(db, claim.sessionId);
+  const row = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .selectAll()
+      .where("session_id", "=", claim.sessionId),
+  ).rows[0];
+  return Boolean(row && matchesWorkspaceResultClaim(placement, row, claim));
+}
 
 export function clearWorkerWorkspacePendingResult(db: DatabaseSync, sessionId: string): void {
   executeSqliteQuerySync(
@@ -124,17 +173,19 @@ function markWorkerWorkspacePendingResultAccepted(
 ): void {
   const placement = getRequired(db, claim.sessionId);
   const environment = resolvePlacementTurnEnvironment(placement, claim);
-  if (!environment) {
+  if (!environment && !hasCurrentWorkspaceResultClaim(db, claim)) {
     throw new Error(`Cannot accept stale worker workspace result for ${claim.sessionId}`);
   }
+  const environmentId = environment?.environmentId ?? placement.environmentId!;
+  const ownerEpoch = environment?.ownerEpoch ?? placement.activeOwnerEpoch!;
   const result = executeSqliteQuerySync(
     db,
     query(db)
       .updateTable("worker_workspace_pending_results")
       .set({ workspace_accepted_at_ms: nowMs })
       .where("session_id", "=", claim.sessionId)
-      .where("environment_id", "=", environment.environmentId)
-      .where("owner_epoch", "=", environment.ownerEpoch)
+      .where("environment_id", "=", environmentId)
+      .where("owner_epoch", "=", ownerEpoch)
       .where("placement_generation", "=", claim.placementGeneration)
       .where("claim_id", "=", claim.claimId)
       .where("run_id", "=", claim.runId),
@@ -148,7 +199,6 @@ export function createPlacementWorkspaceResultOps(runtime: PlacementStoreRuntime
   const { instanceId, now, read, write } = runtime;
   const assertPendingClaim = (db: DatabaseSync, claim: WorkerSessionTurnClaim) => {
     const placement = getRequired(db, claim.sessionId);
-    const environment = resolvePlacementTurnEnvironment(placement, claim);
     const row = executeSqliteQuerySync(
       db,
       query(db)
@@ -156,15 +206,7 @@ export function createPlacementWorkspaceResultOps(runtime: PlacementStoreRuntime
         .selectAll()
         .where("session_id", "=", claim.sessionId),
     ).rows[0];
-    if (
-      !environment ||
-      !row ||
-      row.environment_id !== environment.environmentId ||
-      row.owner_epoch !== environment.ownerEpoch ||
-      row.placement_generation !== claim.placementGeneration ||
-      row.claim_id !== claim.claimId ||
-      row.run_id !== claim.runId
-    ) {
+    if (!row || !matchesWorkspaceResultClaim(placement, row, claim)) {
       throw new Error(`Cannot update stale worker workspace result for ${claim.sessionId}`);
     }
     return row;
@@ -172,6 +214,10 @@ export function createPlacementWorkspaceResultOps(runtime: PlacementStoreRuntime
   return {
     workspaceResultInstanceId(): string {
       return instanceId;
+    },
+
+    validateWorkspaceResultClaim(claim: WorkerSessionTurnClaim): boolean {
+      return hasCurrentWorkspaceResultClaim(read(), claim);
     },
 
     listPendingWorkspaceResults(): WorkerWorkspacePendingResult[] {

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -15,6 +15,7 @@ import { redactSensitiveText } from "../../logging/redact.js";
 import { parseWorkerLaunchPlan } from "../../worker/launch-descriptor.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
 import { supportsWorkerExecutionContextLaunch } from "./admission.js";
+import { placementTurnOwner } from "./placement-record.js";
 import { createRemoteExecPlacementSandbox } from "./placement-sandbox.js";
 import type {
   WorkerSessionPlacementRecord,
@@ -459,11 +460,7 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           ...identity,
           claimId: randomUUID(),
           runId: claim.runId,
-          owner: {
-            kind: "local",
-            environmentId: placement.environmentId,
-            ownerEpoch: placement.activeOwnerEpoch,
-          },
+          owner: placementTurnOwner(placement),
         });
         const refreshed = options.placements.get(claim.sessionId);
         if (

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -431,7 +431,9 @@ export function settleStagedWorkspaceResult(
 export async function settleStagedWorkspaceResult(
   params: StagedWorkspaceResultSettlement,
 ): Promise<WorkerSessionPlacementRecord> {
-  await params.placements.closeWorkerTurnToolState(params.turnClaim);
+  if (params.turnClaim.owner.kind === "worker") {
+    await params.placements.closeWorkerTurnToolState(params.turnClaim);
+  }
   const cleanupRef =
     params.stagedResultRef && !params.conflictRetained
       ? isWorkerWorkspaceResultCleanupRef(params.stagedResultRef)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway restart after staging a remote-exec workspace result could leave the durable result ref and pending-result row wedged indefinitely. Restart correctly clears the local active turn claim, but pending-result recovery was hardcoded to require a persisted worker claim, so the staged remote-exec result could no longer reconcile.

## Why This Change Was Made

The placement now derives its canonical worker/local owner projection from the execution mode everywhere that result ownership is reconstructed. After restart, the exact durable pending-result row grants only the authority needed to reconcile that result; normal `validateTurnClaim` remains false, so the cleared local turn claim is not revived.

Recovery covers active and draining placements. Claim ID, run ID, placement generation, environment ID, and owner epoch must all match; stale claim dimensions continue to fail closed.

The upstream exec-server contract was checked directly at `openai/codex@4861236f06d0df397436531b4aa3d7fa6975959c`: RPC disconnect drains outstanding requests in [`rpc.rs`](https://github.com/openai/codex/blob/4861236f06d0df397436531b4aa3d7fa6975959c/codex-rs/exec-server/src/rpc.rs#L323-L355) and [`rpc.rs`](https://github.com/openai/codex/blob/4861236f06d0df397436531b4aa3d7fa6975959c/codex-rs/exec-server/src/rpc.rs#L563-L628), while client recovery installs a replacement connection and reconstructs process state through explicit reads in [`client_recovery.rs`](https://github.com/openai/codex/blob/4861236f06d0df397436531b4aa3d7fa6975959c/codex-rs/exec-server/src/client_recovery.rs#L307-L405) and [`client_recovery.rs`](https://github.com/openai/codex/blob/4861236f06d0df397436531b4aa3d7fa6975959c/codex-rs/exec-server/src/client_recovery.rs#L448-L523).

## User Impact

Remote-exec workspace results staged immediately before a Gateway restart can now finish reconciliation instead of remaining stuck. This does not restore or broaden turn authority after restart.

## Evidence

- 122 focused and sibling tests passed, including active and draining restart recovery plus stale claim-dimension rejection.
- Production LOC: +147/-150 (net -3). Tests/support: +101/-6.
- Fresh Codex autoreview: clean, with no accepted/actionable findings.
- `git diff --check`: clean.
- `oxfmt --check`: all 14 changed files correctly formatted.
- No changelog entry: this is an internal recovery correctness repair with focused regression coverage.
