### PR TITLE
fix(update): complete high-volume stable upgrades without stalls

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3107,7 +3107,7 @@ src/gateway/server.auth.control-ui.bootstrap-lifecycle.suite.ts	8
 src/gateway/server.auth.control-ui.device-token.suite.ts	2
 src/gateway/server.auth.control-ui.mobile-bootstrap.suite.ts	7
 src/gateway/server.auth.control-ui.owner-bootstrap.suite.ts	5
-src/gateway/server.auth.control-ui.pairing.suite.ts	11
+src/gateway/server.auth.control-ui.pairing.suite.ts	6
 src/gateway/server.auth.control-ui.trusted-proxy.suite.ts	5
 src/gateway/server.auth.default-token.suite.ts	11
 src/gateway/server.auth.modes.suite.ts	1

--- a/package.json
+++ b/package.json
@@ -1848,7 +1848,7 @@
     "test:docker:plugin-lifecycle-matrix": "bash scripts/e2e/plugin-lifecycle-matrix-docker.sh",
     "test:docker:plugin-update": "bash scripts/e2e/plugin-update-unchanged-docker.sh",
     "test:docker:plugins": "bash scripts/e2e/plugins-docker.sh",
-    "test:docker:published-upgrade-survivor": "env OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@latest} OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT=${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s} bash scripts/e2e/upgrade-survivor-docker.sh",
+    "test:docker:published-upgrade-survivor": "node --import tsx scripts/run-with-env.mts OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor -- node scripts/test-docker-all.mjs",
     "test:docker:qr": "bash scripts/e2e/qr-import-docker.sh",
     "test:docker:rerun": "node --import tsx scripts/docker-e2e-rerun.mts",
     "test:docker:root-managed-vps-upgrade": "env OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS=1 OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@2026.5.7} OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT=${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s} bash scripts/e2e/upgrade-survivor-docker.sh",

