### PR TITLE
fix(update): remove false dependency staleness

### DIFF
--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -191,9 +191,6 @@ export function formatUpdateOneLiner(update: UpdateCheckResult): string {
     if (update.deps.status === "missing") {
       parts.push("deps missing");
     }
-    if (update.deps.status === "stale") {
-      parts.push("deps stale");
-    }
   }
   return `Update: ${parts.join(" · ")}`;
 }

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -1001,7 +1001,7 @@ describe("checkUpdateStatus", () => {
     },
   );
 
-  it("reports missing and stale dependency markers for package installs", async () => {
+  it("reports a missing dependency marker and accepts an older valid marker", async () => {
     await withTestDir({ prefix: "openclaw-update-check-deps-" }, async (root) => {
       await fs.writeFile(
         path.join(root, "package.json"),
@@ -1031,27 +1031,16 @@ describe("checkUpdateStatus", () => {
       await fs.utimes(markerPath, staleDate, staleDate);
       await fs.utimes(lockfilePath, freshDate, freshDate);
 
-      const stale = await checkUpdateStatus({
+      const installed = await checkUpdateStatus({
         root,
         includeRegistry: false,
         fetchGit: false,
         timeoutMs: 1000,
       });
-      expect(stale.deps).toMatchObject({
+      expect(installed.deps).toMatchObject({
         manager: "pnpm",
-        status: "stale",
-        reason: "lockfile newer than install marker",
+        status: "ok",
       });
-
-      const newerMarker = new Date(Date.now() + 2_000);
-      await fs.utimes(markerPath, newerMarker, newerMarker);
-      const ok = await checkUpdateStatus({
-        root,
-        includeRegistry: false,
-        fetchGit: false,
-        timeoutMs: 1000,
-      });
-      expect(ok.deps?.status).toBe("ok");
     });
   });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -36,7 +36,7 @@ type GitUpdateStatus = {
 
 type DepsStatus = {
   manager: PackageManager;
-  status: "ok" | "missing" | "stale" | "unknown";
+  status: "ok" | "missing" | "unknown";
   lockfilePath: string | null;
   markerPath: string | null;
   reason?: string;
@@ -370,15 +370,6 @@ async function checkGitUpdateStatus(params: {
   };
 }
 
-async function statMtimeMs(p: string): Promise<number | null> {
-  try {
-    const st = await fs.stat(p);
-    return st.mtimeMs;
-  } catch {
-    return null;
-  }
-}
-
 async function resolveDepsMarker(params: { root: string; manager: PackageManager }): Promise<{
   lockfilePath: string | null;
   markerPath: string | null;
@@ -449,25 +440,6 @@ async function checkDepsStatus(params: {
     };
   }
 
-  const lockMtime = await statMtimeMs(lockfilePath);
-  const markerMtime = await statMtimeMs(markerPath);
-  if (!lockMtime || !markerMtime) {
-    return {
-      manager: params.manager,
-      status: "unknown",
-      lockfilePath,
-      markerPath,
-    };
-  }
-  if (lockMtime > markerMtime + 1000) {
-    return {
-      manager: params.manager,
-      status: "stale",
-      lockfilePath,
-      markerPath,
-      reason: "lockfile newer than install marker",
-    };
-  }
   return {
     manager: params.manager,
     status: "ok",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where package installs with a valid lockfile and dependency marker could be reported as stale solely because their filesystem modification times differed.

## Why This Change Was Made

The mtime of `.modules.yaml` or `node_modules` is not a reliable measure of install freshness. Missing lockfile and marker diagnostics remain intact; when both required artifacts exist, status now reports the dependencies as installed.

## User Impact

`openclaw status` no longer reports false dependency staleness for valid installs, while genuinely missing dependency metadata is still surfaced.

## Evidence

- 53 focused tests passed.
- Production LOC: +1/-32 (net -31); tests: +4/-15.
- Format and diff checks are clean.
- Fresh autoreview is clean with no accepted/actionable findings.
