### PR TITLE
fix(discord): warn when webhook persona send falls back to bot send

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -12,6 +12,20 @@ import {
   resetDiscordOutboundMocks,
 } from "./outbound-adapter.test-harness.js";
 
+const outboundWarnSpy = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "discord/outbound" ? { ...logger, warn: outboundWarnSpy } : logger;
+    },
+  };
+});
+
 const hoisted = createDiscordOutboundHoisted();
 await installDiscordOutboundModuleSpies(hoisted);
 
@@ -91,6 +105,7 @@ describe("normalizeDiscordOutboundTarget", () => {
 describe("discordOutbound", () => {
   beforeEach(() => {
     resetDiscordOutboundMocks(hoisted);
+    outboundWarnSpy.mockClear();
   });
 
   it("routes text sends to thread target when threadId is provided", async () => {
@@ -281,6 +296,11 @@ describe("discordOutbound", () => {
       text: "fallback",
       result,
     });
+    // The fallback is intended, but the persona failure must stay visible.
+    expect(outboundWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("webhook persona send failed"),
+      { error: expect.objectContaining({ message: "rate limited" }) },
+    );
   });
 
   it("routes poll sends to thread target when threadId is provided", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -11,6 +11,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
@@ -40,6 +41,7 @@ import { resolveDiscordReplyReference } from "./reply-reference.js";
 import { createDiscordSendReceiptFromResults } from "./send.receipt.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
+const log = createSubsystemLogger("discord/outbound");
 const loadDiscordThreadBindings = createLazyRuntimeModule(
   () => import("./monitor/thread-bindings.js"),
 );
@@ -199,6 +201,10 @@ export const discordOutbound: ChannelOutboundAdapter = {
           if (webhookSelected) {
             throw error;
           }
+          // Falling back to the plain bot send is intended (persona delivery is
+          // best-effort), but the failure must stay operator-visible: a broken
+          // webhook binding otherwise degrades every reply silently.
+          log.warn("discord webhook persona send failed; falling back to bot send", { error });
         }
       }
       const { send, target, options } = await resolveDiscordOutboundMessageSend(ctx);


### PR DESCRIPTION
## What Problem This Solves

The Discord bound-thread webhook persona path swallowed every pre-dispatch failure (deleted webhook, revoked token, rate limit) and silently fell back to the plain bot send. The fallback itself is correct — persona delivery is best-effort — but the failure was invisible: a broken webhook binding silently degraded every reply in that thread (wrong username/avatar) with no operator signal, indefinitely.

## Why This Change Was Made

Record the fact where it happens: warn with the error before falling back, via the SDK's `createSubsystemLogger` (same pattern as the Telegram plugin). Post-dispatch failures still rethrow (`webhookSelected`) to avoid duplicate sends — that invariant is untouched.

## User Impact

Operators see a `discord/outbound` warn line when persona delivery breaks instead of silently losing persona rendering.

## Evidence

- Extended the existing "falls back to bot send when webhook send fails" regression to assert the warn; fails pre-fix (stash-verified), passes post-fix.
- `node scripts/run-vitest.mjs run extensions/discord/src/outbound-adapter.test.ts` — 51/51 pass.
- tsgo extensions lane green.
- LOC: prod +6, test +20. Justified growth: pure observability at an owner boundary (silent-failure doctrine).
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99.
