### PR TITLE
fix: keep doctor security conditions as single findings

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -922,6 +922,14 @@ unrelated inbound runtime helpers.
     Diagnostics never invent a peer ID. Keep both callbacks pure and
     import-safe because read-only diagnostics run without channel runtime.
 
+    Channel-specific security diagnostics can use `security.collectWarnings`.
+    Legacy string results are warning severity. Return the structured
+    `SecurityAuditFinding` shape (`checkId`, `severity`, `title`, `detail`, and
+    optional `remediation`) when the producer must declare informational or
+    critical severity; the same finding is used by Doctor and the main security
+    audit. Use `collectAuditFindings` only for diagnostics that should appear in
+    the full security audit but not Doctor.
+
     <Accordion title="What createChatChannelPlugin does for you">
       Instead of implementing low-level adapter interfaces manually, you pass
       declarative options and the builder composes them:

--- a/extensions/discord/src/security.ts
+++ b/extensions/discord/src/security.ts
@@ -1,6 +1,9 @@
 // Discord plugin module implements security behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
-import { createOpenProviderConfiguredRouteWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import {
+  createConditionalWarningCollector,
+  createOpenProviderConfiguredRouteWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveDiscordAccountAllowFrom,
@@ -44,6 +47,12 @@ const collectDiscordSecurityWarnings =
         'Set channels.discord.groupPolicy="allowlist" and configure channels.discord.guilds.<id>.channels',
     },
   });
+const collectDiscordSecurityFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectDiscordSecurityWarnings,
+  checkId: "channels.discord.groups.open",
+  severity: "critical",
+  title: "Discord security warning",
+});
 
 const loadDiscordSecurityAuditModule = createLazyRuntimeModule(
   () => import("./security-audit.runtime.js"),
@@ -51,7 +60,7 @@ const loadDiscordSecurityAuditModule = createLazyRuntimeModule(
 
 export const discordSecurityAdapter = {
   resolveDmPolicy: resolveDiscordDmPolicy,
-  collectWarnings: collectDiscordSecurityWarnings,
+  collectWarnings: collectDiscordSecurityFindings,
   collectAuditFindings: async (params) =>
     (await loadDiscordSecurityAuditModule()).collectDiscordSecurityAuditFindings(params),
 } satisfies NonNullable<ChannelPlugin<ResolvedDiscordAccount>["security"]>;

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -22,7 +22,7 @@ import {
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createAllowlistProviderGroupPolicyWarningCollector,
-  projectConfigAccountIdWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import {
@@ -330,6 +330,12 @@ const collectFeishuSecurityWarnings = createAllowlistProviderGroupPolicyWarningC
       `- Feishu[${account.accountId}] groups: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.feishu.groupPolicy="allowlist" + channels.feishu.groupAllowFrom to restrict senders.`,
     ];
   },
+});
+const collectFeishuOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectFeishuSecurityWarnings,
+  checkId: "channels.feishu.groups.open",
+  severity: "critical",
+  title: "Feishu security warning",
 });
 
 function describeFeishuMessageTool({
@@ -1808,10 +1814,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       message: feishuMessageAdapter,
     },
     security: {
-      collectWarnings: projectConfigAccountIdWarningCollector<{
-        cfg: ClawdbotConfig;
-        accountId?: string | null;
-      }>(collectFeishuSecurityWarnings),
+      collectWarnings: ({ cfg, accountId }) => collectFeishuOpenGroupFindings({ cfg, accountId }),
       collectAuditFindings: ({ cfg }) => collectFeishuSecurityAuditFindings({ cfg }),
     },
     pairing: {

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -10,8 +10,8 @@ import {
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
-  composeAccountWarningCollectors,
   createAllowlistProviderOpenWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import {
   createChannelDirectoryAdapter,
@@ -79,19 +79,24 @@ const collectGoogleChatGroupPolicyWarnings =
         'Set channels.googlechat.groupPolicy="allowlist" and configure channels.googlechat.groups',
     },
   });
+const collectGoogleChatOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectGoogleChatGroupPolicyWarnings,
+  checkId: "channels.googlechat.groups.open",
+  severity: "critical",
+  title: "Google Chat security warning",
+});
 
-const collectGoogleChatSecurityWarnings = composeAccountWarningCollectors<
-  ResolvedGoogleChatAccount,
-  {
-    cfg: OpenClawConfig;
-    account: ResolvedGoogleChatAccount;
-  }
->(
-  collectGoogleChatGroupPolicyWarnings,
-  (account) =>
-    account.config.dmPolicy === "open" &&
-    '- Google Chat DMs are open to anyone. Set channels.googlechat.dmPolicy="pairing" or "allowlist".',
-);
+const collectGoogleChatSecurityWarnings = (params: {
+  cfg: OpenClawConfig;
+  account: ResolvedGoogleChatAccount;
+}) => [
+  ...collectGoogleChatOpenGroupFindings(params),
+  ...(params.account.config.dmPolicy === "open"
+    ? [
+        '- Google Chat DMs are open to anyone. Set channels.googlechat.dmPolicy="pairing" or "allowlist".',
+      ]
+    : []),
+];
 
 export const googlechatGroupsAdapter = {
   resolveRequireMention: resolveGoogleChatGroupRequireMention,

--- a/extensions/imessage/src/shared.ts
+++ b/extensions/imessage/src/shared.ts
@@ -53,6 +53,7 @@ export const imessageSecurityAdapter =
     groupPolicyPath: "channels.imessage.groupPolicy",
     groupAllowFromPath: "channels.imessage.groupAllowFrom",
     mentionGated: false,
+    findingTitle: "iMessage security warning",
     policyPathSuffix: "dmPolicy",
   });
 

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -8,8 +8,8 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
-  composeAccountWarningCollectors,
   createAllowlistProviderOpenWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import {
   createChannelDirectoryAdapter,
@@ -142,26 +142,29 @@ const collectIrcGroupPolicyWarnings =
       remediation: 'Prefer channels.irc.groupPolicy="allowlist" with channels.irc.groups',
     },
   });
+const collectIrcOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectIrcGroupPolicyWarnings,
+  checkId: "channels.irc.groups.open",
+  severity: "critical",
+  title: "IRC security warning",
+});
 
-const collectIrcSecurityWarnings = composeAccountWarningCollectors<
-  ResolvedIrcAccount,
-  {
-    account: ResolvedIrcAccount;
-    cfg: CoreConfig;
-  }
->(
-  collectIrcGroupPolicyWarnings,
-  (account) =>
-    !account.config.tls &&
-    "- IRC TLS is disabled (channels.irc.tls=false); traffic and credentials are plaintext.",
-  (account) =>
-    account.config.nickserv?.register &&
-    '- IRC NickServ registration is enabled (channels.irc.nickserv.register=true); this sends "REGISTER" on every connect. Disable after first successful registration.',
-  (account) =>
-    account.config.nickserv?.register &&
-    !account.config.nickserv.password?.trim() &&
-    "- IRC NickServ registration is enabled but no NickServ password is resolved; set channels.irc.nickserv.password, channels.irc.nickserv.passwordFile, or IRC_NICKSERV_PASSWORD.",
-);
+const collectIrcSecurityWarnings = (params: { account: ResolvedIrcAccount; cfg: CoreConfig }) => [
+  ...collectIrcOpenGroupFindings(params),
+  ...(!params.account.config.tls
+    ? ["- IRC TLS is disabled (channels.irc.tls=false); traffic and credentials are plaintext."]
+    : []),
+  ...(params.account.config.nickserv?.register
+    ? [
+        '- IRC NickServ registration is enabled (channels.irc.nickserv.register=true); this sends "REGISTER" on every connect. Disable after first successful registration.',
+      ]
+    : []),
+  ...(params.account.config.nickserv?.register && !params.account.config.nickserv.password?.trim()
+    ? [
+        "- IRC NickServ registration is enabled but no NickServ password is resolved; set channels.irc.nickserv.password, channels.irc.nickserv.passwordFile, or IRC_NICKSERV_PASSWORD.",
+      ]
+    : []),
+];
 
 export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChatChannelPlugin({
   base: {

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -38,6 +38,7 @@ const lineSecurityAdapter = createRestrictSendersChannelSecurity<ResolvedLineAcc
   groupPolicyPath: "channels.line.groupPolicy",
   groupAllowFromPath: "channels.line.groupAllowFrom",
   mentionGated: false,
+  findingTitle: "LINE security warning",
   policyPathSuffix: "dmPolicy",
   approveHint: "openclaw pairing approve line <code>",
   normalizeDmEntry: (raw) => raw.replace(/^line:(?:user:)?/i, ""),

--- a/extensions/matrix/src/channel.directory.test.ts
+++ b/extensions/matrix/src/channel.directory.test.ts
@@ -283,7 +283,13 @@ describe("matrix directory", () => {
         }),
       }),
     ).toEqual([
-      '- Matrix rooms: groupPolicy="open" allows any room to trigger (mention-gated). Set channels.matrix.groupPolicy="allowlist" + channels.matrix.groups (and optionally channels.matrix.groupAllowFrom) to restrict rooms.',
+      {
+        checkId: "channels.matrix.groups.open",
+        severity: "critical",
+        title: "Matrix security warning",
+        detail:
+          'Matrix rooms: groupPolicy="open" allows any room to trigger (mention-gated). Set channels.matrix.groupPolicy="allowlist" + channels.matrix.groups (and optionally channels.matrix.groupAllowFrom) to restrict rooms.',
+      },
     ]);
 
     expect(
@@ -317,7 +323,13 @@ describe("matrix directory", () => {
         }),
       }),
     ).toEqual([
-      '- Matrix rooms: groupPolicy="open" allows any room to trigger (mention-gated). Set channels.matrix.accounts.assistant.groupPolicy="allowlist" + channels.matrix.accounts.assistant.groups (and optionally channels.matrix.accounts.assistant.groupAllowFrom) to restrict rooms.',
+      {
+        checkId: "channels.matrix.groups.open",
+        severity: "critical",
+        title: "Matrix security warning",
+        detail:
+          'Matrix rooms: groupPolicy="open" allows any room to trigger (mention-gated). Set channels.matrix.accounts.assistant.groupPolicy="allowlist" + channels.matrix.accounts.assistant.groups (and optionally channels.matrix.accounts.assistant.groupAllowFrom) to restrict rooms.',
+      },
     ]);
   });
 

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -11,7 +11,7 @@ import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/channel-outbound";
 import {
   createAllowlistProviderOpenWarningCollector,
-  projectAccountConfigWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import { createScopedAccountReplyToModeResolver } from "openclaw/plugin-sdk/conversation-runtime";
@@ -183,7 +183,7 @@ const resolveMatrixDmPolicy = createScopedDmSecurityResolver<ResolvedMatrixAccou
   normalizeEntry: (raw) => normalizeMatrixUserId(raw),
 });
 
