### PR TITLE
fix(gateway): join concurrent node worker tunnel starts

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -194,6 +194,30 @@ describe("node worker tunnel manager", () => {
     );
   });
 
+  it("joins same-owner starts while workspace binding resolution is pending", async () => {
+    const record = environment();
+    const workspaceBinding = createDeferred<undefined>();
+    const resolveWorkspaceBinding = vi.fn(async () => await workspaceBinding.promise);
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: transport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: workspaceTransfer(),
+    });
+    manager.bindWorkspaceBindingResolver(resolveWorkspaceBinding);
+
+    const first = manager.start(startRequest());
+    await vi.waitFor(() => expect(resolveWorkspaceBinding).toHaveBeenCalledOnce());
+    const second = manager.start(startRequest());
+    workspaceBinding.resolve(undefined);
+
+    const [firstHandle, secondHandle] = await Promise.all([first, second]);
+    expect(resolveWorkspaceBinding).toHaveBeenCalledOnce();
+    expect(secondHandle).toBe(firstHandle);
+  });
+
   it.each(["success", "failure"] as const)(
     "keeps same-owner starts behind restored workspace validation on %s",
     async (outcome) => {
@@ -467,10 +491,17 @@ describe("node worker tunnel manager", () => {
     record.ownerEpoch = 3;
     const replacement = manager.start({ ...startRequest(), ownerEpoch: 3 });
 
-    await manager.stop("environment-1", 3);
+    const stopping = manager.stop("environment-1", 3);
+    const stopSettled = vi.fn();
+    void stopping.then(stopSettled, stopSettled);
+    await expect(replacement).rejects.toThrow("stopped before connecting");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(stopSettled).not.toHaveBeenCalled();
     releaseLaunch.resolve();
+    await stopping;
 
-    await expect(replacement).rejects.toThrow("start was cancelled");
     await expect(launched).resolves.toMatchObject({ code: 1, killed: true });
     expect(manager.status("environment-1")).toBe("stopped");
   });

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -27,13 +27,17 @@ import type { WorkerEnvironmentRecord } from "./store.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 
 const workspaceInfo = vi.hoisted(() => vi.fn());
+const tunnelWarn = vi.hoisted(() => vi.fn());
 vi.mock("../../logging/subsystem.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
   return {
     ...actual,
     createSubsystemLogger: (subsystem: string) => {
       const logger = actual.createSubsystemLogger(subsystem);
-      return subsystem === "gateway/worker-workspace" ? { ...logger, info: workspaceInfo } : logger;
+      if (subsystem === "gateway/worker-workspace") {
+        return { ...logger, info: workspaceInfo };
+      }
+      return subsystem === "gateway/worker-tunnel" ? { ...logger, warn: tunnelWarn } : logger;
     },
   };
 });
@@ -216,6 +220,73 @@ describe("node worker tunnel manager", () => {
     const [firstHandle, secondHandle] = await Promise.all([first, second]);
     expect(resolveWorkspaceBinding).toHaveBeenCalledOnce();
     expect(secondHandle).toBe(firstHandle);
+  });
+
+  it.each(["stop", "stopAll"] as const)(
+    "%s fences a pending workspace resolver without waiting for it",
+    async (operation) => {
+      const record = environment();
+      const workspaceBinding = createDeferred<undefined>();
+      const resolverSettled = vi.fn();
+      void workspaceBinding.promise.then(resolverSettled);
+      const transfer = {
+        ...workspaceTransfer(),
+        closeAll: vi.fn(async () => {}),
+      } as unknown as NodeWorkspaceTransferService;
+      const resolveWorkspaceBinding = vi.fn(async () => await workspaceBinding.promise);
+      const manager = createNodeWorkerTunnelManager({
+        gatewayDeviceId: "gateway-device-1",
+        getEnvironment: () => record,
+        getTransport: transport,
+        launchNodeWorker: vi.fn(),
+        validateWorkerTurn: () => true,
+        workspaceTransfer: transfer,
+      });
+      manager.bindWorkspaceBindingResolver(resolveWorkspaceBinding);
+
+      const starting = manager.start(startRequest());
+      await vi.waitFor(() => expect(resolveWorkspaceBinding).toHaveBeenCalledOnce());
+      await (operation === "stop"
+        ? manager.stop("environment-1", record.ownerEpoch)
+        : manager.stopAll());
+
+      expect(resolverSettled).not.toHaveBeenCalled();
+      await expect(starting).rejects.toThrow("stopped before connecting");
+      expect(manager.status("environment-1")).toBe("stopped");
+      workspaceBinding.resolve(undefined);
+    },
+  );
+
+  it("reports a cleanup failure after workspace binding initialization fails", async () => {
+    tunnelWarn.mockClear();
+    const record = environment();
+    const transfer = workspaceTransfer();
+    transfer.close = vi.fn(async () => {
+      throw new Error("workspace cleanup failed");
+    });
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: transport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    });
+    manager.bindWorkspaceBindingResolver(async () => {
+      throw new Error("workspace binding failed");
+    });
+
+    await expect(manager.start(startRequest())).rejects.toThrow("workspace binding failed");
+    await vi.waitFor(() =>
+      expect(tunnelWarn).toHaveBeenCalledWith(
+        "node worker tunnel cleanup failed after initialization error",
+        {
+          environmentId: "environment-1",
+          ownerEpoch: record.ownerEpoch,
+          error: "workspace cleanup failed",
+        },
+      ),
+    );
   });
 
   it.each(["success", "failure"] as const)(

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -2,6 +2,7 @@ import fsp from "node:fs/promises";
 import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SpawnResult } from "../../process/exec.js";
 import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import type { NodeWorkerSupervisorReceipt } from "../../worker/node-supervisor-protocol.js";
