### PR TITLE
fix(update): prevent duplicate managed gateway successors

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3217,7 +3217,6 @@ src/infra/delivery-queue-sqlite-namespace.ts	3
 src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-identity-store.ts	1
 src/infra/device-identity.ts	1
 src/infra/device-pairing-store.ts	6
 src/infra/diagnostic-event-listener-presence.ts	3

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -4,6 +4,7 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../../test/vitest/vitest.agents-paths.mjs";
+import { cliProcessTestFiles } from "../../test/vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../../test/vitest/vitest.commands-light-paths.mjs";
 import {
   gatewayServerExcludedTestFiles,
@@ -228,7 +229,8 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
   // The measured 131s pair split per config; apportioned by the hosted
   // per-config walls (139s/67s) until direct Blacksmith samples exist.
   ["agentic-cli", 88],
-  ["agentic-cli-process", 43],
+  ["agentic-cli-process-support", 39],
+  ["agentic-cli-process-run-loop", 4],
   ["agentic-command-support", 49],
   ["agentic-commands-agent-channel", 76],
   ["agentic-commands-doctor", 23],
@@ -631,6 +633,29 @@ function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGr
     return group;
   }
   return { ...group, env: { ...group.env, ...PINNED_COMPACT_GROUP_ENV } };
+}
+
+const CLI_PROCESS_GROUP_NAME = "agentic-cli-process";
+const CLI_PROCESS_RUN_LOOP_TEST_FILE = "src/cli/gateway-cli/run-loop.test.ts";
+
+function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
+  if (group.shard_name !== CLI_PROCESS_GROUP_NAME) {
+    return [group];
+  }
+  const supportFiles = cliProcessTestFiles.filter(
+    (file) => file !== CLI_PROCESS_RUN_LOOP_TEST_FILE,
+  );
+  if (supportFiles.length + 1 !== cliProcessTestFiles.length) {
+    throw new Error(`missing compact CLI process owner: ${CLI_PROCESS_RUN_LOOP_TEST_FILE}`);
+  }
+  return [
+    { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
+    {
+      ...group,
+      includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
+      shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
+    },
+  ];
 }
 
 function estimateDefaultCompactGroupSeconds(group: NodeTestShardGroup): number {
@@ -2187,7 +2212,7 @@ function createCompactNodeTestShardBundles(
     const runner = resolveCiNodeTestRunner(shard);
     const key = JSON.stringify([runner, shard.requiresDist]);
     const groups = groupsByRunner.get(key) ?? [];
-    const group = applyCompactGroupWorkerPins({
+    const baseGroup = applyCompactGroupWorkerPins({
       configs: shard.configs,
       ...(shard.env ? { env: shard.env } : {}),
       ...(shard.includePatterns ? { includePatterns: shard.includePatterns } : {}),
@@ -2195,15 +2220,17 @@ function createCompactNodeTestShardBundles(
       runner,
       shard_name: shard.shardName,
     });
-    const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
-      ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
-      : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
-    for (const planned of plannedGroups) {
-      groups.push(planned.group);
-      // Synthesized hosted stripes need their divided parent weight. Native
-      // groups must reach the runner-specific stripe estimator during rebalance.
-      if (planned.group.shard_name !== group.shard_name) {
-        synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
+    for (const group of splitCompactCliProcessGroup(baseGroup)) {
+      const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
+        ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
+        : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
+      for (const planned of plannedGroups) {
+        groups.push(planned.group);
+        // Synthesized hosted stripes need their divided parent weight. Native
+        // groups must reach the runner-specific stripe estimator during rebalance.
+        if (planned.group.shard_name !== group.shard_name) {
+          synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
+        }
       }
     }
     groupsByRunner.set(key, groups);

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -623,7 +623,7 @@ function isExclusiveCompactGroup(group: NodeTestShardGroup): boolean {
 // scales with the runner class. infra-process spawns child processes per test
 // and hit worker-startup timeouts under contention before serialization.
 const PINNED_WORKER_COMPACT_GROUP_RE =
-  /^core-tooling(?:-\d+(?:-hosted-\d+)?|-isolated)$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-config$|^core-runtime-media-ui-(?:\d+|support)$|^agentic-cli$|^agentic-gateway-(?:core-\d+|methods)$/u;
+  /^core-tooling(?:-\d+(?:-hosted-\d+)?|-isolated)$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-config$|^core-runtime-media-ui-(?:\d+|support)$|^agentic-cli(?:-process)?$|^agentic-gateway-(?:core-\d+|methods)$/u;
 const PINNED_COMPACT_GROUP_ENV = { OPENCLAW_VITEST_MAX_WORKERS: "2" };
 
 function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGroup {
@@ -1748,7 +1748,6 @@ const SPLIT_NODE_SHARDS = new Map<string, NodeTestSplitShard[]>([
       {
         shardName: "agentic-cli-process",
         configs: ["test/vitest/vitest.cli-process.config.ts"],
-        env: { OPENCLAW_VITEST_MAX_WORKERS: "1" },
         requiresDist: false,
       },
       {

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -4,7 +4,6 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../../test/vitest/vitest.agents-paths.mjs";
-import { cliProcessTestFiles } from "../../test/vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../../test/vitest/vitest.commands-light-paths.mjs";
 import {
   gatewayServerExcludedTestFiles,
@@ -229,10 +228,7 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
   // The measured 131s pair split per config; apportioned by the hosted
   // per-config walls (139s/67s) until direct Blacksmith samples exist.
   ["agentic-cli", 88],
-  // Keep the former composite's 43s admission weight while giving the
-  // run-loop suite a fresh Vitest process in compact CI.
-  ["agentic-cli-process-support", 39],
-  ["agentic-cli-process-run-loop", 4],
+  ["agentic-cli-process", 43],
   ["agentic-command-support", 49],
   ["agentic-commands-agent-channel", 76],
   ["agentic-commands-doctor", 23],
@@ -635,33 +631,6 @@ function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGr
     return group;
   }
   return { ...group, env: { ...group.env, ...PINNED_COMPACT_GROUP_ENV } };
-}
-
-const CLI_PROCESS_GROUP_NAME = "agentic-cli-process";
-const CLI_PROCESS_RUN_LOOP_TEST_FILE = "src/cli/gateway-cli/run-loop.test.ts";
-
-function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
-  if (group.shard_name !== CLI_PROCESS_GROUP_NAME) {
-    return [group];
-  }
-  const supportFiles = cliProcessTestFiles.filter(
-    (file) => file !== CLI_PROCESS_RUN_LOOP_TEST_FILE,
-  );
-  if (supportFiles.length + 1 !== cliProcessTestFiles.length) {
-    throw new Error(`missing compact CLI process owner: ${CLI_PROCESS_RUN_LOOP_TEST_FILE}`);
-  }
-  return [
-    {
-      ...group,
-      includePatterns: supportFiles,
-      shard_name: `${CLI_PROCESS_GROUP_NAME}-support`,
-    },
-    {
-      ...group,
-      includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
-      shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
-    },
-  ];
 }
 
 function estimateDefaultCompactGroupSeconds(group: NodeTestShardGroup): number {
@@ -2218,7 +2187,7 @@ function createCompactNodeTestShardBundles(
     const runner = resolveCiNodeTestRunner(shard);
     const key = JSON.stringify([runner, shard.requiresDist]);
     const groups = groupsByRunner.get(key) ?? [];
-    const baseGroup = applyCompactGroupWorkerPins({
+    const group = applyCompactGroupWorkerPins({
       configs: shard.configs,
       ...(shard.env ? { env: shard.env } : {}),
       ...(shard.includePatterns ? { includePatterns: shard.includePatterns } : {}),
@@ -2226,17 +2195,15 @@ function createCompactNodeTestShardBundles(
       runner,
       shard_name: shard.shardName,
     });
-    for (const group of splitCompactCliProcessGroup(baseGroup)) {
-      const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
-        ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
-        : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
-      for (const planned of plannedGroups) {
-        groups.push(planned.group);
-        // Synthesized hosted stripes need their divided parent weight. Native
-        // groups must reach the runner-specific stripe estimator during rebalance.
-        if (planned.group.shard_name !== group.shard_name) {
-          synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
-        }
+    const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
+      ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
+      : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
+    for (const planned of plannedGroups) {
+      groups.push(planned.group);
+      // Synthesized hosted stripes need their divided parent weight. Native
+      // groups must reach the runner-specific stripe estimator during rebalance.
+      if (planned.group.shard_name !== group.shard_name) {
+        synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
       }
     }
     groupsByRunner.set(key, groups);

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -654,6 +654,7 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
       ...group,
       env: {
         ...group.env,
+        NODE_OPTIONS: "--max-old-space-size=512",
         OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
         OPENCLAW_VITEST_MAX_WORKERS: "1",
       },

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -652,11 +652,6 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
     { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
     {
       ...group,
-      env: {
-        ...group.env,
-        OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
-        OPENCLAW_VITEST_MAX_WORKERS: "1",
-      },
       includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
       shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
     },

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -652,6 +652,11 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
     { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
     {
       ...group,
+      env: {
+        ...group.env,
+        OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
+        OPENCLAW_VITEST_MAX_WORKERS: "1",
+      },
       includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
       shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
     },

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -652,6 +652,7 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
     { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
     {
       ...group,
+      env: { ...group.env, OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
       includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
       shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
     },

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -4,7 +4,6 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../../test/vitest/vitest.agents-paths.mjs";
-import { cliProcessTestFiles } from "../../test/vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../../test/vitest/vitest.commands-light-paths.mjs";
 import {
   gatewayServerExcludedTestFiles,
@@ -229,8 +228,7 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
   // The measured 131s pair split per config; apportioned by the hosted
   // per-config walls (139s/67s) until direct Blacksmith samples exist.
   ["agentic-cli", 88],
-  ["agentic-cli-process-support", 39],
-  ["agentic-cli-process-run-loop", 4],
+  ["agentic-cli-process", 43],
   ["agentic-command-support", 49],
   ["agentic-commands-agent-channel", 76],
   ["agentic-commands-doctor", 23],
@@ -633,34 +631,6 @@ function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGr
     return group;
   }
   return { ...group, env: { ...group.env, ...PINNED_COMPACT_GROUP_ENV } };
-}
-
-const CLI_PROCESS_GROUP_NAME = "agentic-cli-process";
-const CLI_PROCESS_RUN_LOOP_TEST_FILE = "src/cli/gateway-cli/run-loop.test.ts";
-
-function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
-  if (group.shard_name !== CLI_PROCESS_GROUP_NAME) {
-    return [group];
-  }
-  const supportFiles = cliProcessTestFiles.filter(
-    (file) => file !== CLI_PROCESS_RUN_LOOP_TEST_FILE,
-  );
-  if (supportFiles.length + 1 !== cliProcessTestFiles.length) {
-    throw new Error(`missing compact CLI process owner: ${CLI_PROCESS_RUN_LOOP_TEST_FILE}`);
-  }
-  return [
-    { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
-    {
-      ...group,
-      env: {
-        ...group.env,
-        OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
-        OPENCLAW_VITEST_MAX_WORKERS: "1",
-      },
-      includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
-      shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
-    },
-  ];
 }
 
 function estimateDefaultCompactGroupSeconds(group: NodeTestShardGroup): number {
@@ -2217,7 +2187,7 @@ function createCompactNodeTestShardBundles(
     const runner = resolveCiNodeTestRunner(shard);
     const key = JSON.stringify([runner, shard.requiresDist]);
     const groups = groupsByRunner.get(key) ?? [];
-    const baseGroup = applyCompactGroupWorkerPins({
+    const group = applyCompactGroupWorkerPins({
       configs: shard.configs,
       ...(shard.env ? { env: shard.env } : {}),
       ...(shard.includePatterns ? { includePatterns: shard.includePatterns } : {}),
@@ -2225,17 +2195,15 @@ function createCompactNodeTestShardBundles(
       runner,
       shard_name: shard.shardName,
     });
-    for (const group of splitCompactCliProcessGroup(baseGroup)) {
-      const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
-        ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
-        : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
-      for (const planned of plannedGroups) {
-        groups.push(planned.group);
-        // Synthesized hosted stripes need their divided parent weight. Native
-        // groups must reach the runner-specific stripe estimator during rebalance.
-        if (planned.group.shard_name !== group.shard_name) {
-          synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
-        }
+    const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
+      ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
+      : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
+    for (const planned of plannedGroups) {
+      groups.push(planned.group);
+      // Synthesized hosted stripes need their divided parent weight. Native
+      // groups must reach the runner-specific stripe estimator during rebalance.
+      if (planned.group.shard_name !== group.shard_name) {
+        synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
       }
     }
     groupsByRunner.set(key, groups);

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -1748,6 +1748,9 @@ const SPLIT_NODE_SHARDS = new Map<string, NodeTestSplitShard[]>([
       {
         shardName: "agentic-cli-process",
         configs: ["test/vitest/vitest.cli-process.config.ts"],
+        // This process-isolated graph uses dynamic mocks and source children;
+        // restored cross-group transforms can retain its full CLI graph.
+        env: { OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
         requiresDist: false,
       },
       {

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -654,7 +654,6 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
       ...group,
       env: {
         ...group.env,
-        NODE_OPTIONS: "--max-old-space-size=512",
         OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
         OPENCLAW_VITEST_MAX_WORKERS: "1",
       },

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -4,6 +4,7 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../../test/vitest/vitest.agents-paths.mjs";
+import { cliProcessTestFiles } from "../../test/vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../../test/vitest/vitest.commands-light-paths.mjs";
 import {
   gatewayServerExcludedTestFiles,
@@ -228,7 +229,10 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
   // The measured 131s pair split per config; apportioned by the hosted
   // per-config walls (139s/67s) until direct Blacksmith samples exist.
   ["agentic-cli", 88],
-  ["agentic-cli-process", 43],
+  // Keep the former composite's 43s admission weight while giving the
+  // run-loop suite a fresh Vitest process in compact CI.
+  ["agentic-cli-process-support", 39],
+  ["agentic-cli-process-run-loop", 4],
   ["agentic-command-support", 49],
   ["agentic-commands-agent-channel", 76],
   ["agentic-commands-doctor", 23],
@@ -631,6 +635,33 @@ function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGr
     return group;
   }
   return { ...group, env: { ...group.env, ...PINNED_COMPACT_GROUP_ENV } };
+}
+
+const CLI_PROCESS_GROUP_NAME = "agentic-cli-process";
+const CLI_PROCESS_RUN_LOOP_TEST_FILE = "src/cli/gateway-cli/run-loop.test.ts";
+
+function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
+  if (group.shard_name !== CLI_PROCESS_GROUP_NAME) {
+    return [group];
+  }
+  const supportFiles = cliProcessTestFiles.filter(
+    (file) => file !== CLI_PROCESS_RUN_LOOP_TEST_FILE,
+  );
+  if (supportFiles.length + 1 !== cliProcessTestFiles.length) {
+    throw new Error(`missing compact CLI process owner: ${CLI_PROCESS_RUN_LOOP_TEST_FILE}`);
+  }
+  return [
+    {
+      ...group,
+      includePatterns: supportFiles,
+      shard_name: `${CLI_PROCESS_GROUP_NAME}-support`,
+    },
+    {
+      ...group,
+      includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
+      shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
+    },
+  ];
 }
 
 function estimateDefaultCompactGroupSeconds(group: NodeTestShardGroup): number {
@@ -2187,7 +2218,7 @@ function createCompactNodeTestShardBundles(
     const runner = resolveCiNodeTestRunner(shard);
     const key = JSON.stringify([runner, shard.requiresDist]);
     const groups = groupsByRunner.get(key) ?? [];
-    const group = applyCompactGroupWorkerPins({
+    const baseGroup = applyCompactGroupWorkerPins({
       configs: shard.configs,
       ...(shard.env ? { env: shard.env } : {}),
       ...(shard.includePatterns ? { includePatterns: shard.includePatterns } : {}),
@@ -2195,15 +2226,17 @@ function createCompactNodeTestShardBundles(
       runner,
       shard_name: shard.shardName,
     });
-    const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
-      ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
-      : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
-    for (const planned of plannedGroups) {
-      groups.push(planned.group);
-      // Synthesized hosted stripes need their divided parent weight. Native
-      // groups must reach the runner-specific stripe estimator during rebalance.
-      if (planned.group.shard_name !== group.shard_name) {
-        synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
+    for (const group of splitCompactCliProcessGroup(baseGroup)) {
+      const plannedGroups = usesExpandedRunnerProfile(options.runnerBackend)
+        ? splitOversizedGithubCompactGroup(group, options.runnerBackend)
+        : [{ group, seconds: estimateCompactGroupSeconds(group, options.runnerBackend) }];
+      for (const planned of plannedGroups) {
+        groups.push(planned.group);
+        // Synthesized hosted stripes need their divided parent weight. Native
+        // groups must reach the runner-specific stripe estimator during rebalance.
+        if (planned.group.shard_name !== group.shard_name) {
+          synthesizedSplitSeconds.set(planned.group.shard_name, planned.seconds);
+        }
       }
     }
     groupsByRunner.set(key, groups);

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -623,7 +623,7 @@ function isExclusiveCompactGroup(group: NodeTestShardGroup): boolean {
 // scales with the runner class. infra-process spawns child processes per test
 // and hit worker-startup timeouts under contention before serialization.
 const PINNED_WORKER_COMPACT_GROUP_RE =
-  /^core-tooling(?:-\d+(?:-hosted-\d+)?|-isolated)$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-config$|^core-runtime-media-ui-(?:\d+|support)$|^agentic-cli(?:-process)?$|^agentic-gateway-(?:core-\d+|methods)$/u;
+  /^core-tooling(?:-\d+(?:-hosted-\d+)?|-isolated)$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-config$|^core-runtime-media-ui-(?:\d+|support)$|^agentic-cli$|^agentic-gateway-(?:core-\d+|methods)$/u;
 const PINNED_COMPACT_GROUP_ENV = { OPENCLAW_VITEST_MAX_WORKERS: "2" };
 
 function applyCompactGroupWorkerPins(group: NodeTestShardGroup): NodeTestShardGroup {
@@ -1748,9 +1748,7 @@ const SPLIT_NODE_SHARDS = new Map<string, NodeTestSplitShard[]>([
       {
         shardName: "agentic-cli-process",
         configs: ["test/vitest/vitest.cli-process.config.ts"],
-        // This process-isolated graph uses dynamic mocks and source children;
-        // restored cross-group transforms can retain its full CLI graph.
-        env: { OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
+        env: { OPENCLAW_VITEST_MAX_WORKERS: "1" },
         requiresDist: false,
       },
       {

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -652,7 +652,11 @@ function splitCompactCliProcessGroup(group: NodeTestShardGroup): NodeTestShardGr
     { ...group, includePatterns: supportFiles, shard_name: `${CLI_PROCESS_GROUP_NAME}-support` },
     {
       ...group,
-      env: { ...group.env, OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
+      env: {
+        ...group.env,
+        OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
+        OPENCLAW_VITEST_MAX_WORKERS: "1",
+      },
       includePatterns: [CLI_PROCESS_RUN_LOOP_TEST_FILE],
       shard_name: `${CLI_PROCESS_GROUP_NAME}-run-loop`,
     },

--- a/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
+++ b/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
@@ -35,6 +35,8 @@ describe("gateway lifecycle hub import boundaries", () => {
     expect(hub).not.toContain('from "../../daemon/systemd-lifecycle.js"');
     expect(hub).toContain('import("../../daemon/launchd-stop.js")');
     expect(hub).toContain('import("../../daemon/systemd-lifecycle.js")');
+    expect(hub).toContain("parkManagedUpdateLaunchdSuccessor");
+    expect(hub).toContain("parkManagedUpdateSystemdSuccessor");
   });
 
   it("still primes the hub eagerly so signal handlers survive dist chunk rotation", () => {

--- a/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
+++ b/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
@@ -33,6 +33,8 @@ describe("gateway lifecycle hub import boundaries", () => {
     // handoff commits to one platform, never while priming normal lifecycle paths.
     expect(hub).not.toContain('from "../../daemon/launchd-stop.js"');
     expect(hub).not.toContain('from "../../daemon/systemd-lifecycle.js"');
+    expect(hub).toContain('import("../../daemon/launchd-stop.js")');
+    expect(hub).toContain('import("../../daemon/systemd-lifecycle.js")');
   });
 
   it("still primes the hub eagerly so signal handlers survive dist chunk rotation", () => {

--- a/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
+++ b/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
@@ -28,6 +28,11 @@ describe("gateway lifecycle hub import boundaries", () => {
     expect(hub).not.toContain(
       'from "../../agents/main-session-recovery/main-session-restart-recovery.js"',
     );
+
+    // Service-manager control graphs are needed only after a managed update
+    // handoff commits to one platform, never while priming normal lifecycle paths.
+    expect(hub).not.toContain('from "../../daemon/launchd-stop.js"');
+    expect(hub).not.toContain('from "../../daemon/systemd-lifecycle.js"');
   });
 
   it("still primes the hub eagerly so signal handlers survive dist chunk rotation", () => {

--- a/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
+++ b/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
@@ -13,6 +13,7 @@ function readSource(relativePath: string): string {
 describe("gateway lifecycle hub import boundaries", () => {
   it("re-exports primed symbols from their defining modules instead of facades", () => {
     const hub = readSource("src/cli/gateway-cli/lifecycle.runtime.ts");
+    const successorOwner = readSource("src/infra/managed-update-successor.ts");
 
     // server-reload-handlers.ts also re-exports server-reload-hot.ts and
     // server-reload-managed.ts, so routing through it loads the hot-reload and
@@ -31,12 +32,11 @@ describe("gateway lifecycle hub import boundaries", () => {
 
     // Service-manager control graphs are needed only after a managed update
     // handoff commits to one platform, never while priming normal lifecycle paths.
-    expect(hub).not.toContain('from "../../daemon/launchd-stop.js"');
-    expect(hub).not.toContain('from "../../daemon/systemd-lifecycle.js"');
-    expect(hub).toContain('import("../../daemon/launchd-stop.js")');
-    expect(hub).toContain('import("../../daemon/systemd-lifecycle.js")');
-    expect(hub).toContain("parkManagedUpdateLaunchdSuccessor");
-    expect(hub).toContain("parkManagedUpdateSystemdSuccessor");
+    expect(hub).toContain('from "../../infra/managed-update-successor.js"');
+    expect(successorOwner).not.toContain('from "../daemon/');
+    expect(successorOwner).toContain('import("../daemon/launchd-stop.js")');
+    expect(successorOwner).toContain('import("../daemon/systemd-lifecycle.js")');
+    expect(successorOwner).toContain("parkManagedUpdateSuccessor");
   });
 
   it("still primes the hub eagerly so signal handlers survive dist chunk rotation", () => {

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -10,6 +10,8 @@ export {
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
+export { parkCurrentLaunchAgentForMaintenance } from "../../daemon/launchd-stop.js";
+export { parkCurrentSystemdServiceForMaintenance } from "../../daemon/systemd-lifecycle.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -8,9 +8,9 @@ export {
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
-export const parkCurrentLaunchAgentForMaintenance = async () =>
+export const parkManagedUpdateLaunchdSuccessor = async () =>
   await (await import("../../daemon/launchd-stop.js")).parkCurrentLaunchAgentForMaintenance();
-export const parkCurrentSystemdServiceForMaintenance = async () =>
+export const parkManagedUpdateSystemdSuccessor = async () =>
   await (
     await import("../../daemon/systemd-lifecycle.js")
   ).parkCurrentSystemdServiceForMaintenance();

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -10,8 +10,6 @@ export {
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
-export { parkCurrentLaunchAgentForMaintenance } from "../../daemon/launchd-stop.js";
-export { parkCurrentSystemdServiceForMaintenance } from "../../daemon/systemd-lifecycle.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -1,7 +1,5 @@
-// Lazy lifecycle runtime export hub used by gateway run-loop restart paths.
-// run-loop.ts primes this hub before the HTTP listener binds, so each re-export
-// must target the module that defines the symbol rather than a re-export facade;
-// a facade also evaluates its siblings and drags their graphs onto cold start.
+// The run loop primes this hub before the HTTP listener binds. Static re-exports
+// target defining modules; lazy wrappers defer platform graphs until their owner runs.
 export {
   abortEmbeddedAgentRun,
   getActiveEmbeddedRunCount,
@@ -10,6 +8,12 @@ export {
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
+export const parkCurrentLaunchAgentForMaintenance = async () =>
+  await (await import("../../daemon/launchd-stop.js")).parkCurrentLaunchAgentForMaintenance();
+export const parkCurrentSystemdServiceForMaintenance = async () =>
+  await (
+    await import("../../daemon/systemd-lifecycle.js")
+  ).parkCurrentSystemdServiceForMaintenance();
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -1,5 +1,3 @@
-// The run loop primes this hub before the HTTP listener binds. Static re-exports
-// target defining modules; lazy wrappers defer platform graphs until their owner runs.
 export {
   abortEmbeddedAgentRun,
   getActiveEmbeddedRunCount,
@@ -8,12 +6,7 @@ export {
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
-export const parkManagedUpdateLaunchdSuccessor = async () =>
-  await (await import("../../daemon/launchd-stop.js")).parkCurrentLaunchAgentForMaintenance();
-export const parkManagedUpdateSystemdSuccessor = async () =>
-  await (
-    await import("../../daemon/systemd-lifecycle.js")
-  ).parkCurrentSystemdServiceForMaintenance();
+export { parkManagedUpdateSuccessor } from "../../infra/managed-update-successor.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -117,8 +117,8 @@ const respawnGatewayProcessForUpdate = vi.fn<
 const markUpdateRestartSentinelFailure = vi.fn<(reason: string) => Promise<null>>(
   async (_reason: string) => null,
 );
-const parkCurrentLaunchAgentForMaintenance = vi.fn(async () => true);
-const parkCurrentSystemdServiceForMaintenance = vi.fn(async () => true);
+const parkManagedUpdateLaunchdSuccessor = vi.fn(async () => true);
+const parkManagedUpdateSystemdSuccessor = vi.fn(async () => true);
 const abortPendingChannelReloads = vi.fn();
 const abortEmbeddedAgentRun = vi.fn(
   (_sessionId?: string, _opts?: { mode?: "all" | "compacting"; reason?: "restart" }) => false,
@@ -192,11 +192,11 @@ vi.mock("../../infra/restart-handoff.js", () => ({
 }));
 
 vi.mock("../../daemon/launchd-stop.js", () => ({
-  parkCurrentLaunchAgentForMaintenance: () => parkCurrentLaunchAgentForMaintenance(),
+  parkCurrentLaunchAgentForMaintenance: () => parkManagedUpdateLaunchdSuccessor(),
 }));
 
 vi.mock("../../daemon/systemd-lifecycle.js", () => ({
-  parkCurrentSystemdServiceForMaintenance: () => parkCurrentSystemdServiceForMaintenance(),
+  parkCurrentSystemdServiceForMaintenance: () => parkManagedUpdateSystemdSuccessor(),
 }));
 
 vi.mock("../../process/command-queue.js", async (importOriginal) => {
@@ -476,8 +476,8 @@ beforeEach(async () => {
   });
   restartGatewayProcessWithFreshPid.mockReset();
   restartGatewayProcessWithFreshPid.mockReturnValue({ mode: "disabled" });
-  parkCurrentLaunchAgentForMaintenance.mockResolvedValue(true);
-  parkCurrentSystemdServiceForMaintenance.mockResolvedValue(true);
+  parkManagedUpdateLaunchdSuccessor.mockResolvedValue(true);
+  parkManagedUpdateSystemdSuccessor.mockResolvedValue(true);
 });
 
 describe("runGatewayLoop", () => {
@@ -2339,10 +2339,10 @@ describe("runGatewayLoop", () => {
           captureSignal("SIGUSR1")();
 
           await expect(exited).resolves.toBe(0);
-          expect(parkCurrentSystemdServiceForMaintenance).toHaveBeenCalledTimes(
+          expect(parkManagedUpdateSystemdSuccessor).toHaveBeenCalledTimes(
             expectedPark === "systemd" ? 1 : 0,
           );
-          expect(parkCurrentLaunchAgentForMaintenance).toHaveBeenCalledTimes(
+          expect(parkManagedUpdateLaunchdSuccessor).toHaveBeenCalledTimes(
             expectedPark === "launchd" ? 1 : 0,
           );
           expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -457,10 +457,11 @@ function expectRestartHandoffCall(expected: {
   });
 }
 
-let gatewayWorkAdmissionActual: typeof import("../../process/gateway-work-admission.js");
+const gatewayWorkAdmissionActual = await vi.importActual<
+  typeof import("../../process/gateway-work-admission.js")
+>("../../process/gateway-work-admission.js");
 
-beforeEach(async () => {
-  gatewayWorkAdmissionActual = await vi.importActual("../../process/gateway-work-admission.js");
+beforeEach(() => {
   gatewayWorkAdmissionActual.resetGatewayWorkAdmission();
   consumeGatewaySigusr1RestartIntent.mockReturnValue(null);
   respawnGatewayProcessForUpdate.mockReset();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2329,19 +2329,6 @@ describe("runGatewayLoop", () => {
         reason: "update.run",
         successorOwner: "managed-update-handoff",
       });
-      const serviceStarts = ["original"];
-      respawnGatewayProcessForUpdate.mockImplementationOnce(() => {
-        serviceStarts.push("intermediate");
-        return { mode: "supervised" };
-      });
-      let releaseUpdater = () => {};
-      const updaterBlocked = new Promise<void>((resolve) => {
-        releaseUpdater = resolve;
-      });
-      const updater = updaterBlocked.then(() => {
-        serviceStarts.push("final");
-      });
-
       const previousValue = process.env[envKey];
       try {
         setPlatform(platform);
@@ -2359,11 +2346,6 @@ describe("runGatewayLoop", () => {
             expectedPark === "launchd" ? 1 : 0,
           );
           expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
-          expect(serviceStarts).toEqual(["original"]);
-
-          releaseUpdater();
-          await updater;
-          expect(serviceStarts).toEqual(["original", "final"]);
           expect(runtime.exit).toHaveBeenCalledWith(0);
         });
       } finally {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2496,9 +2496,9 @@ describe("runGatewayLoop", () => {
           .fn()
           .mockImplementationOnce(async () => {
             resolveStarted();
-            return { close: closeFirst };
+            return createGatewayServer(closeFirst);
           })
-          .mockResolvedValueOnce({ close: closeSecond });
+          .mockResolvedValueOnce(createGatewayServer(closeSecond));
         const { runtime, exited } = createRuntimeWithExitSignal();
         await runLoopWithStart({ start, runtime });
         await waitForStart(started);

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -624,7 +624,7 @@ describe("runGatewayLoop", () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const { close, start, runtime, exited } = await createSignaledLoopHarness();
+      const { close, start, runtime, exited, loopPromise } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
       flushLogger.mockImplementationOnce(async () => {
         expect(runtime.exit).not.toHaveBeenCalled();
@@ -633,6 +633,7 @@ describe("runGatewayLoop", () => {
       sigterm();
 
       await expect(exited).resolves.toBe(0);
+      await expect(loopPromise).resolves.toBeUndefined();
       expect(close).toHaveBeenCalledWith({
         reason: "gateway stopping",
         restartExpectedMs: null,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -16,7 +16,12 @@ const consumeGatewayRestartIntentPayloadSync = vi.fn<
   () => { reason?: string; force?: boolean; waitMs?: number } | null
 >(() => null);
 const consumeGatewaySigusr1RestartIntent = vi.fn<
-  () => { reason?: string; force?: boolean; waitMs?: number } | null
+  () => {
+    reason?: string;
+    force?: boolean;
+    waitMs?: number;
+    successorOwner?: "managed-update-handoff";
+  } | null
 >(() => null);
 const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const consumeGatewayRestartIntentSync = vi.fn(() => false);
@@ -112,6 +117,8 @@ const respawnGatewayProcessForUpdate = vi.fn<
 const markUpdateRestartSentinelFailure = vi.fn<(reason: string) => Promise<null>>(
   async (_reason: string) => null,
 );
+const parkCurrentLaunchAgentForMaintenance = vi.fn(async () => true);
+const parkCurrentSystemdServiceForMaintenance = vi.fn(async () => true);
 const abortPendingChannelReloads = vi.fn();
 const abortEmbeddedAgentRun = vi.fn(
   (_sessionId?: string, _opts?: { mode?: "all" | "compacting"; reason?: "restart" }) => false,
@@ -182,6 +189,14 @@ vi.mock("../../infra/restart-sentinel.js", () => ({
 
 vi.mock("../../infra/restart-handoff.js", () => ({
   writeGatewayRestartHandoffSync: (opts: unknown) => writeGatewayRestartHandoffSync(opts),
+}));
+
+vi.mock("../../daemon/launchd-stop.js", () => ({
+  parkCurrentLaunchAgentForMaintenance: () => parkCurrentLaunchAgentForMaintenance(),
+}));
+
+vi.mock("../../daemon/systemd-lifecycle.js", () => ({
+  parkCurrentSystemdServiceForMaintenance: () => parkCurrentSystemdServiceForMaintenance(),
 }));
 
 vi.mock("../../process/command-queue.js", async (importOriginal) => {
@@ -453,6 +468,16 @@ let gatewayWorkAdmissionActual: typeof import("../../process/gateway-work-admiss
 beforeEach(async () => {
   gatewayWorkAdmissionActual = await vi.importActual("../../process/gateway-work-admission.js");
   gatewayWorkAdmissionActual.resetGatewayWorkAdmission();
+  consumeGatewaySigusr1RestartIntent.mockReturnValue(null);
+  respawnGatewayProcessForUpdate.mockReset();
+  respawnGatewayProcessForUpdate.mockReturnValue({
+    mode: "disabled",
+    detail: "OPENCLAW_NO_RESPAWN",
+  });
+  restartGatewayProcessWithFreshPid.mockReset();
+  restartGatewayProcessWithFreshPid.mockReturnValue({ mode: "disabled" });
+  parkCurrentLaunchAgentForMaintenance.mockResolvedValue(true);
+  parkCurrentSystemdServiceForMaintenance.mockResolvedValue(true);
 });
 
 describe("runGatewayLoop", () => {
@@ -2277,16 +2302,94 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it.each([
+    {
+      platform: "linux" as const,
+      envKey: "OPENCLAW_SYSTEMD_UNIT" as const,
+      envValue: "openclaw-gateway.service",
+      expectedPark: "systemd" as const,
+    },
+    {
+      platform: "darwin" as const,
+      envKey: "OPENCLAW_LAUNCHD_LABEL" as const,
+      envValue: "ai.openclaw.gateway",
+      expectedPark: "launchd" as const,
+    },
+    {
+      platform: "win32" as const,
+      envKey: "OPENCLAW_WINDOWS_TASK_NAME" as const,
+      envValue: "OpenClaw Gateway",
+      expectedPark: null,
+    },
+  ])(
+    "leaves managed $platform handoff successor ownership to the updater",
+    async ({ platform, envKey, envValue, expectedPark }) => {
+      vi.clearAllMocks();
+      consumeGatewaySigusr1RestartIntent.mockReturnValue({
+        reason: "update.run",
+        successorOwner: "managed-update-handoff",
+      });
+      const serviceStarts = ["original"];
+      respawnGatewayProcessForUpdate.mockImplementationOnce(() => {
+        serviceStarts.push("intermediate");
+        return { mode: "supervised" };
+      });
+      let releaseUpdater = () => {};
+      const updaterBlocked = new Promise<void>((resolve) => {
+        releaseUpdater = resolve;
+      });
+      const updater = updaterBlocked.then(() => {
+        serviceStarts.push("final");
+      });
+
+      const previousValue = process.env[envKey];
+      try {
+        setPlatform(platform);
+        process.env[envKey] = envValue;
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { runtime, exited } = await createSignaledLoopHarness();
+
+          captureSignal("SIGUSR1")();
+
+          await expect(exited).resolves.toBe(0);
+          expect(parkCurrentSystemdServiceForMaintenance).toHaveBeenCalledTimes(
+            expectedPark === "systemd" ? 1 : 0,
+          );
+          expect(parkCurrentLaunchAgentForMaintenance).toHaveBeenCalledTimes(
+            expectedPark === "launchd" ? 1 : 0,
+          );
+          expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+          expect(serviceStarts).toEqual(["original"]);
+
+          releaseUpdater();
+          await updater;
+          expect(serviceStarts).toEqual(["original", "final"]);
+          expect(runtime.exit).toHaveBeenCalledWith(0);
+        });
+      } finally {
+        if (previousValue === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = previousValue;
+        }
+        if (originalPlatformDescriptor) {
+          Object.defineProperty(process, "platform", originalPlatformDescriptor);
+        }
+      }
+    },
+  );
+
   it.each(["update.run", "update.auto"] as const)(
     "writes a handoff before exiting for supervised %s restarts",
     async (reason) => {
       vi.clearAllMocks();
       peekGatewaySigusr1RestartReason.mockReturnValue(reason);
-      respawnGatewayProcessForUpdate.mockReturnValueOnce({
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
         mode: "supervised",
       });
       try {
         setPlatform("freebsd");
+        process.env.OPENCLAW_SUPERVISOR_MODE = "external";
         await withIsolatedSignals(async ({ captureSignal }) => {
           const { runtime, exited } = await createSignaledLoopHarness();
           const sigusr1 = captureSignal("SIGUSR1");
@@ -2302,6 +2405,7 @@ describe("runGatewayLoop", () => {
           });
         });
       } finally {
+        delete process.env.OPENCLAW_SUPERVISOR_MODE;
         if (originalPlatformDescriptor) {
           Object.defineProperty(process, "platform", originalPlatformDescriptor);
         }
@@ -2312,7 +2416,7 @@ describe("runGatewayLoop", () => {
   it("falls back in-process when a launchd update handoff fails to spawn", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue("update.run");
-    respawnGatewayProcessForUpdate.mockReturnValueOnce({
+    restartGatewayProcessWithFreshPid.mockReturnValueOnce({
       mode: "supervised",
       handoffSpawned: Promise.resolve(false),
     });
@@ -2350,7 +2454,7 @@ describe("runGatewayLoop", () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue("update.run");
     process.env.OPENCLAW_SUPERVISOR_MODE = "external";
-    respawnGatewayProcessForUpdate.mockReturnValueOnce({
+    restartGatewayProcessWithFreshPid.mockReturnValueOnce({
       mode: "supervised",
     });
     writeGatewayRestartHandoffSync.mockReturnValueOnce(null);
@@ -2392,7 +2496,7 @@ describe("runGatewayLoop", () => {
     peekGatewaySigusr1RestartReason
       .mockReturnValueOnce("config.patch")
       .mockReturnValueOnce("update.auto");
-    respawnGatewayProcessForUpdate.mockReturnValueOnce({ mode: "supervised" });
+    restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "supervised" });
 
     let releaseClose: () => void = () => {};
     const close = vi.fn<GatewayCloseFn>(
@@ -2404,6 +2508,7 @@ describe("runGatewayLoop", () => {
 
     try {
       setPlatform("freebsd");
+      process.env.OPENCLAW_SUPERVISOR_MODE = "external";
       await withIsolatedSignals(async ({ captureSignal }) => {
         const { start, started } = createSignaledStart(close);
         const { runtime, exited } = createRuntimeWithExitSignal();
@@ -2427,7 +2532,7 @@ describe("runGatewayLoop", () => {
 
         releaseClose();
         await expect(exited).resolves.toBe(0);
-        expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+        expect(restartGatewayProcessWithFreshPid).toHaveBeenCalledTimes(1);
         expectRestartHandoffCall({
           restartKind: "update-process",
           reason: "update.auto",
@@ -2435,6 +2540,7 @@ describe("runGatewayLoop", () => {
         });
       });
     } finally {
+      delete process.env.OPENCLAW_SUPERVISOR_MODE;
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, "platform", originalPlatformDescriptor);
       }
@@ -2453,7 +2559,7 @@ describe("runGatewayLoop", () => {
     peekGatewaySigusr1RestartReason
       .mockReturnValueOnce("config.patch")
       .mockReturnValueOnce("update.auto");
-    respawnGatewayProcessForUpdate.mockReturnValueOnce({ mode: "supervised" });
+    restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "supervised" });
 
     let releaseLock: () => void = () => {};
     const lockReleaseBlocked = new Promise<void>((resolve) => {
@@ -2464,30 +2570,35 @@ describe("runGatewayLoop", () => {
     });
     acquireGatewayLock.mockResolvedValueOnce({ release: lockRelease });
 
-    await withIsolatedSignals(async ({ captureSignal }) => {
-      const { runtime, exited } = await createSignaledLoopHarness();
-      const sigusr1 = captureSignal("SIGUSR1");
+    process.env.OPENCLAW_SUPERVISOR_MODE = "external";
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createSignaledLoopHarness();
+        const sigusr1 = captureSignal("SIGUSR1");
 
-      sigusr1();
-      await waitForLoopCondition(
-        () => lockRelease.mock.calls.length === 1,
-        "restart did not reach lock release",
-      );
-      sigusr1();
-      await waitForLoopCondition(
-        () =>
-          gatewayLog.info.mock.calls.some(([message]) =>
-            String(message).includes("upgrading to update.auto"),
-          ),
-        "lock-release restart was not upgraded",
-      );
+        sigusr1();
+        await waitForLoopCondition(
+          () => lockRelease.mock.calls.length === 1,
+          "restart did not reach lock release",
+        );
+        sigusr1();
+        await waitForLoopCondition(
+          () =>
+            gatewayLog.info.mock.calls.some(([message]) =>
+              String(message).includes("upgrading to update.auto"),
+            ),
+          "lock-release restart was not upgraded",
+        );
 
-      releaseLock();
-      await expect(exited).resolves.toBe(0);
-      expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
-      expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
-      expect(runtime.exit).toHaveBeenCalledWith(0);
-    });
+        releaseLock();
+        await expect(exited).resolves.toBe(0);
+        expect(restartGatewayProcessWithFreshPid).toHaveBeenCalledTimes(1);
+        expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+      });
+    } finally {
+      delete process.env.OPENCLAW_SUPERVISOR_MODE;
+    }
   });
 
   it("probes the configured gateway host for update respawn health", async () => {
@@ -2542,9 +2653,7 @@ describe("runGatewayLoop", () => {
         .mockResolvedValueOnce(createGatewayServer(closeSecond));
 
       await runLoopWithStart({ start, runtime, lockPort: 18789, waitForHealthyChild });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
+      await waitForLoopCondition(() => start.mock.calls.length === 1, "gateway did not start");
       const sigusr1 = captureSignal("SIGUSR1");
       const sigterm = captureSignal("SIGTERM");
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -117,8 +117,7 @@ const respawnGatewayProcessForUpdate = vi.fn<
 const markUpdateRestartSentinelFailure = vi.fn<(reason: string) => Promise<null>>(
   async (_reason: string) => null,
 );
-const parkManagedUpdateLaunchdSuccessor = vi.fn(async () => true);
-const parkManagedUpdateSystemdSuccessor = vi.fn(async () => true);
+const parkManagedUpdateSuccessor = vi.fn(async (_supervisor?: unknown) => {});
 const abortPendingChannelReloads = vi.fn();
 const abortEmbeddedAgentRun = vi.fn(
   (_sessionId?: string, _opts?: { mode?: "all" | "compacting"; reason?: "restart" }) => false,
@@ -191,12 +190,8 @@ vi.mock("../../infra/restart-handoff.js", () => ({
   writeGatewayRestartHandoffSync: (opts: unknown) => writeGatewayRestartHandoffSync(opts),
 }));
 
-vi.mock("../../daemon/launchd-stop.js", () => ({
-  parkCurrentLaunchAgentForMaintenance: () => parkManagedUpdateLaunchdSuccessor(),
-}));
-
-vi.mock("../../daemon/systemd-lifecycle.js", () => ({
-  parkCurrentSystemdServiceForMaintenance: () => parkManagedUpdateSystemdSuccessor(),
+vi.mock("../../infra/managed-update-successor.js", () => ({
+  parkManagedUpdateSuccessor: (supervisor: unknown) => parkManagedUpdateSuccessor(supervisor),
 }));
 
 vi.mock("../../process/command-queue.js", async (importOriginal) => {
@@ -398,7 +393,6 @@ async function runLoopWithStart(params: {
   healthHost?: string;
   waitForHealthyChild?: (port: number, pid?: number, host?: string) => Promise<boolean>;
 }) {
-  vi.resetModules();
   const { runGatewayLoop } = await import("./run-loop.js");
   const loopPromise = runGatewayLoop({
     start: params.start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
@@ -476,8 +470,7 @@ beforeEach(async () => {
   });
   restartGatewayProcessWithFreshPid.mockReset();
   restartGatewayProcessWithFreshPid.mockReturnValue({ mode: "disabled" });
-  parkManagedUpdateLaunchdSuccessor.mockResolvedValue(true);
-  parkManagedUpdateSystemdSuccessor.mockResolvedValue(true);
+  parkManagedUpdateSuccessor.mockResolvedValue(undefined);
 });
 
 describe("runGatewayLoop", () => {
@@ -2302,64 +2295,61 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it.each([
-    {
-      platform: "linux" as const,
-      envKey: "OPENCLAW_SYSTEMD_UNIT" as const,
-      envValue: "openclaw-gateway.service",
-      expectedPark: "systemd" as const,
-    },
-    {
-      platform: "darwin" as const,
-      envKey: "OPENCLAW_LAUNCHD_LABEL" as const,
-      envValue: "ai.openclaw.gateway",
-      expectedPark: "launchd" as const,
-    },
-    {
-      platform: "win32" as const,
-      envKey: "OPENCLAW_WINDOWS_TASK_NAME" as const,
-      envValue: "OpenClaw Gateway",
-      expectedPark: null,
-    },
-  ])(
-    "leaves managed $platform handoff successor ownership to the updater",
-    async ({ platform, envKey, envValue, expectedPark }) => {
-      vi.clearAllMocks();
-      consumeGatewaySigusr1RestartIntent.mockReturnValue({
-        reason: "update.run",
-        successorOwner: "managed-update-handoff",
+  it("parks a managed systemd successor before gateway close can wedge", async () => {
+    vi.clearAllMocks();
+    consumeGatewaySigusr1RestartIntent.mockReturnValue({
+      reason: "update.auto",
+      successorOwner: "managed-update-handoff",
+    });
+    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+    waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+    let releaseClose: () => void = () => {};
+    const close = vi.fn<GatewayCloseFn>(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClose = resolve;
+        }),
+    );
+
+    try {
+      setPlatform("linux");
+      process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, started } = createSignaledStart(close);
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        await runLoopWithStart({ start, runtime });
+        await waitForStart(started);
+
+        captureSignal("SIGUSR1")();
+        await waitForLoopCondition(
+          () => close.mock.calls.length === 1,
+          "restart close did not start",
+        );
+
+        expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+        expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+        expect(parkManagedUpdateSuccessor).toHaveBeenCalledWith("systemd");
+        expect(parkManagedUpdateSuccessor).toHaveBeenCalledTimes(1);
+        expect(parkManagedUpdateSuccessor.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+          close.mock.invocationCallOrder[0] ?? Infinity,
+        );
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        releaseClose();
+        await expect(exited).resolves.toBe(0);
+        expect(parkManagedUpdateSuccessor).toHaveBeenCalledTimes(1);
+        expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+        expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(runtime.exit).toHaveBeenCalledWith(0);
       });
-      const previousValue = process.env[envKey];
-      try {
-        setPlatform(platform);
-        process.env[envKey] = envValue;
-        await withIsolatedSignals(async ({ captureSignal }) => {
-          const { runtime, exited } = await createSignaledLoopHarness();
-
-          captureSignal("SIGUSR1")();
-
-          await expect(exited).resolves.toBe(0);
-          expect(parkManagedUpdateSystemdSuccessor).toHaveBeenCalledTimes(
-            expectedPark === "systemd" ? 1 : 0,
-          );
-          expect(parkManagedUpdateLaunchdSuccessor).toHaveBeenCalledTimes(
-            expectedPark === "launchd" ? 1 : 0,
-          );
-          expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
-          expect(runtime.exit).toHaveBeenCalledWith(0);
-        });
-      } finally {
-        if (previousValue === undefined) {
-          delete process.env[envKey];
-        } else {
-          process.env[envKey] = previousValue;
-        }
-        if (originalPlatformDescriptor) {
-          Object.defineProperty(process, "platform", originalPlatformDescriptor);
-        }
+    } finally {
+      delete process.env.OPENCLAW_SYSTEMD_UNIT;
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
       }
-    },
-  );
+    }
+  });
 
   it.each(["update.run", "update.auto"] as const)(
     "writes a handoff before exiting for supervised %s restarts",
@@ -2466,42 +2456,57 @@ describe("runGatewayLoop", () => {
     }
   });
 
-  it("upgrades an accepted restart when a managed update arrives during shutdown", async () => {
+  it("falls back in-process when managed update parking fails during an accepted restart", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReset();
     consumeGatewayRestartIntentPayloadSync.mockReturnValue(null);
     consumeGatewaySigusr1RestartIntent.mockReset();
-    consumeGatewaySigusr1RestartIntent.mockReturnValue(null);
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null).mockReturnValueOnce({
+      reason: "update.auto",
+      successorOwner: "managed-update-handoff",
+    });
     consumeGatewaySigusr1RestartAuthorization.mockReset();
     consumeGatewaySigusr1RestartAuthorization.mockReturnValue(true);
     peekGatewaySigusr1RestartReason.mockReset();
     peekGatewaySigusr1RestartReason
       .mockReturnValueOnce("config.patch")
       .mockReturnValueOnce("update.auto");
-    restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "supervised" });
-
-    let releaseClose: () => void = () => {};
-    const close = vi.fn<GatewayCloseFn>(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseClose = resolve;
-        }),
+    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+    let releaseDrain: (result: { drained: boolean }) => void = () => {};
+    waitForActiveTasks.mockReturnValueOnce(
+      new Promise<{ drained: boolean }>((resolve) => {
+        releaseDrain = resolve;
+      }),
     );
+    parkManagedUpdateSuccessor.mockRejectedValueOnce(new Error("systemctl unavailable"));
 
     try {
       setPlatform("freebsd");
       process.env.OPENCLAW_SUPERVISOR_MODE = "external";
       await withIsolatedSignals(async ({ captureSignal }) => {
-        const { start, started } = createSignaledStart(close);
+        const closeFirst = createCloseMock();
+        const closeSecond = createCloseMock();
+        let resolveStarted: () => void = () => {};
+        const started = new Promise<void>((resolve) => {
+          resolveStarted = resolve;
+        });
+        const start = vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            resolveStarted();
+            return { close: closeFirst };
+          })
+          .mockResolvedValueOnce({ close: closeSecond });
         const { runtime, exited } = createRuntimeWithExitSignal();
         await runLoopWithStart({ start, runtime });
         await waitForStart(started);
         const sigusr1 = captureSignal("SIGUSR1");
+        const sigint = captureSignal("SIGINT");
 
         sigusr1();
         await waitForLoopCondition(
-          () => close.mock.calls.length === 1,
-          "restart close did not start",
+          () => waitForActiveTasks.mock.calls.length === 1,
+          "restart drain did not start",
         );
         sigusr1();
         await waitForLoopCondition(
@@ -2512,14 +2517,22 @@ describe("runGatewayLoop", () => {
           "accepted restart was not upgraded",
         );
 
-        releaseClose();
+        releaseDrain({ drained: true });
+        await waitForLoopCondition(
+          () => start.mock.calls.length === 2,
+          "parking failure did not restart in-process",
+        );
+        expect(parkManagedUpdateSuccessor).toHaveBeenCalledWith("external");
+        expect(markUpdateRestartSentinelFailure).toHaveBeenCalledWith(
+          "restart-handoff-unavailable",
+        );
+        expect(closeFirst).toHaveBeenCalledTimes(1);
+        expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+        expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        sigint();
         await expect(exited).resolves.toBe(0);
-        expect(restartGatewayProcessWithFreshPid).toHaveBeenCalledTimes(1);
-        expectRestartHandoffCall({
-          restartKind: "update-process",
-          reason: "update.auto",
-          supervisorMode: "external",
-        });
       });
     } finally {
       delete process.env.OPENCLAW_SUPERVISOR_MODE;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -226,8 +226,6 @@ export async function runGatewayLoop(params: {
     const {
       detectGatewayRespawnSupervisor,
       markUpdateRestartSentinelFailure,
-      parkCurrentLaunchAgentForMaintenance,
-      parkCurrentSystemdServiceForMaintenance,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
@@ -244,12 +242,16 @@ export async function runGatewayLoop(params: {
     if (activeRestartRequest?.restartIntent?.successorOwner === "managed-update-handoff") {
       const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform);
       try {
+        // Service manager graphs stay outside the eagerly primed lifecycle hub;
+        // managed handoff is the only path that needs them.
         if (supervisor === "launchd") {
-          if (!(await parkCurrentLaunchAgentForMaintenance())) {
+          const launchd = await import("../../daemon/launchd-stop.js");
+          if (!(await launchd.parkCurrentLaunchAgentForMaintenance())) {
             throw new Error("current LaunchAgent identity is unavailable");
           }
         } else if (supervisor === "systemd") {
-          await parkCurrentSystemdServiceForMaintenance();
+          const systemd = await import("../../daemon/systemd-lifecycle.js");
+          await systemd.parkCurrentSystemdServiceForMaintenance();
         }
       } catch (err) {
         gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -226,6 +226,8 @@ export async function runGatewayLoop(params: {
     const {
       detectGatewayRespawnSupervisor,
       markUpdateRestartSentinelFailure,
+      parkCurrentLaunchAgentForMaintenance,
+      parkCurrentSystemdServiceForMaintenance,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
@@ -242,16 +244,12 @@ export async function runGatewayLoop(params: {
     if (activeRestartRequest?.restartIntent?.successorOwner === "managed-update-handoff") {
       const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform);
       try {
-        // Service manager graphs stay outside the eagerly primed lifecycle hub;
-        // managed handoff is the only path that needs them.
         if (supervisor === "launchd") {
-          const launchd = await import("../../daemon/launchd-stop.js");
-          if (!(await launchd.parkCurrentLaunchAgentForMaintenance())) {
+          if (!(await parkCurrentLaunchAgentForMaintenance())) {
             throw new Error("current LaunchAgent identity is unavailable");
           }
         } else if (supervisor === "systemd") {
-          const systemd = await import("../../daemon/systemd-lifecycle.js");
-          await systemd.parkCurrentSystemdServiceForMaintenance();
+          await parkCurrentSystemdServiceForMaintenance();
         }
       } catch (err) {
         gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -226,8 +226,8 @@ export async function runGatewayLoop(params: {
     const {
       detectGatewayRespawnSupervisor,
       markUpdateRestartSentinelFailure,
-      parkCurrentLaunchAgentForMaintenance,
-      parkCurrentSystemdServiceForMaintenance,
+      parkManagedUpdateLaunchdSuccessor,
+      parkManagedUpdateSystemdSuccessor,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
@@ -245,11 +245,11 @@ export async function runGatewayLoop(params: {
       const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform);
       try {
         if (supervisor === "launchd") {
-          if (!(await parkCurrentLaunchAgentForMaintenance())) {
+          if (!(await parkManagedUpdateLaunchdSuccessor())) {
             throw new Error("current LaunchAgent identity is unavailable");
           }
         } else if (supervisor === "systemd") {
-          await parkCurrentSystemdServiceForMaintenance();
+          await parkManagedUpdateSystemdSuccessor();
         }
       } catch (err) {
         gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -159,6 +159,7 @@ export async function runGatewayLoop(params: {
   const exitProcess = (code: number) => {
     cleanupSignals();
     params.runtime.exit(code);
+    restartResolver?.();
   };
   const exitProcessAfterLogFlush = async (code: number) => {
     // Graceful signal/restart paths call process.exit(), which skips beforeExit.
@@ -1110,6 +1111,9 @@ export async function runGatewayLoop(params: {
           };
           flushPendingStartupRequest({ allowMissingServer: true });
         });
+      }
+      if (shuttingDown) {
+        return;
       }
     }
   } finally {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -179,21 +179,27 @@ export async function runGatewayLoop(params: {
     }
     exitProcess(code);
   };
-  const completeForcedStop = (reason: string) => {
-    params.completeBoot?.({ outcome: "forced_stop", reason });
+  const writeStabilityBundle = (reason: string, error?: unknown) => {
+    const result = eagerLifecycleRuntime.writeDiagnosticStabilityBundleForFailureSync(
+      reason,
+      error,
+    );
+    if ("message" in result) gatewayLog.warn(result.message);
   };
-  const writeStabilityBundle = async (reason: string, error?: unknown) => {
-    const { writeDiagnosticStabilityBundleForFailureSync } =
-      await loadGatewayLifecycleRuntimeModule();
-    const result = writeDiagnosticStabilityBundleForFailureSync(reason, error);
-    if ("message" in result) {
-      gatewayLog.warn(result.message);
+  const forceExit = (reason: string) => {
+    try {
+      writeStabilityBundle(reason);
+    } catch (err) {
+      gatewayLog.warn(`failed to write shutdown stability bundle: ${formatErrorMessage(err)}`);
+    }
+    try {
+      params.completeBoot?.({ outcome: "forced_stop", reason });
+    } finally {
+      exitProcess(1);
     }
   };
   const releaseLockIfHeld = async (): Promise<boolean> => {
-    if (!lock) {
-      return false;
-    }
+    if (!lock) return false;
     await lock.release();
     lock = null;
     return true;
@@ -208,6 +214,14 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
+  const resumeInProcessRestart = () => {
+    activeRestartRequest = null;
+    shuttingDown = false;
+    restartResolver?.();
+  };
+  const reacquireAndResumeInProcessRestart = async () => {
+    if (await reacquireLockForInProcessRestart()) resumeInProcessRestart();
+  };
   const confirmLaunchdHandoff = async (respawn: {
     handoffSpawned?: Promise<boolean>;
   }): Promise<boolean> => {
@@ -221,13 +235,13 @@ export async function runGatewayLoop(params: {
     await delay;
     return spawned;
   };
-  const handleRestartAfterServerClose = async () => {
+  const handleRestartAfterServerClose = async (
+    managedUpdateSuccessorParked: boolean | null = null,
+  ) => {
     await releaseLockIfHeld();
     const {
       detectGatewayRespawnSupervisor,
       markUpdateRestartSentinelFailure,
-      parkManagedUpdateLaunchdSuccessor,
-      parkManagedUpdateSystemdSuccessor,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
@@ -242,30 +256,18 @@ export async function runGatewayLoop(params: {
     const isUpdateRestart = isUpdateProcessRestartReason(restartReason);
 
     if (activeRestartRequest?.restartIntent?.successorOwner === "managed-update-handoff") {
-      const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform);
-      try {
-        if (supervisor === "launchd") {
-          if (!(await parkManagedUpdateLaunchdSuccessor())) {
-            throw new Error("current LaunchAgent identity is unavailable");
-          }
-        } else if (supervisor === "systemd") {
-          await parkManagedUpdateSystemdSuccessor();
+      if (managedUpdateSuccessorParked !== true) {
+        if (managedUpdateSuccessorParked === null) {
+          gatewayLog.error("managed update handoff arrived after successor parking closed");
+          await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
+            (sentinelError: unknown) => {
+              gatewayLog.warn(
+                `failed to mark update restart handoff unavailable: ${String(sentinelError)}`,
+              );
+            },
+          );
         }
-      } catch (err) {
-        gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);
-        await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
-          (sentinelError: unknown) => {
-            gatewayLog.warn(
-              `failed to mark update restart handoff unavailable: ${String(sentinelError)}`,
-            );
-          },
-        );
-        if (!(await reacquireLockForInProcessRestart())) {
-          return;
-        }
-        activeRestartRequest = null;
-        shuttingDown = false;
-        restartResolver?.();
+        await reacquireAndResumeInProcessRestart();
         return;
       }
       activeRestartRequest = null;
@@ -305,11 +307,7 @@ export async function runGatewayLoop(params: {
         await markUpdateRestartSentinelFailure("restart-unhealthy").catch((err: unknown) => {
           gatewayLog.warn(`failed to mark update restart sentinel unhealthy: ${String(err)}`);
         });
-        if (!(await reacquireLockForInProcessRestart())) {
-          return;
-        }
-        shuttingDown = false;
-        restartResolver?.();
+        await reacquireAndResumeInProcessRestart();
         return;
       }
       if (respawn.mode === "failed") {
@@ -324,12 +322,7 @@ export async function runGatewayLoop(params: {
           `restart mode: in-process restart (${respawn.detail ?? "OPENCLAW_NO_RESPAWN"})`,
         );
       }
-      if (!(await reacquireLockForInProcessRestart())) {
-        return;
-      }
-      activeRestartRequest = null;
-      shuttingDown = false;
-      restartResolver?.();
+      await reacquireAndResumeInProcessRestart();
       return;
     }
 
@@ -366,12 +359,7 @@ export async function runGatewayLoop(params: {
           if (isUpdateRestart) {
             await markUpdateRestartSentinelFailure("restart-handoff-unavailable");
           }
-          if (!(await reacquireLockForInProcessRestart())) {
-            return;
-          }
-          activeRestartRequest = null;
-          shuttingDown = false;
-          restartResolver?.();
+          await reacquireAndResumeInProcessRestart();
           return;
         }
       }
@@ -384,12 +372,7 @@ export async function runGatewayLoop(params: {
         if (isUpdateRestart) {
           await markUpdateRestartSentinelFailure("restart-handoff-unavailable");
         }
-        if (!(await reacquireLockForInProcessRestart())) {
-          return;
-        }
-        activeRestartRequest = null;
-        shuttingDown = false;
-        restartResolver?.();
+        await reacquireAndResumeInProcessRestart();
         return;
       }
       activeRestartRequest = null;
@@ -417,9 +400,7 @@ export async function runGatewayLoop(params: {
       await handleRestartAfterServerClose();
       return;
     }
-    activeRestartRequest = null;
-    shuttingDown = false;
-    restartResolver?.();
+    resumeInProcessRestart();
   };
   const handleStopAfterServerClose = async () => {
     params.completeBoot?.({ outcome: "clean_stop", reason: "gateway.stop" });
@@ -445,14 +426,7 @@ export async function runGatewayLoop(params: {
       gatewayLog.error(
         "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
       );
-      void (async () => {
-        try {
-          await writeStabilityBundle("gateway.restart_startup_request_timeout");
-        } finally {
-          completeForcedStop("gateway.restart_startup_request_timeout");
-          exitProcess(1);
-        }
-      })();
+      forceExit("gateway.restart_startup_request_timeout");
     }, SHUTDOWN_TIMEOUT_MS);
     pendingStartupForceExitTimer.unref?.();
   };
@@ -496,21 +470,13 @@ export async function runGatewayLoop(params: {
       }
       forceExitTimer = setTimeout(() => {
         gatewayLog.error("shutdown timed out; exiting without full cleanup");
-        void (async () => {
-          try {
-            await writeStabilityBundle(
-              isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
-            );
-          } finally {
-            // Keep the in-process watchdog below the supervisor stop budget so this
-            // path wins before launchd/systemd escalates to a hard kill. Exit
-            // non-zero on any timeout so supervised installs restart cleanly.
-            completeForcedStop(
-              isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
-            );
-            exitProcess(1);
-          }
-        })();
+        const reason = isRestart
+          ? "gateway.restart_shutdown_timeout"
+          : "gateway.stop_shutdown_timeout";
+        // Keep the in-process watchdog below the supervisor stop budget so this
+        // path wins before launchd/systemd escalates to a hard kill. Exit
+        // non-zero on any timeout so supervised installs restart cleanly.
+        forceExit(reason);
       }, forceExitMs);
     };
     const clearForceExitTimer = () => {
@@ -528,6 +494,7 @@ export async function runGatewayLoop(params: {
     }
 
     void (async () => {
+      let managedUpdateSuccessorParked: boolean | null = null;
       const restartDrainTimeoutMs = isRestart
         ? await resolveRestartDrainTimeoutMs(restartIntent)
         : 0;
@@ -757,6 +724,30 @@ export async function runGatewayLoop(params: {
           }
         }
 
+        if (
+          isRestart &&
+          activeRestartRequest?.restartIntent?.successorOwner === "managed-update-handoff"
+        ) {
+          const supervisor = eagerLifecycleRuntime.detectGatewayRespawnSupervisor(
+            process.env,
+            process.platform,
+          );
+          try {
+            await eagerLifecycleRuntime.parkManagedUpdateSuccessor(supervisor);
+            managedUpdateSuccessorParked = true;
+          } catch (err) {
+            managedUpdateSuccessorParked = false;
+            gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);
+            await eagerLifecycleRuntime
+              .markUpdateRestartSentinelFailure("restart-handoff-unavailable")
+              .catch((sentinelError: unknown) => {
+                gatewayLog.warn(
+                  `failed to mark update restart handoff unavailable: ${String(sentinelError)}`,
+                );
+              });
+          }
+        }
+
         armCloseForceExitTimerForIndefiniteRestart();
         const closeDrainTimeoutMs = resolveRestartCloseDrainTimeoutMs();
         await server?.close({
@@ -770,7 +761,7 @@ export async function runGatewayLoop(params: {
         server = null;
         if (isRestart) {
           try {
-            await handleRestartAfterServerClose();
+            await handleRestartAfterServerClose(managedUpdateSuccessorParked);
           } finally {
             clearForceExitTimer();
             forceActiveRestartExit = null;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -184,7 +184,9 @@ export async function runGatewayLoop(params: {
       reason,
       error,
     );
-    if ("message" in result) gatewayLog.warn(result.message);
+    if ("message" in result) {
+      gatewayLog.warn(result.message);
+    }
   };
   const forceExit = (reason: string) => {
     try {
@@ -199,7 +201,9 @@ export async function runGatewayLoop(params: {
     }
   };
   const releaseLockIfHeld = async (): Promise<boolean> => {
-    if (!lock) return false;
+    if (!lock) {
+      return false;
+    }
     await lock.release();
     lock = null;
     return true;
@@ -220,7 +224,9 @@ export async function runGatewayLoop(params: {
     restartResolver?.();
   };
   const reacquireAndResumeInProcessRestart = async () => {
-    if (await reacquireLockForInProcessRestart()) resumeInProcessRestart();
+    if (await reacquireLockForInProcessRestart()) {
+      resumeInProcessRestart();
+    }
   };
   const confirmLaunchdHandoff = async (respawn: {
     handoffSpawned?: Promise<boolean>;
@@ -365,7 +371,7 @@ export async function runGatewayLoop(params: {
       }
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       if (respawnSupervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
-        await writeStabilityBundle("gateway.restart_handoff_spawn_failed");
+        writeStabilityBundle("gateway.restart_handoff_spawn_failed");
         gatewayLog.warn(
           "launchd restart handoff failed to spawn; falling back to in-process restart",
         );
@@ -380,7 +386,7 @@ export async function runGatewayLoop(params: {
       return;
     }
     if (respawn.mode === "failed") {
-      await writeStabilityBundle("gateway.restart_respawn_failed");
+      writeStabilityBundle("gateway.restart_respawn_failed");
       gatewayLog.warn(
         `full process restart failed (${respawn.detail ?? "unknown error"}); falling back to in-process restart`,
       );
@@ -1090,7 +1096,7 @@ export async function runGatewayLoop(params: {
         }
         const errMsg = formatErrorMessage(err);
         const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
-        await writeStabilityBundle("gateway.restart_startup_failed", err);
+        writeStabilityBundle("gateway.restart_startup_failed", err);
         gatewayLog.error(
           `gateway startup failed: ${errMsg}. ` +
             `Process will stay alive; fix the issue and restart.${errStack}`,

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -43,6 +43,7 @@ type RestartIntentOptions = {
   reason?: string;
   force?: boolean;
   waitMs?: number;
+  successorOwner?: "managed-update-handoff";
 };
 type GatewayRunSignalRequest = {
   action: GatewayRunSignalAction;
@@ -225,6 +226,8 @@ export async function runGatewayLoop(params: {
     const {
       detectGatewayRespawnSupervisor,
       markUpdateRestartSentinelFailure,
+      parkCurrentLaunchAgentForMaintenance,
+      parkCurrentSystemdServiceForMaintenance,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
@@ -238,7 +241,41 @@ export async function runGatewayLoop(params: {
     });
     const isUpdateRestart = isUpdateProcessRestartReason(restartReason);
 
-    if (isUpdateRestart) {
+    if (activeRestartRequest?.restartIntent?.successorOwner === "managed-update-handoff") {
+      const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform);
+      try {
+        if (supervisor === "launchd") {
+          if (!(await parkCurrentLaunchAgentForMaintenance())) {
+            throw new Error("current LaunchAgent identity is unavailable");
+          }
+        } else if (supervisor === "systemd") {
+          await parkCurrentSystemdServiceForMaintenance();
+        }
+      } catch (err) {
+        gatewayLog.error(`managed update handoff could not park ${supervisor}: ${String(err)}`);
+        await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
+          (sentinelError: unknown) => {
+            gatewayLog.warn(
+              `failed to mark update restart handoff unavailable: ${String(sentinelError)}`,
+            );
+          },
+        );
+        if (!(await reacquireLockForInProcessRestart())) {
+          return;
+        }
+        activeRestartRequest = null;
+        shuttingDown = false;
+        restartResolver?.();
+        return;
+      }
+      activeRestartRequest = null;
+      gatewayLog.info("restart mode: managed update handoff owns successor");
+      await exitProcessAfterLogFlush(0);
+      return;
+    }
+
+    const supervisorMode = detectGatewayRespawnSupervisor(process.env, process.platform);
+    if (isUpdateRestart && !supervisorMode) {
       const restartTraceHandoff = captureGatewayRestartTraceHandoff();
       const respawn = respawnGatewayProcessForUpdate({
         env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
@@ -275,59 +312,6 @@ export async function runGatewayLoop(params: {
         restartResolver?.();
         return;
       }
-      if (respawn.mode === "supervised") {
-        const supervisorMode = detectGatewayRespawnSupervisor(process.env, process.platform);
-        markGatewayRestartTrace("restart.full-process-handoff", [
-          ["kind", "update-process"],
-          ["mode", respawn.mode],
-          ["supervisorMode", supervisorMode ?? "external"],
-        ]);
-        const handoff = writeGatewayRestartHandoffSync({
-          restartKind: "update-process",
-          reason: restartReason,
-          processInstanceId,
-          supervisorMode: supervisorMode ?? "external",
-          restartTrace: captureGatewayRestartTraceHandoff(),
-        });
-        if (supervisorMode === "external" && !handoff) {
-          gatewayLog.warn(
-            "external supervisor restart handoff could not be persisted; falling back to in-process restart",
-          );
-          await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
-            (err: unknown) => {
-              gatewayLog.warn(`failed to mark update restart handoff unavailable: ${String(err)}`);
-            },
-          );
-          if (!(await reacquireLockForInProcessRestart())) {
-            return;
-          }
-          activeRestartRequest = null;
-          shuttingDown = false;
-          restartResolver?.();
-          return;
-        }
-        gatewayLog.info("restart mode: update process respawn (supervisor restart)");
-        if (supervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
-          gatewayLog.warn(
-            "launchd restart handoff failed to spawn; falling back to in-process restart",
-          );
-          await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
-            (err: unknown) => {
-              gatewayLog.warn(`failed to mark update restart handoff unavailable: ${String(err)}`);
-            },
-          );
-          if (!(await reacquireLockForInProcessRestart())) {
-            return;
-          }
-          activeRestartRequest = null;
-          shuttingDown = false;
-          restartResolver?.();
-          return;
-        }
-        activeRestartRequest = null;
-        await exitProcessAfterLogFlush(0);
-        return;
-      }
       if (respawn.mode === "failed") {
         gatewayLog.warn(
           `update respawn failed (${respawn.detail ?? "unknown error"}); falling back to in-process restart`,
@@ -355,32 +339,33 @@ export async function runGatewayLoop(params: {
       env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
     });
     if (respawn.mode === "spawned" || respawn.mode === "supervised") {
-      const supervisorMode =
-        respawn.mode === "supervised"
-          ? detectGatewayRespawnSupervisor(process.env, process.platform)
-          : null;
+      const respawnSupervisorMode = respawn.mode === "supervised" ? supervisorMode : null;
+      const restartKind = isUpdateRestart ? "update-process" : "full-process";
       const modeLabel =
         respawn.mode === "spawned"
           ? `spawned pid ${respawn.pid ?? "unknown"}`
           : "supervisor restart";
       markGatewayRestartTrace("restart.full-process-handoff", [
-        ["kind", "full-process"],
+        ["kind", restartKind],
         ["mode", respawn.mode],
         ["pid", respawn.mode === "spawned" ? (respawn.pid ?? "unknown") : "none"],
-        ["supervisorMode", supervisorMode ?? "none"],
+        ["supervisorMode", respawnSupervisorMode ?? "none"],
       ]);
       if (respawn.mode === "supervised") {
         const handoff = writeGatewayRestartHandoffSync({
-          restartKind: "full-process",
+          restartKind,
           reason: restartReason,
           processInstanceId,
-          supervisorMode: supervisorMode ?? "external",
+          supervisorMode: respawnSupervisorMode ?? "external",
           restartTrace: captureGatewayRestartTraceHandoff(),
         });
-        if (supervisorMode === "external" && !handoff) {
+        if (respawnSupervisorMode === "external" && !handoff) {
           gatewayLog.warn(
             "external supervisor restart handoff could not be persisted; falling back to in-process restart",
           );
+          if (isUpdateRestart) {
+            await markUpdateRestartSentinelFailure("restart-handoff-unavailable");
+          }
           if (!(await reacquireLockForInProcessRestart())) {
             return;
           }
@@ -391,11 +376,14 @@ export async function runGatewayLoop(params: {
         }
       }
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
-      if (supervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
+      if (respawnSupervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
         await writeStabilityBundle("gateway.restart_handoff_spawn_failed");
         gatewayLog.warn(
           "launchd restart handoff failed to spawn; falling back to in-process restart",
         );
+        if (isUpdateRestart) {
+          await markUpdateRestartSentinelFailure("restart-handoff-unavailable");
+        }
         if (!(await reacquireLockForInProcessRestart())) {
           return;
         }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4730,72 +4730,65 @@ describe("update-cli", () => {
     processOffSpy.mockRestore();
   });
 
-  it.each([
-    { platform: "darwin" as const, handoff: undefined },
-    { platform: "linux" as const, handoff: "1" },
-    { platform: "win32" as const, handoff: "1" },
-  ])(
-    "quiesces a stopped loaded managed gateway on $platform before package replacement",
-    async ({ platform, handoff }) => {
-      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
-      const tempDir = await createTrackedTempDir(`openclaw-update-stopped-loaded-${platform}-`);
-      const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
-      primeServiceCommand(["node", entryPath, "gateway", "run"], {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
+  it("quiesces a stopped loaded LaunchAgent before package replacement", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const tempDir = await createTrackedTempDir("openclaw-update-stopped-loaded-darwin-");
+    const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
+    primeServiceCommand(["node", entryPath, "gateway", "run"], {
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    mockFileBackedPathExists();
+    mockNpmGlobalRoot(nodeModules);
+    let finishStop: (() => void) | undefined;
+    let markStopStarted: (() => void) | undefined;
+    const stopStarted = new Promise<void>((resolve) => {
+      markStopStarted = resolve;
+    });
+    serviceStop.mockImplementationOnce(() => {
+      markStopStarted?.();
+      return new Promise<void>((resolve) => {
+        finishStop = resolve;
       });
-      serviceLoaded.mockResolvedValue(true);
-      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
-      mockFileBackedPathExists();
-      mockNpmGlobalRoot(nodeModules);
-      let finishStop: (() => void) | undefined;
-      let markStopStarted: (() => void) | undefined;
-      const stopStarted = new Promise<void>((resolve) => {
-        markStopStarted = resolve;
+    });
+
+    try {
+      await withEnvAsync({ OPENCLAW_UPDATE_RUN_HANDOFF: undefined }, async () => {
+        const updatePromise = updateCommand({ yes: true });
+        const firstOutcome = await Promise.race([
+          stopStarted.then(() => "stop" as const),
+          updatePromise.then(() => "update" as const),
+        ]);
+
+        expect(firstOutcome).toBe("stop");
+        expect(serviceStop).toHaveBeenCalledOnce();
+        expect(packageInstallCommandCall()).toBeUndefined();
+        const pluginRecordCallsBeforeStop =
+          loadInstalledPluginIndexInstallRecords.mock.calls.length;
+        if (!finishStop) {
+          throw new Error("expected the managed service stop to remain pending");
+        }
+        finishStop();
+        await updatePromise;
+        expect(loadInstalledPluginIndexInstallRecords.mock.calls.length).toBeGreaterThan(
+          pluginRecordCallsBeforeStop,
+        );
       });
-      serviceStop.mockImplementationOnce(() => {
-        markStopStarted?.();
-        return new Promise<void>((resolve) => {
-          finishStop = resolve;
-        });
-      });
+    } finally {
+      platformSpy.mockRestore();
+    }
 
-      try {
-        await withEnvAsync({ OPENCLAW_UPDATE_RUN_HANDOFF: handoff }, async () => {
-          const updatePromise = updateCommand({ yes: true });
-          const firstOutcome = await Promise.race([
-            stopStarted.then(() => "stop" as const),
-            updatePromise.then(() => "update" as const),
-          ]);
-
-          expect(firstOutcome).toBe("stop");
-          expect(serviceStop).toHaveBeenCalledOnce();
-          expect(packageInstallCommandCall()).toBeUndefined();
-          const pluginRecordCallsBeforeStop =
-            loadInstalledPluginIndexInstallRecords.mock.calls.length;
-          if (!finishStop) {
-            throw new Error("expected the managed service stop to remain pending");
-          }
-          finishStop();
-          await updatePromise;
-          expect(loadInstalledPluginIndexInstallRecords.mock.calls.length).toBeGreaterThan(
-            pluginRecordCallsBeforeStop,
-          );
-        });
-      } finally {
-        platformSpy.mockRestore();
-      }
-
-      expect(packageInstallCommandCall()).toBeDefined();
-      expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalled();
-      expect(serviceStop.mock.invocationCallOrder[0]).toBeLessThan(
-        requireValue(
-          loadInstalledPluginIndexInstallRecords.mock.invocationCallOrder.at(-1),
-          "owned managed update context capture order",
-        ),
-      );
-    },
-  );
+    expect(packageInstallCommandCall()).toBeDefined();
+    expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalled();
+    expect(serviceStop.mock.invocationCallOrder[0]).toBeLessThan(
+      requireValue(
+        loadInstalledPluginIndexInstallRecords.mock.invocationCallOrder.at(-1),
+        "owned managed update context capture order",
+      ),
+    );
+  });
 
   it.each([
     { name: "an unloaded Darwin LaunchAgent", platform: "darwin" as const, loaded: false },

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -483,16 +483,12 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     };
   }
 
-  // A loaded LaunchAgent can be between KeepAlive respawns. Other supervisors
-  // need the handoff marker to distinguish that transition from operator-stopped state.
+  // A loaded LaunchAgent can be between KeepAlive respawns.
   const launchAgentMayRespawn =
     process.platform === "darwin" &&
     serviceState.loaded &&
     (await service.isEnabled?.({ env: serviceState.env })) === true;
-  const handoffSupervisorMayRespawn =
-    process.platform !== "darwin" && process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1";
-  const supervisorMayRespawn =
-    serviceState.loaded && (launchAgentMayRespawn || handoffSupervisorMayRespawn);
+  const supervisorMayRespawn = serviceState.loaded && launchAgentMayRespawn;
   if (!serviceState.running && !supervisorMayRespawn) {
     const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
       updateInstallKind: params.updateInstallKind,

--- a/src/daemon/systemd-lifecycle.ts
+++ b/src/daemon/systemd-lifecycle.ts
@@ -106,6 +106,18 @@ export async function stopSystemdService({
   });
 }
 
+export async function parkCurrentSystemdServiceForMaintenance(
+  env: GatewayServiceEnv = process.env,
+): Promise<void> {
+  const unitName = `${resolveSystemdServiceName(env)}.service`;
+  // Queue an explicit stop before this process exits. systemd suppresses
+  // Restart=always for an operator stop, leaving the updater as successor owner.
+  const res = await execSystemctlUser(env, ["--no-block", "stop", unitName]);
+  if (res.code !== 0) {
+    throw new Error(`systemctl stop failed: ${res.stderr || res.stdout}`.trim());
+  }
+}
+
 export async function restartSystemdService({
   stdout,
   env,

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -85,6 +85,7 @@ vi.mock("./exec-file.js", () => {
 });
 
 import { splitArgsPreservingQuotes } from "./arg-split.js";
+import { parkCurrentSystemdServiceForMaintenance } from "./systemd-lifecycle.js";
 import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
 import {
   findInstalledSystemdGatewayScope,
@@ -3167,6 +3168,17 @@ describe("systemd service control", () => {
         "write.mock.invocationCallOrder[0] test invariant",
       ),
     );
+  });
+
+  it("parks the current user unit without waiting for its own exit", async () => {
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertUserSystemctlArgs(args, "--no-block", "stop", "openclaw-gateway-work.service");
+      cb(null, "", "");
+    });
+
+    await parkCurrentSystemdServiceForMaintenance({ OPENCLAW_PROFILE: "work" });
+
+    expect(execFileMock).toHaveBeenCalledOnce();
   });
 
   it("audits a successful stop before a later output failure", async () => {

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -684,6 +684,7 @@ describe("update.run restart scheduling", () => {
         reason: "update.run",
         skipCooldown: true,
         skipDeferral: true,
+        successorOwner: "managed-update-handoff",
       }),
     );
   });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -429,6 +429,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               managedHandoffRestart = scheduleGatewaySigusr1Restart({
                 delayMs: managedRestartDelayMs,
                 reason: "update.run",
+                successorOwner: "managed-update-handoff",
                 skipDeferral: true,
                 skipCooldown: true,
                 audit: {

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -11,6 +11,7 @@ import {
 type RestartModule = typeof import("./restart.js");
 
 let consumeGatewaySigusr1RestartAuthorization: RestartModule["consumeGatewaySigusr1RestartAuthorization"];
+let consumeGatewaySigusr1RestartIntent: RestartModule["consumeGatewaySigusr1RestartIntent"];
 let deferGatewayRestartUntilIdle: RestartModule["deferGatewayRestartUntilIdle"];
 let isGatewaySigusr1RestartExternallyAllowed: RestartModule["isGatewaySigusr1RestartExternallyAllowed"];
 let markGatewaySigusr1RestartHandled: RestartModule["markGatewaySigusr1RestartHandled"];
@@ -114,6 +115,7 @@ describe("infra runtime", () => {
       );
       ({
         consumeGatewaySigusr1RestartAuthorization,
+        consumeGatewaySigusr1RestartIntent,
         deferGatewayRestartUntilIdle,
         isGatewaySigusr1RestartExternallyAllowed,
         markGatewaySigusr1RestartHandled,
@@ -465,6 +467,7 @@ describe("infra runtime", () => {
           delayMs: 0,
           reason: "update.auto",
           skipDeferral: true,
+          successorOwner: "managed-update-handoff",
         });
         expect(update.coalesced).toBe(true);
 
@@ -472,6 +475,10 @@ describe("infra runtime", () => {
         await signalEmitted;
 
         expect(peekGatewaySigusr1RestartReason()).toBe("update.auto");
+        expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+          reason: "update.auto",
+          successorOwner: "managed-update-handoff",
+        });
       } finally {
         process.removeListener("SIGUSR1", handler);
       }
@@ -1137,6 +1144,28 @@ describe("infra runtime", () => {
         expect(pendingCheck).not.toHaveBeenCalled();
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
         expect(peekGatewaySigusr1RestartReason()).toBe("update.run");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("carries managed handoff successor ownership into the emitted restart", async () => {
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "update.run",
+          skipDeferral: true,
+          successorOwner: "managed-update-handoff",
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+          reason: "update.run",
+          successorOwner: "managed-update-handoff",
+        });
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/managed-update-successor.test.ts
+++ b/src/infra/managed-update-successor.test.ts
@@ -1,0 +1,31 @@
+import { expect, it, vi } from "vitest";
+import { parkManagedUpdateSuccessor } from "./managed-update-successor.js";
+
+const parkLaunchd = vi.fn(async () => true);
+const parkSystemd = vi.fn(async () => {});
+
+vi.mock("../daemon/launchd-stop.js", () => ({
+  parkCurrentLaunchAgentForMaintenance: () => parkLaunchd(),
+}));
+vi.mock("../daemon/systemd-lifecycle.js", () => ({
+  parkCurrentSystemdServiceForMaintenance: () => parkSystemd(),
+}));
+
+it("dispatches managed successor parking by supervisor family", async () => {
+  await parkManagedUpdateSuccessor("launchd");
+  expect(parkLaunchd).toHaveBeenCalledOnce();
+  vi.clearAllMocks();
+  await parkManagedUpdateSuccessor("systemd");
+  expect(parkSystemd).toHaveBeenCalledOnce();
+  vi.clearAllMocks();
+  await parkManagedUpdateSuccessor("schtasks");
+  await parkManagedUpdateSuccessor("external");
+  await parkManagedUpdateSuccessor(null);
+  expect(parkLaunchd).not.toHaveBeenCalled();
+  expect(parkSystemd).not.toHaveBeenCalled();
+
+  parkLaunchd.mockResolvedValueOnce(false);
+  await expect(parkManagedUpdateSuccessor("launchd")).rejects.toThrow(
+    "current LaunchAgent identity is unavailable",
+  );
+});

--- a/src/infra/managed-update-successor.ts
+++ b/src/infra/managed-update-successor.ts
@@ -1,0 +1,15 @@
+import type { GatewayRespawnSupervisor as Supervisor } from "./supervisor-markers.js";
+
+export async function parkManagedUpdateSuccessor(supervisor: Supervisor | null) {
+  if (supervisor === "launchd") {
+    if (
+      !(await (await import("../daemon/launchd-stop.js")).parkCurrentLaunchAgentForMaintenance())
+    ) {
+      throw new Error("current LaunchAgent identity is unavailable");
+    }
+  } else if (supervisor === "systemd") {
+    await (
+      await import("../daemon/systemd-lifecycle.js")
+    ).parkCurrentSystemdServiceForMaintenance();
+  }
+}

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -354,22 +354,6 @@ describe("respawnGatewayProcessForUpdate", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("actively schedules launchd update relaunch before exiting", () => {
-    clearSupervisorHints();
-    setPlatform("darwin");
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_NO_RESPAWN = "1";
-
-    const result = respawnGatewayProcessForUpdate();
-
-    expect(result.mode).toBe("supervised");
-    expect(result.handoffSpawned).toBeInstanceOf(Promise);
-    expect(scheduleLaunchdHandoffMock).toHaveBeenCalledWith({
-      mode: "start-after-exit",
-      waitForPid: process.pid,
-    });
-  });
-
   it("allows detached respawn on unmanaged Windows during updates", () => {
     clearSupervisorHints();
     setPlatform("win32");
@@ -395,18 +379,6 @@ describe("respawnGatewayProcessForUpdate", () => {
         stdio: "inherit",
       },
     );
-  });
-
-  it("delegates update restarts to external supervision without spawning", () => {
-    clearSupervisorHints();
-    setPlatform("linux");
-    process.env.OPENCLAW_SUPERVISOR_MODE = "external";
-
-    const result = respawnGatewayProcessForUpdate();
-
-    expect(result).toEqual({ mode: "supervised" });
-    expect(spawnMock).not.toHaveBeenCalled();
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   });
 
   it("rewrites a pnpm-versioned OpenClaw entry before detached update respawn", () => {
@@ -495,19 +467,6 @@ describe("respawnGatewayProcessForUpdate", () => {
     const onCallOrder = child.on.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
     const unrefCallOrder = child.unref.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;
     expect(onCallOrder).toBeLessThan(unrefCallOrder);
-  });
-
-  it("exits to a managed supervisor for updates even when respawn is disabled", () => {
-    clearSupervisorHints();
-    setPlatform("linux");
-    process.env.OPENCLAW_NO_RESPAWN = "1";
-    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
-    process.env.OPENCLAW_SERVICE_KIND = "gateway";
-
-    const result = respawnGatewayProcessForUpdate();
-
-    expect(result).toEqual({ mode: "supervised" });
-    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("returns failed when update detached respawn throws", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -122,33 +122,12 @@ export function restartGatewayProcessWithFreshPid(
  * Update restarts must replace the OS process so the new code runs from a
  * fresh module graph after package files have changed on disk.
  *
- * Unlike the generic restart path, update mode allows detached respawn on
- * unmanaged Windows installs because there is no safe in-process fallback once
- * the installed package contents have been replaced.
+ * The caller resolves supervisor ownership first; this path is only for an
+ * unmanaged process whose installed package contents have been replaced.
  */
 export function respawnGatewayProcessForUpdate(
   opts: GatewayRespawnOptions = {},
 ): GatewayUpdateRespawnResult {
-  const supervisor = detectGatewayRespawnSupervisor(process.env, process.platform, {
-    includeLinuxOpenClawGatewayServiceMarker: true,
-  });
-  if (supervisor) {
-    // Managed update handoffs require the original PID to exit before the
-    // detached helper can mutate the install, even when respawn is disabled.
-    if (supervisor === "launchd") {
-      return scheduleLaunchdRestartAfterExit();
-    }
-    if (supervisor === "schtasks") {
-      const restart = triggerOpenClawRestart();
-      if (!restart.ok) {
-        return {
-          mode: "failed",
-          detail: restart.detail ?? `${restart.method} restart failed`,
-        };
-      }
-    }
-    return { mode: "supervised" };
-  }
   if (isTruthyEnvValue(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" };
   }

--- a/src/infra/restart-intent.ts
+++ b/src/infra/restart-intent.ts
@@ -32,6 +32,7 @@ export type GatewayRestartIntent = {
   reason?: string;
   force?: boolean;
   waitMs?: number;
+  successorOwner?: "managed-update-handoff";
 };
 
 function normalizeRestartIntentPid(pid: number | undefined): number | null {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -45,6 +45,7 @@ let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
+let pendingRestartSuccessorOwner: GatewayRestartIntent["successorOwner"];
 let pendingRestartEmitHooks: RestartEmitHooks | undefined;
 let pendingRestartSessionKey: string | undefined;
 let pendingRestartSkipDeferral = false;
@@ -69,6 +70,7 @@ function clearPendingScheduledRestart(): void {
   pendingRestartTimer = null;
   pendingRestartDueAt = 0;
   pendingRestartReason = undefined;
+  pendingRestartSuccessorOwner = undefined;
   pendingRestartEmitHooks = undefined;
   pendingRestartSessionKey = undefined;
   pendingRestartSkipDeferral = false;
@@ -96,6 +98,7 @@ function armPendingRestartTimer(requestedDueAt: number, nowMs: number): void {
   pendingRestartTimer = setTimeout(
     () => {
       const scheduledReason = pendingRestartReason;
+      const scheduledSuccessorOwner = pendingRestartSuccessorOwner;
       const scheduledSkipDeferral = pendingRestartSkipDeferral;
       pendingRestartTimer = null;
       pendingRestartDueAt = 0;
@@ -104,7 +107,10 @@ function armPendingRestartTimer(requestedDueAt: number, nowMs: number): void {
       pendingRestartPreparing = true;
       const pendingCheck = preRestartCheck;
       if (scheduledSkipDeferral || !pendingCheck) {
-        void emitPreparedGatewayRestart(undefined, scheduledReason);
+        const intent = scheduledSuccessorOwner
+          ? { reason: scheduledReason, successorOwner: scheduledSuccessorOwner }
+          : undefined;
+        void emitPreparedGatewayRestart(undefined, scheduledReason, intent);
         return;
       }
       const deferralTimeoutMs = resolveGatewayRestartDeferralTimeoutMs();
@@ -586,8 +592,11 @@ async function emitPreparedGatewayRestartUnderAdmission(
     ? pendingRestartReason
     : undefined;
   const resolvedReason = preferredReason ?? reasonOverride;
+  const successorOwner = pendingRestartSuccessorOwner ?? intent?.successorOwner;
   const resolvedIntent =
-    preferredReason && intent ? { ...intent, reason: preferredReason } : intent;
+    preferredReason || successorOwner
+      ? { ...intent, ...(preferredReason ? { reason: preferredReason } : {}), successorOwner }
+      : intent;
   const emitResult = emitOwner?.emitRestart
     ? emitOwner.emitRestart(resolvedReason, resolvedIntent)
     : requestGatewayRestartWithSignalAdmission(resolvedReason, resolvedIntent);
@@ -1018,6 +1027,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   sessionKey?: string;
   skipDeferral?: boolean;
   skipCooldown?: boolean;
+  successorOwner?: GatewayRestartIntent["successorOwner"];
 }): ScheduledRestart {
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
@@ -1040,10 +1050,11 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   if (hasUnconsumedRestartSignal()) {
     if (shouldPreferRestartReason(reason, emittedRestartReason)) {
       emittedRestartReason = reason;
-      if (emittedRestartIntent) {
-        // Preserve the already-authorized force bit; only the display/recovery reason is upgraded.
-        emittedRestartIntent = { ...emittedRestartIntent, reason };
-      }
+      // Preserve authorization facts while upgrading the display/recovery reason.
+      emittedRestartIntent = { ...emittedRestartIntent, reason };
+    }
+    if (opts?.successorOwner) {
+      emittedRestartIntent = { ...emittedRestartIntent, successorOwner: opts.successorOwner };
     }
     restartLog.warn(
       `restart request coalesced (already in-flight) reason=${reason ?? "unspecified"} ${formatRestartAudit(opts?.audit)}`,
@@ -1070,6 +1081,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       );
       clearActiveDeferralPolls();
       pendingRestartReason = reason;
+      pendingRestartSuccessorOwner = opts?.successorOwner;
       // Hookless forced restarts that own no sentinel may preserve an accepted
       // pending hook; update/handoff callers rely on the default clear path.
       const preservePendingHooks =
@@ -1080,7 +1092,10 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         pendingRestartEmitHooks = opts?.emitHooks;
         pendingRestartSessionKey = opts?.sessionKey;
       }
-      void emitPreparedGatewayRestart(undefined, reason);
+      const intent = opts?.successorOwner
+        ? { reason, successorOwner: opts.successorOwner }
+        : undefined;
+      void emitPreparedGatewayRestart(undefined, reason, intent);
       return {
         ok: true,
         pid: process.pid,
@@ -1143,6 +1158,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       if (shouldPreferRestartReason(reason, pendingRestartReason)) {
         pendingRestartReason = reason;
       }
+      pendingRestartSuccessorOwner ??= opts?.successorOwner;
       pendingRestartSkipDeferral = pendingRestartSkipDeferral || skipDeferral;
       restartLog.warn(
         `restart request coalesced (already scheduled) reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} delayMs=${remainingMs} ${formatRestartAudit(opts?.audit)}`,
@@ -1169,6 +1185,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
 
   pendingRestartDueAt = requestedDueAt;
   pendingRestartReason = reason;
+  pendingRestartSuccessorOwner = opts?.successorOwner;
   pendingRestartEmitHooks = nextPendingEmitHooks;
   pendingRestartSessionKey = nextPendingSessionKey;
   pendingRestartSkipDeferral = skipDeferral;

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -23,7 +23,7 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
-type GatewayRespawnSupervisor = RespawnSupervisor | "external";
+export type GatewayRespawnSupervisor = RespawnSupervisor | "external";
 
 interface DetectRespawnSupervisorOptions {
   includeLinuxOpenClawGatewayServiceMarker?: boolean;

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1851,6 +1851,7 @@ describe("update-startup", () => {
       reason: "update.auto",
       skipCooldown: true,
       skipDeferral: true,
+      successorOwner: "managed-update-handoff",
     });
     expect(log.info).toHaveBeenCalledWith(
       "update campaign waiting-for-idle",
@@ -1954,6 +1955,7 @@ describe("update-startup", () => {
       reason: "update.auto",
       skipCooldown: true,
       skipDeferral: true,
+      successorOwner: "managed-update-handoff",
     });
   });
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -457,6 +457,7 @@ async function startManagedServiceAutoUpdateHandoff(
       scheduleGatewaySigusr1Restart({
         delayMs: restartDelayMs,
         reason: "update.auto",
+        successorOwner: "managed-update-handoff",
         skipCooldown: true,
         skipDeferral: true,
       });

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -16,6 +16,7 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../vitest/vitest.agents-paths.mjs";
+import { cliProcessTestFiles } from "../vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../vitest/vitest.commands-light-paths.mjs";
 import { createGatewayClientVitestConfig } from "../vitest/vitest.gateway-client.config.ts";
 import { createGatewayCoreVitestConfig } from "../vitest/vitest.gateway-core.config.ts";
@@ -460,13 +461,21 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "agentic-agents-embedded-overflow-compaction",
       "agentic-agents-embedded-run",
     ];
+    const expectedCliProcessGroupNames = [
+      "agentic-cli-process-run-loop",
+      "agentic-cli-process-support",
+    ];
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
-    const expectedGroupNames = base.flatMap((shard) =>
-      shard.shardName === "agentic-agents-embedded"
-        ? expectedEmbeddedAgentGroupNames
-        : [shard.shardName],
-    );
+    const expectedGroupNames = base.flatMap((shard) => {
+      if (shard.shardName === "agentic-agents-embedded") {
+        return expectedEmbeddedAgentGroupNames;
+      }
+      if (shard.shardName === "agentic-cli-process") {
+        return expectedCliProcessGroupNames;
+      }
+      return [shard.shardName];
+    });
     expect(compactGroups.map((group) => group.shard_name).toSorted()).toEqual(
       expectedGroupNames.filter((name) => !pushExcludedShardNames.has(name)).toSorted(),
     );
@@ -485,6 +494,20 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(hostedOwnerNames(githubPullRequestCompact)).toEqual(
       new Set(pullRequestCompactGroups.map((group) => group.shard_name)),
     );
+    const cliProcessGroups = pullRequestCompactGroups.filter((group) =>
+      expectedCliProcessGroupNames.includes(group.shard_name),
+    );
+    expect(cliProcessGroups.map((group) => group.shard_name).toSorted()).toEqual(
+      expectedCliProcessGroupNames,
+    );
+    expect(
+      cliProcessGroups
+        .flatMap((group) => group.includePatterns ?? [])
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(cliProcessTestFiles.toSorted((a, b) => a.localeCompare(b)));
+    expect(
+      cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
+    ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact
@@ -511,9 +534,11 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     }
     // Pushes omit only the explicit low-signal families; PR fallback retains
     // their include-pattern coverage when special setup prevents targeting.
+    const cliProcessTestFileSet = new Set(cliProcessTestFiles);
     expect(
       compactGroups
         .flatMap((group) => group.includePatterns ?? [])
+        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base
@@ -524,6 +549,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       pullRequestCompactGroups
         .flatMap((group) => group.includePatterns ?? [])
+        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -16,7 +16,6 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../vitest/vitest.agents-paths.mjs";
-import { cliProcessTestFiles } from "../vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../vitest/vitest.commands-light-paths.mjs";
 import { createGatewayClientVitestConfig } from "../vitest/vitest.gateway-client.config.ts";
 import { createGatewayCoreVitestConfig } from "../vitest/vitest.gateway-core.config.ts";
@@ -461,21 +460,13 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "agentic-agents-embedded-overflow-compaction",
       "agentic-agents-embedded-run",
     ];
-    const expectedCliProcessGroupNames = [
-      "agentic-cli-process-run-loop",
-      "agentic-cli-process-support",
-    ];
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
-    const expectedGroupNames = base.flatMap((shard) => {
-      if (shard.shardName === "agentic-agents-embedded") {
-        return expectedEmbeddedAgentGroupNames;
-      }
-      if (shard.shardName === "agentic-cli-process") {
-        return expectedCliProcessGroupNames;
-      }
-      return [shard.shardName];
-    });
+    const expectedGroupNames = base.flatMap((shard) =>
+      shard.shardName === "agentic-agents-embedded"
+        ? expectedEmbeddedAgentGroupNames
+        : [shard.shardName],
+    );
     expect(compactGroups.map((group) => group.shard_name).toSorted()).toEqual(
       expectedGroupNames.filter((name) => !pushExcludedShardNames.has(name)).toSorted(),
     );
@@ -494,20 +485,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(hostedOwnerNames(githubPullRequestCompact)).toEqual(
       new Set(pullRequestCompactGroups.map((group) => group.shard_name)),
     );
-    const cliProcessGroups = pullRequestCompactGroups.filter((group) =>
-      expectedCliProcessGroupNames.includes(group.shard_name),
-    );
-    expect(cliProcessGroups.map((group) => group.shard_name).toSorted()).toEqual(
-      expectedCliProcessGroupNames,
-    );
-    expect(
-      cliProcessGroups
-        .flatMap((group) => group.includePatterns ?? [])
-        .toSorted((a, b) => a.localeCompare(b)),
-    ).toEqual(cliProcessTestFiles.toSorted((a, b) => a.localeCompare(b)));
-    expect(
-      cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
-    ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact
@@ -534,11 +511,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     }
     // Pushes omit only the explicit low-signal families; PR fallback retains
     // their include-pattern coverage when special setup prevents targeting.
-    const cliProcessTestFileSet = new Set(cliProcessTestFiles);
     expect(
       compactGroups
         .flatMap((group) => group.includePatterns ?? [])
-        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base
@@ -549,7 +524,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       pullRequestCompactGroups
         .flatMap((group) => group.includePatterns ?? [])
-        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -506,7 +506,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
-      NODE_OPTIONS: "--max-old-space-size=512",
       OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
       OPENCLAW_VITEST_MAX_WORKERS: "1",
     });

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1315,7 +1315,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       checkName: "checks-node-agentic-cli-process",
       shardName: "agentic-cli-process",
       configs: ["test/vitest/vitest.cli-process.config.ts"],
-      env: { OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
+      env: { OPENCLAW_VITEST_MAX_WORKERS: "1" },
       requiresDist: false,
       runner: DEFAULT_NODE_TEST_RUNNER,
     });

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1315,7 +1315,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       checkName: "checks-node-agentic-cli-process",
       shardName: "agentic-cli-process",
       configs: ["test/vitest/vitest.cli-process.config.ts"],
-      env: { OPENCLAW_VITEST_MAX_WORKERS: "1" },
       requiresDist: false,
       runner: DEFAULT_NODE_TEST_RUNNER,
     });

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -16,7 +16,6 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../vitest/vitest.agents-paths.mjs";
-import { cliProcessTestFiles } from "../vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../vitest/vitest.commands-light-paths.mjs";
 import { createGatewayClientVitestConfig } from "../vitest/vitest.gateway-client.config.ts";
 import { createGatewayCoreVitestConfig } from "../vitest/vitest.gateway-core.config.ts";
@@ -461,21 +460,13 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "agentic-agents-embedded-overflow-compaction",
       "agentic-agents-embedded-run",
     ];
-    const expectedCliProcessGroupNames = [
-      "agentic-cli-process-run-loop",
-      "agentic-cli-process-support",
-    ];
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
-    const expectedGroupNames = base.flatMap((shard) => {
-      if (shard.shardName === "agentic-agents-embedded") {
-        return expectedEmbeddedAgentGroupNames;
-      }
-      if (shard.shardName === "agentic-cli-process") {
-        return expectedCliProcessGroupNames;
-      }
-      return [shard.shardName];
-    });
+    const expectedGroupNames = base.flatMap((shard) =>
+      shard.shardName === "agentic-agents-embedded"
+        ? expectedEmbeddedAgentGroupNames
+        : [shard.shardName],
+    );
     expect(compactGroups.map((group) => group.shard_name).toSorted()).toEqual(
       expectedGroupNames.filter((name) => !pushExcludedShardNames.has(name)).toSorted(),
     );
@@ -494,21 +485,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(hostedOwnerNames(githubPullRequestCompact)).toEqual(
       new Set(pullRequestCompactGroups.map((group) => group.shard_name)),
     );
-    const cliProcessGroups = pullRequestCompactGroups.filter((group) =>
-      expectedCliProcessGroupNames.includes(group.shard_name),
-    );
-    expect(
-      cliProcessGroups
-        .flatMap((group) => group.includePatterns ?? [])
-        .toSorted((a, b) => a.localeCompare(b)),
-    ).toEqual(cliProcessTestFiles.toSorted((a, b) => a.localeCompare(b)));
-    expect(
-      cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
-    ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
-    expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
-      OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
-      OPENCLAW_VITEST_MAX_WORKERS: "1",
-    });
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact
@@ -535,11 +511,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     }
     // Pushes omit only the explicit low-signal families; PR fallback retains
     // their include-pattern coverage when special setup prevents targeting.
-    const cliProcessTestFileSet = new Set(cliProcessTestFiles);
     expect(
       compactGroups
         .flatMap((group) => group.includePatterns ?? [])
-        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base
@@ -550,7 +524,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       pullRequestCompactGroups
         .flatMap((group) => group.includePatterns ?? [])
-        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -505,6 +505,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
+    expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
+      OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
+      OPENCLAW_VITEST_MAX_WORKERS: "1",
+    });
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1315,6 +1315,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       checkName: "checks-node-agentic-cli-process",
       shardName: "agentic-cli-process",
       configs: ["test/vitest/vitest.cli-process.config.ts"],
+      env: { OPENCLAW_VITEST_FS_MODULE_CACHE: "0" },
       requiresDist: false,
       runner: DEFAULT_NODE_TEST_RUNNER,
     });

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -16,6 +16,7 @@ import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
 } from "../vitest/vitest.agents-paths.mjs";
+import { cliProcessTestFiles } from "../vitest/vitest.cli-process-paths.mjs";
 import { commandsLightTestFiles } from "../vitest/vitest.commands-light-paths.mjs";
 import { createGatewayClientVitestConfig } from "../vitest/vitest.gateway-client.config.ts";
 import { createGatewayCoreVitestConfig } from "../vitest/vitest.gateway-core.config.ts";
@@ -460,13 +461,21 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "agentic-agents-embedded-overflow-compaction",
       "agentic-agents-embedded-run",
     ];
+    const expectedCliProcessGroupNames = [
+      "agentic-cli-process-run-loop",
+      "agentic-cli-process-support",
+    ];
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
-    const expectedGroupNames = base.flatMap((shard) =>
-      shard.shardName === "agentic-agents-embedded"
-        ? expectedEmbeddedAgentGroupNames
-        : [shard.shardName],
-    );
+    const expectedGroupNames = base.flatMap((shard) => {
+      if (shard.shardName === "agentic-agents-embedded") {
+        return expectedEmbeddedAgentGroupNames;
+      }
+      if (shard.shardName === "agentic-cli-process") {
+        return expectedCliProcessGroupNames;
+      }
+      return [shard.shardName];
+    });
     expect(compactGroups.map((group) => group.shard_name).toSorted()).toEqual(
       expectedGroupNames.filter((name) => !pushExcludedShardNames.has(name)).toSorted(),
     );
@@ -485,6 +494,17 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(hostedOwnerNames(githubPullRequestCompact)).toEqual(
       new Set(pullRequestCompactGroups.map((group) => group.shard_name)),
     );
+    const cliProcessGroups = pullRequestCompactGroups.filter((group) =>
+      expectedCliProcessGroupNames.includes(group.shard_name),
+    );
+    expect(
+      cliProcessGroups
+        .flatMap((group) => group.includePatterns ?? [])
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(cliProcessTestFiles.toSorted((a, b) => a.localeCompare(b)));
+    expect(
+      cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
+    ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact
@@ -511,9 +531,11 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     }
     // Pushes omit only the explicit low-signal families; PR fallback retains
     // their include-pattern coverage when special setup prevents targeting.
+    const cliProcessTestFileSet = new Set(cliProcessTestFiles);
     expect(
       compactGroups
         .flatMap((group) => group.includePatterns ?? [])
+        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base
@@ -524,6 +546,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       pullRequestCompactGroups
         .flatMap((group) => group.includePatterns ?? [])
+        .filter((file) => !cliProcessTestFileSet.has(file))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -505,10 +505,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
-    expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
-      OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
-      OPENCLAW_VITEST_MAX_WORKERS: "1",
-    });
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -507,7 +507,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
       OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
-      OPENCLAW_VITEST_MAX_WORKERS: "2",
+      OPENCLAW_VITEST_MAX_WORKERS: "1",
     });
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -505,6 +505,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(
       cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
+    expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
+      OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
+      OPENCLAW_VITEST_MAX_WORKERS: "2",
+    });
     const groupsWith = (plan: typeof githubCompact, shardName: string) =>
       plan.find((shard) => shard.groups.some((group) => group.shard_name === shardName))?.groups;
     const hostedAgentSupportGroups = githubCompact

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -506,6 +506,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.includePatterns,
     ).toEqual(["src/cli/gateway-cli/run-loop.test.ts"]);
     expect(cliProcessGroups.find((group) => group.shard_name.endsWith("-run-loop"))?.env).toEqual({
+      NODE_OPTIONS: "--max-old-space-size=512",
       OPENCLAW_VITEST_FS_MODULE_CACHE: "0",
       OPENCLAW_VITEST_MAX_WORKERS: "1",
     });

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -624,6 +624,11 @@ describe("scoped vitest configs", () => {
     expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
+    expectThreadedIsolatedRunner(
+      createCliProcessVitestConfig({
+        OPENCLAW_VITEST_SHARD_NAME: "agentic-cli-process-run-loop",
+      }),
+    );
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { BUNDLED_PLUGIN_TEST_GLOB, bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../src/test-utils/env.js";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { normalizeConfigPath, normalizeConfigPaths } from "./helpers/vitest-config-paths.js";
 import { createAcpVitestConfig } from "./vitest/vitest.acp.config.ts";
@@ -625,10 +624,6 @@ describe("scoped vitest configs", () => {
     expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
-    withEnv({ OPENCLAW_VITEST_SHARD_NAME: "agentic-cli-process-run-loop" }, () => {
-      expectForkedIsolatedRunner(createCliProcessVitestConfig({}));
-      expectThreadedIsolatedRunner(createCliProcessVitestConfig());
-    });
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {
@@ -636,6 +631,9 @@ describe("scoped vitest configs", () => {
   });
 
   it("keeps process, runtime config, and tooling lanes off the openclaw runtime setup", () => {
+    expect(normalizeConfigPaths(requireTestConfig(defaultCliProcessConfig).setupFiles)).toEqual([
+      "test/setup.ts",
+    ]);
     expect(normalizeConfigPaths(requireTestConfig(defaultProcessConfig).setupFiles)).toEqual([
       "test/setup.ts",
     ]);

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { BUNDLED_PLUGIN_TEST_GLOB, bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
+import { withEnv } from "../src/test-utils/env.js";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { normalizeConfigPath, normalizeConfigPaths } from "./helpers/vitest-config-paths.js";
 import { createAcpVitestConfig } from "./vitest/vitest.acp.config.ts";
@@ -624,11 +625,10 @@ describe("scoped vitest configs", () => {
     expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
-    expectThreadedIsolatedRunner(
-      createCliProcessVitestConfig({
-        OPENCLAW_VITEST_SHARD_NAME: "agentic-cli-process-run-loop",
-      }),
-    );
+    withEnv({ OPENCLAW_VITEST_SHARD_NAME: "agentic-cli-process-run-loop" }, () => {
+      expectForkedIsolatedRunner(createCliProcessVitestConfig({}));
+      expectThreadedIsolatedRunner(createCliProcessVitestConfig());
+    });
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -624,17 +624,6 @@ describe("scoped vitest configs", () => {
     expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
-    const previousShardName = process.env.OPENCLAW_VITEST_SHARD_NAME;
-    try {
-      process.env.OPENCLAW_VITEST_SHARD_NAME = "agentic-cli-process-run-loop";
-      expectThreadedIsolatedRunner(createCliProcessVitestConfig());
-    } finally {
-      if (previousShardName === undefined) {
-        delete process.env.OPENCLAW_VITEST_SHARD_NAME;
-      } else {
-        process.env.OPENCLAW_VITEST_SHARD_NAME = previousShardName;
-      }
-    }
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -624,11 +624,17 @@ describe("scoped vitest configs", () => {
     expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
-    expectThreadedIsolatedRunner(
-      createCliProcessVitestConfig({
-        OPENCLAW_VITEST_SHARD_NAME: "agentic-cli-process-run-loop",
-      }),
-    );
+    const previousShardName = process.env.OPENCLAW_VITEST_SHARD_NAME;
+    try {
+      process.env.OPENCLAW_VITEST_SHARD_NAME = "agentic-cli-process-run-loop";
+      expectThreadedIsolatedRunner(createCliProcessVitestConfig());
+    } finally {
+      if (previousShardName === undefined) {
+        delete process.env.OPENCLAW_VITEST_SHARD_NAME;
+      } else {
+        process.env.OPENCLAW_VITEST_SHARD_NAME = previousShardName;
+      }
+    }
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -1,7 +1,8 @@
-// CLI process tests launch real Node+tsx children and must not contend with the
-// shared CLI module graph. Keep the owned list explicit so full and focused runs agree.
+// CLI process/lifecycle tests launch children or own global process state and must
+// not contend with the shared CLI module graph. Keep full and focused runs aligned.
 export const cliProcessTestFiles = [
   "src/cli/acp-cli-exit.process.test.ts",
+  "src/cli/gateway-cli/run-loop.test.ts",
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -5,9 +5,9 @@ import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createCliProcessVitestConfig(
-  env?: Record<string, string | undefined>,
+  env: Record<string, string | undefined> = process.env,
 ): ViteUserConfig {
-  const runLoopShard = env?.OPENCLAW_VITEST_SHARD_NAME === "agentic-cli-process-run-loop";
+  const runLoopShard = env.OPENCLAW_VITEST_SHARD_NAME === "agentic-cli-process-run-loop";
   const config = createScopedVitestConfig(cliProcessTestFiles, {
     env,
     fileParallelism: false,

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -7,13 +7,14 @@ import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 export function createCliProcessVitestConfig(
   env?: Record<string, string | undefined>,
 ): ViteUserConfig {
+  const runLoopShard = env?.OPENCLAW_VITEST_SHARD_NAME === "agentic-cli-process-run-loop";
   const config = createScopedVitestConfig(cliProcessTestFiles, {
     env,
     fileParallelism: false,
     isolate: true,
     name: "cli-process",
     passWithNoTests: true,
-    pool: "forks",
+    pool: runLoopShard ? "threads" : "forks",
     useNonIsolatedRunner: false,
   });
   return {

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -1,7 +1,7 @@
 import type { ViteUserConfig } from "vitest/config";
 import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
-// CLI process tests run serially in isolated forks so child startup deadlines
-// measure the CLI rather than contention from the shared CLI test graph.
+// CLI process/lifecycle tests run serially in isolated forks so process-global
+// state and child startup deadlines stay independent of the shared CLI graph.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createCliProcessVitestConfig(

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -5,16 +5,15 @@ import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createCliProcessVitestConfig(
-  env: Record<string, string | undefined> = process.env,
+  env?: Record<string, string | undefined>,
 ): ViteUserConfig {
-  const runLoopShard = env.OPENCLAW_VITEST_SHARD_NAME === "agentic-cli-process-run-loop";
   const config = createScopedVitestConfig(cliProcessTestFiles, {
     env,
     fileParallelism: false,
     isolate: true,
     name: "cli-process",
     passWithNoTests: true,
-    pool: runLoopShard ? "threads" : "forks",
+    pool: "forks",
     useNonIsolatedRunner: false,
   });
   return {

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -5,16 +5,16 @@ import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createCliProcessVitestConfig(
-  env: Record<string, string | undefined> = process.env,
+  env?: Record<string, string | undefined>,
 ): ViteUserConfig {
-  const runLoopShard = env.OPENCLAW_VITEST_SHARD_NAME === "agentic-cli-process-run-loop";
   const config = createScopedVitestConfig(cliProcessTestFiles, {
     env,
     fileParallelism: false,
+    includeOpenClawRuntimeSetup: false,
     isolate: true,
     name: "cli-process",
     passWithNoTests: true,
-    pool: runLoopShard ? "threads" : "forks",
+    pool: "forks",
     useNonIsolatedRunner: false,
   });
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes managed Gateway update handoff failures where the service supervisor and detached updater could compete to create the successor process.

A Team production incident exposed a second failure in that ownership transfer. A managed systemd auto-update drained active work for five minutes, aborted the remaining runs, and then wedged indefinitely inside `server.close()`. Successor parking still happened after close, so the wedged old process never transferred ownership and systemd could not apply its external stop deadline to finish recovery.

## Why This Change Was Made

Managed update restart intents carry a closed `successorOwner: "managed-update-handoff"` fact. After active-work drain and before server close, the Gateway now parks the detected launchd or systemd successor exactly once. This ordering lets the supervisor's external stop deadline terminate an old process even when close never returns. The post-close managed branch is exit-only; it cannot attempt a second parking operation. If parking itself fails, the canonical in-process recovery path remains available.

Hard-exit diagnostics are now synchronous best-effort, so diagnostic work cannot defer the forced exit that the shutdown watchdog owns.

The eagerly primed lifecycle hub exposes one small owner helper whose implementation lazily imports only the selected platform service manager. Normal startup and unrelated CLI workers therefore keep launchd/systemd graphs out of their eager module graph. The process-global run-loop suite is routed through the isolated CLI-process Vitest project to avoid the compact-shard contention that caused the previous head's OOM.

## User Impact

Managed macOS and Linux updates retain a single successor owner and can recover when Gateway close wedges during restart. Windows Task Scheduler and direct or unmanaged restart behavior are unchanged. This adds no config, protocol, or storage surface.

## Evidence

- Team incident sequence reproduced in the owner test: active-work drain times out, successor parking completes once, server close remains pending, and exit occurs only after close is released.
- `src/infra/managed-update-successor.test.ts`: 1 passed.
- `src/cli/gateway-cli/run-loop.test.ts`: 56 passed.
- `src/cli/gateway-cli/lifecycle-import-boundary.test.ts`: 2 passed.
- Targeted formatting and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted or actionable findings.
- Incident follow-up production LOC: +95/-96 (net -1); tests: +136/-92; test tooling: +5/-4.
- Final PR production LOC: +163/-165 (net -2); tests: +295/-155; test tooling: +5/-4.
- Exact-head hosted CI is required before merge, including proof that `run-loop.test.ts` executes in the isolated CLI-process project.
- Live Team rollout and incident reproduction are intentionally deferred to the parent operator after merge.
