### PR TITLE
fix(pr): support split GitHub CLI auth

### DIFF
--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -187,6 +187,28 @@ export function execGhJson(args, options = {}, params = {}) {
 }
 
 /**
+ * @param {string} repo
+ * @param {string} sha
+ * @param {string} event
+ * @param {number} perPage
+ * @returns {string[]}
+ */
+export function workflowRunsApiArgs(repo, sha, event, perPage) {
+  return [
+    "api",
+    "--method",
+    "GET",
+    `repos/${repo}/actions/workflows/ci.yml/runs`,
+    "-f",
+    `event=${event}`,
+    "-f",
+    `head_sha=${sha}`,
+    "-f",
+    `per_page=${perPage}`,
+  ];
+}
+
+/**
  * @overload
  * @param {string} endpoint
  * @param {ExecFileSyncOptionsWithStringEncoding} options

--- a/scripts/lib/plain-gh.sh
+++ b/scripts/lib/plain-gh.sh
@@ -73,8 +73,22 @@ plain_gh_search_path() {
   printf '%s\n' "$output"
 }
 
+bridge_plain_gh_auth() {
+  if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+    return 0
+  fi
+
+  local gh_path
+  local token
+  gh_path=$(type -P gh 2>/dev/null) || return 0
+  if token=$(plain_gh_env "$gh_path" auth token 2>/dev/null) && [ -n "$token" ]; then
+    export GH_TOKEN="$token"
+  fi
+}
+
 gh_plain() {
   local gh_bin
   gh_bin=$(resolve_plain_gh_bin) || return 1
+  bridge_plain_gh_auth
   plain_gh_env "$gh_bin" "$@"
 }

--- a/scripts/pr-lib/ci-dispatch.mjs
+++ b/scripts/pr-lib/ci-dispatch.mjs
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import { isDirectRunUrl } from "../lib/direct-run.mjs";
-import { execGhJson, execGhRead, execPlainGh } from "../lib/plain-gh.mjs";
+import { execGhJson, execGhRead, execPlainGh, workflowRunsApiArgs } from "../lib/plain-gh.mjs";
 
 const SHA_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 
@@ -41,23 +41,9 @@ function buildCiDispatchArgs(record) {
 }
 
 function listCiRuns(headRefOid) {
-  return execGhJson(
-    [
-      "run",
-      "list",
-      "--commit",
-      headRefOid,
-      "--workflow",
-      "ci.yml",
-      "--event",
-      "workflow_dispatch",
-      "--limit",
-      "20",
-      "--json",
-      "databaseId,url,headSha,createdAt,status",
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
+  return execGhJson(workflowRunsApiArgs("openclaw/openclaw", headRefOid, "workflow_dispatch", 20), {
+    stdio: ["ignore", "pipe", "pipe"],
+  }).workflow_runs;
 }
 
 function readCurrentPrHeadOid(pr) {
@@ -86,7 +72,7 @@ async function dispatchCiForPr(
   } = {},
 ) {
   requirePrRecord(record);
-  const priorRunIds = new Set(listRuns(record.headRefOid).map((run) => run.databaseId));
+  const priorRunIds = new Set(listRuns(record.headRefOid).map((run) => run.id));
   const headBeforeDispatch = readHeadOid(record.pr);
   if (headBeforeDispatch !== record.headRefOid) {
     throw new Error(
@@ -98,10 +84,10 @@ async function dispatchCiForPr(
   for (let attempt = 1; attempt <= pollAttempts; attempt += 1) {
     const run = listRuns(record.headRefOid).find(
       (candidate) =>
-        candidate.headSha === record.headRefOid &&
-        !priorRunIds.has(candidate.databaseId) &&
-        typeof candidate.url === "string" &&
-        candidate.url.length > 0,
+        candidate.head_sha === record.headRefOid &&
+        !priorRunIds.has(candidate.id) &&
+        typeof candidate.html_url === "string" &&
+        candidate.html_url.length > 0,
     );
     if (run) {
       const headAtObservation = readHeadOid(record.pr);
@@ -168,7 +154,7 @@ async function main(argv = process.argv.slice(2)) {
     console.log(
       "Observed a new exact-SHA manual run after dispatch; GitHub does not expose a dispatch correlation ID, so concurrent requests cannot be distinguished.",
     );
-    console.log(`observed_run_url=${run.url}`);
+    console.log(`observed_run_url=${run.html_url}`);
   } else {
     console.log(
       `Requested CI for PR #${record.pr} at unchanged remote head ${record.headRefOid} (${record.headRefName}).`,
@@ -177,7 +163,7 @@ async function main(argv = process.argv.slice(2)) {
       "run_url=pending (GitHub accepted the dispatch, but Actions has not indexed it yet)",
     );
     console.log(
-      `inspect_with=gh run list --commit ${record.headRefOid} --workflow ci.yml --event workflow_dispatch`,
+      `inspect_with=gh api --method GET repos/openclaw/openclaw/actions/workflows/ci.yml/runs -f event=workflow_dispatch -f head_sha=${record.headRefOid} -f per_page=20`,
     );
   }
 }

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -3,7 +3,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { parseArgs as parseNodeArgs } from "node:util";
 import { z } from "zod";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
-import { execGhJson } from "./lib/plain-gh.mjs";
+import { execGhJson, workflowRunsApiArgs } from "./lib/plain-gh.mjs";
 
 const USAGE =
   "Usage: node scripts/watch-pr-ci.mjs <pr-number> <head-sha> [--repo owner/repo] [--after run-id] [--attach-timeout 900] [--timeout 3600] [--interval 120] [--completion rollup|ci-run]";
@@ -66,8 +66,11 @@ const RollupResponseSchema = z.object({
     repository: z.object({ pullRequest: RollupPageSchema.nullish() }).nullish(),
   }),
 });
-const RunListItemSchema = z.object({ databaseId: z.number(), createdAt: z.string() });
-const RunListSchema = validArray(RunListItemSchema).catch([]);
+const RunListItemSchema = z.object({ id: z.number(), created_at: z.string() });
+const RunListSchema = z
+  .object({ workflow_runs: validArray(RunListItemSchema) })
+  .transform((response) => response.workflow_runs)
+  .catch([]);
 const RunStatusSchema = z
   .object({ status: optionalString, conclusion: optionalNullable(z.string()) })
   .catch({});
@@ -298,24 +301,10 @@ const readPr = (pr: number, repo: string) =>
       GH_READ_OPTIONS,
     ),
   );
-export const buildFindRunArgs = (repo: string, sha: string) => [
-  "run",
-  "list",
-  "--repo",
-  repo,
-  "--commit",
-  sha,
-  "--workflow",
-  "ci.yml",
-  "--event",
-  "pull_request",
-  "--limit",
-  "1",
-  "--json",
-  "createdAt,databaseId",
-];
+export const buildFindRunArgs = (repo: string, sha: string) =>
+  workflowRunsApiArgs(repo, sha, "pull_request", 1);
 export const selectRunAfter = (runs: RunListItem[], after?: number) =>
-  runs.find((run) => after === undefined || run.databaseId > after);
+  runs.find((run) => after === undefined || run.id > after);
 const findRun = (repo: string, sha: string, after?: number) =>
   selectRunAfter(
     RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS)),
@@ -492,15 +481,15 @@ async function main(argv = process.argv.slice(2)) {
         const candidate = findRun(args.repo, args.headSha, args.after);
         if (candidate) {
           const classification = classifyRunAttachment(
-            candidate.databaseId,
-            readRun(args.repo, candidate.databaseId),
+            candidate.id,
+            readRun(args.repo, candidate.id),
             args.after,
           );
           if (classification.attach) {
             if (classification.warning) {
               console.log(classification.warning);
             }
-            return { runId: candidate.databaseId };
+            return { runId: candidate.id };
           }
         }
       } catch (error) {

--- a/test/scripts/plain-gh.test.ts
+++ b/test/scripts/plain-gh.test.ts
@@ -39,6 +39,7 @@ printf 'CLICOLOR=%s\\n' "\${CLICOLOR-}"
 printf 'CLICOLOR_FORCE=%s\\n' "\${CLICOLOR_FORCE-}"
 printf 'COLORTERM_SET=%s\\n' "\${COLORTERM+x}"
 printf 'OPENCLAW_GH_BIN_SET=%s\\n' "\${OPENCLAW_GH_BIN+x}"
+printf 'GH_TOKEN_SET=%s\\n' "\${GH_TOKEN:+1}"
 `,
   );
   chmodSync(ghPath, 0o755);
@@ -188,6 +189,7 @@ describe("plain gh helpers", () => {
         CLICOLOR_FORCE: "1",
         COLORTERM: "truecolor",
         FORCE_COLOR: "3",
+        GH_TOKEN: "existing-test-token",
       },
     });
 
@@ -199,6 +201,46 @@ describe("plain gh helpers", () => {
     expect(readFileSync(outputPath, "utf8")).toContain("CLICOLOR=0");
     expect(readFileSync(outputPath, "utf8")).toContain("CLICOLOR_FORCE=0");
     expect(readFileSync(outputPath, "utf8")).toContain("COLORTERM_SET=");
+  });
+
+  it("bridges PATH-shim credentials to the selected plain gh", () => {
+    const ghPath = makeFakeGh();
+    const shimDir = mkdtempSync(path.join(tmpdir(), "plain-gh-auth-shim-"));
+    tempDirs.push(shimDir);
+    const shimPath = path.join(shimDir, "gh");
+    writeFileSync(
+      shimPath,
+      `#!/usr/bin/env bash
+if [ "$*" = "auth token" ]; then
+  printf 'bridged-test-token\\n'
+  exit 0
+fi
+exit 2
+`,
+    );
+    chmodSync(shimPath, 0o755);
+    const script = [
+      "set -euo pipefail",
+      "source scripts/lib/plain-gh.sh",
+      `OPENCLAW_GH_BIN=${JSON.stringify(ghPath)}`,
+      "export OPENCLAW_GH_BIN",
+      "gh_plain api rate_limit",
+    ].join("\n");
+
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GH_TOKEN: "",
+        GITHUB_TOKEN: "",
+        PATH: `${shimDir}${path.delimiter}/usr/bin:/bin`,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("argv=api rate_limit");
+    expect(result.stdout).toContain("GH_TOKEN_SET=1");
+    expect(result.stdout).not.toContain("bridged-test-token");
   });
 
   it("captures large gh payloads by default", () => {

--- a/test/scripts/pr-ci-dispatch.test.ts
+++ b/test/scripts/pr-ci-dispatch.test.ts
@@ -23,14 +23,14 @@ function createFakeGh() {
 set -euo pipefail
 printf '%s\\t%s\\n' "$(basename "$0")" "$*" >> "$OPENCLAW_TEST_GH_CALLS"
 case "$1 $2" in
-  "run list")
+  "api --method")
     if [ "\${OPENCLAW_TEST_GH_MODE:-}" = "pending-head-change" ]; then
-      printf '[]\\n'
+      printf '{"workflow_runs":[]}\\n'
     elif [ -e "$OPENCLAW_TEST_GH_SEEN_RUN_LIST" ]; then
-      printf '[{"databaseId":99,"url":"https://github.com/openclaw/openclaw/actions/runs/99","headSha":"%s","createdAt":"2026-01-01T00:00:00Z","status":"queued"}]\\n' "$OPENCLAW_TEST_HEAD_SHA"
+      printf '{"workflow_runs":[{"id":99,"html_url":"https://github.com/openclaw/openclaw/actions/runs/99","head_sha":"%s","created_at":"2026-01-01T00:00:00Z","status":"queued"}]}\\n' "$OPENCLAW_TEST_HEAD_SHA"
     else
       : > "$OPENCLAW_TEST_GH_SEEN_RUN_LIST"
-      printf '[]\\n'
+      printf '{"workflow_runs":[]}\\n'
     fi
     ;;
   "pr view")
@@ -128,9 +128,11 @@ describePosix("scripts/pr ci-dispatch", () => {
     expect(callLines).toContain(
       `real-gh\tworkflow run ci.yml --ref contributor/fix-hosted-gates -f target_ref=${sha} -f release_gate=true -f pull_request_number=12345`,
     );
-    expect(callLines.some((call) => call.startsWith(`gh\trun list --commit ${sha}`))).toBe(true);
+    expect(callLines).toContain(
+      `gh\tapi --method GET repos/openclaw/openclaw/actions/workflows/ci.yml/runs -f event=workflow_dispatch -f head_sha=${sha} -f per_page=20`,
+    );
     expect(callLines.some((call) => call.startsWith("gh\tpr view 12345"))).toBe(true);
-    expect(callLines.some((call) => /^real-gh\t(?:run list|pr view)/u.test(call))).toBe(false);
+    expect(callLines.some((call) => /^real-gh\t(?:api|pr view)/u.test(call))).toBe(false);
   });
 
   it("refuses a fork-local branch name before invoking GitHub", () => {

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -68,26 +68,22 @@ describe("watch-pr-ci", () => {
 
   it("builds a pull-request-only run attachment query", () => {
     expect(buildFindRunArgs("openclaw/openclaw", sha)).toEqual([
-      "run",
-      "list",
-      "--repo",
-      "openclaw/openclaw",
-      "--commit",
-      sha,
-      "--workflow",
-      "ci.yml",
-      "--event",
-      "pull_request",
-      "--limit",
-      "1",
-      "--json",
-      "createdAt,databaseId",
+      "api",
+      "--method",
+      "GET",
+      "repos/openclaw/openclaw/actions/workflows/ci.yml/runs",
+      "-f",
+      "event=pull_request",
+      "-f",
+      `head_sha=${sha}`,
+      "-f",
+      "per_page=1",
     ]);
   });
 
   it("filters run ids at and before --after", () => {
-    const newer = { databaseId: 102, createdAt: "2026-07-23T02:00:00Z" };
-    const runs = [newer, { databaseId: 101, createdAt: "2026-07-23T01:00:00Z" }];
+    const newer = { id: 102, created_at: "2026-07-23T02:00:00Z" };
+    const runs = [newer, { id: 101, created_at: "2026-07-23T01:00:00Z" }];
     expect(selectRunAfter(runs, 101)).toBe(newer);
     expect(selectRunAfter(runs, 102)).toBeUndefined();
     expect(selectRunAfter(runs)).toBe(newer);


### PR DESCRIPTION
## Summary

- bridge credentials from the authenticated PATH `gh` shim to the modern plain `gh` binary selected for PR writes
- query exact-SHA Actions runs through the stable REST API instead of newer `gh run list --commit` flags
- keep CI dispatch and watcher output compatible with older authenticated GitHub CLIs

## Testing

- `node scripts/run-vitest.mjs test/scripts/plain-gh.test.ts test/scripts/watch-pr-ci.test.ts test/scripts/pr-ci-dispatch.test.ts` (44 tests)
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed`
- authenticated REST query with PATH `gh 2.23.0` against an exact PR head
- authenticated `gh_plain api rate_limit` using selected `/usr/local/bin/gh 2.97.0` with no token pre-exported
- autoreview: clean