@@ -31,6 +32,7 @@ import type {
   WorkerTunnelStatus,
   WorkerWorkspaceCommand,
 } from "./tunnel-contract.js";
+import { boundedWorkerError } from "./worker-error.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 import { createWorkerWorkspaceQuiescence } from "./workspace-quiescence.js";
 import {
@@ -44,6 +46,7 @@ import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
 const RETRY_DELAY_MS = 100;
+const tunnelLog = createSubsystemLogger("gateway/worker-tunnel");
 const RETRYABLE_TRANSPORT_CODES = new Set([
   "DISCONNECTED",
   "NOT_CONNECTED",
@@ -664,11 +667,16 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         if (!isLiveEntry(entry)) {
           return;
         }
-        const restoredWorkspace = await resolveWorkspaceBinding?.({
-          environmentId: request.environmentId,
-          ownerEpoch: request.ownerEpoch,
-          sessionId: request.sessionId,
-        });
+        const restoredWorkspace = resolveWorkspaceBinding
+          ? await raceWithSignal(
+              resolveWorkspaceBinding({
+                environmentId: request.environmentId,
+                ownerEpoch: request.ownerEpoch,
+                sessionId: request.sessionId,
+              }),
+              entry.abortController.signal,
+            )
+          : undefined;
         if (!isLiveEntry(entry)) {
           return;
         }
@@ -682,7 +690,15 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       })();
       void entry.initialization.catch((error: unknown) => {
         readiness.reject(error);
-        void stopEntry(entry);
+        // Startup already reports the owning error through readiness. Keep secondary cleanup
+        // failures visible without replacing that shared result for concurrent callers.
+        void stopEntry(entry).catch((cleanupError: unknown) => {
+          tunnelLog.warn("node worker tunnel cleanup failed after initialization error", {
+            environmentId: entry.environmentId,
+            ownerEpoch: entry.ownerEpoch,
+            error: boundedWorkerError(cleanupError),
+          });
+        });
       });
       return await readiness.promise;
     },

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -112,7 +112,8 @@ type NodeWorkerTunnelStartRequest = {
 type NodeTunnelEntry = NodeWorkerTunnelStartRequest & {
   abortController: AbortController;
   gatewayNamespace: string;
-  handle: WorkerTunnelHandle;
+  handle?: WorkerTunnelHandle;
+  initialization?: Promise<void>;
   launchTasks: Set<Promise<unknown>>;
   readiness: Deferred<WorkerTunnelHandle>;
   stopPromise?: Promise<void>;
@@ -182,7 +183,6 @@ function raceWithSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<
 /** Owns node-channel handles without treating the persistent machine as a disposable lease. */
 export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOptions) {
   const entries = new Map<string, NodeTunnelEntry>();
-  const pendingStarts = new Map<string, { ownerEpoch: number; cancelled: boolean }>();
   let resolveWorkspaceBinding: NodeWorkerWorkspaceBindingResolver | undefined;
   const gatewayNamespace = nodeWorkerGatewayNamespace(options.gatewayDeviceId);
 
@@ -304,7 +304,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
   };
 
   const createHandle = (
-    entry: Omit<NodeTunnelEntry, "handle" | "readiness">,
+    entry: Omit<NodeTunnelEntry, "handle" | "readiness" | "initialization">,
     restoredWorkspace: NodeWorkerWorkspaceBinding | undefined,
   ): { handle: WorkerTunnelHandle; validateRestoredWorkspace: () => Promise<void> } => {
     let workspaceReady = restoredWorkspace !== undefined;
@@ -610,14 +610,16 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
     if (entry.stopPromise) {
       return entry.stopPromise;
     }
+    if (entries.get(entry.environmentId) === entry) {
+      entries.delete(entry.environmentId);
+    }
     entry.abortController.abort(new Error("node worker tunnel owner stopped"));
     entry.readiness.reject(new Error("node worker tunnel stopped before connecting"));
-    entry.stopPromise = Promise.allSettled(entry.launchTasks).then(() => {
-      if (entries.get(entry.environmentId) === entry) {
-        entries.delete(entry.environmentId);
-      }
-      return options.workspaceTransfer.close(entry.environmentId);
-    });
+    entry.stopPromise = (async () => {
+      await entry.initialization?.catch(() => undefined);
+      await Promise.allSettled(entry.launchTasks);
+      await options.workspaceTransfer.close(entry.environmentId);
+    })();
     return entry.stopPromise;
   }
 
@@ -643,73 +645,64 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           return current.readiness.promise; // Share restored-workspace validation without false readiness.
         }
       }
