### PR TITLE
fix(cli): report unknown subcommands instead of excess arguments

### DIFF
--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -111,6 +111,6 @@ export function getCommanderErrorCommandNames(program: Command): string[] | unde
     ? command
         .createHelp()
         .visibleCommands(command)
-        .flatMap((child) => [child.name(), ...child.aliases()])
+        .flatMap((child) => child.aliases().concat(child.name()))
     : undefined;
 }

--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -111,6 +111,6 @@ export function getCommanderErrorCommandNames(program: Command): string[] | unde
     ? command
         .createHelp()
         .visibleCommands(command)
-        .map((child) => child.name())
+        .flatMap((child) => [child.name(), ...child.aliases()])
     : undefined;
 }

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -1,6 +1,60 @@
 // Error output tests cover program-level error display and exit messaging.
+import { CommanderError } from "commander";
 import { describe, expect, it } from "vitest";
+import {
+  getCommanderErrorCommandNames,
+  getCommanderErrorCommandPath,
+} from "./commander-parse-facts.js";
 import { formatCliParseErrorOutput } from "./error-output.js";
+import { OpenClawCommand } from "./openclaw-command.js";
+import { registerLazyCommand } from "./register-lazy-command.js";
+
+async function parseLazyGroupError(params: {
+  argv: string[];
+  group: string;
+  subcommands: Array<{ name: string; aliases?: string[] }>;
+}): Promise<{ error: CommanderError; output: string }> {
+  const originalArgv = process.argv;
+  process.argv = ["node", "openclaw", ...params.argv];
+  let output = "";
+  try {
+    const program = new OpenClawCommand().name("openclaw").exitOverride();
+    program.configureOutput({
+      writeErr: (value) => {
+        output += value;
+      },
+      outputError: (value, write) => {
+        write(
+          formatCliParseErrorOutput(value, {
+            argv: process.argv,
+            commandPath: getCommanderErrorCommandPath(program),
+            commandNames: getCommanderErrorCommandNames(program),
+          }),
+        );
+      },
+    });
+    registerLazyCommand({
+      program,
+      name: params.group,
+      description: `${params.group} commands`,
+      register: () => {
+        const group = program.command(params.group).action(() => {});
+        for (const subcommand of params.subcommands) {
+          const command = group.command(subcommand.name).action(() => {});
+          for (const alias of subcommand.aliases ?? []) {
+            command.alias(alias);
+          }
+        }
+      },
+    });
+
+    const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(CommanderError);
+    return { error: error as CommanderError, output };
+  } finally {
+    process.argv = originalArgv;
+  }
+}
 
 describe("formatCliParseErrorOutput", () => {
   it("explains unknown commands with root help and plugin hints", () => {
@@ -33,6 +87,43 @@ describe("formatCliParseErrorOutput", () => {
 
     expect(output).toBe(
       'OpenClaw webhooks has no command "gmial".\nDid you mean this?\n  openclaw webhooks gmail\nTry: openclaw webhooks --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("reports an unmatched lazy subcommand and suggests a live child command", async () => {
+    const { error, output } = await parseLazyGroupError({
+      argv: ["sessions", "lst"],
+      group: "sessions",
+      subcommands: [{ name: "list" }, { name: "cleanup" }],
+    });
+
+    expect(error.code).toBe("commander.unknownCommand");
+    expect(output).toBe(
+      'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("suggests aliases from the live child command tree", async () => {
+    const { error, output } = await parseLazyGroupError({
+      argv: ["cron", "remov"],
+      group: "cron",
+      subcommands: [{ name: "rm", aliases: ["remove", "delete"] }, { name: "edit" }],
+    });
+
+    expect(error.code).toBe("commander.unknownCommand");
+    expect(output).toContain("Did you mean this?\n  openclaw cron remove\n");
+  });
+
+  it("keeps excess arguments on a matched lazy subcommand", async () => {
+    const { error, output } = await parseLazyGroupError({
+      argv: ["sessions", "list", "extra1", "extra2"],
+      group: "sessions",
+      subcommands: [{ name: "list" }],
+    });
+
+    expect(error.code).toBe("commander.excessArguments");
+    expect(output).toBe(
+      "Too many arguments for this command.\nTry: openclaw sessions list --help\n",
     );
   });
 

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -8,9 +8,23 @@ export class OpenClawCommand extends Command {
   }
 
   override error(message: string, errorOptions?: ErrorOptions): never {
+    const firstArgument = this.args[0];
+    // Commander checks a parent action before its unknown-command branch.
+    // Reclassify only zero-argument parents so genuine leaf excess stays intact.
+    const isUnknownSubcommand =
+      errorOptions?.code === "commander.excessArguments" &&
+      this.registeredArguments.length === 0 &&
+      this.commands.length > 0 &&
+      firstArgument !== undefined &&
+      !this.commands.some(
+        (command) => command.name() === firstArgument || command.aliases().includes(firstArgument),
+      );
     const restoreErrorCommand = setCommanderErrorCommand(this);
     try {
-      return super.error(message, errorOptions);
+      return super.error(
+        isUnknownSubcommand ? `error: unknown command '${firstArgument}'` : message,
+        isUnknownSubcommand ? { ...errorOptions, code: "commander.unknownCommand" } : errorOptions,
+      );
     } finally {
       restoreErrorCommand();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who mistyped a nested CLI command under most command groups saw `Too many arguments for this command` instead of an unknown-command error. The misleading branch also hid the live group context and command suggestions.

## Why This Change Was Made

Commander checks a parent action before its unknown-command branch. Eleven affected groups have a zero-argument parent action for default listing or help, while `webhooks` and `nodes` do not; that structural difference caused the inconsistent messages after lazy registration loaded the real command tree.

The OpenClaw Commander adapter now reclassifies only excess-argument errors raised on zero-argument parents with unmatched live child names. Matched leaf commands keep Commander's genuine excess-argument behavior. Suggestion candidates come from the live child tree, including accepted aliases, without adding per-group command lists or making registration eager.

AI-assisted: yes.

Production LOC: +16/-2 (net +14) | Tests: +91/-0

## User Impact

Every tested command group now names the invalid subcommand, points at group help and CLI docs, and suggests a nearby real command when one exists. Valid aliases continue to work, and extra arguments after a real leaf command are still reported as extra arguments.

## Evidence

### 13-group built-dist sweep

| Group | Before | After |
| --- | --- | --- |
| `cron` | `Too many arguments for this command.` | `OpenClaw cron has no command "bogusxyz".` |
| `sessions` | `Too many arguments for this command.` | `OpenClaw sessions has no command "bogusxyz".` |
| `models` | `Too many arguments for this command.` | `OpenClaw models has no command "bogusxyz".` |
| `tasks` | `Too many arguments for this command.` | `OpenClaw tasks has no command "bogusxyz".` |
| `devices` | `Too many arguments for this command.` | `OpenClaw devices has no command "bogusxyz".` |
| `agents` | `Too many arguments for this command.` | `OpenClaw agents has no command "bogusxyz".` |
| `skills` | `Too many arguments for this command.` | `OpenClaw skills has no command "bogusxyz".` |
| `plugins` | `Too many arguments for this command.` | `OpenClaw plugins has no command "bogusxyz".` |
| `channels` | `Too many arguments for this command.` | `OpenClaw channels has no command "bogusxyz".` |
| `config` | `Too many arguments for this command.` | `OpenClaw config has no command "bogusxyz".` |
| `memory` | `Too many arguments for this command.` | `OpenClaw memory has no command "bogusxyz".` |
| `webhooks` | `OpenClaw webhooks has no command "bogusxyz".` | unchanged, correct shape |
| `nodes` | `OpenClaw nodes has no command "bogusxyz".` | unchanged, correct shape |

Exact head `cc2de5eda1f2349bad09b20262eb6d05605ddab0` built successfully on Blacksmith Testbox `tbx_01m05hz0psprsq72s7kw006qh2`: https://github.com/openclaw/openclaw/actions/runs/31954845647

Focused built-dist behavior:

```text
$ openclaw sessions lst
OpenClaw sessions has no command "lst".
Did you mean this?
  openclaw sessions list
Try: openclaw sessions --help
Docs: https://docs.openclaw.ai/cli

$ openclaw cron remov
OpenClaw cron has no command "remov".
Did you mean this?
  openclaw cron remove
Try: openclaw cron --help
Docs: https://docs.openclaw.ai/cli

$ openclaw sessions list extra1 extra2
Too many arguments for this command.
Try: openclaw sessions list --help
```

`openclaw cron remove --help` also exited successfully, proving the accepted alias remains intact.

### Tests and review

- `node scripts/run-vitest.mjs src/cli/program/error-output.test.ts src/cli/program/help.test.ts src/cli/program/build-program.test.ts src/cli/program/parent-default-help.test.ts src/cli/program/action-reparse.test.ts` — 45 passed
- The new lazy-subcommand regression was run against pre-fix production code and failed for the intended reason: received `commander.excessArguments`, expected `commander.unknownCommand`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings
- `node scripts/check-changed.mjs` selected `core` and `coreTests`, then stopped on the existing global assertion-safety shrink ratchet (`src/gateway/server.auth.control-ui.pairing.suite.ts: 6 < 11`) before the selected type/lint fan-out. This PR does not touch that protected baseline.
