### PR TITLE
fix(nodes): keep MCP calls within the published catalog

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3500,7 +3500,7 @@ src/node-host/invoke-file-commands.ts	1
 src/node-host/invoke-payload.ts	5
 src/node-host/invoke-system-run-plan.ts	3
 src/node-host/invoke.ts	8
-src/node-host/mcp.ts	4
+src/node-host/mcp.ts	3
 src/node-host/node-worker-bundle-installer.ts	1
 src/node-host/node-worker-supervisor.ts	1
 src/node-host/node-worker-transfer-client.ts	3

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3108,7 +3108,7 @@ src/gateway/server.auth.control-ui.bootstrap-lifecycle.suite.ts	8
 src/gateway/server.auth.control-ui.device-token.suite.ts	2
 src/gateway/server.auth.control-ui.mobile-bootstrap.suite.ts	7
 src/gateway/server.auth.control-ui.owner-bootstrap.suite.ts	5
-src/gateway/server.auth.control-ui.pairing.suite.ts	11
+src/gateway/server.auth.control-ui.pairing.suite.ts	6
 src/gateway/server.auth.control-ui.trusted-proxy.suite.ts	5
 src/gateway/server.auth.default-token.suite.ts	11
 src/gateway/server.auth.modes.suite.ts	1

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -29,7 +29,6 @@ async function invokeMcp(manager: NodeHostMcpManager, params: unknown) {
 
 function managerWith(callMcpTool: NodeHostMcpManager["callMcpTool"]): NodeHostMcpManager {
   return {
-    configuredServerCount: 1,
     descriptors: [],
     callMcpTool,
     close: async () => undefined,

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -78,23 +78,6 @@ function itWithFrozenClock(name: string, run: () => Promise<void>): void {
 }
 
 describe("node host MCP manager", () => {
-  it("counts only enabled servers with valid identifiers", async () => {
-    const manager = await startNodeHostMcpManager(
-      {
-        docs: { command: "docs" },
-        disabled: { command: "disabled", enabled: false },
-        " ": { command: "blank" },
-      },
-      {
-        createClient: () => createClient(),
-        resolveTransport: () => transport,
-        warn: vi.fn(),
-      },
-    );
-    expect(manager.configuredServerCount).toBe(1);
-    await manager.close();
-  });
-
   it("starts independent MCP servers concurrently", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstReady = new Promise<void>((resolve) => {
@@ -140,7 +123,6 @@ describe("node host MCP manager", () => {
       warn,
     });
 
-    expect(manager.configuredServerCount).toBe(2);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('server "broken" failed'));
     expect(manager.descriptors).toEqual([
       {
@@ -206,6 +188,41 @@ describe("node host MCP manager", () => {
     await untrusted.close();
   });
 
+  it("withdraws only a closed server's descriptors and notifies the owner", async () => {
+    const closed = createClient({ tools: [tool("closed-tool")] });
+    const healthy = createClient({ tools: [tool("healthy-tool")] });
+    const onDescriptorsChanged = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { closed: { command: "closed" }, healthy: { command: "healthy" } },
+      {
+        createClient: (serverName) => (serverName === "closed" ? closed : healthy),
+        resolveTransport: () => transport,
+        onDescriptorsChanged,
+        warn: vi.fn(),
+      },
+    );
+
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toEqual([
+      "closed",
+      "healthy",
+    ]);
+    closed.onclose?.();
+
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toEqual(["healthy"]);
+    expect(onDescriptorsChanged).toHaveBeenCalledOnce();
+    expect(onDescriptorsChanged).toHaveBeenCalledWith();
+    await expect(
+      manager.callMcpTool({ server: "closed", tool: "closed-tool" }),
+    ).rejects.toMatchObject({ code: "MCP_SERVER_UNAVAILABLE" });
+    await expect(manager.callMcpTool({ server: "healthy", tool: "healthy-tool" })).resolves.toEqual(
+      { content: [{ type: "text", text: "ok" }] },
+    );
+
+    closed.onclose?.();
+    await manager.close();
+    expect(onDescriptorsChanged).toHaveBeenCalledOnce();
+  });
+
   itWithFrozenClock("bounds untrusted descriptor count and schema bytes", async () => {
     const tools = Array.from({ length: 130 }, (_, index) =>
       tool(`tool-${String(index).padStart(3, "0")}`),
@@ -223,6 +240,12 @@ describe("node host MCP manager", () => {
       false,
     );
     expect(Buffer.byteLength(JSON.stringify(manager.descriptors))).toBeLessThan(10 * 1024 * 1024);
+    await expect(manager.callMcpTool({ server: "docs", tool: "oversized" })).rejects.toMatchObject({
+      code: "MCP_TOOL_UNAVAILABLE",
+    });
+    await expect(manager.callMcpTool({ server: "docs", tool: "tool-129" })).rejects.toMatchObject({
+      code: "MCP_TOOL_UNAVAILABLE",
+    });
     await manager.close();
   });
 

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -59,7 +59,6 @@ type NodeHostMcpTransport = {
 type NodeHostMcpSession = {
   client: NodeHostMcpClient;
   connected: boolean;
-  tools: Set<string>;
   toolCallTimeoutMs: number;
   detachStderr?: () => void;
 };
@@ -81,7 +80,6 @@ export class NodeHostMcpError extends Error {
 }
 
 export type NodeHostMcpManager = {
-  configuredServerCount: number;
   descriptors: NodePluginToolDescriptor[];
   callMcpTool(params: {
     server: string;
@@ -96,6 +94,7 @@ export type NodeHostMcpManager = {
 type NodeHostMcpManagerDeps = {
   createClient?: (serverName: string) => NodeHostMcpClient;
   resolveTransport?: (serverName: string, config: McpServerConfig) => NodeHostMcpTransport | null;
+  onDescriptorsChanged?: () => void;
   warn?: (message: string) => void;
   signal?: AbortSignal;
 };
@@ -198,10 +197,6 @@ function buildNodeMcpToolDescriptors(
   return descriptors;
 }
 
-function isOAuthServer(config: McpServerConfig): boolean {
-  return config.auth === "oauth" || Boolean(config.oauth);
-}
-
 function shouldExposeTool(config: McpServerConfig, toolName: string): boolean {
   const include = config.toolFilter?.include ?? [];
   const exclude = config.toolFilter?.exclude ?? [];
@@ -293,19 +288,6 @@ async function listAllTools(
   });
 }
 
-function resolveCallTimeoutMs(value: number | undefined): number {
-  return clampPositiveTimerTimeoutMs(value) ?? NODE_MCP_TOOL_CALL_TIMEOUT_MS;
-}
-
-function isMcpTimeoutError(error: unknown): boolean {
-  return Boolean(
-    error &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code?: unknown }).code === ErrorCode.RequestTimeout,
-  );
-}
-
 /** Starts configured MCP servers once for the lifetime of the node host. */
 export async function startNodeHostMcpManager(
   servers: Record<string, McpServerConfig> | undefined,
@@ -320,13 +302,13 @@ export async function startNodeHostMcpManager(
         { jsonSchemaValidator: createMcpJsonSchemaValidator() },
       ) as NodeHostMcpClient);
   const resolveTransport = deps.resolveTransport ?? resolveMcpTransport;
-  const configured = listEnabledNodeHostMcpServers(servers);
   const sessions = new Map<string, NodeHostMcpSession>();
   const listedTools: ListedNodeMcpTool[] = [];
+  const descriptors: NodePluginToolDescriptor[] = [];
 
   await Promise.all(
-    configured.map(async ([serverName, config]) => {
-      if (isOAuthServer(config)) {
+    listEnabledNodeHostMcpServers(servers).map(async ([serverName, config]) => {
+      if (config.auth === "oauth" || config.oauth) {
         warn(`node host MCP server "${serverName}" skipped: OAuth is not supported`);
         return;
       }
@@ -343,16 +325,22 @@ export async function startNodeHostMcpManager(
         session = {
           client,
           connected: false,
-          tools: new Set<string>(),
           toolCallTimeoutMs: resolveMcpRequestTimeoutMs(config, NODE_MCP_TOOL_CALL_TIMEOUT_MS),
           detachStderr: resolved.detachStderr,
         };
         // MCP Client exposes callback properties rather than an EventTarget surface.
         // oxlint-disable-next-line unicorn/prefer-add-event-listener
         client.onclose = () => {
-          if (session) {
-            session.connected = false;
+          if (!session?.connected) {
+            return;
           }
+          session.connected = false;
+          descriptors.splice(
+            0,
+            descriptors.length,
+            ...descriptors.filter((descriptor) => descriptor.mcp?.server !== serverName),
+          );
+          deps.onDescriptorsChanged?.();
         };
         await withAbort(
           connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs),
@@ -365,11 +353,10 @@ export async function startNodeHostMcpManager(
           (toolName) => shouldExposeTool(config, toolName),
           deps.signal,
         );
-        for (const tool of tools) {
-          session.tools.add(tool.name);
-          listedTools.push({ serverName, tool });
+        if (session.connected) {
+          sessions.set(serverName, session);
+          listedTools.push(...tools.map((tool) => ({ serverName, tool })));
         }
-        sessions.set(serverName, session);
       } catch (error) {
         if (session) {
           session.connected = false;
@@ -385,15 +372,17 @@ export async function startNodeHostMcpManager(
     }),
   );
 
-  const descriptors = buildNodeMcpToolDescriptors(listedTools);
-  if (descriptors.length < listedTools.length) {
+  const publishableTools = listedTools.filter(
+    ({ serverName }) => sessions.get(serverName)?.connected,
+  );
+  descriptors.push(...buildNodeMcpToolDescriptors(publishableTools));
+  if (descriptors.length < publishableTools.length) {
     warn(
-      `node host MCP catalog bounded: published ${descriptors.length} of ${listedTools.length} tools`,
+      `node host MCP catalog bounded: published ${descriptors.length} of ${publishableTools.length} tools`,
     );
   }
   let closed = false;
   return {
-    configuredServerCount: configured.length,
     descriptors,
     async callMcpTool(params) {
       const session = sessions.get(params.server);
@@ -403,18 +392,24 @@ export async function startNodeHostMcpManager(
           `MCP server "${params.server}" is unavailable`,
         );
       }
-      if (!session.tools.has(params.tool)) {
+      const published = descriptors.some(
+        (descriptor) =>
+          descriptor.mcp?.server === params.server && descriptor.mcp.tool === params.tool,
+      );
+      if (!published) {
         throw new NodeHostMcpError(
           "MCP_TOOL_UNAVAILABLE",
           `MCP tool "${params.tool}" is unavailable on server "${params.server}"`,
         );
       }
+      const requestedTimeoutMs =
+        clampPositiveTimerTimeoutMs(params.timeoutMs) ?? NODE_MCP_TOOL_CALL_TIMEOUT_MS;
       try {
         return await session.client.callTool(
           { name: params.tool, arguments: params.arguments ?? {} },
           undefined,
           {
-            timeout: Math.min(resolveCallTimeoutMs(params.timeoutMs), session.toolCallTimeoutMs),
+            timeout: Math.min(requestedTimeoutMs, session.toolCallTimeoutMs),
             ...(params.signal ? { signal: params.signal } : {}),
           },
         );
@@ -426,7 +421,12 @@ export async function startNodeHostMcpManager(
             { cause: error },
           );
         }
-        if (isMcpTimeoutError(error)) {
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          error.code === ErrorCode.RequestTimeout
+        ) {
           throw new NodeHostMcpError("MCP_TOOL_TIMEOUT", formatMcpError(error), { cause: error });
         }
         throw new NodeHostMcpError("MCP_TOOL_ERROR", formatMcpError(error), { cause: error });

--- a/src/node-host/runner.optional-publication.test.ts
+++ b/src/node-host/runner.optional-publication.test.ts
@@ -105,7 +105,6 @@ vi.mock("./plugin-node-host.js", () => ({
 
 vi.mock("./mcp.js", () => ({
   startNodeHostMcpManager: vi.fn(async () => ({
-    configuredServerCount: 0,
     descriptors: [],
     callMcpTool: vi.fn(),
     close: vi.fn(async () => {}),

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -23,8 +23,8 @@ const mocks = vi.hoisted(() => ({
     stop: ReturnType<typeof vi.fn>;
     updateNodeManifest: ReturnType<typeof vi.fn>;
   }>,
-  mcpConfiguredServerCount: 0,
   mcpDescriptors: [] as Array<Record<string, unknown>>,
+  mcpDescriptorsChanged: undefined as (() => void) | undefined,
   nodePluginTools: [] as Array<Record<string, unknown>>,
   nodeSkillDescriptors: [] as Array<Record<string, unknown>>,
   runtimeSteps: [] as string[],
@@ -154,12 +154,21 @@ vi.mock("./plugin-node-host.js", () => ({
 }));
 
 vi.mock("./mcp.js", () => ({
-  startNodeHostMcpManager: vi.fn(async () => ({
-    configuredServerCount: mocks.mcpConfiguredServerCount,
-    descriptors: mocks.mcpDescriptors,
-    callMcpTool: vi.fn(),
-    close: mocks.closeMcpManager,
-  })),
+  startNodeHostMcpManager: vi.fn(
+    async (
+      _servers: unknown,
+      deps?: {
+        onDescriptorsChanged?: () => void;
+      },
+    ) => {
+      mocks.mcpDescriptorsChanged = deps?.onDescriptorsChanged;
+      return {
+        descriptors: mocks.mcpDescriptors,
+        callMcpTool: vi.fn(),
+        close: mocks.closeMcpManager,
+      };
+    },
+  ),
 }));
 
 vi.mock("./skills.js", () => ({
@@ -208,8 +217,8 @@ describe("runNodeHost", () => {
     mocks.capturedGatewayClientOptions.length = 0;
     mocks.capturedConfiguredGatewayConfigs.length = 0;
     mocks.capturedGatewayClients.length = 0;
-    mocks.mcpConfiguredServerCount = 0;
     mocks.mcpDescriptors = [];
+    mocks.mcpDescriptorsChanged = undefined;
     mocks.nodePluginTools = [
       {
         pluginId: "test-plugin",
@@ -847,42 +856,7 @@ describe("runNodeHost", () => {
     );
   });
 
-  it("declares and publishes configured node-host MCP tools", async () => {
-    mocks.mcpConfiguredServerCount = 1;
-    mocks.mcpDescriptors = [
-      {
-        pluginId: "node-mcp",
-        name: "docs_search",
-        description: "Search docs",
-        command: "mcp.tools.call.v1",
-        mcp: { server: "docs", tool: "search" },
-      },
-    ];
-
-    await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toThrow(
-      "event loop readiness timeout",
-    );
-
-    const options = lastCapturedOptions();
-    expect(options?.caps).toContain("mcp");
-    expect(options?.commands).toContain("mcp.tools.call.v1");
-    options?.onHelloOk?.({
-      protocol: 1,
-      features: { methods: [NODE_PLUGIN_TOOLS_UPDATE_METHOD], events: [] },
-    } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
-    expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenCalledWith(
-      "node.pluginTools.update",
-      {
-        tools: expect.arrayContaining([
-          expect.objectContaining({ pluginId: "node-mcp", name: "docs_search" }),
-        ]),
-      },
-    );
-    expect(mocks.closeMcpManager).toHaveBeenCalledOnce();
-  });
-
-  it("publishes plugin tools while MCP discovery is still pending", async () => {
-    mocks.mcpConfiguredServerCount = 1;
+  it("publishes plugin tools during MCP discovery and republishes catalog changes", async () => {
     let resolveReadiness:
       | ((value: { ready: false; aborted: false; elapsedMs: number }) => void)
       | undefined;
@@ -892,11 +866,12 @@ describe("runNodeHost", () => {
       }),
     );
     let resolveManager: ((manager: NodeHostMcpManager) => void) | undefined;
-    vi.mocked(startNodeHostMcpManager).mockReturnValueOnce(
-      new Promise((resolve) => {
+    vi.mocked(startNodeHostMcpManager).mockImplementationOnce(async (_servers, deps) => {
+      mocks.mcpDescriptorsChanged = deps?.onDescriptorsChanged;
+      return await new Promise((resolve) => {
         resolveManager = resolve;
-      }),
-    );
+      });
+    });
     const running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
     await vi.waitFor(() => expect(lastCapturedOptions()).toBeDefined());
     lastCapturedOptions()?.onHelloOk?.({
@@ -908,25 +883,43 @@ describe("runNodeHost", () => {
       { tools: [expect.objectContaining({ pluginId: "test-plugin" })] },
     );
 
+    const descriptors: NodeHostMcpManager["descriptors"] = [
+      {
+        pluginId: "node-mcp",
+        name: "closed_search",
+        description: "Search closed server",
+        command: "mcp.tools.call.v1",
+        mcp: { server: "closed", tool: "search" },
+      },
+      {
+        pluginId: "node-mcp",
+        name: "healthy_search",
+        description: "Search healthy server",
+        command: "mcp.tools.call.v1",
+        mcp: { server: "healthy", tool: "search" },
+      },
+    ];
     resolveManager?.({
-      configuredServerCount: 1,
-      descriptors: [
-        {
-          pluginId: "node-mcp",
-          name: "docs_search",
-          description: "Search docs",
-          command: "mcp.tools.call.v1",
-          mcp: { server: "docs", tool: "search" },
-        },
-      ],
+      descriptors,
       callMcpTool: vi.fn(),
       close: mocks.closeMcpManager,
     });
+    const client = mocks.capturedGatewayClients[0];
+    const publishedToolNames = () => {
+      const params = client?.request.mock.calls.findLast(
+        ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+      )?.[1] as { tools: Array<{ name?: string }> } | undefined;
+      return params?.tools.map((descriptor) => descriptor.name);
+    };
     await vi.waitFor(() => {
-      expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenCalledWith(
-        "node.pluginTools.update",
-        { tools: expect.arrayContaining([expect.objectContaining({ pluginId: "node-mcp" })]) },
-      );
+      expect(publishedToolNames()).toEqual(["closed_search", "healthy_search", "remote_echo"]);
+    });
+
+    descriptors.splice(0, 1);
+    expect(mocks.mcpDescriptorsChanged).toBeDefined();
+    mocks.mcpDescriptorsChanged?.();
+    await vi.waitFor(() => {
+      expect(publishedToolNames()).toEqual(["healthy_search", "remote_echo"]);
     });
     resolveReadiness?.({ ready: false, aborted: false, elapsedMs: 0 });
     await expect(running).rejects.toThrow("event loop readiness timeout");

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => {
     progressStartHeartbeats: vi.fn(),
     progressWrite: vi.fn(async () => undefined),
     startMcp: vi.fn(async (_servers: unknown, _deps?: { signal?: AbortSignal }) => ({
-      configuredServerCount: 0,
       descriptors: [],
       callMcpTool: vi.fn(),
       close: closeMcp,
@@ -266,7 +265,6 @@ describe("node-host invocation cancellation", () => {
     expect(startupSignal?.aborted).toBe(true);
     await vi.waitFor(() => expect(mocks.closeWorkerSupervisor).toHaveBeenCalledOnce());
     resolveStartup({
-      configuredServerCount: 0,
       descriptors: [],
       callMcpTool: vi.fn(),
       close: mocks.closeMcp,

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -211,22 +211,20 @@ function ensureNodePathEnv(): string {
   return DEFAULT_NODE_PATH;
 }
 
-function createInventory(params: {
-  skills: unknown[] | null;
-  pluginTools: unknown[];
-  mcpManager?: NodeHostMcpManager;
-}): NodeHostInventory {
-  const pluginTools = [...params.pluginTools, ...(params.mcpManager?.descriptors ?? [])].toSorted(
-    (left, right) => {
-      const a = left as { pluginId?: string; name?: string };
-      const b = right as { pluginId?: string; name?: string };
-      return (
-        (a.pluginId ?? "").localeCompare(b.pluginId ?? "") ||
-        (a.name ?? "").localeCompare(b.name ?? "")
-      );
-    },
-  );
-  return { skills: params.skills, pluginTools };
+function createInventory(
+  skills: unknown[] | null,
+  pluginTools: unknown[],
+  mcpDescriptors: readonly unknown[] = [],
+): NodeHostInventory {
+  const sortedPluginTools = [...pluginTools, ...mcpDescriptors].toSorted((left, right) => {
+    const a = left as { pluginId?: string; name?: string };
+    const b = right as { pluginId?: string; name?: string };
+    return (
+      (a.pluginId ?? "").localeCompare(b.pluginId ?? "") ||
+      (a.name ?? "").localeCompare(b.name ?? "")
+    );
+  });
+  return { skills, pluginTools: sortedPluginTools };
 }
 
 function sameStringList(left: string[], right: string[]): boolean {
@@ -309,10 +307,7 @@ export async function prepareNodeHostRuntime(params?: {
     pathEnv,
   });
   const manifest = buildManifest(pluginNodeHost);
-  const initialInventory = createInventory({
-    skills,
-    pluginTools: pluginNodeHost.nodePluginTools,
-  });
+  const initialInventory = createInventory(skills, pluginNodeHost.nodePluginTools);
 
   return {
     manifest,
@@ -351,18 +346,21 @@ export async function prepareNodeHostRuntime(params?: {
       let manager: NodeHostMcpManager | undefined;
       let closing = false;
       let closePromise: Promise<void> | undefined;
+      const publishInventory = () =>
+        onInventoryChanged?.(
+          createInventory(skills, currentPluginNodeHost.nodePluginTools, manager?.descriptors),
+        );
       const startup = startNodeHostMcpManager(config.nodeHost?.mcp?.servers, {
         signal: mcpAbort.signal,
+        onDescriptorsChanged: () => {
+          if (!closing && manager) {
+            publishInventory();
+          }
+        },
       }).then((resolved) => {
         manager = resolved;
         if (!closing) {
-          onInventoryChanged?.(
-            createInventory({
-              skills,
-              pluginTools: currentPluginNodeHost.nodePluginTools,
-              mcpManager: manager,
-            }),
-          );
+          publishInventory();
         }
         return resolved;
       });
@@ -374,13 +372,7 @@ export async function prepareNodeHostRuntime(params?: {
           currentManifest = nextManifest;
           onManifestChanged?.(nextManifest);
         }
-        onInventoryChanged?.(
-          createInventory({
-            skills,
-            pluginTools: currentPluginNodeHost.nodePluginTools,
-            mcpManager: manager,
-          }),
-        );
+        publishInventory();
       };
       const stopAvailabilityWatch = onManifestChanged
         ? watchRegisteredNodeHostCommandAvailability(availabilityContext, refreshAvailability)

--- a/src/node-host/runtime.worker-supervisor.test.ts
+++ b/src/node-host/runtime.worker-supervisor.test.ts
@@ -22,7 +22,6 @@ vi.mock("../infra/path-env.js", () => ({
 
 vi.mock("./mcp.js", () => ({
   startNodeHostMcpManager: vi.fn(async () => ({
-    configuredServerCount: 0,
     descriptors: [],
     callMcpTool: vi.fn(),
     close: vi.fn(async () => undefined),


### PR DESCRIPTION
Closes #124580

## What Problem This Solves

Fixes an issue where node-hosted MCP could execute tools omitted from its bounded published catalog, and where a tool remained advertised after its backing MCP server disconnected.

## Why This Change Was Made

The bounded node MCP descriptor list is now the sole call-authority set. When a connected MCP server closes, the node removes that server's descriptors in place and republishes the surviving MCP and plugin inventory. The same change removes obsolete `configuredServerCount` bookkeeping and shrinks the assertion-safety baseline after the production cleanup.

The fix stays inside the node-host MCP owner: no protocol, config, storage, migration, or compatibility surface changes.

AI-assisted: yes. The architecture, live evidence, implementation, simplification, and final diff were reviewed directly; no agent transcript is attached.

## User Impact

Operators can trust the Gateway's node tool inventory as the actual callable MCP surface. Tools dropped by count or byte limits cannot be reached through raw `mcp.tools.call.v1`, and dead MCP servers disappear from new agent turns while healthy sibling servers and ordinary node plugin tools remain available.

## Evidence

- Pre-fix bounded-catalog reproduction: a server listed 130 tools, published 128, and an omitted tool was still callable.
- Post-fix reproduction: the same omitted tool returns `MCP_TOOL_UNAVAILABLE`.
- Authenticated isolated Gateway proof with `openai/gpt-5.6-luna`: the model used the `nodes` tool to invoke a node-local MCP server, received an unprompted MCP-only nonce, and returned it exactly.
- The same live run used official Everything, Filesystem, and Memory MCP reference servers plus a controlled local server; stopping only the controlled server removed all `flaky_*` tools from both `node.list` and `tools.effective` while the node stayed connected.
- Blacksmith Testbox `tbx_01m05az9achqcch9hcws2r676y` ([run 31948957813](https://github.com/openclaw/openclaw/actions/runs/31948957813)):
  - exact source build passed;
  - 107 focused node-host/invoke/agent-tool tests passed;
  - process-boundary Gateway + node + MCP publication/withdrawal proof passed on Linux/Node 24.
- Rebased exact-path `check:changed` passed, including production/test typecheck, core lint, architecture guards, import cycles, formatting, and assertion ratchets.
- Rebased focused Vitest proof: 106 tests passed.
- Rebased `pnpm build` passed.
- Final Codex autoreview: clean, no accepted or actionable findings.

Production LOC: +62/-70 (net -8) | Tests: +96/-85 (net +11) | Ratchet metadata: +2/-2.

Provenance: the split discovered-tool/published-descriptor authority entered with #90431 on 2026-07-11; this repair makes the bounded descriptor catalog canonical for both visibility and invocation.
