### PR TITLE
fix: preserve replies when channel turns overlap

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2211,7 +2211,6 @@ src/auto-reply/chunk.ts	4
 src/auto-reply/command-auth.ts	5
 src/auto-reply/command-turn-context.ts	1
 src/auto-reply/commands-registry.ts	1
-src/auto-reply/dispatch.ts	4
 src/auto-reply/heartbeat-filter.ts	4
 src/auto-reply/heartbeat-tool-response.ts	3
 src/auto-reply/reply-payload.ts	2

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -1,11 +1,8 @@
-/** Tests foreground reply freshness fencing for buffered inbound dispatch. */
+/** Tests foreground reply delivery ordering for buffered inbound dispatch. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { createChannelPartialDeliveryError } from "../channels/turn/delivery-result.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { OutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { getReplyPayloadMetadata } from "./reply-payload.js";
 import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatchBeforeDeliverOptions } from "./reply/reply-dispatcher.types.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
@@ -80,51 +77,7 @@ function dispatchWithDeliveries(
   });
 }
 
-type DispatcherOptions = NonNullable<Parameters<typeof dispatchWithDeliveries>[2]>;
-
-async function runDelayedOlderFinalRace(
-  createNewerOptions: (deliveries: Delivery[]) => DispatcherOptions = () => ({}),
-  olderOptions: DispatcherOptions = {},
-) {
-  const deliveries: Delivery[] = [];
-  const beforeDeliverStarted = createDeferred();
-  const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
-  const beforeDeliver = vi.fn(() => {
-    beforeDeliverStarted.resolve();
-    return releaseBeforeDeliver.promise;
-  });
-
-  hoisted.dispatchReplyFromConfigMock.mockImplementation(
-    async (params: DispatchReplyFromConfigParams) => {
-      if (params.ctx.MessageSid === "old-message") {
-        params.dispatcher.sendFinalReply({ text: "old final" });
-        return queuedFinalResult();
-      }
-      if (params.ctx.MessageSid === "new-message") {
-        params.dispatcher.sendFinalReply({ text: "new final" });
-        return queuedFinalResult();
-      }
-      throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
-    },
-  );
-
-  const olderDispatch = dispatchWithDeliveries(
-    buildForegroundCtx({ MessageSid: "old-message" }),
-    deliveries,
-    { ...olderOptions, beforeDeliver },
-  );
-  await beforeDeliverStarted.promise;
-  const newerResult = await dispatchWithDeliveries(
-    buildForegroundCtx({ MessageSid: "new-message" }),
-    deliveries,
-    createNewerOptions(deliveries),
-  );
-  releaseBeforeDeliver.resolve({ text: "old rewritten final" });
-
-  return { beforeDeliver, deliveries, newerResult, olderResult: await olderDispatch };
-}
-
-describe("foreground reply freshness", () => {
+describe("foreground reply delivery order", () => {
   beforeEach(() => {
     resetGlobalHookRunner();
     hoisted.dispatchReplyFromConfigMock.mockReset();
@@ -134,10 +87,10 @@ describe("foreground reply freshness", () => {
     resetGlobalHookRunner();
   });
 
-  it("suppresses an older foreground final after a newer inbound event starts for the same session target", async () => {
+  it("delivers same-target foreground finals once in inbound order", async () => {
     const deliveries: Delivery[] = [];
-    const cancellationReasons: Array<string | undefined> = [];
     const olderStarted = createDeferred();
+    const newerStarted = createDeferred();
     const releaseOlderFinal = createDeferred();
 
     hoisted.dispatchReplyFromConfigMock.mockImplementation(
@@ -149,6 +102,72 @@ describe("foreground reply freshness", () => {
           return queuedFinalResult();
         }
         if (params.ctx.MessageSid === "new-message") {
+          newerStarted.resolve();
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+    );
+    await olderStarted.promise;
+
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await newerStarted.promise;
+
+    releaseOlderFinal.resolve();
+    const [olderResult, newerResult] = await Promise.all([olderDispatch, newerDispatch]);
+
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old final" },
+      { kind: "final", text: "new final" },
+    ]);
+  });
+
+  it("retains a waiting successor so a third foreground final cannot overtake", async () => {
+    const deliveries: Delivery[] = [];
+    const olderBeforeDeliverStarted = createDeferred();
+    const releaseOlderBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const waitingSuccessorStarted = createDeferred();
+    const newestStarted = createDeferred();
+    const releaseWaitingSuccessor = createDeferred();
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "waiting-message") {
+          waitingSuccessorStarted.resolve();
+          params.replyOptions?.onReplyAdmissionWaitChange?.(true);
+          try {
+            await releaseWaitingSuccessor.promise;
+          } finally {
+            params.replyOptions?.onReplyAdmissionWaitChange?.(false);
+          }
+          return {
+            queuedFinal: false,
+            counts: { tool: 0, block: 0, final: 0 },
+          };
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          newestStarted.resolve();
           params.dispatcher.sendFinalReply({ text: "new final" });
           return queuedFinalResult();
         }
@@ -160,61 +179,36 @@ describe("foreground reply freshness", () => {
       buildForegroundCtx({ MessageSid: "old-message" }),
       deliveries,
       {
-        onBeforeDeliverCancelled: (payload) => {
-          cancellationReasons.push(
-            getReplyPayloadMetadata(payload)?.foregroundDeliverySuppression?.reason,
-          );
+        beforeDeliver: () => {
+          olderBeforeDeliverStarted.resolve();
+          return releaseOlderBeforeDeliver.promise;
         },
       },
     );
-    await olderStarted.promise;
+    await olderBeforeDeliverStarted.promise;
 
-    const newerResult = await dispatchWithDeliveries(
+    const waitingSuccessorDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "waiting-message" }),
+      deliveries,
+    );
+    await waitingSuccessorStarted.promise;
+    const newestDispatch = dispatchWithDeliveries(
       buildForegroundCtx({ MessageSid: "new-message" }),
       deliveries,
     );
+    await newestStarted.promise;
 
-    releaseOlderFinal.resolve();
-    const olderResult = await olderDispatch;
+    releaseOlderBeforeDeliver.resolve({ text: "old final" });
+    await olderDispatch;
+    expect(deliveries).toEqual([{ kind: "final", text: "old final" }]);
 
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-    expect(cancellationReasons).toEqual(["stale-foreground"]);
-  });
+    releaseWaitingSuccessor.resolve();
+    await Promise.all([waitingSuccessorDispatch, newestDispatch]);
 
-  it("leaves configured beforeDeliver cancellations untagged", async () => {
-    const deliveries: Delivery[] = [];
-    const cancellationReasons: Array<string | undefined> = [];
-
-    hoisted.dispatchReplyFromConfigMock.mockImplementation(
-      async (params: DispatchReplyFromConfigParams) => {
-        params.dispatcher.sendFinalReply({ text: "policy-blocked final" });
-        return queuedFinalResult();
-      },
-    );
-
-    const result = await dispatchWithDeliveries(buildForegroundCtx(), deliveries, {
-      beforeDeliver: () => null,
-      onBeforeDeliverCancelled: (payload) => {
-        cancellationReasons.push(
-          getReplyPayloadMetadata(payload)?.foregroundDeliverySuppression?.reason,
-        );
-      },
-    });
-
-    expect(result).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([]);
-    expect(cancellationReasons).toEqual([undefined]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old final" },
+      { kind: "final", text: "new final" },
+    ]);
   });
 
   it("releases a WhatsApp-shaped lane after beforeDeliver times out", async () => {
@@ -411,7 +405,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "old final" }]);
   });
 
-  it("keeps an older final fenced while a newer independent turn resolves", async () => {
+  it("does not make an older final wait for a newer independent turn", async () => {
     const deliveries: Delivery[] = [];
     const olderBeforeDeliverStarted = createDeferred();
     const releaseOlderBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -452,228 +446,74 @@ describe("foreground reply freshness", () => {
     );
     await newerStarted.promise;
     releaseOlderBeforeDeliver.resolve({ text: "old final" });
-    await Promise.resolve();
-    expect(deliveries).toEqual([]);
+    await expect(olderDispatch).resolves.toEqual(queuedFinalResult());
+    expect(deliveries).toEqual([{ kind: "final", text: "old final" }]);
 
     releaseNewerFinal.resolve();
     await expect(newerDispatch).resolves.toEqual(queuedFinalResult());
-    await expect(olderDispatch).resolves.toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old final" },
+      { kind: "final", text: "new final" },
+    ]);
   });
 
-  it("keeps an older foreground final fenced while a newer visible delivery is unresolved", async () => {
-    const deliveries: Delivery[] = [];
-    const beforeDeliverStarted = createDeferred();
-    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
-    const newerDeliverStarted = createDeferred();
-    const releaseNewerDeliver = createDeferred();
-    const beforeDeliver = vi.fn(() => {
-      beforeDeliverStarted.resolve();
-      return releaseBeforeDeliver.promise;
-    });
+  it.each(["onSettled", "onFreshSettledDelivery"] as const)(
+    "orders %s delivery behind an earlier foreground final",
+    async (settledHook) => {
+      const deliveries: Delivery[] = [];
+      const olderBeforeDeliverStarted = createDeferred();
+      const releaseOlderBeforeDeliver = createDeferred<ReplyPayload | null>();
+      const newerStarted = createDeferred();
 
-    hoisted.dispatchReplyFromConfigMock.mockImplementation(
-      async (params: DispatchReplyFromConfigParams) => {
-        if (params.ctx.MessageSid === "old-message") {
-          params.dispatcher.sendFinalReply({ text: "old final" });
-          return queuedFinalResult();
-        }
-        if (params.ctx.MessageSid === "new-message") {
-          params.dispatcher.sendFinalReply({ text: "new final" });
-          return queuedFinalResult();
-        }
-        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
-      },
-    );
-
-    const olderDispatch = dispatchWithDeliveries(
-      buildForegroundCtx({ MessageSid: "old-message" }),
-      deliveries,
-      { beforeDeliver },
-    );
-    await beforeDeliverStarted.promise;
-
-    const newerDispatch = dispatchWithDeliveries(
-      buildForegroundCtx({ MessageSid: "new-message" }),
-      deliveries,
-      {
-        deliver: async (payload, info) => {
-          newerDeliverStarted.resolve();
-          await releaseNewerDeliver.promise;
-          deliveries.push({ kind: info.kind, text: payload.text });
+      hoisted.dispatchReplyFromConfigMock.mockImplementation(
+        async (params: DispatchReplyFromConfigParams) => {
+          if (params.ctx.MessageSid === "old-message") {
+            params.dispatcher.sendFinalReply({ text: "old final" });
+            return queuedFinalResult();
+          }
+          if (params.ctx.MessageSid === "new-message") {
+            newerStarted.resolve();
+            return {
+              queuedFinal: false,
+              counts: { tool: 0, block: 0, final: 0 },
+            };
+          }
+          throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
         },
-      },
-    );
-    await newerDeliverStarted.promise;
+      );
 
-    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
-    await Promise.resolve();
-    expect(deliveries).toEqual([]);
-
-    releaseNewerDeliver.resolve();
-    const newerResult = await newerDispatch;
-    const olderResult = await olderDispatch;
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-  });
-
-  it("keeps an older foreground final when a newer visible delivery fails", async () => {
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      () => ({
-        deliver: async () => {
-          throw new Error("delivery failed");
+      const olderDispatch = dispatchWithDeliveries(
+        buildForegroundCtx({ MessageSid: "old-message" }),
+        deliveries,
+        {
+          beforeDeliver: () => {
+            olderBeforeDeliverStarted.resolve();
+            return releaseOlderBeforeDeliver.promise;
+          },
         },
-      }),
-    );
+      );
+      await olderBeforeDeliverStarted.promise;
+      const newerDispatch = dispatchWithDeliveries(
+        buildForegroundCtx({ MessageSid: "new-message" }),
+        deliveries,
+        {
+          [settledHook]: () => {
+            deliveries.push({ kind: "final", text: "new settled final" });
+            return { visibleReplySent: true };
+          },
+        },
+      );
+      await newerStarted.promise;
 
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-      failedCounts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
-  });
+      releaseOlderBeforeDeliver.resolve({ text: "old final" });
+      await Promise.all([olderDispatch, newerDispatch]);
 
-  it.each([
-    {
-      label: "shared outbound error",
-      createError: () =>
-        new OutboundDeliveryError("second chunk failed", {
-          cause: new Error("second chunk failed"),
-          results: [{ channel: "whatsapp", messageId: "wa-1" }],
-        }),
+      expect(deliveries).toEqual([
+        { kind: "final", text: "old final" },
+        { kind: "final", text: "new settled final" },
+      ]);
     },
-    {
-      label: "channel partial-delivery envelope",
-      createError: () =>
-        createChannelPartialDeliveryError(new Error("finalization failed"), {
-          content: "new final",
-          messageIds: ["provider-1"],
-          visibleReplySent: true,
-        }),
-    },
-  ])("suppresses an older foreground final after $label", async ({ createError }) => {
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      (raceDeliveries) => ({
-        deliver: async (payload, info) => {
-          raceDeliveries.push({ kind: info.kind, text: payload.text });
-          throw createError();
-        },
-      }),
-    );
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-      failedCounts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-  });
-
-  it("keeps an older foreground final when a newer adapter reports non-visible delivery", async () => {
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      () => ({
-        deliver: async () => ({ visibleReplySent: false }),
-      }),
-    );
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
-  });
-
-  it("suppresses an older foreground final when a newer settled hook reports visible delivery", async () => {
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      () => ({
-        deliver: async () => ({ visibleReplySent: false }),
-        onSettled: async () => ({ visibleReplySent: true }),
-      }),
-    );
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([]);
-  });
-
-  it("still runs stale generic settled hooks after a newer visible reply", async () => {
-    const olderSettled = vi.fn();
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      () => ({}),
-      { onSettled: olderSettled },
-    );
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(olderSettled).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-  });
-
-  it("suppresses an older fresh settled delivery after a newer visible reply", async () => {
-    const olderFreshDelivery = vi.fn(() => {
-      return { visibleReplySent: true };
-    });
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      () => ({}),
-      {
-        onFreshSettledDelivery: olderFreshDelivery,
-      },
-    );
-
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(olderFreshDelivery).not.toHaveBeenCalled();
-    expect(newerResult).toEqual({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-  });
+  );
 
   it("runs the settled delivery hook when dispatch fails after queueing a reply", async () => {
     const deliveries: Delivery[] = [];

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,7 +1,6 @@
 /** Auto-reply dispatch orchestration, hook composition, and foreground delivery fencing. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../channels/chat-type.js";
-import { isChannelPartialDeliveryError } from "../channels/turn/delivery-result.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import {
@@ -14,9 +13,7 @@ import {
   buildProjectedInboundMessageSendingBeforeDeliver,
   type ReplyPayloadSuppressedObserver,
 } from "../infra/outbound/deliver-hooks.js";
-import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import { logMessageReceived } from "../logging/diagnostic.js";
-import { hasOutboundReplyContent } from "../plugin-sdk/reply-payload.js";
 import type { SilentReplyConversationType } from "../shared/silent-reply-policy.js";
 import {
   resolveCommandTurnContext,
@@ -28,7 +25,6 @@ import {
   type ForegroundReplyFenceState,
   notifyForegroundReplyFenceWaiters,
 } from "./foreground-reply-fence-state.js";
-import { setReplyPayloadMetadata } from "./reply-payload.js";
 import type { CommandSessionMetadataChange } from "./reply/command-session-metadata.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
@@ -48,14 +44,12 @@ import {
 } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { ReplyPayload } from "./types.js";
 
 type InternalDispatchReplyOptions = Omit<InternalGetReplyOptions, "onBlockReply">;
 
 type ForegroundReplyFenceSnapshot = {
   key: string;
   generation: number;
-  state: ForegroundReplyFenceState;
 };
 
 type ReplyPayloadRunState = {
@@ -113,169 +107,60 @@ function beginForegroundReplyFence(
   }
   const state = foregroundReplyFenceByKey.get(key) ?? {
     generation: 0,
-    visibleDeliveryGeneration: 0,
-    activeDispatches: 0,
-    activeGenerations: new Map<number, number>(),
-    suspendedGenerations: new Set<number>(),
+    activeGenerations: new Set<number>(),
     waiters: new Set<() => void>(),
   };
-  // Generation ordering lets newer foreground replies suppress stale visible deliveries.
+  // Keep every admitted generation until it settles so successors cannot overtake it.
   state.generation += 1;
-  state.activeDispatches += 1;
-  state.activeGenerations.set(
-    state.generation,
-    (state.activeGenerations.get(state.generation) ?? 0) + 1,
-  );
+  state.activeGenerations.add(state.generation);
   foregroundReplyFenceByKey.set(key, state);
   return {
     key,
     generation: state.generation,
-    state,
   };
 }
 
-function setForegroundReplyFenceAdmissionWaiting(
-  snapshot: ForegroundReplyFenceSnapshot | undefined,
-  waiting: boolean,
-): void {
-  if (!snapshot) {
-    return;
-  }
-  const state = foregroundReplyFenceByKey.get(snapshot.key);
-  if (state !== snapshot.state) {
-    return;
-  }
-  if (waiting) {
-    if (state.activeGenerations.delete(snapshot.generation)) {
-      state.suspendedGenerations.add(snapshot.generation);
-    }
-  } else if (state.suspendedGenerations.delete(snapshot.generation)) {
-    state.activeGenerations.set(snapshot.generation, 1);
-  }
-  notifyForegroundReplyFenceWaiters(state);
-}
-
-function hasNewerActiveForegroundReplyFenceGeneration(
+function hasEarlierActiveForegroundReplyFenceGeneration(
   state: ForegroundReplyFenceState,
   generation: number,
 ): boolean {
-  for (const [activeGeneration, count] of state.activeGenerations) {
-    if (activeGeneration > generation && count > 0) {
+  for (const activeGeneration of state.activeGenerations) {
+    if (activeGeneration < generation) {
       return true;
     }
   }
   return false;
 }
 
-async function shouldCancelForegroundReplyDelivery(
+async function waitForEarlierForegroundReplyFenceGenerations(
   snapshot: ForegroundReplyFenceSnapshot | undefined,
-): Promise<boolean> {
+): Promise<void> {
   if (!snapshot) {
-    return false;
+    return;
   }
   while (true) {
     const state = foregroundReplyFenceByKey.get(snapshot.key);
-    if (!state) {
-      return false;
+    if (!state || !hasEarlierActiveForegroundReplyFenceGeneration(state, snapshot.generation)) {
+      return;
     }
-    if (state.visibleDeliveryGeneration > snapshot.generation) {
-      return true;
-    }
-    if (!hasNewerActiveForegroundReplyFenceGeneration(state, snapshot.generation)) {
-      return false;
-    }
-    // Wait for newer generations to settle before deciding whether this delivery is stale.
+    // Delivery is FIFO; model work remains concurrent and only the visible boundary waits.
     await new Promise<void>((resolve) => {
       state.waiters.add(resolve);
     });
   }
 }
 
-function markForegroundReplyFenceVisibleDelivery(
+async function runForegroundReplyFenceSettledDeliveries(
   snapshot: ForegroundReplyFenceSnapshot | undefined,
-  payload: ReplyPayload,
-  deliveryResult: unknown,
-): void {
-  if (!snapshot || !hasOutboundReplyContent(payload, { trimText: true })) {
-    return;
-  }
-  if (isExplicitlyNonVisibleDelivery(deliveryResult)) {
-    return;
-  }
-  // A visible payload with no explicit negative delivery result becomes the generation winner.
-  markForegroundReplyFenceVisibleDeliveryGeneration(snapshot);
-}
-
-function markForegroundReplyFenceVisibleDeliveryGeneration(
-  snapshot: ForegroundReplyFenceSnapshot | undefined,
-): void {
-  if (!snapshot) {
-    return;
-  }
-  const state = foregroundReplyFenceByKey.get(snapshot.key);
-  if (!state) {
-    return;
-  }
-  state.visibleDeliveryGeneration = Math.max(state.visibleDeliveryGeneration, snapshot.generation);
-  notifyForegroundReplyFenceWaiters(state);
-}
-
-function isExplicitlyNonVisibleDelivery(deliveryResult: unknown): boolean {
-  return (
-    typeof deliveryResult === "object" &&
-    deliveryResult !== null &&
-    !Array.isArray(deliveryResult) &&
-    "visibleReplySent" in deliveryResult &&
-    (deliveryResult as { visibleReplySent?: unknown }).visibleReplySent === false
-  );
-}
-
-function isExplicitlyVisibleDelivery(deliveryResult: unknown): boolean {
-  return (
-    typeof deliveryResult === "object" &&
-    deliveryResult !== null &&
-    !Array.isArray(deliveryResult) &&
-    (deliveryResult as { visibleReplySent?: unknown }).visibleReplySent === true
-  );
-}
-
-function isVisiblePartialDeliveryError(error: unknown): boolean {
-  if (isOutboundDeliveryError(error)) {
-    return error.sentBeforeError;
-  }
-  if (isChannelPartialDeliveryError(error)) {
-    return true;
-  }
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    !Array.isArray(error) &&
-    ((error as { visibleReplySent?: unknown }).visibleReplySent === true ||
-      (error as { sentBeforeError?: unknown }).sentBeforeError === true)
-  );
-}
-
-async function runForegroundReplyFenceFreshSettledDelivery(
-  snapshot: ForegroundReplyFenceSnapshot | undefined,
+  onSettled: (() => unknown) | undefined,
   onFreshSettledDelivery: (() => unknown) | undefined,
 ): Promise<void> {
-  if (!onFreshSettledDelivery) {
+  if (!onSettled && !onFreshSettledDelivery) {
     return;
   }
-  if (await shouldCancelForegroundReplyDelivery(snapshot)) {
-    return;
-  }
-  try {
-    const deliveryResult = await onFreshSettledDelivery();
-    if (isExplicitlyVisibleDelivery(deliveryResult)) {
-      markForegroundReplyFenceVisibleDeliveryGeneration(snapshot);
-    }
-  } catch (err: unknown) {
-    if (isVisiblePartialDeliveryError(err)) {
-      markForegroundReplyFenceVisibleDeliveryGeneration(snapshot);
-    }
-    throw err;
-  }
+  await waitForEarlierForegroundReplyFenceGenerations(snapshot);
+  await onSettled?.();
+  await onFreshSettledDelivery?.();
 }
 
 function endForegroundReplyFence(snapshot: ForegroundReplyFenceSnapshot): void {
@@ -283,16 +168,9 @@ function endForegroundReplyFence(snapshot: ForegroundReplyFenceSnapshot): void {
   if (!state) {
     return;
   }
-  const activeGenerationCount = state.activeGenerations.get(snapshot.generation) ?? 0;
-  if (activeGenerationCount <= 1) {
-    state.activeGenerations.delete(snapshot.generation);
-  } else {
-    state.activeGenerations.set(snapshot.generation, activeGenerationCount - 1);
-  }
-  state.suspendedGenerations.delete(snapshot.generation);
-  state.activeDispatches -= 1;
+  state.activeGenerations.delete(snapshot.generation);
   notifyForegroundReplyFenceWaiters(state);
-  if (state.activeDispatches <= 0) {
+  if (state.activeGenerations.size === 0) {
     foregroundReplyFenceByKey.delete(snapshot.key);
   }
 }
@@ -535,48 +413,13 @@ async function dispatchInboundMessageWithBufferedDispatcherCore(
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
       ? markReplyDispatchBeforeDeliverDeadlineOwned(async (payload, info) => {
-          // Check both before and after hooks because hooks can await while newer replies finish.
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
-            // Only the foreground fence proves "not shown because stale"; hook
-            // cancellations may be intentional policy and must stay untagged.
-            setReplyPayloadMetadata(payload, {
-              foregroundDeliverySuppression: { reason: "stale-foreground" },
-            });
-            return null;
-          }
-          const deliverPayload = configuredBeforeDeliver
-            ? await configuredBeforeDeliver(payload, info)
-            : payload;
-          if (!deliverPayload) {
-            return null;
-          }
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
-            setReplyPayloadMetadata(payload, {
-              foregroundDeliverySuppression: { reason: "stale-foreground" },
-            });
-            return null;
-          }
-          return deliverPayload;
+          await waitForEarlierForegroundReplyFenceGenerations(foregroundReplyFence);
+          return configuredBeforeDeliver ? await configuredBeforeDeliver(payload, info) : payload;
         })
       : undefined;
-  const deliver: ReplyDispatcherWithTypingOptions["deliver"] = async (payload, info) => {
-    try {
-      const result = await params.dispatcherOptions.deliver(payload, info);
-      markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, result);
-      return result;
-    } catch (err: unknown) {
-      if (isVisiblePartialDeliveryError(err)) {
-        markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, {
-          visibleReplySent: true,
-        });
-      }
-      throw err;
-    }
-  };
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
       ...params.dispatcherOptions,
-      deliver,
       beforeDeliver,
       silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
     });
@@ -598,11 +441,6 @@ async function dispatchInboundMessageWithBufferedDispatcherCore(
         ...params.replyOptions,
         ...replyOptions,
         onTypingController,
-        onReplyAdmissionWaitChange: (waiting) => {
-          // A turn waiting to own the lane cannot make the current owner's reply stale.
-          // Suspend only that generation so independent newer turns still fence old replies.
-          setForegroundReplyFenceAdmissionWaiting(foregroundReplyFence, waiting);
-        },
       },
       replyPayloadRunState,
       outboundHooks: ownership.outboundHooks,
@@ -610,12 +448,9 @@ async function dispatchInboundMessageWithBufferedDispatcherCore(
     });
   } finally {
     try {
-      const settledResult = await params.dispatcherOptions.onSettled?.();
-      if (isExplicitlyVisibleDelivery(settledResult)) {
-        markForegroundReplyFenceVisibleDeliveryGeneration(foregroundReplyFence);
-      }
-      await runForegroundReplyFenceFreshSettledDelivery(
+      await runForegroundReplyFenceSettledDeliveries(
         foregroundReplyFence,
+        params.dispatcherOptions.onSettled,
         params.dispatcherOptions.onFreshSettledDelivery,
       );
     } finally {

--- a/src/auto-reply/foreground-reply-fence-state.ts
+++ b/src/auto-reply/foreground-reply-fence-state.ts
@@ -2,10 +2,7 @@ import { resolveGlobalMap } from "../shared/global-singleton.js";
 
 export type ForegroundReplyFenceState = {
   generation: number;
-  visibleDeliveryGeneration: number;
-  activeDispatches: number;
-  activeGenerations: Map<number, number>;
-  suspendedGenerations: Set<number>;
+  activeGenerations: Set<number>;
   waiters: Set<() => void>;
 };
 

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -248,10 +248,6 @@ export type ReplyPayloadMetadata = {
   replyDispatcherNormalizationOwner?: object;
   /** Exact key for replacing a runtime-owned assistant row after media materialization. */
   assistantTranscriptIdempotencyKey?: string;
