### PR TITLE
fix(memory): keep truncated workspace files reachable

### DIFF
--- a/packages/memory-host-sdk/src/host/read-file-manager-compat.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file-manager-compat.test.ts
@@ -308,7 +308,8 @@ describe("MemoryIndexManager.readFile", () => {
       relPath: "extra/oversized.md",
     });
     expect(oversized.truncated).toBe(true);
-    expect(oversized.text).not.toContain("use read on the source file");
+    expect(oversized.nextFrom).toBeUndefined();
+    expect(oversized.text).toContain("use read on the source file");
 
     const linkPath = path.join(extraDir, "linked.md");
     let symlinkOk = true;

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -166,7 +166,7 @@ export async function readMemoryFile(params: {
     lines: params.lines,
     defaultLines: params.defaultLines ?? DEFAULT_MEMORY_READ_LINES,
     maxChars: params.maxChars,
-    suggestReadFallback: allowedWorkspace,
+    suggestReadFallback: inWorkspace,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents reading a configured extra-memory file inside their workspace could receive a permanently truncated single-line excerpt with no usable continuation when the line exceeded the memory tool's character budget.

## Why This Change Was Made

The memory reader now bases its existing ordinary-file-read guidance on whether the validated file is actually inside the workspace, rather than whether it belongs to the narrower canonical memory path set. External configured memory paths remain unchanged and do not advertise a workspace-only fallback.

This is an AI-assisted change. The implementation and evidence were reviewed against the owner, caller, result shaper, ordinary read contract, sibling paths, and introduction history.

## User Impact

Agents can recover the complete raw line from workspace-resident configured memory files instead of reaching a dead end after a hard truncation. The change does not broaden filesystem permissions or alter which memory paths are authorized.

## Evidence

Pre-fix real-filesystem boundary reproduction:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/read-file-manager-compat.test.ts --testNamePattern 'allows additional memory paths and blocks symlinks' --reporter=verbose
```

Observed on the pre-fix baseline: 1 failed, 12 skipped. The 20,003-character single-line workspace fixture returned `truncated=true`, `nextFrom=undefined`, and no `use read on the source file` guidance.

Post-fix validation at head `129822bbf8e82e53dc86b41a4c04c56740bbab32`:

- 25/25 focused memory-host tests passed.
- 2/2 selected ordinary read/path sibling tests passed.
- Source-blind temporary-filesystem validation passed 7/7 clauses: workspace oversized fallback, external oversized non-fallback, rewritten short content, randomized marker isolation, and cleanup.
- Targeted formatting, oxlint, declaration typecheck, import-cycle check, and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings.
- Production LOC: +1/-1 (net 0). Tests: +2/-1.

Changed-gate note: Blacksmith Testbox run `31954907894` passed conflict-marker, environment-count, and max-lines checks, then stopped on the unrelated current-main shrink-only assertion-safety baseline `src/gateway/server.auth.control-ui.pairing.suite.ts: 6 < 11`. This PR does not touch that suite or the protected baseline; no baseline edit was made. Exact-head hosted CI remains the landing authority.

### Review blocker and scope decision

Exact-head CI run `31955145928` passed. ClawSweeper then identified a restricted-tool-surface case: an explicit `toolsAllow: ["memory_search", "memory_get"]` plan constructs plugin tools with `includeBaseCodingTools=false`, so the ordinary `read` tool is absent even though this patch would recommend it for the newly covered workspace-extra case.

The finding is accepted. The rank-up move to pass active `read` availability through the memory tool boundary is not applied in this PR because it requires a new prepared capability fact across the core/plugin boundary plus memory-only/read-enabled session coverage. That is broader than this PR's approved one-line owner repair. This PR is therefore not land-ready and will not be merged in its current form.
