### PR TITLE
fix(codex): reject malformed native tool arguments

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -191,7 +191,7 @@ extensions/codex/src/app-server/config-utils.ts	1
 extensions/codex/src/app-server/context-engine-projection.ts	4
 extensions/codex/src/app-server/dynamic-tool-build.ts	1
 extensions/codex/src/app-server/dynamic-tool-response-state.ts	1
-extensions/codex/src/app-server/dynamic-tools.ts	7
+extensions/codex/src/app-server/dynamic-tools.ts	6
 extensions/codex/src/app-server/effective-mcp-catalog.ts	1
 extensions/codex/src/app-server/elicitation-bridge.ts	1
 extensions/codex/src/app-server/event-projector-reasoning.ts	1

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -137,7 +137,7 @@ function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTest {
     parameters: {
       type: "object",
       properties: {},
-      additionalProperties: false,
+      additionalProperties: true,
     },
     execute: vi.fn(async () => ({
       content: [{ type: "text" as const, text: `${name} done` }],

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -225,6 +225,7 @@ async function runSchemaToolCall(params: {
   name?: string;
   namespace?: SchemaToolNamespace;
   parameters?: AnyAgentTool["parameters"];
+  prepareArguments?: AnyAgentTool["prepareArguments"];
 }) {
   const name = params.name ?? "strict_tool";
   const namespace = params.namespace ?? null;
@@ -232,6 +233,7 @@ async function runSchemaToolCall(params: {
   const tool = createTool({
     name,
     parameters: params.parameters ?? STRICT_INSTRUCTION_SCHEMA,
+    prepareArguments: params.prepareArguments,
     execute,
   });
   const bridge = createCodexDynamicToolBridge({
@@ -339,31 +341,38 @@ describe("createCodexDynamicToolBridge", () => {
     expect((contentItem.text as string).length).toBeLessThanOrEqual(260);
   });
 
-  it.each([
-    { label: "number", arguments: 47 },
-    { label: "string", arguments: "unexpected" },
-    { label: "array", arguments: [] },
-    { label: "null", arguments: null },
-  ])(
-    "rejects a $label root before optional-only object arguments are normalized",
-    async (testCase) => {
-      const { execute, response } = await runSchemaToolCall({
-        arguments: testCase.arguments as JsonValue,
-        callId: `call-non-object-${testCase.label}`,
-        name: "optional_object_tool",
-        parameters: {
-          type: "object",
-          properties: { note: { type: "string" } },
-          additionalProperties: false,
-        },
-        namespace: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
-      });
+  it("prepares raw null arguments before native Codex schema validation", async () => {
+    const prepareArguments = vi.fn(function (this: AnyAgentTool, arguments_: unknown) {
+      return arguments_ === null ? { preparedBy: this.name } : arguments_;
+    });
+    const { execute, response } = await runSchemaToolCall({
+      arguments: null,
+      callId: "call-null-compatibility",
+      name: "optional_object_tool",
+      parameters: {
+        type: "object",
+        properties: { preparedBy: { type: "string" } },
+        additionalProperties: false,
+      },
+      prepareArguments,
+      namespace: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+    });
 
-      expectSchemaRejection(response, execute, "must be object");
+    expect(prepareArguments).toHaveBeenCalledWith(null);
+    expect(response).toEqual(expectInputText("done"));
+    expectExecuteCall(execute, {
+      callId: "call-null-compatibility",
+      args: { preparedBy: "optional_object_tool" },
+    });
+  });
+
+  it.each([
+    {
+      label: "repairs primitive input",
+      initial: 47,
+      adjusted: { instruction: "repaired" },
+      executes: true,
     },
-  );
-
-  it.each([
     {
       label: "repairs invalid input",
       initial: { instruction: 47 },

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -7,6 +7,7 @@ import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
 import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
+  getPluginToolMeta,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -72,7 +73,7 @@ function createTool(overrides: Partial<AnyAgentTool>): AnyAgentTool {
   return {
     name: "tts",
     description: "Convert text to speech.",
-    parameters: { type: "object", properties: {} },
+    parameters: { type: "object", properties: {}, additionalProperties: true },
     execute: vi.fn(),
     ...overrides,
   } as unknown as AnyAgentTool;
@@ -206,12 +207,293 @@ async function handleMessageToolCall(
   });
 }
 
+const STRICT_INSTRUCTION_SCHEMA = {
+  type: "object",
+  properties: { instruction: { type: "string" } },
+  required: ["instruction"],
+  additionalProperties: false,
+} as const;
+
+type SchemaToolNamespace =
+  | null
+  | typeof CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE
+  | typeof CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE;
+
+async function runSchemaToolCall(params: {
+  arguments: JsonValue;
+  callId: string;
+  name?: string;
+  namespace?: SchemaToolNamespace;
+  parameters?: AnyAgentTool["parameters"];
+}) {
+  const name = params.name ?? "strict_tool";
+  const namespace = params.namespace ?? null;
+  const execute = vi.fn(async () => textToolResult("done"));
+  const tool = createTool({
+    name,
+    parameters: params.parameters ?? STRICT_INSTRUCTION_SCHEMA,
+    execute,
+  });
+  const bridge = createCodexDynamicToolBridge({
+    tools: [tool],
+    signal: new AbortController().signal,
+    loading: namespace === CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE ? "searchable" : undefined,
+    directToolNames:
+      namespace === CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE ? [name] : undefined,
+  });
+  const response = await bridge.handleToolCall({
+    threadId: "thread-1",
+    turnId: "turn-1",
+    callId: params.callId,
+    namespace,
+    tool: name,
+    arguments: params.arguments,
+  });
+  return { bridge, execute, response, tool };
+}
+
+function expectSchemaRejection(
+  response: Awaited<ReturnType<typeof runSchemaToolCall>>["response"],
+  execute: ReturnType<typeof vi.fn>,
+  message: string,
+) {
+  expect(execute).not.toHaveBeenCalled();
+  expect(response).toMatchObject({
+    success: false,
+    executionStarted: false,
+    contentItems: [{ type: "inputText", text: expect.stringContaining(message) }],
+  });
+}
+
 afterEach(() => {
   resetGlobalHookRunner();
   setActivePluginRegistry(createEmptyPluginRegistry());
 });
 
 describe("createCodexDynamicToolBridge", () => {
+  it("rejects invalid deferred-tool arguments before execution", async () => {
+    const { execute, response } = await runSchemaToolCall({
+      arguments: { instruction: 47 },
+      callId: "call-deferred-invalid",
+      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+    });
+
+    expectSchemaRejection(response, execute, "instruction: must be string");
+  });
+
+  it("rejects the beta.2 session_status wrong-type regression before execution", async () => {
+    const { execute, response } = await runSchemaToolCall({
+      arguments: { sessionKey: 47 },
+      callId: "call-session-status",
+      name: "session_status",
+      parameters: {
+        type: "object",
+        properties: { sessionKey: { type: "string" } },
+        additionalProperties: false,
+      },
+      namespace: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+    });
+
+    expectSchemaRejection(response, execute, "sessionKey: must be string");
+  });
+
+  it("bounds high-cardinality validation errors returned to Codex", async () => {
+    const propertyNames = Array.from({ length: 10 }, (_, index) => `field${index}`);
+    const invalidArguments = Object.fromEntries(propertyNames.map((name) => [name, 47]));
+    const { execute, response } = await runSchemaToolCall({
+      arguments: invalidArguments,
+      callId: "call-many-invalid-fields",
+      name: "bounded_validation_tool",
+      parameters: {
+        type: "object",
+        properties: Object.fromEntries(propertyNames.map((name) => [name, { type: "string" }])),
+        required: propertyNames,
+        additionalProperties: false,
+      },
+    });
+
+    expectSchemaRejection(response, execute, "more violation(s) omitted");
+    const contentItem = requireRecord(response.contentItems[0], "validation response");
+    expect(contentItem.text).toEqual(expect.any(String));
+    expect((contentItem.text as string).length).toBeLessThanOrEqual(800);
+  });
+
+  it("bounds aggregated unexpected-property details returned to Codex", async () => {
+    const invalidArguments = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [`unexpected_property_${index}`, true]),
+    );
+    const { execute, response } = await runSchemaToolCall({
+      arguments: invalidArguments,
+      callId: "call-many-unexpected-fields",
+      name: "bounded_additional_properties_tool",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    });
+
+    expectSchemaRejection(response, execute, "[detail truncated]");
+    const contentItem = requireRecord(response.contentItems[0], "validation response");
+    expect(contentItem.text).toEqual(expect.any(String));
+    expect((contentItem.text as string).length).toBeLessThanOrEqual(260);
+  });
+
+  it.each([
+    { label: "number", arguments: 47 },
+    { label: "string", arguments: "unexpected" },
+    { label: "array", arguments: [] },
+    { label: "null", arguments: null },
+  ])(
+    "rejects a $label root before optional-only object arguments are normalized",
+    async (testCase) => {
+      const { execute, response } = await runSchemaToolCall({
+        arguments: testCase.arguments as JsonValue,
+        callId: `call-non-object-${testCase.label}`,
+        name: "optional_object_tool",
+        parameters: {
+          type: "object",
+          properties: { note: { type: "string" } },
+          additionalProperties: false,
+        },
+        namespace: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+      });
+
+      expectSchemaRejection(response, execute, "must be object");
+    },
+  );
+
+  it.each([
+    {
+      label: "repairs invalid input",
+      initial: { instruction: 47 },
+      adjusted: { instruction: "repaired" },
+      executes: true,
+    },
+    {
+      label: "rejects invalid rewritten input",
+      initial: { instruction: "inspect" },
+      adjusted: { instruction: 47 },
+      executes: false,
+    },
+  ])("validates final arguments after a hook $label", async (testCase) => {
+    const beforeToolCall = vi.fn(async () => ({ params: testCase.adjusted }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const callId = `call-hook-schema-${testCase.executes}`;
+    const { execute, response } = await runSchemaToolCall({
+      arguments: testCase.initial,
+      callId,
+      name: "hook_schema_tool",
+    });
+
+    if (testCase.executes) {
+      expect(response).toEqual(expectInputText("done"));
+      expectExecuteCall(execute, {
+        callId,
+        args: { instruction: "repaired" },
+      });
+    } else {
+      expectSchemaRejection(response, execute, "instruction: must be string");
+    }
+  });
+
+  it("leaves external MCP tool argument validation to the MCP bridge", async () => {
+    const tool = createOwnerBackedContractTool({
+      pluginId: "mcp-bridge",
+      name: "external_mcp_tool",
+      result: textToolResult("mcp handled"),
+    });
+    tool.parameters = {
+      type: "object",
+      properties: { instruction: { type: "string" } },
+      required: ["instruction"],
+      additionalProperties: false,
+    };
+    const meta = getPluginToolMeta(tool);
+    expect(meta).toBeDefined();
+    Object.assign(meta ?? {}, {
+      mcp: {
+        serverName: "external",
+        safeServerName: "external",
+        toolName: tool.name,
+        operation: "tool",
+      },
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+    });
+
+    const response = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-external-mcp",
+      namespace: null,
+      tool: tool.name,
+      arguments: { instruction: 47 },
+    });
+
+    expect(response).toEqual(expectInputText("mcp handled"));
+  });
+
+  it("scopes normalized input validation to the projected Codex wrapper", async () => {
+    const execute = vi.fn(async () => textToolResult("done"));
+    const source = wrapToolWithBeforeToolCallHook(
+      createTool({
+        name: "provider_scoped_tool",
+        parameters: {
+          type: "object",
+          properties: { instruction: { type: "string" } },
+          required: ["instruction"],
+          additionalProperties: false,
+        },
+        execute,
+      }),
+    );
+    const bridge = createCodexDynamicToolBridge({
+      tools: [source],
+      signal: new AbortController().signal,
+    });
+
+    const response = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-provider-scoped-codex",
+      namespace: null,
+      tool: source.name,
+      arguments: { instruction: 47 },
+    });
+
+    expect(response.success).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+
+    await source.execute?.("call-provider-scoped-source", { instruction: 47 });
+
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("isolates cached validators for same-name tools with different schemas", async () => {
+    const call = (instructionType: "string" | "number", callId: string) =>
+      runSchemaToolCall({
+        arguments: { instruction: "inspect" },
+        callId,
+        name: "schema_cache_tool",
+        parameters: {
+          type: "object",
+          properties: { instruction: { type: instructionType } },
+          required: ["instruction"],
+          additionalProperties: false,
+        },
+      });
+    const stringCase = await call("string", "call-cache-string");
+    const numberCase = await call("number", "call-cache-number");
+
+    expect(stringCase.response).toEqual(expectInputText("done"));
+    expectSchemaRejection(numberCase.response, numberCase.execute, "instruction: must be number");
+  });
+
   it("surfaces a rejected owner-backed memory write before a false final claim", async () => {
     const tool = createOwnerBackedContractTool({
       pluginId: "memory-lancedb",
@@ -911,29 +1193,44 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
-  it("repairs a null dynamic-tool schema type before Codex registration", () => {
-    const bridge = createCodexDynamicToolBridge({
-      tools: [
-        createTool({
-          name: "codex_app__automation_update",
-          parameters: {
-            type: null,
-            properties: {
-              action: { type: "string", description: null },
-            },
-          } as never,
-        }),
-      ],
-      signal: new AbortController().signal,
+  it("validates execution against the repaired schema published to Codex", async () => {
+    const { bridge, execute, response } = await runSchemaToolCall({
+      arguments: { action: "inspect" },
+      callId: "call-repaired-schema",
+      name: "codex_app__automation_update",
+      parameters: {
+        type: null,
+        properties: { action: { type: "string", description: null } },
+      } as never,
     });
 
     expect(flattenSpecsWithNamespace(bridge.specs)[0]?.inputSchema).toEqual({
       type: "object",
-      properties: {
-        action: { type: "string" },
-      },
+      properties: { action: { type: "string" } },
     });
     expect(bridge.telemetry.quarantinedTools).toEqual([]);
+    expect(response).toEqual(expectInputText("done"));
+    expectExecuteCall(execute, {
+      callId: "call-repaired-schema",
+      args: { action: "inspect" },
+    });
+  });
+
+  it("enforces the strict empty-object schema published to Codex", async () => {
+    const { bridge, execute, response } = await runSchemaToolCall({
+      arguments: { unexpected: true },
+      callId: "call-strict-empty-schema",
+      name: "strict_empty_tool",
+      parameters: {},
+    });
+
+    expect(flattenSpecsWithNamespace(bridge.specs)[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    expectSchemaRejection(response, execute, 'must not have additional properties: "unexpected"');
   });
 
   it("quarantines dynamic tools with unsupported input schemas", async () => {
@@ -4403,7 +4700,7 @@ describe("createCodexDynamicToolBridge", () => {
       callId: "call-terminal-middleware",
       namespace: null,
       tool: "web_fetch",
-      arguments: { url: "https://private.example" },
+      arguments: {},
     });
 
     expect(onToolOutcome).toHaveBeenLastCalledWith(
@@ -4459,7 +4756,7 @@ describe("createCodexDynamicToolBridge", () => {
       callId: "call-terminal-middleware-error",
       namespace: null,
       tool: "web_fetch",
-      arguments: { url: "https://private.example" },
+      arguments: {},
     });
 
     expect(onToolOutcome).toHaveBeenLastCalledWith(

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -679,18 +679,9 @@ export function createCodexDynamicToolBridge(params: {
         }
       };
       try {
-        // Keep non-object roots intact long enough to validate them. The execution
-        // boundary still uses record arguments, but normalizing first would turn
-        // values such as `null`, arrays, or numbers into `{}` and could let them
-        // satisfy schemas whose object properties are all optional.
-        if (!isRecord(rawArguments) && shouldValidateCodexDynamicToolInput(tool)) {
-          assertCodexDynamicToolInputMatchesSchema({
-            toolName,
-            schema: toolEntry.inputSchema,
-            value: rawArguments,
-          });
-        }
-        const toolArgs = tool.prepareArguments ? tool.prepareArguments(args) : args;
+        // Compatibility preparation owns raw arguments; record coercion must not run first.
+        const prepare = tool.prepareArguments;
+        const toolArgs = prepare ? Reflect.apply(prepare, tool, [rawArguments]) : args;
         const preparedArgs =
           toolName === "message" && isRecord(toolArgs)
             ? await prepareCodexRemoteWorkspaceMessageMedia({

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -44,6 +44,10 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import {
+  type JsonSchemaObject,
+  validateJsonSchemaValue,
+} from "openclaw/plugin-sdk/json-schema-runtime";
 import type { ImageContent, TextContent } from "openclaw/plugin-sdk/llm";
 import { normalizeOpenAIToolSchemas } from "openclaw/plugin-sdk/provider-tools";
 import {
@@ -105,13 +109,64 @@ type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
   name: string;
   description: string;
-  inputSchema: JsonValue;
+  inputSchema: JsonSchemaObject & JsonValue;
 };
 
 type CodexDynamicToolSchemaQuarantine = {
   tool: string;
   violations: readonly string[];
 };
+
+const INTERNAL_TOOL_EXECUTION_VALIDATION = Symbol.for("openclaw.internalToolExecutionValidation");
+const MAX_CODEX_DYNAMIC_TOOL_VALIDATION_ERRORS = 4;
+const MAX_CODEX_DYNAMIC_TOOL_VALIDATION_ERROR_CHARS = 160;
+const CODEX_DYNAMIC_TOOL_VALIDATION_TRUNCATED_SUFFIX = " [detail truncated]";
+
+function shouldValidateCodexDynamicToolInput(tool: AnyAgentTool): boolean {
+  return getPluginToolMeta(tool)?.mcp?.operation !== "tool";
+}
+
+function assertCodexDynamicToolInputMatchesSchema(params: {
+  toolName: string;
+  schema: JsonSchemaObject;
+  value: unknown;
+}): void {
+  const validation = validateJsonSchemaValue({
+    schema: params.schema,
+    cacheKey: `codex-dynamic-tool-input:${params.toolName}:${JSON.stringify(params.schema)}`,
+    value: params.value,
+  });
+  if (validation.ok) {
+    return;
+  }
+  const visibleErrors = validation.errors.slice(0, MAX_CODEX_DYNAMIC_TOOL_VALIDATION_ERRORS);
+  const details = visibleErrors
+    .map((error) => {
+      if (error.text.length <= MAX_CODEX_DYNAMIC_TOOL_VALIDATION_ERROR_CHARS) {
+        return error.text;
+      }
+      return `${error.text.slice(
+        0,
+        MAX_CODEX_DYNAMIC_TOOL_VALIDATION_ERROR_CHARS -
+          CODEX_DYNAMIC_TOOL_VALIDATION_TRUNCATED_SUFFIX.length,
+      )}${CODEX_DYNAMIC_TOOL_VALIDATION_TRUNCATED_SUFFIX}`;
+    })
+    .join("; ");
+  const omitted = validation.errors.length - visibleErrors.length;
+  const omittedSuffix = omitted > 0 ? `; ${omitted} more violation(s) omitted` : "";
+  throw new Error(`Invalid arguments for tool "${params.toolName}": ${details}${omittedSuffix}.`);
+}
+
+function createCodexDynamicToolValidationControl(params: {
+  toolCallId: string;
+  validate: (value: unknown) => void;
+}): Record<PropertyKey, unknown> {
+  return {
+    [INTERNAL_TOOL_EXECUTION_VALIDATION]: true,
+    toolCallId: params.toolCallId,
+    validate: params.validate,
+  };
+}
 
 function applyCurrentMessageProvider(
   toolName: string,
@@ -589,7 +644,8 @@ export function createCodexDynamicToolBridge(params: {
         });
       }
       const { tool, name: toolName } = toolEntry;
-      const args = asNonArrayRecord(call.arguments);
+      const rawArguments = call.arguments;
+      const args = asNonArrayRecord(rawArguments);
       const startedAt = Date.now();
       const signal = composeAbortSignals(params.signal, options?.signal);
       let didStartExecution = false;
@@ -623,6 +679,17 @@ export function createCodexDynamicToolBridge(params: {
         }
       };
       try {
+        // Keep non-object roots intact long enough to validate them. The execution
+        // boundary still uses record arguments, but normalizing first would turn
+        // values such as `null`, arrays, or numbers into `{}` and could let them
+        // satisfy schemas whose object properties are all optional.
+        if (!isRecord(rawArguments) && shouldValidateCodexDynamicToolInput(tool)) {
+          assertCodexDynamicToolInputMatchesSchema({
+            toolName,
+            schema: toolEntry.inputSchema,
+            value: rawArguments,
+          });
+        }
         const toolArgs = tool.prepareArguments ? tool.prepareArguments(args) : args;
         const preparedArgs =
           toolName === "message" && isRecord(toolArgs)
@@ -648,7 +715,21 @@ export function createCodexDynamicToolBridge(params: {
             : undefined,
         };
         didDispatchExecution = true;
-        const rawResult = await tool.execute(call.callId, preparedArgs, signal);
+        const executionArgs: unknown[] = [call.callId, preparedArgs, signal];
+        if (shouldValidateCodexDynamicToolInput(tool)) {
+          executionArgs.push(
+            createCodexDynamicToolValidationControl({
+              toolCallId: call.callId,
+              validate: (value) =>
+                assertCodexDynamicToolInputMatchesSchema({
+                  toolName,
+                  schema: toolEntry.inputSchema,
+                  value,
+                }),
+            }),
+          );
+        }
+        const rawResult = await Reflect.apply(tool.execute, tool, executionArgs);
         captureExecutionBoundary();
         const telemetryRawResult = sanitizeToolResult(rawResult);
         const rawIsError = isToolResultError(rawResult);
@@ -1119,11 +1200,18 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
       quarantinedTools.push({ tool: descriptor.name, violations: projection.violations });
       continue;
     }
+    if (!isRecord(projection.schema)) {
+      quarantinedTools.push({
+        tool: descriptor.name,
+        violations: [`${descriptor.name}.inputSchema must be a JSON object schema`],
+      });
+      continue;
+    }
     projectedTools.push({
       tool,
       name: descriptor.name,
       description: descriptor.description,
-      inputSchema: projection.schema as JsonValue,
+      inputSchema: projection.schema,
     });
   }
   return { tools: projectedTools, quarantinedTools };

--- a/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
@@ -16,7 +16,7 @@ function createContractTool(overrides: Partial<AnyAgentTool>): AnyAgentTool {
   return {
     name: "exec",
     description: "Run a command.",
-    parameters: { type: "object", properties: {} },
+    parameters: { type: "object", properties: {}, additionalProperties: true },
     execute: vi.fn(),
     ...overrides,
   } as unknown as AnyAgentTool;

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -420,7 +420,12 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
           {
             name: "cron",
             description: "Cron",
-            parameters: { type: "object", properties: {} },
+            parameters: {
+              type: "object",
+              properties: { action: { type: "string" } },
+              required: ["action"],
+              additionalProperties: false,
+            },
             execute: vi.fn(async () => toolResult),
           } as never,
         ],

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -445,7 +445,7 @@ async function runSideQuestionWithManagedWebSearchCall(
       {
         name: "web_search",
         description: "Search the web",
-        parameters: { type: "object", properties: {} },
+        parameters: { type: "object", properties: {}, additionalProperties: true },
         execute: toolExecuteMock,
       },
     ]);
@@ -516,13 +516,13 @@ describe("runCodexAppServerSideQuestion", () => {
       {
         name: "wiki_status",
         description: "Check wiki status",
-        parameters: { type: "object", properties: {} },
+        parameters: { type: "object", properties: {}, additionalProperties: true },
         execute: toolExecuteMock,
       },
       {
         name: "web_search",
         description: "Search the web",
-        parameters: { type: "object", properties: {} },
+        parameters: { type: "object", properties: {}, additionalProperties: true },
         execute: toolExecuteMock,
       },
     ]);
@@ -1160,7 +1160,7 @@ describe("runCodexAppServerSideQuestion", () => {
             {
               name: "web_search",
               description: "Search the web",
-              parameters: { type: "object", properties: {} },
+              parameters: { type: "object", properties: {}, additionalProperties: true },
               execute: toolExecuteMock,
             },
           ],
@@ -1236,7 +1236,7 @@ describe("runCodexAppServerSideQuestion", () => {
               {
                 name: "web_search",
                 description: "Search the web",
-                parameters: { type: "object", properties: {} },
+                parameters: { type: "object", properties: {}, additionalProperties: true },
                 execute: toolExecuteMock,
               },
             ]
@@ -2376,7 +2376,7 @@ describe("runCodexAppServerSideQuestion", () => {
       {
         name: "computer",
         description: "Control a desktop",
-        parameters: { type: "object", properties: {} },
+        parameters: { type: "object", properties: {}, additionalProperties: true },
         execute: computerExecute,
       },
     ]);

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -218,6 +218,32 @@ describe("before_tool_call hook integration", () => {
     expect(consumeTrackedToolExecutionStarted("call-1")).toBeUndefined();
   });
 
+  it("consumes private execution validation through the standard update slot", async () => {
+    beforeToolCallHook = installBeforeToolCallHook({ enabled: false });
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const tool = wrapToolWithBeforeToolCallHook(asAgentTool({ name: "Read", execute }));
+    const validate = vi.fn(() => {
+      throw new Error("invalid projected arguments");
+    });
+    const validationControl = {
+      [Symbol.for("openclaw.internalToolExecutionValidation")]: true,
+      toolCallId: "call-private-validation",
+      validate,
+    };
+
+    await expect(
+      Reflect.apply(tool.execute, tool, [
+        "call-private-validation",
+        { path: 47 },
+        undefined,
+        validationControl,
+      ]),
+    ).rejects.toThrow("invalid projected arguments");
+
+    expect(validate).toHaveBeenCalledWith({ path: 47 });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("records structured replay trust only for concrete core-owned tools", async () => {
     beforeToolCallHook = installBeforeToolCallHook({ enabled: false });
     const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -57,7 +57,10 @@ import {
   createInternalExecutionPreparer,
   readInternalExecutionControl,
 } from "./agent-tools.execution-preparer.js";
-import { validateToolExecutionParams } from "./agent-tools.execution-validation.js";
+import {
+  readInternalToolExecutionValidation,
+  validateToolExecutionParams,
+} from "./agent-tools.execution-validation.js";
 import {
   BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
@@ -304,6 +307,13 @@ export function wrapToolWithBeforeToolCallHook(
       if (prepareControl) {
         executionArgs.pop();
       }
+      const onUpdateValidation = readInternalToolExecutionValidation(onUpdate);
+      const internalValidation =
+        onUpdateValidation ?? readInternalToolExecutionValidation(executionArgs.at(-1));
+      const forwardedOnUpdate = onUpdateValidation ? undefined : onUpdate;
+      if (!onUpdateValidation && internalValidation) {
+        executionArgs.pop();
+      }
       const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.(toolCallId);
       const preExecutionStartedAt = Date.now();
       const normalizedToolName = normalizeToolPolicyName(toolName || "tool");
@@ -466,6 +476,9 @@ export function wrapToolWithBeforeToolCallHook(
         // Hooks can repair or rewrite arguments; only the final execution
         // shape is safe to validate, after vetoes but before side effects.
         await validateToolExecutionParams(toolCallId, executeParams);
+        if (internalValidation?.toolCallId === toolCallId) {
+          await internalValidation.validate(executeParams);
+        }
         await reconcileLoopCallExecutionParams({
           ctx,
           toolName: normalizedToolName,
@@ -519,7 +532,7 @@ export function wrapToolWithBeforeToolCallHook(
             toolCallId,
             executeParams,
             signal,
-            onUpdate,
+            forwardedOnUpdate,
             ...executionArgs,
           );
         } catch (error) {

--- a/src/agents/agent-tools.execution-validation.ts
+++ b/src/agents/agent-tools.execution-validation.ts
@@ -7,6 +7,12 @@ type ScopedToolExecutionValidator = {
 };
 
 const executionValidators = new AsyncLocalStorage<ScopedToolExecutionValidator>();
+const INTERNAL_TOOL_EXECUTION_VALIDATION = Symbol.for("openclaw.internalToolExecutionValidation");
+
+type InternalToolExecutionValidation = {
+  toolCallId: string;
+  validate: ToolExecutionValidator;
+};
 
 /** Keep per-call validation inside the policy wrapper's final execution boundary. */
 export async function runWithToolExecutionValidation<T>(
@@ -26,4 +32,25 @@ export async function validateToolExecutionParams(
   if (scopedValidator?.toolCallId === toolCallId) {
     await scopedValidator.validate(params);
   }
+}
+
+/** Read the private validation control carried by one native harness call. */
+export function readInternalToolExecutionValidation(
+  value: unknown,
+): InternalToolExecutionValidation | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const marker = Reflect.get(value, INTERNAL_TOOL_EXECUTION_VALIDATION);
+  const toolCallId = Reflect.get(value, "toolCallId");
+  const validate = Reflect.get(value, "validate");
+  if (marker !== true || typeof toolCallId !== "string" || typeof validate !== "function") {
+    return undefined;
+  }
+  return {
+    toolCallId,
+    validate: async (params) => {
+      await Reflect.apply(validate, undefined, [params]);
+    },
+  };
 }

--- a/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -73,7 +73,7 @@ export function createOwnerBackedContractTool(params: {
     name: params.name,
     label: `${params.name} owner contract tool`,
     description: `${params.name} owner contract tool`,
-    parameters: { type: "object", properties: {} },
+    parameters: { type: "object", properties: {}, additionalProperties: true },
     execute: vi.fn(async () => params.result),
   } as AnyAgentTool;
   setPluginToolMeta(tool, {


### PR DESCRIPTION
Related: #111704

## What Problem This Solves

Native Codex dynamic tool calls could execute even when their arguments violated the JSON schema shown to Codex. In the published `2026.8.1-beta.2` package, `session_status({ sessionKey: 47 })` succeeded even though `sessionKey` is declared as a string.

Published-package reproduction: https://github.com/openclaw/openclaw/issues/111704#issuecomment-5307253874

## Why This Change Was Made

PR #114461 validates the compact Tool Search path, but native Codex dynamic tools use a separate bridge. This change validates OpenClaw-owned native-tool arguments against the exact normalized schema projected to Codex, after `before_tool_call` rewrites and before any side effect.

The implementation:

- keeps the public four-argument tool-execution contract and Plugin SDK surface unchanged
- carries a call-scoped private validation control in the standard fourth update slot, where the existing policy wrapper consumes it before execution
- preserves ordinary update callbacks and the finalized abort/approval wrapper chain
- excludes external MCP-owned tools, whose server remains responsible for validation
- bounds returned validation details by count and length

Regression coverage includes wrong types, missing and extra properties, primitive roots, normalized empty-object and repaired `type: null` schemas, direct and deferred surfaces, hook rewrites, same-name tools with different schemas, external MCP ownership, approval metadata, cancellation, and the fully finalized four-argument adapter path that exposed the earlier P1.

## User Impact

Malformed native Codex tool calls now return a structured validation error instead of reaching execution or silently using tool-specific fallback behavior. Valid calls, ordinary update callbacks, and external MCP tools retain their existing behavior.

## Evidence

Exact packaged and public head: `7d62c1549377a98bcee394b4e915616abecf9370`

Current-head validation:

- exact-head GitHub CI passed, including lint, type, build, boundary, security, and test shards
- Codex extension suite passed: 143 tests
- shared schema normalization suite passed: 67 tests
- exact-head autoreview completed with no findings
- local offline ClawSweeper found no actionable issue

Exact-head packaged-runtime proof:

- image: `sha256:921b8efab8ade0f813cff2583c9311b5be54cc203189052508182509d5a3526c`
- image version: `OpenClaw 2026.8.1 (7d62c15)`
- bundled extension: `codex`
- model: `openai/gpt-5.6-sol`
- native runtime: OpenAI Codex using ChatGPT authentication
- no fallback, source-tree mount, production OpenClaw state, workspace mount, container socket, or channel credentials

Malformed native call argument:

```json
47
```

Result:

```text
Invalid arguments for tool "session_status": sessionKey: must be string.
```

The turn completed with one `session_status` call, one tool failure, and no successful tool execution.

Valid control:

```json
{}
```

The same exact-head runtime returned live session status identifying `OpenClaw 2026.8.1 (7d62c15)` and the OpenAI Codex runtime. The turn completed with one `session_status` call, zero failures, and `session_status` listed as successfully executed.

The sanitized evidence bundle contains the turn summaries, malformed/valid native trace, image identity, and secret scan. Session and run identifiers, quota text, timestamps, and raw authentication material were omitted. TruffleHog scanned the captured envelopes, stderr logs, and sanitized artifacts with zero verified or unverified secrets. The auth-bearing disposable container was removed after capture.

Key artifact hashes:

- proof summary: `d3d28a91d883564540121795c62d1a9b008aa9f91e633c49cd2133354262cd37`
- native trace: `c5b845244230a9b56d8d7caab0b1e59ee29e773946e58bece48cb51fb2c0b9eb`
- malformed turn: `a03f6f70bfaef8de99efdcaf3594dfdfa2914349787cb2e0f95cf69a53a7b0a3`
- valid control: `294f4ad126b94b982247be205d153cf79ad8dc0c93971a09f265e531ebd82430`
- image identity: `4a80c2bea202573a4a8dbb0df4a56ac26cd1a0bfede3146cd80bec225419da80`
- secret scan: `1b32917d75e78c13c5752af7898e3b0d039bc886bae2d8412df048d0dc1cfafd`

AI-assisted: Codex helped implement and review this change. The author reviewed the diff, resolved the normalized-schema, validation-bounding, abort-lifecycle, adapter-transport, provider-ownership, and public-SDK-scope findings, and ran the validation above.