-const collectMatrixSecurityWarnings =
+const collectMatrixGroupPolicyWarnings =
   createAllowlistProviderOpenWarningCollector<ResolvedMatrixAccount>({
     providerConfigPresent: (cfg) => (cfg as CoreConfig).channels?.matrix !== undefined,
     resolveGroupPolicy: (account) => account.config.groupPolicy,
@@ -201,11 +201,11 @@ function resolveMatrixAccountConfigPath(accountId: string, field: string): strin
     : `channels.matrix.accounts.${accountId}.${field}`;
 }
 
-function collectMatrixSecurityWarningsForAccount(params: {
+function collectMatrixGroupPolicyWarningsForAccount(params: {
   account: ResolvedMatrixAccount;
   cfg: CoreConfig;
 }): string[] {
-  const warnings = collectMatrixSecurityWarnings(params);
+  const warnings = collectMatrixGroupPolicyWarnings(params);
   if (params.account.accountId !== DEFAULT_ACCOUNT_ID) {
     const groupPolicyPath = resolveMatrixAccountConfigPath(params.account.accountId, "groupPolicy");
     const groupsPath = resolveMatrixAccountConfigPath(params.account.accountId, "groups");
@@ -220,8 +220,26 @@ function collectMatrixSecurityWarningsForAccount(params: {
         .replace("channels.matrix.groupAllowFrom", groupAllowFromPath),
     );
   }
-  if (params.account.config.autoJoin !== "always") {
-    return warnings;
+  return warnings;
+}
+
+const collectMatrixOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectMatrixGroupPolicyWarningsForAccount,
+  checkId: "channels.matrix.groups.open",
+  severity: "critical",
+  title: "Matrix security warning",
+});
+
+function collectMatrixSecurityWarningsForAccount(params: {
+  account: ResolvedMatrixAccount;
+  cfg: CoreConfig;
+}) {
+  const findings = collectMatrixOpenGroupFindings(params);
+  if (
+    params.account.accountId !== DEFAULT_ACCOUNT_ID ||
+    params.account.config.autoJoin !== "always"
+  ) {
+    return findings;
   }
   const autoJoinPath = resolveMatrixAccountConfigPath(params.account.accountId, "autoJoin");
   const autoJoinAllowlistPath = resolveMatrixAccountConfigPath(
@@ -229,7 +247,7 @@ function collectMatrixSecurityWarningsForAccount(params: {
     "autoJoinAllowlist",
   );
   return [
-    ...warnings,
+    ...findings,
     `- Matrix invites: autoJoin="always" joins any invited room before message policy applies. Set ${autoJoinPath}="allowlist" + ${autoJoinAllowlistPath} (or ${autoJoinPath}="off") to restrict joins.`,
   ];
 }
@@ -602,10 +620,8 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
     },
     security: {
       resolveDmPolicy: resolveMatrixDmPolicy,
-      collectWarnings: projectAccountConfigWarningCollector(
-        (cfg) => cfg as CoreConfig,
-        collectMatrixSecurityWarningsForAccount,
-      ),
+      collectWarnings: ({ account, cfg }) =>
+        collectMatrixSecurityWarningsForAccount({ account, cfg: cfg as CoreConfig }),
     },
     pairing: {
       text: createMatrixPairingText(

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -158,6 +158,7 @@ const mattermostSecurityAdapter = createRestrictSendersChannelSecurity<ResolvedM
   openScope: "any member",
   groupPolicyPath: "channels.mattermost.groupPolicy",
   groupAllowFromPath: "channels.mattermost.groupAllowFrom",
+  findingTitle: "Mattermost security warning",
   policyPathSuffix: "dmPolicy",
   normalizeDmEntry: (raw) => normalizeAllowEntry(raw),
 });

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -13,7 +13,7 @@ import {
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createAllowlistProviderGroupPolicyWarningCollector,
-  projectConfigWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import {
   createChannelDirectoryAdapter,
@@ -103,6 +103,12 @@ const collectMSTeamsSecurityWarnings = createAllowlistProviderGroupPolicyWarning
           '- MS Teams groups: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.msteams.groupPolicy="allowlist" + channels.msteams.groupAllowFrom to restrict senders.',
         ]
       : [],
+});
+const collectMSTeamsSecurityFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectMSTeamsSecurityWarnings,
+  checkId: "channels.msteams.groups.open",
+  severity: "critical",
+  title: "MS Teams security warning",
 });
 
 const loadMSTeamsChannelRuntime = createLazyRuntimeNamedExport(
@@ -1138,9 +1144,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       },
     },
     security: {
-      collectWarnings: projectConfigWarningCollector<{ cfg: OpenClawConfig }>(
-        collectMSTeamsSecurityWarnings,
-      ),
+      collectWarnings: ({ cfg }) => collectMSTeamsSecurityFindings({ cfg }),
     },
     pairing: {
       text: {

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -2,7 +2,10 @@
 import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { createLoggedPairingApprovalNotifier } from "openclaw/plugin-sdk/channel-pairing";
-import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import {
+  createAllowlistProviderRouteAllowlistWarningCollector,
+  createConditionalWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
 import {
   buildWebhookChannelStatusSummary,
   createComputedAccountStatusAdapter,
@@ -70,6 +73,12 @@ const collectNextcloudTalkSecurityWarnings =
       groupAllowFromPath: "channels.nextcloud-talk.groupAllowFrom",
     },
   });
+const collectNextcloudTalkOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectNextcloudTalkSecurityWarnings,
+  checkId: "channels.nextcloud-talk.groups.open",
+  severity: "critical",
+  title: "Nextcloud Talk security warning",
+});
 
 export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
   createChatChannelPlugin({
@@ -184,7 +193,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
     },
     security: {
       ...nextcloudTalkSecurityAdapter,
-      collectWarnings: collectNextcloudTalkSecurityWarnings,
+      collectWarnings: collectNextcloudTalkOpenGroupFindings,
     },
     outbound: {
       base: {

--- a/extensions/signal/src/shared.ts
+++ b/extensions/signal/src/shared.ts
@@ -75,6 +75,7 @@ export const signalSecurityAdapter = createRestrictSendersChannelSecurity<Resolv
   groupPolicyPath: "channels.signal.groupPolicy",
   groupAllowFromPath: "channels.signal.groupAllowFrom",
   mentionGated: false,
+  findingTitle: "Signal security warning",
   policyPathSuffix: "dmPolicy",
   normalizeDmEntry: (raw) => normalizeE164(raw.replace(/^signal:/i, "").trim()),
 });

--- a/extensions/slack/src/security.ts
+++ b/extensions/slack/src/security.ts
@@ -1,6 +1,9 @@
 // Slack plugin module implements security behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
-import { createOpenProviderConfiguredRouteWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import {
+  createConditionalWarningCollector,
+  createOpenProviderConfiguredRouteWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveSlackAccountAllowFrom,
@@ -44,12 +47,18 @@ const collectSlackSecurityWarnings =
         'Set channels.slack.groupPolicy="allowlist" and configure channels.slack.channels',
     },
   });
