### PR TITLE
fix(qa-lab): stop matrix probe re-polling at the deadline

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
@@ -11,6 +11,8 @@ export const MATRIX_QA_SERVICE = "matrix-qa-homeserver";
 export const MATRIX_QA_CLEANUP_TIMEOUT_MS = 90_000;
 const MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS = 2_000;
 
+class MatrixQaHarnessTimeoutError extends Error {}
+
 export type MatrixQaHarnessFiles = {
   outputDir: string;
   composeFile: string;
@@ -27,12 +29,11 @@ export function buildVersionsUrl(baseUrl: string) {
 export async function isMatrixVersionsReachable(
   baseUrl: string,
   fetchImpl: FetchLike,
-  timeoutMs = MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS,
+  timeoutSignal = AbortSignal.timeout(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS),
   signal?: AbortSignal,
 ) {
   let response: Awaited<ReturnType<FetchLike>> | undefined;
   try {
-    const timeoutSignal = AbortSignal.timeout(Math.max(1, timeoutMs));
     response = await fetchImpl(buildVersionsUrl(baseUrl), {
       signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
     });
@@ -57,7 +58,7 @@ export async function withMatrixQaHarnessTimeout<T>(
       task,
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
-          reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+          reject(new MatrixQaHarnessTimeoutError(`${label} timed out after ${timeoutMs}ms`));
         }, timeoutMs);
       }),
     ]);
@@ -93,6 +94,7 @@ export async function waitForReachableMatrixBaseUrl(params: {
     const probeController = new AbortController();
     let reachableCandidate: string | undefined;
     let probeConsumedDeadline = false;
+    const requestTimeoutMs = Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, remainingMs);
     try {
       // Race both network paths so neither stalled probe can starve or delay
       // a healthy peer. The outer deadline also bounds injected fetch fakes.
@@ -101,26 +103,28 @@ export async function waitForReachableMatrixBaseUrl(params: {
         remainingMs,
         Promise.any(
           candidateBaseUrls.map(async (baseUrl) => {
+            const requestTimeoutSignal = AbortSignal.timeout(Math.max(1, requestTimeoutMs));
             if (
               await isMatrixVersionsReachable(
                 baseUrl,
                 params.fetchImpl,
-                Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, remainingMs),
+                requestTimeoutSignal,
                 probeController.signal,
               )
             ) {
               return baseUrl;
+            }
+            if (requestTimeoutMs === remainingMs && requestTimeoutSignal.aborted) {
+              probeConsumedDeadline = true;
             }
             throw new Error("Matrix versions endpoint unreachable");
           }),
         ),
       );
     } catch (error) {
-      // A stalled probe consumed the entire remaining budget; its timeout can
-      // fire marginally before Date.now() crosses the deadline, so re-polling
-      // here would start a doomed extra probe. Fast candidate failures re-poll.
-      probeConsumedDeadline =
-        error instanceof Error && error.message.startsWith("Matrix health probes timed out");
+      // The outer timeout covers injected fetches that ignore abort signals.
+      // Request timeouts record the same deadline fact before rejecting.
+      probeConsumedDeadline ||= error instanceof MatrixQaHarnessTimeoutError;
     } finally {
       probeController.abort();
     }

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -88,6 +88,28 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean):
   return count;
 }
 
