### PR TITLE
docs(tasks): document timestamp audit finding

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -275,6 +275,7 @@ openclaw tasks notify <lookup> state_changes
     | `cancel_stuck`         | warn       | Cancel requested over 5 minutes ago, no active child tasks, still nonterminal |
     | `missing_linked_tasks` | warn/error | Stale managed flow with no linked tasks or wait state                       |
     | `blocked_task_missing` | warn       | Blocked flow points at a task id that no longer exists                      |
+    | `inconsistent_timestamps` | warn    | Flow timestamps are not in chronological order                              |
 
   </Accordion>
   <Accordion title="tasks maintenance">

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -106,8 +106,8 @@ Task Flow records. Lost tasks retained until `cleanupAfter` are warnings;
 expired or unstamped lost tasks are errors.
 
 `--code` accepts task codes (`stale_queued`, `stale_running`, `lost`,
-`delivery_failed`, `missing_cleanup`, `inconsistent_timestamps`) and Task
-Flow codes (`restore_failed`, `stale_waiting`, `stale_blocked`,
+`delivery_failed`, `missing_cleanup`, `inconsistent_timestamps`) and additional
+Task Flow codes (`restore_failed`, `stale_waiting`, `stale_blocked`,
 `cancel_stuck`, `missing_linked_tasks`, `blocked_task_missing`). See
 [Background Tasks](/automation/tasks) for severity and trigger detail per
 code.


### PR DESCRIPTION
## What Problem This Solves

Document the existing `inconsistent_timestamps` TaskFlow audit warning. Operators can see this warning when flow timestamps are out of chronological order, but the Background Tasks findings table omitted its severity and meaning.

The CLI reference now says “additional Task Flow codes” to make clear that the shared task codes, including `stale_running` and `inconsistent_timestamps`, also apply to flows.

Thanks @qingminglong.

## Evidence

- Read the complete TaskFlow audit owner and vocabulary, human and JSON audit callers, task-audit sibling, maintenance owner and existing regression coverage. The warning is emitted when `updatedAt` precedes `createdAt`, or `endedAt` precedes `createdAt` or `updatedAt`.
- Existing maintenance coverage observes the warning for an inconsistent mirrored flow before reconciliation and its absence afterward. This PR changes the explanation of that behavior, not the behavior itself.
- Trusted documentation checks passed against the candidate: docs index with headings, MDX syntax, explicit-config formatting, internal link audit (6,496 links, zero broken), and whitespace checks.
- Production and tests: zero changed lines. Documentation: one findings-table row plus a one-word clarification in the CLI reference.
- Independent full-candidate P0 review passed with no findings. Exact-head CI remains pending publication. No runtime execution is required for this documentation-only correction.