+const collectSlackSecurityFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectSlackSecurityWarnings,
+  checkId: "channels.slack.groups.open",
+  severity: "critical",
+  title: "Slack security warning",
+});
 
 const loadSlackSecurityAuditModule = createLazyRuntimeModule(() => import("./security-audit.js"));
 
 export const slackSecurityAdapter = {
   resolveDmPolicy: resolveSlackDmPolicy,
-  collectWarnings: collectSlackSecurityWarnings,
+  collectWarnings: collectSlackSecurityFindings,
   collectAuditFindings: async (params) => {
     const { collectSlackSecurityAuditFindings } = await loadSlackSecurityAuditModule();
     return await collectSlackSecurityAuditFindings(params);

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -105,11 +105,18 @@ const collectSmsSecurityWarnings = createConditionalWarningCollector<ResolvedSms
   (account) =>
     account.dangerouslyDisableSignatureValidation &&
     "- SMS: Twilio signature validation is disabled. Only use this for local testing.",
-  (account) =>
-    account.dmPolicy === "open" &&
-    account.allowFrom.includes("*") &&
-    '- SMS: dmPolicy="open" allows any phone number to message the bot.',
 );
+const collectSmsOpenDmFindings = createConditionalWarningCollector.findings({
+  collectWarnings: createConditionalWarningCollector<ResolvedSmsAccount>(
+    (account) =>
+      account.dmPolicy === "open" &&
+      account.allowFrom.includes("*") &&
+      '- SMS: dmPolicy="open" allows any phone number to message the bot.',
+  ),
+  checkId: "channels.sms.dm.open",
+  severity: "critical",
+  title: "SMS security warning",
+});
 
 function smsSetupPatch(input: SmsSetupInput): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
@@ -520,7 +527,10 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount, SmsProbe> = createChat
   },
   security: {
     resolveDmPolicy: resolveSmsDmPolicy,
-    collectWarnings: ({ account }) => collectSmsSecurityWarnings(account),
+    collectWarnings: ({ account }) => [
+      ...collectSmsSecurityWarnings(account),
+      ...collectSmsOpenDmFindings(account),
+    ],
   },
   outbound: {
     deliveryMode: "gateway",

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -45,8 +45,11 @@ function makeSecurityAccount(
   return { ...securityAccountDefaults, ...overrides };
 }
 
-function expectIncludesSubstring(values: readonly string[], expected: string): void {
-  expect(values.join("\n")).toContain(expected);
+function expectIncludesSubstring(values: unknown[], text: string, severity?: string): void {
+  expect(JSON.stringify(values)).toContain(text);
+  if (severity) {
+    expect(values).toContainEqual(expect.objectContaining({ severity }));
+  }
 }
 
 function mockStringMessages(mock: { mock: { calls: unknown[][] } }): string[] {
@@ -447,21 +450,21 @@ describe("createSynologyChatPlugin", () => {
       const plugin = synologyChatPlugin;
       const account = makeSecurityAccount({ dmPolicy: "open", allowedUserIds: ["*"] });
       const warnings = plugin.security.collectWarnings({ cfg: {}, account });
-      expectIncludesSubstring(warnings, "open");
+      expectIncludesSubstring(warnings, "open", "critical");
     });
 
     it("warns when dmPolicy is open and allowedUserIds is empty", () => {
       const plugin = synologyChatPlugin;
       const account = makeSecurityAccount({ dmPolicy: "open", allowedUserIds: [] });
       const warnings = plugin.security.collectWarnings({ cfg: {}, account });
-      expectIncludesSubstring(warnings, "empty allowedUserIds");
+      expectIncludesSubstring(warnings, "empty allowedUserIds", "critical");
     });
 
     it("warns when dmPolicy is allowlist and allowedUserIds is empty", () => {
       const plugin = synologyChatPlugin;
       const account = makeSecurityAccount();
       const warnings = plugin.security.collectWarnings({ cfg: {}, account });
-      expectIncludesSubstring(warnings, "empty allowedUserIds");
+      expectIncludesSubstring(warnings, "empty allowedUserIds", "critical");
     });
 
     it("warns when named multi-account routes inherit a shared webhookPath", () => {
@@ -501,7 +504,7 @@ describe("createSynologyChatPlugin", () => {
       cfg.channels["synology-chat"].webhookUrl = "https://gateway.example.com/synology?b=2&a=1";
       const account = plugin.config.resolveAccount(cfg, "alerts");
       const warnings = plugin.security.collectWarnings({ cfg, account });
-      expectIncludesSubstring(warnings, "conflicts on webhookUrl");
+      expectIncludesSubstring(warnings, "conflicts on webhookUrl", "critical");
     });
 
     it("returns no warnings for fully configured account", () => {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -22,12 +22,7 @@ import {
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
-import {
-  composeWarningCollectors,
-  createConditionalWarningCollector,
-  projectAccountConfigWarningCollector,
-  projectAccountWarningCollector,
-} from "openclaw/plugin-sdk/channel-policy";
+import { createConditionalWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import { createEmptyChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import {
   channelBlockedPatch,
@@ -56,7 +51,7 @@ import { SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT, sendHostedFileUrl, sendMessage } from "
 import { SynologyChatChannelConfigSchema } from "./config-schema.js";
 import { synologyChatDoctor } from "./doctor.js";
 import {
-  collectSynologyGatewayRoutingWarnings,
+  collectSynologyGatewayRoutingFindings,
   registerSynologyWebhookRoute,
   validateSynologyGatewayAccountStartup,
 } from "./gateway-runtime.js";
@@ -114,11 +109,6 @@ type SynologyChannelOutboundContext = {
 };
 type SynologyChannelSendTextContext = SynologyChannelOutboundContext & { text: string };
 type SynologyChannelSendMediaContext = SynologyChannelOutboundContext & { mediaUrl: string };
-type SynologySecurityWarningContext = {
-  cfg: OpenClawConfig;
-  account: ResolvedSynologyChatAccount;
-};
-
 const synologyChatConfigAdapter = createHybridChannelConfigAdapter<ResolvedSynologyChatAccount>({
   sectionKey: CHANNEL_ID,
   listAccountIds,
@@ -163,6 +153,10 @@ const collectSynologyChatSecurityWarnings =
       account.dangerouslyAllowInheritedWebhookPath &&
       account.webhookPathSource === "inherited-base" &&
       "- Synology Chat: dangerouslyAllowInheritedWebhookPath=true opts a named account into a shared inherited webhook path. Prefer an explicit per-account webhookPath.",
+  );
+
+const collectSynologyChatCriticalFindings = createConditionalWarningCollector.findings({
+  collectWarnings: createConditionalWarningCollector<ResolvedSynologyChatAccount>(
     (account) =>
       account.dmPolicy === "open" &&
       account.allowedUserIds.length === 0 &&
@@ -175,7 +169,11 @@ const collectSynologyChatSecurityWarnings =
       account.dmPolicy === "allowlist" &&
       account.allowedUserIds.length === 0 &&
       '- Synology Chat: dmPolicy="allowlist" with empty allowedUserIds blocks all senders. Add users or set dmPolicy="open" with allowedUserIds=["*"].',
-  );
+  ),
+  checkId: "channels.synology-chat.dm.policy",
+  severity: "critical",
+  title: "Synology Chat security warning",
+});
 
 type SynologyChatOutboundResult = {
   channel: typeof CHANNEL_ID;
@@ -202,7 +200,7 @@ type SynologyChatPlugin = Omit<
     collectWarnings: (params: {
       cfg: OpenClawConfig;
       account: ResolvedSynologyChatAccount;
-    }) => string[];
+    }) => Array<string | ReturnType<typeof collectSynologyGatewayRoutingFindings>[number]>;
   };
   messaging: {
     targetPrefixes?: readonly string[];
@@ -241,15 +239,6 @@ type SynologyChatPlugin = Omit<
     messageToolHints: () => string[];
   };
 };
-
-const collectSynologyChatRoutingWarnings = projectAccountConfigWarningCollector<
-  ResolvedSynologyChatAccount,
-  OpenClawConfig,
-  SynologySecurityWarningContext
->(
-  (cfg) => cfg,
-  ({ account, cfg }) => collectSynologyGatewayRoutingWarnings({ account, cfg }),
-);
 
 function resolveOutboundAccount(
   cfg: OpenClawConfig,
@@ -546,12 +535,11 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
     },
     security: {
       resolveDmPolicy: resolveSynologyChatDmPolicy,
-      collectWarnings: composeWarningCollectors(
-        projectAccountWarningCollector<ResolvedSynologyChatAccount, SynologySecurityWarningContext>(
-          collectSynologyChatSecurityWarnings,
-        ),
-        collectSynologyChatRoutingWarnings,
-      ),
+      collectWarnings: ({ account, cfg }) => [
+        ...collectSynologyChatSecurityWarnings(account),
+        ...collectSynologyChatCriticalFindings(account),
+        ...collectSynologyGatewayRoutingFindings({ account, cfg }),
+      ],
       collectAuditFindings: collectSynologyChatSecurityAuditFindings,
     },
     outbound: {

--- a/extensions/synology-chat/src/gateway-runtime.ts
+++ b/extensions/synology-chat/src/gateway-runtime.ts
@@ -173,10 +173,10 @@ function collectSynologyGatewayStartupIssues(params: {
   return issues;
 }
 
-export function collectSynologyGatewayRoutingWarnings(params: {
+export function collectSynologyGatewayRoutingFindings(params: {
   cfg: OpenClawConfig;
   account: ResolvedSynologyChatAccount;
-}): string[] {
+}) {
   return collectSynologyGatewayStartupIssues({
     cfg: params.cfg,
     account: params.account,
@@ -188,7 +188,12 @@ export function collectSynologyGatewayRoutingWarnings(params: {
         issue.code === "duplicate-webhook-path" ||
         issue.code === "duplicate-webhook-url",
     )
-    .map((issue) => `- Synology Chat: ${issue.message}`);
+    .map((issue) => ({
+      checkId: `channels.synology-chat.routing.${issue.code}`,
+      severity: issue.code === "duplicate-webhook-url" ? ("critical" as const) : ("warn" as const),
+      title: "Synology Chat security warning",
+      detail: `Synology Chat: ${issue.message}`,
+    }));
 }
 
 export function validateSynologyGatewayAccountStartup(params: {

--- a/extensions/telegram/src/security.ts
+++ b/extensions/telegram/src/security.ts
@@ -1,7 +1,10 @@
 // Telegram plugin module implements security behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
-import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import {
+  createAllowlistProviderRouteAllowlistWarningCollector,
+  createConditionalWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
 import { resolveDefaultTelegramAccountId } from "./account-selection.js";
 import type { ResolvedTelegramAccount } from "./accounts.js";
 import { resolveTelegramSecurityDmRoute } from "./dm-session-key.js";
@@ -35,6 +38,12 @@ const collectTelegramSecurityWarnings =
       groupAllowFromPath: "channels.telegram.groupAllowFrom",
     },
   });
+const collectTelegramOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectTelegramSecurityWarnings,
+  checkId: "channels.telegram.groups.open",
+  severity: "critical",
+  title: "Telegram security warning",
+});
 
 export const telegramSecurityAdapter = {
   resolveDmPolicy: resolveTelegramDmPolicy,
@@ -42,6 +51,6 @@ export const telegramSecurityAdapter = {
     resolveDmRoute: (ctx) =>
       resolveTelegramSecurityDmRoute(resolveDefaultTelegramAccountId(ctx.cfg), ctx),
   },
-  collectWarnings: collectTelegramSecurityWarnings,
+  collectWarnings: collectTelegramOpenGroupFindings,
   collectAuditFindings: collectTelegramSecurityAuditFindings,
 } satisfies NonNullable<ChannelPlugin<ResolvedTelegramAccount>["security"]>;

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -322,7 +322,13 @@ describe("whatsapp setup wizard", () => {
     });
 
     expect(warnings).toEqual([
-      '- WhatsApp groups: groupPolicy="open" with no channels.whatsapp.accounts.default.groups allowlist; any group can add + ping (mention-gated). Set channels.whatsapp.accounts.default.groupPolicy="allowlist" + channels.whatsapp.accounts.default.groupAllowFrom or configure channels.whatsapp.accounts.default.groups.',
+      {
+        checkId: "channels.whatsapp.groups.open",
+        severity: "critical",
+        title: "WhatsApp security warning",
+        detail:
+          'WhatsApp groups: groupPolicy="open" with no channels.whatsapp.accounts.default.groups allowlist; any group can add + ping (mention-gated). Set channels.whatsapp.accounts.default.groupPolicy="allowlist" + channels.whatsapp.accounts.default.groupAllowFrom or configure channels.whatsapp.accounts.default.groups.',
+      },
     ]);
   });
 
@@ -354,7 +360,13 @@ describe("whatsapp setup wizard", () => {
     });
 
     expect(warnings).toEqual([
-      '- WhatsApp groups: groupPolicy="open" with no channels.whatsapp.accounts.Default.groups allowlist; any group can add + ping (mention-gated). Set channels.whatsapp.accounts.Default.groupPolicy="allowlist" + channels.whatsapp.accounts.Default.groupAllowFrom or configure channels.whatsapp.accounts.Default.groups.',
+      {
+        checkId: "channels.whatsapp.groups.open",
+        severity: "critical",
+        title: "WhatsApp security warning",
+        detail:
+          'WhatsApp groups: groupPolicy="open" with no channels.whatsapp.accounts.Default.groups allowlist; any group can add + ping (mention-gated). Set channels.whatsapp.accounts.Default.groupPolicy="allowlist" + channels.whatsapp.accounts.Default.groupAllowFrom or configure channels.whatsapp.accounts.Default.groups.',
+      },
     ]);
   });
 

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -9,6 +9,7 @@ import {
 import {
   collectOpenGroupPolicyRouteAllowlistWarnings,
   createAllowlistProviderGroupPolicyWarningCollector,
+  createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
@@ -145,6 +146,12 @@ export function createWhatsAppPluginBase(params: {
         },
       }),
   });
+  const collectWhatsAppOpenGroupFindings = createConditionalWarningCollector.findings({
+    collectWarnings: collectWhatsAppSecurityWarnings,
+    checkId: "channels.whatsapp.groups.open",
+    severity: "critical",
+    title: "WhatsApp security warning",
+  });
   const base = createChannelPluginBase({
     id: WHATSAPP_CHANNEL,
     meta: {
@@ -209,7 +216,7 @@ export function createWhatsAppPluginBase(params: {
     security: {
       applyConfigFixes: applyWhatsAppSecurityConfigFixes,
       resolveDmPolicy: whatsappResolveDmPolicy,
-      collectWarnings: collectWhatsAppSecurityWarnings,
+      collectWarnings: collectWhatsAppOpenGroupFindings,
     },
     doctor: whatsappDoctor,
     setupContract: params.setupContract,

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -21,6 +21,7 @@ import {
 import {
   buildOpenGroupPolicyRestrictSendersWarning,
   buildOpenGroupPolicyWarning,
+  createConditionalWarningCollector,
   createOpenProviderGroupPolicyWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import {
@@ -189,6 +190,12 @@ const collectZaloSecurityWarnings = createOpenProviderGroupPolicyWarningCollecto
     ];
   },
 });
+const collectZaloOpenGroupFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectZaloSecurityWarnings,
+  checkId: "channels.zalo.groups.open",
+  severity: "critical",
+  title: "Zalo security warning",
+});
 
 export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
   createChatChannelPlugin({
@@ -285,7 +292,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
     },
     security: {
       resolveDmPolicy: resolveZaloDmPolicy,
-      collectWarnings: collectZaloSecurityWarnings,
+      collectWarnings: collectZaloOpenGroupFindings,
     },
     pairing: {
       text: {

--- a/src/channels/plugins/group-policy-warnings.ts
+++ b/src/channels/plugins/group-policy-warnings.ts
@@ -10,6 +10,7 @@ import {
 } from "../../config/runtime-group-policy.js";
 import type { GroupPolicy } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SecurityAuditFinding } from "../../security/audit.types.js";
 
 type GroupPolicyWarningCollector = (groupPolicy: GroupPolicy) => string[];
 type AccountGroupPolicyWarningCollector<ResolvedAccount> = (params: {
@@ -72,18 +73,39 @@ export function projectAccountConfigWarningCollector<
   );
 }
 
-export function createConditionalWarningCollector<Params>(
-  ...collectors: Array<(params: Params) => string | string[] | null | undefined | false>
-): WarningCollector<Params> {
+function createSecurityAuditFindingCollector<Params>(options: {
+  collectWarnings: (params: Params) => string[];
+  checkId: string;
+  severity: SecurityAuditFinding["severity"];
+  title: string;
+}): (params: Params) => SecurityAuditFinding[] {
   return (params) =>
-    collectors.flatMap((collector) => {
-      const next = collector(params);
-      if (!next) {
-        return [];
-      }
-      return Array.isArray(next) ? next : [next];
-    });
+    options
+      .collectWarnings(params)
+      .map((message) => message.trim())
+      .filter(Boolean)
+      .map((message) => ({
+        checkId: options.checkId,
+        severity: options.severity,
+        title: options.title,
+        detail: message.replace(/^-\s*/, ""),
+      }));
 }
+
+export const createConditionalWarningCollector = Object.assign(
+  <Params>(
+    ...collectors: Array<(params: Params) => string | string[] | null | undefined | false>
+  ): WarningCollector<Params> =>
+    (params) =>
+      collectors.flatMap((collector) => {
+        const next = collector(params);
+        if (!next) {
+          return [];
+        }
+        return Array.isArray(next) ? next : [next];
+      }),
+  { findings: createSecurityAuditFindingCollector },
+);
 
 export function composeAccountWarningCollectors<
   ResolvedAccount,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -20,6 +20,7 @@ import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { ResolverContext, SecretDefaults } from "../../secrets/runtime-shared.js";
 import type { SecretTargetRegistryEntry } from "../../secrets/target-registry-types.js";
+import type { SecurityAuditFinding } from "../../security/audit.types.js";
 import type { ChannelApprovalNativeAdapter } from "./approval-native.types.js";
 import type { ChannelRuntimeSurface } from "./channel-runtime-surface.types.js";
 import type { ConfigWriteTarget } from "./config-writes.js";
@@ -832,7 +833,9 @@ export type ChannelSecurityAdapter<ResolvedAccount = unknown> = {
     ) => { kind: "core" | "isolated" } | { sessionKey: string } | undefined;
   };
   collectWarnings?: ChannelAdapterCallback<
-    (ctx: ChannelSecurityContext<ResolvedAccount>) => Promise<string[]> | string[]
+    (
+      ctx: ChannelSecurityContext<ResolvedAccount>,
+    ) => Promise<Array<string | SecurityAuditFinding>> | Array<string | SecurityAuditFinding>
   >;
   collectAuditFindings?: ChannelAdapterCallback<
     (
@@ -841,23 +844,7 @@ export type ChannelSecurityAdapter<ResolvedAccount = unknown> = {
         orderedAccountIds: string[];
         hasExplicitAccountPath: boolean;
       },
-    ) =>
-      | Promise<
-          Array<{
-            checkId: string;
-            severity: "info" | "warn" | "critical";
-            title: string;
-            detail: string;
-            remediation?: string;
-          }>
-        >
-      | Array<{
-          checkId: string;
-          severity: "info" | "warn" | "critical";
-          title: string;
-          detail: string;
-          remediation?: string;
-        }>
+    ) => Promise<SecurityAuditFinding[]> | SecurityAuditFinding[]
   >;
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -34,7 +34,7 @@ vi.mock("../secrets/target-registry-data.js", async (importOriginal) => {
   };
 });
 
-import { noteSecurityWarnings } from "./doctor-security.js";
+import { collectSecurityWarnings, noteSecurityWarnings } from "./doctor-security.js";
 
 describe("noteSecurityWarnings gateway exposure", () => {
   let prevToken: string | undefined;
@@ -152,13 +152,32 @@ describe("noteSecurityWarnings gateway exposure", () => {
 
   it("warns when exposed without auth", async () => {
     const cfg = { gateway: { bind: "lan" } } as OpenClawConfig;
+    const findings = await collectSecurityWarnings(cfg, {});
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "gateway.bind_no_auth",
+        severity: "critical",
+        title: "CRITICAL",
+        detail: expect.stringContaining("without authentication"),
+        remediation: expect.stringContaining("openclaw doctor --fix"),
+      }),
+    ]);
+
     await noteSecurityWarnings(cfg);
     const message = lastMessage();
-    expect(message).toContain("CRITICAL");
-    expect(message).toContain("without authentication");
-    expect(message).toContain("Safer remote access");
-    expect(message).toContain("ssh -N -L 18789:127.0.0.1:18789");
-    expect(message).toContain("openclaw security audit --deep");
+    expect(message).toBe(
+      [
+        '- CRITICAL: Gateway bound to "lan" (0.0.0.0) without authentication.',
+        "  Anyone on your network (or internet if port-forwarded) can fully control your agent.",
+        "  Fix: openclaw config set gateway.bind loopback",
+        "  Safer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.",
+        "  Example tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host",
+        "  Docs: https://docs.openclaw.ai/gateway/remote",
+        "  Fix: openclaw doctor --fix to generate a token",
+        "  Or set token directly: openclaw config set gateway.auth.mode token",
+        "- Run: openclaw security audit --deep",
+      ].join("\n"),
+    );
   });
 
   it("uses env token to avoid critical warning", async () => {
@@ -373,7 +392,7 @@ describe("noteSecurityWarnings gateway exposure", () => {
   });
 
   it("warns when model provider API keys are stored as plaintext in config", async () => {
-    await noteSecurityWarnings({
+    const cfg = {
       models: {
         providers: {
           openai: {
@@ -381,7 +400,19 @@ describe("noteSecurityWarnings gateway exposure", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig);
+    } as unknown as OpenClawConfig;
+    const findings = await collectSecurityWarnings(cfg, {});
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "config.plaintext_secrets",
+        severity: "warn",
+        title: "WARNING",
+        detail: "openclaw.json contains plaintext secret-bearing config fields.",
+        remediation: expect.stringContaining("models.providers.openai.apiKey"),
+      }),
+    ]);
+
+    await noteSecurityWarnings(cfg);
 
     const message = lastMessage();
     expect(message).toContain("plaintext secret-bearing config fields");

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -21,10 +21,11 @@ import { isLikelySensitiveModelProviderHeaderName } from "../secrets/model-provi
 import { hasConfiguredPlaintextSecretValue } from "../secrets/secret-value.js";
 import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
 import { collectChannelSecurityFindingsCore } from "../security/audit-channel.js";
+import type { SecurityAuditFinding } from "../security/audit.types.js";
 import { collectExecFilesystemPolicyDriftHits } from "../security/exec-filesystem-policy.js";
 
-function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): string[] {
-  const warnings: string[] = [];
+function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
 
   const maybeWarn = (params: {
     label: string;
@@ -38,10 +39,14 @@ function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): stri
     if (heartbeat.directPolicy !== undefined) {
       return;
     }
-    warnings.push(
-      `- ${params.label}: heartbeat delivery is configured while ${params.pathHint} is unset.`,
-      '  Heartbeat now allows direct/DM targets by default. Set it explicitly to "allow" or "block" to pin upgrade behavior.',
-    );
+    findings.push({
+      checkId: "doctor.heartbeat_direct_policy_unset",
+      severity: "warn",
+      title: params.label,
+      detail: `heartbeat delivery is configured while ${params.pathHint} is unset.`,
+      remediation:
+        'Heartbeat now allows direct/DM targets by default. Set it explicitly to "allow" or "block" to pin upgrade behavior.',
+    });
   };
 
   maybeWarn({
@@ -59,7 +64,7 @@ function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): stri
     });
   }
 
-  return warnings;
+  return findings;
 }
 
 function execSecurityRank(value: ExecSecurity): number {
@@ -86,8 +91,8 @@ function execAskRank(value: ExecAsk): number {
   throw new Error("Unsupported exec ask value");
 }
 
-function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
-  const warnings: string[] = [];
+function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
   const approvals = loadExecApprovalsReadOnly();
   const defaultRequestedSecuritySource = "OpenClaw default (full)";
   const defaultRequestedAskSource = "OpenClaw default (off)";
@@ -155,16 +160,19 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
       hostParts.push(`${snapshot.ask.hostSource}="${snapshot.ask.host}"`);
     }
 
-    warnings.push(
-      [
-        `- ${params.scopeLabel} is broader than the host exec policy.`,
-        `  Config: ${configParts.join(", ")}`,
-        `  Host: ${hostParts.join(", ")}`,
-        `  Effective host exec stays security="${snapshot.security.effective}" ask="${snapshot.ask.effective}" because the stricter side wins.`,
-        "  Headless runs like isolated cron cannot answer approval prompts; align both files or enable Web UI, terminal UI, or chat exec approvals.",
-        `  Inspect with: ${formatCliCommand("openclaw approvals get --gateway")}`,
+    findings.push({
+      checkId: "doctor.exec_policy_conflict",
+      severity: "warn",
+      title: `${params.scopeLabel} is broader than the host exec policy.`,
+      detail: "",
+      remediation: [
+        `Config: ${configParts.join(", ")}`,
+        `Host: ${hostParts.join(", ")}`,
+        `Effective host exec stays security="${snapshot.security.effective}" ask="${snapshot.ask.effective}" because the stricter side wins.`,
+        "Headless runs like isolated cron cannot answer approval prompts; align both files or enable Web UI, terminal UI, or chat exec approvals.",
+        `Inspect with: ${formatCliCommand("openclaw approvals get --gateway")}`,
       ].join("\n"),
-    );
+    });
   };
 
   maybeWarn({
@@ -182,27 +190,30 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
     });
   }
 
-  return warnings;
+  return findings;
 }
 
-function collectDurableExecApprovalWarnings(cfg: OpenClawConfig): string[] {
+function collectDurableExecApprovalWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   void cfg;
   return [];
 }
 
-function collectExecFilesystemPolicyWarnings(cfg: OpenClawConfig): string[] {
-  return collectExecFilesystemPolicyDriftHits(cfg).map((hit) =>
-    [
-      `- ${hit.scopeLabel}: filesystem write tools are disabled, but exec is still available.`,
-      `  Runtime tools: ${hit.runtimeTools.join(", ")}; disabled filesystem tools: ${hit.disabledFilesystemTools.join(", ")}.`,
-      `  Effective exec host is "${hit.execHost}" with sandbox.mode="${hit.sandboxMode}" and workspaceAccess="${hit.sandboxWorkspaceAccess}".`,
-      "  The exec shell can still write wherever that host or sandbox filesystem permits.",
-      '  For read-only agents, also deny exec/process; otherwise use sandbox mode "all" with workspaceAccess "ro" or "none".',
+function collectExecFilesystemPolicyWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  return collectExecFilesystemPolicyDriftHits(cfg).map((hit) => ({
+    checkId: "doctor.exec_filesystem_policy",
+    severity: "warn",
+    title: hit.scopeLabel,
+    detail: "filesystem write tools are disabled, but exec is still available.",
+    remediation: [
+      `Runtime tools: ${hit.runtimeTools.join(", ")}; disabled filesystem tools: ${hit.disabledFilesystemTools.join(", ")}.`,
+      `Effective exec host is "${hit.execHost}" with sandbox.mode="${hit.sandboxMode}" and workspaceAccess="${hit.sandboxWorkspaceAccess}".`,
+      "The exec shell can still write wherever that host or sandbox filesystem permits.",
+      'For read-only agents, also deny exec/process; otherwise use sandbox mode "all" with workspaceAccess "ro" or "none".',
     ].join("\n"),
-  );
+  }));
 }
 
-function collectPlaintextConfigSecretWarnings(cfg: OpenClawConfig): string[] {
+function collectPlaintextConfigSecretWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const plaintextPaths: string[] = [];
   const defaults = cfg.secrets?.defaults;
 
@@ -240,33 +251,45 @@ function collectPlaintextConfigSecretWarnings(cfg: OpenClawConfig): string[] {
     extraCount > 0 ? `${samplePaths.join(", ")} (+${extraCount} more)` : samplePaths.join(", ");
 
   return [
-    "- WARNING: openclaw.json contains plaintext secret-bearing config fields.",
-    `  Paths: ${pathLine}`,
-    "  Agents or workspace tools that can read config files may see these API keys/tokens.",
-    `  Migrate them to SecretRefs with ${formatCliCommand("openclaw secrets configure")} or ${formatCliCommand("openclaw secrets apply")}, then verify with ${formatCliCommand("openclaw secrets audit --check")}.`,
+    {
+      checkId: "config.plaintext_secrets",
+      severity: "warn",
+      title: "WARNING",
+      detail: "openclaw.json contains plaintext secret-bearing config fields.",
+      remediation: [
+        `Paths: ${pathLine}`,
+        "Agents or workspace tools that can read config files may see these API keys/tokens.",
+        `Migrate them to SecretRefs with ${formatCliCommand("openclaw secrets configure")} or ${formatCliCommand("openclaw secrets apply")}, then verify with ${formatCliCommand("openclaw secrets audit --check")}.`,
+      ].join("\n"),
+    },
   ];
 }
 
-/** Collects doctor security warnings without emitting terminal notes. */
+/** Collects doctor security findings without emitting terminal notes. */
 export async function collectSecurityWarnings(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
-): Promise<string[]> {
-  const warnings: string[] = [];
+): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
 
   if (cfg.approvals?.exec?.enabled === false) {
-    warnings.push(
-      "- Note: approvals.exec.enabled=false disables approval forwarding only.",
-      `  Host exec gating still comes from ${resolveExecApprovalsDisplayPath()}.`,
-      `  Check local policy with: ${formatCliCommand("openclaw approvals get --gateway")}`,
-    );
+    findings.push({
+      checkId: "doctor.approval_forwarding_disabled",
+      severity: "warn",
+      title: "Note",
+      detail: "approvals.exec.enabled=false disables approval forwarding only.",
+      remediation: [
+        `Host exec gating still comes from ${resolveExecApprovalsDisplayPath()}.`,
+        `Check local policy with: ${formatCliCommand("openclaw approvals get --gateway")}`,
+      ].join("\n"),
+    });
   }
 
-  warnings.push(...collectImplicitHeartbeatDirectPolicyWarnings(cfg));
-  warnings.push(...collectExecPolicyConflictWarnings(cfg));
-  warnings.push(...collectExecFilesystemPolicyWarnings(cfg));
-  warnings.push(...collectPlaintextConfigSecretWarnings(cfg));
-  warnings.push(...collectDurableExecApprovalWarnings(cfg));
+  findings.push(...collectImplicitHeartbeatDirectPolicyWarnings(cfg));
+  findings.push(...collectExecPolicyConflictWarnings(cfg));
+  findings.push(...collectExecFilesystemPolicyWarnings(cfg));
+  findings.push(...collectPlaintextConfigSecretWarnings(cfg));
+  findings.push(...collectDurableExecApprovalWarnings(cfg));
 
   // Network exposure needs auth proof before doctor can treat non-loopback bind as intentional.
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
@@ -299,9 +322,9 @@ export async function collectSecurityWarnings(
     (resolvedAuth.mode === "password" && hasPassword);
   const bindDescriptor = `"${gatewayBind}" (${resolvedBindHost})`;
   const saferRemoteAccessLines = [
-    "  Safer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.",
-    "  Example tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host",
-    "  Docs: https://docs.openclaw.ai/gateway/remote",
+    "Safer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.",
+    "Example tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host",
+    "Docs: https://docs.openclaw.ai/gateway/remote",
   ];
 
   if (isExposed) {
@@ -309,35 +332,53 @@ export async function collectSecurityWarnings(
       const authFixLines =
         resolvedAuth.mode === "password"
           ? [
-              `  Fix: ${formatCliCommand("openclaw configure")} to set a password`,
-              `  Or switch to token: ${formatCliCommand("openclaw config set gateway.auth.mode token")}`,
+              `Fix: ${formatCliCommand("openclaw configure")} to set a password`,
+              `Or switch to token: ${formatCliCommand("openclaw config set gateway.auth.mode token")}`,
             ]
           : [
-              `  Fix: ${formatCliCommand("openclaw doctor --fix")} to generate a token`,
-              `  Or set token directly: ${formatCliCommand(
+              `Fix: ${formatCliCommand("openclaw doctor --fix")} to generate a token`,
+              `Or set token directly: ${formatCliCommand(
                 "openclaw config set gateway.auth.mode token",
               )}`,
             ];
-      warnings.push(
-        `- CRITICAL: Gateway bound to ${bindDescriptor} without authentication.`,
-        `  Anyone on your network (or internet if port-forwarded) can fully control your agent.`,
-        `  Fix: ${formatCliCommand("openclaw config set gateway.bind loopback")}`,
-        ...saferRemoteAccessLines,
-        ...authFixLines,
-      );
+      findings.push({
+        checkId: "gateway.bind_no_auth",
+        severity: "critical",
+        title: "CRITICAL",
+        detail: [
+          `Gateway bound to ${bindDescriptor} without authentication.`,
+          "Anyone on your network (or internet if port-forwarded) can fully control your agent.",
+        ].join("\n"),
+        remediation: [
+          `Fix: ${formatCliCommand("openclaw config set gateway.bind loopback")}`,
+          ...saferRemoteAccessLines,
+          ...authFixLines,
+        ].join("\n"),
+      });
     } else {
       // Auth is configured, but still warn about network exposure
-      warnings.push(
-        `- WARNING: Gateway bound to ${bindDescriptor} (network-accessible).`,
-        `  Ensure your auth credentials are strong and not exposed.`,
-        ...saferRemoteAccessLines,
-      );
+      findings.push({
+        checkId: "gateway.bind_network_accessible",
+        severity: "warn",
+        title: "WARNING",
+        detail: [
+          `Gateway bound to ${bindDescriptor} (network-accessible).`,
+          "Ensure your auth credentials are strong and not exposed.",
+        ].join("\n"),
+        remediation: saferRemoteAccessLines.join("\n"),
+      });
     }
   }
 
   const tokenConflict = resolveGatewayAuthTokenSourceConflict({ cfg, env });
   if (tokenConflict) {
-    warnings.push(...tokenConflict.warningLines);
+    findings.push({
+      checkId: tokenConflict.checkId,
+      severity: tokenConflict.severity,
+      title: "WARNING",
+      detail: `${tokenConflict.title}.\n${tokenConflict.detail}`,
+      remediation: `Fix: ${tokenConflict.remediation}`,
+    });
   }
 
   const channelFindings = await collectChannelSecurityFindingsCore({
@@ -348,20 +389,27 @@ export async function collectSecurityWarnings(
       includeSetupFallbackPlugins: true,
     }),
   });
-  for (const finding of channelFindings) {
-    warnings.push(`- ${finding.title}: ${finding.detail}`);
-    if (finding.remediation) {
-      warnings.push(`  ${finding.remediation}`);
-    }
+  findings.push(...channelFindings);
+  return findings;
+}
+
+function renderSecurityFindingLines(finding: SecurityAuditFinding): string[] {
+  const detailLines = finding.detail.split("\n");
+  const firstDetail = detailLines.shift() ?? "";
+  const lines = [`- ${finding.title}${firstDetail ? `: ${firstDetail}` : ""}`];
+  lines.push(...detailLines.map((line) => `  ${line}`));
+  if (finding.remediation) {
+    lines.push(...finding.remediation.split("\n").map((line) => `  ${line}`));
   }
-  return warnings;
+  return lines;
 }
 
 /** Emits security warnings plus the deep audit follow-up command. */
 export async function noteSecurityWarnings(cfg: OpenClawConfig) {
-  const warnings = await collectSecurityWarnings(cfg);
-  if (warnings.length > 0) {
-    warnings.push(`- Run: ${formatCliCommand("openclaw security audit --deep")}`);
-    note(warnings.join("\n"), "Security");
+  const findings = await collectSecurityWarnings(cfg);
+  if (findings.length > 0) {
+    const lines = findings.flatMap(renderSecurityFindingLines);
+    lines.push(`- Run: ${formatCliCommand("openclaw security audit --deep")}`);
+    note(lines.join("\n"), "Security");
   }
 }

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -100,7 +100,7 @@ function createDeps(overrides: Partial<CoreHealthCheckDeps> = {}): CoreHealthChe
     async detectUnavailableSkills(): Promise<readonly SkillStatusEntry[]> {
       return [];
     },
-    async collectSecurityWarnings(): Promise<readonly string[]> {
+    async collectSecurityWarnings() {
       return [];
     },
     async collectWorkspaceSuggestionNotes(): Promise<readonly string[]> {
@@ -539,14 +539,25 @@ describe("CORE_HEALTH_CHECKS", () => {
     );
   });
 
-  it("converts security doctor warnings into health findings", async () => {
+  it("keeps one structured security condition as one health finding", async () => {
     const check = getCheck(
       createCoreHealthChecks(
         createDeps({
-          async collectSecurityWarnings(): Promise<readonly string[]> {
+          async collectSecurityWarnings() {
             return [
-              '- CRITICAL: Gateway bound to "lan" (0.0.0.0) without authentication.',
-              '- WARNING: Gateway bound to "lan" (0.0.0.0).',
+              {
+                checkId: "gateway.bind_no_auth",
+                severity: "critical" as const,
+                title: "CRITICAL",
+                detail: [
+                  'Gateway bound to "lan" (0.0.0.0) without authentication.',
+                  "Anyone on your network can fully control your agent.",
+                ].join("\n"),
+                remediation: [
+                  "Fix: openclaw config set gateway.bind loopback",
+                  "Fix: openclaw doctor --fix to generate a token",
+                ].join("\n"),
+              },
             ];
           },
         }),
@@ -567,20 +578,18 @@ describe("CORE_HEALTH_CHECKS", () => {
       },
     });
 
-    expect(findings).toContainEqual(
+    expect(findings).toEqual([
       expect.objectContaining({
         checkId: "core/doctor/security",
         severity: "error",
-        message: expect.stringContaining("Gateway bound"),
+        message: 'CRITICAL: Gateway bound to "lan" (0.0.0.0) without authentication.',
+        fixHint: [
+          "Anyone on your network can fully control your agent.",
+          "Fix: openclaw config set gateway.bind loopback",
+          "Fix: openclaw doctor --fix to generate a token",
+        ].join("\n"),
       }),
-    );
-    expect(findings).toContainEqual(
-      expect.objectContaining({
-        checkId: "core/doctor/security",
-        severity: "warning",
-        message: expect.stringContaining("Gateway bound"),
-      }),
-    );
+    ]);
   });
 
   it("reports disabled Codex plugin routes as core health findings", async () => {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -38,6 +38,7 @@ import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugin-metadata-snapshot.js";
 import { getSkippedExecRefStaticError } from "../secrets/exec-resolution-policy.js";
+import type { SecurityAuditFinding } from "../security/audit.types.js";
 import type { SkillStatusEntry } from "../skills/discovery/status.js";
 import { resolveSkillWorkshopConfig } from "../skills/workshop/config.js";
 import { detectSkillWorkshopToolPolicyDiagnostic } from "../skills/workshop/tool-policy-diagnostic.js";
@@ -74,7 +75,9 @@ const loadDoctorWorkspaceModule = async () => await import("../commands/doctor-w
 
 export type CoreHealthCheckDeps = {
   readonly detectUnavailableSkills: typeof detectUnavailableSkillsWithRuntime;
-  readonly collectSecurityWarnings: (cfg: OpenClawConfig) => Promise<readonly string[]>;
+  readonly collectSecurityWarnings: (
+    cfg: OpenClawConfig,
+  ) => Promise<readonly SecurityAuditFinding[]>;
   readonly collectWorkspaceSuggestionNotes: (workspaceDir: string) => Promise<readonly string[]>;
   readonly collectRuntimeToolSchemaFindings: (
     ctx: HealthCheckContext,
@@ -99,7 +102,9 @@ async function detectUnavailableSkillsWithRuntime(
   return ctx.cwd ? runtime.detectUnavailableSkills(ctx.cfg, ctx.cwd) : [];
 }
 
-async function collectSecurityWarningsWithRuntime(cfg: OpenClawConfig): Promise<readonly string[]> {
+async function collectSecurityWarningsWithRuntime(
+  cfg: OpenClawConfig,
+): Promise<readonly SecurityAuditFinding[]> {
   const { collectSecurityWarnings } = await import("../commands/doctor-security.js");
   return collectSecurityWarnings(cfg);
 }
@@ -764,15 +769,22 @@ function createSecurityCheck(deps: CoreHealthCheckDeps): HealthCheck {
     description: "Security posture checks produce structured findings.",
     source: "doctor",
     async detect(ctx) {
-      const warnings = await deps.collectSecurityWarnings(ctx.cfg);
-      return warnings.map((warning) =>
-        noteTextToFinding({
-          checkId: "core/doctor/security",
-          severity: warning.includes("CRITICAL") ? "error" : "warning",
-          text: warning,
-        }),
-      );
+      const findings = await deps.collectSecurityWarnings(ctx.cfg);
+      return findings.map(securityAuditFindingToHealthFinding);
     },
+  };
+}
+
+function securityAuditFindingToHealthFinding(finding: SecurityAuditFinding): HealthFinding {
+  const detailLines = finding.detail.split("\n");
+  const firstDetail = detailLines.shift() ?? "";
+  const fixHint = [...detailLines, ...(finding.remediation?.split("\n") ?? [])].join("\n");
+  return {
+    checkId: "core/doctor/security",
+    severity:
+      finding.severity === "critical" ? "error" : finding.severity === "warn" ? "warning" : "info",
+    message: `${finding.title}${firstDetail ? `: ${firstDetail}` : ""}`,
+    ...(fixHint ? { fixHint } : {}),
   };
 }
 

--- a/src/gateway/auth-token-source-conflict.ts
+++ b/src/gateway/auth-token-source-conflict.ts
@@ -11,10 +11,10 @@ const GATEWAY_SERVICE_KIND = "gateway";
 // make direct clients use a different token than the managed gateway service.
 type GatewayAuthTokenSourceConflict = {
   checkId: "gateway.env_token_overrides_config";
+  severity: "warn";
   title: string;
   detail: string;
   remediation: string;
-  warningLines: string[];
   diagnostic: string;
 };
 
@@ -72,10 +72,10 @@ export function resolveGatewayAuthTokenSourceConflict(params: {
 
   return {
     checkId: "gateway.env_token_overrides_config",
+    severity: "warn",
     title,
     detail,
     remediation,
-    warningLines: [`- WARNING: ${title}.`, `  ${detail}`, `  Fix: ${remediation}`],
     diagnostic: `${title}: ${remediation}`,
   };
 }

--- a/src/plugin-sdk/channel-policy.test.ts
+++ b/src/plugin-sdk/channel-policy.test.ts
@@ -171,6 +171,7 @@ describe("createRestrictSendersChannelSecurity", () => {
       groupPolicyPath: "channels.line.groupPolicy",
       groupAllowFromPath: "channels.line.groupAllowFrom",
       mentionGated: false,
+      findingTitle: "LINE security warning",
       policyPathSuffix: "dmPolicy",
       dmRouting,
     });
@@ -206,7 +207,13 @@ describe("createRestrictSendersChannelSecurity", () => {
         },
       }),
     ).toEqual([
-      '- LINE groups: groupPolicy="open" allows any member in groups to trigger. Set channels.line.groupPolicy="allowlist" + channels.line.groupAllowFrom to restrict senders.',
+      {
+        checkId: "channels.line.groups.open",
+        severity: "critical",
+        title: "LINE security warning",
+        detail:
+          'LINE groups: groupPolicy="open" allows any member in groups to trigger. Set channels.line.groupPolicy="allowlist" + channels.line.groupAllowFrom to restrict senders.',
+      },
     ]);
   });
 });

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -5,7 +5,10 @@ import {
   uniqueStrings,
 } from "../../packages/normalization-core/src/string-normalization.js";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
-import { createAllowlistProviderRestrictSendersWarningCollector } from "../channels/plugins/group-policy-warnings.js";
+import {
+  createAllowlistProviderRestrictSendersWarningCollector,
+  createConditionalWarningCollector,
+} from "../channels/plugins/group-policy-warnings.js";
 import type { ChannelSecurityAdapter } from "../channels/plugins/types.adapters.js";
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 import type { GroupPolicy } from "../config/types.base.js";
@@ -374,6 +377,8 @@ export function createRestrictSendersChannelSecurity<
   groupAllowFromPath: string;
   /** Whether group replies require mentions, reducing open-policy warning severity. */
   mentionGated?: boolean;
+  /** Existing channel label used by the audit and Doctor finding renderer. */
+  findingTitle?: string;
   /** Override for channels whose provider presence is not the channel config key itself. */
   providerConfigPresent?: (cfg: OpenClawConfig) => boolean;
   /** Fallback account id used when scoped config inherits from another account. */
@@ -394,6 +399,21 @@ export function createRestrictSendersChannelSecurity<
   inheritSharedDefaultsFromDefaultAccount?: boolean;
   dmRouting?: ChannelSecurityAdapter<ResolvedAccount>["dmRouting"];
 }): ChannelSecurityAdapter<ResolvedAccount> {
+  const collectOpenGroupFindings = createConditionalWarningCollector.findings({
+    collectWarnings: createAllowlistProviderRestrictSendersWarningCollector<ResolvedAccount>({
+      providerConfigPresent:
+        params.providerConfigPresent ?? ((cfg) => cfg.channels?.[params.channelKey] !== undefined),
+      resolveGroupPolicy: params.resolveGroupPolicy,
+      surface: params.surface,
+      openScope: params.openScope,
+      groupPolicyPath: params.groupPolicyPath,
+      groupAllowFromPath: params.groupAllowFromPath,
+      mentionGated: params.mentionGated,
+    }),
+    checkId: `channels.${params.channelKey}.groups.open`,
+    severity: "critical",
+    title: params.findingTitle ?? `${params.surface} security warning`,
+  });
   return {
     resolveDmPolicy: createScopedDmSecurityResolver<ResolvedAccount>({
       channelKey: params.channelKey,
@@ -409,15 +429,6 @@ export function createRestrictSendersChannelSecurity<
       inheritSharedDefaultsFromDefaultAccount: params.inheritSharedDefaultsFromDefaultAccount,
     }),
     ...(params.dmRouting ? { dmRouting: params.dmRouting } : {}),
-    collectWarnings: createAllowlistProviderRestrictSendersWarningCollector<ResolvedAccount>({
-      providerConfigPresent:
-        params.providerConfigPresent ?? ((cfg) => cfg.channels?.[params.channelKey] !== undefined),
-      resolveGroupPolicy: params.resolveGroupPolicy,
-      surface: params.surface,
-      openScope: params.openScope,
-      groupPolicyPath: params.groupPolicyPath,
-      groupAllowFromPath: params.groupAllowFromPath,
-      mentionGated: params.mentionGated,
-    }),
+    collectWarnings: collectOpenGroupFindings,
   };
 }

--- a/src/security/audit-channel-dm-policy.test.ts
+++ b/src/security/audit-channel-dm-policy.test.ts
@@ -80,6 +80,23 @@ function createDmPlugin(
 }
 
 describe("security audit channel dm policy", () => {
+  it("keeps legacy channel warning severity independent of prose", async () => {
+    const plugin = createDmPlugin();
+    if (!plugin.security) {
+      throw new Error("test plugin security adapter missing");
+    }
+    plugin.security.collectWarnings = () => [
+      "- public access warning",
+      "- disabled integration warning",
+    ];
+
+    const findings = await collectChannelSecurityFindingsCore({ cfg: {}, plugins: [plugin] });
+    expect(findings.filter((finding) => finding.title.endsWith("security warning"))).toEqual([
+      expect.objectContaining({ severity: "warn", detail: "public access warning" }),
+      expect.objectContaining({ severity: "warn", detail: "disabled integration warning" }),
+    ]);
+  });
+
   it.each([
     {
       name: "global main + winning isolated binding is safe",

--- a/src/security/audit-channel-dm-policy.test.ts
+++ b/src/security/audit-channel-dm-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { collectChannelSecurityFindingsCore } from "./audit-channel.js";
+import { runSecurityAuditCore } from "./audit.js";
 
 type ChannelSecurityFinding = Awaited<
   ReturnType<typeof collectChannelSecurityFindingsCore>
@@ -80,21 +81,35 @@ function createDmPlugin(
 }
 
 describe("security audit channel dm policy", () => {
-  it("keeps legacy channel warning severity independent of prose", async () => {
-    const plugin = createDmPlugin();
+  it("keeps producer-owned channel severity through the audit summary", async () => {
+    const pluginOptions = {
+      accounts: { default: { policy: "disabled", allowFrom: [] } },
+    };
+    const plugin = createDmPlugin(pluginOptions);
     if (!plugin.security) {
       throw new Error("test plugin security adapter missing");
     }
     plugin.security.collectWarnings = () => [
-      "- public access warning",
-      "- disabled integration warning",
+      {
+        checkId: "channels.whatsapp.test.open_access",
+        severity: "critical",
+        title: "WhatsApp security warning",
+        detail: "Open access test finding",
+      },
     ];
 
-    const findings = await collectChannelSecurityFindingsCore({ cfg: {}, plugins: [plugin] });
-    expect(findings.filter((finding) => finding.title.endsWith("security warning"))).toEqual([
-      expect.objectContaining({ severity: "warn", detail: "public access warning" }),
-      expect.objectContaining({ severity: "warn", detail: "disabled integration warning" }),
-    ]);
+    const auditOptions = { config: {}, includeFilesystem: false } as const;
+    const baseline = await runSecurityAuditCore({
+      ...auditOptions,
+      plugins: [createDmPlugin(pluginOptions)],
+    });
+    const report = await runSecurityAuditCore({ ...auditOptions, plugins: [plugin] });
+
+    expect(requireFinding(report.findings, "channels.whatsapp.test.open_access")).toMatchObject({
+      severity: "critical",
+      detail: "Open access test finding",
+    });
+    expect(report.summary.critical).toBe(baseline.summary.critical + 1);
   });
 
   it.each([

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -22,32 +22,13 @@ import {
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
 import { parseSessionDeliveryRoute, resolveLinkedDirectPeerId } from "../routing/session-key.js";
-import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.types.js";
+import type { SecurityAuditFinding } from "./audit.types.js";
 
 type DmPrincipalRoute = {
   accountKey: string;
   logicalPrincipalKey: string;
   bucketKey: string;
 };
-
-/** Classify free-form channel warnings into audit severities. */
-function classifyChannelWarningSeverity(message: string): SecurityAuditSeverity {
-  const s = message.toLowerCase();
-  if (
-    s.includes("dms: open") ||
-    s.includes('grouppolicy="open"') ||
-    s.includes('dmpolicy="open"')
-  ) {
-    return "critical";
-  }
-  if (s.includes("allows any") || s.includes("anyone can dm") || s.includes("public")) {
-    return "critical";
-  }
-  if (s.includes("locked") || s.includes("disabled")) {
-    return "info";
-  }
-  return "warn";
-}
 
 function dedupeFindings(findings: SecurityAuditFinding[]): SecurityAuditFinding[] {
   const seen = new Set<string>();
@@ -495,7 +476,9 @@ export async function collectChannelSecurityFindingsCore(params: {
           }
           findings.push({
             checkId: `channels.${plugin.id}.warning.${findings.length + 1}`,
-            severity: classifyChannelWarningSeverity(trimmed),
+            // The legacy collectWarnings contract records warnings only. Producers that need
+            // critical or informational severity must return a structured audit finding.
+            severity: "warn",
             title: `${plugin.meta.label ?? plugin.id} security warning`,
             detail: trimmed.replace(/^-\s*/, ""),
           });

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -469,7 +469,12 @@ export async function collectChannelSecurityFindingsCore(params: {
           accountId,
           account,
         });
-        for (const message of warnings ?? []) {
+        for (const warning of warnings ?? []) {
+          if (typeof warning !== "string") {
+            findings.push(warning);
+            continue;
+          }
+          const message = warning;
           const trimmed = message.trim();
           if (!trimmed) {
             continue;

--- a/src/security/audit.types.ts
+++ b/src/security/audit.types.ts
@@ -1,5 +1,5 @@
 /** Severity levels emitted by security audit checks. */
-export type SecurityAuditSeverity = "info" | "warn" | "critical";
+type SecurityAuditSeverity = "info" | "warn" | "critical";
 
 /** One actionable or informational security audit finding. */
 export type SecurityAuditFinding = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where one doctor security condition appeared as several unrelated findings in `openclaw doctor --json` and `openclaw doctor --lint`. An unauthenticated LAN-bound Gateway was reported as eight findings—one error plus seven warning-severity remediation lines—and a plaintext config secret was reported as four warnings.

## Why This Change Was Made

Doctor security collection now keeps one canonical `SecurityAuditFinding` per condition, including the producer-recorded severity, detail, and remediation. The structured health adapter maps that recorded severity directly, while a small terminal renderer projects the same finding back into the existing human-readable lines. Existing structured channel findings no longer make a structure-to-prose-to-structure round trip.

The channel security contract now accepts either a legacy warning string or the existing canonical `SecurityAuditFinding`. Legacy strings remain warnings; producers return structured findings when they own critical or informational severity. All 26 bundled warning templates that current `main` promoted to critical now declare critical severity at their producer. No core substring classifier remains. The separate legacy Claude/browser note-capture classifier remains unchanged because it does not split lines and changing it would alter which browser status notes become failing findings.

## User Impact

Each security problem is now one actionable finding. The exposed Gateway case is one error with its consequence and all remediation attached; the plaintext-secret case is one warning with paths and migration guidance attached. Human `openclaw doctor` output is unchanged.

Consumer trace:

- `doctor --json`: exposed Gateway 8 → 1; plaintext secret 4 → 1; `checksRun` remains 28 and `ok` remains false.
- `doctor --lint`: the displayed finding count now matches logical conditions; severity-threshold behavior is unchanged for these cases.
- `openclaw health`: unchanged; it is a separate Gateway runtime snapshot and carries no doctor findings.
- Control UI health/debug surfaces: unchanged; they consume Gateway status/health data and have no doctor finding count or badge.
- `openclaw status` security audit: unchanged; it already uses canonical audit findings and reports the exposed Gateway as one critical finding.

## Evidence

Before, built dist `e38a645a751`:

```text
security findings: 8
  error    CRITICAL: Gateway bound to "lan" (0.0.0.0) without authentication.
  warning  Anyone on your network (or internet if port-forwarded) can fully control your agent.
  warning  Fix: openclaw config set gateway.bind loopback
  warning  Safer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.
  warning  Example tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host
  warning  Docs: https://docs.openclaw.ai/gateway/remote
  warning  Fix: openclaw doctor --fix to generate a token
  warning  Or set token directly: openclaw config set gateway.auth.mode token
```

After, built from this branch in Testbox run https://github.com/openclaw/openclaw/actions/runs/31960474554:

```json
{
  "security": [
    {
      "severity": "error",
      "message": "CRITICAL: Gateway bound to \"lan\" (0.0.0.0) without authentication.",
      "fixHint": "Anyone on your network (or internet if port-forwarded) can fully control your agent.\nFix: openclaw config set gateway.bind loopback\nSafer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.\nExample tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host\nDocs: https://docs.openclaw.ai/gateway/remote\nFix: openclaw doctor --fix to generate a token\nOr set token directly: openclaw config set gateway.auth.mode token"
    }
  ]
}
```

The same isolated built-dist run reproduced the plaintext-secret case as four warnings before and one warning after, with the affected path and migration guidance retained in `fixHint`. Both cases kept `checksRun: 28`. The runner used synthetic temporary configs and state directories, did not start a Gateway, and did not access the real OpenClaw profile.

Terminal rendering was captured before and after and is identical. `src/commands/doctor-security.test.ts` also asserts the complete unwrapped Security note byte-for-byte.

Validation:

- `node scripts/run-vitest.mjs src/commands/doctor-security.test.ts` — 32 passed
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.test.ts` — 23 passed
- `node scripts/run-vitest.mjs src/commands/audit.test.ts` — 34 passed
- six `src/security/audit-channel*.test.ts` files — 27 passed
- SDK plus affected Synology/Matrix/WhatsApp producer tests — 134 passed
- `node scripts/check-changed.mjs --base 5f561999a9d849d1c4fe61d13a2e932aa0ca809f` — passed every selected format, SDK, boundary, dead-code, typecheck, lint, schema, and architecture gate in Testbox run https://github.com/openclaw/openclaw/actions/runs/31959420058
- `pnpm build` — passed; all 144 public Plugin SDK subpaths verified in Testbox run https://github.com/openclaw/openclaw/actions/runs/31960178349
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base 5f561999a9d849d1c4fe61d13a2e932aa0ca809f --stream-engine-output` — clean, no accepted/actionable findings, 0.98 confidence

Production LOC: +407/-251 (net +156). Tests: +140/-34 (net +106). Docs: +8. The production growth replaces presentation-line arrays with the existing structured security contract, adds the two necessary projections, and moves 26 shipped critical classifications to 17 producer-owned channel adapters. The reusable conversion is attached to an existing SDK helper, so the public SDK budget remains exactly flat at 4,317 exports and 2,565 callable exports.

## Channel severity decision

`collectAuditFindings` was not sufficient because Doctor intentionally skips that audit-only hook. Adding another overlapping hook would duplicate the model. Instead, `collectWarnings` additively accepts `string | SecurityAuditFinding`: existing third-party string collectors remain source-compatible and warning severity, while a producer-owned structured finding flows unchanged through Doctor and the main audit. This reuses the canonical model and keeps `SecurityAuditSeverity` module-local; producers type the complete finding rather than importing the severity union separately.

The regression test first failed on the old branch with `TypeError: message.trim is not a function`. It now proves a producer-owned critical finding increments `runSecurityAuditCore`'s `summary.critical` count, not merely the channel collector output.

## Full legacy-classifier inventory

Previously critical (26 emitted templates/branches):

- Discord: open guild policy with a route allowlist; open guild policy without one.
- Feishu: open group policy allowing any member.
- Google Chat: open space policy allowing any space.
- IRC: open channel policy allowing all channels and senders.
- LINE: open group policy allowing any member in groups.
- iMessage: open group policy allowing any member.
- Matrix: open room policy allowing any room, including account-scoped path variants.
- Mattermost: open channel policy allowing any member.
- Microsoft Teams: open group policy allowing any member.
- Nextcloud Talk: open room policy with configured rooms; open room policy without a room allowlist.
- Slack: open channel policy with a route allowlist; open channel policy without one.
- SMS: open DM policy allowing any phone number.
- Synology Chat: open DM policy with an empty sender list; open DM policy with wildcard access; empty allowlist remediation that mentions switching to `dmPolicy="open"`; duplicate webhook URL warning that says “ambiguous public route.”
- Telegram: open group policy with configured groups; open group policy without a group allowlist.
- WhatsApp: open group policy with configured groups; open group policy without a group allowlist, including account-scoped path variants.
- Zalo: open group policy with an effective sender allowlist; open group policy without one.
- Signal: open group policy allowing any member.

Previously informational (three templates): IRC TLS disabled, SMS signature validation disabled, and Synology Chat SSL verification disabled. These remain legacy strings and now map to warning, which is stricter rather than a downgrade.

No active `collectWarnings` output matched the deleted classifier's `dms: open`, `anyone can dm`, or `locked` branches. The eleven remaining templates were warnings on `main` and remain warnings.

## Follow-up debt retained

- `inferCapturedNoteSeverity` remains unchanged: it classifies separately captured browser/Claude notes, does not split one condition into several findings, and changing it here would alter which status notes fail Doctor.
- `ui/src/pages/debug/view.ts` still reads `status.securityAudit`, while the current status shape does not provide that field. This unrelated mismatch remains deliberately out of scope.
