### PR TITLE
fix(android): stop wrapper subprocess trees on cancellation

### DIFF
--- a/scripts/run-android-gradle.mts
+++ b/scripts/run-android-gradle.mts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 
 const repoRoot = resolveRepoRoot(import.meta.url);
@@ -80,25 +80,12 @@ export function run(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ) {
-  return new Promise<number>((resolve) => {
-    const child = spawn(command, args, {
-      cwd,
-      env,
-      stdio: "inherit",
-    });
-    child.on("close", (status, signal) => {
-      if (typeof status === "number") {
-        resolve(status);
-      } else if (signal) {
-        resolve(128);
-      } else {
-        resolve(1);
-      }
-    });
-    child.on("error", (error) => {
-      console.error(error instanceof Error ? error.message : String(error));
-      resolve(1);
-    });
+  return runManagedCommand({
+    args: [...args],
+    bin: command,
+    cwd,
+    env,
+    shell: false,
   });
 }
 

--- a/scripts/run-android-gradle.mts
+++ b/scripts/run-android-gradle.mts
@@ -74,19 +74,24 @@ export function resolveAndroidSdkEnv(options: SdkOptions = {}) {
   return { ...env, ANDROID_HOME: defaultSdkDir };
 }
 
-export function run(
+export async function run(
   command: string,
   args: readonly string[],
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ) {
-  return runManagedCommand({
-    args: [...args],
-    bin: command,
-    cwd,
-    env,
-    shell: false,
-  });
+  try {
+    return await runManagedCommand({
+      args: [...args],
+      bin: command,
+      cwd,
+      env,
+      shell: false,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
 }
 
 export async function main(argv: string[] = process.argv.slice(2)) {

--- a/test/scripts/run-android-gradle.test.ts
+++ b/test/scripts/run-android-gradle.test.ts
@@ -4,15 +4,18 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   linuxArmAndroidGradleSkipMessage,
   resolveAndroidSdkEnv,
+  run,
   shouldSkipLinuxArmAndroidGradle,
   splitAndroidGradleArgs,
 } from "../../scripts/run-android-gradle.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("run-android-gradle", () => {
   it("splits Gradle args from an optional post command", () => {
@@ -99,19 +102,27 @@ describe("run-android-gradle", () => {
   });
 
   posixIt("terminates the active command tree when the wrapper is terminated", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-android-gradle-process-"));
-    const childPidPath = path.join(dir, "child.pid");
+    const dir = tempDirs.make("openclaw-android-gradle-process-");
+    const processTreePath = path.join(dir, "process-tree.json");
     const moduleUrl = pathToFileURL(path.resolve("scripts/run-android-gradle.mts")).href;
     const childSource = `
+const { spawn } = require("node:child_process");
 const fs = require("node:fs");
-fs.writeFileSync(process.argv[1], String(process.pid));
+const descendant = spawn(process.execPath, [
+  "-e",
+  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1_000);",
+], { stdio: "ignore" });
+fs.writeFileSync(
+  process.argv[1],
+  JSON.stringify({ childPid: process.pid, descendantPid: descendant.pid }),
+);
 setInterval(() => {}, 1_000);
 `;
     const runnerSource = `
 import { run } from ${JSON.stringify(moduleUrl)};
 process.exitCode = await run(
   process.execPath,
-  ["-e", ${JSON.stringify(childSource)}, ${JSON.stringify(childPidPath)}],
+  ["-e", ${JSON.stringify(childSource)}, ${JSON.stringify(processTreePath)}],
   process.cwd(),
 );
 `;
@@ -122,18 +133,28 @@ process.exitCode = await run(
     );
     const runnerPid = expectPid(runner.pid);
     let childPid = 0;
+    let descendantPid = 0;
 
     try {
-      await waitFor(() => fs.existsSync(childPidPath));
-      childPid = Number(fs.readFileSync(childPidPath, "utf8"));
+      await waitFor(() => fs.existsSync(processTreePath));
+      const processTree = JSON.parse(fs.readFileSync(processTreePath, "utf8")) as {
+        childPid: number;
+        descendantPid: number;
+      };
+      childPid = processTree.childPid;
+      descendantPid = processTree.descendantPid;
       expect(Number.isInteger(childPid)).toBe(true);
+      expect(Number.isInteger(descendantPid)).toBe(true);
       expect(isProcessAlive(childPid)).toBe(true);
+      expect(isProcessAlive(descendantPid)).toBe(true);
 
       process.kill(runnerPid, "SIGTERM");
       const result = await waitForClose(runner);
-      await delay(100);
+      await waitFor(() => !isProcessAlive(childPid), 1_500);
+      await waitFor(() => !isProcessAlive(descendantPid), 1_500);
 
       expect(isProcessAlive(childPid)).toBe(false);
+      expect(isProcessAlive(descendantPid)).toBe(false);
       expect(result).toEqual({ code: 143, signal: null });
     } finally {
       if (isProcessAlive(runnerPid)) {
@@ -142,7 +163,21 @@ process.exitCode = await run(
       if (childPid && isProcessAlive(childPid)) {
         process.kill(childPid, "SIGKILL");
       }
-      fs.rmSync(dir, { force: true, recursive: true });
+      if (descendantPid && isProcessAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
+      }
+    }
+  });
+
+  it("reports spawn errors and returns a failure status", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const missingCommand = path.join(os.tmpdir(), `openclaw-missing-command-${process.pid}`);
+    try {
+      await expect(run(missingCommand, [], process.cwd(), {})).resolves.toBe(1);
+      expect(error).toHaveBeenCalledOnce();
+      expect(String(error.mock.calls[0]?.[0])).toContain("ENOENT");
+    } finally {
+      error.mockRestore();
     }
   });
 });
@@ -173,7 +208,15 @@ async function waitForClose(child: ReturnType<typeof spawn>) {
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  if (process.platform !== "linux") {
     return true;
+  }
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    return stat.charAt(stat.lastIndexOf(")") + 2) !== "Z";
   } catch {
     return false;
   }

--- a/test/scripts/run-android-gradle.test.ts
+++ b/test/scripts/run-android-gradle.test.ts
@@ -1,4 +1,9 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   linuxArmAndroidGradleSkipMessage,
@@ -6,6 +11,8 @@ import {
   shouldSkipLinuxArmAndroidGradle,
   splitAndroidGradleArgs,
 } from "../../scripts/run-android-gradle.mts";
+
+const posixIt = process.platform === "win32" ? it.skip : it;
 
 describe("run-android-gradle", () => {
   it("splits Gradle args from an optional post command", () => {
@@ -90,4 +97,84 @@ describe("run-android-gradle", () => {
       expect(result).toBe(env);
     });
   });
+
+  posixIt("terminates the active command tree when the wrapper is terminated", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-android-gradle-process-"));
+    const childPidPath = path.join(dir, "child.pid");
+    const moduleUrl = pathToFileURL(path.resolve("scripts/run-android-gradle.mts")).href;
+    const childSource = `
+const fs = require("node:fs");
+fs.writeFileSync(process.argv[1], String(process.pid));
+setInterval(() => {}, 1_000);
+`;
+    const runnerSource = `
+import { run } from ${JSON.stringify(moduleUrl)};
+process.exitCode = await run(
+  process.execPath,
+  ["-e", ${JSON.stringify(childSource)}, ${JSON.stringify(childPidPath)}],
+  process.cwd(),
+);
+`;
+    const runner = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", runnerSource],
+      { stdio: "ignore" },
+    );
+    const runnerPid = expectPid(runner.pid);
+    let childPid = 0;
+
+    try {
+      await waitFor(() => fs.existsSync(childPidPath));
+      childPid = Number(fs.readFileSync(childPidPath, "utf8"));
+      expect(Number.isInteger(childPid)).toBe(true);
+      expect(isProcessAlive(childPid)).toBe(true);
+
+      process.kill(runnerPid, "SIGTERM");
+      const result = await waitForClose(runner);
+      await delay(100);
+
+      expect(isProcessAlive(childPid)).toBe(false);
+      expect(result).toEqual({ code: 143, signal: null });
+    } finally {
+      if (isProcessAlive(runnerPid)) {
+        process.kill(runnerPid, "SIGKILL");
+      }
+      if (childPid && isProcessAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
+
+function expectPid(pid: number | undefined): number {
+  if (pid === undefined) {
+    throw new Error("expected child process pid");
+  }
+  return pid;
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const startedAt = Date.now();
+  while (!condition()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("timed out waiting for condition");
+    }
+    await delay(5);
+  }
+}
+
+async function waitForClose(child: ReturnType<typeof spawn>) {
+  return await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers cancelling `pnpm android:assemble`, `android:install`, `android:run`, `android:lint:android`, or `android:test` could leave the active Gradle or post-command process tree running after the Node wrapper exited.

On the pre-fix baseline, terminating the wrapper left the direct child reparented to PID 1 and a resistant descendant alive in the inherited process group. Captured stdio could also keep the parent-side close event open after the wrapper had exited.

## Why This Change Was Made

The Android wrapper now delegates process lifecycle and signal handling to the existing `runManagedCommand` owner instead of carrying a second raw-`spawn` policy. It preserves explicit `shell: false`, sequential Gradle-then-post-command execution, and the existing printed-error plus exit-1 behavior for launch failures.

The regression exercises wrapper integration with a direct child and SIGTERM-resistant descendant. It also covers spawn-error compatibility and uses the repository temp-directory tracker for cleanup.

## User Impact

Developers can interrupt Android build, install, run, lint, and test wrapper commands without leaving Gradle/ADB subprocess trees behind. Normal success and failure behavior is unchanged except that signal exits now use the conventional shell status, such as 143 for SIGTERM.

There is no product UI, configuration, SDK, protocol, persistence, release, or deployment change.

## Evidence

Before the fix, an immutable-baseline process probe observed wrapper PID 99647 exit on SIGTERM while child PID 99746 was reparented to PID 1 and descendant PID 99748 remained live; both required explicit cleanup.

Post-rebase proof on head `ffba327ed96a8039708f5a35bb7989fb5535c081`:

- Focused tests: `node scripts/run-vitest.mjs test/scripts/run-android-gradle.test.ts test/scripts/managed-child-process.test.ts --reporter=verbose` — 29/29 passed.
- Source-blind real Gradle CLI proof: wrapper PID 23933, child/group leader PID 24161, resistant descendant PID 24167; both children absent after SIGTERM, wrapper exit 143, validator cleanup signalled no process. Gradle-success sequencing, invalid-task suppression of the post-command, and missing-executable ENOENT/exit-1 behavior also passed.
- Hosted changed gate: Blacksmith Testbox `tbx_01m05ns2jr3cfx2bdb5v903ad8`, Actions run https://github.com/openclaw/openclaw/actions/runs/31958143502, exit 0. Both tsgo graphs, targeted Oxlint, formatting, temp-directory guard, Docker boundary guard, and selected repository guards passed.
- Targeted checks: Oxlint clean; runtime import cycles 0; Madge cycles 0; `git diff --check` clean.
- Fresh Codex autoreview: TruffleHog clean, no accepted/actionable findings, correctness 0.98.
- Production LOC: `+11/-19` (net `-8`). Tests: `+131/-1`.

Proof gaps: no native Windows host was exercised and this does not claim native Windows Android support. Explicit non-shell spawning and Windows `taskkill /T` + `/F` behavior are covered by the shared managed-process tests. No physical Android device was available; this is a host subprocess-lifecycle repair and no simulator/device proof was substituted.

AI-assisted: implemented and reviewed with Codex; behavior and proof were independently inspected before publication.
