### PR TITLE
fix(gateway): accidental gateway run against a live install no longer mutates its state before refusing

### DIFF
--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -372,6 +372,17 @@ async function guardGatewayRunSelectedConfig(
       return true;
     }
     // Recovery writes audit/config state, so run it only after config and state selection is stable.
+    // It is also this startup's first state-directory write (config-health reads open the shared
+    // SQLite store, which quarantines orphaned sidecars), so a live gateway owner refuses here
+    // before any mutation instead of after the run loop's lock acquisition.
+    const { describeLiveGatewayOwnerStartupBlocker } =
+      await import("../../commands/doctor-startup-migration-refusal.js");
+    const liveOwnerBlocker = await describeLiveGatewayOwnerStartupBlocker(process.env);
+    if (liveOwnerBlocker) {
+      params.runtime.error(liveOwnerBlocker);
+      params.runtime.exit(1);
+      return false;
+    }
     const recoveredSnapshot = await recoverGuardedGatewayRunConfig(params);
     if (!recoveredSnapshot) {
       return false;

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -1,5 +1,5 @@
 // Process regression for typed gateway startup-migration refusal and lease cleanup.
-import { execFile, spawnSync } from "node:child_process";
+import { execFile, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -233,6 +233,14 @@ describe.concurrent("gateway startup-migration refusal", () => {
   }, 45_000);
 
   it("refuses before relocating legacy state when a live gateway owns the state directory", async () => {
+    // Live owner fixture with gateway-shaped argv: on Windows no file-lock start
+    // time exists, so the lock reader validates the owner through process argv
+    // (isGatewayArgv); the Vitest process itself would read as a dead owner there.
+    const ownerChild = spawn(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 120_000)", "src/entry.ts", "gateway"],
+      { cwd: path.resolve("."), stdio: "ignore" },
+    );
     const temporaryRoot = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), "openclaw-live-owner-refusal-"),
     );
