### PR TITLE
fix(cli): devices approve blames profile mismatch for superseded pairing requests

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -330,16 +330,28 @@ function resolveLocalPairingFallback(
   }
 }
 
-function buildFallbackStateMismatchError(details: ConnectPairingRequiredDetails): Error {
-  return new Error(
-    [
-      details.requestId
-        ? `${FALLBACK_STATE_MISMATCH_MESSAGE} Missing requestId: ${details.requestId}.`
-        : FALLBACK_STATE_MISMATCH_MESSAGE,
-      "The running gateway is probably using a different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR than this CLI.",
-      "Rerun with the same profile/state-dir as the gateway, or pass --token/--password so the CLI can approve through the gateway.",
-    ].join("\n"),
-  );
+function buildFallbackStateMismatchError(
+  details: ConnectPairingRequiredDetails,
+  pendingRequestIds: string[],
+): Error {
+  const heading = details.requestId
+    ? `${FALLBACK_STATE_MISMATCH_MESSAGE} Missing requestId: ${details.requestId}.`
+    : FALLBACK_STATE_MISMATCH_MESSAGE;
+  // A populated local pending list means the CLI and gateway share this store:
+  // each rejected connect re-mints the request, so the held id is stale rather
+  // than foreign. Only an empty list suggests a genuinely different store, and
+  // shared-auth flags are only a fix when the gateway actually uses shared auth.
+  const guidance =
+    pendingRequestIds.length > 0
+      ? [
+          "That request was superseded by a newer pending request.",
+          `Approve the current request instead: openclaw devices approve ${pendingRequestIds[0]}`,
+        ]
+      : [
+          "The running gateway may be using a different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR than this CLI.",
+          "Rerun with the gateway's profile/state-dir; if the gateway uses shared auth, pass --token/--password to approve through it.",
+        ];
+  return new Error([heading, ...guidance].join("\n"));
 }
 
 function assertLocalFallbackMatchesGatewayRequest(
@@ -350,11 +362,11 @@ function assertLocalFallbackMatchesGatewayRequest(
   if (!requestId) {
     return;
   }
-  const hasRequest = (list.pending ?? []).some(
-    (request) => normalizeOptionalString(request.requestId) === requestId,
-  );
-  if (!hasRequest) {
-    throw buildFallbackStateMismatchError(details);
+  const pendingRequestIds = (list.pending ?? [])
+    .map((request) => normalizeOptionalString(request.requestId))
+    .filter((id): id is string => Boolean(id));
+  if (!pendingRequestIds.includes(requestId)) {
+    throw buildFallbackStateMismatchError(details, pendingRequestIds);
   }
 }
 
@@ -473,7 +485,9 @@ async function approvePairingWithFallback(
       if (!hasOriginalPending && !hasGatewayPending) {
         return null;
       }
-      throw buildFallbackStateMismatchError(fallback.details);
+      // Fail-closed replacement validation refused to substitute; do not point
+      // at the incompatible pending id as a recovery step.
+      throw buildFallbackStateMismatchError(fallback.details, []);
     }
     const approved = await approveDevicePairing(requestId, {
       // Local CLI fallback already assumes direct machine access; treat it as an
@@ -482,7 +496,7 @@ async function approvePairingWithFallback(
     });
     if (!approved) {
       if (gatewayRequestId && gatewayRequestId === requestId) {
-        throw buildFallbackStateMismatchError(fallback.details);
+        throw buildFallbackStateMismatchError(fallback.details, []);
       }
       return null;
     }

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -992,7 +992,7 @@ describe("devices cli local fallback", () => {
     expect(readRuntimeOutput()).toContain(fallbackNotice);
   });
 
-  it("refuses local fallback when the gateway request is absent from local pairing state", async () => {
+  it("points at the current pending request when the gateway request id went stale", async () => {
     rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-profile)");
     listDevicePairing.mockResolvedValueOnce({
       pending: [{ requestId: "req-default", deviceId: "device-1", publicKey: "pk", ts: 1 }],
@@ -1000,9 +1000,18 @@ describe("devices cli local fallback", () => {
     });
     summarizeDeviceTokens.mockReturnValue(undefined);
 
-    await expect(runDevicesCommand(["list"])).rejects.toThrow(
-      "different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR",
+    // A populated shared pending list means supersession, not a foreign state
+    // dir — the recovery is the current id, never profile or shared-auth flags.
+    const failure = await runDevicesCommand(["list"]).then(
+      () => {
+        throw new Error("expected devices list to fail");
+      },
+      (error: unknown) => String(error),
     );
+    expect(failure).toContain("superseded by a newer pending request");
+    expect(failure).toContain("openclaw devices approve req-default");
+    expect(failure).not.toContain("OPENCLAW_PROFILE");
+    expect(failure).not.toContain("--token");
     expect(readRuntimeOutput()).not.toContain(fallbackNotice);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed `openclaw devices approve` (or `devices list` local fallback) misdiagnosed its own state: whenever the gateway's pairing `requestId` was not found in the CLI's local pairing store, the error asserted "The running gateway is probably using a different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR" and told the operator to "pass --token/--password" — even on gateways with `auth.mode: "none"` where those flags do nothing, and even in the common case where the CLI and gateway share one store and the held id was merely superseded by a re-minted pending request. Operators chasing a phantom profile mismatch was the dead-end reported in the auth-none self-wedge investigation (follow-up to #124545/#124589, which fixed the wedge itself).

## Why This Change Was Made

The local pending list already distinguishes the two realities. If it has entries, the CLI is reading the same store the gateway wrote — the id went stale through supersession — so the error now names the current pending `requestId` with the exact `openclaw devices approve <id>` command. Only an empty local pending list keeps the profile/state-dir hypothesis, now phrased as a possibility with the shared-auth flags as a conditional ("if the gateway uses shared auth") rather than a prescription. The fail-closed replacement-validation paths deliberately keep the mismatch wording so they never point at an incompatible pending request as a recovery step.

## User Impact

A stale approve id now ends with a copy-pasteable next step instead of sending operators to debug profiles and tokens that were never the problem. Nothing changes about which requests can be approved.

## Evidence

- Updated `src/cli/devices-cli.test.ts`: the stale-id case asserts the supersession message, the exact recovery command, and the absence of `OPENCLAW_PROFILE`/`--token` blame; the empty-store and fail-closed replacement cases keep the mismatch wording. Full `devices-cli` suite green (all tests).
- `tsgo` config-cli shard and type-aware oxlint clean on both files.
- Codex autoreview: no accepted/actionable findings (overall 0.99).

Production LOC: +13/-8 in `src/cli/devices-cli.runtime.ts` (the branch that chooses guidance from the pending list); tests +17/-6.
