### PR TITLE
feat(feishu): add organization event bridge

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -42,6 +42,28 @@ OpenClaw durably queues authenticated `im.message.receive_v1` and `drive.notice.
 
 If a WebSocket event cannot be persisted after bounded retries, OpenClaw closes that socket and forces a fresh authenticated connection instead of continuing past an uncommitted turn. Other Feishu event types, including reactions and VC meeting invitations, use their normal event paths and do not receive this durable-queue guarantee.
 
+## Organization event bridge for code plugins
+
+An installed code plugin can subscribe to Feishu directory events without creating a second WebSocket connection or opening an HTTP listener. Import the public Feishu plugin API and subscribe before the Feishu channel starts:
+
+```ts
+import { subscribeFeishuOrganizationEvents } from "@openclaw/feishu/api.js";
+
+const stopOrganizationEvents = subscribeFeishuOrganizationEvents(async (event) => {
+  // event: { accountId, eventId, eventType, data }
+  await enqueueDirectorySync(event.eventId, event.eventType);
+});
+
+// Call stopOrganizationEvents() when this code plugin stops or reloads.
+```
+
+The bridge opts the channel's existing dispatcher into these event types only when a subscriber exists at monitor startup:
+
+- `contact.user.created_v3`, `contact.user.updated_v3`, `contact.user.deleted_v3`
+- `contact.department.created_v3`, `contact.department.updated_v3`, `contact.department.deleted_v3`
+
+`eventId` and `eventType` are preserved for downstream idempotency. A failing subscriber is isolated from other subscribers and normal Feishu message handling. The `data` field contains the provider event payload, so consuming plugins must treat it as tenant-private data and avoid logging it.
+
 ## Access control
 
 ### Direct messages

--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -1,5 +1,11 @@
 // Feishu API module exposes the plugin public contract.
 export { feishuPlugin } from "./src/channel.js";
+export {
+  subscribeFeishuOrganizationEvents,
+  type FeishuOrganizationEvent,
+  type FeishuOrganizationEventListener,
+  type FeishuOrganizationEventType,
+} from "./src/organization-event-bridge.js";
 export { registerFeishuDocTools } from "./src/docx.js";
 export { registerFeishuChatTools } from "./src/chat.js";
 export { registerFeishuWikiTools } from "./src/wiki.js";

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/openclaw/openclaw"
   },
   "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./api.js": "./dist/api.js"
+  },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "1.71.1",
     "mdast-util-from-markdown": "2.0.3",

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -24,6 +24,7 @@ import { botNames, botOpenIds } from "./monitor.state.js";
 import { FeishuRetryableSyntheticEventError } from "./monitor.synthetic-error.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { createFeishuVcMeetingInvitedHandler } from "./monitor.vc-meeting-invited-handler.js";
+import { createFeishuOrganizationEventHandlers } from "./organization-event-bridge.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
@@ -460,6 +461,12 @@ function registerEventHandlers(
         error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
       }
     },
+    ...createFeishuOrganizationEventHandlers({
+      accountId,
+      onConsumerError: (_cause, eventType) => {
+        error(`feishu[${accountId}]: organization event consumer failed for ${eventType}`);
+      },
+    }),
   });
 }
 

--- a/extensions/feishu/src/monitor.organization-event.test.ts
+++ b/extensions/feishu/src/monitor.organization-event.test.ts
@@ -1,0 +1,107 @@
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { hasControlCommand, isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+// Feishu tests cover organization-event monitor registration behavior.
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import { monitorSingleAccount } from "./monitor.account.js";
+import { subscribeFeishuOrganizationEvents } from "./organization-event-bridge.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
+const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
+
+vi.mock("./client.js", () => ({ createEventDispatcher: createEventDispatcherMock }));
+vi.mock("./monitor.transport.js", () => ({
+  monitorWebSocket: monitorWebSocketMock,
+  monitorWebhook: monitorWebhookMock,
+}));
+vi.mock("./thread-bindings.js", () => ({
+  createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
+}));
+
+let registeredHandlers: Record<string, (data: unknown) => Promise<void>> = {};
+const unsubscribeCallbacks: Array<() => void> = [];
+
+afterEach(() => {
+  for (const unsubscribe of unsubscribeCallbacks.splice(0)) {
+    unsubscribe();
+  }
+  createEventDispatcherMock.mockReset();
+  monitorWebSocketMock.mockClear();
+  monitorWebhookMock.mockClear();
+  createFeishuThreadBindingManagerMock.mockClear();
+  registeredHandlers = {};
+});
+
+afterAll(() => {
+  vi.doUnmock("./client.js");
+  vi.doUnmock("./monitor.transport.js");
+  vi.doUnmock("./thread-bindings.js");
+  vi.resetModules();
+});
+
+function setupDispatcher() {
+  createEventDispatcherMock.mockReturnValue({
+    register: vi.fn((handlers: Record<string, (data: unknown) => Promise<void>>) => {
+      registeredHandlers = handlers;
+    }),
+  });
+}
+
+async function startMonitor() {
+  await monitorSingleAccount({
+    cfg: { channels: { feishu: { enabled: true } } } as ClawdbotConfig,
+    account: {
+      accountId: "fabricos",
+      enabled: true,
+      configured: true,
+      appId: "cli_test",
+      appSecret: "secret_test", // pragma: allowlist secret
+      domain: "feishu",
+      config: { enabled: true, connectionMode: "websocket" },
+    } as ResolvedFeishuAccount,
+    channelRuntime: {
+      inbound: { run: vi.fn() },
+      debounce: { createInboundDebouncer, resolveInboundDebounceMs },
+      commands: { isControlCommandMessage },
+      text: { hasControlCommand },
+    } as unknown as PluginRuntime["channel"],
+    runtime: createNonExitingRuntimeEnv(),
+    botOpenIdSource: { kind: "prefetched", botOpenId: "ou_bot" },
+  });
+}
+
+describe("Feishu organization-event monitor registration", () => {
+  it("does not register contact handlers without a subscriber", async () => {
+    setupDispatcher();
+
+    await startMonitor();
+
+    expect(registeredHandlers).not.toHaveProperty("contact.user.updated_v3");
+    expect(registeredHandlers).not.toHaveProperty("contact.department.updated_v3");
+  });
+
+  it("registers and delivers contact handlers when a subscriber exists at startup", async () => {
+    const listener = vi.fn();
+    unsubscribeCallbacks.push(subscribeFeishuOrganizationEvents(listener));
+    setupDispatcher();
+
+    await startMonitor();
+    await registeredHandlers["contact.department.updated_v3"]?.({ event_id: "evt_department_1" });
+
+    expect(registeredHandlers).toHaveProperty("contact.user.created_v3");
+    expect(registeredHandlers).toHaveProperty("contact.department.deleted_v3");
+    expect(listener).toHaveBeenCalledWith({
+      accountId: "fabricos",
+      eventId: "evt_department_1",
+      eventType: "contact.department.updated_v3",
+      data: { event_id: "evt_department_1" },
+    });
+  });
+});

--- a/extensions/feishu/src/organization-event-bridge.test.ts
+++ b/extensions/feishu/src/organization-event-bridge.test.ts
@@ -1,0 +1,98 @@
+// Feishu tests cover the organization-event bridge plugin behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createFeishuOrganizationEventHandlers,
+  subscribeFeishuOrganizationEvents,
+  type FeishuOrganizationEventType,
+} from "./organization-event-bridge.js";
+
+const ORGANIZATION_EVENT_TYPES = [
+  "contact.user.created_v3",
+  "contact.user.updated_v3",
+  "contact.user.deleted_v3",
+  "contact.department.created_v3",
+  "contact.department.updated_v3",
+  "contact.department.deleted_v3",
+] as const satisfies readonly FeishuOrganizationEventType[];
+
+const unsubscribeCallbacks: Array<() => void> = [];
+
+afterEach(() => {
+  for (const unsubscribe of unsubscribeCallbacks.splice(0)) {
+    unsubscribe();
+  }
+});
+
+function subscribe(listener: Parameters<typeof subscribeFeishuOrganizationEvents>[0]) {
+  const unsubscribe = subscribeFeishuOrganizationEvents(listener);
+  unsubscribeCallbacks.push(unsubscribe);
+  return unsubscribe;
+}
+
+describe("Feishu organization-event bridge", () => {
+  it("does not register contact handlers without a subscriber", () => {
+    expect(
+      createFeishuOrganizationEventHandlers({ accountId: "default", onConsumerError: vi.fn() }),
+    ).toEqual({});
+  });
+
+  it.each(ORGANIZATION_EVENT_TYPES)("delivers %s with its stable envelope", async (eventType) => {
+    const listener = vi.fn();
+    subscribe(listener);
+    const handlers = createFeishuOrganizationEventHandlers({
+      accountId: "fabricos",
+      onConsumerError: vi.fn(),
+    });
+    const data = { event_id: `evt_${eventType}`, field: "current-value" };
+
+    await handlers[eventType]?.(data);
+
+    expect(listener).toHaveBeenCalledWith({
+      accountId: "fabricos",
+      eventId: `evt_${eventType}`,
+      eventType,
+      data,
+    });
+  });
+
+  it("isolates a failing subscriber and continues delivery", async () => {
+    const failure = new Error("consumer failed");
+    const failingListener = vi.fn(async () => {
+      throw failure;
+    });
+    const healthyListener = vi.fn();
+    const onConsumerError = vi.fn();
+    subscribe(failingListener);
+    subscribe(healthyListener);
+    const handlers = createFeishuOrganizationEventHandlers({
+      accountId: "fabricos",
+      onConsumerError,
+    });
+
+    await handlers["contact.user.updated_v3"]?.({ event_id: "evt_1" });
+
+    expect(onConsumerError).toHaveBeenCalledWith(failure, "contact.user.updated_v3");
+    expect(healthyListener).toHaveBeenCalledWith({
+      accountId: "fabricos",
+      eventId: "evt_1",
+      eventType: "contact.user.updated_v3",
+      data: { event_id: "evt_1" },
+    });
+  });
+
+  it("removes a stopped subscriber before the next monitor registration", () => {
+    const unsubscribe = subscribe(vi.fn());
+
+    expect(
+      Object.keys(
+        createFeishuOrganizationEventHandlers({ accountId: "default", onConsumerError: vi.fn() }),
+      ),
+    ).toHaveLength(6);
+
+    unsubscribe();
+
+    expect(
+      createFeishuOrganizationEventHandlers({ accountId: "default", onConsumerError: vi.fn() }),
+    ).toEqual({});
+  });
+});

--- a/extensions/feishu/src/organization-event-bridge.ts
+++ b/extensions/feishu/src/organization-event-bridge.ts
@@ -1,0 +1,95 @@
+// Feishu plugin module owns organization-event subscriptions.
+import { isRecord, readStringValue } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const FEISHU_ORGANIZATION_EVENT_TYPES = [
+  "contact.user.created_v3",
+  "contact.user.updated_v3",
+  "contact.user.deleted_v3",
+  "contact.department.created_v3",
+  "contact.department.updated_v3",
+  "contact.department.deleted_v3",
+] as const;
+
+export type FeishuOrganizationEventType = (typeof FEISHU_ORGANIZATION_EVENT_TYPES)[number];
+
+export type FeishuOrganizationEvent = {
+  accountId: string;
+  eventId: string;
+  eventType: FeishuOrganizationEventType;
+  data: unknown;
+};
+
+export type FeishuOrganizationEventListener = (
+  event: FeishuOrganizationEvent,
+) => void | Promise<void>;
+
+type FeishuOrganizationEventHandlers = Partial<
+  Record<FeishuOrganizationEventType, (data: unknown) => Promise<void>>
+>;
+
+const listeners = new Set<FeishuOrganizationEventListener>();
+
+/**
+ * Subscribe before the Feishu channel starts so its sole EventDispatcher can
+ * opt into the six organization event handlers for the current Gateway run.
+ */
+export function subscribeFeishuOrganizationEvents(
+  listener: FeishuOrganizationEventListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function readEventId(data: unknown): string | undefined {
+  if (!isRecord(data)) {
+    return undefined;
+  }
+  const eventId = readStringValue(data.event_id)?.trim();
+  return eventId || undefined;
+}
+
+async function dispatchFeishuOrganizationEvent(params: {
+  accountId: string;
+  eventType: FeishuOrganizationEventType;
+  data: unknown;
+  onConsumerError: (cause: unknown, eventType: FeishuOrganizationEventType) => void;
+}): Promise<void> {
+  const eventId = readEventId(params.data);
+  if (!eventId) {
+    params.onConsumerError(
+      new Error("Feishu organization event is missing event_id"),
+      params.eventType,
+    );
+    return;
+  }
+  const event: FeishuOrganizationEvent = {
+    accountId: params.accountId,
+    eventId,
+    eventType: params.eventType,
+    data: params.data,
+  };
+  for (const listener of listeners) {
+    try {
+      await listener(event);
+    } catch (cause) {
+      params.onConsumerError(cause, params.eventType);
+    }
+  }
+}
+
+export function createFeishuOrganizationEventHandlers(params: {
+  accountId: string;
+  onConsumerError: (cause: unknown, eventType: FeishuOrganizationEventType) => void;
+}): FeishuOrganizationEventHandlers {
+  if (listeners.size === 0) {
+    return {};
+  }
+  return Object.fromEntries(
+    FEISHU_ORGANIZATION_EVENT_TYPES.map((eventType) => [
+      eventType,
+      async (data: unknown) => {
+        await dispatchFeishuOrganizationEvent({ ...params, eventType, data });
+      },
+    ]),
+  ) as FeishuOrganizationEventHandlers;
+}


### PR DESCRIPTION
## What problem this solves

Feishu delivers an app's long-connection events to one Gateway process. A second provider-independent listener for the same app can therefore race the existing Feishu channel and miss organization events. Code plugins had no supported, typed way to consume organization changes from the channel that already owns that connection.

Relates to #124620.

## What changed

- Adds a provider-local, opt-in `@openclaw/feishu/api.js` subscription API for the six `contact.user.*_v3` and `contact.department.*_v3` events.
- Registers those handlers only when a code plugin subscribed before the Feishu monitor starts.
- Delivers a stable event ID and event type, isolates consumer failures, and returns an unsubscribe cleanup function.
- Documents queued/idempotent downstream consumption without exposing tenant-private event payloads in logs.

## User impact

Downstream code plugins can enqueue a directory reconciliation from the single existing Feishu Gateway connection. There are no new ports, listeners, secrets, or changes to the legacy standalone listener.

## Evidence

- Targeted bridge and monitor tests: 11 passed.
- `pnpm tsgo:extensions` passed.
- Feishu extension oxlint passed.
- Plugin npm runtime build check passed for `feishu`.
- Internal docs link check passed (6,496 links).

The full `pnpm test:extension feishu` run was started, but an existing webhook typing-indicator E2E test did not finish after repeated 60-second TTL warnings; it was interrupted without a test failure. This PR's direct coverage passed.

## Review metrics

- Production code: 112 added lines.
- Tests: 205 added lines.
- Documentation: 22 added lines.

## AI assistance

Prepared with Codex; implementation and validation were reviewed by the maintainer submitting this PR.
