### PR TITLE
fix(ui): surface command-palette chat search failures

### DIFF
--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -204,6 +204,32 @@ describe("CommandPalette lifecycle", () => {
     expect(palette.textContent).not.toContain("Stale chat");
   });
 
+  it("shows a search failure instead of a false empty result", async () => {
+    const { gateway } = createGateway(true);
+    const list = vi
+      .fn<ApplicationContext<RouteId>["sessions"]["list"]>()
+      .mockRejectedValueOnce(new Error("store needs doctor migration"))
+      .mockResolvedValueOnce(createSessionResult("agent:main:zz", "Recovered chat"));
+    const { palette } = await mountPalette(createContext(gateway, list));
+    // The query matches no navigation item, so a swallowed search failure
+    // would render the plain "No results" empty state.
+    await enterQuery(palette, "zzz-unmatched");
+    await vi.advanceTimersByTimeAsync(250);
+    await palette.updateComplete;
+
+    expect(list).toHaveBeenCalledOnce();
+    expect(palette.textContent).toContain("Chat search failed");
+    expect(palette.textContent).not.toContain("No results");
+
+    // A new keystroke clears the failure state and retries cleanly.
+    await enterQuery(palette, "zz");
+    await palette.updateComplete;
+    expect(palette.textContent).not.toContain("Chat search failed");
+    await vi.advanceTimersByTimeAsync(250);
+    await palette.updateComplete;
+    expect(palette.textContent).toContain("Recovered chat");
+  });
+
   it("navigates to the plugin manager from search", async () => {
     const { gateway } = createGateway(true);
     const { palette } = await mountPalette(

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -124,6 +124,7 @@ type CommandPaletteProps = {
   query: string;
   activeIndex: number;
   sessionItems: readonly PaletteItem[];
+  sessionSearchFailed: boolean;
   onToggle: () => void;
   onQueryChange: (query: string) => void;
   onActiveIndexChange: (index: number) => void;
@@ -315,7 +316,11 @@ function renderCommandPalette(props: CommandPaletteProps) {
                 <span class="nav-item__icon" style="opacity:0.3;width:20px;height:20px"
                   >${icons.search}</span
                 >
-                <span>${t("palette.noResults")}</span>
+                <span
+                  >${props.sessionSearchFailed
+                    ? t("palette.searchFailed")
+                    : t("palette.noResults")}</span
+                >
               </div>`
             : grouped.map(
                 ([category, groupedItems]) => html`
@@ -369,6 +374,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   @state() private query = "";
   @state() private activeIndex = 0;
   @state() private sessionItems: readonly PaletteItem[] = [];
+  @state() private sessionSearchFailed = false;
 
   private readonly subscriptions = new SubscriptionsController(this);
   private sessionSearchTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -458,6 +464,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     }
     this.sessionSearchId += 1;
     this.sessionItems = [];
+    this.sessionSearchFailed = false;
   }
 
   private scheduleSessionSearch(query: string) {
@@ -469,6 +476,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     // repopulate selectable stale rows during the debounce window.
     this.sessionSearchId += 1;
     this.sessionItems = [];
+    this.sessionSearchFailed = false;
     const search = normalizeOptionalString(query);
     if (!this.open || !search || !this.onSelectSession) {
       return;
@@ -551,7 +559,13 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       }));
       this.activeIndex = 0;
     } catch {
-      // Session search is best-effort; navigation commands stay usable.
+      // Session search is best-effort; navigation commands stay usable. But a
+      // failed search must not render as "No results" — that reads as a
+      // successful search with zero matches and hides gateway-side failures
+      // (e.g. a store needing doctor migration) from the operator.
+      if (requestId === this.sessionSearchId && this.open) {
+        this.sessionSearchFailed = true;
+      }
     }
   }
 
@@ -573,6 +587,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       query: this.query,
       activeIndex: this.activeIndex,
       sessionItems: this.sessionItems,
+      sessionSearchFailed: this.sessionSearchFailed,
       desktopAvailable: this.desktopAvailable,
       onToggle: this.togglePalette,
       onQueryChange: (query) => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3850,6 +3850,7 @@ export const en: TranslationMap = {
   palette: {
     placeholder: "Search chats and commands…",
     noResults: "No results",
+    searchFailed: "Chat search failed — check the gateway logs and retry",
     categories: {
       search: "Search",
       navigation: "Navigation",


### PR DESCRIPTION
## What Problem This Solves

Found by live Control UI QA: opening the command palette and typing any chat query rendered "No results" even when every visible session title matched. The gateway was actually rejecting `sessions.list` (store pending a doctor canonical-key migration), but the palette's `searchSessions` catch swallowed the error and the empty state rendered as if the search succeeded with zero matches — a silent failure on a default path, the worst bug class per the repo doctrine.

## Why This Change Was Made

A failed search and an empty search are different facts and must render differently. The palette now records the failure (`sessionSearchFailed`, scoped to the current request id while open, cleared on every new query) and the empty state says "Chat search failed — check the gateway logs and retry" instead of "No results". Navigation commands stay usable throughout — the search remains best-effort.

## User Impact

Operators with a broken session store (or any gateway-side search failure) now see that search is failing instead of concluding their chats are gone.

## Evidence

- Live repro on the QA gateway: `sessions.list` rejected with `SessionCanonicalKeyMigrationRequiredError` while the palette showed plain "No results" (gateway log confirms 6 consecutive rejections).
- New regression "shows a search failure instead of a false empty result" fails pre-fix (stash-verified), passes post-fix; also covers failure-state clearing + clean retry on the next keystroke.
- `node scripts/run-vitest.mjs run ui/src/components/command-palette.test.ts` — 8/8 pass.
- `pnpm ui:i18n:baseline` + `pnpm ui:i18n:verify` clean (new `palette.searchFailed` key, English source only per ui/AGENTS.md).
- tsgo ui lane green.
- LOC: prod +18/−2, test +26.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99.
