### PR TITLE
refactor(sessions): delete dead maintenanceReport and evict-budget surfaces

### DIFF
--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -126,7 +126,6 @@ describe("sessionsCleanupCommand", () => {
         missingKeys: Set<string>;
         staleKeys: Set<string>;
         cappedKeys: Set<string>;
-        budgetEvictedKeys: Set<string>;
         dmScopeRetiredKeys: Set<string>;
         modelRunPrunedKeys?: Set<string>;
       }) => {
@@ -141,9 +140,6 @@ describe("sessionsCleanupCommand", () => {
         }
         if (params.cappedKeys.has(params.key)) {
           return "cap-overflow";
-        }
-        if (params.budgetEvictedKeys.has(params.key)) {
-          return "evict-budget";
         }
         return "keep";
       },
@@ -376,7 +372,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set<string>(),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
           modelRunPrunedKeys: new Set<string>(),
         },
@@ -447,7 +442,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set(["missing"]),
           staleKeys: new Set<string>(),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
           modelRunPrunedKeys: new Set<string>(),
         },
@@ -517,7 +511,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set(["stale"]),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
           modelRunPrunedKeys: new Set<string>(),
         },
@@ -617,7 +610,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set(["cronPruned", "unsafePruned", "malformedLabelPruned"]),
           cappedKeys: new Set(["directCapped"]),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
         },
       ],
@@ -687,7 +679,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set<string>(),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
         },
       ],
@@ -743,7 +734,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set(["stale"]),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
           modelRunPrunedKeys: new Set<string>(),
         },
@@ -767,7 +757,6 @@ describe("sessionsCleanupCommand", () => {
           missingKeys: new Set<string>(),
           staleKeys: new Set(["stale"]),
           cappedKeys: new Set<string>(),
-          budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
           modelRunPrunedKeys: new Set<string>(),
         },

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -82,7 +82,6 @@ function buildActionRows(params: {
   modelRunPrunedKeys: Set<string>;
   staleKeys: Set<string>;
   cappedKeys: Set<string>;
-  budgetEvictedKeys: Set<string>;
   dmScopeRetiredKeys: Set<string>;
 }): SessionCleanupActionRow[] {
   // Recompute row actions from the preview sets so dry-run output uses the same
@@ -96,7 +95,6 @@ function buildActionRows(params: {
         modelRunPrunedKeys: params.modelRunPrunedKeys,
         staleKeys: params.staleKeys,
         cappedKeys: params.cappedKeys,
-        budgetEvictedKeys: params.budgetEvictedKeys,
         dmScopeRetiredKeys: params.dmScopeRetiredKeys,
       }),
     }),

--- a/src/config/sessions/cleanup-service.agent-purge.test.ts
+++ b/src/config/sessions/cleanup-service.agent-purge.test.ts
@@ -7,16 +7,12 @@ const sessionAccessorMocks = vi.hoisted(() => ({
     removedEntries: 0,
     removedSessionKeys: [],
     archivedTranscriptDirectories: [],
-    unreferencedArtifacts: null,
-    maintenanceReport: null,
     afterCount: 0,
   })),
   purgeDeletedAgentSessionEntries: vi.fn(async () => ({
     removedEntries: 0,
     removedSessionKeys: [],
     archivedTranscriptDirectories: [],
-    unreferencedArtifacts: null,
-    maintenanceReport: null,
     afterCount: 0,
   })),
 }));

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -59,7 +59,6 @@ type SessionCleanupAction =
   | "prune-model-run"
   | "prune-stale"
   | "cap-overflow"