+function createStalledVersionsFetch() {
+  const probeSignals: AbortSignal[] = [];
+  const fetchImpl = vi.fn(
+    async (_input: string, init?: Pick<RequestInit, "signal">) =>
+      await new Promise<never>((_resolve, reject) => {
+        const probeSignal = init?.signal ?? undefined;
+        if (!probeSignal) {
+          reject(new Error("versions probe signal missing"));
+          return;
+        }
+        probeSignals.push(probeSignal);
+        const rejectAborted = () => reject(new Error("versions probe aborted"));
+        if (probeSignal.aborted) {
+          rejectAborted();
+          return;
+        }
+        probeSignal.addEventListener("abort", rejectAborted, { once: true });
+      }),
+  );
+  return { fetchImpl, probeSignals };
+}
+
 describe("matrix harness runtime", () => {
   it("writes a pinned Tuwunel compose file", async () => {
     const outputDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-harness-"));
@@ -315,29 +337,14 @@ describe("matrix harness runtime", () => {
   });
 
   it("bounds a stalled versions probe by the remaining discovery deadline", async () => {
-    const probeSignals: AbortSignal[] = [];
-    const fetchImpl = vi.fn(
-      async (_input: string, init?: Pick<RequestInit, "signal">) =>
-        await new Promise<never>((_resolve, reject) => {
-          const probeSignal = init?.signal ?? undefined;
-          if (!probeSignal) {
-            reject(new Error("versions probe signal missing"));
-            return;
-          }
-          probeSignals.push(probeSignal);
-          const rejectAborted = () => reject(new Error("versions probe aborted"));
-          if (probeSignal.aborted) {
-            rejectAborted();
-            return;
-          }
-          probeSignal.addEventListener("abort", rejectAborted, { once: true });
-        }),
-    );
-    const sleepImpl = vi.fn(async (_ms: number) => {});
-    const startedAt = Date.now();
-
-    await expect(
-      testing.waitForReachableMatrixBaseUrl({
+    vi.useFakeTimers();
+    const requestTimeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(requestTimeout.signal);
+    try {
+      const { fetchImpl, probeSignals } = createStalledVersionsFetch();
+      const sleepImpl = vi.fn(async () => {});
+      const startedAt = Date.now();
+      const waiting = testing.waitForReachableMatrixBaseUrl({
         composeFile: "/tmp/docker-compose.matrix-qa.yml",
         containerBaseUrl: null,
         fetchImpl,
@@ -345,22 +352,51 @@ describe("matrix harness runtime", () => {
         sleepImpl,
         timeoutMs: 25,
         pollMs: 1_000,
-      }),
-    ).rejects.toThrow("did not become healthy");
+      });
+      const rejection = expect(waiting).rejects.toThrow("did not become healthy");
 
-    expect(Date.now() - startedAt).toBeLessThan(500);
-    expect(probeSignals).not.toHaveLength(0);
-    expect(probeSignals.length).toBeLessThanOrEqual(2);
-    expect(probeSignals.every((signal) => signal.aborted)).toBe(true);
-    // The inner AbortSignal.timeout (clamped to the remaining budget) and the
-    // outer deadline timer race at ~timeoutMs. When the inner fires first the
-    // loop takes one residual micro-sleep before Date.now() crosses the
-    // deadline. The protected invariant is bounded exit, not zero sleeps:
-    // allow at most one sleep and require it to be within the deadline budget.
-    expect(sleepImpl.mock.calls.length).toBeLessThanOrEqual(1);
-    const residualSleepMs = sleepImpl.mock.calls[0]?.[0];
-    if (residualSleepMs !== undefined) {
-      expect(residualSleepMs).toBeLessThanOrEqual(25);
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+
+      expect(Date.now() - startedAt).toBe(25);
+      expect(probeSignals).toHaveLength(1);
+      expect(probeSignals[0]?.aborted).toBe(true);
+      expect(sleepImpl).not.toHaveBeenCalled();
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-poll when the request timeout wins at the discovery deadline", async () => {
+    vi.useFakeTimers();
+    const requestTimeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(requestTimeout.signal);
+    try {
+      const { fetchImpl } = createStalledVersionsFetch();
+      const startedAt = Date.now();
+      const sleepImpl = vi.fn(async (ms: number) => {
+        vi.setSystemTime(Date.now() + ms);
+      });
+      const waiting = testing.waitForReachableMatrixBaseUrl({
+        composeFile: "/tmp/docker-compose.matrix-qa.yml",
+        containerBaseUrl: null,
+        fetchImpl,
+        hostBaseUrl: "http://127.0.0.1:28008/",
+        sleepImpl,
+        timeoutMs: 25,
+        pollMs: 1_000,
+      });
+
+      vi.setSystemTime(startedAt + 24);
+      requestTimeout.abort(new DOMException("request timed out", "TimeoutError"));
+      await expect(waiting).rejects.toThrow("did not become healthy");
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(sleepImpl).not.toHaveBeenCalled();
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix QA health discovery could sleep and start a doomed extra poll when the per-request timeout won a race with the overall discovery timeout at the same deadline. The race caused unrelated CI jobs to flake with an observed `sleepImpl(1)` call.

Related: https://github.com/openclaw/openclaw/actions/runs/31954674724

## Why This Change Was Made

The probe loop now owns each request timeout signal and records when that timeout represents the remaining discovery budget, so the re-poll decision comes from the deadline rather than timer ordering. The outer harness timeout uses an internal typed error instead of a message-prefix contract. Fast candidate failures still re-poll, while either deadline-owned timeout ordering stops immediately.

The tests force the outer-timeout-wins and request-timeout-wins orderings independently. This supersedes the temporary residual-sleep tolerance added in #124656 with a production repair and restores the zero-extra-poll assertion.

AI-assisted: yes.

## User Impact

No normal Matrix harness behavior changes. QA runs retain fast-failure retries but no longer spend an extra poll cycle after the discovery budget is exhausted, eliminating this timing-dependent CI flake.

## Evidence

- Pre-fix deterministic regression: `does not re-poll when the request timeout wins at the discovery deadline` failed with exactly one `sleepImpl(1)` call.
- Final focused proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts` passed 20/20 consecutive runs (15 tests per run).
- Changed gate: the full `check:changed` plan passed in an isolated native-arm64 Linux container after Blacksmith/AWS capacity was unavailable (`local-container`, lease `cbx_ddea227e302e`, exit 0), including extension production/test typechecks, lint, runtime-sidecar loading, and import-cycle checks.
- `git diff --check origin/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` reported no accepted/actionable findings.
