### PR TITLE
fix(scripts): drop redundant boolean comparison in worker detection

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -242,7 +242,7 @@ function isDedicatedLinuxWorker(
   if (env.DISPLAY || env.WAYLAND_DISPLAY || env.SSH_TTY) {
     return false;
   }
-  if ((options.interactive ?? process.stdin.isTTY) === true) {
+  if (options.interactive ?? process.stdin.isTTY) {
     return false;
   }
   if (options.virtualized !== undefined) {


### PR DESCRIPTION
## What Problem This Solves

`main` is red on `check-lint`, which blocks the merge gate for every open PR:

```
scripts/check-changed.mts
  245:7  error  This expression unnecessarily compares a boolean value to a boolean instead of using it directly.  typescript(no-unnecessary-boolean-literal-compare)
```

Confirmed on `main` itself (run 31955692694, commit `eb174bcaffd`, job `check-lint`), not only on PR branches. Three unrelated PRs hit the identical failure.

## Why This Change Was Made

`ChangedCheckDelegateOptions.interactive` is `boolean | undefined` and `process.stdin.isTTY` is `boolean`, so `options.interactive ?? process.stdin.isTTY` already narrows to `boolean`. The `=== true` comparison is redundant and the type-aware rule is correct to reject it.

Dropping the comparison is behavior-preserving across all three cases: `true` and `false` keep their truthiness, and an `undefined` fallback result was already falsy under `=== true`.

## User Impact

None at runtime. This only unblocks CI.

## Evidence

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/check-changed.mts` — clean (exit 0).
- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts` — 151 passed, 1 failed, and that same test (`runs trusted changed gates on a dedicated Linux worker`) fails identically on unmodified `origin/main` in this environment while passing on hosted CI, so it is ambient-environment sensitivity rather than a regression from this change. Recorded here rather than fixed, since it is a separate defect from the lint break this PR unblocks.