-  | "evict-budget"
   | "retire-dm-scope";
 
 export type SessionCleanupSummary = {
@@ -99,7 +98,6 @@ type SessionsCleanupRunResult = {
     modelRunPrunedKeys: Set<string>;
     staleKeys: Set<string>;
     cappedKeys: Set<string>;
-    budgetEvictedKeys: Set<string>;
     dmScopeRetiredKeys: Set<string>;
   }>;
   appliedSummaries: SessionCleanupSummary[];
@@ -176,7 +174,6 @@ export function resolveSessionCleanupAction(params: {
   modelRunPrunedKeys: Set<string>;
   staleKeys: Set<string>;
   cappedKeys: Set<string>;
-  budgetEvictedKeys: Set<string>;
   dmScopeRetiredKeys: Set<string>;
 }): SessionCleanupAction {
   if (params.dmScopeRetiredKeys.has(params.key)) {
@@ -193,9 +190,6 @@ export function resolveSessionCleanupAction(params: {
   }
   if (params.cappedKeys.has(params.key)) {
     return "cap-overflow";
-  }
-  if (params.budgetEvictedKeys.has(params.key)) {
-    return "evict-budget";
   }
   return "keep";
 }
@@ -477,7 +471,6 @@ async function previewStoreCleanup(params: {
     dryRun: true,
     excludeCanonicalPaths: entryCleanupArtifactPaths,
   });
-  const budgetEvictedKeys = new Set<string>();
   const beforeCount = Object.keys(beforeStore).length;
   const afterPreviewCount = Object.keys(previewStore).length;
   const wouldMutate =
@@ -515,7 +508,6 @@ async function previewStoreCleanup(params: {
     modelRunPrunedKeys,
     staleKeys,
     cappedKeys,
-    budgetEvictedKeys,
     dmScopeRetiredKeys,
   };
 }
@@ -611,12 +603,6 @@ export async function runSessionsCleanup(params: {
               dryRun: false,
             });
       const removedSessionKeys = new Set(lifecycleResult.removedSessionKeys);
-      const missingApplied = missingRemovals.filter(({ sessionKey }) =>
-        removedSessionKeys.has(sessionKey),
-      ).length;
-      const dmScopeRetiredApplied = dmScopeRetiredRemovals.filter(({ sessionKey }) =>
-        removedSessionKeys.has(sessionKey),
-      ).length;
       const unreferencedArtifacts =
         mode === "warn"
           ? {
@@ -625,8 +611,7 @@ export async function runSessionsCleanup(params: {
               freedBytes: 0,
               olderThanMs: maintenance.pruneAfterMs,
             }
-          : (lifecycleResult.unreferencedArtifacts ??
-            appliedUnreferencedArtifacts ?? {
+          : (appliedUnreferencedArtifacts ?? {
               scannedFiles: 0,
               removedFiles: 0,
               freedBytes: 0,
@@ -641,71 +626,38 @@ export async function runSessionsCleanup(params: {
       const preview = previewResults.find(
         (result) => result.summary.storePath === target.storePath,
       );
-      const appliedReport = lifecycleResult.maintenanceReport;
-      const summary: SessionCleanupSummary =
-        appliedReport === null
-          ? {
-              ...(preview?.summary ?? {
-                agentId: target.agentId,
-                storePath: target.storePath,
-                mode,
-                dryRun: false,
-                beforeCount: 0,
-                afterCount: 0,
-                missing: 0,
-                dmScopeRetired: 0,
-                modelRunPruned: 0,
-                pruned: 0,
-                capped: 0,
-                unreferencedArtifacts,
-                diskBudget: null,
-                wouldMutate: false,
-              }),
-              dryRun: false,
-              unreferencedArtifacts,
-              diskBudget: appliedDiskBudget,
-              wouldMutate:
-                removedSessionKeys.size > 0 ||
-                unreferencedArtifacts.removedFiles > 0 ||
-                (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
-                (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
-                // Checkpoint/incremental-vacuum reclamation mutates the store
-                // even when no session or archive was removed.
-                (appliedDiskBudget != null &&
-                  appliedDiskBudget.totalBytesAfter < appliedDiskBudget.totalBytesBefore),
-              applied: true,
-              appliedCount: lifecycleResult.afterCount,
-            }
-          : {
-              agentId: target.agentId,
-              storePath: target.storePath,
-              mode: appliedReport.mode,
-              dryRun: false,
-              beforeCount: appliedReport.beforeCount,
-              afterCount: appliedReport.afterCount,
-              missing: missingApplied,
-              dmScopeRetired: dmScopeRetiredApplied,
-              modelRunPruned: appliedReport.modelRunPruned,
-              pruned: appliedReport.pruned,
-              capped: appliedReport.capped,
-              unreferencedArtifacts,
-              diskBudget: appliedDiskBudget,
-              wouldMutate:
-                missingApplied > 0 ||
-                dmScopeRetiredApplied > 0 ||
-                appliedReport.modelRunPruned > 0 ||
-                appliedReport.pruned > 0 ||
-                appliedReport.capped > 0 ||
-                unreferencedArtifacts.removedFiles > 0 ||
-                (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
-                (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
-                // Checkpoint/incremental-vacuum reclamation mutates the store
-                // even when no session or archive was removed.
-                (appliedDiskBudget != null &&
-                  appliedDiskBudget.totalBytesAfter < appliedDiskBudget.totalBytesBefore),
-              applied: true,
-              appliedCount: lifecycleResult.afterCount,
-            };
+      const summary: SessionCleanupSummary = {
+        ...(preview?.summary ?? {
+          agentId: target.agentId,
+          storePath: target.storePath,
+          mode,
+          dryRun: false,
+          beforeCount: 0,
+          afterCount: 0,
+          missing: 0,
+          dmScopeRetired: 0,
+          modelRunPruned: 0,
+          pruned: 0,
+          capped: 0,
+          unreferencedArtifacts,
+          diskBudget: null,
+          wouldMutate: false,
+        }),
+        dryRun: false,
+        unreferencedArtifacts,
+        diskBudget: appliedDiskBudget,
+        wouldMutate:
+          removedSessionKeys.size > 0 ||
+          unreferencedArtifacts.removedFiles > 0 ||
+          (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
+          (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
+          // Checkpoint/incremental-vacuum reclamation mutates the store
+          // even when no session or archive was removed.
+          (appliedDiskBudget != null &&
+            appliedDiskBudget.totalBytesAfter < appliedDiskBudget.totalBytesBefore),
+        applied: true,
+        appliedCount: lifecycleResult.afterCount,
+      };
       appliedSummaries.push(summary);
     }
   }

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -1,8 +1,6 @@
 import type { OpenClawConfig } from "../types.openclaw.js";
-import type { SessionUnreferencedArtifactSweepResult } from "./disk-budget.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
 import type { SessionResetBoundaryReason } from "./session-reset-boundary-event.js";
-import type { SessionMaintenanceApplyReport } from "./store-maintenance-operations.js";
 import type { SessionEntry } from "./types.js";
 
 export type SessionLifecycleArtifactCleanupParams = {
@@ -158,8 +156,6 @@ export type SessionEntryLifecycleMutationResult = {
   removedEntries: number;
   removedSessionKeys: string[];
   archivedTranscriptDirectories: string[];
-  unreferencedArtifacts: SessionUnreferencedArtifactSweepResult | null;
-  maintenanceReport: SessionMaintenanceApplyReport | null;
   afterCount: number;
   artifactCleanupError?: unknown;
 };

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -473,8 +473,6 @@ export async function applySessionEntryLifecycleMutation(params: {
     removedEntries: committed.removedSessionKeys.length,
     removedSessionKeys: committed.removedSessionKeys,
     archivedTranscriptDirectories,
-    unreferencedArtifacts: null,
-    maintenanceReport: null,
     afterCount,
     artifactCleanupError,
   };
@@ -580,8 +578,6 @@ export async function purgeDeletedAgentSessionEntries(
     archivedTranscriptDirectories: uniqueStrings(
       archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
     ).toSorted(),
-    unreferencedArtifacts: null,
-    maintenanceReport: null,
     afterCount,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The sessions cleanup pipeline carried two dead reporting surfaces:

1. `SessionEntryLifecycleMutationResult.maintenanceReport` and `.unreferencedArtifacts` have been `null` at both SQLite producers since the legacy JSON store collapsed (c440ae3e866). cleanup-service still carried a ~60-line ternary on `maintenanceReport !== null` — an unreachable branch with its own count math — plus dead fallback reads and dead `missingApplied`/`dmScopeRetiredApplied` computations feeding only that branch.
2. The `evict-budget` cleanup action was unreachable: `budgetEvictedKeys` has been a literal `new Set()` never populated since the SQLite storage flip (0a8e3604ba24), so the action label could never render in `openclaw sessions cleanup`.

## Why This Change Was Made

Tests pinning obsolete internals and unreachable branches are exactly what the repo's test doctrine says to delete, not maintain. Disk-budget eviction reporting is owned by the `diskBudget` summary field, which remains untouched.

## User Impact

None — all deleted paths were provably unreachable. CLI cleanup output, summaries, and apply behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs run src/config/sessions` — 72 files, 868/868 pass.
- Focused: sessions-cleanup.test.ts, cleanup-service.fix-missing.test.ts, cleanup-service.agent-purge.test.ts all green.
- tsgo core + core-test shards green.
- LOC: prod +33/−91 (net −58), test −15.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99 — "removed lifecycle fields and budget-eviction action were consistently eliminated ... disk-budget reporting remains intact."
- History proof: `git log -S maintenanceReport` shows null-only producers since c440ae3e866; `git log -S budgetEvictedKeys` shows the set never populated since 0a8e3604ba24.