--- a/scripts/crabbox-wrapper-providers.mts
+++ b/scripts/crabbox-wrapper-providers.mts
@@ -30,7 +30,7 @@ export function canonicalProviderName(provider: string) {
 
 function addProviderNames(names: Set<string>, text: string) {
   for (const name of text
-    .replace(/\s+\(default\b.*$/u, "")
+    .replace(/\s+\(defaults?\b.*$/u, "")
     .split(/\s*(?:,|\||\bor\b)\s*/u)
     .map((s) => s.trim())
     .filter(Boolean)) {
@@ -42,12 +42,12 @@ function addProviderNames(names: Set<string>, text: string) {
 
 function providerListContinuation(line: string, previousText: string) {
   const match = line.match(
-    /^\s*((?:or\s+)?[a-z0-9][a-z0-9-]*(?:\s*(?:,|\||\bor\b)\s*(?:or\s+)?[a-z0-9][a-z0-9-]*)*\s*(?:,|\|)?)(?:\s+\(default\b.*)?\s*$/u,
+    /^\s*((?:or\s+)?[a-z0-9][a-z0-9-]*(?:\s*(?:,|\||\bor\b)\s*(?:or\s+)?[a-z0-9][a-z0-9-]*)*\s*(?:,|\|)?)(?:\s+\(defaults?\b.*)?\s*$/u,
   );
   if (!match) {
     return "";
   }
-  if (/[,|]\s*$/u.test(previousText) || /[,|]|\bor\b|\(default\b/u.test(line)) {
+  if (/[,|]\s*$/u.test(previousText) || /[,|]|\bor\b|\(defaults?\b/u.test(line)) {
     return match[1] ?? "";
   }
   return "";
@@ -58,10 +58,10 @@ export function parseProvidersFromHelp(text: string) {
   const lines = text.split(/\r?\n/u);
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
-    const providerMatch = line.match(/provider:\s*([a-z0-9][a-z0-9, -]*)(?:\s*\(default\b|$)/u);
+    const providerMatch = line.match(/provider:\s*([a-z0-9][a-z0-9, -]*)(?:\s*\(defaults?\b|$)/u);
     if (providerMatch) {
       let providerText = providerMatch[1] ?? "";
-      while (!/\(default\b/u.test(lines[index] ?? "") && index + 1 < lines.length) {
+      while (!/\(defaults?\b/u.test(lines[index] ?? "") && index + 1 < lines.length) {
         const continuation = providerListContinuation(lines[index + 1] ?? "", providerText);
         if (!continuation) {
           break;

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -394,7 +394,7 @@ configure_clawhub_fixture() {
   local fixture_root="$ARTIFACT_ROOT/clawhub-fixture" port_file log_file
   port_file="$fixture_root/port"
   log_file="$fixture_root/server.log"
-  mkdir -p "$fixture_root"
+  mkdir -p "$fixture_root" && rm -f "$port_file"
   node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
     prepublish-artifacts "$port_file" \
     "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" >"$log_file" 2>&1 &
@@ -537,7 +537,7 @@ NODE
     return 0
   fi
 
-  mkdir -p "$fixture_root"
+  mkdir -p "$fixture_root" && rm -f "$port_file"
   OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version" \
   OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node scripts/e2e/lib/plugins/npm-registry-server.mjs \

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1207,6 +1207,24 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
   console.log(`==> OpenClaw package: ${baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ}`);
 }
 
+function preparePrepublishPluginRegistry(
+  plan: DockerCandidatePlan,
+  logDir: string,
+  sourceSha: string,
+  candidateVersion: string,
+) {
+  const registryDir = path.join(logDir, "prepublish-plugin-registry");
+  fs.rmSync(registryDir, { force: true, recursive: true });
+  const artifact = createPrepublishPluginRegistryArtifact({
+    repoRoot: ROOT_DIR,
+    outputDir: registryDir,
+    sourceSha,
+    candidateVersion,
+    requiredPackages: plan.requiredPrepublishPluginPackages,
+  });
+  return { dir: registryDir, candidateVersion, manifestSha256: artifact.manifestSha256 };
+}
+
 async function prepareDockerCandidate(
   plan: DockerCandidatePlan,
   logDir: string,
@@ -1231,20 +1249,7 @@ async function prepareDockerCandidate(
     }
     let registry = null;
     if (plan.needs.prepublishPluginRegistry) {
-      const registryDir = path.join(logDir, "prepublish-plugin-registry");
-      fs.rmSync(registryDir, { force: true, recursive: true });
-      const artifact = createPrepublishPluginRegistryArtifact({
-        repoRoot: ROOT_DIR,
-        outputDir: registryDir,
-        sourceSha,
-        candidateVersion: version,
-        requiredPackages: plan.requiredPrepublishPluginPackages,
-      });
-      registry = {
-        dir: registryDir,
-        candidateVersion: version,
-        manifestSha256: artifact.manifestSha256,
-      };
+      registry = preparePrepublishPluginRegistry(plan, logDir, sourceSha, version);
     }
     candidate = {
       package: { path: packagePath, name: packed.packageJson.name, version, sha256: packed.sha256 },
@@ -1927,6 +1932,19 @@ async function main() {
     });
   } else {
     console.log("==> OpenClaw package: not needed for selected lanes");
+  }
+  if (plan.needs.prepublishPluginRegistry && !baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR) {
+    await runPhase(phases, "prepare-prepublish-plugin-registry", {}, async () => {
+      const registry = preparePrepublishPluginRegistry(
+        plan,
+        logDir,
+        gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
+        rootPackageVersion(ROOT_DIR),
+      );
+      baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = registry.dir;
+      baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION = registry.candidateVersion;
+      baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256 = registry.manifestSha256;
+    });
   }
 
   if (buildEnabled) {

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -121,6 +121,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       await runCommandWithRuntime(defaultRuntime, async () => {
         setVerbose(verboseLevel === "on");
         await agentCliCommand(opts, defaultRuntime);
+        requestExitAfterOneShotOutput(defaultRuntime);
       });
     });
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   agentsListCommandMock: vi.fn(),
   agentsSetIdentityCommandMock: vi.fn(),
   agentsUnbindCommandMock: vi.fn(),
+  requestExitAfterOneShotOutputMock: vi.fn(),
   setVerboseMock: vi.fn(),
   runtime: {
     log: vi.fn(),
@@ -31,6 +32,7 @@ const agentsDeleteCommandMock = mocks.agentsDeleteCommandMock;
 const agentsListCommandMock = mocks.agentsListCommandMock;
 const agentsSetIdentityCommandMock = mocks.agentsSetIdentityCommandMock;
 const agentsUnbindCommandMock = mocks.agentsUnbindCommandMock;
+const requestExitAfterOneShotOutputMock = mocks.requestExitAfterOneShotOutputMock;
 const setVerboseMock = mocks.setVerboseMock;
 const runtime = mocks.runtime;
 
@@ -70,6 +72,10 @@ vi.mock("../../global-state.js", () => ({
 
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../one-shot-exit.js", () => ({
+  requestExitAfterOneShotOutput: mocks.requestExitAfterOneShotOutputMock,
 }));
 
 describe("agent command registration", () => {
@@ -176,6 +182,7 @@ describe("agent command registration", () => {
 
     expect(agentCliCommandMock).toHaveBeenCalledTimes(1);
     expect(agentExecCommandMock).not.toHaveBeenCalled();
+    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledWith(runtime);
   });
 
   it("keeps an exec-valued parent message on the existing parent action", async () => {

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -58,6 +58,8 @@ export type TranscriptArchiveWorkerMessage = {
   results: TranscriptArchiveWorkerResult[];
 };
 
+export const MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES = 256 * 1024 * 1024;
+
 export type TranscriptArchivePublishPlan = {
   agentId: string;
   archiveDirectory: string;
@@ -312,11 +314,11 @@ function spawnSqliteTranscriptArchiveWorker<Result>(params: {
   return new Promise((resolve, reject) => {
     let results: Result[] | undefined;
     let workerError: Error | undefined;
-    worker.once(
+    worker.on(
       "message",
       (message: TranscriptArchiveWorkerMessage | TranscriptArchivePublishWorkerMessage) => {
         if (message.type === params.expectedMessageType) {
-          results = message.results as Result[];
+          (results ??= []).push(...(message.results as Result[]));
         }
       },
     );
@@ -399,12 +401,9 @@ export async function materializeSessionStateDeletePlans(
   plans: readonly SessionStateDeletePlan[],
 ): Promise<MaterializedSessionStateDeletePlan[]> {
   const deduped = dedupeSqliteSessionStateDeletePlans(plans);
-  const archivePlans = deduped.filter((plan) => plan.archiveTranscript);
   const workerResults: TranscriptArchiveWorkerResult[] = [];
-  let materializedBytes = 0;
-  // Archive bytes must never accumulate for an unbounded cleanup batch. One
-  // generation crosses the Worker boundary at a time, then becomes transaction input.
-  for (const archivePlan of archivePlans) {
+  const workerPlans: TranscriptArchiveWorkerPlan[] = [];
+  for (const archivePlan of deduped.filter((plan) => plan.archiveTranscript)) {
     if (archivePlan.snapshot.lastSeq === null) {
       // Empty transcripts still need a fresh snapshot fence, but have no bytes
       // to encode off-thread and should not pay Worker startup latency.
@@ -412,16 +411,10 @@ export async function materializeSessionStateDeletePlans(
       workerResults.push({ archive: null, sessionId: archivePlan.sessionId });
       continue;
     }
-    const [result] = await runSqliteTranscriptArchiveWorker([archivePlan]);
-    if (result) {
-      materializedBytes += result.archive?.bytes.byteLength ?? 0;
-      if (materializedBytes > MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES) {
-        throw new Error(
-          `SQLite transcript archive batch exceeds ${MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES} bytes; retry with fewer sessions.`,
-        );
-      }
-      workerResults.push(result);
-    }
+    workerPlans.push(archivePlan);
+  }
+  if (workerPlans.length > 0) {
+    workerResults.push(...(await runSqliteTranscriptArchiveWorker(workerPlans)));
   }
   const resultBySessionId = new Map(workerResults.map((result) => [result.sessionId, result]));
 
@@ -451,10 +444,6 @@ export async function materializeSessionStateDeletePlans(
     return Object.assign({}, plan, { archive: result.archive, archivedTranscript });
   });
 }
-
-// Bulk cleanup plans retain encoded bytes until one atomic lifecycle commit.
-// Bound that retained input while still allowing exceptionally large single transcripts.
-const MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES = 256 * 1024 * 1024;
 
 // Multiple removed entries can point at one transcript session. If any owner
 // asked to keep an archive, the shared row gets exported once.

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -6,6 +6,7 @@ import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-age
 import {
   encodeMaterializedSessionTranscriptArchive,
   hashSessionArchiveBytes,
+  MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES,
   publishEncodedSessionTranscriptArchive,
   type TranscriptArchivePublishPlan,
   type TranscriptArchivePublishResult,
@@ -248,8 +249,17 @@ function runWorkerPort(
   port: NonNullable<typeof parentPort>,
   plans: readonly TranscriptArchiveWorkerPlan[],
 ): void {
-  const results = plans.map((plan) => materializeTranscriptArchiveInWorker(plan));
-  port.postMessage({ type: "done", results } satisfies TranscriptArchiveWorkerMessage);
+  let materializedBytes = 0;
+  for (const plan of plans) {
+    const result = materializeTranscriptArchiveInWorker(plan);
+    materializedBytes += result.archive?.bytes.byteLength ?? 0;
+    if (materializedBytes > MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES) {
+      throw new Error(
+        `Archive batch exceeds ${MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES} bytes; use fewer sessions`,
+      );
+    }
+    port.postMessage({ type: "done", results: [result] } satisfies TranscriptArchiveWorkerMessage);
+  }
   port.close();
 }
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -3259,7 +3259,7 @@ describe("scripts/crabbox-wrapper", () => {
     );
   });
 
-  it("parses provider choices from the --provider flag help format", () => {
+  it("parses provider choices from the supported --provider help formats", () => {
     const helpText =
       "Usage: crabbox run [options]\n  --provider hetzner|aws|local-container|blacksmith-testbox|cloudflare\n";
 
@@ -3270,6 +3270,11 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "cloudflare",
     ]);
+    expect(
+      parseProvidersFromHelp(
+        "  -provider string\n    provider: aws, blacksmith-testbox, local-container (defaults to configured selection)\n",
+      ),
+    ).toEqual(["aws", "blacksmith-testbox", "local-container"]);
   });
 
   it("uses a temporary full checkout for clean sparse Blacksmith syncs", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a published stable install with many SQLite session transcripts and configured plugins could hit unreliable survivor validation, extremely slow cleanup, or a successful local agent turn that never returned control to the shell.

## Why This Change Was Made

The published-upgrade lane now prepares the candidate package and its unpublished companion-plugin tuple through the normal scheduler path, uses the repository's cross-platform environment runner, tolerates current Crabbox provider help text, and resets fixture ports safely on retry. Transcript archives are materialized by one streaming worker per cleanup batch while retaining the cumulative 256 MiB safety limit, and successful one-shot legacy agent turns now request a clean exit.

This is AI-assisted work. I reviewed the implementation and the complete validation evidence. Production code remains net zero lines (23 additions, 23 deletions).

## User Impact

Operators can upgrade a heavily configured stable installation to current OpenClaw while retaining sessions, cron/crawl data, channel configuration, pairing/allowlist/delivery state, and installed plugins in SQLite. Large session cleanup no longer scales worker startup with the number of sessions, and one-shot agent commands exit promptly after printing their result. No configuration changes are required.

## Evidence

- Published package upgrade from `openclaw@2026.7.1-2` to candidate `2026.8.1` passed twice in Testbox: 104 s and 102 s.
  - Candidate source: `fdb819f6c4cf08a414a435b6256870e35f9aee02`
  - Candidate tarball SHA-256: `e9f8dc91b608c2a373dd41dcc5a011228dd882de080aa9ba090be06beb265701`
  - Companion registry manifest SHA-256: `9022dc7ed8161153e1423b5b29868637fc4c4599ac04cb7623bb337e347441e6`
- Fresh high-volume upgrade fixture passed with:
  - 3 agents, 4,500 sessions, and 18,000 transcript events
  - 2,000 seeded crawl/cron jobs plus one runtime job
  - Discord, Telegram, and WhatsApp configuration
  - 150 pairing requests, 3,000 allowlist entries, and 1,500 deliveries
  - 40 meeting sessions and 4,000 meeting utterances
- Upgrade timing: 5.755 s stable install, 19.826 s candidate install, 81.290 s first doctor repair, 1.237 s first session import, 1.211 s idempotent second import, 9.823 s second doctor run, 17.863 s plugin inspection/install; 150.219 s total.
- All four durable state databases used WAL, every SQLite database returned `integrity_check = ok`, and every database had zero foreign-key violations.
- Post-upgrade cleanup archived and pruned 1,500 sessions / 6,000 transcript events in 4.501 s (about 481 s before batching), then passed integrity verification with zero remaining rows.
- One isolated, non-delivery live request with the migrated state returned `OK` from `openai/gpt-5.5` in 4.691 s and persisted the turn. No channel messages were sent.
- Focused Vitest validation: 326 tests passed across archive workers, agent CLI, Docker scheduler, and Crabbox wrapper; the final archive edge-case rerun passed 17/17.
- After exact-head CI identified a POSIX-only package-script assignment, the cross-platform fix passed 95/95 package-script and Docker scheduler tests.
- `pnpm check:changed` passed on Testbox, including typechecks, oxlint, dead-export scans, import-cycle checks, package guards, and Docker scheduler dry-run.
- Formatting, shell syntax, JSON parsing, and `git diff --check` passed.
- Autoreview: Codex clean, TruffleHog clean, no actionable findings.
