### PR TITLE
test(gateway): assert the exact pinned-clock dispatch timeout

### DIFF
--- a/src/gateway/worker-environments/workspace-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-sync.test.ts
@@ -75,7 +75,9 @@ describe("worker workspace command transport retry", () => {
     ).resolves.toMatchObject({ code: 255, termination: "exit" });
     expect(run).toHaveBeenCalledOnce();
     expect(sshArgvPort(run.mock.calls[0]![0])).toBe(2222);
-    expect(run.mock.calls[0]![1].timeoutMs).toBeLessThanOrEqual(777);
+    // The pinned clock makes the derived dispatch timeout deterministic; a
+    // less-than bound would also accept zero and mask a broken deadline.
+    expect(run.mock.calls[0]![1].timeoutMs).toBe(777);
 
     await actions.runWorkspaceCommand({
       transportRetry: "idempotent",


### PR DESCRIPTION
## What Problem This Solves

`workspace-sync.test.ts` pins `Date.now` explicitly so the derived dispatch timeout is deterministic (its own comment says the pin exists to avoid a loaded-runner flake on "the exact 777 assertion") — but the assertion was weakened to `toBeLessThanOrEqual(777)`, which also accepts 0 and would pass if the deadline derivation broke entirely.

## Why This Change Was Made

With the clock pinned there is exactly one correct value; assert it. A weakened bound on a deterministic setup protects nothing.

## User Impact

None (test-only); the dispatch-deadline invariant is now actually protected.

## Evidence

- `node scripts/run-vitest.mjs run src/gateway/worker-environments/workspace-sync.test.ts` — 7/7 pass.
- LOC: test +3/−1, prod 0.
