### PR TITLE
fix(ui): recover channel setup after status check failure

### DIFF
--- a/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
+++ b/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
@@ -134,12 +134,30 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
         path: path.join(artifactDir, "01-after-model-ready-continue-setup.png"),
       });
 
+      await gateway.deferNext("channels.status", { probe: false });
       await continueSetup.click();
       await waitForControlUiRoute(page, {
         pathname: "/custodian",
         routeId: "custodian",
         search: "?onboarding=1",
       });
+      await gateway.waitForRequest("channels.status");
+      await gateway.rejectDeferred("channels.status", {
+        code: "UNAVAILABLE",
+        message: "channel status temporarily unavailable",
+        retryable: true,
+      });
+      const channelStatusError = page.getByRole("alert").filter({
+        hasText: "Channel status is unavailable",
+      });
+      await channelStatusError.waitFor();
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(artifactDir, "02-channel-status-error-before-retry.png"),
+      });
+
+      await gateway.setMethodResponse("channels.status", emptyChannelSnapshot);
+      await channelStatusError.getByRole("button", { name: "Retry" }).click();
       const channelNudge = page.locator(".custodian__nudge--channel-onboarding");
       await channelNudge.waitFor();
       await expect.poll(() => channelNudge.textContent()).toContain("The web app already works");
@@ -185,8 +203,9 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
       await page.setViewportSize({ height: 900, width: 1280 });
 
       const channelStatusRequests = await gateway.getRequests("channels.status");
-      expect(channelStatusRequests).toHaveLength(1);
+      expect(channelStatusRequests).toHaveLength(2);
       expect(channelStatusRequests[0]?.params).toMatchObject({ probe: false });
