### PR TITLE
fix(gateway): warn on placement session evidence pipeline failure

### DIFF
--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -189,22 +189,12 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         workspacePluginRootPresent,
         context,
       );
-      if (staleDynamicOwner) {
-        // Existing leases retain their immutable snapshot. Publish a distinct owner so their release
-        // cannot delete the replacement generation admitted for new work at the same dynamic key.
-        snapshot = await publishModelRuntimeSnapshot(
-          input,
-          context.owners,
-          context.agentBuildCompletions,
-          context.getBuildTimeoutMs(),
-          undefined,
-          provenance,
-          options.catalogMode,
-          reusablePluginGeneration,
-        );
-      } else if (existing) {
+      if (existing && !staleDynamicOwner) {
         snapshot = await context.prepareSnapshot(input);
       } else {
+        // Fresh keys publish a first generation; stale dynamic owners publish a distinct
+        // replacement owner because existing leases retain their immutable snapshot, so
+        // their release cannot delete the generation admitted for new work at this key.
         snapshot = await publishModelRuntimeSnapshot(
           input,
           context.owners,

--- a/src/gateway/server-worker-placement-session-evidence.test.ts
+++ b/src/gateway/server-worker-placement-session-evidence.test.ts
@@ -1,6 +1,21 @@
 import fsSync from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const evidenceWarnSpy = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../logging/subsystem.js")>("../logging/subsystem.js");
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/placement-session-evidence"
+        ? { ...logger, warn: evidenceWarnSpy }
+        : logger;
+    },
+  };
+});
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -27,6 +42,7 @@ afterEach(() => {
   resetConfigRuntimeState();
   resolveTargetsReadOnlySpy.mockClear();
   readIdentityEvidenceBatchSpy.mockClear();
+  evidenceWarnSpy.mockClear();
 });
 
 function localPlacement(
@@ -205,6 +221,23 @@ describe("worker placement session evidence", () => {
 
       await expect(resolvePlacementEvidence(localPlacement(sessionId, sessionKey))).resolves.toBe(
         "unknown",
+      );
+    });
+  });
+
+  it("warns instead of silently swallowing resolver pipeline failures", async () => {
+    const stateDir = tempDirs.make("openclaw-placement-session-pipeline-failure-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      resolveTargetsReadOnlySpy.mockImplementationOnce(() => {
+        throw new Error("evidence pipeline exploded");
+      });
+      const placement = localPlacement("session-pipeline-failure", "agent:main:pipeline-failure");
+
+      await expect(resolvePlacementEvidence(placement)).resolves.toBe("unknown");
+      expect(evidenceWarnSpy).toHaveBeenCalledOnce();
+      expect(evidenceWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("session evidence resolution failed"),
+        { error: expect.objectContaining({ message: "evidence pipeline exploded" }) },
       );
     });
   });

--- a/src/gateway/server-worker-placement-session-evidence.ts
+++ b/src/gateway/server-worker-placement-session-evidence.ts
@@ -1,6 +1,7 @@
 import { getRuntimeConfig } from "../config/config.js";
 import type { SessionStoreTargetsReadCache } from "../config/sessions/targets-read-availability.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   isIncognitoSessionKey,
   normalizeAgentId,
@@ -14,6 +15,8 @@ import type {
   PlacementSessionEvidence,
   PlacementSessionEvidenceResolver,
 } from "./worker-environments/placement-session-retirement.js";
+
+const log = createSubsystemLogger("gateway/placement-session-evidence");
 
 const loadPlacementSessionEvidenceRuntime = createLazyRuntimeModule(async () => {
   const [sessionTargetsReadAvailability, sessionAccessor] = await Promise.all([
@@ -138,7 +141,12 @@ export async function createWorkerPlacementSessionEvidenceResolver(
       }
     }
     return async (placement) => evidenceByPlacement.get(placement) ?? "unknown";
-  } catch {
+  } catch (error) {
+    // "unknown" keeps retirement fail-open, but a silent catch would hide a broken
+    // evidence pipeline (bad config, store corruption) behind indefinite retention.
+    log.warn("worker placement session evidence resolution failed; treating all as unknown", {
+      error,
+    });
     return async () => "unknown";
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Two gateway-lane findings from the auto-QA admission sweep:

1. `createWorkerPlacementSessionEvidenceResolver` swallowed every pipeline failure into a bare `catch` returning `"unknown"` for all placements. Fail-open is correct for retirement safety, but the silent catch hid a broken evidence pipeline (bad config, store corruption) behind indefinite placement retention with **no operator-visible signal** — the worst bug class per the repo doctrine (action path ending with no visible outcome and no recorded reason).
2. `acquirePreparedModelRuntimeLeaseFromOwners` had two byte-identical `publishModelRuntimeSnapshot` branches (`staleDynamicOwner` and missing-owner) — duplicate policy that invites drift.

## Why This Change Was Made

Record the fact where it happens: the resolver now warns with the error before returning `unknown`, so operators can see a degraded evidence pipeline instead of inferring it from indefinite retention. The lease publish branches collapse into one publication path with the stale-owner invariant comment preserved — same behavior, one owner.

## User Impact

Operators get a `gateway/placement-session-evidence` warn line when evidence resolution breaks, instead of silence. No behavior change otherwise.

## Evidence

- New regression `warns instead of silently swallowing resolver pipeline failures` fails pre-fix (verified via stash/rerun), passes post-fix.
- `node scripts/run-vitest.mjs run src/gateway/server-worker-placement-session-evidence.test.ts src/agents/prepared-model-runtime.lifecycle.test.ts` — 52/52 pass.
- tsgo core + core-test shards green.
- LOC: prod +13/−15 (net −2), test +33.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99 — "lease-branch consolidation preserves prior behavior across stale-owner, existing-owner, and fresh-key cases."
