### PR TITLE
feat(codex): show sessions from additional homes

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -71,7 +71,11 @@ computer and opted-in paired nodes by default. Disable only that catalog with:
 }
 ```
 
-Additional local Codex stores can be registered for managed stdio connections:
+Discovery automatically covers the Gateway process Codex home (`CODEX_HOME` or
+`~/.codex`) and the Codex home of every configured OpenClaw agent. Register
+additional local Codex stores only when sessions live in a home OpenClaw does
+not already know about, for example a store created with a custom `CODEX_HOME`
+outside OpenClaw:
 
 ```json5
 {
@@ -90,9 +94,17 @@ Additional local Codex stores can be registered for managed stdio connections:
 }
 ```
 
+Configured stores appear in the sidebar alongside automatically discovered
+ones, labeled `Local Codex · configured <n>` and grouped by each session's
+working directory. Sessions in these stores support the same view, continue,
+and archive actions, and the selected OpenClaw agent still owns the resulting
+connection; `homes` only adds catalog sources.
+
 Only existing directories are included. Equivalent paths are canonicalized and
-deduplicated. Changes require a Gateway restart. `sessionCatalog.homes` is
-rejected with Unix or WebSocket app-server transports because those transports
+deduplicated against the automatic homes, and automatic homes keep priority
+under the 100-source catalog cap. Changes require a Gateway restart.
+`sessionCatalog.homes` needs the default managed stdio app-server transport;
+Unix and WebSocket transports reject it with a visible error because they
 cannot start a source-bound app-server for each home.
 
 `supervision` separately controls agent-facing tools:

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -46,7 +46,7 @@ Top-level fields:
 | `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                    |
 | `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
 | `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                               |
-| `sessionCatalog`           | enabled                  | Native Codex session discovery for the sidebar. Set `enabled: false` to disable discovery without disabling the provider or harness.           |
+| `sessionCatalog`           | enabled                  | Native Codex session discovery for the sidebar. Set `enabled: false` to disable it, or set `homes` to include additional local Codex stores.   |
 | `supervision`              | disabled                 | Agent-facing native-session transcript and write-control policy. See [Codex supervision](/plugins/codex-supervision).                          |
 
 ## Supervision
@@ -70,6 +70,28 @@ computer and opted-in paired nodes by default. Disable only that catalog with:
   },
 }
 ```
+
+Additional local Codex stores can be registered explicitly:
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        enabled: true,
+        config: {
+          sessionCatalog: {
+            homes: ["/path/to/additional-codex-home"],
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Only existing directories are included. Equivalent paths are canonicalized and
+deduplicated. Changes require a Gateway restart.
 
 `supervision` separately controls agent-facing tools:
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -71,7 +71,7 @@ computer and opted-in paired nodes by default. Disable only that catalog with:
 }
 ```
 
-Additional local Codex stores can be registered explicitly:
+Additional local Codex stores can be registered for managed stdio connections:
 
 ```json5
 {
@@ -91,7 +91,9 @@ Additional local Codex stores can be registered explicitly:
 ```
 
 Only existing directories are included. Equivalent paths are canonicalized and
-deduplicated. Changes require a Gateway restart.
+deduplicated. Changes require a Gateway restart. `sessionCatalog.homes` is
+rejected with Unix or WebSocket app-server transports because those transports
+cannot start a source-bound app-server for each home.
 
 `supervision` separately controls agent-facing tools:
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -218,6 +218,7 @@ rules, paired-node limits, metadata exposure, and troubleshooting.
 | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | Enable the harness                                  | `plugins.entries.codex.enabled: true`                                                                     | OpenClaw config                    |
 | Hide native Codex session discovery                 | `plugins.entries.codex.config.sessionCatalog.enabled: false`                                              | Codex plugin config                |
+| Include additional local Codex stores               | `plugins.entries.codex.config.sessionCatalog.homes`                                                       | Codex plugin config                |
 | Keep an allowlisted plugin install                  | Include `codex` in `plugins.allow`                                                                        | OpenClaw config                    |
 | Allow eligible OpenAI turns to use Codex implicitly | Exact official HTTPS Responses/ChatGPT route, no authored provider request override, runtime unset/`auto` | OpenAI provider/model config       |
 | Sign in with ChatGPT/Codex OAuth                    | `openclaw models auth login --provider openai`                                                            | CLI auth profile                   |

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -218,7 +218,7 @@ rules, paired-node limits, metadata exposure, and troubleshooting.
 | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | Enable the harness                                  | `plugins.entries.codex.enabled: true`                                                                     | OpenClaw config                    |
 | Hide native Codex session discovery                 | `plugins.entries.codex.config.sessionCatalog.enabled: false`                                              | Codex plugin config                |
