### PR TITLE
fix(cron): missing automations show recovery guidance

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1557,6 +1557,24 @@ public struct ErrorShape: Codable, Sendable {
     }
 }
 
+public struct CronJobNotFoundErrorDetails: Codable, Sendable {
+    public let code: String
+    public let jobid: String
+
+    public init(
+        code: String,
+        jobid: String)
+    {
+        self.code = code
+        self.jobid = jobid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case jobid = "jobId"
+    }
+}
+
 public struct MissingScopeErrorDetails: Codable, Sendable {
     public let code: String
     public let missingscope: String
@@ -20003,6 +20021,7 @@ public enum BoardCommand: Codable, Sendable {
 }
 
 public enum GatewayErrorDetails: Codable, Sendable {
+    case cronJobNotFound(CronJobNotFoundErrorDetails)
     case missingScope(MissingScopeErrorDetails)
     case mcpAppViewExpired(McpAppViewExpiredErrorDetails)
     case userPrefsLimitExceeded(UserPrefsLimitExceededErrorDetails)
@@ -20022,6 +20041,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
 
     public var code: String {
         switch self {
+        case .cronJobNotFound(let value): value.code
         case .missingScope(let value): value.code
         case .mcpAppViewExpired(let value): value.code
         case .userPrefsLimitExceeded(let value): value.code
@@ -20049,6 +20069,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let discriminator = try container.decode(String.self, forKey: .discriminator)
         switch discriminator {
+        case "CRON_JOB_NOT_FOUND": self = try .cronJobNotFound(CronJobNotFoundErrorDetails(from: decoder))
         case "MISSING_SCOPE": self = try .missingScope(MissingScopeErrorDetails(from: decoder))
         case "MCP_APP_VIEW_EXPIRED": self = try .mcpAppViewExpired(McpAppViewExpiredErrorDetails(from: decoder))
         case "USER_PREFS_LIMIT_EXCEEDED": self = try .userPrefsLimitExceeded(UserPrefsLimitExceededErrorDetails(from: decoder))
@@ -20066,6 +20087,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
 
     public func encode(to encoder: Encoder) throws {
         switch self {
+        case .cronJobNotFound(let value): try value.encode(to: encoder)
         case .missingScope(let value): try value.encode(to: encoder)
         case .mcpAppViewExpired(let value): try value.encode(to: encoder)
         case .userPrefsLimitExceeded(let value): try value.encode(to: encoder)

--- a/packages/gateway-protocol/src/error-details.ts
+++ b/packages/gateway-protocol/src/error-details.ts
@@ -1,0 +1,32 @@
+export * from "./clawhub-trust-error-details.js";
+export * from "./install-policy-warning-error-details.js";
+export * from "./system-agent-error-details.js";
+export {
+  ErrorCodes,
+  GatewayErrorDetailCodes,
+  isMcpAppViewExpiredError,
+  readCronJobNotFoundError,
+  readMissingScopeError,
+  readMissingScopeErrorDetails,
+} from "./gateway-error-details.js";
+export type {
+  CronJobNotFoundErrorDetails,
+  GatewayErrorDetails,
+  McpAppViewExpiredErrorDetails,
+  MissingScopeErrorDetails,
+  UserPrefsLimitExceededErrorDetails,
+  ProjectCloneErrorDetails,
+  ProjectCloneFailureCause,
+  WizardNotFoundErrorDetails,
+} from "./gateway-error-details.js";
+export {
+  CronJobNotFoundErrorDetailsSchema,
+  GatewayErrorDetailsSchema,
+  MissingScopeErrorDetailsSchema,
+  UserPrefsLimitExceededErrorDetailsSchema,
+  ProjectCloneErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
+  buildMissingScopeErrorDetails,
+  errorShape,
+  missingScopeErrorShape,
+} from "./schema/error-codes.js";

--- a/packages/gateway-protocol/src/gateway-error-details.ts
+++ b/packages/gateway-protocol/src/gateway-error-details.ts
@@ -23,6 +23,7 @@ export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
 
 /** Stable discriminants for structured method-level failures. */
 export const GatewayErrorDetailCodes = {
+  CRON_JOB_NOT_FOUND: "CRON_JOB_NOT_FOUND",
   MISSING_SCOPE: "MISSING_SCOPE",
   MCP_APP_VIEW_EXPIRED: "MCP_APP_VIEW_EXPIRED",
   USER_PREFS_LIMIT_EXCEEDED: "USER_PREFS_LIMIT_EXCEEDED",
@@ -31,6 +32,12 @@ export const GatewayErrorDetailCodes = {
   UNKNOWN_AGENT_ID: "UNKNOWN_AGENT_ID",
   WIZARD_NOT_FOUND: "WIZARD_NOT_FOUND",
 } as const;
+
+/** Missing cron automation identified by its exact store key. */
+export type CronJobNotFoundErrorDetails = {
+  code: typeof GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND;
+  jobId: string;
+};
 
 /** Missing operator-scope details shared by WebSocket and HTTP responses. */
 export type MissingScopeErrorDetails = {
@@ -76,6 +83,7 @@ export type ProjectCloneErrorDetails = {
 
 /** Structured details emitted by method-level failures. */
 export type GatewayErrorDetails =
+  | CronJobNotFoundErrorDetails
   | MissingScopeErrorDetails
   | McpAppViewExpiredErrorDetails
   | UserPrefsLimitExceededErrorDetails
@@ -91,6 +99,17 @@ type GatewayErrorLike = {
 };
 
 const LEGACY_MISSING_SCOPE_PATTERN = /\bmissing scope:\s*([a-z0-9._-]+)/i;
+
+/** Reads a typed cron lookup miss without parsing operator-facing prose. */
+export function readCronJobNotFoundError(error: unknown): CronJobNotFoundErrorDetails | null {
+  const record = asProtocolRecord(error);
+  const details = asProtocolRecord(record?.details);
+  if (details?.code !== GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND) {
+    return null;
+  }
+  const jobId = typeof details.jobId === "string" ? details.jobId.trim() : "";
+  return jobId ? { code: GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND, jobId } : null;
+}
 
 /** Reads validated missing-scope details from an untrusted protocol payload. */
 export function readMissingScopeErrorDetails(details: unknown): MissingScopeErrorDetails | null {

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -1,11 +1,4 @@
-export * from "./clawhub-trust-error-details.js";
-export * from "./install-policy-warning-error-details.js";
-export * from "./system-agent-error-details.js";
-export {
-  isMcpAppViewExpiredError,
-  readMissingScopeError,
-  readMissingScopeErrorDetails,
-} from "./gateway-error-details.js";
+export * from "./error-details.js";
 export * from "./session-agent-status.js";
 export * from "./terminal-validators.js";
 export {
@@ -18,16 +11,6 @@ export type { ProtocolValidator } from "./protocol-validator.js";
 export * from "./schema/worker-inference.js";
 export * from "./schema/skill-history.js";
 export * from "./schema/ui-command.js";
-export type {
-  CronJobNotFoundErrorDetails,
-  GatewayErrorDetails,
-  McpAppViewExpiredErrorDetails,
-  MissingScopeErrorDetails,
-  UserPrefsLimitExceededErrorDetails,
-  ProjectCloneErrorDetails,
-  ProjectCloneFailureCause,
-  WizardNotFoundErrorDetails,
-} from "./schema/error-codes.js";
 export * from "./schema/board.js";
 export {
   SessionCreatedActorSchema,
@@ -77,12 +60,6 @@ export {
   PresenceEntrySchema,
   SnapshotSchema,
   ErrorShapeSchema,
-  CronJobNotFoundErrorDetailsSchema,
-  GatewayErrorDetailsSchema,
-  MissingScopeErrorDetailsSchema,
-  UserPrefsLimitExceededErrorDetailsSchema,
-  ProjectCloneErrorDetailsSchema,
-  WizardNotFoundErrorDetailsSchema,
   WorkerAdmissionFailureReasonSchema,
   WorkerAdmissionHandshakeSchema,
   WorkerAdmissionResponseFrameSchema,
@@ -687,12 +664,6 @@ export {
   FsDirEntrySchema,
   FsListDirParamsSchema,
   FsListDirResultSchema,
-  ErrorCodes,
-  buildMissingScopeErrorDetails,
-  GatewayErrorDetailCodes,
-  readCronJobNotFoundError,
-  errorShape,
-  missingScopeErrorShape,
 } from "./schema-modules.js";
 export {
   MIN_CLIENT_PROTOCOL_VERSION,

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -19,6 +19,7 @@ export * from "./schema/worker-inference.js";
 export * from "./schema/skill-history.js";
 export * from "./schema/ui-command.js";
 export type {
+  CronJobNotFoundErrorDetails,
   GatewayErrorDetails,
   McpAppViewExpiredErrorDetails,
   MissingScopeErrorDetails,
@@ -76,6 +77,7 @@ export {
   PresenceEntrySchema,
   SnapshotSchema,
   ErrorShapeSchema,
+  CronJobNotFoundErrorDetailsSchema,
   GatewayErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
   UserPrefsLimitExceededErrorDetailsSchema,
@@ -688,6 +690,7 @@ export {
   ErrorCodes,
   buildMissingScopeErrorDetails,
   GatewayErrorDetailCodes,
+  readCronJobNotFoundError,
   errorShape,
   missingScopeErrorShape,
 } from "./schema-modules.js";

--- a/packages/gateway-protocol/src/schema/error-codes.test.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.test.ts
@@ -2,6 +2,7 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
   ErrorCodes,
+  CronJobNotFoundErrorDetailsSchema,
   GatewayErrorDetailCodes,
   GatewayErrorDetailsSchema,
   isMcpAppViewExpiredError,
@@ -11,11 +12,24 @@ import {
   missingScopeErrorShape,
   readMissingScopeError,
   readMissingScopeErrorDetails,
+  readCronJobNotFoundError,
   UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetailsSchema,
 } from "./error-codes.js";
 
 describe("gateway error details", () => {
+  it("validates and reads cron job lookup misses", () => {
+    const details = {
+      code: GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND,
+      jobId: "job-123",
+    };
+
+    expect(Value.Check(CronJobNotFoundErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
+    expect(readCronJobNotFoundError({ details })).toEqual(details);
+    expect(readCronJobNotFoundError({ details: { ...details, jobId: "" } })).toBeNull();
+  });
+
   it("validates missing-scope details", () => {
     const details = {
       code: GatewayErrorDetailCodes.MISSING_SCOPE,

--- a/packages/gateway-protocol/src/schema/error-codes.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.ts
@@ -13,6 +13,7 @@ import { NonEmptyString } from "./primitives.js";
 export {
   ErrorCodes,
   GatewayErrorDetailCodes,
+  type CronJobNotFoundErrorDetails,
   type ErrorCode,
   type GatewayErrorDetails,
   type McpAppViewExpiredErrorDetails,
@@ -22,10 +23,16 @@ export {
   type ProjectCloneFailureCause,
   type UnknownAgentIdErrorDetails,
   type WizardNotFoundErrorDetails,
+  readCronJobNotFoundError,
   isMcpAppViewExpiredError,
   readMissingScopeError,
   readMissingScopeErrorDetails,
 } from "../gateway-error-details.js";
+
+export const CronJobNotFoundErrorDetailsSchema = closedObject({
+  code: Type.Literal(GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND),
+  jobId: NonEmptyString,
+});
 
 /** Missing operator-scope details shared by WebSocket and HTTP responses. */
 export const MissingScopeErrorDetailsSchema = closedObject({
@@ -62,6 +69,7 @@ export const ProjectCloneErrorDetailsSchema = closedObject({
 
 /** Structured details emitted by method-level failures. */
 export const GatewayErrorDetailsSchema = Type.Union([
+  CronJobNotFoundErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetailsSchema,
   UserPrefsLimitExceededErrorDetailsSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
@@ -16,6 +16,7 @@ export const TransportProtocolSchemas = {
   StateVersion: snapshot.StateVersionSchema,
   Snapshot: snapshot.SnapshotSchema,
   ErrorShape: frames.ErrorShapeSchema,
+  CronJobNotFoundErrorDetails: errorCodes.CronJobNotFoundErrorDetailsSchema,
   MissingScopeErrorDetails: errorCodes.MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetails: errorCodes.McpAppViewExpiredErrorDetailsSchema,
   UnknownAgentIdErrorDetails: errorCodes.UnknownAgentIdErrorDetailsSchema,

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -2,12 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
 import type { CronJob } from "../../cron/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
+import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveCronCreateScheduleFromArgs } from "./schedule-options.js";
 import {
   coerceCronDeliveryPreviews,
   enrichCronJsonWithStatus,
   getCronChannelOptions,
+  handleCronCliError,
   parseAt,
   parseCronToolsAllow,
   parsePositiveCronDurationMs,
@@ -39,6 +41,29 @@ function expectLogsToInclude(logs: readonly string[], text: string): void {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("handleCronCliError", () => {
+  it("renders typed automation lookup misses with the cron list recovery command", () => {
+    const error = new GatewayClientRequestError({
+      code: "INVALID_REQUEST",
+      message: "transport-neutral lookup miss",
+      details: { code: "CRON_JOB_NOT_FOUND", jobId: "missing-job" },
+    });
+    const errorOutput = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+
+    expect(() => handleCronCliError(error)).toThrow("exit 1");
+    expect(errorOutput).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Automation not found: missing-job. Run `openclaw cron list` to see recent automation ids.",
+      ),
+    );
+    errorOutput.mockRestore();
+    exit.mockRestore();
+  });
 });
 
 function createBaseJob(overrides: Partial<CronJob>): CronJob {

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { readCronJobNotFoundError } from "../../../packages/gateway-protocol/src/index.js";
 import { truncateToVisibleWidth, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
@@ -21,6 +22,7 @@ import {
 } from "../../infra/format-time/parse-offsetless-zoned-datetime.js";
 import { formatTimestamp } from "../../logging/timestamps.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { formatLookupMiss } from "../error-format.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { callGatewayFromCli } from "../gateway-rpc.js";
 import { parseDurationMs as parseSharedDurationMs } from "../parse-duration.js";
@@ -202,7 +204,16 @@ function formatCronStatusForDisplay(job: CronJob): string {
 }
 
 export function handleCronCliError(err: unknown) {
-  defaultRuntime.error(danger(formatErrorMessage(err)));
+  const missingJob = readCronJobNotFoundError(err);
+  const message = missingJob
+    ? formatLookupMiss({
+        noun: "Automation",
+        value: sanitizeTerminalText(missingJob.jobId),
+        listCommand: "openclaw cron list",
+        valueLabel: "automation id",
+      })
+    : formatErrorMessage(err);
+  defaultRuntime.error(danger(message));
   defaultRuntime.exit(1);
 }
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -4,6 +4,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   ErrorCodes,
   errorShape,
+  GatewayErrorDetailCodes,
   validateCronAddParams,
   validateCronGetParams,
   validateCronListParams,
@@ -386,6 +387,23 @@ function respondMissingCronJobId(respond: RespondFn, method: string): void {
   respondInvalidCronParams(respond, method, "missing id");
 }
 
+function respondCronJobNotFound(
+  respond: RespondFn,
+  jobId: string,
+  options: { preserveCronGetWireMessage?: boolean } = {},
+): void {
+  const message = options.preserveCronGetWireMessage
+    ? `cron job not found: ${jobId}. List automations and retry with a current job id.`
+    : `Automation not found: ${jobId}. List automations and retry with a current job id.`;
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, message, {
+      details: { code: GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND, jobId },
+    }),
+  );
+}
+
 /** Gateway request handlers for cron jobs and cron run-log access. */
 export const cronHandlers: GatewayRequestHandlers = {
   wake: async ({ params, respond, context, client }) => {
@@ -583,13 +601,9 @@ export const cronHandlers: GatewayRequestHandlers = {
         allowCurrentJob: true,
       })
     ) {
-      respond(
-        false,
-        undefined,
-        // Wire contract: shipped CLI matchers parse this exact wording for the
-        // name-lookup fallback (isMissingCronGetError). Rename is CLI-display only.
-        errorShape(ErrorCodes.INVALID_REQUEST, `cron job not found: ${jobId}`),
-      );
+      // Shipped CLI matchers parse this exact wording for name lookup fallback.
+      // Structured details let current consumers render their own recovery hint.
+      respondCronJobNotFound(respond, jobId, { preserveCronGetWireMessage: true });
       return;
     }
     respond(true, cronJobReadView(job), undefined);
@@ -613,7 +627,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         defaultAgentId: context.cron.getDefaultAgentId(),
       })
     ) {
-      respondInvalidCronParams(respond, "cron.scratch.get", "id not found");
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     const state = await context.cron.readScratch(jobId);
@@ -650,7 +664,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         defaultAgentId: context.cron.getDefaultAgentId(),
       })
     ) {
-      respondInvalidCronParams(respond, "cron.scratch.set", "id not found");
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     try {
@@ -927,7 +941,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         defaultAgentId: context.cron.getDefaultAgentId(),
       })
     ) {
-      respondInvalidCronParams(respond, "cron.update", "id not found");
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     if (callerScope && "agentId" in patch) {
@@ -1087,11 +1101,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         allowCurrentJob: true,
       })
     ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron.remove params: id not found"),
-      );
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     if (!ensureActiveAgentRuntimeAuthority({ client, context, method: "cron.remove", respond })) {
@@ -1111,11 +1121,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       throw error;
     }
     if (!result.removed) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron.remove params: id not found"),
-      );
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     context.logGateway.info("cron: job removed", { jobId });
@@ -1144,7 +1150,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         defaultAgentId: context.cron.getDefaultAgentId(),
       })
     ) {
-      respondInvalidCronParams(respond, "cron.run", "id not found");
+      respondCronJobNotFound(respond, jobId);
       return;
     }
     if (
@@ -1234,7 +1240,11 @@ export const cronHandlers: GatewayRequestHandlers = {
           : undefined;
       // Operator history survives job deletion; scoped reads still need a live, matching owner.
       if ((callerScope || p.agentId) && !matchedJob) {
-        respondInvalidCronParams(respond, "cron.runs", "id not found");
+        if (!jobId) {
+          respondMissingCronJobId(respond, "cron.runs");
+          return;
+        }
+        respondCronJobNotFound(respond, jobId);
         return;
       }
       const jobNameById =

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -552,7 +552,7 @@ function expectCronUpdateDeliveryPatch(
 
 function expectResponseError(
   respond: ReturnType<typeof vi.fn>,
-  expected: { code?: string; messageIncludes?: string },
+  expected: { code?: string; messageIncludes?: string; details?: Record<string, unknown> },
 ) {
   const call = respond.mock.calls.at(0);
   if (!call) {
@@ -566,6 +566,9 @@ function expectResponseError(
   }
   if (expected.messageIncludes) {
     expect(String(error.message)).toContain(expected.messageIncludes);
+  }
+  if (expected.details) {
+    expect(error.details).toEqual(expected.details);
   }
 }
 
@@ -617,7 +620,8 @@ describe("cron method validation", () => {
     );
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.remove params: id not found",
+      messageIncludes: "Automation not found: missing-id",
+      details: { code: "CRON_JOB_NOT_FOUND", jobId: "missing-id" },
     });
   });
 
@@ -646,7 +650,7 @@ describe("cron method validation", () => {
     expect(context.cron.remove).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.remove params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -672,7 +676,7 @@ describe("cron method validation", () => {
     expect(context.cron.remove).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.remove params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -730,6 +734,7 @@ describe("cron method validation", () => {
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
       messageIncludes: "cron job not found: cron-42",
+      details: { code: "CRON_JOB_NOT_FOUND", jobId: "cron-42" },
     });
   });
 
@@ -1690,7 +1695,7 @@ describe("cron method validation", () => {
     expect(siblingUpdate.respond).toHaveBeenCalledWith(
       false,
       undefined,
-      expect.objectContaining({ message: "invalid cron.update params: id not found" }),
+      expect.objectContaining({ message: expect.stringContaining("Automation not found: cron-1") }),
     );
     expect(context.cron.updateWithPrecondition).not.toHaveBeenCalled();
 
@@ -1795,13 +1800,13 @@ describe("cron method validation", () => {
     );
     expectResponseError(update.respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.update params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
 
     const run = await invokeCron("cron.run", { id: accountJob.id }, { context, client: runClient });
     expectResponseError(run.respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.run params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
     expect(context.cron.enqueueRun).not.toHaveBeenCalled();
   });
@@ -2309,7 +2314,7 @@ describe("cron method validation", () => {
     expect(context.cron.update).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.update params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3618,7 +3623,7 @@ describe("cron method validation", () => {
     expect(context.cron.update).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.update params: id not found",
+      messageIncludes: "Automation not found: missing",
     });
   });
 
@@ -3666,7 +3671,7 @@ describe("cron method validation", () => {
     expect(context.cron.update).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.update params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3678,8 +3683,24 @@ describe("cron method validation", () => {
     expect(context.cron.enqueueRun).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.run params: id not found",
+      messageIncludes: "Automation not found: missing",
+      details: { code: "CRON_JOB_NOT_FOUND", jobId: "missing" },
     });
+  });
+
+  it("keeps malformed cron.run params classified as invalid params", async () => {
+    const { context, respond } = await invokeCron(
+      "cron.run",
+      { id: 42 },
+      { context: createCronContext() },
+    );
+
+    expect(context.cron.readJob).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "invalid cron.run params",
+    });
+    expect(requireRecord(respond.mock.calls[0]?.[2], "response error").details).toBeUndefined();
   });
 
   it("allows caller-scoped cron.run for the same agent", async () => {
@@ -3736,7 +3757,7 @@ describe("cron method validation", () => {
     expect(context.cron.enqueueRun).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.run params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3763,7 +3784,7 @@ describe("cron method validation", () => {
     expect(context.cron.enqueueRun).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.run params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3830,7 +3851,7 @@ describe("cron method validation", () => {
     expect(context.cron.list).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.runs params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3892,7 +3913,7 @@ describe("cron method validation", () => {
     expect(context.cron.list).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.runs params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 
@@ -3919,7 +3940,7 @@ describe("cron method validation", () => {
     expect(context.cron.list).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
-      messageIncludes: "invalid cron.runs params: id not found",
+      messageIncludes: "Automation not found: cron-1",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators and agents running or removing a missing automation received `invalid cron.<method> params: id not found`. That misclassified a lookup miss as malformed input, leaked an internal RPC method name, and gave the caller no recovery step.

Before (built `e38a645a751`, isolated profile):

```text
$ openclaw cron run nonexistent-job
invalid cron.run params: id not found

$ openclaw cron rm nonexistent-job
invalid cron.remove params: id not found
```

The closest existing CLI sibling is `tasks show`, which uses the shared lookup-miss formatter:

```text
Task not found: nonexistent-task. Run `openclaw tasks list` to see recent task ids.
```

## Why This Change Was Made

The Gateway now records the producer-owned fact as structured `CRON_JOB_NOT_FOUND` details with the exact job ID, while retaining the closed top-level `INVALID_REQUEST` code set. All cron lookup misses use one responder, including both previously hand-written `cron.remove` branches and the existing `cron.get` compatibility path.

The server message stays transport-neutral: it says which automation is missing and tells consumers to list automations and retry. The cron CLI reads the structured detail and reuses the same `formatLookupMiss` formatter as `tasks show`, adding the CLI-owned `openclaw cron list` command. This avoids hardcoding CLI syntax in a generic Gateway helper.

`GatewayErrorDetailCodes` is the right seam: it already distinguishes method-level failures such as `WIZARD_NOT_FOUND` without expanding the closed top-level error-code set. I do not recommend a generic top-level `NOT_FOUND` code for this fix; that would require owner sign-off and a broader protocol/client migration, while the structured detail fully distinguishes lookup failure from malformed params today. The additive detail is also projected into generated Swift protocol models.

Consumer trace:

- CLI: every cron subcommand funnels failures through `handleCronCliError`, which renders the typed detail with `openclaw cron list` guidance.
- Agent tool: the automations tool uses `GatewayClientRequestError`; tool lifecycle errors preserve the Gateway message, so the model now sees the missing automation plus the actionable list-and-retry step. `cron.get` keeps its shipped wire prefix for mixed-version name lookup while gaining the recovery sentence and typed detail.
- Control UI: cron mutations use `withCronBusy` and run-history loading catches the same `GatewayRequestError`; both surface the Gateway's transport-neutral actionable message.
- Raw RPC/native clients: receive `INVALID_REQUEST` plus `{ code: "CRON_JOB_NOT_FOUND", jobId }`; generated Swift can decode the new detail.

Sibling gateway families checked: `tasks.*`, `sessions.*`, `devices.*`, and `nodes.*`. None shares the `invalid <method> params: <thing> not found` cause. Tasks and devices already add CLI recovery at their owning consumer; sessions uses object-specific `session not found` messages without method-name leakage; nodes returns pairing/inventory outcomes rather than this invalid-params pattern. Those surfaces are deliberately unchanged.

AI-assisted: yes. The change and its ownership boundary were reviewed and validated by the author.

## User Impact

Missing automations are now clearly identified and recoverable:

```text
$ openclaw cron run nonexistent-job
Automation not found: nonexistent-job. Run `openclaw cron list` to see recent automation ids.
```

Malformed payloads remain a separate failure class and still report `invalid cron.run params: ...`.

## Evidence

Pre-fix regression proof:

- The new `cron.run` and `cron.remove` assertions failed against the original code because both returned the old invalid-params strings.

Focused tests:

```text
node scripts/run-vitest.mjs src/gateway/server-methods/cron.validation.test.ts
  196 passed
node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/error-codes.test.ts
  11 passed
node scripts/run-vitest.mjs src/cli/cron-cli/shared.test.ts
  80 passed
node --import tsx scripts/protocol-gen-swift.ts --check
  passed
```

Build:

```text
pnpm build
  passed (3m40.8s)
```

Live built-dist proof used an isolated `OPENCLAW_STATE_DIR`, loopback port `19763`, `OPENCLAW_SKIP_CHANNELS=1`, and auth-none scratch config. The scratch Gateway was stopped and its state was moved to Trash afterward. All six affected method families returned the same producer-owned classification:

```text
cron.scratch.get  -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
cron.scratch.set  -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
cron.update       -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
cron.remove       -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
cron.run          -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
cron.runs         -> Gateway call failed: Automation not found: nonexistent-job. List automations and retry with a current job id.
```

High-level CLI rendering:

```text
openclaw cron disable nonexistent-job
openclaw cron rm nonexistent-job
openclaw cron run nonexistent-job
openclaw cron scratch nonexistent-job

Automation not found: nonexistent-job. Run `openclaw cron list` to see recent automation ids.
```

Malformed-payload control:

```text
Gateway call failed: invalid cron.run params: at /id: must be string; ...
```

`node scripts/check-changed.mjs` was run after the focused fixes. Its task-owned cron assertion ratchet is clean, but the repo-wide gate currently stops on an unrelated moving-`main` shrink in `src/gateway/server.auth.control-ui.pairing.suite.ts` (`6 < 11`) that this PR does not touch. The delegated run was https://github.com/openclaw/openclaw/actions/runs/31955040306.

Autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
autoreview clean: no accepted/actionable findings reported
```

LOC classification: production TypeScript `+75/-23` (net `+52`), generated Swift `+22/-0`, tests `+77/-17`. The production growth is the typed cross-consumer detail contract, schema/registry/native projection, canonical responder, and CLI renderer; duplicated remove response construction was deleted.