-      const pending = { ownerEpoch: request.ownerEpoch, cancelled: false };
-      pendingStarts.set(request.environmentId, pending);
-      try {
+      const readiness = createDeferredCore<WorkerTunnelHandle>();
+      void readiness.promise.catch(() => undefined);
+      const entry: NodeTunnelEntry = {
+        ...request,
+        gatewayNamespace,
+        abortController: new AbortController(),
+        launchTasks: new Set(),
+        readiness,
+      };
+      // Publish the new epoch before any teardown or initialization await so stop and replacement
+      // can fence it, while exact same-owner callers share this readiness barrier.
+      entries.set(entry.environmentId, entry);
+      entry.initialization = (async () => {
         if (current) {
           await stopEntry(current);
         }
-        if (pending.cancelled || pendingStarts.get(request.environmentId) !== pending) {
-          throw new Error("node worker tunnel start was cancelled");
+        if (!isLiveEntry(entry)) {
+          return;
         }
         const restoredWorkspace = await resolveWorkspaceBinding?.({
           environmentId: request.environmentId,
           ownerEpoch: request.ownerEpoch,
           sessionId: request.sessionId,
         });
-        if (pending.cancelled || pendingStarts.get(request.environmentId) !== pending) {
-          throw new Error("node worker tunnel start was cancelled");
+        if (!isLiveEntry(entry)) {
+          return;
         }
-        const base = {
-          ...request,
-          gatewayNamespace,
-          abortController: new AbortController(),
-          launchTasks: new Set<Promise<unknown>>(),
-        };
-        const readiness = createDeferredCore<WorkerTunnelHandle>();
-        void readiness.promise.catch(() => undefined);
-        const created = createHandle(base, restoredWorkspace);
-        const entry = Object.assign(base, { readiness, handle: created.handle });
-        entries.set(entry.environmentId, entry);
-        try {
-          await created.validateRestoredWorkspace();
-          if (pending.cancelled || pendingStarts.get(request.environmentId) !== pending) {
-            throw new Error("node worker tunnel start was cancelled");
-          }
-          readiness.resolve(entry.handle);
-          return entry.handle;
-        } catch (error) {
-          readiness.reject(error);
-          await stopEntry(entry);
-          throw error;
+        const created = createHandle(entry, restoredWorkspace);
+        await created.validateRestoredWorkspace();
+        if (!isLiveEntry(entry)) {
+          return;
         }
-      } finally {
-        if (pendingStarts.get(request.environmentId) === pending) {
-          pendingStarts.delete(request.environmentId);
-        }
-      }
+        entry.handle = created.handle;
+        readiness.resolve(created.handle);
+      })();
+      void entry.initialization.catch((error: unknown) => {
+        readiness.reject(error);
+        void stopEntry(entry);
+      });
+      return await readiness.promise;
     },
     async stop(environmentId: string, ownerEpoch?: number): Promise<void> {
-      const pending = pendingStarts.get(environmentId);
-      if (pending && (ownerEpoch === undefined || ownerEpoch === pending.ownerEpoch)) {
-        pending.cancelled = true;
-      }
       const entry = entries.get(environmentId);
       if (entry && (ownerEpoch === undefined || ownerEpoch === entry.ownerEpoch)) {
         await stopEntry(entry);
       }
     },
     async stopAll(): Promise<void> {
-      for (const pending of pendingStarts.values()) {
-        pending.cancelled = true;
-      }
       await Promise.all([...entries.values()].map(stopEntry));
       await options.workspaceTransfer.closeAll();
     },
     status(environmentId: string): WorkerTunnelStatus {
       const entry = entries.get(environmentId);
-      const status = entry && !entry.abortController.signal.aborted ? "connected" : "stopped";
-      return pendingStarts.get(environmentId)?.cancelled === false ? "connecting" : status;
+      return entry && !entry.abortController.signal.aborted
+        ? entry.handle
+          ? "connected"
+          : "connecting"
+        : "stopped";
     },
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: Yes.

## What Problem This Solves

Fixes an issue where concurrent identical node/device worker tunnel starts during pending workspace resolution could cancel a valid turn even though the same tunnel later connected.

## Why This Change Was Made

The tunnel manager now publishes one authoritative lifecycle entry and readiness owner before any await, matching the SSH sibling's ownership model. Same-owner starts join that entry, while newer epochs and explicit stop fence initialization. Workspace resolution is raced against owner cancellation so shutdown remains bounded, secondary cleanup failures are surfaced through bounded logging, and the shadow pending-start state is removed.

## User Impact

Turn launch, recovery, and disk probing can converge on the same connecting tunnel without spurious visible failures. Newer owners still fence old work, and stopping the Gateway does not wait indefinitely on a pending workspace resolver.

## Evidence

- Pre-fix regression: the original focused suite failed 1/11 at the concurrent `Promise.all` with `node worker tunnel start was cancelled`.
- Final focused proof: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-worker-tunnel.test.ts` passed 14/14, including same-owner join, pending-resolver stop/stop-all, and cleanup-error visibility.
- Initial changed gate: Testbox `tbx_01m05dz537txg8zsv5wa37yd40`; [Actions run 31951439324](https://github.com/openclaw/openclaw/actions/runs/31951439324) passed core/coreTests, typecheck, lint, deadcode, cycles, and guards for the original lifecycle repair. Warning-only plugin temp-directory migration notices were unrelated.
- Final exact-head CI: [Actions run 31954078230](https://github.com/openclaw/openclaw/actions/runs/31954078230) passed for `3ae523fe0fda03f118a8d58c7b2d2d95728a72d1` after one infrastructure-only CodeQL retry (`ECONNRESET` downloading the CodeQL bundle before analysis).
- Final boundary E2E: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts` passed 1/1; the device-runner workspace transfer/reconcile scenario took 135.0s after a stale-dist rebuild.
- Final production LOC: +66/-57 (net +9). Tests: +105/-3. The production growth is the abort fence and bounded cleanup-failure reporting required by the shutdown and observability invariants.
- Fresh full-branch Codex autoreview: clean, no actionable findings (0.99 confidence).
- ClawSweeper reviewed the final head with no findings; its remaining exact-head-check rank-up move is satisfied.
- Local `check:changed` retries stopped on protected assertion-baseline drift in unrelated current-main files, and the remote wrapper failed closed before allocation when it could not validate the provider list. No baseline or testing-infrastructure files were changed; exact-head PR CI is the authoritative final gate.
- Proof gap: deterministic owner-boundary coverage and the node-worker launch-wire E2E were run; this was not a physical paired-device disconnect/race test.
