### PR TITLE
fix: keep dirty changed checks scoped to local edits

### DIFF
--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3200,7 +3200,13 @@ function analyzeRemoteCommand(invocation: RunInvocation) {
   };
 }
 
-function prepareRemoteWsl2JsBootstrapScript(run: RunInvocation, facts: RunFacts, provider: string) {
+function prepareRemoteWsl2JsBootstrapScript(
+  run: RunInvocation,
+  facts: RunFacts,
+  provider: string,
+  changedGateBase: string,
+  changedGateAlias: string,
+) {
   const runtimeEntrypoint = awsMacosBunEntrypoints.has(facts.runtimeEntrypoint)
     ? ""
     : facts.runtimeEntrypoint;
@@ -3220,7 +3226,7 @@ function prepareRemoteWsl2JsBootstrapScript(run: RunInvocation, facts: RunFacts,
   const originalShellCommand = facts.scopedEnvCommand?.shellCommand ?? renderRunShellCommand(run);
   const script = `${remoteWsl2JsBootstrap({
     packageManager: facts.packageManager,
-  })} || exit $?\n{ ${originalShellCommand}\n}\n`;
+  })} || exit $?\n${facts.changedGate && changedGateBase ? `${remoteGitBootstrapForChangedGate(changedGateBase, changedGateAlias)} || exit $?\n` : ""}{ ${originalShellCommand}\n}\n`;
   writeFileSync(scriptPath, script, "utf8");
   chmodSync(scriptPath, 0o700);
 
@@ -3419,7 +3425,7 @@ function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], _providerName
   }
 
   const changedGate = isChangedGateCommand(parseRunInvocation(help.text, commandArgs).commandArgs);
-  if (changedGate && !isWindowsRemoteTarget(commandArgs)) {
+  if (changedGate && !isNativeWindowsRemoteTarget(commandArgs)) {
     return true;
   }
   return isWorktreeClean() && (isSparseCheckout() || changedGate);
@@ -3774,6 +3780,8 @@ function applyRunTransforms(
     invocation,
     facts,
     options.provider,
+    options.changedGateBase,
+    options.changedGateAlias,
   );
   let transformedArgs = wsl2ScriptBootstrap.args;
   invocation = parseRunInvocation(help.text, transformedArgs);

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -541,9 +541,9 @@ function satisfiesMinimumCrabboxVersion(version: string, minimum: number[]) {
   return !parsed.suffix || isPostReleaseDescribeSuffix(parsed.suffix);
 }
 
-function gitOutput(commandArgs: string[]) {
+function gitOutput(commandArgs: string[], extraEnv: ProcessEnv = {}) {
   const gitBinary = resolvePathBinary("git", process.env, process.platform) ?? "git";
-  const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" };
+  const gitEnv = { ...process.env, ...extraEnv, GIT_CONFIG_GLOBAL: "/dev/null" };
   const invocation = spawnInvocation(gitBinary, commandArgs, gitEnv, process.platform);
   const result = spawnSync(invocation.command, invocation.args, {
     cwd: repoRoot,
@@ -3410,21 +3410,19 @@ function isWorktreeClean() {
   return status.status === 0 && status.stdout === "";
 }
 
-function shouldUseFullCheckoutForCleanRemoteSync(commandArgs: string[], _providerName: string) {
+function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], _providerName: string) {
   if (commandArgs[0] !== "run") {
     return false;
   }
   if (hasOption(commandArgs, "--no-sync")) {
     return false;
   }
-  if (!isWorktreeClean()) {
-    return false;
-  }
 
-  return (
-    isSparseCheckout() ||
-    isChangedGateCommand(parseRunInvocation(help.text, commandArgs).commandArgs)
-  );
+  const changedGate = isChangedGateCommand(parseRunInvocation(help.text, commandArgs).commandArgs);
+  if (changedGate && !isWindowsRemoteTarget(commandArgs)) {
+    return true;
+  }
+  return isWorktreeClean() && (isSparseCheckout() || changedGate);
 }
 
 function defaultFullCheckoutSyncRoot() {
@@ -3498,9 +3496,27 @@ function assertFullCheckoutSyncDisk(root: string) {
   );
 }
 
+function currentWorktreeTree(syncRoot: string) {
+  const indexDir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-index-"));
+  const indexPath = resolve(indexDir, "index");
+  const indexEnv = { GIT_INDEX_FILE: indexPath };
+  try {
+    const read = gitOutput(["read-tree", "HEAD"], indexEnv);
+    const add = gitOutput(["add", "-A", "--", "."], indexEnv);
+    const tree = gitOutput(["write-tree"], indexEnv);
+    if (read.status !== 0 || add.status !== 0 || tree.status !== 0 || !tree.stdout) {
+      throw new Error(read.text || add.text || tree.text || "git write-tree failed");
+    }
+    return tree.stdout;
+  } finally {
+    rmSync(indexDir, { recursive: true, force: true });
+  }
+}
+
 function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) {
   const syncRoot = fullCheckoutSyncRoot();
   assertFullCheckoutSyncDisk(syncRoot);
+  const changedGateTree = options.changedGateBase ? currentWorktreeTree(syncRoot) : "";
   const dir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-sync-"));
   let active = false;
   let resolvedChangedGateBase = options.changedGateBase ?? "";
@@ -3526,19 +3542,15 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
       try {
         bundleTempDir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-bundle-"));
         const bundleTempPath = resolve(bundleTempDir, "changed-gate.bundle");
-        const head = gitOutput(["-C", dir, "rev-parse", "HEAD"]);
         const base = gitOutput(["-C", dir, "rev-parse", options.changedGateBase]);
-        if (head.status !== 0 || base.status !== 0 || !head.stdout || !base.stdout) {
-          throw new Error(`git rev-parse failed: ${head.text || base.text}`);
+        const baseTree = gitOutput(["-C", dir, "rev-parse", `${options.changedGateBase}^{tree}`]);
+        if (base.status !== 0 || baseTree.status !== 0 || !base.stdout || !baseTree.stdout) {
+          throw new Error(`git rev-parse failed: ${base.text || baseTree.text}`);
         }
         resolvedChangedGateBase = base.stdout;
-        if (head.stdout === base.stdout) {
+        if (changedGateTree === baseTree.stdout) {
           writeFileSync(bundleTempPath, "", "utf8");
         } else {
-          const headTree = gitOutput(["-C", dir, "rev-parse", "HEAD^{tree}"]);
-          if (headTree.status !== 0 || !headTree.stdout) {
-            throw new Error(headTree.text || "git rev-parse HEAD tree failed");
-          }
           // A parentless carrier makes the bundle self-contained while sending
           // only the final tree. The remote attaches the fetched base as parent.
           const transportCommit = gitOutput([
@@ -3549,7 +3561,7 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
             "-c",
             "user.email=ci@openclaw.local",
             "commit-tree",
-            headTree.stdout,
+            changedGateTree,
             "-m",
             "remote-changed-gate-tree",
           ]);
@@ -3938,7 +3950,7 @@ normalizedArgs = scriptBootstrap.args;
 const scriptStdinPrepared = scriptBootstrap.prepared;
 let wsl2ScriptBootstrap = { args: normalizedArgs, cleanup: () => {}, prepared: false };
 try {
-  if (shouldUseFullCheckoutForCleanRemoteSync(normalizedArgs, provider)) {
+  if (shouldUseFullCheckoutForRemoteSync(normalizedArgs, provider)) {
     const invocation = parseRunInvocation(help.text, normalizedArgs);
     const facts = analyzeRemoteCommand(invocation);
     const changedGate = facts.changedGate ? changedGateBaseForCommand(facts.commandArgs) : null;
@@ -3953,11 +3965,11 @@ try {
     remoteChangedGateBase = checkout.changedGateBase;
     remoteChangedGateAlias = changedGate?.remoteAlias ?? "";
     console.error(
-      `[crabbox] sparse clean checkout detected; syncing from temporary full checkout ${checkout.dir}`,
+      `[crabbox] isolated checkout sync; syncing from temporary full checkout ${checkout.dir}`,
     );
     if (checkout.changedGateBase) {
       console.error(
-        `[crabbox] remote changed gate detected; overlaying local HEAD as worktree changes from ${checkout.changedGateBase}`,
+        `[crabbox] remote changed gate detected; overlaying the local worktree as changes from ${checkout.changedGateBase}`,
       );
     }
   }
@@ -4124,7 +4136,7 @@ if (childStderr) {
   });
 }
 const childKillGraceMs = resolveChildKillGraceMs(process.env);
-let childForceKillTimer: NodeJS.Timeout | undefined;
+let childForceKillTimer: ReturnType<typeof setTimeout> | undefined;
 let childTreeShutdownStarted = false;
 if (fullCheckout) {
   try {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -333,13 +333,17 @@ if (args[0] === "worktree" && args[1] === "add") {
   fs.mkdirSync(args[3], { recursive: true });
   if (process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET) fs.symlinkSync(process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET, path.join(args[3], ".openclaw-crabbox-changed-gate.bundle")); process.exit(0);
 }
+if (args[0] === "read-tree") { fs.writeFileSync(process.env.GIT_INDEX_FILE, ""); process.exit(0); }
+if (args[0] === "add" && process.env.GIT_INDEX_FILE) process.exit(0);
+if (args[0] === "write-tree") { process.stdout.write((process.env.OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA || "tree456") + "\n"); process.exit(0); }
 if (args[0] === "-C" && args[2] === "sparse-checkout" && args[3] === "disable") process.exit(0);
 if (args[0] === "-C" && args[2] === "rev-parse") {
-  const value = args[3] === "HEAD" ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || "def456" : args[3] === "HEAD^{tree}" ? process.env.OPENCLAW_FAKE_GIT_HEAD_TREE_SHA || "tree456" : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || "abc123";
+  const value = args[3] === "HEAD" ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || "def456" : args[3] === "HEAD^{tree}" ? process.env.OPENCLAW_FAKE_GIT_HEAD_TREE_SHA || "tree456" : args[3].endsWith("^{tree}") ? process.env.OPENCLAW_FAKE_GIT_BASE_TREE_SHA || "base-tree123" : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || "abc123";
   process.stdout.write(value + "\n"); process.exit(0);
 }
 if (args[0] === "-C" && args[2] === "-c" && args[6] === "commit-tree") {
   if (process.env.OPENCLAW_FAKE_GIT_ROOT_COMMIT_MARKER && args.includes("-p")) process.exit(68);
+  if (process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE && args[7] !== process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE) process.exit(69);
   touch("OPENCLAW_FAKE_GIT_ROOT_COMMIT_MARKER"); touch("OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER");
   process.stdout.write((process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_SHA || "synthetic789") + "\n"); process.exit(0);
 }
@@ -3303,7 +3307,7 @@ describe("scripts/crabbox-wrapper", () => {
       cleanSparseSyncOptions,
     );
     expect(result.stderr).toContain("syncing from temporary full checkout");
-    expect(result.stderr).toContain("overlaying local HEAD as worktree changes from abc123");
+    expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
     expect(output.args.join(" ")).toContain(
       "openclaw_changed_gate_bundle=.openclaw-crabbox-changed-gate.bundle",
     );
@@ -3370,7 +3374,7 @@ describe("scripts/crabbox-wrapper", () => {
         },
       },
     );
-    expect(result.stderr).toContain("overlaying local HEAD as worktree changes from release123");
+    expect(result.stderr).toContain("overlaying the local worktree as changes from release123");
     expect(remoteCommand).toContain("openclaw_changed_gate_base=release123");
     expect(remoteCommand).toContain(
       "openclaw_changed_gate_alias=refs/remotes/origin/release/2026.7.2",
@@ -3534,7 +3538,7 @@ describe("scripts/crabbox-wrapper", () => {
       },
     );
     expect(result.stderr).toContain("syncing from temporary full checkout");
-    expect(result.stderr).toContain("overlaying local HEAD as worktree changes from abc123");
+    expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
     expect(output.cwd).toContain("openclaw-crabbox-sync-");
     expect(output.args).toContain("--shell");
     expect(remoteCommand).toContain("git init -q");
@@ -3542,6 +3546,38 @@ describe("scripts/crabbox-wrapper", () => {
     expect(remoteCommand).toMatch(
       /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
     );
+  });
+
+  it("bootstraps the exact dirty worktree tree for remote changed gates", () => {
+    const dirtyTree = "dirty-tree-123";
+    const { output, remoteCommand, result } = runSuccessfulDefaultWrapper(
+      [
+        "run",
+        "--provider",
+        "blacksmith-testbox",
+        "--blacksmith-ref",
+        "main",
+        "--",
+        "corepack",
+        "pnpm",
+        "check:changed",
+      ],
+      {
+        env: {
+          OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE: dirtyTree,
+          OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA: dirtyTree,
+        },
+        gitResponses: {
+          [GIT_STATUS_PORCELAIN_KEY]: { stdout: " M scripts/crabbox-wrapper.mts\n" },
+          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
+        },
+      },
+    );
+
+    expect(result.stderr).toContain("syncing from temporary full checkout");
+    expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
+    expect(output.cwd).toContain("openclaw-crabbox-sync-");
+    expectChangedGateGitBootstrap(remoteCommand);
   });
 
   it("bootstraps Git metadata for env-prefixed sparse changed gates", () => {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1952,17 +1952,31 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it("prefers Azure for unqualified Windows runs", () => {
-    const { output, result } = runSuccessfulWrapper(azureProviderHelp, [
-      "run",
-      "--target",
-      "windows",
-      "--windows-mode",
-      "wsl2",
-      "--",
-      "corepack",
-      "pnpm",
-      "check:changed",
-    ]);
+    const dirtyTree = "dirty-wsl2-tree-123";
+    const { output, result } = runSuccessfulWrapper(
+      azureProviderHelp,
+      [
+        "run",
+        "--target",
+        "windows",
+        "--windows-mode",
+        "wsl2",
+        "--",
+        "corepack",
+        "pnpm",
+        "check:changed",
+      ],
+      {
+        env: {
+          OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE: dirtyTree,
+          OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA: dirtyTree,
+        },
+        gitResponses: {
+          [GIT_STATUS_PORCELAIN_KEY]: { stdout: " M scripts/crabbox-wrapper.mts\n" },
+          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
+        },
+      },
+    );
 
     const remoteCommand = normalizeShellLineEndings(output.scriptContent!);
     expect(output.args.slice(0, 7)).toEqual([
@@ -1984,9 +1998,12 @@ describe("scripts/crabbox-wrapper", () => {
     expect(remoteCommand).toContain("corepack enable --install-directory");
     expect(remoteCommand).toContain("pnpm install --frozen-lockfile");
     expect(remoteCommand).toContain("openclaw_crabbox_bootstrap_wsl2_js || exit $?");
+    expectChangedGateGitBootstrap(remoteCommand);
     expect(remoteCommand).toContain(
       `{ openclaw_crabbox_env ${remoteChangedGateEnvPrefix} corepack pnpm check:changed\n}`,
     );
+    expect(output.cwd).toContain("openclaw-crabbox-sync-");
+    expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
     expect(result.stderr).toContain("provider=azure");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running delegated changed checks from a dirty worktree could test dozens of unrelated recent-main files because the remote box retained stale Git metadata.

## Why This Change Was Made

Dirty POSIX changed gates now use the existing isolated-checkout transport. A private Git index snapshots the exact final worktree tree without mutating the user's index, while the existing bundle bootstrap reconstructs the exact merge base and final tree remotely. WSL2 uses that same transport and includes the bootstrap in its generated POSIX script; native Windows keeps its existing PowerShell path.

## User Impact

Delegated `check:changed` runs from staged, unstaged, deleted, or eligible untracked edits stay scoped to the user's actual changes. This makes remote validation faster and prevents unrelated baseline failures.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts` — 239 passed.
- The focused dirty WSL2 generated-script regression failed before the follow-up and passes with the exact-tree Git bootstrap.
- Dirty-worktree Blacksmith Testbox proof: [run 31957878108](https://github.com/openclaw/openclaw/actions/runs/31957878108), lease `tbx_01m05newzp26dy8yzsj462w9ba` (completed). Sync reported exactly 3 targeted transport/changed files; remote classification was only `scripts, testRoot, tooling`; all changed checks passed in 2m56s.
- Exact-head Blacksmith Testbox proof: [run 31958898971](https://github.com/openclaw/openclaw/actions/runs/31958898971), lease `tbx_01m05pnda8z13v18p9csd62t9v` (completed). Remote classification remained `scripts, testRoot, tooling`; all changed checks passed in 2m55s.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings; overall correctness 0.98.