+      expect(channelStatusRequests[1]?.params).toMatchObject({ probe: false });
 
       await page.getByRole("button", { name: "Set up a channel" }).click();
       await waitForControlUiRoute(page, {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2527,6 +2527,8 @@ export const en: TranslationMap = {
         "The web app already works. Add a channel only if you want to message OpenClaw from another service.",
       channelSetupAction: "Set up a channel",
       channelSetupDismiss: "Keep using the web app",
+      channelStatusErrorTitle: "Channel status is unavailable",
+      channelStatusErrorBody: "Retry the check, or keep using the web app without a channel.",
     },
   },
   mcpServers: {

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -619,6 +619,42 @@ describe("channels controller DM pairing", () => {
 });
 
 describe("channel refresh sequencing", () => {
+  it("clears a failed request generation on reconnect so status can recover", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("status unavailable"))
+      .mockResolvedValueOnce(createChannelsSnapshot("recovered"));
+    const client = { request };
+    let snapshot = { client, phase: "connected" };
+    const listeners = new Set<(next: typeof snapshot) => void>();
+    const channels = createChannelCapability({
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener: (next: typeof snapshot) => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    } as never);
+
+    await channels.refresh();
+    expect(channels.state.channelsError).toBe("status unavailable");
+
+    snapshot = { client, phase: "reconnecting" };
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+    snapshot = { client, phase: "connected" };
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+
+    expect(channels.state.channelsError).toBeNull();
+    await channels.refresh();
+    expect(channels.state.channelsSnapshot?.channelLabels.test).toBe("recovered");
+    channels.dispose();
+  });
+
   it("rejects an in-flight channel snapshot after read access is revoked", async () => {
     const pending = createDeferred<ChannelsStatusSnapshot | null>();
     const request = vi.fn(() => pending.promise);

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -202,7 +202,6 @@ async function loadChannels(
   state.channelsRefreshSeq = refreshSeq;
   state.channelsLoading = true;
   state.channelsLoadingProbe = probe;
-  state.channelsError = null;
   const refresh = (async () => {
     try {
       const res = await client.request<ChannelsStatusSnapshot | null>("channels.status", {
@@ -213,6 +212,7 @@ async function loadChannels(
         return;
       }
       state.channelsSnapshot = res;
+      state.channelsError = null;
       state.channelsLastSuccess = Date.now();
     } catch (err) {
       if (!isCurrentChannelRefresh(state, client, refreshSeq)) {

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -654,9 +654,9 @@ export function createChannelCapability(gateway: ChannelGateway): ChannelCapabil
       state.channelsLoading = false;
       state.channelsLoadingProbe = null;
       state.channelsRefreshSeq = (state.channelsRefreshSeq ?? 0) + 1;
+      state.channelsError = connected || !nextChannelReadAccess ? null : state.channelsError;
       if (!nextChannelReadAccess) {
         state.channelsSnapshot = null;
-        state.channelsError = null;
         state.channelsLastSuccess = null;
       }
     }

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -655,10 +655,8 @@ export function createChannelCapability(gateway: ChannelGateway): ChannelCapabil
       state.channelsLoadingProbe = null;
       state.channelsRefreshSeq = (state.channelsRefreshSeq ?? 0) + 1;
       state.channelsError = connected || !nextChannelReadAccess ? null : state.channelsError;
-      if (!nextChannelReadAccess) {
-        state.channelsSnapshot = null;
-        state.channelsLastSuccess = null;
-      }
+      state.channelsSnapshot = null;
+      state.channelsLastSuccess = null;
     }
     if (clientChanged || connectionChanged || whatsappAdminAccessChanged) {
       lifecycle.whatsappEpoch += 1;

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -63,7 +63,16 @@ function createGateway(): TestGateway {
             commandOwnerConfigured: true,
             limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
           }
-        : {},
+        : method === "channels.status"
+          ? {
+              ts: 0,
+              channelOrder: [],
+              channelLabels: {},
+              channels: {},
+              channelAccounts: {},
+              channelDefaultAccountId: {},
+            }
+          : {},
     ),
   } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {

--- a/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
+++ b/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
@@ -100,6 +100,43 @@ describe("custodian channel onboarding", () => {
     expect(context.channels.refresh).toHaveBeenNthCalledWith(2, false);
   });
 
+  it("shows an error instead of a healthy nudge when refresh fails with a stale snapshot", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Ready.",
+      action: "none",
+    });
+    const { context, setChannelsError } = createContext(request, ["openclaw.chat"], {
+      channelsSnapshot: channelSnapshot(),
+    });
+    const { page } = await mountPage(context, { onboarding: true });
+
+    setChannelsError("status unavailable");
+    await page.updateComplete;
+
+    expect(page.querySelector('[role="alert"]')?.textContent).toContain(
+      "Channel status is unavailable",
+    );
+    expect(page.textContent).not.toContain("The web app already works");
+  });
+
+  it("does not refresh after the channel prompt is dismissed", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Ready.",
+      action: "none",
+    });
+    const { context, setChannelsConnected } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: true });
+    await waitForFast(() => expect(context.channels.refresh).toHaveBeenCalledOnce());
+
+    page.store.dismissChannelOnboardingNudge();
+    setChannelsConnected(false);
+    setChannelsConnected(true);
+
+    expect(context.channels.refresh).toHaveBeenCalledOnce();
+  });
+
   it.each([
     {
       name: "normal caretaker visits",

--- a/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
+++ b/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChannelsStatusSnapshot } from "../../api/types.ts";
+import { createChannelCapability } from "../../lib/channels/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -98,6 +100,54 @@ describe("custodian channel onboarding", () => {
 
     expect(context.channels.refresh).toHaveBeenCalledTimes(2);
     expect(context.channels.refresh).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("awaits fresh channel status after reconnecting with a stale successful snapshot and error", async () => {
+    const freshStatus = createDeferred<ChannelsStatusSnapshot>();
+    let statusRequestCount = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "channels.status") {
+        statusRequestCount += 1;
+        if (statusRequestCount === 1) {
+          return Promise.resolve(channelSnapshot());
+        }
+        if (statusRequestCount === 2) {
+          return Promise.reject(new Error("status unavailable"));
+        }
+        return freshStatus.promise;
+      }
+      return Promise.resolve({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Ready.",
+        action: "none",
+      });
+    });
+    const { context, setGatewaySnapshot } = createContext(request);
+    const channels = createChannelCapability(context.gateway);
+    Object.assign(context, { channels });
+    await channels.refresh();
+    await channels.refresh();
+    expect(channels.state.channelsSnapshot).not.toBeNull();
+    expect(channels.state.channelsError).toBe("status unavailable");
+    const { page } = await mountPage(context, { onboarding: true });
+
+    setGatewaySnapshot({ phase: "reconnecting" });
+    setGatewaySnapshot({ phase: "connected" });
+
+    await waitForFast(() => expect(statusRequestCount).toBe(3));
+    expect(channels.state.channelsSnapshot).toBeNull();
+    expect(channels.state.channelsLoading).toBe(true);
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+
+    freshStatus.resolve(
+      channelSnapshot({
+        channels: { telegram: { configured: true, running: true, connected: true } },
+      }),
+    );
+    await waitForFast(() => expect(channels.state.channelsLoading).toBe(false));
+    expect(channels.state.channelsSnapshot?.channels.telegram?.connected).toBe(true);
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+    channels.dispose();
   });
 
   it("shows an error instead of a healthy nudge when refresh fails with a stale snapshot", async () => {

--- a/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
+++ b/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChannelsStatusSnapshot } from "../../api/types.ts";
-import { createChannelCapability } from "../../lib/channels/index.ts";
+import { channelSnapshotEntryIsActive, createChannelCapability } from "../../lib/channels/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -145,7 +145,7 @@ describe("custodian channel onboarding", () => {
       }),
     );
     await waitForFast(() => expect(channels.state.channelsLoading).toBe(false));
