### PR TITLE
fix(config): correct compaction mode help text; repair main lint + qa-lab flake

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -352,7 +352,16 @@ describe("matrix harness runtime", () => {
     expect(probeSignals).not.toHaveLength(0);
     expect(probeSignals.length).toBeLessThanOrEqual(2);
     expect(probeSignals.every((signal) => signal.aborted)).toBe(true);
-    expect(sleepImpl).not.toHaveBeenCalled();
+    // The inner AbortSignal.timeout (clamped to the remaining budget) and the
+    // outer deadline timer race at ~timeoutMs. When the inner fires first the
+    // loop takes one residual micro-sleep before Date.now() crosses the
+    // deadline. The protected invariant is bounded exit, not zero sleeps:
+    // allow at most one sleep and require it to be within the deadline budget.
+    expect(sleepImpl.mock.calls.length).toBeLessThanOrEqual(1);
+    const residualSleepMs = sleepImpl.mock.calls[0]?.[0];
+    if (residualSleepMs !== undefined) {
+      expect(residualSleepMs).toBeLessThanOrEqual(25);
+    }
   });
 
   it("probes the container fallback when the host versions probe stalls", async () => {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -333,7 +333,7 @@ describe("matrix harness runtime", () => {
           probeSignal.addEventListener("abort", rejectAborted, { once: true });
         }),
     );
-    const sleepImpl = vi.fn(async () => {});
+    const sleepImpl = vi.fn(async (_ms: number) => {});
     const startedAt = Date.now();
 
     await expect(

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -242,7 +242,7 @@ function isDedicatedLinuxWorker(
   if (env.DISPLAY || env.WAYLAND_DISPLAY || env.SSH_TTY) {
     return false;
   }
-  if ((options.interactive ?? process.stdin.isTTY) === true) {
+  if (options.interactive ?? process.stdin.isTTY) {
     return false;
   }
   if (options.virtualized !== undefined) {

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -125,7 +125,7 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.enabled":
     "Enable embedded proactive auto-compaction (default: true). Set false to stop threshold-driven embedded compaction while preserving OpenClaw overflow recovery, preflight compaction, and manual /compact.",
   "agents.defaults.compaction.mode":
-    'Compaction strategy mode: "default" uses baseline behavior, while "safeguard" applies stricter guardrails to preserve recent context. Keep "default" unless you observe aggressive history loss near limit boundaries.',
+    'Compaction strategy mode: "safeguard" (the effective default when unset) applies guardrails to preserve recent context, while "default" uses baseline summarization without them. Set "default" only if safeguard summarization causes problems for your provider.',
   "agents.defaults.compaction.provider":
     "Id of a registered compaction provider plugin used for summarization. When set and the provider is registered, its summarize() method is called instead of the built-in summarizeInStages pipeline. Falls back to built-in on provider failure. Leave unset to use the default built-in summarization.",
   "agents.defaults.compaction.thinkingLevel":


### PR DESCRIPTION
## What Problem This Solves

Three things, bundled per the broken-CI-is-your-job default:

1. **Config help contradicts shipped behavior**: schema help for `agents.defaults.compaction.mode` told operators to `Keep "default"`, but `applyCompactionDefaults` has written `mode: "safeguard"` for unset configs since dd1b08b3e8f (docs/concepts/compaction.md already documents this). Operators following the help string would explicitly opt out of the shipped default believing they were keeping it.
2. **Flaky qa-lab assertion (hit this PR's CI)**: the matrix stalled-probe test asserted `sleepImpl` is never called, but the inner `AbortSignal.timeout` (clamped to remainingMs) and the outer deadline timer race at ~timeoutMs — when the inner fires first the loop takes one residual deadline-clamped sleep. Assertion now protects the real invariant (bounded exit, ≤1 clamped sleep).
3. **Red main check-lint (hit this PR's CI)**: 55240929f5a introduced `(options.interactive ?? process.stdin.isTTY) === true` in scripts/check-changed.mts, rejected by the type-aware `no-unnecessary-boolean-literal-compare` lane. Fixed by using the boolean directly.

## Why This Change Was Made

Help text is part of the product contract; the two CI repairs follow "broken CI is always someone's job; default to making it yours — fix it in the landing PR."

## User Impact

Config help now describes the real default. CI unblocked for every PR behind the lint break.

## Evidence

- `applyCompactionDefaults` at src/config/defaults.ts:546 ships `mode: "safeguard"`; docs already agree.
- qa-lab harness test: 5/5 local reruns green after the assertion repair; `sleepImpl` typed so check-test-types passes (TS2493 fixed).
- `oxlint --type-aware scripts/check-changed.mts` clean after the boolean fix; failing lane log: run 31955832138.
- Codex autoreview (branch mode): clean.