-  /** Foreground freshness prevented a visible final after transcript persistence. */
-  foregroundDeliverySuppression?: {
-    reason: "stale-foreground";
-  };
   /** Opaque owner for one final-delivery transcript capture on a shared dispatcher. */
   finalDeliveryCapture?: object;
   /** Exact persisted delivery owner; WeakMap-only and never serialized. */

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -10,7 +10,6 @@ import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import {
-  appendReplyDispatcherBeforeDeliverCancelled,
   attachReplyDispatchUndeliveredFallback,
   captureReplyDispatchDeliveryOutcome,
   createReplyDispatcher,
@@ -214,49 +213,6 @@ describe("beforeDeliver in reply dispatcher", () => {
     expect(cancelled).toEqual(["blocked reply"]);
     expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 2 });
     expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-  });
-
-  it("notifies appended cancellation observers when beforeDeliver returns null", async () => {
-    const delivered: string[] = [];
-    const cancelled: string[] = [];
-    const errors: string[] = [];
-
-    const dispatcher = createReplyDispatcher({
-      deliver: async (payload) => {
-        delivered.push(payload.text ?? "");
-      },
-      beforeDeliver: () => null,
-      onBeforeDeliverCancelled: (payload) => {
-        cancelled.push(`constructed:${payload.text ?? ""}`);
-      },
-      onError: (err) => {
-        errors.push(err instanceof Error ? err.message : String(err));
-      },
-    });
-    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, (payload) => {
-      cancelled.push(`appended-a:${payload.text ?? ""}`);
-    });
-    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, () => {
-      throw new Error("observer failed");
-    });
-    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, (payload) => {
-      cancelled.push(`appended-b:${payload.text ?? ""}`);
-    });
-
-    dispatcher.sendFinalReply({ text: "blocked reply" });
-    dispatcher.markComplete();
-    await dispatcher.waitForIdle();
-
-    expect(delivered).toEqual([]);
-    expect(cancelled).toEqual([
-      "constructed:blocked reply",
-      "appended-a:blocked reply",
-      "appended-b:blocked reply",
-    ]);
-    expect(errors).toEqual(["observer failed"]);
-    expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 1 });
-    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
   });
 
   it("notifies cancellation when beforeDeliver throws before delivery", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -53,7 +53,6 @@ import {
   describe0BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
 import { getPreparedReplyDispatchRuntime } from "./prepared-reply-dispatch-context.js";
-import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
 import { buildChannelSourceTurnId } from "./source-turn-id.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -615,76 +614,6 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(result.queuedFinal).toBe(true);
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
-  });
-
-  it("records stale-foreground suppressed CLI-owned finals without duplicating answer text", async () => {
-    setNoAbort();
-    const dispatcher = createReplyDispatcher({
-      deliver: vi.fn(async () => undefined),
-      beforeDeliver: (payload, info) => {
-        if (info.kind !== "final") {
-          return payload;
-        }
-        setReplyPayloadMetadata(payload, {
-          foregroundDeliverySuppression: { reason: "stale-foreground" },
-        });
-        return null;
-      },
-    });
-    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
-
-    const result = await dispatchReplyFromConfig({
-      ctx: buildTestCtx({
-        Provider: "slack",
-        Surface: "slack",
-        OriginatingChannel: "slack",
-        OriginatingTo: "channel:C123",
-        SessionKey: "agent:main:slack:channel:C123",
-        MessageSid: "slack-message-cli",
-      }),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async (_ctx, opts) => {
-        (
-          opts as GetReplyOptions & {
-            onSessionPrepared?: (binding: {
-              sessionKey?: string;
-              sessionId: string;
-              storePath?: string;
-            }) => void;
-          }
-        ).onSessionPrepared?.({
-          sessionKey: "agent:main:slack:channel:c123",
-          sessionId: "prepared-session",
-          storePath: "/tmp/prepared-sessions.json",
-        });
-        return setReplyPayloadMetadata(
-          { text: "The CLI answer already lives in the transcript." },
-          { assistantTranscriptOwned: true },
-        );
-      },
-    });
-    await settleReplyDispatcher({ dispatcher });
-
-    expect(result.queuedFinal).toBe(true);
-    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
-    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
-      sessionKey: "agent:main:slack:channel:C123",
-      agentId: "main",
-      expectedSessionId: "prepared-session",
-      text: "Channel final suppressed before delivery: stale foreground",
-      mediaUrls: undefined,
-      idempotencyKey: "channel-final-suppressed:slack-message-cli:0",
-      deliveryMirror: {
-        kind: "channel-final-suppressed",
-        reason: "stale-foreground",
-        sourceMessageId: "slack-message-cli",
-      },
-      storePath: "/tmp/prepared-sessions.json",
-      updateMode: "inline",
-      config: emptyConfig,
-      beforeMessageWrite: expect.any(Function),
-    });
   });
 
   it("disables routed delivery mirrors for CLI-owned finals", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -500,7 +500,6 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       ? captureDeliveredTranscriptMirror({
           dispatcher,
           metadata: transcriptMirror,
-          deliveryId: options.deliveryId,
           captureToken: finalDeliveryCapture,
         })
       : undefined;
@@ -519,8 +518,8 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     );
     if (queuedFinal && deliveredTranscriptMirror && finalOutcomeBefore) {
       // The common settle owner runs this after successful delivery or
-      // cancellation. Keeping reconciliation out of the reply operation lets a
-      // newer foreground turn settle without creating an operation/idle cycle.
+      // cancellation. Keeping reconciliation out of the reply operation avoids
+      // creating another operation/idle cycle during delivery settlement.
       registerReplyDispatcherSettledTask(dispatcher, () =>
         mirrorTranscriptAfterDispatcherSettled({
           dispatcher,

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -383,6 +383,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
       : {}),
     ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
+    ...(replyAdmission?.status === "accepted" ? { deferredToActiveRun: replyAdmission.mode } : {}),
     // Eligibility keys off settled visible delivery: a suppressed or cancelled
     // final (including the core fallback itself) leaves channel-level recovery
     // eligible, while any settled visible delivery clears it. An aborted or

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -660,7 +660,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
   });
 
-  it("does not treat an active-run accepted turn as an empty completion", async () => {
+  it("reports an active-run accepted turn as deferred instead of empty", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
@@ -688,6 +688,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
+      deferredToActiveRun: "followup",
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.transcript.ts
+++ b/src/auto-reply/reply/dispatch-from-config.transcript.ts
@@ -1,4 +1,3 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import {
@@ -9,7 +8,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
-import { appendReplyDispatcherBeforeDeliverCancelled } from "./reply-dispatcher.js";
 import type { DispatcherOutcomeCountsView, ReplyDispatcher } from "./reply-dispatcher.types.js";
 import { readDispatcherFailedCounts } from "./reply-dispatcher.types.js";
 
@@ -91,49 +89,9 @@ export function transcriptMirrorForDeliveredPayload(
   };
 }
 
-const STALE_FOREGROUND_SUPPRESSED_FINAL_TEXT =
-  "Channel final suppressed before delivery: stale foreground";
-
-function captureSuppressedTranscriptMirror(params: {
-  metadata: TranscriptMirror;
-  payload: ReplyPayload;
-  deliveryId?: string | number;
-}): TranscriptMirror | undefined {
-  const payloadMetadata = getReplyPayloadMetadata(params.payload);
-  if (
-    !params.metadata.transcriptOwner ||
-    payloadMetadata?.foregroundDeliverySuppression?.reason !== "stale-foreground"
-  ) {
-    return undefined;
-  }
-  const deliveryMirror = params.metadata.deliveryMirror;
-  if (!deliveryMirror) {
-    return undefined;
-  }
-  const sourceMessageId = normalizeOptionalString(deliveryMirror.sourceMessageId);
-  if (!sourceMessageId) {
-    return undefined;
-  }
-  const { transcriptOwner: _transcriptOwner, ...metadata } = params.metadata;
-  return {
-    ...metadata,
-    // The transcript owner already persisted the answer; this row records only delivery state.
-    text: STALE_FOREGROUND_SUPPRESSED_FINAL_TEXT,
-    mediaUrls: undefined,
-    preferText: true,
-    idempotencyKey: `channel-final-suppressed:${sourceMessageId}:${params.deliveryId ?? "single"}`,
-    deliveryMirror: {
-      kind: "channel-final-suppressed",
-      reason: "stale-foreground",
-      sourceMessageId,
-    },
-  };
-}
-
 export function captureDeliveredTranscriptMirror(params: {
   dispatcher: ReplyDispatcher;
   metadata?: TranscriptMirror;
-  deliveryId?: string | number;
   captureToken?: object;
 }): () => TranscriptMirror | undefined {
   if (!params.metadata || !params.dispatcher.appendBeforeDeliver) {
@@ -141,7 +99,6 @@ export function captureDeliveredTranscriptMirror(params: {
   }
   const metadata = params.metadata;
   let deliveredMetadata: TranscriptMirror | undefined;
-  let suppressedMetadata: TranscriptMirror | undefined;
   let observedFinal = false;
   const { idempotencyKey, sessionKey } = metadata;
   params.dispatcher.appendBeforeDeliver((payload, info) => {
@@ -182,26 +139,8 @@ export function captureDeliveredTranscriptMirror(params: {
     }
     return payload;
   });
-  appendReplyDispatcherBeforeDeliverCancelled(params.dispatcher, (payload, info) => {
-    if (info.kind !== "final") {
-      return;
-    }
-    if (getReplyPayloadMetadata(payload)?.finalDeliveryCapture !== params.captureToken) {
-      return;
-    }
-    observedFinal = true;
-    suppressedMetadata = captureSuppressedTranscriptMirror({
-      metadata,
-      payload,
-      deliveryId: params.deliveryId,
-    });
-  });
   return () =>
-    observedFinal
-      ? (suppressedMetadata ?? deliveredMetadata)
-      : metadata.transcriptOwner
-        ? undefined
-        : metadata;
+    observedFinal ? deliveredMetadata : metadata.transcriptOwner ? undefined : metadata;
 }
 
 export async function mirrorTranscriptAfterDispatcherSettled(params: {
@@ -215,11 +154,7 @@ export async function mirrorTranscriptAfterDispatcherSettled(params: {
   if (!metadata) {
     return;
   }
-  const suppressedFinal = metadata.deliveryMirror?.kind === "channel-final-suppressed";
-  if (
-    !suppressedFinal &&
-    (after.cancelled > params.before.cancelled || after.failed > params.before.failed)
-  ) {
+  if (after.cancelled > params.before.cancelled || after.failed > params.before.failed) {
     return;
   }
   await mirrorDeliveredReplyToTranscript({

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -14,6 +14,7 @@ export type DispatchFromConfigResult = {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sendPolicyDenied?: boolean;
   observedReplyDelivery?: boolean;
+  deferredToActiveRun?: "steer" | "followup";
   noVisibleReplyFallbackEligible?: boolean;
   noVisibleReplyFallbackDelivered?: boolean;
   deliberateSilentTerminalReply?: true;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -100,7 +100,6 @@ const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
 const DEFAULT_BEFORE_DELIVER_TIMEOUT_MS = 15_000;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
-const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
 const deliveryOutcomeTrackers = new WeakMap<ReplyPayload, ReplyDispatchDeliveryOutcomeTracker>();
 const undeliveredFallbacks = new WeakMap<ReplyPayload, ReplyPayload>();
 const replyDispatcherPreparers = new WeakMap<
@@ -228,19 +227,6 @@ export function markReplyDispatchBeforeDeliverDeadlineOwned(
 ): ReplyDispatchBeforeDeliver {
   beforeDeliverStagesByHook.set(hook, [{ hook }]);
   return hook;
-}
-
-/** Adds a core-internal cancellation observer without expanding the plugin-facing dispatcher. */
-export function appendReplyDispatcherBeforeDeliverCancelled(
-  dispatcher: ReplyDispatcher,
-  hook: ReplyDispatchCancelHandler,
-): boolean {
-  const hooks = beforeDeliverCancelledHooks.get(dispatcher);
-  if (!hooks) {
-    return false;
-  }
-  hooks.push(hook);
-  return true;
 }
 
 /** Capture one core-dispatcher delivery outcome without changing send* return types. */
@@ -414,7 +400,6 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       ? { hook: options.beforeDeliver, options: options.beforeDeliverOptions }
       : undefined,
   );
-  const appendedBeforeDeliverCancelledHooks: ReplyDispatchCancelHandler[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
   // Start with pending=1 as a "reservation" to prevent premature gateway restart.
@@ -474,26 +459,24 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     payload: ReplyPayload,
     info: ReplyDispatchRuntimeInfo,
   ) => {
-    const observers = [
-      ...(options.onBeforeDeliverCancelled ? [options.onBeforeDeliverCancelled] : []),
-      ...appendedBeforeDeliverCancelledHooks,
-    ];
-    for (const observer of observers) {
-      try {
-        await runReplyDispatchBeforeDeliverStage(
-          {
-            hook: async (current, currentInfo) => {
-              await observer(current, currentInfo);
-              return current;
-            },
-            timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS,
+    const observer = options.onBeforeDeliverCancelled;
+    if (!observer) {
+      return;
+    }
+    try {
+      await runReplyDispatchBeforeDeliverStage(
+        {
+          hook: async (current, currentInfo) => {
+            await observer(current, currentInfo);
+            return current;
           },
-          payload,
-          info,
-        );
-      } catch (err: unknown) {
-        reportObserverError(err, info);
-      }
+          timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS,
+        },
+        payload,
+        info,
+      );
+    } catch (err: unknown) {
+      reportObserverError(err, info);
     }
   };
 
@@ -722,7 +705,6 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     owner: dispatcher,
     normalize: (kind, payload) => normalizeForDispatch(kind, payload, true),
   });
-  beforeDeliverCancelledHooks.set(dispatcher, appendedBeforeDeliverCancelledHooks);
   return dispatcher;
 }
 

--- a/src/channels/turn/dispatch-result.ts
+++ b/src/channels/turn/dispatch-result.ts
@@ -7,6 +7,7 @@ export type ChannelTurnDispatchResultLike =
       queuedFinal?: boolean;
       counts?: Partial<Record<ReplyDispatchKind, number>>;
       observedReplyDelivery?: boolean;
+      deferredToActiveRun?: "steer" | "followup";
     }
   | null
   | undefined;

--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -95,6 +95,9 @@ function maybeWarnZeroCountVisibleDispatch<TDispatchResult>(
     return;
   }
   const dispatchResult = params.dispatchResult as ChannelTurnDispatchResultLike;
+  if (dispatchResult?.deferredToActiveRun) {
+    return;
+  }
   // The canonical visible signal includes observed delivery paths with zero queued counts.
   if (hasVisibleChannelTurnDispatch(dispatchResult, NO_ADDITIONAL_DELIVERY_SIGNALS)) {
     return;

--- a/src/channels/turn/run-channel-turn.pipeline.test.ts
+++ b/src/channels/turn/run-channel-turn.pipeline.test.ts
@@ -950,6 +950,37 @@ describe("channel turn pipeline", () => {
     ]);
   });
 
+  it("does not warn when an active run accepts deferred steer ownership", async () => {
+    const events: string[] = [];
+    const log = vi.fn();
+    const recordInboundSession = createRecordInboundSession(events);
+    const runDispatch = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      deferredToActiveRun: "steer" as const,
+    }));
+
+    const result = await runPreparedChannelTurn({
+      channel: "test",
+      routeSessionKey: "agent:main:test:peer",
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx(),
+      recordInboundSession,
+      runDispatch,
+      log,
+      messageId: "msg-deferred-steer",
+      record: {
+        onRecordError: vi.fn(),
+      },
+    });
+
+    expectDispatched(result);
+    expect(result.dispatchResult?.deferredToActiveRun).toBe("steer");
+    expect(log.mock.calls).not.toContainEqual([
+      expect.objectContaining({ reason: "zero-count-visible-dispatch" }),
+    ]);
+  });
+
   it("still warns when a visible turn has zero counts and no observed delivery", async () => {
     const events: string[] = [];
     const log = vi.fn();


### PR DESCRIPTION
Closes #124618

AI-assisted: investigated, implemented, and independently reviewed with coding agents; maintainer verified the code path, tests, and final diff.

## What Problem This Solves

Fixes an issue where users sending a second message before an earlier answer crossed channel delivery could lose the first completed reply. The answer remained in the session transcript, but only the newer reply appeared in the channel.

The production incident reproduced on iMessage: two same-target turns completed successfully, the first assistant answer was persisted, and the first channel turn later reported zero visible reply payloads.

## Why This Change Was Made

Visible delivery for the same channel/account/session/target is now serialized in inbound arrival order, while model execution and steer admission remain concurrent. A newer message no longer implicitly supersedes an already-generated answer; explicit abort/reset/supersede owners still control genuinely stale work.

The change also carries accepted steer/followup ownership into the dispatch result so a deferred turn with zero immediate payloads is recorded as intentional ownership transfer rather than unexplained silence. Obsolete stale-foreground writer and test-only cancellation-observer machinery was removed; historical persisted transcript records remain readable.

This completes the overlap case left by #100205 and #107799. The original newest-visible-wins policy came from #76970.

## User Impact

Rapid consecutive messages now receive every generated answer exactly once and in arrival order. Users no longer need to repeat a message because a later turn made its completed reply disappear.

Release-note context: preserve channel replies when rapid same-target turns overlap.

## Evidence

Pre-fix deterministic regression:

- Turn A generated a transcript-owned final and paused at pre-delivery.
- Turn B for the same route delivered visibly.
- Releasing A produced zero visible counts and only B reached the transport.
- A separate accepted-steer case emitted the zero-count visible-dispatch warning despite intentional active-run ownership.

Post-fix proof:

- `node scripts/run-vitest.mjs src/auto-reply/reply/before-deliver.test.ts src/auto-reply/dispatch.freshness.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/channels/turn/run-channel-turn.pipeline.test.ts`
  - 413 tests passed across auto-reply and channel shards.
- Blacksmith Testbox `tbx_01m05cg1a0d7bxgmwntmw0jy5a` ([run](https://github.com/openclaw/openclaw/actions/runs/31950209496)):
  - core typecheck: exit 0
  - core-test typecheck shards: exit 0
  - core oxlint: 0 warnings, 0 errors
- Changed-scope guards passed through formatting, assertion/max-lines/env ratchets, plugin boundaries, package guards, and production/full-tree/script dead-export scans.
- `git diff --check`: passed.
- Autoreview (`codex`, high): clean, no accepted/actionable findings.
- Rebase onto `7f842da4bd45c1850562892a1003bc573e516d42` was patch-identical.

Production LOC: +52/-302 (net -250) | Tests/test support: +165/-408 (net -243) | Tooling baseline: -1

Live iMessage replay was not run because it would require sending a new message into an operator conversation. The observed production transcript/log sequence plus failing/passing owner-boundary and channel-turn regressions cover the reported path without that external side effect.