-    expect(channels.state.channelsSnapshot?.channels.telegram?.connected).toBe(true);
+    expect(channelSnapshotEntryIsActive(channels.state.channelsSnapshot, "telegram")).toBe(true);
     expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
     channels.dispose();
   });
@@ -168,6 +168,51 @@ describe("custodian channel onboarding", () => {
       "Channel status is unavailable",
     );
     expect(page.textContent).not.toContain("The web app already works");
+  });
+
+  it("keeps retry feedback visible until a deferred channel refresh succeeds", async () => {
+    const retryStatus = createDeferred<ChannelsStatusSnapshot>();
+    let statusRequestCount = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "channels.status") {
+        statusRequestCount += 1;
+        return statusRequestCount === 1
+          ? Promise.reject(new Error("status unavailable"))
+          : retryStatus.promise;
+      }
+      return Promise.resolve({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Ready.",
+        action: "none",
+      });
+    });
+    const { context } = createContext(request);
+    const channels = createChannelCapability(context.gateway);
+    Object.assign(context, { channels });
+    await channels.refresh();
+    const { page } = await mountPage(context, { onboarding: true });
+
+    const retry = page.querySelector<HTMLButtonElement>(".custodian__nudge-cta");
+    expect(retry?.textContent).toContain("Retry");
+    retry?.click();
+
+    await waitForFast(() => expect(statusRequestCount).toBe(2));
+    await page.updateComplete;
+    expect(channels.state.channelsLoading).toBe(true);
+    expect(channels.state.channelsError).toBe("status unavailable");
+    expect(page.querySelector('[role="alert"]')).not.toBeNull();
+    expect(page.querySelector<HTMLButtonElement>(".custodian__nudge-cta")?.disabled).toBe(true);
+    expect(page.querySelector(".custodian__nudge-cta")?.textContent).toContain("Loading");
+
+    retryStatus.resolve(
+      channelSnapshot({
+        channels: { telegram: { configured: true, running: true, connected: true } },
+      }),
+    );
+    await waitForFast(() => expect(channels.state.channelsLoading).toBe(false));
+    expect(channels.state.channelsError).toBeNull();
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+    channels.dispose();
   });
 
   it("does not refresh after the channel prompt is dismissed", async () => {

--- a/ui/src/pages/custodian/custodian-page.test-harness.ts
+++ b/ui/src/pages/custodian/custodian-page.test-harness.ts
@@ -30,6 +30,7 @@ type ContextHarness = {
   setGatewayToken: (token: string) => void;
   setChannelsConnected: (connected: boolean) => void;
   setChannelsSnapshot: (snapshot: ChannelsStatusSnapshot | null) => void;
+  setChannelsError: (error: string | null) => void;
   emitGatewayEvent: (event: Pick<GatewayEventFrame, "event" | "payload">) => void;
 };
 
@@ -88,7 +89,7 @@ export function createContext(
   } as unknown as ApplicationGateway;
   const agentListeners = new Set<() => void>();
   const channelListeners = new Set<(state: ApplicationContext["channels"]["state"]) => void>();
-  const channelState = {
+  const channelState: ApplicationContext["channels"]["state"] = {
     client,
     connected: true,
     channelsLoading: false,
@@ -108,6 +109,13 @@ export function createContext(
     whatsappLoginConnected: null,
     whatsappBusy: false,
   };
+  const refreshChannels = vi.fn(() => {
+    channelState.channelsLoading = true;
+    for (const listener of channelListeners) {
+      listener(channelState);
+    }
+    return new Promise<void>(() => {});
+  });
   const context = {
     gateway,
     agents: {
@@ -128,7 +136,7 @@ export function createContext(
     agentSelection: { state: { selectedId: "main" } },
     channels: {
       state: channelState,
-      refresh: vi.fn().mockResolvedValue(undefined),
+      refresh: refreshChannels,
       subscribe: (listener: (state: ApplicationContext["channels"]["state"]) => void) => {
         channelListeners.add(listener);
         return () => channelListeners.delete(listener);
@@ -152,6 +160,8 @@ export function createContext(
     },
     setChannelsConnected: (connected) => {
       channelState.connected = connected;
+      channelState.channelsLoading = false;
+      channelState.channelsError = null;
       for (const listener of channelListeners) {
         listener(channelState);
       }
@@ -159,6 +169,13 @@ export function createContext(
     setChannelsSnapshot: (nextSnapshot) => {
       channelState.channelsSnapshot = nextSnapshot;
       channelState.channelsLastSuccess = nextSnapshot ? Date.now() : null;
+      for (const listener of channelListeners) {
+        listener(channelState);
+      }
+    },
+    setChannelsError: (error: string | null) => {
+      channelState.channelsLoading = false;
+      channelState.channelsError = error;
       for (const listener of channelListeners) {
         listener(channelState);
       }

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -39,17 +39,11 @@ export class CustodianPage extends OpenClawLightDomElement {
   private subscribedStore: CustodianSessionStore | null = null;
   private storeCleanup: (() => void) | null = null;
   private channelsSource: ApplicationContext["channels"] | null = null;
-  private channelRefreshRequested = false;
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.channels,
     (channels) => {
       this.channelsSource = channels;
-      this.channelRefreshRequested = false;
-      const stop = channels.subscribe((channelState) => {
-        if (!channelState.connected) {
-          // Disconnect invalidates an in-flight refresh; reconnect must be able to retry.
-          this.channelRefreshRequested = false;
-        }
+      const stop = channels.subscribe(() => {
         this.ensureOnboardingChannelStatus();
         this.requestUpdate();
       });
@@ -95,7 +89,7 @@ export class CustodianPage extends OpenClawLightDomElement {
 
   private ensureOnboardingChannelStatus(): void {
     const channels = this.channelsSource;
-    if (!this.onboarding || !channels || this.channelRefreshRequested) {
+    if (!this.onboarding || this.store.channelOnboardingNudgeClosed || !channels) {
       return;
     }
     const channelState = channels.state;
@@ -107,7 +101,6 @@ export class CustodianPage extends OpenClawLightDomElement {
     ) {
       return;
     }
-    this.channelRefreshRequested = true;
     void channels.refresh(false);
   }
 
@@ -199,10 +192,18 @@ export class CustodianPage extends OpenClawLightDomElement {
   }
 
   override render() {
-    const channelSnapshot = this.channelsSource?.state.channelsSnapshot ?? null;
+    const channelState = this.channelsSource?.state;
+    const channelSnapshot = channelState?.channelsSnapshot ?? null;
+    const channelStatusError =
+      this.onboarding && !this.store.channelOnboardingNudgeClosed && channelState?.connected
+        ? (channelState?.channelsError ?? null)
+        : null;
     const showChannelOnboardingNudge =
       this.onboarding &&
       !this.store.channelOnboardingNudgeClosed &&
+      channelState?.connected &&
+      !channelState.channelsLoading &&
+      channelStatusError === null &&
       channelSnapshot !== null &&
       channelSnapshot.partial !== true &&
       !channelSnapshotHasActiveChannel(channelSnapshot);
@@ -272,6 +273,9 @@ export class CustodianPage extends OpenClawLightDomElement {
           .onboarding=${this.onboarding}
           .newAgentIntent=${this.newAgentIntent}
           .showChannelOnboardingNudge=${showChannelOnboardingNudge}
+          .channelOnboardingError=${channelStatusError}
+          .channelOnboardingRetrying=${channelState?.channelsLoading ?? false}
+          .onRetryChannelOnboarding=${() => void this.channelsSource?.refresh(false)}
           .historyContent=${historyContent}
         ></openclaw-custodian-surface>
       </section>

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -24,6 +24,9 @@ class CustodianSurface extends OpenClawLightDomElement {
   @property({ attribute: false }) onboarding = false;
   @property({ attribute: false }) newAgentIntent = false;
   @property({ attribute: false }) showChannelOnboardingNudge = false;
+  @property({ attribute: false }) channelOnboardingError: string | null = null;
+  @property({ attribute: false }) channelOnboardingRetrying = false;
+  @property({ attribute: false }) onRetryChannelOnboarding: () => void = () => undefined;
   @property({ attribute: false }) compact = false;
   @property({ attribute: false }) historyContent: TemplateResult | typeof nothing = nothing;
 
@@ -143,12 +146,18 @@ class CustodianSurface extends OpenClawLightDomElement {
           : ""}"
       >
         <div class="custodian__messages" aria-live="polite">
-          ${this.showChannelOnboardingNudge
-            ? eventNudgeState.renderCustodianChannelOnboardingNudge({
-                onOpenChannels: () => store.openChannelsFromOnboarding(),
+          ${this.channelOnboardingError
+            ? eventNudgeState.renderCustodianChannelOnboardingError({
+                retrying: this.channelOnboardingRetrying,
+                onRetry: this.onRetryChannelOnboarding,
                 onDismiss: () => store.dismissChannelOnboardingNudge(),
               })
-            : nothing}
+            : this.showChannelOnboardingNudge
+              ? eventNudgeState.renderCustodianChannelOnboardingNudge({
+                  onOpenChannels: () => store.openChannelsFromOnboarding(),
+                  onDismiss: () => store.dismissChannelOnboardingNudge(),
+                })
+              : nothing}
           ${!this.onboarding && store.eventNudge && !store.eventNudgePending
             ? eventNudgeState.renderCustodianEventNudge({
                 nudge: store.eventNudge,

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -128,6 +128,35 @@ export function renderCustodianChannelOnboardingNudge(params: {
   </div>`;
 }
 
+export function renderCustodianChannelOnboardingError(params: {
+  retrying: boolean;
+  onRetry: () => void;
+  onDismiss: () => void;
+}) {
+  return html`<div class="custodian__nudge custodian__nudge--channel-onboarding" role="alert">
+    <div class="custodian__nudge-copy">
+      <strong>${t("custodian.nudge.channelStatusErrorTitle")}</strong>
+      <span>${t("custodian.nudge.channelStatusErrorBody")}</span>
+    </div>
+    <button
+      class="btn btn--sm primary custodian__nudge-cta"
+      type="button"
+      ?disabled=${params.retrying}
+      @click=${params.onRetry}
+    >
+      ${params.retrying ? t("common.loading") : t("common.retry")}
+    </button>
+    <button
+      class="custodian__nudge-dismiss"
+      type="button"
+      aria-label=${t("custodian.nudge.channelSetupDismiss")}
+      @click=${params.onDismiss}
+    >
+      ×
+    </button>
+  </div>`;
+}
+
 type UnknownRecord = Record<string, unknown>;
 
 const CONSEQUENTIAL_CHANNEL_STATES = new Set([


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users finishing Custodian setup could lose the channel onboarding status after a transient `channels.status` failure. The flow neither explained that only the channel check failed nor offered a direct recovery action.

## Why This Change Was Made

Custodian now keeps the channel-status failure visible at the owning onboarding surface, offers Retry and dismiss actions, and clears the stale failure only after reconnection or channel-read access loss. The existing channel setup nudge returns after a successful retry, without treating a temporary status failure as a Gateway-wide outage.

## User Impact

Users can retry a failed channel status check or dismiss the optional channel setup prompt and continue using the web app. Desktop and mobile layouts preserve the same visible recovery path.

## Evidence

- Node 24.19.0 unit/JSDOM owner tests: 30 passed (`ui/src/lib/channels/index.test.ts`, `ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts`).
- Node 24.19.0 mock-Gateway Playwright Chromium E2E: 1 passed, exercising the status failure, Retry recovery, dismissible setup nudge, desktop 1280×900, and mobile 390px layouts (`ui/src/e2e/custodian-channel-onboarding.e2e.test.ts`).
- Final-head screenshots were visually inspected: intended channel-only error and recovered states; no Gateway connection errors or sensitive data.
- Target oxfmt and oxlint: passed. `git diff --check`: passed. Changed-path classification: UI + UI tests. Target core test-types stripe 2/5: passed. TruffleHog 3.97.0 changed-file scan: 0 verified/unverified secrets.
- `check:changed` could not acquire its Crabbox/Testbox route because the installed Crabbox binary failed its sanity preflight; focused owner tests and E2E were run locally in this dedicated Linux orb instead.
- Independent exact-head review before rebase found no P0–P2 findings and judged this the best fix. Codex autoreview was unavailable (HTTP 401); no Codex verdict is claimed.

### Before: channel status check fails with a focused retry/dismiss action

_Final-head screenshot captured and inspected; GitHub attachment upload was blocked by a 404 from the user-attachments endpoint._

### After: successful retry restores the channel setup nudge (desktop)

_Final-head screenshot captured and inspected; GitHub attachment upload was blocked by a 404 from the user-attachments endpoint._

### After: successful retry at 390px mobile width

_Final-head screenshot captured and inspected; GitHub attachment upload was blocked by a 404 from the user-attachments endpoint._

Production LOC: +59/-15 (net +44) | Tests/test support: +112/-3. Production growth adds the visible status-error ownership and recovery controls; tests cover reconnect clearing, retry, dismiss, and responsive E2E behavior.

AI-assisted: yes. I understand the change and verified the final rebased head. No transcript is included, per publication instructions.
