### PR TITLE
fix(pr): bridge split auth in Node CI dispatch

### DIFF
--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -45,6 +45,51 @@ function pathEntries(env) {
 }
 
 /**
+ * Credential-injecting PATH wrappers may be the only authenticated gh entry
+ * point even though writes need the unwrapped CLI. Forward its token only to
+ * the selected plain CLI process; never persist it in process.env.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {NodeJS.ProcessEnv}
+ */
+function plainGhAuthenticatedEnv(env) {
+  const next = plainGhEnv(env);
+  if (
+    next.GH_TOKEN ||
+    next.GITHUB_TOKEN ||
+    next.GH_ENTERPRISE_TOKEN ||
+    next.GITHUB_ENTERPRISE_TOKEN
+  ) {
+    return next;
+  }
+
+  const tokenEnv = { ...next };
+  delete tokenEnv.OPENCLAW_GH_BIN;
+  const args = ["auth", "token"];
+  if (tokenEnv.GH_HOST) {
+    args.push("--hostname", tokenEnv.GH_HOST);
+  }
+  try {
+    const token = execFileSync("gh", args, {
+      encoding: "utf8",
+      env: tokenEnv,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10_000,
+    }).trim();
+    if (token) {
+      if (tokenEnv.GH_HOST && tokenEnv.GH_HOST !== "github.com") {
+        next.GH_ENTERPRISE_TOKEN = token;
+      } else {
+        next.GH_TOKEN = token;
+      }
+    }
+  } catch {
+    // The selected CLI may have usable credentials in its own config.
+  }
+  return next;
+}
+
+/**
  * @param {NodeJS.ProcessEnv} [env]
  * @returns {NodeJS.ProcessEnv}
  */