-| Include additional local Codex stores               | `plugins.entries.codex.config.sessionCatalog.homes`                                                       | Codex plugin config                |
+| Include additional local Codex stores (stdio only)  | `plugins.entries.codex.config.sessionCatalog.homes`                                                       | Codex plugin config                |
 | Keep an allowlisted plugin install                  | Include `codex` in `plugins.allow`                                                                        | OpenClaw config                    |
 | Allow eligible OpenAI turns to use Codex implicitly | Exact official HTTPS Responses/ChatGPT route, no authored provider request override, runtime unset/`auto` | OpenAI provider/model config       |
 | Sign in with ChatGPT/Codex OAuth                    | `openclaw models auth login --provider openai`                                                            | CLI auth profile                   |

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -406,7 +406,7 @@
     },
     "sessionCatalog.homes": {
       "label": "Additional Codex Homes",
-      "help": "Existing local Codex home directories to include in native session discovery. Paths are canonicalized and deduplicated. Applies to managed local app-server connections and requires a Gateway restart.",
+      "help": "Existing local Codex home directories to include in native session discovery. Paths are canonicalized and deduplicated. Requires appServer.transport=stdio and a Gateway restart.",
       "advanced": true
     },
     "codexDynamicToolsLoading": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -52,6 +52,7 @@
     "onConfigPaths": [
       "plugins.entries.codex.config.appServer.transport",
       "plugins.entries.codex.config.sessionCatalog.enabled",
+      "plugins.entries.codex.config.sessionCatalog.homes",
       "plugins.entries.codex.config.supervision.enabled"
     ]
   },
