### PR TITLE
refactor: make dense test fixtures type-safe

### DIFF
--- a/extensions/telegram/src/bot.command-menu.test.ts
+++ b/extensions/telegram/src/bot.command-menu.test.ts
@@ -38,8 +38,7 @@ function waitForNextSetMyCommands() {
 }
 
 function resolveSkillCommands(config: Parameters<typeof listNativeCommandSpecsForConfig>[0]) {
-  void config;
-  return listSkillCommandsForAgents() as NonNullable<
+  return listSkillCommandsForAgents({ cfg: config }) as NonNullable<
     Parameters<typeof listNativeCommandSpecsForConfig>[1]
   >["skillCommands"];
 }

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -136,7 +136,7 @@ export function getUpsertChannelPairingRequestMock(): MockFn<
 }
 
 const skillCommandListHoisted = vi.hoisted(() => ({
-  listSkillCommandsForAgents: vi.fn(() => []),
+  listSkillCommandsForAgents: vi.fn<TelegramBotDeps["listSkillCommandsForAgents"]>(() => []),
 }));
 const modelProviderDataHoisted = vi.hoisted(() => ({
   buildModelsProviderData: vi.fn() as MockFn<TelegramBotDeps["buildModelsProviderData"]>,

--- a/extensions/telegram/src/bot.test-helpers.ts
+++ b/extensions/telegram/src/bot.test-helpers.ts
@@ -1,3 +1,5 @@
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+
 export type TelegramTestContext = Record<string, unknown>;
 export type TelegramTestMiddleware = (
   ctx: TelegramTestContext,
@@ -12,6 +14,24 @@ type ChannelInboundModule = typeof import("openclaw/plugin-sdk/channel-inbound")
 type ChannelInboundRunParams = Parameters<ChannelInboundModule["runChannelInboundEvent"]>[0];
 type BufferedReplyDispatcher =
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").dispatchReplyWithBufferedBlockDispatcher;
+
+export function makeTelegramKeyedStoreTestMock<Value>(
+  overrides: Partial<PluginStateKeyedStore<Value>> = {},
+): PluginStateKeyedStore<Value> {
+  const unexpectedCall = async (operation: string): Promise<never> => {
+    throw new Error(`unexpected Telegram keyed-store ${operation} call`);
+  };
+  return {
+    register: () => unexpectedCall("register"),
+    registerIfAbsent: () => unexpectedCall("registerIfAbsent"),
+    lookup: () => unexpectedCall("lookup"),
+    consume: () => unexpectedCall("consume"),
+    delete: () => unexpectedCall("delete"),
+    entries: () => unexpectedCall("entries"),
+    clear: () => unexpectedCall("clear"),
+    ...overrides,
+  };
+}
 
 export async function runTelegramChannelInboundEventWithHarness(
   actual: ChannelInboundModule,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -37,6 +37,7 @@ import {
 import {
   createTelegramCallbackContext,
   createTelegramReactionContext,
+  makeTelegramKeyedStoreTestMock,
   runTelegramChannelInboundEventWithHarness,
 } from "./bot.test-helpers.js";
 import {
@@ -193,12 +194,12 @@ const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
 type TelegramPollRegistryEntry = Omit<
   Parameters<typeof recordTelegramPollRegistryEntry>[0],
   "accountId" | "env"
-> & { createdAt: number };
+>;
 
 function makeTelegramPollRegistryEntry(
   overrides: Pick<TelegramPollRegistryEntry, "messageId" | "pollId"> &
-    Partial<Omit<TelegramPollRegistryEntry, "createdAt" | "messageId" | "pollId">>,
-): Omit<TelegramPollRegistryEntry, "createdAt"> {
+    Partial<Omit<TelegramPollRegistryEntry, "messageId" | "pollId">>,
+): TelegramPollRegistryEntry {
   return {
     chat: { id: 9876, type: "private", first_name: "Ada" },
     threadSpec: { scope: "dm" },
@@ -427,9 +428,7 @@ function createTelegramTestStorePath(label: string): string {
   return telegramTestState.path(`${label}-${telegramTestStoreSequence}.json`);
 }
 
-async function installTelegramPollRegistryForTests(
-  entry?: Omit<TelegramPollRegistryEntry, "createdAt">,
-) {
+async function installTelegramPollRegistryForTests(entry?: TelegramPollRegistryEntry) {
   setTelegramPluginStateRuntimeForTests();
   const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
     namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
@@ -500,11 +499,11 @@ function mockCall(source: MockCallSource, callIndex: number, label: string) {
 }
 
 function firstEditMessageTextArg(argIndex: number) {
-  return mockArg(editMessageTextSpy as unknown as MockCallSource, 0, argIndex, "edit message text");
+  return mockArg(editMessageTextSpy, 0, argIndex, "edit message text");
 }
 
 function firstSystemEventArg(argIndex: number) {
-  return mockArg(enqueueSystemEventSpy as unknown as MockCallSource, 0, argIndex, "system event");
+  return mockArg(enqueueSystemEventSpy, 0, argIndex, "system event");
 }
 
 function mockMsgContextArg(
@@ -600,12 +599,7 @@ async function writeDirectTelegramTranscriptContext(params: {
 }
 
 function latestConversationContextMessages(): Record<string, unknown>[] {
-  const payload = mockMsgContextArg(
-    replySpy as unknown as MockCallSource,
-    replySpy.mock.calls.length - 1,
-    0,
-    "replySpy call",
-  );
+  const payload = mockMsgContextArg(replySpy, replySpy.mock.calls.length - 1, 0, "replySpy call");
   const [conversationContext] = requireArray(
     payload.ChannelStructuredContext,
     "structured context",
@@ -661,7 +655,7 @@ async function seedTelegramPromptContextMessages(params: {
 
 function execApprovalCall(index = 0) {
   return requireRecord(
-    mockArg(resolveExecApprovalSpy as unknown as MockCallSource, index, 0, "exec approval call"),
+    mockArg(resolveExecApprovalSpy, index, 0, "exec approval call"),
     "exec approval call",
   );
 }
@@ -682,7 +676,7 @@ function execApprovalTargetConfig(call = execApprovalCall()) {
 
 function systemEventOptions(index = 0) {
   return requireRecord(
-    mockArg(enqueueSystemEventSpy as unknown as MockCallSource, index, 1, "system event options"),
+    mockArg(enqueueSystemEventSpy, index, 1, "system event options"),
     "system event options",
   );
 }
@@ -1239,10 +1233,12 @@ describe("createTelegramBot", () => {
       messageId: 44,
     });
     const register = vi.fn(async () => {});
-    setTelegramPollRegistryRuntimeForTests({
-      lookup: async () => entry,
-      register,
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    setTelegramPollRegistryRuntimeForTests(
+      makeTelegramKeyedStoreTestMock<TelegramPollRegistryEntry>({
+        lookup: async () => entry,
+        register,
+      }),
+    );
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1292,9 +1288,9 @@ describe("createTelegramBot", () => {
     const lookup = vi.fn(async () => {
       throw new Error("registry should not be read");
     });
-    setTelegramPollRegistryRuntimeForTests({
-      lookup,
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    setTelegramPollRegistryRuntimeForTests(
+      makeTelegramKeyedStoreTestMock<TelegramPollRegistryEntry>({ lookup }),
+    );
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1311,11 +1307,13 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     const readError = new Error("registry db unavailable");
-    setTelegramPollRegistryRuntimeForTests({
-      lookup: async () => {
-        throw readError;
-      },
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    setTelegramPollRegistryRuntimeForTests(
+      makeTelegramKeyedStoreTestMock<TelegramPollRegistryEntry>({
+        lookup: async () => {
+          throw readError;
+        },
+      }),
+    );
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1401,7 +1399,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.InboundEventKind).toBe("room_event");
     expect(payload.InboundHistory).toEqual(
       expect.arrayContaining([
@@ -1548,12 +1546,7 @@ describe("createTelegramBot", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       expect(payload.ReplyChain).toEqual([
         expect.objectContaining({
           messageId: String(replyMessageId),
@@ -1838,7 +1831,7 @@ describe("createTelegramBot", () => {
 
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
     const [chatId, messageId, terminalText, editOptions] = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
+      editMessageTextSpy,
       0,
       "edit terminal approval message",
     );
@@ -2470,11 +2463,7 @@ describe("createTelegramBot", () => {
       messageId: 14,
     },
   ])("$name", async ({ callbackId, callbackData, messageId }) => {
-    (
-      listSkillCommandsForAgents as unknown as {
-        mockImplementationOnce(implementation: TelegramBotDeps["listSkillCommandsForAgents"]): void;
-      }
-    ).mockImplementationOnce(({ agentIds }) => {
+    listSkillCommandsForAgents.mockImplementationOnce(({ agentIds }) => {
       if (agentIds?.length !== 1 || agentIds[0] !== "main") {
         throw new Error("pagination queried commands for the wrong agent");
       }
@@ -2494,7 +2483,7 @@ describe("createTelegramBot", () => {
     expect(listSkillCommandsForAgents).toHaveBeenCalledOnce();
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
     const [chatId, renderedMessageId, text, params] = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
+      editMessageTextSpy,
       0,
       "edit message text",
     );
@@ -2858,11 +2847,7 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
-    const editCall = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
-      0,
-      "edit message text",
-    );
+    const editCall = mockCall(editMessageTextSpy, 0, "edit message text");
     expect(editCall[0]).toBe(1234);
     expect(editCall[1]).toBe(17);
     expect(editCall[2]).toBe(
@@ -3012,7 +2997,7 @@ describe("createTelegramBot", () => {
 
     expect(loadConfig).toHaveBeenCalledTimes(2);
     const dispatchParams = mockArg(
-      dispatchReplyWithBufferedBlockDispatcher as unknown as MockCallSource,
+      dispatchReplyWithBufferedBlockDispatcher,
       0,
       0,
       "buffered dispatch",
@@ -3089,7 +3074,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const { expectChannelInboundContextContract: expectInboundContextContract } =
       await loadInboundContextContract();
     const { escapeRegExp, formatEnvelopeTimestamp } = await loadEnvelopeTimestampHelpers();
@@ -3168,7 +3153,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3232,7 +3217,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ChannelStructuredContext).toEqual([
       {
         label: "Conversation context",
@@ -3333,12 +3318,7 @@ describe("createTelegramBot", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       const [conversationContext] = requireArray(
         payload.ChannelStructuredContext,
         "structured context",
@@ -3400,7 +3380,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ChannelStructuredContext).toBeUndefined();
     expect(payload.Body).not.toContain("Do not include this cached group line.");
   });
@@ -3474,7 +3454,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3530,7 +3510,7 @@ describe("createTelegramBot", () => {
     );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3705,12 +3685,7 @@ describe("createTelegramBot", () => {
       );
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       const [conversationContext] = requireArray(
         payload.ChannelStructuredContext,
         "structured context",
@@ -4125,7 +4100,7 @@ describe("createTelegramBot", () => {
     );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(JSON.stringify(payload.ChannelStructuredContext ?? [])).not.toContain(
       "old private transcript text",
     );
@@ -4156,7 +4131,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9001]");
     expect(payload.Body).toContain('"summarize this"');
@@ -4190,7 +4165,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9001]");
     expect(payload.Body).not.toContain("PK");
@@ -4229,12 +4204,7 @@ describe("createTelegramBot", () => {
         me: { username: "openclaw_bot" },
         getFile: async () => ({}),
       });
-      replyGetFileSignal = mockArg(
-        getFileSpy as unknown as MockCallSource,
-        0,
-        1,
-        "reply getFile signal",
-      ) as AbortSignal;
+      replyGetFileSignal = mockArg(getFileSpy, 0, 1, "reply getFile signal") as AbortSignal;
       expect(replyGetFileSignal.aborted).toBe(false);
     } finally {
       mediaAbort.abort();
@@ -4242,12 +4212,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       MediaPath?: string;
       MediaPaths?: string[];
       ReplyToBody?: string;
@@ -4289,7 +4254,7 @@ describe("createTelegramBot", () => {
     expect(mediaFetch).toHaveBeenCalledTimes(1);
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("continue without the old image");
   });
 
@@ -4314,7 +4279,7 @@ describe("createTelegramBot", () => {
     expect(result).toEqual({ kind: "completed" });
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("continue after polling restart");
   });
 
@@ -4426,12 +4391,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: Array<{
         messageId?: string;
         body?: string;
@@ -4555,12 +4515,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: Array<{
         messageId?: string;
         sender?: string;
@@ -4688,12 +4643,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: unknown[];
       ChannelStructuredContext?: unknown[];
     };
@@ -4780,12 +4730,9 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as { ChannelStructuredContext?: unknown[] };
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
+      ChannelStructuredContext?: unknown[];
+    };
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -4914,12 +4861,7 @@ describe("createTelegramBot", () => {
 
       expect(runtimeError).not.toHaveBeenCalled();
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      ) as {
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
         ChannelStructuredContext?: unknown[];
       };
       const [conversationContext] = requireArray(
@@ -5079,7 +5021,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. unknown sender");
     expect(payload.Body).toContain('"summarize this"');
@@ -5111,7 +5053,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9002");
     expect(payload.Body).toContain('"summarize this"');
@@ -5162,12 +5104,9 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as { ReplyChain?: Array<{ messageId?: string; mediaPath?: string }> };
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
+      ReplyChain?: Array<{ messageId?: string; mediaPath?: string }>;
+    };
     expect(payload.ReplyChain?.[0]).toMatchObject({ messageId: "9003" });
     expect(payload.ReplyChain?.[0]?.mediaPath).toBeTypeOf("string");
     expect(getFileSpy).toHaveBeenCalledWith("external-photo-1", expect.any(AbortSignal));
@@ -5212,7 +5151,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToForwardedFrom).toBe("Bob Smith (@bobsmith)");
     expect(payload.ReplyToForwardedFromType).toBe("user");
     expect(payload.ReplyToForwardedFromId).toBe("999");
@@ -5259,7 +5198,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToForwardedFrom).toBe("Bob Smith (@bobsmith)");
     expect(payload.Body).toContain("[Forwarded from Bob Smith (@bobsmith)]");
     expect(payload.Body).not.toContain("+275760");
@@ -5307,7 +5246,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToId).toBe("9003");
     expect(payload.ReplyToBody).toBe("forwarded text");
     expect(payload.ReplyToSender).toBe("Ada");
@@ -5341,7 +5280,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.WasMentioned).toBe(true);
   });
 
@@ -5555,7 +5494,7 @@ describe("createTelegramBot", () => {
       reply_markup: { inline_keyboard: [] },
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("Fix a broken tool");
     expect(payload.SenderId).toBe("9");
     expect(payload.SenderUsername).toBe("ada_bot");
@@ -5588,7 +5527,7 @@ describe("createTelegramBot", () => {
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("callback_data: openclaw-smart-replies");
     expect(payload.Body).not.toContain("Ignore this");
     expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
@@ -5676,7 +5615,7 @@ describe("createTelegramBot", () => {
       reply_markup: { inline_keyboard: [] },
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("Investigate topic callback");
     expect(payload.MessageSid).toBe("cbq-smart-reply-topic-submit");
     expect(payload.WasMentioned).toBe(true);
@@ -5732,12 +5671,7 @@ describe("createTelegramBot", () => {
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(9, 11, {
       reply_markup: { inline_keyboard: [] },
     });
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      1,
-      0,
-      "replySpy retry call",
-    );
+    const payload = mockMsgContextArg(replySpy, 1, 0, "replySpy retry call");
     expect(payload.Body).toContain("Make Alice funnier");
   });
 
@@ -6072,12 +6006,7 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     if (expectedSessionKey) {
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       expect(payload.CommandTargetSessionKey).toBe(expectedSessionKey);
     }
     if (assertAuthorized) {

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -10,16 +10,25 @@ import { beforeEach, vi } from "vitest";
 import { markdownToTelegramHtml } from "./format.js";
 import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
 
+type TelegramApiMethod = (...args: never[]) => unknown;
 type TelegramApiTestOverrides = {
-  [Key in keyof Bot["api"] as Bot["api"][Key] extends (...args: never[]) => unknown
-    ? Key
-    : never]?: MockFn;
+  [Key in keyof Bot["api"] as Bot["api"][Key] extends TelegramApiMethod ? Key : never]?: MockFn<
+    Extract<Bot["api"][Key], TelegramApiMethod>
+  >;
 };
 
 export function makeTelegramApiTestMock<Overrides extends TelegramApiTestOverrides>(
   overrides: Overrides,
 ): Overrides & Partial<Bot["api"]> {
   return overrides as Overrides & Partial<Bot["api"]>;
+}
+
+export function makeTelegramInvalidApiResultMock<Key extends keyof Bot["api"]>(
+  _method: Key,
+  implementation: (...args: Parameters<Extract<Bot["api"][Key], TelegramApiMethod>>) => unknown,
+): MockFn<Extract<Bot["api"][Key], TelegramApiMethod>> {
+  return vi.fn(implementation) as ReturnType<typeof vi.fn> &
+    MockFn<Extract<Bot["api"][Key], TelegramApiMethod>>;
 }
 
 function richMessagePlainTextForTest(richMessage: {

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -1,4 +1,5 @@
 // Telegram plugin module implements send harness behavior.
+import type { Bot } from "grammy";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   buildOutboundMediaLoadOptions,
@@ -8,6 +9,18 @@ import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, vi } from "vitest";
 import { markdownToTelegramHtml } from "./format.js";
 import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
+
+type TelegramApiTestOverrides = {
+  [Key in keyof Bot["api"] as Bot["api"][Key] extends (...args: never[]) => unknown
+    ? Key
+    : never]?: MockFn;
+};
+
+export function makeTelegramApiTestMock<Overrides extends TelegramApiTestOverrides>(
+  overrides: Overrides,
+): Overrides & Partial<Bot["api"]> {
+  return overrides as Overrides & Partial<Bot["api"]>;
+}
 
 function richMessagePlainTextForTest(richMessage: {
   blocks?: InputRichBlock[];

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover send plugin behavior.
 import fs from "node:fs";
+import type { Bot } from "grammy";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -48,6 +49,7 @@ import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
   installTelegramSendTestHooks,
+  makeTelegramInvalidApiResultMock,
   makeTelegramApiTestMock,
 } from "./send.test-harness.js";
 import { recordSentMessage, wasSentByBot } from "./sent-message-cache.js";
@@ -57,6 +59,71 @@ import {
 } from "./sent-message-cache.legacy-state.js";
 
 installTelegramSendTestHooks();
+
+type TelegramPollMessage = Awaited<ReturnType<Bot["api"]["sendPoll"]>>;
+type TelegramChatFullInfo = Awaited<ReturnType<Bot["api"]["getChat"]>>;
+
+function makeTelegramPollMessage(
+  overrides: {
+    messageId?: number;
+    chat?: {
+      id?: number | string;
+      type?: "private" | "supergroup";
+      firstName?: string;
+      title?: string;
+    };
+    poll?: Partial<TelegramPollMessage["poll"]>;
+  } = {},
+): TelegramPollMessage {
+  const chatId = Number(overrides.chat?.id ?? 555);
+  const chat =
+    overrides.chat?.type === "supergroup"
+      ? {
+          id: chatId,
+          type: "supergroup" as const,
+          title: overrides.chat.title ?? "Test group",
+        }
+      : {
+          id: chatId,
+          type: "private" as const,
+          first_name: overrides.chat?.firstName ?? "Ada",
+        };
+  return {
+    message_id: overrides.messageId ?? 123,
+    date: 0,
+    chat,
+    poll: {
+      id: "test-poll",
+      question: "Ready?",
+      options: [],
+      total_voter_count: 0,
+      is_closed: false,
+      is_anonymous: true,
+      type: "regular",
+      allows_multiple_answers: false,
+      allows_revoting: false,
+      members_only: false,
+      ...overrides.poll,
+    },
+  };
+}
+
+function makeTelegramChatFullInfo(id: number): TelegramChatFullInfo {
+  return {
+    id,
+    type: "private",
+    first_name: "Test chat",
+    accent_color_id: 0,
+    max_reaction_count: 0,
+    accepted_gift_types: {
+      unlimited_gifts: false,
+      limited_gifts: false,
+      unique_gifts: false,
+      premium_subscription: false,
+      gifts_from_channels: false,
+    },
+  };
+}
 
 const {
   botApi,
@@ -5642,7 +5709,9 @@ describe("sendPollTelegram", () => {
 
   it("sends polls with 12 options", async () => {
     const api = makeTelegramApiTestMock({
-      sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
+      sendPoll: vi.fn<Bot["api"]["sendPoll"]>(async () =>
+        makeTelegramPollMessage({ poll: { id: "p1" } }),
+      ),
     });
     const options = Array.from({ length: 12 }, (_, index) => `Option ${index + 1}`);
 
@@ -5658,11 +5727,13 @@ describe("sendPollTelegram", () => {
   it("records a successful General-topic poll for later message mutations", async () => {
     const storePath = `/tmp/openclaw-telegram-poll-context-${process.pid}-${Date.now()}.json`;
     const chatId = "-100123";
-    const sendPoll = vi.fn().mockResolvedValue({
-      message_id: 124,
-      chat: { id: chatId, type: "supergroup" },
-      poll: { id: "p2", question: "Q", options: [] },
-    });
+    const sendPoll = vi.fn<Bot["api"]["sendPoll"]>().mockResolvedValue(
+      makeTelegramPollMessage({
+        messageId: 124,
+        chat: { id: chatId, type: "supergroup" },
+        poll: { id: "p2", question: "Q", options: [] },
+      }),
+    );
     const api = makeTelegramApiTestMock({ sendPoll });
 
     await sendPollTelegram(
@@ -5683,8 +5754,10 @@ describe("sendPollTelegram", () => {
 
   it("propagates gateway client scopes when resolving legacy poll targets", async () => {
     const api = makeTelegramApiTestMock({
-      getChat: vi.fn(async () => ({ id: -100321 })),
-      sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
+      getChat: vi.fn<Bot["api"]["getChat"]>(async () => makeTelegramChatFullInfo(-100321)),
+      sendPoll: vi.fn<Bot["api"]["sendPoll"]>(async () =>
+        makeTelegramPollMessage({ poll: { id: "p1" } }),
+      ),
     });
 
     await sendPollTelegram(
@@ -5708,7 +5781,9 @@ describe("sendPollTelegram", () => {
 
   it("maps durationSeconds to open_period", async () => {
     const api = makeTelegramApiTestMock({
-      sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
+      sendPoll: vi.fn<Bot["api"]["sendPoll"]>(async () =>
+        makeTelegramPollMessage({ poll: { id: "p1" } }),
+      ),
     });
 
     const res = await sendPollTelegram(
@@ -6073,11 +6148,9 @@ describe("sendPollTelegram", () => {
   it("reports default anonymous polls as unavailable without registering them", async () => {
     const store = await installPollRegistryStore();
     const api = makeTelegramApiTestMock({
-      sendPoll: vi.fn(async () => ({
-        message_id: 123,
-        chat: { id: 555, type: "private", first_name: "Ada" },
-        poll: { id: "poll-anonymous" },
-      })),
+      sendPoll: vi.fn<Bot["api"]["sendPoll"]>(async () =>
+        makeTelegramPollMessage({ poll: { id: "poll-anonymous" } }),
+      ),
     });
 
     await expect(
@@ -6122,11 +6195,9 @@ describe("sendPollTelegram", () => {
       channel: {},
     } as TelegramRuntime);
     const api = makeTelegramApiTestMock({
-      sendPoll: vi.fn(async () => ({
-        message_id: 123,
-        chat: { id: 555, type: "private", first_name: "Ada" },
-        poll: { id: "poll-write-error" },
-      })),
+      sendPoll: vi.fn<Bot["api"]["sendPoll"]>(async () =>
+        makeTelegramPollMessage({ poll: { id: "poll-write-error" } }),
+      ),
     });
 
     await expect(
@@ -6155,7 +6226,7 @@ describe("sendPollTelegram", () => {
   it("fails poll sends instead of retrying without message_thread_id", async () => {
     const api = makeTelegramApiTestMock({
       sendPoll: vi
-        .fn()
+        .fn<Bot["api"]["sendPoll"]>()
         .mockRejectedValueOnce(new Error("400: Bad Request: message thread not found")),
     });
 
@@ -6180,7 +6251,7 @@ describe("sendPollTelegram", () => {
   });
 
   it("rejects durationHours for Telegram polls", async () => {
-    const api = makeTelegramApiTestMock({ sendPoll: vi.fn() });
+    const api = makeTelegramApiTestMock({ sendPoll: vi.fn<Bot["api"]["sendPoll"]>() });
 
     await expect(
       sendPollTelegram(
@@ -6195,7 +6266,10 @@ describe("sendPollTelegram", () => {
 
   it("fails when poll send returns no message_id", async () => {
     const api = makeTelegramApiTestMock({
-      sendPoll: vi.fn(async () => ({ chat: { id: 555 }, poll: { id: "p1" } })),
+      sendPoll: makeTelegramInvalidApiResultMock("sendPoll", async () => ({
+        chat: { id: 555 },
+        poll: { id: "p1" },
+      })),
     });
 
     await expect(

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,6 +1,5 @@
 // Telegram tests cover send plugin behavior.
 import fs from "node:fs";
-import type { Bot } from "grammy";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -49,6 +48,7 @@ import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
   installTelegramSendTestHooks,
+  makeTelegramApiTestMock,
 } from "./send.test-harness.js";
 import { recordSentMessage, wasSentByBot } from "./sent-message-cache.js";
 import {
@@ -1195,7 +1195,7 @@ describe("sendMessageTelegram", () => {
       {
         cfg,
         token: "tok",
-        api: { sendLocation } as unknown as TelegramApiOverride,
+        api: makeTelegramApiTestMock({ sendLocation }),
         promptContextProjectionPlan: { cursor, finalPart: true },
       },
     );
@@ -1226,9 +1226,7 @@ describe("sendMessageTelegram", () => {
       "</code>",
     ].join("\n");
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 44, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     const res = await sendMessageTelegram(chatId, text, {
       cfg: TELEGRAM_TEST_CFG,
@@ -1261,9 +1259,7 @@ describe("sendMessageTelegram", () => {
         channels: { telegram: { linkPreview: false } },
       };
       loadConfig.mockReturnValue(cfg);
-      const api = { sendMessage: testCase.sendMessage } as unknown as {
-        sendMessage: typeof testCase.sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendMessage: testCase.sendMessage });
       await sendMessageTelegram("123", testCase.text, {
         cfg,
         token: "tok",
@@ -2275,9 +2271,7 @@ describe("sendMessageTelegram", () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chat: { id: "123" },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram("123", "hi", {
@@ -2293,9 +2287,7 @@ describe("sendMessageTelegram", () => {
     const sendPhoto = vi.fn().mockResolvedValue({
       chat: { id: "123" },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     await expect(
       sendMessageTelegram("123", "caption", {
@@ -2310,7 +2302,7 @@ describe("sendMessageTelegram", () => {
   it("uses native fetch for BAN compatibility when api is omitted", async () => {
     const originalFetch = globalThis.fetch;
     const originalBun = (globalThis as { Bun?: unknown }).Bun;
-    const fetchSpy = vi.fn() as unknown as typeof fetch;
+    const fetchSpy = vi.fn<typeof fetch>();
     globalThis.fetch = fetchSpy;
     (globalThis as { Bun?: unknown }).Bun = {};
     botApi.sendMessage.mockResolvedValue({
@@ -2341,9 +2333,7 @@ describe("sendMessageTelegram", () => {
       message_id: 1,
       chat: { id: "123" },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram("telegram:123", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2362,10 +2352,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: "-100123" },
     });
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { sendMessage, getChat } as unknown as {
-      sendMessage: typeof sendMessage;
-      getChat: typeof getChat;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage, getChat });
 
     await sendMessageTelegram("https://t.me/mychannel", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2391,10 +2378,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: "-100123" },
     });
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { sendMessage, getChat } as unknown as {
-      sendMessage: typeof sendMessage;
-      getChat: typeof getChat;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage, getChat });
 
     await sendMessageTelegram("https://t.me/mychannel", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2413,9 +2397,7 @@ describe("sendMessageTelegram", () => {
 
   it("fails clearly when a legacy target cannot be resolved", async () => {
     const getChat = vi.fn().mockRejectedValue(new Error("400: Bad Request: chat not found"));
-    const api = { getChat } as unknown as {
-      getChat: typeof getChat;
-    };
+    const api = makeTelegramApiTestMock({ getChat });
 
     await expect(
       sendMessageTelegram("@missingchannel", "hi", {
@@ -2433,9 +2415,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 99,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2472,10 +2452,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2521,7 +2498,7 @@ describe("sendMessageTelegram", () => {
     });
     const sendMessage = vi.fn();
     const onDeliveryResult = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as TelegramApiOverride;
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
     mockLoadedMedia({ contentType: "image/jpeg", fileName: "photo.jpg" });
 
     let observed: unknown;
@@ -2682,10 +2659,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2747,10 +2721,7 @@ describe("sendMessageTelegram", () => {
       .mockResolvedValueOnce({ message_id: 73, chat: { id: chatId } })
       .mockResolvedValueOnce({ message_id: 74, chat: { id: chatId } })
       .mockResolvedValueOnce({ message_id: 75, chat: { id: chatId } });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2814,10 +2785,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendMessage = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2846,10 +2814,7 @@ describe("sendMessageTelegram", () => {
     const formattedCaption = `**${visibleCaption}**`;
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 72, chat: { id: chatId } });
     const sendMessage = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2879,9 +2844,7 @@ describe("sendMessageTelegram", () => {
       message_id: 90,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2926,9 +2889,7 @@ describe("sendMessageTelegram", () => {
           message_id: 91,
           chat: { id: chatId },
         });
-      const api = { sendPhoto } as unknown as {
-        sendPhoto: typeof sendPhoto;
-      };
+      const api = makeTelegramApiTestMock({ sendPhoto });
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-image"),
@@ -2977,10 +2938,7 @@ describe("sendMessageTelegram", () => {
         message_id: 102,
         chat: { id: chatId },
       });
-      const api = { sendVideoNote, sendMessage } as unknown as {
-        sendVideoNote: typeof sendVideoNote;
-        sendMessage: typeof sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendVideoNote, sendMessage });
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3014,9 +2972,7 @@ describe("sendMessageTelegram", () => {
         message_id: 201,
         chat: { id: chatId },
       });
-      const api = { sendVideo } as unknown as {
-        sendVideo: typeof sendVideo;
-      };
+      const api = makeTelegramApiTestMock({ sendVideo });
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3081,7 +3037,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "123";
     const sendLocation = vi.fn().mockResolvedValue({ message_id: 301, chat: { id: chatId } });
     const sendVenue = vi.fn().mockResolvedValue({ message_id: 302, chat: { id: chatId } });
-    const api = { sendLocation, sendVenue } as unknown as TelegramApiOverride;
+    const api = makeTelegramApiTestMock({ sendLocation, sendVenue });
 
     await sendLocationTelegram(
       chatId,
@@ -3158,7 +3114,7 @@ describe("sendMessageTelegram", () => {
       await sendLocationTelegram(`${chatId}:topic:99`, location, {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendLocation, sendVenue } as unknown as TelegramApiOverride,
+        api: makeTelegramApiTestMock({ sendLocation, sendVenue }),
       });
     } catch (error) {
       observed = error;
@@ -3190,9 +3146,7 @@ describe("sendMessageTelegram", () => {
       message_id: 201,
       chat: { id: chatId },
     });
-    const api = { sendVideo } as unknown as {
-      sendVideo: typeof sendVideo;
-    };
+    const api = makeTelegramApiTestMock({ sendVideo });
     probeVideoDimensions.mockResolvedValueOnce({ width: 720, height: 1280 });
 
     mockLoadedMedia({
@@ -3227,10 +3181,7 @@ describe("sendMessageTelegram", () => {
       message_id: 102,
       chat: { id: chatId },
     });
-    const api = { sendVideoNote, sendMessage } as unknown as {
-      sendVideoNote: typeof sendVideoNote;
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendVideoNote, sendMessage });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-video"),
@@ -3301,10 +3252,7 @@ describe("sendMessageTelegram", () => {
         message_id: 302,
         chat: { id: chatId },
       });
-      const api = { sendVideoNote, sendMessage } as unknown as {
-        sendVideoNote: typeof sendVideoNote;
-        sendMessage: typeof sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendVideoNote, sendMessage });
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3363,9 +3311,7 @@ describe("sendMessageTelegram", () => {
         message_id: 1,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendMessageTelegram(chatId, "hi", {
@@ -3395,9 +3341,7 @@ describe("sendMessageTelegram", () => {
         message_id: 2,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendMessageTelegram(chatId, "hi", {
@@ -3437,9 +3381,7 @@ describe("sendMessageTelegram", () => {
         message_id: 1,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     const promise = sendMessageTelegram(chatId, "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -3461,7 +3403,7 @@ describe("sendMessageTelegram", () => {
       error: new TelegramRequestNotStartedError(),
     });
     const sendMessage = vi.fn().mockRejectedValue(terminal);
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     let observed: unknown;
     try {
@@ -3484,7 +3426,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "123";
     const edgeError = Object.assign(new Error("421 Misdirected Request"), { status: 421 });
     const sendMessage = vi.fn().mockRejectedValue(edgeError);
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3500,9 +3442,7 @@ describe("sendMessageTelegram", () => {
   it("does not retry on non-transient errors", async () => {
     const chatId = "123";
     const sendMessage = vi.fn().mockRejectedValue(new Error("400: Bad Request"));
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3522,9 +3462,7 @@ describe("sendMessageTelegram", () => {
       .mockRejectedValueOnce(
         new Error("Network request for 'sendMessage' failed after 1 attempts."),
       );
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3543,9 +3481,7 @@ describe("sendMessageTelegram", () => {
       message_id: 9,
       chat: { id: chatId },
     });
-    const api = { sendAnimation } as unknown as {
-      sendAnimation: typeof sendAnimation;
-    };
+    const api = makeTelegramApiTestMock({ sendAnimation });
 
     mockLoadedMedia({
       buffer: Buffer.from("GIF89a"),
@@ -3796,12 +3732,7 @@ describe("sendMessageTelegram", () => {
     });
     const sendPhoto = vi.fn();
     const sendVideo = vi.fn();
-    const api = { sendAnimation, sendDocument, sendPhoto, sendVideo } as unknown as {
-      sendAnimation: typeof sendAnimation;
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-      sendVideo: typeof sendVideo;
-    };
+    const api = makeTelegramApiTestMock({ sendAnimation, sendDocument, sendPhoto, sendVideo });
 
     mockLoadedMedia({
       buffer: testCase.buffer,
@@ -3844,10 +3775,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendPhoto = vi.fn();
-    const api = { sendDocument, sendPhoto } as unknown as {
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendDocument, sendPhoto });
 
     imageMetadata.width = width;
     imageMetadata.height = height;
@@ -3884,10 +3812,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendPhoto = vi.fn();
-    const api = { sendDocument, sendPhoto } as unknown as {
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendDocument, sendPhoto });
 
     imageMetadata.width = undefined;
     imageMetadata.height = undefined;
@@ -3923,9 +3848,7 @@ describe("sendMessageTelegram", () => {
       message_id: 11,
       chat: { id: chatId },
     });
-    const api = { sendDocument } as unknown as {
-      sendDocument: typeof sendDocument;
-    };
+    const api = makeTelegramApiTestMock({ sendDocument });
 
     mockLoadedMedia({
       buffer: Buffer.from("%PDF-1.7"),
@@ -4044,10 +3967,7 @@ describe("sendMessageTelegram", () => {
           : {}),
         chat: { id: testCase.chatId },
       });
-      const api = { sendAudio, sendVoice } as unknown as {
-        sendAudio: typeof sendAudio;
-        sendVoice: typeof sendVoice;
-      };
+      const api = makeTelegramApiTestMock({ sendAudio, sendVoice });
 
       mockLoadedMedia({
         buffer: Buffer.from("audio"),
@@ -4110,9 +4030,7 @@ describe("sendMessageTelegram", () => {
         message_thread_id: 271,
         chat: { id: testCase.chatId },
       });
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendMessage });
 
       const result = await sendMessageTelegram(testCase.chatId, testCase.text, {
         cfg: TELEGRAM_TEST_CFG,
@@ -4143,7 +4061,7 @@ describe("sendMessageTelegram", () => {
       await sendMessageTelegram(chatId, "hello forum", {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: makeTelegramApiTestMock({ sendMessage }),
         messageThreadId: 271,
         onDeliveryResult,
       });
@@ -4179,7 +4097,7 @@ describe("sendMessageTelegram", () => {
       await sendMessageTelegram(chatId, "A".repeat(9000), {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: makeTelegramApiTestMock({ sendMessage }),
         textMode: "html",
         messageThreadId: 271,
         buttons: [[{ text: "OK", callback_data: "ok" }]],
@@ -4209,7 +4127,7 @@ describe("sendMessageTelegram", () => {
       sendMessageTelegram("123456789", "hello private topic", {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: makeTelegramApiTestMock({ sendMessage }),
         messageThreadId: 1,
       }),
     ).rejects.toThrow("topic unknown; expected topic 1");
@@ -4233,9 +4151,7 @@ describe("sendMessageTelegram", () => {
         message_thread_id: 271,
         chat: { id: "-1001234567890" },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     const result = await sendMessageTelegram("-1001234567890", `BEGIN ${"A".repeat(4100)} END`, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4294,9 +4210,7 @@ describe("sendMessageTelegram", () => {
       .mockResolvedValueOnce({ message_id: 101, chat: { id: "-1001234567890" } })
       .mockResolvedValueOnce({ message_id: 102, chat: { id: "-1001234567890" } })
       .mockResolvedValueOnce({ message_id: 103, chat: { id: "-1001234567890" } });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram("-1001234567890", `BEGIN ${"A".repeat(4100)} END`, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4322,9 +4236,7 @@ describe("sendMessageTelegram", () => {
 
     for (const testCase of cases) {
       const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendMessage });
 
       await expect(
         sendMessageTelegram(testCase.chatId, testCase.text, {
@@ -4346,9 +4258,7 @@ describe("sendMessageTelegram", () => {
   it("does not retry private DM topic sends without the topic id", async () => {
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram("123456789", "hello private", {
@@ -4398,9 +4308,7 @@ describe("sendMessageTelegram", () => {
 
     for (const testCase of cases) {
       const sendMessage = vi.fn().mockRejectedValueOnce(testCase.error);
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = makeTelegramApiTestMock({ sendMessage });
 
       await expect(
         sendMessageTelegram(testCase.chatId, testCase.text, {
@@ -4422,9 +4330,7 @@ describe("sendMessageTelegram", () => {
       message_id: 1,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram(chatId, "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4446,9 +4352,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram(`telegram:group:${chatId}:topic:271`, "hello forum", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4471,9 +4375,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram(`telegram:group:${chatId}:topic:271`, body, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4503,9 +4405,7 @@ describe("sendMessageTelegram", () => {
     const body = "topic reply body should stay private";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await expect(
       sendMessageTelegram(`telegram:group:${chatId}:topic:271`, body, {
@@ -4537,9 +4437,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 45,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4574,9 +4472,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "-100123";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendPhoto = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4619,9 +4515,7 @@ describe("sendMessageTelegram", () => {
       message_id: 60,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4654,9 +4548,7 @@ describe("sendMessageTelegram", () => {
       message_id: 61,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = makeTelegramApiTestMock({ sendPhoto });
     const cfg = {
       channels: {
         telegram: {
@@ -4692,7 +4584,7 @@ describe("sendMessageTelegram", () => {
     const htmlText = `<b>${"A".repeat(5000)}</b>`;
 
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 91, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     const res = await sendMessageTelegram(chatId, htmlText, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4716,7 +4608,7 @@ describe("sendMessageTelegram", () => {
     const markdownText = `**${"A".repeat(5000)}**`;
 
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 91, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     const res = await sendMessageTelegram(chatId, markdownText, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4768,9 +4660,7 @@ describe("reactMessageTelegram", () => {
     },
   ] as const)("$testName", async (testCase) => {
     const setMessageReaction = vi.fn().mockResolvedValue(undefined);
-    const api = { setMessageReaction } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-    };
+    const api = makeTelegramApiTestMock({ setMessageReaction });
 
     await reactMessageTelegram(testCase.target, testCase.messageId, testCase.emoji, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4785,10 +4675,7 @@ describe("reactMessageTelegram", () => {
   it("resolves legacy telegram targets before reacting", async () => {
     const setMessageReaction = vi.fn().mockResolvedValue(undefined);
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { setMessageReaction, getChat } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-      getChat: typeof getChat;
-    };
+    const api = makeTelegramApiTestMock({ setMessageReaction, getChat });
 
     await reactMessageTelegram("@mychannel", 456, "✅", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4815,7 +4702,7 @@ describe("deleteMessageTelegram", () => {
     "MESSAGE_DELETE_FORBIDDEN",
   ] as const)("returns a warning for benign delete no-op error: %s", async (message) => {
     const deleteMessage = vi.fn().mockRejectedValue(new Error(message));
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = makeTelegramApiTestMock({ deleteMessage });
 
     const result = await deleteMessageTelegram("123", 456, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4833,7 +4720,7 @@ describe("deleteMessageTelegram", () => {
 
   it("throws non-benign delete errors", async () => {
     const deleteMessage = vi.fn().mockRejectedValue(new Error("500: Internal Server Error"));
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = makeTelegramApiTestMock({ deleteMessage });
 
     await expect(
       deleteMessageTelegram("123", 456, {
@@ -4846,7 +4733,7 @@ describe("deleteMessageTelegram", () => {
 
   it("rejects partial message id strings", async () => {
     const deleteMessage = vi.fn();
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = makeTelegramApiTestMock({ deleteMessage });
 
     await expect(
       deleteMessageTelegram("123", "456abc", {
@@ -4882,9 +4769,7 @@ describe("sendStickerTelegram", () => {
         message_id: testCase.expectedMessageId,
         chat: { id: chatId },
       });
-      const api = { sendSticker } as unknown as {
-        sendSticker: typeof sendSticker;
-      };
+      const api = makeTelegramApiTestMock({ sendSticker });
 
       const res = await sendStickerTelegram(chatId, testCase.fileId, {
         cfg: TELEGRAM_TEST_CFG,
@@ -4908,7 +4793,7 @@ describe("sendStickerTelegram", () => {
       message_thread_id: 77,
       sticker: { file_id: "fileId123", file_unique_id: "unique", type: "regular" },
     });
-    const api = { sendSticker } as unknown as { sendSticker: typeof sendSticker };
+    const api = makeTelegramApiTestMock({ sendSticker });
 
     await sendStickerTelegram(`${chatId}:topic:77`, "fileId123", {
       cfg: { session: { store: storePath } },
@@ -4941,9 +4826,7 @@ describe("sendStickerTelegram", () => {
     const chatId = "-100123";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendSticker = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = makeTelegramApiTestMock({ sendSticker });
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -4965,9 +4848,7 @@ describe("sendStickerTelegram", () => {
     const sendSticker = vi.fn().mockResolvedValue({
       chat: { id: chatId },
     });
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = makeTelegramApiTestMock({ sendSticker });
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -4983,9 +4864,7 @@ describe("sendStickerTelegram", () => {
     const sendSticker = vi
       .fn()
       .mockRejectedValueOnce(new Error("Network request for 'sendSticker' failed!"));
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = makeTelegramApiTestMock({ sendSticker });
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -5011,9 +4890,7 @@ describe("sendStickerTelegram", () => {
         message_id: 109,
         chat: { id: chatId },
       });
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = makeTelegramApiTestMock({ sendSticker });
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendStickerTelegram(chatId, "fileId123", {
@@ -5043,9 +4920,7 @@ describe("shared send behaviors", () => {
             message_id: 56,
             chat: { id: chatId },
           });
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = makeTelegramApiTestMock({ sendMessage });
           await sendMessageTelegram(chatId, "reply text", {
             cfg: TELEGRAM_TEST_CFG,
             token: "tok",
@@ -5068,9 +4943,7 @@ describe("shared send behaviors", () => {
             message_id: 102,
             chat: { id: chatId },
           });
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = makeTelegramApiTestMock({ sendSticker });
           await sendStickerTelegram(chatId, fileId, {
             cfg: TELEGRAM_TEST_CFG,
             token: "tok",
@@ -5096,9 +4969,7 @@ describe("shared send behaviors", () => {
       message_id: 56,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram(chatId, "reply text", {
       cfg: TELEGRAM_TEST_CFG,
@@ -5127,9 +4998,7 @@ describe("shared send behaviors", () => {
         message_id: 57,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = makeTelegramApiTestMock({ sendMessage });
 
     await sendMessageTelegram(chatId, "reply text", {
       cfg: TELEGRAM_TEST_CFG,
@@ -5170,7 +5039,7 @@ describe("shared send behaviors", () => {
         chat: { id: chatId, type: "private" },
         photo: [{ file_id: "photo-file", file_unique_id: "photo-unique", width: 10, height: 10 }],
       });
-    const api = { sendPhoto } as unknown as { sendPhoto: typeof sendPhoto };
+    const api = makeTelegramApiTestMock({ sendPhoto });
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
       contentType: "image/jpeg",
@@ -5229,10 +5098,7 @@ describe("shared send behaviors", () => {
         message_id: 102,
         chat: { id: chatId },
       });
-      const api = { sendMessage, sendSticker } as unknown as {
-        sendMessage: typeof sendMessage;
-        sendSticker: typeof sendSticker;
-      };
+      const api = makeTelegramApiTestMock({ sendMessage, sendSticker });
 
       await sendMessageTelegram(chatId, "reply text", {
         cfg: TELEGRAM_TEST_CFG,
@@ -5270,9 +5136,7 @@ describe("shared send behaviors", () => {
           const chatId = "123";
           const err = new Error("400: Bad Request: chat not found");
           const sendMessage = vi.fn().mockRejectedValue(err);
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = makeTelegramApiTestMock({ sendMessage });
           await expectChatNotFoundWithChatId(
             sendMessageTelegram(chatId, "hi", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5285,9 +5149,7 @@ describe("shared send behaviors", () => {
           const chatId = "123";
           const err = new Error("400: Bad Request: chat not found");
           const sendSticker = vi.fn().mockRejectedValue(err);
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = makeTelegramApiTestMock({ sendSticker });
           await expectChatNotFoundWithChatId(
             sendStickerTelegram(chatId, "fileId123", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5308,9 +5170,7 @@ describe("shared send behaviors", () => {
         errorText: "403: Forbidden: bot is not a member of the channel chat",
         run: async (chatId: string, err: Error) => {
           const sendMessage = vi.fn().mockRejectedValue(err);
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = makeTelegramApiTestMock({ sendMessage });
           await expectTelegramMembershipErrorWithChatId(
             sendMessageTelegram(chatId, "hi", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5323,9 +5183,7 @@ describe("shared send behaviors", () => {
         errorText: "403: Forbidden: bot was kicked from the group chat",
         run: async (chatId: string, err: Error) => {
           const sendSticker = vi.fn().mockRejectedValue(err);
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = makeTelegramApiTestMock({ sendSticker });
           await expectTelegramMembershipErrorWithChatId(
             sendStickerTelegram(chatId, "fileId123", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5783,15 +5641,15 @@ describe("sendPollTelegram", () => {
   }
 
   it("sends polls with 12 options", async () => {
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
-    };
+    });
     const options = Array.from({ length: 12 }, (_, index) => `Option ${index + 1}`);
 
     await sendPollTelegram(
       "123",
       { question: "Q", options },
-      { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+      { cfg: TELEGRAM_TEST_CFG, token: "t", api },
     );
 
     expect(firstMockCall(api.sendPoll, "send poll call")[2]).toEqual(options);
@@ -5805,7 +5663,7 @@ describe("sendPollTelegram", () => {
       chat: { id: chatId, type: "supergroup" },
       poll: { id: "p2", question: "Q", options: [] },
     });
-    const api = { sendPoll } as unknown as Bot["api"];
+    const api = makeTelegramApiTestMock({ sendPoll });
 
     await sendPollTelegram(
       `${chatId}:topic:1`,
@@ -5824,10 +5682,10 @@ describe("sendPollTelegram", () => {
   });
 
   it("propagates gateway client scopes when resolving legacy poll targets", async () => {
-    const api = {
+    const api = makeTelegramApiTestMock({
       getChat: vi.fn(async () => ({ id: -100321 })),
       sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
-    };
+    });
 
     await sendPollTelegram(
       "https://t.me/mychannel",
@@ -5835,7 +5693,7 @@ describe("sendPollTelegram", () => {
       {
         cfg: TELEGRAM_TEST_CFG,
         token: "t",
-        api: api as unknown as Bot["api"],
+        api,
         gatewayClientScopes: ["operator.admin"],
       },
     );
@@ -5849,14 +5707,14 @@ describe("sendPollTelegram", () => {
   });
 
   it("maps durationSeconds to open_period", async () => {
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
-    };
+    });
 
     const res = await sendPollTelegram(
       "123",
       { question: " Q ", options: [" A ", "B "], durationSeconds: 60 },
-      { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+      { cfg: TELEGRAM_TEST_CFG, token: "t", api },
     );
 
     expect(res).toMatchObject({
@@ -6214,13 +6072,13 @@ describe("sendPollTelegram", () => {
 
   it("reports default anonymous polls as unavailable without registering them", async () => {
     const store = await installPollRegistryStore();
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi.fn(async () => ({
         message_id: 123,
         chat: { id: 555, type: "private", first_name: "Ada" },
         poll: { id: "poll-anonymous" },
       })),
-    };
+    });
 
     await expect(
       sendPollTelegram(
@@ -6229,7 +6087,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api,
         },
       ),
     ).resolves.toMatchObject({
@@ -6242,28 +6100,34 @@ describe("sendPollTelegram", () => {
 
   it("does not retry an already-sent poll when origin storage fails", async () => {
     const pollRegistryKey = "default:poll-write-error";
-    const register = vi.fn(async (key: string) => {
+    const pollRegistryStore = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>(
+      "telegram",
+      {
+        namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+        maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      },
+    );
+    const register = vi.spyOn(pollRegistryStore, "register").mockImplementation(async (key) => {
       if (key === pollRegistryKey) {
         throw new Error("registry db unavailable");
       }
     });
     setTelegramRuntime({
       state: {
-        openKeyedStore: (() => ({
-          register,
-        })) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+        openKeyedStore: (() => pollRegistryStore) as TelegramRuntime["state"]["openKeyedStore"],
         openSyncKeyedStore: (() =>
           sentMessageStore) as TelegramRuntime["state"]["openSyncKeyedStore"],
       },
       channel: {},
     } as TelegramRuntime);
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi.fn(async () => ({
         message_id: 123,
         chat: { id: 555, type: "private", first_name: "Ada" },
         poll: { id: "poll-write-error" },
       })),
-    };
+    });
 
     await expect(
       sendPollTelegram(
@@ -6272,7 +6136,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api,
           isAnonymous: false,
         },
       ),
@@ -6289,11 +6153,11 @@ describe("sendPollTelegram", () => {
   });
 
   it("fails poll sends instead of retrying without message_thread_id", async () => {
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi
         .fn()
         .mockRejectedValueOnce(new Error("400: Bad Request: message thread not found")),
-    };
+    });
 
     await expect(
       sendPollTelegram(
@@ -6302,7 +6166,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api,
           messageThreadId: 99,
         },
       ),
@@ -6316,13 +6180,13 @@ describe("sendPollTelegram", () => {
   });
 
   it("rejects durationHours for Telegram polls", async () => {
-    const api = { sendPoll: vi.fn() };
+    const api = makeTelegramApiTestMock({ sendPoll: vi.fn() });
 
     await expect(
       sendPollTelegram(
         "123",
         { question: "Q", options: ["A", "B"], durationHours: 1 },
-        { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "t", api },
       ),
     ).rejects.toThrow(/durationHours is not supported/i);
 
@@ -6330,15 +6194,15 @@ describe("sendPollTelegram", () => {
   });
 
   it("fails when poll send returns no message_id", async () => {
-    const api = {
+    const api = makeTelegramApiTestMock({
       sendPoll: vi.fn(async () => ({ chat: { id: 555 }, poll: { id: "p1" } })),
-    };
+    });
 
     await expect(
       sendPollTelegram(
         "123",
         { question: "Q", options: ["A", "B"] },
-        { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "t", api },
       ),
     ).rejects.toThrow(/returned no message_id/i);
   });
@@ -6383,7 +6247,7 @@ describe("createForumTopicTelegram", () => {
   for (const testCase of cases) {
     it(testCase.name, async () => {
       const createForumTopic = vi.fn().mockResolvedValue(testCase.response);
-      const api = { createForumTopic } as unknown as Bot["api"];
+      const api = makeTelegramApiTestMock({ createForumTopic });
 
       const result = await createForumTopicTelegram(testCase.target, testCase.title, {
         cfg: TELEGRAM_TEST_CFG,
@@ -6404,7 +6268,7 @@ describe("createForumTopicTelegram", () => {
     ["128 CJK characters", "界".repeat(128)],
   ])("accepts %s forum topic names by Unicode code points", async (_label, name) => {
     const createForumTopic = vi.fn().mockResolvedValue({ message_thread_id: 400, name });
-    const api = { createForumTopic } as unknown as Bot["api"];
+    const api = makeTelegramApiTestMock({ createForumTopic });
 
     await createForumTopicTelegram("-1001234567890", name, {
       cfg: TELEGRAM_TEST_CFG,
@@ -6434,7 +6298,7 @@ describe("createForumTopicTelegram", () => {
   ])("rejects %s exceeding 128 Unicode code points on create and edit", async (_label, name) => {
     const createForumTopic = vi.fn();
     const editForumTopic = vi.fn();
-    const api = { createForumTopic, editForumTopic } as unknown as Bot["api"];
+    const api = makeTelegramApiTestMock({ createForumTopic, editForumTopic });
 
     await expect(
       createForumTopicTelegram("-1001234567890", name, {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -60,12 +60,12 @@ type ChannelStructuredContextResolution =
   | { kind: "present"; entries: ChannelStructuredContextEntries };
 type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>;
 
-// Vitest's Mock<T> erases generic and overload relationships. Keep that unsoundness in one
+type GenericMockProcedure = (...args: never[]) => unknown;
+
+// Vitest's Mock<T> erases generic and overload relationships. Keep that conversion in one
 // test-only boundary while ordinary runtime methods continue to use exact vi.fn<T> checking.
-// oxlint-disable-next-line typescript/no-explicit-any
-function createGenericMock<T extends (...args: any[]) => any>(
-  // oxlint-disable-next-line typescript/no-explicit-any
-  implementation?: T | ((...args: any[]) => any),
+function createGenericMock<T extends GenericMockProcedure>(
+  implementation?: T | GenericMockProcedure,
 ): T {
   return (implementation ? vi.fn(implementation) : vi.fn()) as ReturnType<typeof vi.fn> & T;
 }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { vi } from "vitest";
 import type { InboundDebounceCreateParams } from "../../auto-reply/inbound-debounce.js";
 import { normalizeInboundTextNewlines } from "../../auto-reply/reply/inbound-text.js";
+import { normalizeThinkLevel } from "../../auto-reply/thinking.shared.js";
 import {
   createAckReactionHandle,
   removeAckReactionAfterReply,
@@ -11,6 +12,7 @@ import {
 } from "../../channels/ack-reactions.js";
 import { createChannelReplyPipeline } from "../../channels/message/reply-pipeline.js";
 import { resolveSessionEntryResetFreshness } from "../../config/sessions/entry-freshness.js";
+import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
 import { createChannelRuntimeContextRegistry } from "../../plugins/runtime/channel-runtime-contexts.js";
 import { resolveAgentCatalogCreateTarget } from "../../plugins/runtime/runtime-agent-session-catalog.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
@@ -56,6 +58,17 @@ type ChannelStructuredContextEntries = NonNullable<
 type ChannelStructuredContextResolution =
   | { kind: "absent" }
   | { kind: "present"; entries: ChannelStructuredContextEntries };
+type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>;
+
+// Vitest's Mock<T> erases generic and overload relationships. Keep that unsoundness in one
+// test-only boundary while ordinary runtime methods continue to use exact vi.fn<T> checking.
+// oxlint-disable-next-line typescript/no-explicit-any
+function createGenericMock<T extends (...args: any[]) => any>(
+  // oxlint-disable-next-line typescript/no-explicit-any
+  implementation?: T | ((...args: any[]) => any),
+): T {
+  return (implementation ? vi.fn(implementation) : vi.fn()) as ReturnType<typeof vi.fn> & T;
+}
 
 function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
   const result: Record<string, unknown> = { ...(base as Record<string, unknown>) };
@@ -73,23 +86,23 @@ function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
   return result as T;
 }
 
-function createTaskFlowSessionMock() {
+function createTaskFlowSessionMock(): BoundTaskFlowRuntime {
   return {
     sessionKey: "agent:main:main",
-    createManaged: vi.fn(),
-    tryCreateManaged: vi.fn(),
-    get: vi.fn(),
-    list: vi.fn(() => []),
-    findLatest: vi.fn(),
-    resolve: vi.fn(),
-    getTaskSummary: vi.fn(),
-    setWaiting: vi.fn(),
-    resume: vi.fn(),
-    finish: vi.fn(),
-    fail: vi.fn(),
-    requestCancel: vi.fn(),
-    cancel: vi.fn(),
-    runTask: vi.fn(),
+    createManaged: vi.fn<BoundTaskFlowRuntime["createManaged"]>(),
+    tryCreateManaged: vi.fn<BoundTaskFlowRuntime["tryCreateManaged"]>(),
+    get: vi.fn<BoundTaskFlowRuntime["get"]>(),
+    list: vi.fn<BoundTaskFlowRuntime["list"]>(() => []),
+    findLatest: vi.fn<BoundTaskFlowRuntime["findLatest"]>(),
+    resolve: vi.fn<BoundTaskFlowRuntime["resolve"]>(),
+    getTaskSummary: vi.fn<BoundTaskFlowRuntime["getTaskSummary"]>(),
+    setWaiting: vi.fn<BoundTaskFlowRuntime["setWaiting"]>(),
+    resume: vi.fn<BoundTaskFlowRuntime["resume"]>(),
+    finish: vi.fn<BoundTaskFlowRuntime["finish"]>(),
+    fail: vi.fn<BoundTaskFlowRuntime["fail"]>(),
+    requestCancel: vi.fn<BoundTaskFlowRuntime["requestCancel"]>(),
+    cancel: vi.fn<BoundTaskFlowRuntime["cancel"]>(),
+    runTask: vi.fn<BoundTaskFlowRuntime["runTask"]>(),
   };
 }
 
@@ -134,61 +147,73 @@ function resolveMockChannelStructuredContext(
 
 export type PluginRuntimeMediaMock = PluginRuntime["channel"]["media"];
 
+const TEST_CONFIG_SNAPSHOT = {
+  path: "/tmp/openclaw.json",
+  exists: true,
+  raw: "{}",
+  parsed: {},
+  sourceConfig: {},
+  resolved: {},
+  valid: true,
+  runtimeConfig: {},
+  config: {},
+  issues: [],
+  warnings: [],
+  legacyIssues: [],
+} satisfies ConfigFileSnapshot;
+
+const TEST_SAVED_MEDIA = {
+  id: "test-media.jpg",
+  path: "/tmp/test-media.jpg",
+  size: 0,
+  contentType: "image/jpeg",
+} satisfies Awaited<ReturnType<PluginRuntimeMediaMock["saveMediaBuffer"]>>;
+
 export function createPluginRuntimeMediaMock(
   overrides: Partial<PluginRuntimeMediaMock> = {},
 ): PluginRuntimeMediaMock {
-  const readRemoteMediaBuffer =
-    vi.fn() as unknown as PluginRuntimeMediaMock["readRemoteMediaBuffer"];
+  const readRemoteMediaBuffer = vi.fn<PluginRuntimeMediaMock["readRemoteMediaBuffer"]>();
   return {
     readRemoteMediaBuffer,
-    fetchRemoteMedia:
-      readRemoteMediaBuffer as unknown as PluginRuntimeMediaMock["fetchRemoteMedia"],
-    saveRemoteMedia: vi.fn().mockResolvedValue({
-      path: "/tmp/test-media.jpg",
-      contentType: "image/jpeg",
-    }) as unknown as PluginRuntimeMediaMock["saveRemoteMedia"],
-    saveResponseMedia: vi.fn().mockResolvedValue({
-      path: "/tmp/test-media.jpg",
-      contentType: "image/jpeg",
-    }) as unknown as PluginRuntimeMediaMock["saveResponseMedia"],
-    saveMediaBuffer: vi.fn().mockResolvedValue({
-      path: "/tmp/test-media.jpg",
-      contentType: "image/jpeg",
-    }) as unknown as PluginRuntimeMediaMock["saveMediaBuffer"],
+    fetchRemoteMedia: readRemoteMediaBuffer,
+    saveRemoteMedia: vi
+      .fn<PluginRuntimeMediaMock["saveRemoteMedia"]>()
+      .mockResolvedValue(TEST_SAVED_MEDIA),
+    saveResponseMedia: vi
+      .fn<PluginRuntimeMediaMock["saveResponseMedia"]>()
+      .mockResolvedValue(TEST_SAVED_MEDIA),
+    saveMediaBuffer: vi
+      .fn<PluginRuntimeMediaMock["saveMediaBuffer"]>()
+      .mockResolvedValue(TEST_SAVED_MEDIA),
     ...overrides,
   };
 }
 
 export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   const runtimeContexts = createChannelRuntimeContextRegistry();
-  const runEmbeddedAgentMock = vi.fn().mockResolvedValue({
-    payloads: [],
-    meta: {},
-  }) as unknown as PluginRuntime["agent"]["runEmbeddedAgent"];
+  const runEmbeddedAgentMock = vi
+    .fn<PluginRuntime["agent"]["runEmbeddedAgent"]>()
+    .mockResolvedValue({
+      payloads: [],
+      meta: { durationMs: 0 },
+    });
   const taskFlow = {
-    bindSession: vi.fn(
-      createTaskFlowSessionMock,
-    ) as unknown as PluginRuntime["tasks"]["managedFlows"]["bindSession"],
-    fromToolContext: vi.fn(
-      createTaskFlowSessionMock,
-    ) as unknown as PluginRuntime["tasks"]["managedFlows"]["fromToolContext"],
+    bindSession:
+      vi.fn<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>(createTaskFlowSessionMock),
+    fromToolContext:
+      vi.fn<PluginRuntime["tasks"]["managedFlows"]["fromToolContext"]>(createTaskFlowSessionMock),
   };
-  const dispatchAssembledChannelTurnMock = vi.fn(async (params: Record<string, unknown>) => {
-    const admission = (params.admission ?? { kind: "dispatch" }) as { kind: string };
-    const ctxPayload = params.ctxPayload as Record<string, unknown>;
-    const record = params.record as
-      | Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]["record"]
-      | undefined;
-    const recordInboundSession = params.recordInboundSession as Parameters<
-      PluginRuntime["channel"]["inbound"]["runPreparedReply"]
-    >[0]["recordInboundSession"];
-    const routeSessionKey = params.routeSessionKey as string;
-    const storePath = params.storePath as string;
-    const sourceDelivery = params.delivery as {
-      deliver?: (payload: unknown, info: unknown) => Promise<unknown>;
-      deliverWithProviderMessageSending?: (payload: unknown, info: unknown) => Promise<unknown>;
-      onDelivered?: (payload: unknown, info: unknown, result: unknown) => Promise<void> | void;
-      onError?: (err: unknown, info: unknown) => void;
+  const dispatchAssembledChannelTurnMock = vi.fn<
+    PluginRuntime["channel"]["inbound"]["dispatchReply"]
+  >(async (params) => {
+    const admission = params.admission ?? { kind: "dispatch" as const };
+    const ctxPayload = params.ctxPayload;
+    const record = params.record;
+    const recordInboundSession = params.recordInboundSession;
+    const routeSessionKey = params.routeSessionKey;
+    const storePath = params.storePath;
+    const sourceDelivery = params.delivery as typeof params.delivery & {
+      deliverWithProviderMessageSending?: typeof params.delivery.deliver;
     };
     const sourceDeliver =
       sourceDelivery.deliverWithProviderMessageSending ?? sourceDelivery.deliver;
@@ -197,31 +222,22 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     }
     const delivery =
       admission.kind === "observeOnly"
-        ? { deliver: async () => ({ visibleReplySent: false }) }
+        ? { ...sourceDelivery, deliver: async () => ({ visibleReplySent: false }) }
         : { ...sourceDelivery, deliver: sourceDeliver! };
     const ctxSessionKey = ctxPayload.SessionKey;
     const sessionKey = typeof ctxSessionKey === "string" ? ctxSessionKey : routeSessionKey;
     const dispatchReplyWithBufferedBlockDispatcher =
-      params.dispatchReplyWithBufferedBlockDispatcher as (params: {
-        ctx: unknown;
-        cfg: unknown;
-        dispatcherOptions: {
-          deliver: (payload: unknown, info: unknown) => Promise<unknown>;
-          onError?: (err: unknown, info: unknown) => void;
-        };
-        replyOptions?: unknown;
-        replyResolver?: unknown;
-      }) => Promise<unknown>;
+      params.dispatchReplyWithBufferedBlockDispatcher;
     const pipeline = params.replyPipeline
       ? createChannelReplyPipeline({
           ...(params.replyPipeline as Omit<
             Parameters<typeof createChannelReplyPipeline>[0],
             "cfg" | "agentId" | "channel" | "accountId"
           >),
-          cfg: params.cfg as Parameters<typeof createChannelReplyPipeline>[0]["cfg"],
-          agentId: params.agentId as string,
-          channel: params.channel as string,
-          accountId: params.accountId as string | undefined,
+          cfg: params.cfg,
+          agentId: params.agentId,
+          channel: params.channel,
+          accountId: params.accountId,
         })
       : undefined;
     const { onModelSelected, ...dispatcherPipeline } = pipeline ?? {};
@@ -235,13 +251,13 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       onRecordError: record?.onRecordError ?? (() => undefined),
       trackSessionMetaTask: record?.trackSessionMetaTask,
     });
-    await (params.afterRecord as (() => void | Promise<void>) | undefined)?.();
+    await params.afterRecord?.();
     const rawDispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg: params.cfg,
       dispatcherOptions: {
         ...dispatcherPipeline,
-        ...(params.dispatcherOptions as Record<string, unknown> | undefined),
+        ...params.dispatcherOptions,
         deliver: async (payload, info) => {
           const result = await delivery.deliver(payload, info);
           await delivery.onDelivered?.(payload, info, result);
@@ -251,7 +267,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       },
       replyOptions: {
         ...(onModelSelected ? { onModelSelected } : {}),
-        ...(params.replyOptions as Record<string, unknown> | undefined),
+        ...params.replyOptions,
         ...(params.turnAdoptionLifecycle
           ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
           : {}),
@@ -270,67 +286,67 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       dispatchResult,
     };
   });
-  const runPreparedChannelTurnMock = vi.fn(
-    async (params: Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]) => {
-      try {
-        await params.recordInboundSession({
-          storePath: params.storePath,
-          sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
-          ctx: params.ctxPayload,
-          groupResolution: params.record?.groupResolution,
-          createIfMissing: params.record?.createIfMissing,
-          updateLastRoute: params.record?.updateLastRoute,
-          onRecordError: params.record?.onRecordError ?? (() => undefined),
-          trackSessionMetaTask: params.record?.trackSessionMetaTask,
-        });
-        await params.afterRecord?.();
-      } catch (err) {
-        try {
-          await params.onPreDispatchFailure?.(err);
-        } catch {
-          // Preserve the original session-recording error.
-        }
-        throw err;
-      }
-      const admission = params.admission ?? { kind: "dispatch" as const };
-      let dispatchResult;
-      if (admission.kind === "observeOnly") {
-        await params.runDispatchLifecycle?.onDispatchSkipped("observeOnly");
-        dispatchResult = params.observeOnlyDispatchResult ?? {
-          queuedFinal: false,
-          counts: { tool: 0, block: 0, final: 0 },
-        };
-      } else {
-        dispatchResult = await params.runDispatch();
-      }
-      return {
-        admission,
-        dispatched: true,
-        ctxPayload: params.ctxPayload,
-        routeSessionKey: params.routeSessionKey,
-        dispatchResult,
-      };
-    },
-  ) as unknown as PluginRuntime["channel"]["inbound"]["runPreparedReply"];
-  const dispatchChannelTurnPlanMock = vi.fn(
-    async (params: Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0]) => {
-      if (!mergedRuntime) {
-        throw new Error("plugin runtime mock dispatch used before initialization");
-      }
-      return await dispatchAssembledChannelTurnMock({
-        ...params,
-        agentId: params.route.agentId,
-        routeSessionKey: params.route.sessionKey,
-        storePath: mergedRuntime.channel.session.resolveStorePath(params.cfg.session?.store, {
-          agentId: params.route.agentId,
-        }),
-        recordInboundSession: mergedRuntime.channel.session.recordInboundSession,
-        dispatchReplyWithBufferedBlockDispatcher:
-          mergedRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+  const runPreparedChannelTurnMock = createGenericMock<
+    PluginRuntime["channel"]["inbound"]["runPreparedReply"]
+  >(async (params: Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]) => {
+    try {
+      await params.recordInboundSession({
+        storePath: params.storePath,
+        sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+        ctx: params.ctxPayload,
+        groupResolution: params.record?.groupResolution,
+        createIfMissing: params.record?.createIfMissing,
+        updateLastRoute: params.record?.updateLastRoute,
+        onRecordError: params.record?.onRecordError ?? (() => undefined),
+        trackSessionMetaTask: params.record?.trackSessionMetaTask,
       });
-    },
-  ) as unknown as PluginRuntime["channel"]["inbound"]["dispatch"];
-  const runChannelTurnMock = vi.fn(
+      await params.afterRecord?.();
+    } catch (err) {
+      try {
+        await params.onPreDispatchFailure?.(err);
+      } catch {
+        // Preserve the original session-recording error.
+      }
+      throw err;
+    }
+    const admission = params.admission ?? { kind: "dispatch" as const };
+    let dispatchResult;
+    if (admission.kind === "observeOnly") {
+      await params.runDispatchLifecycle?.onDispatchSkipped("observeOnly");
+      dispatchResult = params.observeOnlyDispatchResult ?? {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      };
+    } else {
+      dispatchResult = await params.runDispatch();
+    }
+    return {
+      admission,
+      dispatched: true,
+      ctxPayload: params.ctxPayload,
+      routeSessionKey: params.routeSessionKey,
+      dispatchResult,
+    };
+  });
+  const dispatchChannelTurnPlanMock = createGenericMock<
+    PluginRuntime["channel"]["inbound"]["dispatch"]
+  >(async (params: Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0]) => {
+    if (!mergedRuntime) {
+      throw new Error("plugin runtime mock dispatch used before initialization");
+    }
+    return await dispatchAssembledChannelTurnMock({
+      ...params,
+      agentId: params.route.agentId,
+      routeSessionKey: params.route.sessionKey,
+      storePath: mergedRuntime.channel.session.resolveStorePath(params.cfg.session?.store, {
+        agentId: params.route.agentId,
+      }),
+      recordInboundSession: mergedRuntime.channel.session.recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher:
+        mergedRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    });
+  });
+  const runChannelTurnMock = createGenericMock<PluginRuntime["channel"]["inbound"]["run"]>(
     async (params: Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0]) => {
       const input = await params.adapter.ingest(params.raw);
       if (!input) {
@@ -400,10 +416,13 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
                 };
               })()
             : resolved;
-        dispatchResult = await runPreparedChannelTurnMock({
+        const preparedReply: Parameters<
+          PluginRuntime["channel"]["inbound"]["runPreparedReply"]
+        >[0] = {
           ...prepared,
           admission,
-        } as unknown as Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]);
+        };
+        dispatchResult = await runPreparedChannelTurnMock(preparedReply);
       } else if ("route" in resolved) {
         dispatchResult = await dispatchChannelTurnPlanMock({
           ...resolved,
@@ -428,8 +447,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       await params.adapter.onFinalize?.(result);
       return result;
     },
-  ) as unknown as PluginRuntime["channel"]["inbound"]["run"];
-  const buildChannelInboundEventContextMock = vi.fn((params: BuildContextParams) => {
+  );
+  const buildChannelInboundEventContextMock = createGenericMock<
+    PluginRuntime["channel"]["inbound"]["buildContext"]
+  >((params: BuildContextParams) => {
     const channelStructuredContext = resolveMockChannelStructuredContext(params);
     const extra = { ...params.extra };
     delete extra.UntrustedStructuredContext;
@@ -468,19 +489,18 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       ...extra,
       ...structuredContextField,
     } as Awaited<BuildContextResult>;
-  }) as unknown as PluginRuntime["channel"]["inbound"]["buildContext"];
+  });
   const sessionRuntime = {
-    resolveStorePath: vi.fn(
+    resolveStorePath: vi.fn<PluginRuntime["channel"]["session"]["resolveStorePath"]>(
       () => "/tmp/sessions.json",
-    ) as unknown as PluginRuntime["channel"]["session"]["resolveStorePath"],
-    readSessionUpdatedAt: vi.fn(
+    ),
+    readSessionUpdatedAt: vi.fn<PluginRuntime["channel"]["session"]["readSessionUpdatedAt"]>(
       () => undefined,
-    ) as unknown as PluginRuntime["channel"]["session"]["readSessionUpdatedAt"],
+    ),
     recordSessionMetaFromInbound:
-      vi.fn() as unknown as PluginRuntime["channel"]["session"]["recordSessionMetaFromInbound"],
-    recordInboundSession:
-      vi.fn() as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
-    updateLastRoute: vi.fn() as unknown as PluginRuntime["channel"]["session"]["updateLastRoute"],
+      vi.fn<PluginRuntime["channel"]["session"]["recordSessionMetaFromInbound"]>(),
+    recordInboundSession: vi.fn<PluginRuntime["channel"]["session"]["recordInboundSession"]>(),
+    updateLastRoute: vi.fn<PluginRuntime["channel"]["session"]["updateLastRoute"]>(),
     resolveEntryResetFreshness: vi.fn(resolveSessionEntryResetFreshness),
   };
   const base: PluginRuntime = {
@@ -490,54 +510,53 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       request: vi.fn(),
     },
     config: {
-      current: vi.fn(() => ({})) as unknown as PluginRuntime["config"]["current"],
-      mutateConfigFile: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        previousHash: null,
-        persistedHash: null,
-        snapshot: {} as never,
-        nextConfig: {},
-        afterWrite: { mode: "auto" },
-        followUp: { mode: "auto", requiresRestart: false },
-        result: undefined,
-      })) as unknown as PluginRuntime["config"]["mutateConfigFile"],
-      replaceConfigFile: vi.fn(async ({ nextConfig }) => ({
-        path: "/tmp/openclaw.json",
-        previousHash: null,
-        persistedHash: null,
-        snapshot: {} as never,
-        nextConfig,
-        afterWrite: { mode: "auto" },
-        followUp: { mode: "auto", requiresRestart: false },
-      })) as unknown as PluginRuntime["config"]["replaceConfigFile"],
+      current: vi.fn<PluginRuntime["config"]["current"]>(() => ({})),
+      mutateConfigFile: createGenericMock<PluginRuntime["config"]["mutateConfigFile"]>(
+        async () => ({
+          path: "/tmp/openclaw.json",
+          previousHash: null,
+          persistedHash: null,
+          snapshot: TEST_CONFIG_SNAPSHOT,
+          nextConfig: {},
+          afterWrite: { mode: "auto" },
+          followUp: { mode: "auto", requiresRestart: false },
+          result: undefined,
+        }),
+      ),
+      replaceConfigFile: vi.fn<PluginRuntime["config"]["replaceConfigFile"]>(
+        async ({ nextConfig }) => ({
+          path: "/tmp/openclaw.json",
+          previousHash: null,
+          persistedHash: null,
+          snapshot: TEST_CONFIG_SNAPSHOT,
+          nextConfig,
+          afterWrite: { mode: "auto" },
+          followUp: { mode: "auto", requiresRestart: false },
+        }),
+      ),
     },
     agent: {
       defaults: {
         model: DEFAULT_MODEL,
         provider: DEFAULT_PROVIDER,
       },
-      resolveAgentDir: vi.fn(
-        () => "/tmp/agent",
-      ) as unknown as PluginRuntime["agent"]["resolveAgentDir"],
-      resolveAgentWorkspaceDir: vi.fn(
+      resolveAgentDir: vi.fn<PluginRuntime["agent"]["resolveAgentDir"]>(() => "/tmp/agent"),
+      resolveAgentWorkspaceDir: vi.fn<PluginRuntime["agent"]["resolveAgentWorkspaceDir"]>(
         () => "/tmp/workspace",
-      ) as unknown as PluginRuntime["agent"]["resolveAgentWorkspaceDir"],
-      resolveAgentIdentity: vi.fn(() => ({
+      ),
+      resolveAgentIdentity: vi.fn<PluginRuntime["agent"]["resolveAgentIdentity"]>(() => ({
         name: "test-agent",
-      })) as unknown as PluginRuntime["agent"]["resolveAgentIdentity"],
-      resolveSessionCatalogCreateTarget: vi.fn(
-        resolveAgentCatalogCreateTarget,
-      ) as unknown as PluginRuntime["agent"]["resolveSessionCatalogCreateTarget"],
-      resolveThinkingDefault: vi.fn(
-        () => "off",
-      ) as unknown as PluginRuntime["agent"]["resolveThinkingDefault"],
-      resolveCliBackendDispatchEligibility: vi.fn(
-        () => undefined,
-      ) as unknown as PluginRuntime["agent"]["resolveCliBackendDispatchEligibility"],
-      normalizeThinkingLevel: vi.fn(
-        (raw?: string | null) => raw,
-      ) as unknown as PluginRuntime["agent"]["normalizeThinkingLevel"],
-      resolveThinkingPolicy: vi.fn(() => ({
+      })),
+      resolveSessionCatalogCreateTarget: vi.fn<
+        PluginRuntime["agent"]["resolveSessionCatalogCreateTarget"]
+      >(resolveAgentCatalogCreateTarget),
+      resolveThinkingDefault: vi.fn<PluginRuntime["agent"]["resolveThinkingDefault"]>(() => "off"),
+      resolveCliBackendDispatchEligibility: vi.fn<
+        PluginRuntime["agent"]["resolveCliBackendDispatchEligibility"]
+      >(() => undefined),
+      normalizeThinkingLevel:
+        vi.fn<PluginRuntime["agent"]["normalizeThinkingLevel"]>(normalizeThinkLevel),
+      resolveThinkingPolicy: vi.fn<PluginRuntime["agent"]["resolveThinkingPolicy"]>(() => ({
         levels: [
           { id: "off", label: "off" },
           { id: "minimal", label: "minimal" },
@@ -545,18 +564,16 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           { id: "medium", label: "medium" },
           { id: "high", label: "high" },
         ],
-      })) as unknown as PluginRuntime["agent"]["resolveThinkingPolicy"],
+      })),
       runEmbeddedAgent: runEmbeddedAgentMock,
-      resolveAgentTimeoutMs: vi.fn(
-        () => 30_000,
-      ) as unknown as PluginRuntime["agent"]["resolveAgentTimeoutMs"],
+      resolveAgentTimeoutMs: vi.fn<PluginRuntime["agent"]["resolveAgentTimeoutMs"]>(() => 30_000),
       ensureAgentWorkspace: vi
-        .fn()
-        .mockResolvedValue(undefined) as unknown as PluginRuntime["agent"]["ensureAgentWorkspace"],
+        .fn<PluginRuntime["agent"]["ensureAgentWorkspace"]>()
+        .mockResolvedValue({ dir: "/tmp/workspace" }),
       session: {
-        resolveStorePath: vi.fn(
+        resolveStorePath: vi.fn<PluginRuntime["agent"]["session"]["resolveStorePath"]>(
           () => "/tmp/agent-sessions.json",
-        ) as unknown as PluginRuntime["agent"]["session"]["resolveStorePath"],
+        ),
         createSessionEntry: vi.fn(
           async (
             params: Parameters<PluginRuntime["agent"]["session"]["createSessionEntry"]>[0],
@@ -619,89 +636,79 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
             };
           },
         ) as PluginRuntime["agent"]["session"]["createSessionEntry"],
-        getSessionEntry: vi.fn(
+        getSessionEntry: vi.fn<PluginRuntime["agent"]["session"]["getSessionEntry"]>(
           () => undefined,
-        ) as unknown as PluginRuntime["agent"]["session"]["getSessionEntry"],
-        listSessionEntries: vi.fn(
+        ),
+        listSessionEntries: vi.fn<PluginRuntime["agent"]["session"]["listSessionEntries"]>(
           () => [],
-        ) as unknown as PluginRuntime["agent"]["session"]["listSessionEntries"],
+        ),
         patchSessionEntry: vi
-          .fn()
-          .mockResolvedValue(
-            null,
-          ) as unknown as PluginRuntime["agent"]["session"]["patchSessionEntry"],
+          .fn<PluginRuntime["agent"]["session"]["patchSessionEntry"]>()
+          .mockResolvedValue(null),
         upsertSessionEntry: vi
-          .fn()
-          .mockResolvedValue(
-            undefined,
-          ) as unknown as PluginRuntime["agent"]["session"]["upsertSessionEntry"],
+          .fn<PluginRuntime["agent"]["session"]["upsertSessionEntry"]>()
+          .mockResolvedValue(undefined),
         runWithWorkAdmission: vi.fn(
           async (_params, run) => await run(new AbortController().signal),
         ) as PluginRuntime["agent"]["session"]["runWithWorkAdmission"],
         updateSessionStoreEntry: vi
-          .fn()
-          .mockResolvedValue(
-            null,
-          ) as unknown as PluginRuntime["agent"]["session"]["updateSessionStoreEntry"],
+          .fn<PluginRuntime["agent"]["session"]["updateSessionStoreEntry"]>()
+          .mockResolvedValue(null),
       },
     },
     system: {
-      enqueueSystemEvent: vi.fn() as unknown as PluginRuntime["system"]["enqueueSystemEvent"],
-      requestHeartbeat: vi.fn() as unknown as PluginRuntime["system"]["requestHeartbeat"],
-      requestHeartbeatNow: vi.fn() as unknown as PluginRuntime["system"]["requestHeartbeatNow"],
-      runHeartbeatOnce: vi.fn(async () => ({
+      enqueueSystemEvent: vi.fn<PluginRuntime["system"]["enqueueSystemEvent"]>(),
+      requestHeartbeat: vi.fn<PluginRuntime["system"]["requestHeartbeat"]>(),
+      requestHeartbeatNow: vi.fn<PluginRuntime["system"]["requestHeartbeatNow"]>(),
+      runHeartbeatOnce: vi.fn<PluginRuntime["system"]["runHeartbeatOnce"]>(async () => ({
         status: "ran" as const,
         durationMs: 0,
-      })) as unknown as PluginRuntime["system"]["runHeartbeatOnce"],
-      runCommandWithTimeout: vi.fn() as unknown as PluginRuntime["system"]["runCommandWithTimeout"],
-      formatNativeDependencyHint: vi.fn(
+      })),
+      runCommandWithTimeout: vi.fn<PluginRuntime["system"]["runCommandWithTimeout"]>(),
+      formatNativeDependencyHint: vi.fn<PluginRuntime["system"]["formatNativeDependencyHint"]>(
         () => "",
-      ) as unknown as PluginRuntime["system"]["formatNativeDependencyHint"],
+      ),
     },
     media: {
-      loadWebMedia: vi.fn() as unknown as PluginRuntime["media"]["loadWebMedia"],
-      detectMime: vi.fn() as unknown as PluginRuntime["media"]["detectMime"],
-      mediaKindFromMime: vi.fn() as unknown as PluginRuntime["media"]["mediaKindFromMime"],
-      isVoiceCompatibleAudio:
-        vi.fn() as unknown as PluginRuntime["media"]["isVoiceCompatibleAudio"],
-      getImageMetadata: vi.fn() as unknown as PluginRuntime["media"]["getImageMetadata"],
-      resizeToJpeg: vi.fn() as unknown as PluginRuntime["media"]["resizeToJpeg"],
+      loadWebMedia: vi.fn<PluginRuntime["media"]["loadWebMedia"]>(),
+      detectMime: vi.fn<PluginRuntime["media"]["detectMime"]>(),
+      mediaKindFromMime: vi.fn<PluginRuntime["media"]["mediaKindFromMime"]>(),
+      isVoiceCompatibleAudio: vi.fn<PluginRuntime["media"]["isVoiceCompatibleAudio"]>(),
+      getImageMetadata: vi.fn<PluginRuntime["media"]["getImageMetadata"]>(),
+      resizeToJpeg: vi.fn<PluginRuntime["media"]["resizeToJpeg"]>(),
     },
     tts: {
-      prepareTtsRequest: vi.fn() as unknown as PluginRuntime["tts"]["prepareTtsRequest"],
-      textToSpeech: vi.fn() as unknown as PluginRuntime["tts"]["textToSpeech"],
-      textToSpeechStream: vi.fn() as unknown as PluginRuntime["tts"]["textToSpeechStream"],
-      textToSpeechTelephony: vi.fn() as unknown as PluginRuntime["tts"]["textToSpeechTelephony"],
-      listVoices: vi.fn() as unknown as PluginRuntime["tts"]["listVoices"],
+      prepareTtsRequest: vi.fn<PluginRuntime["tts"]["prepareTtsRequest"]>(),
+      textToSpeech: vi.fn<PluginRuntime["tts"]["textToSpeech"]>(),
+      textToSpeechStream: vi.fn<PluginRuntime["tts"]["textToSpeechStream"]>(),
+      textToSpeechTelephony: vi.fn<PluginRuntime["tts"]["textToSpeechTelephony"]>(),
+      listVoices: vi.fn<PluginRuntime["tts"]["listVoices"]>(),
     },
     mediaUnderstanding: {
-      runFile: vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["runFile"],
-      describeImageFile:
-        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeImageFile"],
+      runFile: vi.fn<PluginRuntime["mediaUnderstanding"]["runFile"]>(),
+      describeImageFile: vi.fn<PluginRuntime["mediaUnderstanding"]["describeImageFile"]>(),
       describeImageFileWithModel:
-        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeImageFileWithModel"],
+        vi.fn<PluginRuntime["mediaUnderstanding"]["describeImageFileWithModel"]>(),
       extractStructuredWithModel:
-        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["extractStructuredWithModel"],
-      describeVideoFile:
-        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeVideoFile"],
-      transcribeAudioFile:
-        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["transcribeAudioFile"],
+        vi.fn<PluginRuntime["mediaUnderstanding"]["extractStructuredWithModel"]>(),
+      describeVideoFile: vi.fn<PluginRuntime["mediaUnderstanding"]["describeVideoFile"]>(),
+      transcribeAudioFile: vi.fn<PluginRuntime["mediaUnderstanding"]["transcribeAudioFile"]>(),
     },
     imageGeneration: {
-      generate: vi.fn() as unknown as PluginRuntime["imageGeneration"]["generate"],
-      listProviders: vi.fn() as unknown as PluginRuntime["imageGeneration"]["listProviders"],
+      generate: vi.fn<PluginRuntime["imageGeneration"]["generate"]>(),
+      listProviders: vi.fn<PluginRuntime["imageGeneration"]["listProviders"]>(),
     },
     musicGeneration: {
-      generate: vi.fn() as unknown as PluginRuntime["musicGeneration"]["generate"],
-      listProviders: vi.fn() as unknown as PluginRuntime["musicGeneration"]["listProviders"],
+      generate: vi.fn<PluginRuntime["musicGeneration"]["generate"]>(),
+      listProviders: vi.fn<PluginRuntime["musicGeneration"]["listProviders"]>(),
     },
     videoGeneration: {
-      generate: vi.fn() as unknown as PluginRuntime["videoGeneration"]["generate"],
-      listProviders: vi.fn() as unknown as PluginRuntime["videoGeneration"]["listProviders"],
+      generate: vi.fn<PluginRuntime["videoGeneration"]["generate"]>(),
+      listProviders: vi.fn<PluginRuntime["videoGeneration"]["listProviders"]>(),
     },
     webSearch: {
-      listProviders: vi.fn() as unknown as PluginRuntime["webSearch"]["listProviders"],
-      search: vi.fn() as unknown as PluginRuntime["webSearch"]["search"],
+      listProviders: vi.fn<PluginRuntime["webSearch"]["listProviders"]>(),
+      search: vi.fn<PluginRuntime["webSearch"]["search"]>(),
     },
     channel: {
       text: {
@@ -710,109 +717,122 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         chunkMarkdownTextWithMode: vi.fn((text: string) => (text ? [text] : [])),
         chunkText: vi.fn((text: string) => (text ? [text] : [])),
         chunkTextWithMode: vi.fn((text: string) => (text ? [text] : [])),
-        resolveChunkMode: vi.fn(
+        resolveChunkMode: vi.fn<PluginRuntime["channel"]["text"]["resolveChunkMode"]>(
           () => "length",
-        ) as unknown as PluginRuntime["channel"]["text"]["resolveChunkMode"],
+        ),
         resolveTextChunkLimit: vi.fn(() => 4000),
         hasControlCommand: vi.fn(() => false),
-        resolveMarkdownTableMode: vi.fn(
-          () => "code",
-        ) as unknown as PluginRuntime["channel"]["text"]["resolveMarkdownTableMode"],
+        resolveMarkdownTableMode: vi.fn<
+          PluginRuntime["channel"]["text"]["resolveMarkdownTableMode"]
+        >(() => "code"),
         convertMarkdownTables: vi.fn((text: string) => text),
       },
       reply: {
-        dispatchReplyWithBufferedBlockDispatcher: vi.fn(
-          async () => undefined,
-        ) as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn<
+          PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]
+        >(async () => ({
+          queuedFinal: false,
+          counts: { tool: 0, block: 0, final: 0 },
+        })),
         createReplyDispatcherWithTyping:
-          vi.fn() as unknown as PluginRuntime["channel"]["reply"]["createReplyDispatcherWithTyping"],
+          vi.fn<PluginRuntime["channel"]["reply"]["createReplyDispatcherWithTyping"]>(),
         resolveEffectiveMessagesConfig:
-          vi.fn() as unknown as PluginRuntime["channel"]["reply"]["resolveEffectiveMessagesConfig"],
+          vi.fn<PluginRuntime["channel"]["reply"]["resolveEffectiveMessagesConfig"]>(),
         resolveHumanDelayConfig:
-          vi.fn() as unknown as PluginRuntime["channel"]["reply"]["resolveHumanDelayConfig"],
+          vi.fn<PluginRuntime["channel"]["reply"]["resolveHumanDelayConfig"]>(),
         dispatchReplyFromConfig:
-          vi.fn() as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"],
-        settleReplyDispatcher: vi.fn(async ({ dispatcher, onSettled }) => {
-          dispatcher.markComplete();
-          try {
-            await dispatcher.waitForIdle();
-          } finally {
-            await onSettled?.();
-          }
-        }) as unknown as PluginRuntime["channel"]["reply"]["settleReplyDispatcher"],
-        withReplyDispatcher: vi.fn(async ({ dispatcher, run, onSettled }) => {
-          try {
-            return await run();
-          } finally {
+          vi.fn<PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"]>(),
+        settleReplyDispatcher: vi.fn<PluginRuntime["channel"]["reply"]["settleReplyDispatcher"]>(
+          async ({ dispatcher, onSettled }) => {
             dispatcher.markComplete();
             try {
               await dispatcher.waitForIdle();
             } finally {
               await onSettled?.();
             }
-          }
-        }) as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
-        finalizeInboundContext: vi.fn(
-          (ctx: Record<string, unknown>) => ctx,
-        ) as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
-        formatAgentEnvelope: vi.fn(
+          },
+        ),
+        withReplyDispatcher: createGenericMock<
+          PluginRuntime["channel"]["reply"]["withReplyDispatcher"]
+        >(
+          async ({
+            dispatcher,
+            run,
+            onSettled,
+          }: Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]) => {
+            try {
+              return await run();
+            } finally {
+              dispatcher.markComplete();
+              try {
+                await dispatcher.waitForIdle();
+              } finally {
+                await onSettled?.();
+              }
+            }
+          },
+        ),
+        finalizeInboundContext: createGenericMock<
+          PluginRuntime["channel"]["reply"]["finalizeInboundContext"]
+        >((ctx: Record<string, unknown>) => ctx),
+        formatAgentEnvelope: vi.fn<PluginRuntime["channel"]["reply"]["formatAgentEnvelope"]>(
           (opts: { body: string }) => opts.body,
-        ) as unknown as PluginRuntime["channel"]["reply"]["formatAgentEnvelope"],
-        resolveEnvelopeFormatOptions: vi.fn(() => ({
-          template: "channel+name+time",
-        })) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+        ),
+        resolveEnvelopeFormatOptions: vi.fn<
+          PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"]
+        >(() => ({})),
       },
       routing: {
-        buildAgentSessionKey: vi.fn(
-          ({
-            agentId,
-            channel,
-            peer,
-          }: {
-            agentId: string;
-            channel: string;
-            peer?: { kind?: string; id?: string };
-          }) => `agent:${agentId}:${channel}:${peer?.kind ?? "direct"}:${peer?.id ?? "peer"}`,
-        ) as unknown as PluginRuntime["channel"]["routing"]["buildAgentSessionKey"],
-        resolveAgentRoute: vi.fn(() => ({
+        buildAgentSessionKey: vi.fn<PluginRuntime["channel"]["routing"]["buildAgentSessionKey"]>(
+          ({ agentId, channel, peer }) =>
+            `agent:${agentId}:${channel}:${peer?.kind ?? "direct"}:${peer?.id ?? "peer"}`,
+        ),
+        resolveAgentRoute: vi.fn<PluginRuntime["channel"]["routing"]["resolveAgentRoute"]>(() => ({
           agentId: "main",
+          channel: "test",
           accountId: "default",
           sessionKey: "agent:main:test:dm:peer",
-        })) as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+          mainSessionKey: "agent:main:main",
+          lastRoutePolicy: "session",
+          matchedBy: "default",
+        })),
       },
       pairing: {
-        buildPairingReply: vi.fn(
+        buildPairingReply: vi.fn<PluginRuntime["channel"]["pairing"]["buildPairingReply"]>(
           () => "Pairing code: TESTCODE",
-        ) as unknown as PluginRuntime["channel"]["pairing"]["buildPairingReply"],
+        ),
         readAllowFromStore: vi
-          .fn()
-          .mockResolvedValue(
-            [],
-          ) as unknown as PluginRuntime["channel"]["pairing"]["readAllowFromStore"],
-        removeAllowFromStoreEntry: vi.fn().mockResolvedValue({
-          changed: false,
-          allowFrom: [],
-        }) as unknown as PluginRuntime["channel"]["pairing"]["removeAllowFromStoreEntry"],
-        upsertPairingRequest: vi.fn().mockResolvedValue({
-          code: "TESTCODE",
-          created: true,
-        }) as unknown as PluginRuntime["channel"]["pairing"]["upsertPairingRequest"],
+          .fn<PluginRuntime["channel"]["pairing"]["readAllowFromStore"]>()
+          .mockResolvedValue([]),
+        removeAllowFromStoreEntry: vi
+          .fn<PluginRuntime["channel"]["pairing"]["removeAllowFromStoreEntry"]>()
+          .mockResolvedValue({
+            changed: false,
+            allowFrom: [],
+          }),
+        upsertPairingRequest: vi
+          .fn<PluginRuntime["channel"]["pairing"]["upsertPairingRequest"]>()
+          .mockResolvedValue({
+            code: "TESTCODE",
+            created: true,
+          }),
       },
       media: createPluginRuntimeMediaMock(),
       session: sessionRuntime,
       mentions: {
-        buildMentionRegexes: vi.fn(() => [
-          /\bbert\b/i,
-        ]) as unknown as PluginRuntime["channel"]["mentions"]["buildMentionRegexes"],
-        matchesMentionPatterns: vi.fn((text: string, regexes: RegExp[]) =>
-          regexes.some((regex) => regex.test(text)),
-        ) as unknown as PluginRuntime["channel"]["mentions"]["matchesMentionPatterns"],
-        matchesMentionWithExplicit: vi.fn(
-          (params: { text: string; mentionRegexes: RegExp[]; explicitWasMentioned?: boolean }) =>
-            params.explicitWasMentioned === true
-              ? true
-              : params.mentionRegexes.some((regex) => regex.test(params.text)),
-        ) as unknown as PluginRuntime["channel"]["mentions"]["matchesMentionWithExplicit"],
+        buildMentionRegexes: vi.fn<PluginRuntime["channel"]["mentions"]["buildMentionRegexes"]>(
+          () => [/\bbert\b/i],
+        ),
+        matchesMentionPatterns: vi.fn<
+          PluginRuntime["channel"]["mentions"]["matchesMentionPatterns"]
+        >((text: string, regexes: RegExp[]) => regexes.some((regex) => regex.test(text))),
+        matchesMentionWithExplicit: vi.fn<
+          PluginRuntime["channel"]["mentions"]["matchesMentionWithExplicit"]
+        >((params: { text: string; mentionRegexes: RegExp[]; explicitWasMentioned?: boolean }) =>
+          params.explicitWasMentioned === true
+            ? true
+            : params.mentionRegexes.some((regex) => regex.test(params.text)),
+        ),
         implicitMentionKindWhen,
         resolveInboundMentionDecision,
       },
@@ -823,36 +843,39 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         removeAckReactionHandleAfterReply,
       },
       groups: {
-        resolveGroupPolicy: vi.fn(
-          () => "open",
-        ) as unknown as PluginRuntime["channel"]["groups"]["resolveGroupPolicy"],
-        resolveRequireMention: vi.fn(
+        resolveGroupPolicy: vi.fn<PluginRuntime["channel"]["groups"]["resolveGroupPolicy"]>(() => ({
+          allowlistEnabled: false,
+          allowed: true,
+        })),
+        resolveRequireMention: vi.fn<PluginRuntime["channel"]["groups"]["resolveRequireMention"]>(
           () => false,
-        ) as unknown as PluginRuntime["channel"]["groups"]["resolveRequireMention"],
+        ),
       },
       debounce: {
-        createInboundDebouncer: vi.fn(
-          (params: Pick<InboundDebounceCreateParams<unknown>, "onFlush">) => {
-            const activeCompletions = new Set<Promise<void>>();
-            const runFlush = async (flush: InboundDebounceFlush) => {
-              const completion = flush.completion.catch(() => undefined);
-              activeCompletions.add(completion);
-              void completion.finally(() => activeCompletions.delete(completion));
-              await Promise.race([flush.admission, completion]);
-            };
-            return {
-              enqueue: async (item: unknown) => {
-                await runFlush(params.onFlush([item], createTestInboundDebounceFlush));
-              },
-              flushKey: vi.fn(),
-              cancelKey: vi.fn(() => false),
-              drain: async () => {
-                await Promise.all(activeCompletions);
-              },
-            };
-          },
-        ) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"],
-        resolveInboundDebounceMs: vi.fn((params: unknown) => {
+        createInboundDebouncer: createGenericMock<
+          PluginRuntime["channel"]["debounce"]["createInboundDebouncer"]
+        >((params: Pick<InboundDebounceCreateParams<unknown>, "onFlush">) => {
+          const activeCompletions = new Set<Promise<void>>();
+          const runFlush = async (flush: InboundDebounceFlush) => {
+            const completion = flush.completion.catch(() => undefined);
+            activeCompletions.add(completion);
+            void completion.finally(() => activeCompletions.delete(completion));
+            await Promise.race([flush.admission, completion]);
+          };
+          return {
+            enqueue: async (item: unknown) => {
+              await runFlush(params.onFlush([item], createTestInboundDebounceFlush));
+            },
+            flushKey: vi.fn(),
+            cancelKey: vi.fn(() => false),
+            drain: async () => {
+              await Promise.all(activeCompletions);
+            },
+          };
+        }),
+        resolveInboundDebounceMs: vi.fn<
+          PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"]
+        >((params: unknown) => {
           // Match the production contract so channel plugins that delegate to
           // `core.channel.debounce.resolveInboundDebounceMs({ cfg, channel })`
           // see the same per-channel/global/default precedence in tests as
@@ -889,46 +912,43 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
             return inbound.debounceMs;
           }
           return 0;
-        }) as unknown as PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"],
+        }),
       },
       commands: {
-        resolveCommandAuthorizedFromAuthorizers: vi.fn(
-          () => false,
-        ) as unknown as PluginRuntime["channel"]["commands"]["resolveCommandAuthorizedFromAuthorizers"],
+        resolveCommandAuthorizedFromAuthorizers: vi.fn<
+          PluginRuntime["channel"]["commands"]["resolveCommandAuthorizedFromAuthorizers"]
+        >(() => false),
         isControlCommandMessage:
-          vi.fn() as unknown as PluginRuntime["channel"]["commands"]["isControlCommandMessage"],
+          vi.fn<PluginRuntime["channel"]["commands"]["isControlCommandMessage"]>(),
         shouldComputeCommandAuthorized:
-          vi.fn() as unknown as PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"],
+          vi.fn<PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"]>(),
         shouldHandleTextCommands:
-          vi.fn() as unknown as PluginRuntime["channel"]["commands"]["shouldHandleTextCommands"],
+          vi.fn<PluginRuntime["channel"]["commands"]["shouldHandleTextCommands"]>(),
       },
       outbound: {
-        loadAdapter: vi.fn() as unknown as PluginRuntime["channel"]["outbound"]["loadAdapter"],
+        loadAdapter: vi.fn<PluginRuntime["channel"]["outbound"]["loadAdapter"]>(),
       },
       inbound: {
         run: runChannelTurnMock,
         dispatch: dispatchChannelTurnPlanMock,
-        dispatchReply:
-          dispatchAssembledChannelTurnMock as unknown as PluginRuntime["channel"]["inbound"]["dispatchReply"],
+        dispatchReply: dispatchAssembledChannelTurnMock,
         buildContext: buildChannelInboundEventContextMock,
         runPreparedReply: runPreparedChannelTurnMock,
       },
       threadBindings: {
         setIdleTimeoutBySessionKey:
-          vi.fn() as unknown as PluginRuntime["channel"]["threadBindings"]["setIdleTimeoutBySessionKey"],
+          vi.fn<PluginRuntime["channel"]["threadBindings"]["setIdleTimeoutBySessionKey"]>(),
         setMaxAgeBySessionKey:
-          vi.fn() as unknown as PluginRuntime["channel"]["threadBindings"]["setMaxAgeBySessionKey"],
+          vi.fn<PluginRuntime["channel"]["threadBindings"]["setMaxAgeBySessionKey"]>(),
       },
       runtimeContexts: {
-        register: vi.fn(
+        register: vi.fn<PluginRuntime["channel"]["runtimeContexts"]["register"]>(
           runtimeContexts.register,
-        ) as unknown as PluginRuntime["channel"]["runtimeContexts"]["register"],
-        get: vi.fn(
+        ),
+        get: createGenericMock<PluginRuntime["channel"]["runtimeContexts"]["get"]>(
           runtimeContexts.get,
-        ) as unknown as PluginRuntime["channel"]["runtimeContexts"]["get"],
-        watch: vi.fn(
-          runtimeContexts.watch,
-        ) as unknown as PluginRuntime["channel"]["runtimeContexts"]["watch"],
+        ),
+        watch: vi.fn<PluginRuntime["channel"]["runtimeContexts"]["watch"]>(runtimeContexts.watch),
       },
       activity: {
         record: vi.fn(),
@@ -936,10 +956,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       },
     },
     events: {
-      onAgentEvent: vi.fn(() => () => {}) as unknown as PluginRuntime["events"]["onAgentEvent"],
-      onSessionTranscriptUpdate: vi.fn(
+      onAgentEvent: vi.fn<PluginRuntime["events"]["onAgentEvent"]>(() => () => {}),
+      onSessionTranscriptUpdate: vi.fn<PluginRuntime["events"]["onSessionTranscriptUpdate"]>(
         () => () => {},
-      ) as unknown as PluginRuntime["events"]["onSessionTranscriptUpdate"],
+      ),
     },
     logging: {
       shouldLogVerbose: vi.fn(() => false),
@@ -952,21 +972,25 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     state: {
       resolveStateDir: vi.fn(() => "/tmp/openclaw"),
-      openBlobStore: vi.fn(() => {
+      openBlobStore: createGenericMock<PluginRuntime["state"]["openBlobStore"]>(() => {
         throw new Error("openBlobStore mock is not configured");
-      }) as unknown as PluginRuntime["state"]["openBlobStore"],
-      openKeyedStore: vi.fn(() => {
+      }),
+      openKeyedStore: createGenericMock<PluginRuntime["state"]["openKeyedStore"]>(() => {
         throw new Error("openKeyedStore mock is not configured");
-      }) as unknown as PluginRuntime["state"]["openKeyedStore"],
-      openSyncKeyedStore: vi.fn(() => {
+      }),
+      openSyncKeyedStore: createGenericMock<PluginRuntime["state"]["openSyncKeyedStore"]>(() => {
         throw new Error("openSyncKeyedStore mock is not configured");
-      }) as unknown as PluginRuntime["state"]["openSyncKeyedStore"],
-      openChannelIngressQueue: vi.fn(() => {
-        throw new Error("openChannelIngressQueue mock is not configured");
-      }) as unknown as PluginRuntime["state"]["openChannelIngressQueue"],
-      openChannelIngressDrain: vi.fn(() => {
-        throw new Error("openChannelIngressDrain mock is not configured");
-      }) as unknown as PluginRuntime["state"]["openChannelIngressDrain"],
+      }),
+      openChannelIngressQueue: createGenericMock<PluginRuntime["state"]["openChannelIngressQueue"]>(
+        () => {
+          throw new Error("openChannelIngressQueue mock is not configured");
+        },
+      ),
+      openChannelIngressDrain: createGenericMock<PluginRuntime["state"]["openChannelIngressDrain"]>(
+        () => {
+          throw new Error("openChannelIngressDrain mock is not configured");
+        },
+      ),
     },
     tasks: {
       runs: {
@@ -980,11 +1004,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       managedFlows: taskFlow,
     },
     modelAuth: {
-      getApiKeyForModel: vi.fn() as unknown as PluginRuntime["modelAuth"]["getApiKeyForModel"],
-      getRuntimeAuthForModel:
-        vi.fn() as unknown as PluginRuntime["modelAuth"]["getRuntimeAuthForModel"],
-      resolveApiKeyForProvider:
-        vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
+      getApiKeyForModel: vi.fn<PluginRuntime["modelAuth"]["getApiKeyForModel"]>(),
+      getRuntimeAuthForModel: vi.fn<PluginRuntime["modelAuth"]["getRuntimeAuthForModel"]>(),
+      resolveApiKeyForProvider: vi.fn<PluginRuntime["modelAuth"]["resolveApiKeyForProvider"]>(),
     },
     subagent: {
       run: vi.fn(),

--- a/src/tui/tui-session-actions-test-support.ts
+++ b/src/tui/tui-session-actions-test-support.ts
@@ -1,0 +1,85 @@
+// Provides typed dependency fixtures for TUI session-action tests.
+import { TUI } from "@earendil-works/pi-tui";
+import { vi } from "vitest";
+import { ChatLog } from "./components/chat-log.js";
+import type { TuiBackend } from "./tui-backend.js";
+
+type TuiSessionList = Awaited<ReturnType<TuiBackend["listSessions"]>>;
+
+export function makeTuiSessionList(overrides: Partial<TuiSessionList> = {}): TuiSessionList {
+  const sessions = overrides.sessions ?? [];
+  return {
+    ts: 0,
+    path: "",
+    count: sessions.length,
+    defaults: {},
+    ...overrides,
+    sessions,
+  };
+}
+
+/** Creates a complete backend fixture while keeping scenario overrides type-checked. */
+export function makeTuiBackend(overrides: Partial<TuiBackend> = {}): TuiBackend {
+  const backend: TuiBackend = {
+    connection: { url: "ws://test.invalid" },
+    start: vi.fn<TuiBackend["start"]>(),
+    stop: vi.fn<TuiBackend["stop"]>(),
+    sendChat: vi.fn<TuiBackend["sendChat"]>(async () => ({ runId: "test-run" })),
+    abortChat: vi.fn<TuiBackend["abortChat"]>(async () => ({ ok: true, aborted: false })),
+    loadHistory: vi.fn<TuiBackend["loadHistory"]>(async () => ({ messages: [] })),
+    listSessions: vi.fn<TuiBackend["listSessions"]>(async () => ({
+      ts: 0,
+      path: "",
+      count: 0,
+      defaults: {},
+      sessions: [],
+    })),
+    listAgents: vi.fn<TuiBackend["listAgents"]>(async () => ({
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      scope: "global",
+      agents: [],
+    })),
+    patchSession: vi.fn<TuiBackend["patchSession"]>(async () => ({
+      ok: true,
+      path: "",
+      key: "agent:main:main",
+      entry: {},
+    })),
+    createSession: vi.fn<TuiBackend["createSession"]>(async () => ({ ok: true })),
+    resetSession: vi.fn<TuiBackend["resetSession"]>(async () => ({ ok: true })),
+    getGatewayStatus: vi.fn<TuiBackend["getGatewayStatus"]>(async () => ({})),
+    listModels: vi.fn<TuiBackend["listModels"]>(async () => []),
+  };
+  return { ...backend, ...overrides };
+}
+
+/** Creates a real chat log with optional typed method spies. */
+export function makeChatLog(): ChatLog;
+export function makeChatLog<T extends Partial<ChatLog>>(overrides: T): ChatLog & T;
+export function makeChatLog(overrides: Partial<ChatLog> = {}): ChatLog {
+  return Object.assign(new ChatLog(), overrides);
+}
+
+/** Creates a real TUI backed by an inert terminal and a render spy. */
+export function makeTui(overrides: Partial<TUI> = {}): TUI {
+  const terminal = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    drainInput: vi.fn(async () => {}),
+    write: vi.fn(),
+    columns: 120,
+    rows: 40,
+    kittyProtocolActive: false,
+    moveBy: vi.fn(),
+    hideCursor: vi.fn(),
+    showCursor: vi.fn(),
+    clearLine: vi.fn(),
+    clearFromCursor: vi.fn(),
+    clearScreen: vi.fn(),
+    setTitle: vi.fn(),
+    setProgress: vi.fn(),
+  } satisfies ConstructorParameters<typeof TUI>[0];
+  const tui = new TUI(terminal);
+  return Object.assign(tui, { requestRender: vi.fn(), ...overrides });
+}

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -4,6 +4,12 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { ChatLog } from "./components/chat-log.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
+import {
+  makeChatLog,
+  makeTui,
+  makeTuiBackend,
+  makeTuiSessionList,
+} from "./tui-session-actions-test-support.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import {
@@ -16,6 +22,8 @@ import {
   type TuiPendingSubmit,
 } from "./tui-submit-state.js";
 import type { TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
+
+type TuiSessionList = Awaited<ReturnType<TuiBackend["listSessions"]>>;
 
 describe("tui session actions", () => {
   const sendingSubmit = (runId: string, draftText = "pending"): TuiPendingSubmit => ({
@@ -35,7 +43,7 @@ describe("tui session actions", () => {
     const addSystem = vi.fn();
     const addUser = vi.fn();
     const clearAll = vi.fn();
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem,
       clearAll,
       clearPendingUsers: vi.fn(),
@@ -45,7 +53,7 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       updateAssistant: vi.fn(),
       startTool: vi.fn(),
-    } as unknown as ChatLog;
+    });
     return { chatLog, addSystem, addUser, clearAll };
   };
 
@@ -103,8 +111,8 @@ describe("tui session actions", () => {
     overrides: Partial<Parameters<typeof createSessionActions>[0]>,
   ) =>
     createSessionActions({
-      client: { listSessions: vi.fn() } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn() }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         addUser: vi.fn(),
         addLiveUser: vi.fn(),
@@ -112,9 +120,9 @@ describe("tui session actions", () => {
         finalizeAssistant: vi.fn(),
         clearPendingUsers: vi.fn(),
         clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       btw: createBtwPresenter(),
-      tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
+      tui: makeTui(),
       opts: {},
       state: createBaseState(),
       agentNames: new Map(),
@@ -143,10 +151,10 @@ describe("tui session actions", () => {
     const agentNames = new Map([["cached", "Cached Agent"]]);
     const addSystem = vi.fn();
     const { refreshAgents } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listAgents: vi.fn().mockRejectedValue(new Error("gateway unavailable")),
-      } as unknown as TuiBackend,
-      chatLog: { addSystem } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
+      chatLog: makeChatLog({ addSystem }),
       state,
       agentNames,
     });
@@ -170,7 +178,7 @@ describe("tui session actions", () => {
     });
     const loadHistory = vi.fn().mockResolvedValue({ messages: [] });
     const { setSession } = createTestSessionActions({
-      client: { loadHistory, listSessions: vi.fn() } as unknown as TuiBackend,
+      client: makeTuiBackend({ loadHistory, listSessions: vi.fn() }),
       state,
       resolveSessionSelection: vi.fn(() => ({ key: "global", agentId: "ops" })),
     });
@@ -193,7 +201,7 @@ describe("tui session actions", () => {
     const updateHeader = vi.fn();
     const updateFooter = vi.fn();
     const { refreshAgents } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listAgents: vi.fn().mockResolvedValue({
           defaultId: " Team Lead ",
           mainKey: " Primary ",
@@ -203,7 +211,7 @@ describe("tui session actions", () => {
             { id: " System Agent ", kind: "system", name: " System Agent " },
           ],
         }),
-      } as unknown as TuiBackend,
+      }),
       state,
       agentNames,
       updateHeader,
@@ -253,10 +261,10 @@ describe("tui session actions", () => {
     const requestRender = vi.fn();
 
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
-      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      client: makeTuiBackend({ listSessions }),
+      chatLog: makeChatLog({ addSystem: vi.fn() }),
       btw: createBtwPresenter(),
-      tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
+      tui: makeTui({ requestRender }),
       state,
       updateFooter,
       updateAutocompleteProvider,
@@ -341,7 +349,7 @@ describe("tui session actions", () => {
           }),
       );
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
     });
 
     const first = refreshSessionInfo();
@@ -400,11 +408,11 @@ describe("tui session actions", () => {
     const requestRender = vi.fn();
 
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
       state,
       updateFooter,
       updateAutocompleteProvider,
-      tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
+      tui: makeTui({ requestRender }),
     });
 
     await refreshSessionInfo();
@@ -440,7 +448,7 @@ describe("tui session actions", () => {
     });
 
     const { applySessionInfoFromPatch, refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
       state,
     });
 
@@ -593,7 +601,7 @@ describe("tui session actions", () => {
     });
 
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
       state,
     });
 
@@ -616,7 +624,7 @@ describe("tui session actions", () => {
     });
 
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
       state,
     });
 
@@ -646,7 +654,7 @@ describe("tui session actions", () => {
     });
 
     const { refreshSessionInfo } = createTestSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions }),
       state,
     });
 
@@ -666,10 +674,10 @@ describe("tui session actions", () => {
     const chatLog = new ChatLog();
     const state = createBaseState({ currentSessionId: "session-main" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -711,10 +719,10 @@ describe("tui session actions", () => {
     });
     const state = createBaseState({ currentSessionId: "session-main" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -757,10 +765,10 @@ describe("tui session actions", () => {
     const chatLog = new ChatLog();
     const state = createBaseState({ currentSessionId: "session-main" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -800,10 +808,10 @@ describe("tui session actions", () => {
     const chatLog = new ChatLog();
     const state = createBaseState({ currentSessionId: "session-main" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -850,7 +858,7 @@ describe("tui session actions", () => {
     const state = createBaseState({ currentSessionId: "session-main" });
     const sharedId = "provider-local-user";
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn().mockResolvedValue({
           sessionId: "session-main",
@@ -905,7 +913,7 @@ describe("tui session actions", () => {
             },
           ],
         }),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -930,10 +938,10 @@ describe("tui session actions", () => {
       runId: "previous-run",
     });
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -973,10 +981,10 @@ describe("tui session actions", () => {
     const chatLog = new ChatLog(20);
     const state = createBaseState({ currentSessionId: "session-main" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -1019,10 +1027,10 @@ describe("tui session actions", () => {
     const chatLog = new ChatLog();
     const state = createBaseState({ currentSessionId: "session-before-reset" });
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn(() => deferredHistory.promise),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -1084,10 +1092,10 @@ describe("tui session actions", () => {
 
     const setActivityStatus = vi.fn();
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       btw,
       state,
       setActivityStatus,
@@ -1132,10 +1140,10 @@ describe("tui session actions", () => {
     });
 
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 
@@ -1172,10 +1180,10 @@ describe("tui session actions", () => {
     });
 
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 
@@ -1193,7 +1201,7 @@ describe("tui session actions", () => {
     });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
@@ -1201,11 +1209,11 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       chatLog,
       state,
       setActivityStatus,
@@ -1232,7 +1240,7 @@ describe("tui session actions", () => {
       });
       const chatLog = new ChatLog();
       const addPendingSystem = vi.spyOn(chatLog, "addPendingSystem");
-      const tui = { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI;
+      const tui = makeTui();
       const setActivityStatus = vi.fn((status: string) => {
         state.activityStatus = status;
       });
@@ -1258,7 +1266,7 @@ describe("tui session actions", () => {
       expect(state.activeChatRunId).toBe(previousRunId);
 
       const actions = createTestSessionActions({
-        client: {
+        client: makeTuiBackend({
           listSessions: vi.fn(),
           loadHistory: vi.fn().mockResolvedValue({
             sessionId: "session-next",
@@ -1270,7 +1278,7 @@ describe("tui session actions", () => {
             messages: [],
             inFlightRun: { runId: nextRunId, text: "new partial" },
           }),
-        } as unknown as TuiBackend,
+        }),
         chatLog,
         state,
         tui,
@@ -1305,14 +1313,14 @@ describe("tui session actions", () => {
     const invalidateRunOwnership = vi.fn();
     const state = createBaseState({ currentSessionKey: sessionKey });
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn().mockResolvedValue({
           sessionId: "session-main",
           sessionInfo: { key: sessionKey, sessionId: "session-main" },
           messages: [],
         }),
-      } as unknown as TuiBackend,
+      }),
       state,
       invalidateRunOwnership,
     });
@@ -1330,7 +1338,7 @@ describe("tui session actions", () => {
     });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
@@ -1338,11 +1346,11 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       chatLog,
       state,
       setActivityStatus,
@@ -1360,7 +1368,7 @@ describe("tui session actions", () => {
     const loadHistory = vi.fn().mockResolvedValue({ sessionId: "session-x", messages: [] });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
@@ -1368,11 +1376,11 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       chatLog,
       state,
       setActivityStatus,
@@ -1403,7 +1411,7 @@ describe("tui session actions", () => {
       messages: [],
     });
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       state,
     });
 
@@ -1455,7 +1463,7 @@ describe("tui session actions", () => {
     const setActivityStatus = vi.fn();
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       chatLog,
       state,
       setActivityStatus,
@@ -1498,7 +1506,7 @@ describe("tui session actions", () => {
     const setActivityStatus = vi.fn();
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       chatLog,
       state,
       setActivityStatus,
@@ -1528,8 +1536,8 @@ describe("tui session actions", () => {
   it("keeps the newer session when an earlier history load awaits session info", async () => {
     const historyA = createDeferred<unknown>();
     const historyB = createDeferred<unknown>();
-    const sessionInfoA = createDeferred<unknown>();
-    const sessionInfoB = createDeferred<unknown>();
+    const sessionInfoA = createDeferred<TuiSessionList>();
+    const sessionInfoB = createDeferred<TuiSessionList>();
     const loadHistory = vi
       .fn()
       .mockImplementationOnce(() => historyA.promise)
@@ -1542,7 +1550,7 @@ describe("tui session actions", () => {
     const state = createBaseState({ currentSessionKey: "agent:main:home" });
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions, loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions, loadHistory }),
       chatLog,
       state,
     });
@@ -1560,15 +1568,19 @@ describe("tui session actions", () => {
       messages: [{ role: "user", content: "message from B" }],
     });
 
-    sessionInfoA.resolve({
-      defaults: {},
-      sessions: [{ key: "agent:main:A", sessionId: "session-a", updatedAt: 10 }],
-    });
+    sessionInfoA.resolve(
+      makeTuiSessionList({
+        defaults: {},
+        sessions: [{ key: "agent:main:A", sessionId: "session-a", updatedAt: 10 }],
+      }),
+    );
     await vi.waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
-    sessionInfoB.resolve({
-      defaults: {},
-      sessions: [{ key: "agent:main:B", sessionId: "session-b", updatedAt: 20 }],
-    });
+    sessionInfoB.resolve(
+      makeTuiSessionList({
+        defaults: {},
+        sessions: [{ key: "agent:main:B", sessionId: "session-b", updatedAt: 20 }],
+      }),
+    );
     await Promise.all([firstSwitch, secondSwitch]);
 
     expect(state.currentSessionKey).toBe("agent:main:B");
@@ -1583,7 +1595,7 @@ describe("tui session actions", () => {
     const firstHistoryA = createDeferred<unknown>();
     const historyB = createDeferred<unknown>();
     const secondHistoryA = createDeferred<unknown>();
-    const firstSessionInfoA = createDeferred<unknown>();
+    const firstSessionInfoA = createDeferred<TuiSessionList>();
     const loadHistory = vi
       .fn()
       .mockImplementationOnce(() => firstHistoryA.promise)
@@ -1593,7 +1605,7 @@ describe("tui session actions", () => {
     const state = createBaseState({ currentSessionKey: "agent:main:home" });
 
     const { setSession } = createTestSessionActions({
-      client: { listSessions, loadHistory } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions, loadHistory }),
       state,
     });
 
@@ -1620,17 +1632,19 @@ describe("tui session actions", () => {
     });
     await secondSwitchA;
 
-    firstSessionInfoA.resolve({
-      defaults: {},
-      sessions: [
-        {
-          key: "agent:main:A",
-          sessionId: "session-a-old",
-          model: "old-model",
-          updatedAt: 10,
-        },
-      ],
-    });
+    firstSessionInfoA.resolve(
+      makeTuiSessionList({
+        defaults: {},
+        sessions: [
+          {
+            key: "agent:main:A",
+            sessionId: "session-a-old",
+            model: "old-model",
+            updatedAt: 10,
+          },
+        ],
+      }),
+    );
     await firstSwitchA;
 
     expect(state.currentSessionKey).toBe("agent:main:A");
@@ -1675,10 +1689,10 @@ describe("tui session actions", () => {
     };
 
     const { refreshSessionInfo } = createSessionActions({
-      client: { listSessions } as unknown as TuiBackend,
-      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      client: makeTuiBackend({ listSessions }),
+      chatLog: makeChatLog({ addSystem: vi.fn() }),
       btw: createBtwPresenter(),
-      tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
+      tui: makeTui(),
       opts: {},
       state,
       agentNames: new Map(),
@@ -1722,10 +1736,10 @@ describe("tui session actions", () => {
     });
 
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
       setActivityStatus,
     });
@@ -1755,10 +1769,10 @@ describe("tui session actions", () => {
     });
 
     const { setSession } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 
@@ -1781,11 +1795,11 @@ describe("tui session actions", () => {
     });
 
     const { applySessionMutationResult } = createTestSessionActions({
-      client: { loadHistory } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ loadHistory }),
+      chatLog: makeChatLog({
         addSystem,
         clearAll,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -1814,7 +1828,7 @@ describe("tui session actions", () => {
 
   it("fences pre-reset history and session-info reads when reset commits", async () => {
     const history = createDeferred<unknown>();
-    const sessionInfo = createDeferred<unknown>();
+    const sessionInfo = createDeferred<TuiSessionList>();
     const loadHistory = vi.fn(() => history.promise);
     const listSessions = vi.fn(() => sessionInfo.promise);
     const { chatLog, addUser, clearAll } = createHistoryChatLog();
@@ -1828,7 +1842,7 @@ describe("tui session actions", () => {
       loadHistory: readHistory,
       refreshSessionInfo,
     } = createTestSessionActions({
-      client: { loadHistory, listSessions } as unknown as TuiBackend,
+      client: makeTuiBackend({ loadHistory, listSessions }),
       chatLog,
       state,
     });
@@ -1861,17 +1875,19 @@ describe("tui session actions", () => {
       },
       messages: [{ role: "user", content: "before reset" }],
     });
-    sessionInfo.resolve({
-      defaults: {},
-      sessions: [
-        {
-          key: "agent:main:main",
-          sessionId: "session-before-reset",
-          model: "stale-session-info-model",
-          updatedAt: 10,
-        },
-      ],
-    });
+    sessionInfo.resolve(
+      makeTuiSessionList({
+        defaults: {},
+        sessions: [
+          {
+            key: "agent:main:main",
+            sessionId: "session-before-reset",
+            model: "stale-session-info-model",
+            updatedAt: 10,
+          },
+        ],
+      }),
+    );
 
     await expect(staleHistory).resolves.toEqual({ loaded: false });
     await staleSessionInfo;
@@ -1894,7 +1910,7 @@ describe("tui session actions", () => {
       sessionInfo: { model: "current-model", modelProvider: "openai" },
     });
     const { applySessionMutationResult } = createTestSessionActions({
-      chatLog: { addSystem, clearAll } as unknown as ChatLog,
+      chatLog: makeChatLog({ addSystem, clearAll }),
       state,
       updateHeader,
     });
@@ -1932,10 +1948,10 @@ describe("tui session actions", () => {
     });
 
     const { applySessionMutationResult } = createTestSessionActions({
-      chatLog: {
+      chatLog: makeChatLog({
         addSystem,
         clearAll,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -1959,13 +1975,13 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem,
         clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       btw: createBtwPresenter(),
-      tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
+      tui: makeTui(),
       opts: {},
       state,
       agentNames: new Map(),
@@ -2000,12 +2016,12 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         clearAll: vi.fn(),
         dropPendingUser,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -2024,12 +2040,12 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         clearAll: vi.fn(),
         dropPendingUser,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -2051,12 +2067,12 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         clearAll: vi.fn(),
         dropPendingUser,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -2082,12 +2098,12 @@ describe("tui session actions", () => {
       pendingSubmit: acceptedSubmit("run-queued", "queued"),
     });
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         clearAll: vi.fn(),
         dropPendingUser,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -2165,7 +2181,7 @@ describe("tui session actions", () => {
       pendingSubmit: acceptedSubmit("first-pending-run"),
     });
     const { abortActive, setSession } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory, abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory, abortChat }),
       chatLog: Object.assign(chatLog, { dropPendingUser }),
       state,
       setActivityStatus,
@@ -2223,7 +2239,7 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
       state,
     });
 
@@ -2241,12 +2257,12 @@ describe("tui session actions", () => {
     const requestRender = vi.fn();
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem,
         clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
-      tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
+      }),
+      tui: makeTui({ requestRender }),
     });
 
     await abortActive();
@@ -2265,12 +2281,12 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem: vi.fn(),
         clearAll: vi.fn(),
         dropPendingUser,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      }),
       state,
     });
 
@@ -2292,12 +2308,12 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
+      chatLog: makeChatLog({
         addSystem,
         clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
-      tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
+      }),
+      tui: makeTui({ requestRender }),
       opts: { local: true },
       state,
     });
@@ -2322,7 +2338,7 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
       opts: { local: true },
       state,
       setActivityStatus,
@@ -2347,7 +2363,7 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
       opts: { local: true },
       state,
       setActivityStatus,
@@ -2372,7 +2388,7 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
       opts: { local: false },
       state,
       setActivityStatus,
@@ -2397,7 +2413,7 @@ describe("tui session actions", () => {
     });
 
     const { abortActive } = createTestSessionActions({
-      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      client: makeTuiBackend({ listSessions: vi.fn(), abortChat }),
       opts: { local: true },
       state,
       setActivityStatus,
@@ -2430,10 +2446,10 @@ describe("tui session actions", () => {
     const state = createBaseState({ currentSessionKey: "main" });
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
       rememberSessionKey,
     });
@@ -2460,23 +2476,23 @@ describe("tui session actions", () => {
         { role: "assistant", content: [{ type: "text", text: "reply" }] },
       ],
     });
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       addUser: vi.fn(),
       addPendingUser: vi.fn(),
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
-    };
+    });
     const state = createBaseState({ currentSessionId: "session-main" });
     sendPendingUser(state, "optimistic-run", "optimistic prompt");
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
-      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      }),
+      chatLog,
       state,
     });
 
@@ -2502,15 +2518,15 @@ describe("tui session actions", () => {
         { role: "assistant", content: [{ type: "file", url: "file:///etc/passwd" }] },
       ],
     });
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
-    };
+    });
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
-      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
+      chatLog,
     });
 
     await runLoadHistory();
@@ -2539,20 +2555,20 @@ describe("tui session actions", () => {
         },
       ],
     });
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
-    };
+    });
     const state = createBaseState({
       pendingSubmit: acceptedSubmit("run-pending", "persisted"),
     });
     sendPendingUser(state, "run-pending", "persisted");
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
-      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
+      chatLog,
       state,
     });
 
@@ -2569,7 +2585,7 @@ describe("tui session actions", () => {
     });
     sendPendingUser(state, "run-pending", "persisted");
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn().mockResolvedValue({
           sessionId: "session-main",
@@ -2586,7 +2602,7 @@ describe("tui session actions", () => {
             },
           ],
         }),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -2611,7 +2627,7 @@ describe("tui session actions", () => {
     });
     sendPendingUser(state, "local-run", "continue");
     const { loadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory: vi.fn().mockResolvedValue({
           sessionId: "session-main",
@@ -2629,7 +2645,7 @@ describe("tui session actions", () => {
             },
           ],
         }),
-      } as unknown as TuiBackend,
+      }),
       chatLog,
       state,
     });
@@ -2648,21 +2664,21 @@ describe("tui session actions", () => {
 
   it("keeps a pending submit when reconnect history has not accepted it", async () => {
     const loadHistory = vi.fn().mockResolvedValue({ sessionId: "session-main", messages: [] });
-    const chatLog = {
+    const chatLog = makeChatLog({
       addSystem: vi.fn(),
       addUser: vi.fn(),
       addPendingUser: vi.fn(),
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
-    };
+    });
     const state = createBaseState({
       pendingSubmit: acceptedSubmit("run-pending", "not persisted"),
     });
     sendPendingUser(state, "run-pending", "not persisted");
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
-      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
+      chatLog,
       state,
     });
 
@@ -2683,11 +2699,11 @@ describe("tui session actions", () => {
     const requestRender = vi.fn();
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory,
-      } as unknown as TuiBackend,
-      tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
+      }),
+      tui: makeTui({ requestRender }),
     });
 
     await runLoadHistory();
@@ -2717,10 +2733,10 @@ describe("tui session actions", () => {
     const state = createBaseState();
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 
@@ -2751,10 +2767,10 @@ describe("tui session actions", () => {
     const state = createBaseState();
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions,
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 
@@ -2775,10 +2791,10 @@ describe("tui session actions", () => {
     });
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
-      client: {
+      client: makeTuiBackend({
         listSessions: vi.fn(),
         loadHistory,
-      } as unknown as TuiBackend,
+      }),
       state,
     });
 

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -1,46 +1,38 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type {
+  GatewaySessionRow,
+  SessionsListResult,
+  SessionsPatchResult,
+} from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import { t } from "../../i18n/index.ts";
-import type { SessionCapability, SessionPatch } from "../../lib/sessions/index.ts";
-import type { SessionPatchOptions } from "../../lib/sessions/patch.ts";
+import { createSessionCapability, type SessionCapability } from "../../lib/sessions/index.ts";
 import {
   createResolvedModelPatch,
   createModelCatalog,
   DEEPSEEK_CHAT_MODEL,
   OPENAI_GPT5_MINI_MODEL,
 } from "../../test-helpers/chat-model.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { executeSlashCommand as executeSlashCommandImpl } from "./chat-command-executor.ts";
 
-function createSessionCapability(client: GatewayBrowserClient): SessionCapability {
-  const request = client.request.bind(client);
-  return {
-    state: {
-      result: null,
-      agentId: null,
-      loading: false,
-      error: null,
-    },
-    list: (options = {}) => request("sessions.list", options),
-    refresh: async () => undefined,
-    create: async () => null,
-    patch: (key: string, patch: SessionPatch, options: SessionPatchOptions = {}) =>
-      request("sessions.patch", { key, agentId: options.agentId, ...patch }),
-    setModelOverride: () => undefined,
-    delete: async () => false,
-    deleteMany: async () => ({ deleted: [], errors: [], preservedWorktrees: [] }),
-    reset: async () => true,
-    compact: (key: string, options: { agentId?: string | null } = {}) =>
-      request("sessions.compact", { key, ...options }),
-    steer: (key: string, message: string, options: { agentId?: string | null } = {}) =>
-      request("sessions.steer", { key, ...options, message }),
-    listFiles: async () => null,
-    getFile: async () => null,
+function createTestSessionCapability(client: GatewayBrowserClient): SessionCapability {
+  const sessions = createSessionCapability({
+    snapshot: { client, phase: "connected", hello: null },
     subscribe: () => () => undefined,
-    dispose: () => undefined,
-  } as unknown as SessionCapability;
+    subscribeEvents: () => () => undefined,
+  });
+  const list: SessionCapability["list"] = async (options = {}) =>
+    (await client.request<SessionsListResult | undefined>("sessions.list", options)) ?? null;
+  const patch: SessionCapability["patch"] = async (key, sessionPatch, options) =>
+    await client.request<SessionsPatchResult>("sessions.patch", {
+      key,
+      ...(options?.agentId ? { agentId: options.agentId } : {}),
+      ...sessionPatch,
+    });
+  return Object.assign(sessions, { list, patch });
 }
 
 function executeSlashCommand(
@@ -64,7 +56,7 @@ function executeSlashCommand(
     ...rest
   } = context;
   return executeSlashCommandImpl(client, sessionKey, commandName, args, {
-    sessions: createSessionCapability(client),
+    sessions: createTestSessionCapability(client),
     ...rest,
     sessionAccessSnapshot,
   });
@@ -131,7 +123,7 @@ function expectNoRequestCall(request: ReturnType<typeof vi.fn>, method: string) 
 describe("executeSlashCommand directives", () => {
   it("does not compact a session without operator.admin", async () => {
     const request = vi.fn();
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
 
     const result = await executeSlashCommand(client, "main", "compact", "", {
       sessionAccessSnapshot: restrictedSnapshot(client, ["sessions.compact"]),
@@ -146,7 +138,7 @@ describe("executeSlashCommand directives", () => {
     { name: "rejects /model without operator.write", scopes: ["operator.read"], allowed: false },
   ])("$name", async ({ scopes, allowed }) => {
     const request = vi.fn(async () => createResolvedModelPatch("gpt-5-mini", "openai"));
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
 
     const result = await executeSlashCommand(client, "main", "model", "gpt-5-mini", {
       sessionAccessSnapshot: restrictedSnapshot(client, ["sessions.patch"], scopes),
@@ -165,7 +157,7 @@ describe("executeSlashCommand directives", () => {
   });
 
   it("defers slash-command model cache publication to the captured chat owner", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(vi.fn());
     const patch = vi
       .fn()
       .mockResolvedValue(
@@ -174,7 +166,7 @@ describe("executeSlashCommand directives", () => {
     const setModelOverride = vi.fn();
     const ownsModelOverride = vi.fn(() => true);
     const sessions = {
-      ...createSessionCapability(client),
+      ...createTestSessionCapability(client),
       patch,
       setModelOverride,
     } as SessionCapability;
@@ -205,10 +197,10 @@ describe("executeSlashCommand directives", () => {
   });
 
   it("does not publish a slash-command model cache value after its owner retires", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(vi.fn());
     const setModelOverride = vi.fn();
     const sessions = {
-      ...createSessionCapability(client),
+      ...createTestSessionCapability(client),
       patch: vi
         .fn()
         .mockResolvedValue(
@@ -247,7 +239,7 @@ describe("executeSlashCommand directives", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     let current = true;
 
     const pending = executeSlashCommand(client, "agent:main:main", "think", "high", {
@@ -281,7 +273,7 @@ describe("executeSlashCommand directives", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     let snapshot: Pick<ApplicationGatewaySnapshot, "client" | "hello" | "phase"> = {
       client,
       phase: "connected" as const,
@@ -330,12 +322,7 @@ describe("executeSlashCommand directives", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
-    const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
-      "main",
-      "model",
-      "",
-    );
+    const result = await executeSlashCommand(createTestGatewayClient(request), "main", "model", "");
 
     expect(result.content).toBe(
       [
@@ -365,7 +352,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "",
@@ -418,7 +405,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "model",
       "",
@@ -449,7 +436,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "model",
       "",
@@ -481,7 +468,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "model",
       "",
@@ -533,7 +520,7 @@ describe("executeSlashCommand directives", () => {
     };
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "model",
       "",
@@ -567,7 +554,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "gpt-5-mini",
@@ -594,16 +581,10 @@ describe("executeSlashCommand directives", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
-    await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
-      "global",
-      "model",
-      "gpt-5-mini",
-      {
-        agentId: "work",
-        chatModelCatalog: [{ id: "gpt-5-mini", name: "gpt-5-mini", provider: "openai" }],
-      },
-    );
+    await executeSlashCommand(createTestGatewayClient(request), "global", "model", "gpt-5-mini", {
+      agentId: "work",
+      chatModelCatalog: [{ id: "gpt-5-mini", name: "gpt-5-mini", provider: "openai" }],
+    });
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "global",
@@ -620,13 +601,9 @@ describe("executeSlashCommand directives", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
-    await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
-      "global",
-      "compact",
-      "",
-      { agentId: "work" },
-    );
+    await executeSlashCommand(createTestGatewayClient(request), "global", "compact", "", {
+      agentId: "work",
+    });
 
     expect(request).toHaveBeenCalledWith("sessions.compact", {
       key: "global",
@@ -647,7 +624,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "compact",
       "",
@@ -676,7 +653,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "gpt-5-mini",
@@ -703,7 +680,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "deepseek-chat",
@@ -724,7 +701,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "google/gemma-4-26b-a4b-it",
@@ -758,7 +735,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "gpt-5-mini",
@@ -782,7 +759,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "nvidia/moonshotai/kimi-k2.5",
@@ -803,7 +780,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "main",
       "model",
       "gpt-5-mini",
@@ -835,12 +812,7 @@ describe("executeSlashCommand directives", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
-    const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
-      "main",
-      "usage",
-      "",
-    );
+    const result = await executeSlashCommand(createTestGatewayClient(request), "main", "usage", "");
 
     expect(result.content).toBe(
       [
@@ -875,7 +847,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "usage",
       "",
@@ -912,7 +884,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "usage",
       "",
@@ -947,7 +919,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "",
@@ -990,23 +962,17 @@ describe("executeSlashCommand directives", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
-    await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
-      "agent:work:main",
-      "think",
-      "",
-      {
-        agentId: "work",
-        chatModelCatalog: [
-          {
-            id: "work-model",
-            name: "Work Model",
-            provider: "openai",
-            reasoning: true,
-          },
-        ],
-      },
-    );
+    await executeSlashCommand(createTestGatewayClient(request), "agent:work:main", "think", "", {
+      agentId: "work",
+      chatModelCatalog: [
+        {
+          id: "work-model",
+          name: "Work Model",
+          provider: "openai",
+          reasoning: true,
+        },
+      ],
+    });
 
     expect(request).toHaveBeenCalledWith("sessions.list", { agentId: "work" });
   });
@@ -1028,7 +994,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "think",
       "",
@@ -1067,7 +1033,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "think",
       "",
@@ -1106,13 +1072,13 @@ describe("executeSlashCommand directives", () => {
     });
 
     const minimal = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "minimal",
     );
     const xhigh = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "xhigh",
@@ -1141,7 +1107,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "default",
@@ -1199,31 +1165,31 @@ describe("executeSlashCommand directives", () => {
     });
 
     const status = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "",
     );
     const setXhigh = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "xhigh",
     );
     const setMax = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "max",
     );
     const setMaximum = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "maximum",
     );
     const setAdaptive = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "auto",
@@ -1303,13 +1269,13 @@ describe("executeSlashCommand directives", () => {
     });
 
     const status = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "",
     );
     const setMax = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "max",
@@ -1366,7 +1332,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const status = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "",
@@ -1408,7 +1374,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const status = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "think",
       "",
@@ -1435,7 +1401,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "verbose",
       "",
@@ -1461,7 +1427,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "",
@@ -1491,7 +1457,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "",
@@ -1526,7 +1492,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "",
@@ -1548,7 +1514,7 @@ describe("executeSlashCommand directives", () => {
     const request = vi.fn().mockResolvedValue({ ok: true });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "on",
@@ -1565,7 +1531,7 @@ describe("executeSlashCommand directives", () => {
     const request = vi.fn().mockResolvedValue({ ok: true });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "auto",
@@ -1587,7 +1553,7 @@ describe("executeSlashCommand directives", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "fast",
       "default",
@@ -1615,7 +1581,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "try a different approach",
@@ -1650,7 +1616,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "continue with the smaller fix",
@@ -1688,7 +1654,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "continue safely",
@@ -1710,7 +1676,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "try a different approach",
@@ -1739,7 +1705,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
       });
 
       const result = await executeSlashCommand(
-        { request } as unknown as GatewayBrowserClient,
+        createTestGatewayClient(request),
         "agent:main:main",
         "steer",
         "try a different approach",
@@ -1765,7 +1731,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "global",
       "steer",
       "try a different approach",
@@ -1795,7 +1761,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:work:main",
       "steer",
       "try the alias",
@@ -1821,7 +1787,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "researcher try a different approach",
@@ -1858,7 +1824,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "all good now",
@@ -1888,7 +1854,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "main refine the plan",
@@ -1921,7 +1887,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "researcher try again",
@@ -1943,7 +1909,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "try again",
@@ -1958,7 +1924,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     const request = vi.fn();
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "",
@@ -1977,7 +1943,7 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "steer",
       "try again",
@@ -2002,7 +1968,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "start over with a new plan",
@@ -2025,7 +1991,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "start over with a new plan",
@@ -2047,7 +2013,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "start over with a new plan",
@@ -2066,7 +2032,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "global",
       "redirect",
       "start over",
@@ -2091,7 +2057,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "researcher start over completely",
@@ -2109,7 +2075,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     const request = vi.fn();
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "",
@@ -2128,7 +2094,7 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     });
 
     const result = await executeSlashCommand(
-      { request } as unknown as GatewayBrowserClient,
+      createTestGatewayClient(request),
       "agent:main:main",
       "redirect",
       "try again",

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -1,6 +1,12 @@
 import { vi } from "vitest";
+import type { ModelCatalogEntry } from "../../api/types.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
+import {
+  createGatewayRequestMock,
+  createTestGatewayClient,
+  type GatewayRequestMock,
+} from "../../test-helpers/gateway-client.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatComposerMemoryFallback } from "./chat-state-host.ts";
@@ -8,8 +14,8 @@ import type { RenderLifecycle } from "./render-lifecycle.ts";
 
 type RequestHandlers = Record<string, unknown>;
 
-export function makeRequestMock(handlers: RequestHandlers = {}) {
-  return vi.fn((method: string, params?: unknown) => {
+export function makeRequestMock(handlers: RequestHandlers = {}): GatewayRequestMock {
+  return createGatewayRequestMock((method: string, params?: unknown) => {
     if (!Object.hasOwn(handlers, method)) {
       // Keep unrelated Gateway traffic inert so each test declares only the responses it observes.
       return Promise.resolve({});
@@ -26,10 +32,6 @@ export function makeRequestMock(handlers: RequestHandlers = {}) {
 
 type RequestMock = ReturnType<typeof makeRequestMock>;
 
-function clientWithRequest(request: unknown): ChatHost["client"] {
-  return { request } as unknown as ChatHost["client"];
-}
-
 type TestChatHost = Omit<ChatHost, "settings"> & {
   applySettings: (patch: Partial<UiSettings>) => void;
   basePath: string;
@@ -38,6 +40,8 @@ type TestChatHost = Omit<ChatHost, "settings"> & {
   chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;
   chatAvatarReason?: string | null;
   chatComposerFallbackByScope: Record<string, ChatComposerMemoryFallback>;
+  chatModelCatalog: ModelCatalogEntry[];
+  chatModelSwitchPromises?: Record<string, Promise<boolean>>;
   sessionsError?: string | null;
   sessionsResultAgentId?: string | null;
   sessionsArchivedFilter?: "active" | "archived" | "all";
@@ -103,7 +107,7 @@ export function makeChatHost(
     },
   };
   const host = {
-    client: request ? clientWithRequest(request) : null,
+    client: request ? createTestGatewayClient(request) : null,
     chatMessages: [],
     chatDisplayedLeafEntryId: undefined,
     chatStream: null,

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -14,6 +14,10 @@ import {
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
 import { createResolvedModelPatch } from "../../test-helpers/chat-model.ts";
+import {
+  createTestGatewayClient,
+  type GatewayRequestHandler,
+} from "../../test-helpers/gateway-client.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
@@ -53,12 +57,12 @@ import {
 type ExecuteSlashCommand = typeof executeSlashCommand;
 type TestChatHost = ReturnType<typeof makeChatHost>;
 
-function clientWithRequest(request: unknown): ChatHost["client"] {
-  return { request } as unknown as ChatHost["client"];
+function clientWithRequest(request: GatewayRequestHandler): NonNullable<ChatHost["client"]> {
+  return createTestGatewayClient(request);
 }
 
 function asChatPageHost(host: TestChatHost): ChatPageHost {
-  return host as unknown as ChatPageHost;
+  return host as ChatPageHost;
 }
 
 function requireChatMessageCache(host: ChatHost): ChatMessageCache {
@@ -206,6 +210,12 @@ function requestUrl(input: string | URL | Request): string {
     return input.toString();
   }
   return input.url;
+}
+
+function createJsonResponse(body: unknown, options: { ok?: boolean } = {}): Response {
+  const response = new Response(null, { status: options.ok === false ? 500 : 200 });
+  response.json = async () => await body;
+  return response;
 }
 
 type MockCallSource = {
@@ -811,24 +821,24 @@ describe("refreshChatAvatar", () => {
       },
     );
     const metadataUrl = `${basePath.replace(/\/$/, "")}/avatar/main?meta=1`;
-    const fetchMock = vi.fn((input: string | URL | Request) => {
+    const fetchMock = vi.fn<typeof fetch>((input: string | URL | Request) => {
       const url = requestUrl(input);
       if (url === metadataUrl) {
-        return Promise.resolve({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) });
+        return Promise.resolve(createJsonResponse({ avatarUrl: "/avatar/main" }));
       }
       if (url === "/avatar/main") {
-        return Promise.resolve({ ok: true, blob: async () => new Blob(["avatar"]) });
+        return Promise.resolve(new Response(new Blob(["avatar"])));
       }
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubGlobal("fetch", fetchMock);
     const host = makeChatHost({ basePath, sessionKey: "agent:main", ...overrides });
 
     await refreshChatAvatar(host);
 
     for (const [index, url] of [metadataUrl, "/avatar/main"].entries()) {
-      expect(fetchUrl(fetchMock as unknown as MockCallSource, index)).toBe(url);
-      const init = fetchInit(fetchMock as unknown as MockCallSource, index);
+      expect(fetchUrl(fetchMock, index)).toBe(url);
+      const init = fetchInit(fetchMock, index);
       expect(init.method).toBe("GET");
       if (expectedToken) {
         expect(init.headers).toEqual({ Authorization: `Bearer ${expectedToken}` });
@@ -841,31 +851,29 @@ describe("refreshChatAvatar", () => {
     expect(host.chatAvatarUrl).toBe(objectUrl);
   });
   it("keeps mounted dashboard avatar endpoints under the normalized base path", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: false,
-      json: async () => ({}),
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createJsonResponse({}, { ok: false }));
+    vi.stubGlobal("fetch", fetchMock);
 
     const host = makeChatHost({ basePath: "/openclaw/", sessionKey: "agent:ops:main" });
     await refreshChatAvatar(host);
 
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/openclaw/avatar/ops?meta=1");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).method).toBe("GET");
+    expect(fetchUrl(fetchMock, 0)).toBe("/openclaw/avatar/ops?meta=1");
+    expect(fetchInit(fetchMock, 0).method).toBe("GET");
     expect(host.chatAvatarUrl).toBeNull();
   });
 
   it("drops remote avatar metadata so the control UI can rely on same-origin images only", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      createJsonResponse({
         avatarUrl: "https://example.com/avatar.png",
         avatarSource: "https://example.com/avatar.png",
         avatarStatus: "remote",
         avatarReason: null,
       }),
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    );
+    vi.stubGlobal("fetch", fetchMock);
 
     const host = makeChatHost({ basePath: "", sessionKey: "agent:main" });
     await refreshChatAvatar(host);
@@ -876,16 +884,15 @@ describe("refreshChatAvatar", () => {
   });
 
   it("keeps unresolved IDENTITY.md avatar metadata when falling back to the logo", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      createJsonResponse({
         avatarUrl: null,
         avatarSource: "assets/avatars/nova-portrait.png",
         avatarStatus: "none",
         avatarReason: "missing",
       }),
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    );
+    vi.stubGlobal("fetch", fetchMock);
 
     const host = makeChatHost({ basePath: "", sessionKey: "agent:main" });
     await refreshChatAvatar(host);
@@ -931,20 +938,20 @@ describe("refreshChatAvatar", () => {
     const firstRequest = createDeferred<{ avatarUrl?: string }>();
     const opsRequest = createDeferred<{ avatarUrl?: string }>();
     const firstMetadataUrl = `/avatar/${firstAgent}?meta=1`;
-    const fetchMock = vi.fn((input: string | URL | Request) => {
+    const fetchMock = vi.fn<typeof fetch>((input: string | URL | Request) => {
       const url = requestUrl(input);
       if (url === firstMetadataUrl) {
-        return Promise.resolve({ ok: true, json: async () => firstRequest.promise });
+        return Promise.resolve(createJsonResponse(firstRequest.promise));
       }
       if (url === "/avatar/ops?meta=1") {
-        return Promise.resolve({ ok: true, json: async () => opsRequest.promise });
+        return Promise.resolve(createJsonResponse(opsRequest.promise));
       }
       if (url === "/avatar/ops") {
-        return Promise.resolve({ ok: true, blob: async () => new Blob(["avatar"]) });
+        return Promise.resolve(new Response(new Blob(["avatar"])));
       }
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubGlobal("fetch", fetchMock);
     const host = makeChatHost({ basePath: "", ...overrides });
 
     const firstRefresh = refreshChatAvatar(host);
@@ -960,8 +967,8 @@ describe("refreshChatAvatar", () => {
     expect(revokeObjectURL).not.toHaveBeenCalled();
     expect(host.chatAvatarUrl).toBe("blob:ops-avatar");
     for (const [index, url] of [firstMetadataUrl, "/avatar/ops?meta=1", "/avatar/ops"].entries()) {
-      expect(fetchUrl(fetchMock as unknown as MockCallSource, index)).toBe(url);
-      expect(fetchInit(fetchMock as unknown as MockCallSource, index).method).toBe("GET");
+      expect(fetchUrl(fetchMock, index)).toBe(url);
+      expect(fetchInit(fetchMock, index).method).toBe("GET");
     }
   });
 });
@@ -1309,11 +1316,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("/reset");
     expect(host.chatMessage).toBe("");
@@ -1445,11 +1448,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe(expected);
     expect(host.chatMessage).toBe("");
@@ -1466,11 +1465,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     const runId = String(payload.idempotencyKey);
     const runState = host as ChatHost & {
       chatStreamStartedAt?: number | null;
@@ -1744,11 +1739,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("use the newly selected model");
     expect(host.chatMessage).toBe("");
@@ -1782,7 +1773,7 @@ describe("handleSendChat", () => {
       chatMessage: "use the new reasoning and speed",
       sessionsResult,
     });
-    const settingsHost = host as unknown as Parameters<typeof switchChatThinkingLevel>[0];
+    const settingsHost: Parameters<typeof switchChatThinkingLevel>[0] = host;
 
     const thinkingPatch = switchChatThinkingLevel(settingsHost, "high");
     const fastModePatch = switchChatFastMode(settingsHost, "on");
@@ -1809,11 +1800,7 @@ describe("handleSendChat", () => {
 
     fastModeUpdate.resolve({});
     await Promise.all([fastModePatch, send]);
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload).toMatchObject({
       message: "use the new reasoning and speed",
       sessionKey: "agent:main",
@@ -2130,7 +2117,7 @@ describe("handleSendChat", () => {
       sessions: settingsPane.sessions,
       sessionsResult,
     });
-    const settingsHost = settingsPane as unknown as Parameters<typeof switchChatThinkingLevel>[0];
+    const settingsHost: Parameters<typeof switchChatThinkingLevel>[0] = settingsPane;
 
     const thinkingPatch = switchChatThinkingLevel(settingsHost, "high");
     const send = handleSendChat(sendPane);
@@ -2146,9 +2133,7 @@ describe("handleSendChat", () => {
     await Promise.all([thinkingPatch, send]);
 
     expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
-    expect(
-      findRequestPayload(request as unknown as MockCallSource, "chat.send", "chat send payload"),
-    ).toMatchObject({
+    expect(findRequestPayload(request, "chat.send", "chat send payload")).toMatchObject({
       message: "wait for the other pane",
       sessionKey: "agent:work:home",
     });
@@ -2330,7 +2315,7 @@ describe("handleSendChat", () => {
       sessionsResult,
     });
     vi.spyOn(host.sessions, "patch").mockResolvedValue(null);
-    const settingsHost = host as unknown as Parameters<typeof switchChatThinkingLevel>[0];
+    const settingsHost: Parameters<typeof switchChatThinkingLevel>[0] = host;
 
     const thinkingPatch = switchChatThinkingLevel(settingsHost, "high");
     const send = handleSendChat(host);
@@ -2368,11 +2353,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("send this");
     expect(host.chatMessage).toBe("keep typing");
@@ -2408,11 +2389,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("send this");
     const attachments = payload.attachments as Array<Record<string, unknown>>;
     expect(attachments).toHaveLength(1);
@@ -2466,11 +2443,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("send this");
     const attachments = payload.attachments as Array<Record<string, unknown>>;
     expect(attachments).toHaveLength(1);
@@ -2515,11 +2488,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("send this");
     const attachments = payload.attachments as Array<Record<string, unknown>>;
     expect(attachments).toHaveLength(1);
@@ -2555,11 +2524,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("summarize this");
     expect(payload.attachments).toStrictEqual([
       {
@@ -2587,11 +2552,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.sessionKey).toBe("agent:main:matrix:group:!room:Example");
     expect(payload.message).toBe("send in other session");
     otherSessionSwitch.resolve(false);
@@ -2896,11 +2857,7 @@ describe("handleSendChat", () => {
     switchUpdate.resolve(true);
     await send;
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("wait for selected model");
   });
 
@@ -3192,10 +3149,7 @@ describe("handleSendChat", () => {
   it("keeps slash-command model changes in sync with the chat header cache", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        json: async () => ({}),
-      }) as unknown as typeof fetch,
+      vi.fn<typeof fetch>().mockResolvedValue(createJsonResponse({}, { ok: false })),
     );
 
     const refreshCurrentSessionTools = vi.fn();
@@ -3319,11 +3273,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "approval command payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "approval command payload");
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("/approve approval-123 allow-once");
     expect(payload.deliver).toBe(false);
@@ -3830,11 +3780,7 @@ describe("handleSendChat", () => {
     await handleSendChat(host);
 
     await waitForFast(() => expect(host.request).toHaveBeenCalled());
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
     expect(payload.message).toBe("use the live server mode");
     expect(payload).not.toHaveProperty("queueMode");
   });
@@ -5858,7 +5804,7 @@ describe("handleSendChat", () => {
       },
     });
     const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
+      host.request,
       "skills.proposals.requestRevision",
       "revision request payload",
     );
@@ -5979,7 +5925,7 @@ describe("handleSendChat", () => {
     await Promise.resolve();
 
     const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
+      host.request,
       "skills.proposals.requestRevision",
       "revision slash payload",
     );
@@ -6775,11 +6721,7 @@ describe("handleSendChat", () => {
     host.connected = true;
     await retryReconnectableQueuedChatSends(host);
 
-    const payload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "chat.send",
-      "queued global send payload",
-    );
+    const payload = findRequestPayload(request, "chat.send", "queued global send payload");
     expect(payload.sessionKey).toBe("global");
     expect(payload.agentId).toBe("work");
     expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
@@ -6824,9 +6766,7 @@ describe("handleSendChat", () => {
     host.connected = true;
     await retryReconnectableQueuedChatSends(host);
 
-    expect(
-      findRequestPayload(request as unknown as MockCallSource, "chat.send", "canonical alias"),
-    ).toMatchObject({
+    expect(findRequestPayload(request, "chat.send", "canonical alias")).toMatchObject({
       agentId: "work",
       message: "survive alias canonicalization",
       sessionKey: "global",
@@ -7134,7 +7074,7 @@ describe("handleSendChat", () => {
 
     expect(
       findRequestPayload(
-        host.request as unknown as MockCallSource,
+        host.request,
         "skills.proposals.requestRevision",
         "revision retry payload",
       ),
@@ -7303,9 +7243,10 @@ describe("handleSendChat", () => {
 
     await retryReconnectableQueuedChatSends(host);
 
-    expect(
-      findRequestPayload(host.request as unknown as MockCallSource, "chat.send", "tail"),
-    ).toMatchObject({ idempotencyKey: "reconnect-tail-run", message: "safe automatic tail" });
+    expect(findRequestPayload(host.request, "chat.send", "tail")).toMatchObject({
+      idempotencyKey: "reconnect-tail-run",
+      message: "safe automatic tail",
+    });
     expect(host.chatQueue.map((item) => item.id)).toEqual(["manual-head"]);
   });
 
@@ -7372,11 +7313,7 @@ describe("handleSendChat", () => {
     host.connected = true;
     await retryReconnectableQueuedChatSends(host);
 
-    const payload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "chat.send",
-      "queued global send payload",
-    );
+    const payload = findRequestPayload(request, "chat.send", "queued global send payload");
     expect(payload.sessionKey).toBe("global");
     expect(payload.agentId).toBe("work");
     expect(loadChatComposerSnapshot({ ...host, assistantAgentId: "main" }, "global")).toBeNull();
@@ -7432,7 +7369,7 @@ describe("handleSendChat", () => {
       chatMessage: "stay on this branch",
     });
 
-    await loadChatBranches(host as unknown as Parameters<typeof loadChatBranches>[0]);
+    await loadChatBranches(host);
     expect(host.chatBranches).toEqual([
       expect.objectContaining({ leafEntryId: "leaf-server-new", active: true }),
     ]);
@@ -7440,9 +7377,9 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(
-      findRequestPayload(host.request as unknown as MockCallSource, "chat.send", "foreground send"),
-    ).toMatchObject({ expectedLeafEntryId: "leaf-rendered" });
+    expect(findRequestPayload(host.request, "chat.send", "foreground send")).toMatchObject({
+      expectedLeafEntryId: "leaf-rendered",
+    });
   });
 
   it("attaches an authoritative empty displayed leaf to a foreground send", async () => {
@@ -7459,9 +7396,10 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(
-      findRequestPayload(host.request as unknown as MockCallSource, "chat.send", "empty-leaf send"),
-    ).toHaveProperty("expectedLeafEntryId", null);
+    expect(findRequestPayload(host.request, "chat.send", "empty-leaf send")).toHaveProperty(
+      "expectedLeafEntryId",
+      null,
+    );
   });
 
   it("waits for terminal history reconciliation before sending a follow-up", async () => {
@@ -7477,7 +7415,7 @@ describe("handleSendChat", () => {
       chatDisplayedLeafEntryId: "leaf-before-terminal",
       chatMessage: "immediate follow-up",
     });
-    const historyLoad = loadChatHistory(host as unknown as Parameters<typeof loadChatHistory>[0]);
+    const historyLoad = loadChatHistory(host);
 
     const sending = handleSendChat(host);
     await Promise.resolve();
@@ -7495,9 +7433,9 @@ describe("handleSendChat", () => {
     await Promise.all([historyLoad, sending]);
 
     expect(sendsBeforeHistory).toBe(0);
-    expect(
-      findRequestPayload(host.request as unknown as MockCallSource, "chat.send", "follow-up send"),
-    ).toMatchObject({ expectedLeafEntryId: "leaf-after-terminal" });
+    expect(findRequestPayload(host.request, "chat.send", "follow-up send")).toMatchObject({
+      expectedLeafEntryId: "leaf-after-terminal",
+    });
   });
 
   it("omits the active leaf when draining a restored outbox", async () => {
@@ -7525,9 +7463,9 @@ describe("handleSendChat", () => {
 
     await retryReconnectableQueuedChatSends(host);
 
-    expect(
-      findRequestPayload(request as unknown as MockCallSource, "chat.send", "restored send"),
-    ).not.toHaveProperty("expectedLeafEntryId");
+    expect(findRequestPayload(request, "chat.send", "restored send")).not.toHaveProperty(
+      "expectedLeafEntryId",
+    );
   });
 
   it("preserves a foreground leaf past an earlier outbox row", async () => {
@@ -7665,9 +7603,9 @@ describe("handleSendChat", () => {
     host.chatMessage = "after clear";
     await handleSendChat(host);
 
-    expect(
-      findRequestPayload(host.request as unknown as MockCallSource, "chat.send", "post-clear send"),
-    ).not.toHaveProperty("expectedLeafEntryId");
+    expect(findRequestPayload(host.request, "chat.send", "post-clear send")).not.toHaveProperty(
+      "expectedLeafEntryId",
+    );
   });
 
   it("preserves the replacement route leaf when post-clear history resolves late", async () => {
@@ -8073,11 +8011,7 @@ describe("handleSendChat", () => {
 
     await steerQueuedChatMessage(host, "queued-1");
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "steered chat send payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "steered chat send payload");
     const idempotencyKey = payload.idempotencyKey;
     expect(typeof idempotencyKey).toBe("string");
     expect(uuidPattern.test(idempotencyKey as string)).toBe(true);
@@ -8121,11 +8055,7 @@ describe("handleSendChat", () => {
 
     await steerQueuedChatMessage(host, original.id);
 
-    const payload = findRequestPayload(
-      host.request as unknown as MockCallSource,
-      "chat.send",
-      "session-row steer payload",
-    );
+    const payload = findRequestPayload(host.request, "chat.send", "session-row steer payload");
     expect(payload).toMatchObject({
       sessionKey: "agent:main:main",
       message: "tighten the plan",
@@ -8218,7 +8148,7 @@ describe("handleSendChat", () => {
       ],
     });
 
-    await loadChatHistory(host as unknown as Parameters<typeof loadChatHistory>[0]);
+    await loadChatHistory(host);
 
     expect(host.chatMessages).toEqual([historyUser]);
     expect(host.chatQueue).toEqual([]);
@@ -8254,7 +8184,7 @@ describe("handleSendChat", () => {
       ],
     });
 
-    await loadChatHistory(host as unknown as Parameters<typeof loadChatHistory>[0]);
+    await loadChatHistory(host);
 
     expect(host.chatMessages).toHaveLength(1);
     expect(host.chatQueue).toEqual([]);
@@ -8287,7 +8217,7 @@ describe("handleSendChat", () => {
       chatQueue: [inflight],
     });
 
-    await loadChatHistory(host as unknown as Parameters<typeof loadChatHistory>[0]);
+    await loadChatHistory(host);
 
     expect(host.chatQueue).toEqual([inflight]);
   });
@@ -9704,7 +9634,7 @@ describe("handleAbortChat", () => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
     const sessionKey = "agent:main:openclaw-weixin:direct:wechat-user";
     const host = makeChatHost({
-      client: { request } as unknown as ChatHost["client"],
+      client: clientWithRequest(request),
       chatRunId: null,
       chatMessage: "/stop",
       sessionKey,
@@ -9726,7 +9656,7 @@ describe("handleAbortChat", () => {
   it("keeps selected global aborts on the compatible key-only request", async () => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
     const host = makeChatHost({
-      client: { request } as unknown as ChatHost["client"],
+      client: clientWithRequest(request),
       chatRunId: null,
       chatMessage: "/stop",
       sessionKey: "global",
@@ -9767,7 +9697,7 @@ describe("handleAbortChat", () => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
     const sessionKey = "agent:work:main";
     const host = makeChatHost({
-      client: { request } as unknown as ChatHost["client"],
+      client: clientWithRequest(request),
       chatRunId: null,
       sessionKey,
       agentsList: { defaultId: "main", mainKey: "main", scope },
@@ -9829,7 +9759,7 @@ describe("handleAbortChat", () => {
 
   it("queues a typed exact-run stop while disconnected", async () => {
     const request = vi.fn();
-    const client = { request } as unknown as NonNullable<ChatHost["client"]>;
+    const client = clientWithRequest(request);
     const host = makeChatHost({
       client,
       connected: false,
@@ -9850,7 +9780,7 @@ describe("handleAbortChat", () => {
   });
 
   it("queues the active run abort while disconnected", async () => {
-    const client = { request: vi.fn() } as unknown as NonNullable<ChatHost["client"]>;
+    const client = clientWithRequest(vi.fn());
     const host = makeChatHost({
       client,
       connected: false,
@@ -9871,7 +9801,7 @@ describe("handleAbortChat", () => {
   });
 
   it("preserves the draft when queueing a toolbar abort while disconnected", async () => {
-    const client = { request: vi.fn() } as unknown as NonNullable<ChatHost["client"]>;
+    const client = clientWithRequest(vi.fn());
     const host = makeChatHost({
       client,
       connected: false,
@@ -9893,7 +9823,7 @@ describe("handleAbortChat", () => {
 
   it("does not queue an unversioned session stop while disconnected", async () => {
     const request = vi.fn();
-    const client = { request } as unknown as NonNullable<ChatHost["client"]>;
+    const client = clientWithRequest(request);
     const sessionKey = "agent:main:telegram:direct:queued-user";
     const host = makeChatHost({
       client,
@@ -9916,7 +9846,7 @@ describe("handleAbortChat", () => {
 
   it("does not queue an unversioned global stop while disconnected", async () => {
     const request = vi.fn();
-    const client = { request } as unknown as NonNullable<ChatHost["client"]>;
+    const client = clientWithRequest(request);
     const host = makeChatHost({
       client,
       connected: false,

--- a/ui/src/test-helpers/gateway-client.ts
+++ b/ui/src/test-helpers/gateway-client.ts
@@ -1,0 +1,19 @@
+import { vi, type Mock } from "vitest";
+import { GatewayBrowserClient } from "../api/gateway.ts";
+
+export type GatewayRequestHandler = (method: string, params?: unknown) => unknown;
+
+export type GatewayRequestMock = Mock<GatewayRequestHandler>;
+
+export function createGatewayRequestMock(
+  implementation: GatewayRequestHandler = async () => ({}),
+): GatewayRequestMock {
+  return vi.fn(implementation);
+}
+
+export function createTestGatewayClient(request: GatewayRequestHandler): GatewayBrowserClient {
+  const client = new GatewayBrowserClient({ url: "ws://test.invalid" });
+  client.request = async <T = unknown>(method: string, params?: unknown): Promise<T> =>
+    (await request(method, params)) as T;
+  return client;
+}


### PR DESCRIPTION
## What Problem This Solves

The densest test fixtures repeatedly erased their real types with `as unknown as`, making contract drift invisible and teaching future tests to copy unsafe setup patterns.

## Why This Change Was Made

This pilot replaces those repeated chains with typed fixture builders at the owning test-support boundaries: the shared plugin runtime, Telegram API and keyed-store mocks, TUI backend/session fixtures, and Control UI gateway/chat hosts. Existing assertions and test behavior are preserved; the two remaining chains intentionally inject invalid Telegram reply IDs for negative coverage.

## User Impact

No user-visible runtime behavior changes. Contributors get reusable, compiler-checked fixture patterns in the repo's highest-density test clusters.

## Evidence

| Cluster | Chained assertions | Tests before → after |
| --- | ---: | ---: |
| Plugin runtime mock | 114 → 0 | 11 → 11 |
| Telegram send + bot | 141 → 2 intentional negative inputs | 386 → 386 |
| TUI session actions | 94 → 0 | 73 → 73 |
| Control UI chat | 129 → 0 | 363 → 363 |
| Total | 478 → 2 | unchanged |

- `node scripts/run-vitest.mjs` passed every target suite; adjacent Telegram command-menu coverage also passed after the shared mock was tightened.
- Final rebased-head rerun: plugin runtime 11/11, TUI 73/73, Control UI 364/364, and Telegram send/bot/command-menu 389/389. The original pre-rebase before/after counts in the table prove this patch dropped no tests; upstream added/reorganized cases while the branch was open.
- `node scripts/check-changed.mjs` passed all selected lanes locally after the remote CI-fast backend was unavailable: core, core tests, UI, extensions, extension tests, lint, SDK/boundary, and repository guards.
- `pnpm plugin-sdk:surface:check` passed; the changed plugin runtime helper remains local-only test support and does not alter the shipped SDK surface.
- ClawSweeper's rank-up move is applied: every Telegram API override is mapped to its exact grammY method signature; the one intentionally malformed Bot API response uses an explicitly named invalid-result helper.
- ClawSweeper's final exact-head inspection gap is closed by installed-dependency proof on `bfb414f4b4f6a2e3d5e76a254c420b53867e7790`: extension-test typecheck, Telegram send tests, and the complete Testbox `check-changed` matrix all passed against the installed grammY declarations.
- Exact anti-slop scan reports only the two documented invalid reply-ID inputs.
- Production LOC: `+0/-0`; test and test-support LOC: `+1246/-1296` (net `-50`).
- Autoreview: clean, no accepted/actionable findings (`--mode branch --base origin/main`).