@@ -128,7 +173,7 @@ export function resolvePlainGhBin(
  * @returns {string | Uint8Array<ArrayBuffer>}
  */
 export function execPlainGh(args, options = {}) {
-  const env = plainGhEnv(options.env ?? process.env);
+  const env = plainGhAuthenticatedEnv(options.env ?? process.env);
   const ghBin = resolvePlainGhBin(env);
   return execFileSync(ghBin, args, {
     ...options,

--- a/scripts/lib/plain-gh.sh
+++ b/scripts/lib/plain-gh.sh
@@ -73,22 +73,34 @@ plain_gh_search_path() {
   printf '%s\n' "$output"
 }
 
-bridge_plain_gh_auth() {
-  if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
-    return 0
+plain_gh_auth_token() {
+  if [ -n "${GH_TOKEN:-}" ] ||
+    [ -n "${GITHUB_TOKEN:-}" ] ||
+    [ -n "${GH_ENTERPRISE_TOKEN:-}" ] ||
+    [ -n "${GITHUB_ENTERPRISE_TOKEN:-}" ]; then
+    return 1
   fi
 
-  local gh_path
-  local token
-  gh_path=$(type -P gh 2>/dev/null) || return 0
-  if token=$(plain_gh_env "$gh_path" auth token 2>/dev/null) && [ -n "$token" ]; then
-    export GH_TOKEN="$token"
+  local path_gh
+  path_gh=$(type -P gh 2>/dev/null) || return 1
+  local args=(auth token)
+  if [ -n "${GH_HOST:-}" ]; then
+    args+=(--hostname "$GH_HOST")
   fi
+  OPENCLAW_GH_BIN= plain_gh_env "$path_gh" "${args[@]}"
 }
 
 gh_plain() {
   local gh_bin
   gh_bin=$(resolve_plain_gh_bin) || return 1
-  bridge_plain_gh_auth
+  local token
+  if token=$(plain_gh_auth_token 2>/dev/null) && [ -n "$token" ]; then
+    local token_name=GH_TOKEN
+    if [ -n "${GH_HOST:-}" ] && [ "$GH_HOST" != "github.com" ]; then
+      token_name=GH_ENTERPRISE_TOKEN
+    fi
+    plain_gh_env "$token_name=$token" "$gh_bin" "$@"
+    return
+  fi
   plain_gh_env "$gh_bin" "$@"
 }

--- a/test/scripts/plain-gh.test.ts
+++ b/test/scripts/plain-gh.test.ts
@@ -1,7 +1,6 @@
 // Plain GitHub CLI helper tests cover wrapper-safe gh execution for maintainer scripts.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -13,18 +12,12 @@ import {
   PLAIN_GH_SYSTEM_CANDIDATES,
   resolvePlainGhBin,
 } from "../../scripts/lib/plain-gh.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeFakeGh(): string {
-  const dir = mkdtempSync(path.join(tmpdir(), "plain-gh-"));
-  tempDirs.push(dir);
+  const dir = tempDirs.make("plain-gh-");
   const binDir = path.join(dir, "bin");
   mkdirSync(binDir);
   const ghPath = path.join(binDir, "gh");
@@ -47,8 +40,7 @@ printf 'GH_TOKEN_SET=%s\\n' "\${GH_TOKEN:+1}"
 }
 
 function makeLargeFakeGh(): string {
-  const dir = mkdtempSync(path.join(tmpdir(), "plain-gh-large-"));
-  tempDirs.push(dir);
+  const dir = tempDirs.make("plain-gh-large-");
   const ghPath = path.join(dir, "gh");
   writeFileSync(
     ghPath,
@@ -59,6 +51,44 @@ process.stdout.write("x".repeat(bytes));
   );
   chmodSync(ghPath, 0o755);
   return ghPath;
+}
+
+function makeCredentialForwardingGh() {
+  const dir = tempDirs.make("plain-gh-auth-forward-");
+  const binDir = path.join(dir, "bin");
+  const calls = path.join(dir, "calls.log");
+  const realGh = path.join(dir, "real-gh");
+  mkdirSync(binDir);
+  writeFileSync(
+    path.join(binDir, "gh"),
+    `#!/bin/sh
+printf 'path:%s\\n' "$*" >> "$PLAIN_GH_FAKE_CALLS"
+if [ "$1 $2" = "auth token" ]; then
+  printf 'forwarded-test-token\\n'
+  exit 0
+fi
+exit 9
+`,
+  );
+  writeFileSync(
+    realGh,
+    `#!/bin/sh
+printf 'plain:%s\\n' "$*" >> "$PLAIN_GH_FAKE_CALLS"
+case "$PLAIN_GH_EXPECTED_TOKEN_ENV" in
+  GH_TOKEN) token="\${GH_TOKEN-}"; other_token="\${GH_ENTERPRISE_TOKEN-}" ;;
+  GH_ENTERPRISE_TOKEN) token="\${GH_ENTERPRISE_TOKEN-}"; other_token="\${GH_TOKEN-}" ;;
+  *) echo 'unexpected token environment' >&2; exit 7 ;;
+esac
+if [ "$token" != "forwarded-test-token" ] || [ -n "$other_token" ]; then
+  echo 'missing forwarded credentials' >&2
+  exit 8
+fi
+printf 'authenticated plain gh\\n'
+`,
+  );
+  chmodSync(path.join(binDir, "gh"), 0o755);
+  chmodSync(realGh, 0o755);
+  return { binDir, calls, realGh };
 }
 
 describe("plain gh helpers", () => {
@@ -203,44 +233,59 @@ describe("plain gh helpers", () => {
     expect(readFileSync(outputPath, "utf8")).toContain("COLORTERM_SET=");
   });
 
-  it("bridges PATH-shim credentials to the selected plain gh", () => {
-    const ghPath = makeFakeGh();
-    const shimDir = mkdtempSync(path.join(tmpdir(), "plain-gh-auth-shim-"));
-    tempDirs.push(shimDir);
-    const shimPath = path.join(shimDir, "gh");
-    writeFileSync(
-      shimPath,
-      `#!/usr/bin/env bash
-if [ "$*" = "auth token" ]; then
-  printf 'bridged-test-token\\n'
-  exit 0
-fi
-exit 2
-`,
-    );
-    chmodSync(shimPath, 0o755);
-    const script = [
-      "set -euo pipefail",
-      "source scripts/lib/plain-gh.sh",
-      `OPENCLAW_GH_BIN=${JSON.stringify(ghPath)}`,
-      "export OPENCLAW_GH_BIN",
-      "gh_plain api rate_limit",
-    ].join("\n");
+  it.each([
+    {
+      host: undefined,
+      name: "github.com",
+      tokenArgs: "auth token",
+      tokenEnv: "GH_TOKEN",
+    },
+    {
+      host: "github.example.com",
+      name: "an Enterprise host",
+      tokenArgs: "auth token --hostname github.example.com",
+      tokenEnv: "GH_ENTERPRISE_TOKEN",
+    },
+  ])("forwards $name credentials from a PATH wrapper to the plain CLI", (testCase) => {
+    const fixture = makeCredentialForwardingGh();
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      OPENCLAW_GH_BIN: fixture.realGh,
+      PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      PLAIN_GH_EXPECTED_TOKEN_ENV: testCase.tokenEnv,
+      PLAIN_GH_FAKE_CALLS: fixture.calls,
+    };
+    if (testCase.host) {
+      env.GH_HOST = testCase.host;
+    } else {
+      delete env.GH_HOST;
+    }
+    for (const name of [
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "GH_ENTERPRISE_TOKEN",
+      "GITHUB_ENTERPRISE_TOKEN",
+    ]) {
+      delete env[name];
+    }
 
-    const result = spawnSync("bash", ["-c", script], {
+    expect(execPlainGh(["api", "user"], { encoding: "utf8", env })).toBe(
+      "authenticated plain gh\n",
+    );
+    const shell = spawnSync("bash", ["-c", "source scripts/lib/plain-gh.sh; gh_plain api user"], {
+      cwd: process.cwd(),
       encoding: "utf8",
-      env: {
-        ...process.env,
-        GH_TOKEN: "",
-        GITHUB_TOKEN: "",
-        PATH: `${shimDir}${path.delimiter}/usr/bin:/bin`,
-      },
+      env,
     });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("argv=api rate_limit");
-    expect(result.stdout).toContain("GH_TOKEN_SET=1");
-    expect(result.stdout).not.toContain("bridged-test-token");
+    expect(shell.status, shell.stderr).toBe(0);
+    expect(shell.stdout).toBe("authenticated plain gh\n");
+    expect(readFileSync(fixture.calls, "utf8").trim().split("\n")).toEqual([
+      `path:${testCase.tokenArgs}`,
+      "plain:api user",
+      `path:${testCase.tokenArgs}`,
+      "plain:api user",
+    ]);
   });
 
   it("captures large gh payloads by default", () => {
@@ -251,6 +296,7 @@ exit 2
       encoding: "utf8",
       env: {
         ...process.env,
+        GH_TOKEN: "large-payload-test-token",
         OPENCLAW_GH_BIN: ghPath,
         PLAIN_GH_FAKE_BYTES: String(bytes),
       },

--- a/test/scripts/pr-ci-dispatch.test.ts
+++ b/test/scripts/pr-ci-dispatch.test.ts
@@ -23,6 +23,7 @@ function createFakeGh() {
 set -euo pipefail
 printf '%s\\t%s\\n' "$(basename "$0")" "$*" >> "$OPENCLAW_TEST_GH_CALLS"
 case "$1 $2" in
+  "auth token") printf 'forwarded-test-token\\n' ;;
   "api --method")
     if [ "\${OPENCLAW_TEST_GH_MODE:-}" = "pending-head-change" ]; then
       printf '{"workflow_runs":[]}\\n'
@@ -40,7 +41,13 @@ case "$1 $2" in
       printf '%s\\n' "$OPENCLAW_TEST_HEAD_SHA"
     fi
     ;;
-  "workflow run") : > "$OPENCLAW_TEST_GH_DISPATCHED" ;;
+  "workflow run")
+    if [ "\${GH_TOKEN-}" != "forwarded-test-token" ]; then
+      echo "missing forwarded credentials" >&2
+      exit 3
+    fi
+    : > "$OPENCLAW_TEST_GH_DISPATCHED"
+    ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 2 ;;
 esac
 `;
@@ -65,24 +72,33 @@ function runDispatch(
     writeFileSync(preload, "global.setTimeout = (callback) => { callback(); return 0; };\n");
     nodeOptions = `${nodeOptions} --require ${preload}`.trim();
   }
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_OPTIONS: nodeOptions,
+    OPENCLAW_GH_BIN: fakeGh.realGh,
+    OPENCLAW_TEST_CHANGED_HEAD_SHA: changedSha,
+    OPENCLAW_TEST_GH_CALLS: fakeGh.calls,
+    OPENCLAW_TEST_GH_DISPATCHED: fakeGh.dispatched,
+    OPENCLAW_TEST_GH_MODE: options.mode ?? "",
+    OPENCLAW_TEST_GH_SEEN_RUN_LIST: fakeGh.seenRunList,
+    OPENCLAW_TEST_HEAD_SHA: sha,
+    PATH: `${fakeGh.binDir}:${process.env.PATH ?? ""}`,
+  };
+  for (const name of [
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_ENTERPRISE_TOKEN",
+    "GITHUB_ENTERPRISE_TOKEN",
+  ]) {
+    delete env[name];
+  }
   return spawnSync(
     process.execPath,
     [dispatchScript, "12345", "contributor/fix-hosted-gates", sha, "false"],
     {
       cwd: options.cwd,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        NODE_OPTIONS: nodeOptions,
-        OPENCLAW_GH_BIN: fakeGh.realGh,
-        OPENCLAW_TEST_CHANGED_HEAD_SHA: changedSha,
-        OPENCLAW_TEST_GH_CALLS: fakeGh.calls,
-        OPENCLAW_TEST_GH_DISPATCHED: fakeGh.dispatched,
-        OPENCLAW_TEST_GH_MODE: options.mode ?? "",
-        OPENCLAW_TEST_GH_SEEN_RUN_LIST: fakeGh.seenRunList,
-        OPENCLAW_TEST_HEAD_SHA: sha,
-        PATH: `${fakeGh.binDir}:${process.env.PATH ?? ""}`,
-      },
+      env,
     },
   );
 }
@@ -128,6 +144,7 @@ describePosix("scripts/pr ci-dispatch", () => {
     expect(callLines).toContain(
       `real-gh\tworkflow run ci.yml --ref contributor/fix-hosted-gates -f target_ref=${sha} -f release_gate=true -f pull_request_number=12345`,
     );
+    expect(callLines).toContain("gh\tauth token");
     expect(callLines).toContain(
       `gh\tapi --method GET repos/openclaw/openclaw/actions/workflows/ci.yml/runs -f event=workflow_dispatch -f head_sha=${sha} -f per_page=20`,
     );


### PR DESCRIPTION
## What Problem This Solves

The split-auth repair in #124671 covered the shell helper but missed the Node executor used by `scripts/pr ci-dispatch`. When only the `gh` entry on `PATH` can obtain credentials, the selected plain CLI still receives no token and workflow dispatch fails.

## Why This Change Was Made

The credential handoff now lives at the Node plain-CLI execution boundary used by CI dispatch. It asks the authenticated `PATH` entry for a token only when no token environment already exists, forwards that value only to the selected plain CLI child, and leaves the caller environment unchanged. The shell path uses the same scoped behavior instead of exporting the token into the rest of the shell session. Tokens fetched for a non-public `GH_HOST` use the CLI's Enterprise token variable in both implementations.

This directly addresses the Node owner-boundary finding recorded on #124671 and the host-variable findings on this PR while retaining the already-landed REST compatibility work unchanged.

This PR is AI-assisted; the implementation and proof were reviewed before publication.

## User Impact

Maintainers and automated workers can dispatch exact-head CI when authentication is supplied by a `PATH` wrapper and writes use a separate full CLI. Existing explicit token environments, Enterprise hosts, and plain CLI configuration continue to work.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plain-gh.test.ts test/scripts/pr-ci-dispatch.test.ts` — 16 tests passed, including a full dispatcher route that rejects the write unless credentials are forwarded and process-boundary cases for public and Enterprise hosts.
- `node scripts/check-changed.mjs -- scripts/lib/plain-gh.mjs scripts/lib/plain-gh.sh test/scripts/plain-gh.test.ts test/scripts/pr-ci-dispatch.test.ts` — formatting, script/test typechecks, lint, and repository guards passed.
- Live compatibility probes: both the Node and shell helpers authenticated the separately selected plain CLI with no token pre-exported.
- Final branch autoreview: clean, no accepted/actionable findings; TruffleHog preflight clean.
