### PR TITLE
fix(cron): honor explicit delivery agent ownership

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -94,14 +94,24 @@ vi.mock("../../channels/plugins/message-action-dispatch.js", () => ({
 const TEST_AGENT_WORKSPACE = "/tmp/openclaw-test-workspace";
 let sendHandlers: typeof import("./send.js").sendHandlers;
 
-function resolveAgentIdFromSessionKeyForTests(params: { sessionKey?: string }): string {
+function resolveAgentIdFromSessionKeyForTests(params: {
+  sessionKey?: string;
+  agentId?: string;
+}): string {
+  const explicitAgentId = params.agentId?.trim().toLowerCase();
   if (typeof params.sessionKey === "string") {
     const match = params.sessionKey.match(/^agent:([^:]+)/i);
     if (match?.[1]) {
-      return match[1];
+      const sessionAgentId = match[1].toLowerCase();
+      if (explicitAgentId && explicitAgentId !== sessionAgentId) {
+        throw new Error(
+          `agent "${explicitAgentId}" does not match session key agent "${sessionAgentId}"`,
+        );
+      }
+      return sessionAgentId;
     }
   }
-  return "main";
+  return explicitAgentId ?? "main";
 }
 
 function messageActionContextFromSessionKeyForTests(sessionKey: string): {
@@ -139,11 +149,12 @@ vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
   resolveSessionAgentId: ({
     sessionKey,
+    agentId,
   }: {
     sessionKey?: string;
     config?: unknown;
     agentId?: string;
-  }) => resolveAgentIdFromSessionKeyForTests({ sessionKey }),
+  }) => resolveAgentIdFromSessionKeyForTests({ sessionKey, agentId }),
   resolveAgentConfig: () => undefined,
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: () => TEST_AGENT_WORKSPACE,

--- a/src/infra/outbound/session-context.test.ts
+++ b/src/infra/outbound/session-context.test.ts
@@ -60,20 +60,31 @@ describe("buildOutboundSessionContext", () => {
     expect(resolveSessionAgentIdMock).toHaveBeenCalledWith({
       sessionKey: "session:main:123",
       config: { agents: {} },
+      agentId: undefined,
     });
   });
 
-  it("prefers an explicit trimmed agent id over the derived one", () => {
-    resolveSessionAgentIdMock.mockReturnValueOnce("derived-agent");
+  it("passes explicit ownership when resolving an unscoped session key", () => {
+    resolveSessionAgentIdMock.mockImplementationOnce(({ agentId }: { agentId?: string }) => {
+      if (!agentId) {
+        throw new Error("missing explicit agent ownership");
+      }
+      return agentId;
+    });
 
     expect(
       buildOutboundSessionContext({
-        cfg: {} as never,
-        sessionKey: "session:main:123",
+        cfg: { agents: {} } as never,
+        sessionKey: "cron:job-123:failure",
         agentId: "  explicit-agent  ",
       }),
     ).toEqual({
-      key: "session:main:123",
+      key: "cron:job-123:failure",
+      agentId: "explicit-agent",
+    });
+    expect(resolveSessionAgentIdMock).toHaveBeenCalledWith({
+      sessionKey: "cron:job-123:failure",
+      config: { agents: {} },
       agentId: "explicit-agent",
     });
   });

--- a/src/infra/outbound/session-context.ts
+++ b/src/infra/outbound/session-context.ts
@@ -103,12 +103,9 @@ export function buildOutboundSessionContext(params: {
   const requesterSenderName = normalizeOptionalString(params.requesterSenderName);
   const requesterSenderUsername = normalizeOptionalString(params.requesterSenderUsername);
   const requesterSenderE164 = normalizeOptionalString(params.requesterSenderE164);
-  const derivedAgentId = key
-    ? resolveSessionAgentId({ sessionKey: key, config: params.cfg })
-    : undefined;
-  // Prefer explicit caller ownership, but derive from the canonical session key
-  // so redirected deliveries still get workspace-scoped media policy.
-  const agentId = explicitAgentId ?? derivedAgentId;
+  const agentId = key
+    ? resolveSessionAgentId({ sessionKey: key, config: params.cfg, agentId: explicitAgentId })
+    : explicitAgentId;
   if (
     !key &&
     !policyKey &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unscoped synthetic cron failure keys were resolved before an explicit `job.agentId`, causing delivery session setup to throw in multi-agent configurations.

## Why This Change Was Made

The canonical session-agent resolver now receives explicit job ownership when deriving the delivery session context. This keeps ownership resolution in one path while preserving the existing mismatch checks and session-key derivation behavior.

## User Impact

Cron failure delivery can honor an explicitly owned job in multi-agent configurations instead of failing during session setup.

## Evidence

- Focused session-context suite: 13/13 tests passed.
- Full Gateway send suite: 109/109 tests passed.
- Production LOC: +3/-6 (net -3); tests and test support: +31/-9.
- Fresh autoreview: clean, with no accepted or actionable findings.
- The changed-file gate also reported unrelated assertion-baseline drift in untouched files. Those baselines were not edited; exact-head CI remains required for the final verdict.
