### PR TITLE
fix: keep Workboard dispatch alive for oversized notifications

### DIFF
--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -16,7 +16,6 @@ import {
 } from "@openclaw/workboard-contract";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   BLOCKED_TOO_LONG_MS,
   MAX_CARD_ATTEMPTS,
@@ -26,11 +25,14 @@ import {
 } from "./store-constants.js";
 import type { WorkboardMutationScope } from "./store-inputs.js";
 import {
+  capText,
   metadataIsEmpty,
   normalizeEvents,
   normalizeTimestamp,
   removeUndefinedMetadataFields,
 } from "./store-normalizers.js";
+
+export { capText } from "./store-normalizers.js";
 
 export function compareCards(left: WorkboardCard, right: WorkboardCard): number {
   if (left.status !== right.status) {
@@ -515,13 +517,6 @@ export function computeCardDiagnostics(card: WorkboardCard, now: number): Workbo
     );
   }
   return diagnostics;
-}
-
-export function capText(value: string | undefined, max: number): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  return value.length <= max ? value : `${truncateUtf16Safe(value, Math.max(0, max - 1))}…`;
 }
 
 export function cardBoardId(card: WorkboardCard): string {

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -48,6 +48,7 @@ import {
 } from "@openclaw/workboard-contract";
 import { resolveNonNegativeIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   MAX_ATTACHMENT_BYTES,
   MAX_CARD_ARTIFACTS,
@@ -69,6 +70,13 @@ import type {
   WorkboardProofInput,
 } from "./store-inputs.js";
 import { isAbsoluteWorkspacePath } from "./workspace-path.js";
+
+export function capText(value: string | undefined, max: number): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.length <= max ? value : `${truncateUtf16Safe(value, Math.max(0, max - 1))}…`;
+}
 
 export function normalizeBoardId(value: unknown, fallback?: string): string | undefined {
   const raw = normalizeBoundedString(value, fallback, 80, "board id");
@@ -945,7 +953,7 @@ function normalizeNotification(value: unknown): WorkboardNotification | null {
     : undefined;
   const createdAt = normalizeTimestamp(record.createdAt, Date.now());
   const sequence = normalizeTimestamp(record.sequence, 0) || undefined;
-  const message = normalizeBoundedString(record.message, undefined, 240, "notification message");
+  const message = capText(normalizeOptionalString(record.message), 240);
   if (!kind || !message) {
     return null;
   }

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -277,6 +277,56 @@ describe("WorkboardStore", () => {
     }
   });
 
+  it("keeps dispatch alive when a persisted notification exceeds its limit", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-notification-limit-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    let stores: ReturnType<typeof createWorkboardSqliteStores> | undefined;
+    try {
+      stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      const card = await store.create({
+        title: "Persisted notification",
+        status: "ready",
+        metadata: {
+          notifications: [
+            {
+              id: "notification-1",
+              kind: "completed",
+              createdAt: 1,
+              message: "Stored safely",
+            },
+          ],
+        },
+      });
+      stores.close();
+      stores = undefined;
+
+      const rawDb = new DatabaseSync(dbPath);
+      rawDb
+        .prepare("UPDATE workboard_card_notifications SET message = ? WHERE card_id = ?")
+        .run("x".repeat(300), card.id);
+      rawDb.close();
+
+      stores = createWorkboardSqliteStores({ dbPath });
+      const reopened = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      await expect(reopened.dispatch()).resolves.toMatchObject({ count: 0 });
+      await expect(reopened.get(card.id)).resolves.toMatchObject({
+        metadata: { notifications: [{ message: expect.stringMatching(/^x+…$/) }] },
+      });
+    } finally {
+      stores?.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("lists sqlite board summaries without hydrating card child rows", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-summary-"));
     const dbPath = path.join(dir, "workboard.sqlite");


### PR DESCRIPTION
Closes #120956

## What Problem This Solves

Fixes an issue where a persisted Workboard notification longer than 240 characters could make `workboard dispatch` fail instead of continuing to process cards.

## Why This Change Was Made

The notification write path already truncates messages with the Workboard `capText` policy, but the persisted-read normalizer still rejected oversized legacy rows. This change makes the read path reuse that existing policy while preserving the 240-character boundary for notification delivery.

## User Impact

Workboard dispatch remains available when an oversized notification is already present in SQLite. Messages are capped to 240 characters with an ellipsis, and messages within the limit are unchanged.

## Evidence

- Final runtime proof: a real SQLite Workboard store was given a persisted 300-character notification, reopened, and dispatched successfully; the read-back message was 240 characters and ended with `…`.
- Regression test: `keeps dispatch alive when a persisted notification exceeds its limit`.
- Supporting checks: focused Workboard test passed, targeted `oxfmt --check` passed, and `git diff --check` passed.
- Autoreview: clean with no accepted/actionable findings.
- Proof boundary: local SQLite/runtime proof; no external delivery was performed or claimed.
- Exact head: `0e11b0cd195cb8c67560f95e13315884f3653b73`.

AI-assisted: yes. The change and validation were completed with Codex assistance and manually reviewed against the Workboard persistence and dispatch paths.
