### PR TITLE
perf(plugins): memoize failed facade module resolutions

### DIFF
--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -262,11 +262,15 @@ describe("plugin-sdk facade runtime", () => {
     );
   });
 
-  it("retries missing facade locations when a plugin artifact appears", () => {
+  it("memoizes missing facade locations until the plugin lifecycle clears", () => {
     const dir = createTrustedBundledFixtureRoot("openclaw-facade-location-retry-");
     useBundledPluginDirOverrideForTest(dir);
+    let registryProbes = 0;
     testing.setFacadeActivationCheckRuntimeForTest({
-      resolveRegistryPluginModuleLocation: () => null,
+      resolveRegistryPluginModuleLocation: () => {
+        registryProbes += 1;
+        return null;
+      },
     } as never);
     const params = {
       dirName: "future-demo",
@@ -274,11 +278,20 @@ describe("plugin-sdk facade runtime", () => {
     };
 
     expect(testing.resolveFacadeModuleLocation(params)).toBeNull();
+    // Plugin topology is process-stable: repeated lookups for a missing plugin
+    // must not re-walk the filesystem or registry on every request.
+    expect(testing.resolveFacadeModuleLocation(params)).toBeNull();
+    expect(registryProbes).toBe(1);
 
     const pluginDir = path.join(dir, params.dirName);
     fs.mkdirSync(pluginDir, { recursive: true });
     writePluginPackageJson(pluginDir, params.dirName);
     fs.writeFileSync(path.join(pluginDir, "api.js"), 'export const marker = "ready";\n', "utf8");
+
+    // Install/reload flows clear the metadata lifecycle memo; only then does
+    // the new artifact become visible.
+    expect(testing.resolveFacadeModuleLocation(params)).toBeNull();
+    clearPluginMetadataLifecycleCaches();
 
     expect(testing.resolveFacadeModuleLocation(params)).toEqual({
       modulePath: path.join(pluginDir, "api.js"),

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -34,7 +34,10 @@ const OPENCLAW_PACKAGE_ROOT =
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
 const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const OPENCLAW_SOURCE_EXTENSIONS_ROOT = path.resolve(OPENCLAW_PACKAGE_ROOT, "extensions");
-const facadeModuleLocationCache = new PluginLruCache<FacadeModuleLocation>(128);
+// Null entries memoize failed resolutions: plugin install topology is
+// process-stable, so a missing plugin must not re-walk the filesystem on
+// every request-time lookup. Install/reload flows clear via the lifecycle hook.
+const facadeModuleLocationCache = new PluginLruCache<FacadeModuleLocation | null>(128);
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   facadeModuleLocationCache.clear();
@@ -96,14 +99,12 @@ function resolveFacadeModuleLocation(params: {
     return resolveFacadeModuleLocationUncached(params);
   }
   const resolutionKey = createFacadeResolutionKey(params);
-  const cached = facadeModuleLocationCache.get(resolutionKey);
-  if (cached) {
-    return cached;
+  const cached = facadeModuleLocationCache.getResult(resolutionKey);
+  if (cached.hit) {
+    return cached.value;
   }
   const location = resolveFacadeModuleLocationUncached(params);
-  if (location) {
-    facadeModuleLocationCache.set(resolutionKey, location);
-  }
+  facadeModuleLocationCache.set(resolutionKey, location);
   return location;
 }
 


### PR DESCRIPTION
## What Problem This Solves

`resolveFacadeModuleLocation` cached only successful resolutions. Every lookup for a plugin that is not installed re-walked the bundled-plugins directory and the installed-plugin registry on every request — request-time freshness polling of process-stable install topology, which the architecture doctrine explicitly forbids ("runtime hot paths never freshness-poll ... reuse current snapshots").

## Why This Change Was Made

Cache null results too (via `getResult` hit/miss so `null` is a real hit). The freshness owner already exists: install/reload/doctor flows clear this cache through `registerPluginMetadataProcessMemoLifecycleClear`, so a newly installed plugin becomes visible exactly when the lifecycle owner says so.

The prior "retries missing facade locations when a plugin artifact appears" test pinned accidental per-call refresh; it now pins the lifecycle contract instead (memoized miss → lifecycle clear → visible), with a probe counter proving the registry is hit once per lifecycle generation.

## User Impact

Removes repeated filesystem/registry walks on hot request paths when optional plugins are absent (the common case for most operators).

## Evidence

- Rewritten regression fails pre-fix (stash-verified: registryProbes was 2, expected 1).
- `node scripts/run-vitest.mjs run src/plugin-sdk src/plugins/loader.test.ts` — 5 shards, all pass.
- tsgo core green.
- LOC: prod +8/−7 (net +1, comment included), test +15/−2.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99.