@@ -80,7 +81,11 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean", "default": true }
+          "enabled": { "type": "boolean", "default": true },
+          "homes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1, "pattern": "\\S" }
+          }
         }
       },
       "discovery": {
@@ -398,6 +403,11 @@
     "sessionCatalog.enabled": {
       "label": "Discover Codex Sessions",
       "help": "List native Codex sessions in the sidebar from this Gateway and eligible paired nodes."
+    },
+    "sessionCatalog.homes": {
+      "label": "Additional Codex Homes",
+      "help": "Existing local Codex home directories to include in native session discovery. Paths are canonicalized and deduplicated. Applies to managed local app-server connections and requires a Gateway restart.",
+      "advanced": true
     },
     "codexDynamicToolsLoading": {
       "label": "Dynamic Tools Loading",

--- a/extensions/codex/src/app-server/config-runtime.ts
+++ b/extensions/codex/src/app-server/config-runtime.ts
@@ -107,6 +107,11 @@ export function resolveCodexAppServerRuntimeOptions(
   const config = pluginConfig.appServer ?? {};
   const transport = resolveTransport(config.transport);
   const homeScope = resolveCodexAppServerHomeScope({ appServer: config });
+  if (transport !== "stdio" && pluginConfig.sessionCatalog?.homes?.length) {
+    throw new Error(
+      "plugins.entries.codex.config.sessionCatalog.homes requires appServer.transport=stdio",
+    );
+  }
   const configCommand = readNonEmptyString(config.command);
   const envCommand = readNonEmptyString(env.OPENCLAW_CODEX_APP_SERVER_BIN);
   const command = configCommand ?? envCommand ?? "codex";

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -367,10 +367,13 @@ describe("Codex app-server config", () => {
     ).toStrictEqual({});
   });
 
-  it("parses the native session discovery toggle", () => {
-    expect(readCodexPluginConfig({ sessionCatalog: { enabled: false } }).sessionCatalog).toEqual({
-      enabled: false,
-    });
+  it("parses native session discovery options", () => {
+    expect(
+      readCodexPluginConfig({
+        sessionCatalog: { enabled: false, homes: [" /srv/codex-extra "] },
+      }).sessionCatalog,
+    ).toEqual({ enabled: false, homes: ["/srv/codex-extra"] });
+    expect(readCodexPluginConfig({ sessionCatalog: { homes: [" "] } })).toStrictEqual({});
   });
 
   it("rejects unknown app-server fields", () => {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -376,6 +376,20 @@ describe("Codex app-server config", () => {
     expect(readCodexPluginConfig({ sessionCatalog: { homes: [" "] } })).toStrictEqual({});
   });
 
+  it.each([
+    { transport: "unix", homeScope: "user" },
+    { transport: "websocket", url: "ws://127.0.0.1:39175" },
+  ] as const)("rejects additional session homes for $transport app servers", (appServer) => {
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: { appServer, sessionCatalog: { homes: ["/srv/codex-extra"] } },
+        env: {},
+      }),
+    ).toThrow(
+      "plugins.entries.codex.config.sessionCatalog.homes requires appServer.transport=stdio",
+    );
+  });
+
   it("rejects unknown app-server fields", () => {
     expect(
       readCodexPluginConfig({

--- a/extensions/codex/src/app-server/session-discovery-config.ts
+++ b/extensions/codex/src/app-server/session-discovery-config.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 export const codexSessionCatalogConfigSchema = z
-  .object({ enabled: z.boolean().optional() })
+  .object({
+    enabled: z.boolean().optional(),
+    homes: z.array(z.string().trim().min(1)).optional(),
+  })
   .strict();
 
 export const codexDiscoveryConfigSchema = z

--- a/extensions/codex/src/session-catalog-homes.ts
+++ b/extensions/codex/src/session-catalog-homes.ts
@@ -89,6 +89,19 @@ function resolveCodexCatalogHomes(params: {
       label: "Local Codex · user",
       usesProcessHomeFallback: !processHomeConfigured,
     });
+    const agentIds = listAgentIds(config).toSorted((left, right) =>
+      left === ownerAgentId ? -1 : right === ownerAgentId ? 1 : left.localeCompare(right),
+    );
+    candidates.push(
+      ...agentIds.flatMap((agentId) => {
+        const codexHome = canonicalCatalogHome(
+          resolveCodexAppServerHomeDir(resolveAgentDir(config, agentId, env)),
+        );
+        return fs.existsSync(codexHome)
+          ? [{ codexHome, label: `Local Codex · ${agentId}`, usesProcessHomeFallback: false }]
+          : [];
+      }),
+    );
     candidates.push(
       ...configuredHomes.flatMap((value, index) => {
         const codexHome = existingCanonicalCatalogHome(value);
@@ -100,19 +113,6 @@ function resolveCodexCatalogHomes(params: {
                 usesProcessHomeFallback: false,
               },
             ]
-          : [];
-      }),
-    );
-    const agentIds = listAgentIds(config).toSorted((left, right) =>
-      left === ownerAgentId ? -1 : right === ownerAgentId ? 1 : left.localeCompare(right),
-    );
-    candidates.push(
-      ...agentIds.flatMap((agentId) => {
-        const codexHome = canonicalCatalogHome(
-          resolveCodexAppServerHomeDir(resolveAgentDir(config, agentId, env)),
-        );
-        return fs.existsSync(codexHome)
-          ? [{ codexHome, label: `Local Codex · ${agentId}`, usesProcessHomeFallback: false }]
           : [];
       }),
     );

--- a/extensions/codex/src/session-catalog-homes.ts
+++ b/extensions/codex/src/session-catalog-homes.ts
@@ -8,6 +8,7 @@ import {
   resolveCodexAppServerLocalHomeDir,
 } from "./app-server/auth-start-options.js";
 import {
+  readCodexPluginConfig,
   resolveCodexAppServerUserHomeDir,
   resolveCodexSupervisionAppServerRuntimeOptions,
 } from "./app-server/config.js";
@@ -35,6 +36,15 @@ function canonicalCatalogHome(value: string): string {
   }
 }
 
+function existingCanonicalCatalogHome(value: string): string | undefined {
+  try {
+    const codexHome = fs.realpathSync.native(path.resolve(value));
+    return fs.statSync(codexHome).isDirectory() ? codexHome : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function catalogHomeId(codexHome: string): string {
   return createHash("sha256")
     .update("openclaw:codex-session-catalog-home:v1\0")
@@ -51,6 +61,7 @@ function resolveCodexCatalogHomes(params: {
 }): CodexCatalogHome[] {
   const { config, env, ownerAgentId, pluginConfig } = params;
   const ownerAgentDir = resolveAgentDir(config, ownerAgentId, env);
+  const configuredHomes = readCodexPluginConfig(pluginConfig).sessionCatalog?.homes ?? [];
   const base = resolveCodexSupervisionAppServerRuntimeOptions({
     pluginConfig,
     env,
@@ -78,6 +89,20 @@ function resolveCodexCatalogHomes(params: {
       label: "Local Codex · user",
       usesProcessHomeFallback: !processHomeConfigured,
     });
+    candidates.push(
+      ...configuredHomes.flatMap((value, index) => {
+        const codexHome = existingCanonicalCatalogHome(value);
+        return codexHome
+          ? [
+              {
+                codexHome,
+                label: `Local Codex · configured ${index + 1}`,
+                usesProcessHomeFallback: false,
+              },
+            ]
+          : [];
+      }),
+    );
     const agentIds = listAgentIds(config).toSorted((left, right) =>
       left === ownerAgentId ? -1 : right === ownerAgentId ? 1 : left.localeCompare(right),
     );

--- a/extensions/codex/src/session-catalog-listing.test.ts
+++ b/extensions/codex/src/session-catalog-listing.test.ts
@@ -285,7 +285,7 @@ describe("Codex supervision catalog", () => {
     });
   });
 
-  it("discovers every existing Codex home while retaining the route owner directory", async () => {
+  it("discovers configured and automatic Codex homes while retaining the route owner", async () => {
     const root = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-catalog-homes-")),
     );
@@ -295,11 +295,18 @@ describe("Codex supervision catalog", () => {
     const processCodexHome = path.join(root, "process-codex-home");
     const alphaCodexHome = resolveCodexAppServerHomeDir(alphaAgentDir);
     const betaCodexHome = resolveCodexAppServerHomeDir(betaAgentDir);
+    const configuredCodexHome = path.join(root, "configured-codex-home");
+    const configuredCodexHomeAlias = path.join(root, "configured-codex-home-alias");
+    const configuredFile = path.join(root, "not-a-codex-home");
     await Promise.all(
-      [processCodexHome, alphaCodexHome, betaCodexHome].map((dir) =>
+      [processCodexHome, alphaCodexHome, betaCodexHome, configuredCodexHome].map((dir) =>
         fs.mkdir(dir, { recursive: true }),
       ),
     );
+    await Promise.all([
+      fs.symlink(configuredCodexHome, configuredCodexHomeAlias, "dir"),
+      fs.writeFile(configuredFile, "not a directory"),
+    ]);
     const runtimeConfig = {
       agents: {
         ownership: "explicit",
@@ -315,7 +322,18 @@ describe("Codex supervision catalog", () => {
       config: runtimeConfig,
       env,
       getRuntimeConfig: () => runtimeConfig,
-      getPluginConfig: () => ({ supervision: { enabled: true } }),
+      getPluginConfig: () => ({
+        supervision: { enabled: true },
+        sessionCatalog: {
+          homes: [
+            configuredCodexHome,
+            configuredCodexHomeAlias,
+            alphaCodexHome,
+            path.join(root, "missing-codex-home"),
+            configuredFile,
+          ],
+        },
+      }),
     });
     const homes = control.homesForAgent("beta");
 
@@ -325,11 +343,11 @@ describe("Codex supervision catalog", () => {
           resolveCodexAppServerLocalHomeDir(home.appServer.start, home.agentDir, env),
         ),
       ),
-    ).toEqual(new Set([processCodexHome, alphaCodexHome, betaCodexHome]));
-    expect(homes.map((home) => home.agentDir)).toEqual([betaAgentDir, betaAgentDir, betaAgentDir]);
+    ).toEqual(new Set([processCodexHome, configuredCodexHome, alphaCodexHome, betaCodexHome]));
+    expect(homes.map((home) => home.agentDir)).toEqual(Array(4).fill(betaAgentDir));
     expect(homes[0]?.hostId).toBe(CODEX_LOCAL_SESSION_HOST_ID);
     expect(homes.slice(1).every((home) => home.hostId.startsWith("gateway:local:"))).toBe(true);
-    expect(new Set(homes.map((home) => home.sourceHomeId)).size).toBe(3);
+    expect(new Set(homes.map((home) => home.sourceHomeId)).size).toBe(4);
     expect(
       JSON.stringify(homes.map(({ hostId, sourceHomeId }) => ({ hostId, sourceHomeId }))),
     ).not.toContain(root);
@@ -338,18 +356,18 @@ describe("Codex supervision catalog", () => {
     pinnedConnectionMocks.request.mockResolvedValue({
       thread: idleThread({ id: "thread-source" }),
     });
-    const alphaSource = homes.find(
+    const configuredSource = homes.find(
       (home) =>
         resolveCodexAppServerLocalHomeDir(home.appServer.start, home.agentDir, env) ===
-        alphaCodexHome,
+        configuredCodexHome,
     );
-    expect(alphaSource).toBeDefined();
+    expect(configuredSource).toBeDefined();
 
-    const alphaFingerprint = buildCodexAppServerConnectionFingerprint(
-      alphaSource!.appServer,
-      alphaSource!.agentDir,
+    const configuredFingerprint = buildCodexAppServerConnectionFingerprint(
+      configuredSource!.appServer,
+      configuredSource!.agentDir,
     );
-    const boundControl = control.forUpstream("beta", alphaFingerprint);
+    const boundControl = control.forUpstream("beta", configuredFingerprint);
     expect(boundControl).toBeDefined();
     expect(control.forUpstream("beta", "unknown-fingerprint")).toBeUndefined();
     await boundControl!.listPage({});
@@ -359,13 +377,13 @@ describe("Codex supervision catalog", () => {
 
     expect(commandRpcMocks.codexControlRequest.mock.calls[0]?.[3]).toMatchObject({
       agentDir: betaAgentDir,
-      startOptions: { env: { CODEX_HOME: alphaCodexHome } },
+      startOptions: { env: { CODEX_HOME: configuredCodexHome } },
     });
     expect(pinnedConnectionMocks.getClient).toHaveBeenCalledWith(
       expect.objectContaining({
         agentDir: betaAgentDir,
         startOptions: expect.objectContaining({
-          env: expect.objectContaining({ CODEX_HOME: alphaCodexHome }),
+          env: expect.objectContaining({ CODEX_HOME: configuredCodexHome }),
         }),
       }),
     );

--- a/extensions/codex/src/session-catalog-listing.test.ts
+++ b/extensions/codex/src/session-catalog-listing.test.ts
@@ -1,5 +1,6 @@
 // Codex supervision tests cover passive listing and safe local session takeover.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_HOST_COUNT } from "./session-catalog-parsing.js";
 import {
   tempDirs,
   createCodexSessionCatalogControl,
@@ -295,11 +296,14 @@ describe("Codex supervision catalog", () => {
     const processCodexHome = path.join(root, "process-codex-home");
     const alphaCodexHome = resolveCodexAppServerHomeDir(alphaAgentDir);
     const betaCodexHome = resolveCodexAppServerHomeDir(betaAgentDir);
-    const configuredCodexHome = path.join(root, "configured-codex-home");
+    const configuredCodexHomes = Array.from({ length: MAX_HOST_COUNT }, (_, index) =>
+      path.join(root, "configured-codex-home", String(index)),
+    );
+    const configuredCodexHome = configuredCodexHomes[0]!;
     const configuredCodexHomeAlias = path.join(root, "configured-codex-home-alias");
     const configuredFile = path.join(root, "not-a-codex-home");
     await Promise.all(
-      [processCodexHome, alphaCodexHome, betaCodexHome, configuredCodexHome].map((dir) =>
+      [processCodexHome, alphaCodexHome, betaCodexHome, ...configuredCodexHomes].map((dir) =>
         fs.mkdir(dir, { recursive: true }),
       ),
     );
@@ -331,23 +335,25 @@ describe("Codex supervision catalog", () => {
             alphaCodexHome,
             path.join(root, "missing-codex-home"),
             configuredFile,
+            ...configuredCodexHomes.slice(1),
           ],
         },
       }),
     });
     const homes = control.homesForAgent("beta");
 
-    expect(
-      new Set(
-        homes.map((home) =>
-          resolveCodexAppServerLocalHomeDir(home.appServer.start, home.agentDir, env),
-        ),
-      ),
-    ).toEqual(new Set([processCodexHome, configuredCodexHome, alphaCodexHome, betaCodexHome]));
-    expect(homes.map((home) => home.agentDir)).toEqual(Array(4).fill(betaAgentDir));
+    const resolvedHomes = homes.map((home) =>
+      resolveCodexAppServerLocalHomeDir(home.appServer.start, home.agentDir, env),
+    );
+    expect(homes).toHaveLength(MAX_HOST_COUNT);
+    expect(resolvedHomes.slice(0, 3)).toEqual([processCodexHome, betaCodexHome, alphaCodexHome]);
+    expect(resolvedHomes.filter((home) => configuredCodexHomes.includes(home))).toHaveLength(
+      MAX_HOST_COUNT - 3,
+    );
+    expect(homes.map((home) => home.agentDir)).toEqual(Array(MAX_HOST_COUNT).fill(betaAgentDir));
     expect(homes[0]?.hostId).toBe(CODEX_LOCAL_SESSION_HOST_ID);
     expect(homes.slice(1).every((home) => home.hostId.startsWith("gateway:local:"))).toBe(true);
-    expect(new Set(homes.map((home) => home.sourceHomeId)).size).toBe(4);
+    expect(new Set(homes.map((home) => home.sourceHomeId)).size).toBe(MAX_HOST_COUNT);
     expect(
       JSON.stringify(homes.map(({ hostId, sourceHomeId }) => ({ hostId, sourceHomeId }))),
     ).not.toContain(root);


### PR DESCRIPTION
[AI-assisted]

Closes #124621

## What Problem This Solves

Fixes an issue where sessions in operator-created `CODEX_HOME` stores were absent from the Codex session catalog unless the store also belonged to a configured OpenClaw agent.

## Why This Change Was Made

Codex resolves one canonical home per app-server process and has no global home registry. This adds the generic `plugins.entries.codex.config.sessionCatalog.homes` registry for managed stdio connections. Existing process and agent homes keep priority under the 100-host cap; configured extras fill only the remaining slots. Paths are canonicalized, limited to existing directories, and deduplicated. Unix and WebSocket configurations now fail visibly instead of silently ignoring `homes`.

The selected OpenClaw agent remains the owner. Only the source connection's `CODEX_HOME` changes, and the existing source-bound catalog pipeline continues to own list, read, continue/adoption, archive, and terminal routing. No store-specific name or filesystem scan is introduced.

## User Impact

Operators can register arbitrary additional local Codex stores and manage their sessions through the existing catalog, still grouped by each session's working directory. Automatic homes cannot be displaced by a long extras list.

## Evidence

Exact-head validation passed on `ea3553a6a454400e2d0632770b3b184c79949960`, rebased onto `main` at `886e5c049005845135dfc25f7a3cb9bebc4ea01e`. The two ClawSweeper P2 cases have dedicated regression coverage: automatic-home priority at saturation and visible rejection for both Unix and WebSocket transports.

Redacted output from a fresh isolated built Gateway and real Codex app-server boundary:

```text
proof_head=ea3553a6a454400e2d0632770b3b184c79949960
invalid_transport=visible_error:plugins.entries.codex.config.sessionCatalog.homes requires appServer.transport=stdio
cold_catalog=hosts:2 configured_sessions:2 duplicate_and_invalid_filtered:true
configured_source=host:gateway:local:<sha256> sourceHomeId:<same-sha256> cwd:<proof-root>/workspace-configured
read=items:16 source_bound:true
continue=session_created:true source_bound:true
terminal=open:true source_bound:true
archive=ok:true configured_rollout_archived:1
```

<details>
<summary>Exact-head checks</summary>

- **Proof head:** `ea3553a6a454400e2d0632770b3b184c79949960`
- `pnpm test:extension codex -- extensions/codex/src/manifest.test.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/session-catalog-listing.test.ts` — 174/174 passed.
- `pnpm tsgo:extensions` — passed.
- `pnpm lint:extensions` — 0 errors and 0 warnings across 8,139 files.
- `pnpm docs:check-config-examples` — 1,175 examples validated.
- `pnpm format:docs:check` — 758 files clean.
- `pnpm build` — passed, including bundles, plugin control plane, SDK exports, and Control UI.
- `pnpm test:extension codex` — 3,720 tests passed; one unrelated context-engine test failed because its unchanged `codex-context-test-sandbox` backend was not registered. The focused retry reproduced the same harness error with the other 30 tests in that file passing.

Proof profile: `cli-config`, cold startup plus warm catalog actions. Environment: Ubuntu/WSL, Node 24.16.0, pnpm 11.15.1, Codex CLI 0.147.0. Direct Codex contract inspection used `openai/codex@e363b08c9175ac1cbe5893615dd2cb9ddf95043b`: `find_codex_home` accepts one canonical existing directory, and app-server initialization constructs its config manager from that one home.

No proof gap remains for the scoped behavior.

</details>
