### PR TITLE
perf(test): replace ingress capacity waits

### DIFF
--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -185,6 +185,7 @@ describe("LINE webhook spool", () => {
           activeDeliveries -= 1;
         }
       });
+      const listPending = vi.spyOn(queue, "listPending");
       const spool = createLineWebhookSpool({
         accountId: "default",
         runtime: runtime(),
@@ -203,15 +204,24 @@ describe("LINE webhook spool", () => {
       try {
         await spool.accept({ destination: "destination-1", events: firstBatch });
         await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(8));
-
-        await spool.accept(callback(ninth));
-        // Hold the eight adopted-but-unfinished deliveries across two timer pumps.
         await new Promise<void>((resolve) => {
-          setTimeout(resolve, 1_100);
+          setImmediate(resolve);
         });
+
+        const drainScansBeforeNinth = listPending.mock.calls.length;
+        await spool.accept(callback(ninth));
+        await vi.waitFor(() =>
+          expect(listPending.mock.calls.length).toBeGreaterThan(drainScansBeforeNinth),
+        );
 
         expect(deliver).toHaveBeenCalledTimes(8);
         expect(maxActiveDeliveries).toBe(8);
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({
+            id: "message:message-event-concurrency-8",
+            laneKey: "user:user-8",
+          }),
+        ]);
 
         releaseDeliveries();
         await vi.waitFor(() => expect(activeDeliveries).toBe(0));

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -348,20 +348,31 @@ describe("Microsoft Teams durable ingress", () => {
           active -= 1;
         }
       });
+      const listPending = vi.spyOn(queue, "listPending");
       const ingress = makeIngress(queue, dispatch);
       ingress.start();
       try {
-        for (let index = 0; index < 9; index += 1) {
+        for (let index = 0; index < 8; index += 1) {
           await ingress.accept(
             activity({ id: `activity-concurrency-${index}`, conversationId: `lane-${index}` }),
           );
         }
         await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(8));
         await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
+          setImmediate(resolve);
         });
+
+        const drainScansBeforeNinth = listPending.mock.calls.length;
+        await ingress.accept(activity({ id: "activity-concurrency-8", conversationId: "lane-8" }));
+        await vi.waitFor(() =>
+          expect(listPending.mock.calls.length).toBeGreaterThan(drainScansBeforeNinth),
+        );
+
         expect(dispatch).toHaveBeenCalledTimes(8);
         expect(maxActive).toBe(8);
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({ id: "activity-concurrency-8", laneKey: "lane-8" }),
+        ]);
 
         releaseDeliveries?.();
         await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(9));


### PR DESCRIPTION
## What Problem This Solves

The LINE and Microsoft Teams ingress concurrency regressions wait 1.1 seconds and 600 milliseconds respectively to prove that a ninth durable delivery does not exceed each plugin's eight-delivery cap. The ninth admission already requests an explicit second drain pump, so waiting for periodic timer pumps adds wall time without strengthening the owner-boundary assertion.

## Why This Change Was Made

Replace both elapsed observation windows with deterministic pump and durable-state proof:

- Record the queue scan count after the first eight deliveries occupy every slot.
- Admit the ninth event, which explicitly requests another drain pump.
- Wait until that pump scans the durable queue.
- Assert the ninth event remains pending with its exact event id and lane while only eight deliveries are active.

The real SQLite-backed queue, plugin ingress wrappers, shared monitor, adoption lifecycle, and blocked delivery promises remain. Production behavior is unchanged.

## User Impact

Maintainers get roughly 1.5 seconds faster feedback from these two extension suites without weakening the per-plugin concurrency-cap regression.

## Evidence

Controlled same-Testbox A/B on `tbx_01m05d90rdmy52emrah1vt62vc`, with one excluded warmup and two retained samples per state, the same commands, one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 17.75s | 16.28s | -1.47s (-8.3%) |
| Vitest | 17.61s | 16.14s | -1.47s (-8.4%) |
| Test body | 9.58s | 8.02s | -1.56s (-16.3%) |
| Imports | 4.02s | 4.07s | effectively flat |

CPU and peak RSS were effectively flat/noisy, so this PR makes no resource-usage claim.

Validation:

- LINE and Microsoft Teams focused suites: 29/29 tests passed.
- Capacity tests passed 10/10 repeated focused runs.
- Shared ingress-monitor owner suite: 22/22 tests passed.
- Nextcloud Talk sibling concurrency suite: 13/13 tests passed.
- Mutation proof: changing either plugin's production delivery cap from 8 to 9 makes its rewritten test fail immediately with 9 active deliveries.
- Full post-rebase extension changed gate passed, including typecheck, targeted lint, plugin boundaries, dead exports, formatting, and assertion guards.
- Fresh post-rebase autoreview: no accepted/actionable findings.
- Production LOC: `+0/-0`; test LOC: `+27/-6`.

Benchmark Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/31950863434

Final post-rebase changed gate: https://github.com/openclaw/openclaw/actions/runs/31951565544

AI-assisted: yes. The change and evidence were reviewed by the maintainer agent and fresh structured autoreview.
