### PR TITLE
fix(update): bound automatic dev update attempts

### DIFF
--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1517,6 +1517,50 @@ describe("update-startup", () => {
     );
   });
 
+  it("keeps a new dev target visible during the automatic attempt cooldown", async () => {
+    writePersistedUpdateCheckState({
+      autoLastAttemptVersion: "upstream-one",
+      autoLastAttemptAt: new Date(Date.now()).toISOString(),
+    });
+    mockDevGitStatus({ upstreamSha: "upstream-two", behind: 3 });
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+    const cfg = { update: { channel: "dev" as const, auto: { enabled: true } } };
+
+    await runGatewayUpdateCheck({
+      cfg,
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      activeWorkInspectors: idleActiveWorkInspectors(),
+      runAutoUpdate,
+    });
+
+    expect(getUpdateAvailable()).toMatchObject({ upstreamSha: "upstream-two" });
+    expect(getUpdateSchedule()?.target).toMatchObject({ upstreamSha: "upstream-two" });
+    expect(getUpdateSchedule()?.campaign).toBeUndefined();
+    expect(runAutoUpdate).not.toHaveBeenCalled();
+
+    vi.setSystemTime(Date.now() + 60 * 60 * 1000 + 1);
+    await runGatewayUpdateCheck({
+      cfg,
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      activeWorkInspectors: idleActiveWorkInspectors(),
+      runAutoUpdate,
+    });
+
+    expect(getUpdateSchedule()?.campaign?.state).toBe("countdown");
+    expect(runAutoUpdate).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runAutoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "dev",
+        devTarget: expect.objectContaining({ upstreamSha: "upstream-two" }),
+      }),
+    );
+  });
+
   it("supersedes and clears dev git campaigns from fresh git facts", async () => {
     mockDevGitStatus({ upstreamSha: "upstream-one" });
     const runAutoUpdate = createAutoUpdateSuccessMock();

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -1130,7 +1130,6 @@ export async function runGatewayUpdateCheck(params: {
     if (shouldRunAutoUpdate && canRunTrackedDevCampaign) {
       const lastAttemptAt = state.autoLastAttemptAt ? Date.parse(state.autoLastAttemptAt) : null;
       const recentAttempt =
-        state.autoLastAttemptVersion === upstreamSha &&
         lastAttemptAt != null &&
         Number.isFinite(lastAttemptAt) &&
         now - lastAttemptAt < ONE_HOUR_MS;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automatic dev updates could repeatedly start a long build after gateway restarts whenever `main` advanced to a new SHA. The previous same-SHA cooldown treated each newly advanced SHA as a fresh automatic attempt, allowing rapid upstream movement to bypass the intended one-hour backoff.

## Why This Change Was Made

The cooldown now gates all automatic update attempts for one hour, regardless of target SHA. Update availability remains visible and manual updates remain available while automatic execution waits for the cooldown to expire.

## User Impact

Operators on the dev channel no longer get repeated long automatic builds across restarts while `main` is advancing. Newly available updates are still reported immediately and can still be applied manually.

## Evidence

- Focused `src/infra/update-startup.test.ts` suite: 73/73 tests passed, including the new cooldown regression.
- Production LOC: -1; tests: +44.
- `git diff --check`: clean.
- Fresh autoreview: clean, with no accepted/actionable findings.
- AI-assisted; maintainer reviewed.