@@ -272,15 +280,15 @@ describe.concurrent("gateway startup-migration refusal", () => {
       fs.mkdirSync(sharedStateDbDir, { recursive: true });
       const orphanWalPath = path.join(sharedStateDbDir, "openclaw.sqlite-wal");
       fs.writeFileSync(orphanWalPath, Buffer.alloc(64, 1));
-      // A live gateway owner: this test process is alive and its start time
-      // matches, which is exactly how a real concurrent gateway verifies.
+      // A live gateway owner: the spawned gateway-shaped child is alive with a
+      // matching start time, which is exactly how a real concurrent gateway verifies.
       const lockDir = resolveGatewayLockDir(stateDir);
       fs.mkdirSync(lockDir, { recursive: true });
-      const startTime = getFileLockProcessStartTime(process.pid);
+      const startTime = getFileLockProcessStartTime(ownerChild.pid!);
       fs.writeFileSync(
         path.join(lockDir, "gateway.state.lock"),
         JSON.stringify({
-          pid: process.pid,
+          pid: ownerChild.pid,
           ownerId: "live-owner-refusal-test",
           createdAt: new Date().toISOString(),
           configPath,
@@ -313,6 +321,7 @@ describe.concurrent("gateway startup-migration refusal", () => {
       expect(result.stderr, output).toContain("already owns this state directory");
       expect(hasActiveStartupMigrationLease({ env })).toBe(false);
     } finally {
+      ownerChild.kill();
       await fs.promises.rm(root, { recursive: true, force: true });
     }
   }, 45_000);

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -265,6 +265,13 @@ describe.concurrent("gateway startup-migration refusal", () => {
       const legacyArtifactPath = path.join(legacyAgentDir, "auth-profiles.json");
       fs.mkdirSync(legacyAgentDir, { recursive: true });
       fs.writeFileSync(legacyArtifactPath, JSON.stringify({ profiles: {} }));
+      // A pending state write admission side effect: a nonempty WAL beside a
+      // missing main database gets copied to an .orphaned-* quarantine file by
+      // sidecar quarantine unless the live-owner refusal runs first.
+      const sharedStateDbDir = path.join(stateDir, "state");
+      fs.mkdirSync(sharedStateDbDir, { recursive: true });
+      const orphanWalPath = path.join(sharedStateDbDir, "openclaw.sqlite-wal");
+      fs.writeFileSync(orphanWalPath, Buffer.alloc(64, 1));
       // A live gateway owner: this test process is alive and its start time
       // matches, which is exactly how a real concurrent gateway verifies.
       const lockDir = resolveGatewayLockDir(stateDir);
@@ -300,6 +307,8 @@ describe.concurrent("gateway startup-migration refusal", () => {
       // relocation stayed untouched for the live owner.
       expect(fs.existsSync(legacyArtifactPath), output).toBe(true);
       expect(fs.existsSync(path.join(stateDir, "agents", "main", "agent")), output).toBe(false);
+      // No orphan-sidecar quarantine copy either: write admission never ran.
+      expect(fs.readdirSync(sharedStateDbDir), output).toEqual(["openclaw.sqlite-wal"]);
       expect(result.status, output).toBe(1);
       expect(result.stderr, output).toContain("already owns this state directory");
       expect(hasActiveStartupMigrationLease({ env })).toBe(false);

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -8,8 +8,10 @@ import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveGatewayLockDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasActiveStartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
+import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 
 const STARTUP_REFUSAL =
   "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.";
@@ -224,6 +226,82 @@ describe.concurrent("gateway startup-migration refusal", () => {
       expect(result.stderr).toContain(STARTUP_RECOVERY);
       expect(result.stderr.split(STARTUP_REFUSAL)).toHaveLength(2);
       expect(result.stderr).not.toContain("[openclaw] Could not start the CLI.");
+      expect(hasActiveStartupMigrationLease({ env })).toBe(false);
+    } finally {
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  }, 45_000);
+
+  it("refuses before relocating legacy state when a live gateway owns the state directory", async () => {
+    const temporaryRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-live-owner-refusal-"),
+    );
+    const root = await fs.promises.realpath(temporaryRoot);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+
+    try {
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ gateway: { mode: "local", auth: { mode: "none" } } }),
+      );
+      // A pending automatic migration: legacy agent dir relocation moves this
+      // file to agents/main/agent/ on the first unguarded gateway startup.
+      const legacyAgentDir = path.join(stateDir, "agent");
+      const legacyArtifactPath = path.join(legacyAgentDir, "auth-profiles.json");
+      fs.mkdirSync(legacyAgentDir, { recursive: true });
+      fs.writeFileSync(legacyArtifactPath, JSON.stringify({ profiles: {} }));
+      // A live gateway owner: this test process is alive and its start time
+      // matches, which is exactly how a real concurrent gateway verifies.
+      const lockDir = resolveGatewayLockDir(stateDir);
+      fs.mkdirSync(lockDir, { recursive: true });
+      const startTime = getFileLockProcessStartTime(process.pid);
+      fs.writeFileSync(
+        path.join(lockDir, "gateway.state.lock"),
+        JSON.stringify({
+          pid: process.pid,
+          ownerId: "live-owner-refusal-test",
+          createdAt: new Date().toISOString(),
+          configPath,
+          port: 18789,
+          stateDir,
+          ...(startTime !== null ? { startTime } : {}),
+        }),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", path.resolve("src/entry.ts"), "gateway", "run", "--allow-unconfigured"],
+        {
+          cwd: path.resolve("."),
+          encoding: "utf8",
+          env,
+          timeout: 30_000,
+        },
+      );
+      const output = `${result.stderr}\n${result.stdout}`;
+
+      expect(result.error, output).toBeUndefined();
+      // The refused startup must be side-effect-free: the pending legacy
+      // relocation stayed untouched for the live owner.
+      expect(fs.existsSync(legacyArtifactPath), output).toBe(true);
+      expect(fs.existsSync(path.join(stateDir, "agents", "main", "agent")), output).toBe(false);
+      expect(result.status, output).toBe(1);
+      expect(result.stderr, output).toContain("already owns this state directory");
       expect(hasActiveStartupMigrationLease({ env })).toBe(false);
     } finally {
       await fs.promises.rm(root, { recursive: true, force: true });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -22,7 +22,6 @@ import type {
 } from "../infra/startup-migration-checkpoint.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
-import { ExitError } from "../runtime.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { assertOpenClawStateWriteAllowedAtPath } from "../state/openclaw-state-ownership.js";
@@ -45,6 +44,13 @@ import {
   runStartupUpgradeConvergence,
 } from "./doctor-config-preflight-plugin-verification.js";
 import * as cronMigration from "./doctor-config-preflight.cron.js";
+import {
+  formatStartupMigrationFailure,
+  refuseStartupMigrationsForLiveGatewayOwner,
+  throwStartupMigrationGuardRejected,
+  throwStartupMigrationIdentityChanged,
+  throwStartupMigrationRefusal,
+} from "./doctor-startup-migration-refusal.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
@@ -131,36 +137,6 @@ function noteStateMigrationResult(result: {
   }
 }
 
-function formatStartupMigrationFailure(params: { warnings: string[]; blockers: string[] }): string {
-  const details = [
-    ...params.warnings.map((warning) => `- ${warning}`),
-    ...params.blockers.map((blocker) => `- ${blocker}`),
-  ];
-  return [
-    "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
-    ...details,
-    'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
-  ].join("\n");
-}
-
-function throwStartupMigrationRefusal(message: string): never {
-  // ExitError bypasses entry.ts's generic failure formatter, so report the owned reason here.
-  console.error(message);
-  throw new ExitError(1, message);
-}
-
-function throwStartupMigrationGuardRejected(): never {
-  throw new Error(
-    "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
-  );
-}
-
-function throwStartupMigrationIdentityChanged(): never {
-  throwStartupMigrationRefusal(
-    "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.",
-  );
-}
-
 /**
  * Runs early doctor config checks before the main config repair flow.
  *
@@ -232,6 +208,9 @@ export async function runDoctorConfigPreflight(
   const ensureStartupMigrationLease = async () => {
     if (startupMigrationLease || !migrationCheckpoint) {
       return;
+    }
+    if (gatewayStartupCheckpointRequired) {
+      await refuseStartupMigrationsForLiveGatewayOwner(startupMigrationEnv);
     }
     startupMigrationLease = await migrationCheckpoint.acquireStartupMigrationLeaseWithWait({
       env: startupMigrationEnv,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -167,6 +167,12 @@ export async function runDoctorConfigPreflight(
   } = {},
 ): Promise<DoctorConfigPreflightResult> {
   const stateMigrationsRequested = options.migrateState !== false;
+  const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
+  if (gatewayStartupCheckpointRequired) {
+    // First preflight operation: state write admission below already quarantines orphaned
+    // SQLite sidecars, so the live-owner refusal must precede every mutation-capable step.
+    await refuseStartupMigrationsForLiveGatewayOwner(process.env);
+  }
   if (stateMigrationsRequested) {
     await assertOpenClawStateWriteAllowedAtPath({
       databasePath: resolveOpenClawStateSqlitePath(process.env),
@@ -175,7 +181,6 @@ export async function runDoctorConfigPreflight(
   }
   const measurePreflightStep = <T>(name: string, run: () => T | Promise<T>) =>
     measureDoctorConfigPreflightStep(name, run, options.measure);
-  const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
   const migrationCheckpointRequired =
     gatewayStartupCheckpointRequired || options.requireStateMigrationCheckpoint === true;
   let migrationCheckpoint = migrationCheckpointRequired
@@ -210,6 +215,8 @@ export async function runDoctorConfigPreflight(
       return;
     }
     if (gatewayStartupCheckpointRequired) {
+      // Re-probe past the entry gate: the lease wait below can block behind a sibling
+      // startup that becomes the live owner before our migrations would mutate its state.
       await refuseStartupMigrationsForLiveGatewayOwner(startupMigrationEnv);
     }
     startupMigrationLease = await migrationCheckpoint.acquireStartupMigrationLeaseWithWait({

--- a/src/commands/doctor-startup-migration-refusal.ts
+++ b/src/commands/doctor-startup-migration-refusal.ts
@@ -35,23 +35,32 @@ export function throwStartupMigrationIdentityChanged(): never {
 }
 
 /**
- * A gateway startup that will refuse readiness must stay side-effect-free: when a live
- * gateway owns this state directory, the pending automatic migrations behind the startup
- * lease would relocate its files before the runtime lock acquisition refuses. Refuse first.
+ * A gateway startup that will refuse readiness must stay side-effect-free: a live owner of
+ * this state directory means every pending startup write (config-health recovery, sidecar
+ * quarantine, automatic migrations) would mutate its files before the runtime lock refuses.
  * Probe-only: the runtime lock stays owned by the gateway run loop's restart lifecycle.
  * Test runs skip the probe like acquireGatewayLock does (locks are disabled under Vitest).
+ * Returns the refusal message so each mutation boundary can report through its own runtime.
  */
-export async function refuseStartupMigrationsForLiveGatewayOwner(
+export async function describeLiveGatewayOwnerStartupBlocker(
   env: NodeJS.ProcessEnv,
-): Promise<void> {
+): Promise<string | undefined> {
   if (env.VITEST || env.NODE_ENV === "test") {
-    return;
+    return undefined;
   }
   const { readActiveGatewayLockIdentity } = await import("../infra/gateway-lock.js");
   const activeGateway = await readActiveGatewayLockIdentity({ env });
-  if (activeGateway) {
-    throwStartupMigrationRefusal(
-      `Another gateway (pid ${activeGateway.pid}) already owns this state directory; refusing to run automatic startup migrations or report the gateway ready. Stop it with "openclaw gateway stop" (or select a different OPENCLAW_STATE_DIR), then retry startup.`,
-    );
+  if (!activeGateway) {
+    return undefined;
+  }
+  return `Another gateway (pid ${activeGateway.pid}) already owns this state directory; refusing to run automatic startup migrations or report the gateway ready. Stop it with "openclaw gateway stop" (or select a different OPENCLAW_STATE_DIR), then retry startup.`;
+}
+
+export async function refuseStartupMigrationsForLiveGatewayOwner(
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const blocker = await describeLiveGatewayOwnerStartupBlocker(env);
+  if (blocker) {
+    throwStartupMigrationRefusal(blocker);
   }
 }

--- a/src/commands/doctor-startup-migration-refusal.ts
+++ b/src/commands/doctor-startup-migration-refusal.ts
@@ -1,0 +1,57 @@
+// Gateway startup-migration readiness refusals shared by doctor config preflight.
+import { ExitError } from "../runtime.js";
+
+export function formatStartupMigrationFailure(params: {
+  warnings: string[];
+  blockers: string[];
+}): string {
+  const details = [
+    ...params.warnings.map((warning) => `- ${warning}`),
+    ...params.blockers.map((blocker) => `- ${blocker}`),
+  ];
+  return [
+    "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
+    ...details,
+    'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
+  ].join("\n");
+}
+
+export function throwStartupMigrationRefusal(message: string): never {
+  // ExitError bypasses entry.ts's generic failure formatter, so report the owned reason here.
+  console.error(message);
+  throw new ExitError(1, message);
+}
+
+export function throwStartupMigrationGuardRejected(): never {
+  throw new Error(
+    "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
+  );
+}
+
+export function throwStartupMigrationIdentityChanged(): never {
+  throwStartupMigrationRefusal(
+    "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.",
+  );
+}
+
+/**
+ * A gateway startup that will refuse readiness must stay side-effect-free: when a live
+ * gateway owns this state directory, the pending automatic migrations behind the startup
+ * lease would relocate its files before the runtime lock acquisition refuses. Refuse first.
+ * Probe-only: the runtime lock stays owned by the gateway run loop's restart lifecycle.
+ * Test runs skip the probe like acquireGatewayLock does (locks are disabled under Vitest).
+ */
+export async function refuseStartupMigrationsForLiveGatewayOwner(
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return;
+  }
+  const { readActiveGatewayLockIdentity } = await import("../infra/gateway-lock.js");
+  const activeGateway = await readActiveGatewayLockIdentity({ env });
+  if (activeGateway) {
+    throwStartupMigrationRefusal(
+      `Another gateway (pid ${activeGateway.pid}) already owns this state directory; refusing to run automatic startup migrations or report the gateway ready. Stop it with "openclaw gateway stop" (or select a different OPENCLAW_STATE_DIR), then retry startup.`,
+    );
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators accidentally running `openclaw gateway run` against a state directory owned by an already-running gateway (for example, forgetting to set `OPENCLAW_STATE_DIR` for a dev run) would have that live gateway's state mutated before the run was refused. The CLI startup chain executed durable writes — config-health recovery, orphan SQLite sidecar quarantine, and all automatic legacy state migrations — before the run loop's `acquireGatewayLock` refusal, so a launch that never served could still relocate legacy artifacts and quarantine sidecars in the operator's live `~/.openclaw` (observed live: a legacy sqlite relocated before the refusal exit).

## Why This Change Was Made

The refusal is a probe-only gate (`readActiveGatewayLockIdentity`, zero migration dependencies) placed at every mutation-capable startup boundary so the first write is always preceded by an ownership check:

1. **Gateway pre-bootstrap** (`src/cli/gateway-cli/pre-bootstrap.ts`): suspicious-config recovery is this startup's first state-directory write (config-health reads open the shared state DB, whose write admission quarantines orphaned sidecars). A live owner refuses here, before recovery runs.
2. **Preflight entry** (`src/commands/doctor-config-preflight.ts`): the gate runs before `assertOpenClawStateWriteAllowedAtPath` (which also quarantines sidecars) when the gateway startup checkpoint is required.
3. **Migration lease boundary**: a re-probe before `acquireStartupMigrationLeaseWithWait`, because the lease wait can block behind a sibling startup that becomes the live owner in the window.

A live foreign owner yields a typed refusal and exit 1 with no lease acquired, no quarantine copies, and no migrations run. The runtime gateway lock remains solely owned by the run loop — these gates only sequence startup writes behind the same ownership fact. Shared refusal helpers live in `src/commands/doctor-startup-migration-refusal.ts` (pure extraction forced by the `max-lines` limit).

## User Impact

Accidentally launching a gateway against a running install is now side-effect-free: the command refuses with a clear typed error and exit 1 before touching any state, instead of silently migrating the live gateway's files or quarantining its SQLite sidecars first.

## Evidence

- Regression test (`src/commands/doctor-config-preflight.process.test.ts`): real `gateway run` subprocess against a live-locked state dir seeded with a migratable legacy agent dir **and** an orphaned nonempty `openclaw.sqlite-wal` beside a missing main DB — fails pre-fix (artifact relocated; WAL copied to `.orphaned-*` by write admission), passes post-fix (legacy artifact untouched, state DB dir byte-identical, exit 1, no leaked lease). Verified failing with each gate individually removed (pre-fix ordering and pre-bootstrap gate stashed).
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight src/infra/gateway-lock src/cli/gateway-cli` post-rebase on latest `origin/main`: 4 files, 56 tests passed.
- `node scripts/check-changed.mjs` green (typecheck core + core tests, oxlint, import cycles, assertion/env ratchets, coercion guard; heavy lanes fell back to local because no Crabbox provider CLI is available on this host — noted per Validation policy).
- Autoreview (Codex, gpt-5.6-sol high) clean on the final diff, score 0.97, no actionable findings.
