### PR TITLE
fix(onboarding): stop printing gateway token URLs

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -360,7 +360,7 @@ Skills: `--node-manager <npm|pnpm|bun>` (default `npm`), `--skip-skills`.
 
 UI and hook setup: `--skip-ui` (skip Control UI/TUI prompts), `--skip-hooks` (skip webhook/hook setup), `--skip-channels`, `--skip-search`.
 
-Output: `--suppress-gateway-token-output` suppresses token-bearing Gateway/UI output (token hints, auto-login URL with embedded token, and automatic Control UI launch) - useful in shared terminals and CI.
+Output: `--suppress-gateway-token-output` disables the automatic Control UI handoff in guided onboarding. Classic onboarding never prints reusable Gateway token values or tokenized URLs; it still prints safe recovery commands.
 
 <Note>
 `--json` does not imply non-interactive mode in guided or classic onboarding.

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -244,7 +244,7 @@ export function registerOnboardCommand(program: Command): void {
     .option("--skip-search", "Skip search provider setup")
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI prompts")
-    .option("--suppress-gateway-token-output", "Suppress token-bearing Gateway/UI output")
+    .option("--suppress-gateway-token-output", "Disable the guided Control UI handoff")
     .option("--skip-hooks", "Skip hook setup")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
     .option("--import-from <provider>", "Migration provider to run during onboarding")

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -252,7 +252,7 @@ export function registerSetupCommand(program: Command): void {
     .option("--skip-search", "Skip search provider setup")
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI launch")
-    .option("--suppress-gateway-token-output", "Suppress token-bearing Gateway/UI output")
+    .option("--suppress-gateway-token-output", "Disable the guided Control UI handoff")
     .option("--skip-hooks", "Accepted for onboard compatibility; hooks setup is skipped")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
     .option("--import-from <provider>", "Migration provider to run during onboarding")

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -20,7 +20,6 @@ import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
-import type { GatewayAuthMode } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveAdvertisedControlUiLinks,
@@ -50,18 +49,6 @@ export { randomToken } from "./random-token.js";
 export { detectBinary };
 export { detectBrowserOpenSupport, openUrl, resolveBrowserOpenCommand };
 export { resolveAdvertisedControlUiLinks, resolveControlUiLinks, resolveLocalControlUiProbeLinks };
-
-/** Builds the token-authenticated Control UI URL shown by onboarding surfaces. */
-export function buildOnboardingControlUiUrl(params: {
-  httpUrl: string;
-  authMode?: GatewayAuthMode;
-  token?: string;
-  suppressTokenOutput?: boolean;
-}): string {
-  return params.authMode === "token" && params.token && !params.suppressTokenOutput
-    ? `${params.httpUrl}#token=${encodeURIComponent(params.token)}`
-    : params.httpUrl;
-}
 
 /** Handles Clack cancellation by exiting through the runtime. */
 export function guardCancel<T>(value: T | symbol, runtime: RuntimeEnv, exitCode = 0): T {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -192,24 +192,16 @@ export function applyWizardMetadata(
 }
 
 /** Formats the no-GUI SSH tunnel hint for opening the Control UI remotely. */
-export function formatControlUiSshHint(params: {
-  port: number;
-  basePath?: string;
-  token?: string;
-}): string {
+export function formatControlUiSshHint(params: { port: number; basePath?: string }): string {
   const basePath = normalizeControlUiBasePath(params.basePath);
   const uiPath = basePath ? `${basePath}/` : "/";
   const localUrl = `http://localhost:${params.port}${uiPath}`;
-  const authedUrl = params.token
-    ? `${localUrl}#token=${encodeURIComponent(params.token)}`
-    : undefined;
   const sshTarget = resolveSshTargetHint();
   return [
     "No GUI detected. Open from your computer:",
     `ssh -N -L ${params.port}:127.0.0.1:${params.port} ${sshTarget}`,
     "Then open:",
     localUrl,
-    authedUrl,
     "BYOH note: lan, tailnet, and custom bind are currently IPv4-only.",
     "If your host is IPv6-only, use an IPv4 sidecar or proxy in front of the Gateway.",
     "Docs:",

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -1104,14 +1104,9 @@ export const en = {
       controlUiTitle: "Control UI",
       controlUiDocs: "Docs: https://docs.openclaw.ai/web/control-ui",
       dashboardCopyPaste: "Copy/paste this URL in a browser on this machine to control OpenClaw.",
-      dashboardLinkWithToken: "Dashboard link (with token): {url}",
       dashboardOpened: "Opened in your browser. Keep that tab to control OpenClaw.",
       dashboardOpenAnytime: "Open the dashboard anytime: {command}",
       dashboardReady: "Dashboard ready",
-      dashboardTokenMemory:
-        "Web UI keeps dashboard URL tokens in memory for the current tab and strips them from the URL after load.",
-      dashboardTokenPrompt:
-        "If prompted: paste the token into Control UI settings (or use the tokenized dashboard URL).",
       dashboardWhenReady: "When you're ready: {command}",
       daemonRuntime: "Gateway service runtime",
       daemonRuntimeNode: "Node (recommended)",
@@ -1214,7 +1209,6 @@ export const en = {
       webSearchUnavailableAction:
         "web_search will not work until the provider is re-enabled or a different provider is selected.",
       webUiUrl: "Web UI: {url}",
-      webUiWithTokenUrl: "Web UI (with token): {url}",
       whatNow: 'What now: https://openclaw.ai/showcase ("What People Are Building").',
       whatNowTitle: "What now",
       workspaceBackupTitle: "Workspace backup",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -1067,14 +1067,9 @@ export const zh_CN = {
       controlUiTitle: "Control UI",
       controlUiDocs: "文档：https://docs.openclaw.ai/web/control-ui",
       dashboardCopyPaste: "在本机浏览器中复制/粘贴这个 URL 来控制 OpenClaw。",
-      dashboardLinkWithToken: "Dashboard 链接（含令牌）：{url}",
       dashboardOpened: "已在浏览器中打开。保留该标签页以控制 OpenClaw。",
       dashboardOpenAnytime: "随时打开 dashboard：{command}",
       dashboardReady: "Dashboard 已就绪",
-      dashboardTokenMemory:
-        "Web UI 会把 dashboard URL 中的令牌保存在当前标签页内存中，并在加载后从 URL 中移除。",
-      dashboardTokenPrompt:
-        "如果被提示：把令牌粘贴到 Control UI 设置中（或使用带令牌的 dashboard URL）。",
       dashboardWhenReady: "准备好后运行：{command}",
       daemonRuntime: "Gateway 服务运行时",
       daemonRuntimeNode: "Node（推荐）",
@@ -1170,7 +1165,6 @@ export const zh_CN = {
       webSearchUnavailableAction:
         "重新启用该 provider 或选择其他 provider 前，web_search 无法工作。",
       webUiUrl: "Web UI：{url}",
-      webUiWithTokenUrl: "Web UI（含令牌）：{url}",
       whatNow: '下一步：https://openclaw.ai/showcase（"What People Are Building"）。',
       whatNowTitle: "下一步",
       workspaceBackupTitle: "工作区备份",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -1068,14 +1068,9 @@ export const zh_TW = {
       controlUiTitle: "Control UI",
       controlUiDocs: "文件：https://docs.openclaw.ai/web/control-ui",
       dashboardCopyPaste: "在本機瀏覽器中複製/貼上這個 URL 來控制 OpenClaw。",
-      dashboardLinkWithToken: "Dashboard 連結（含權杖）：{url}",
       dashboardOpened: "已在瀏覽器中開啟。保留該分頁以控制 OpenClaw。",
       dashboardOpenAnytime: "隨時開啟 dashboard：{command}",
       dashboardReady: "Dashboard 已就緒",
-      dashboardTokenMemory:
-        "Web UI 會把 dashboard URL 中的權杖保存在目前分頁記憶體中，並在載入後從 URL 中移除。",
-      dashboardTokenPrompt:
-        "如果被提示：把權杖貼到 Control UI 設定中（或使用帶權杖的 dashboard URL）。",
       dashboardWhenReady: "準備好後執行：{command}",
       daemonRuntime: "Gateway 服務執行環境",
       daemonRuntimeNode: "Node（建議）",
@@ -1171,7 +1166,6 @@ export const zh_TW = {
       webSearchUnavailableAction:
         "重新啟用該 provider 或選擇其他 provider 前，web_search 無法運作。",
       webUiUrl: "Web UI：{url}",
-      webUiWithTokenUrl: "Web UI（含權杖）：{url}",
       whatNow: '下一步：https://openclaw.ai/showcase（"What People Are Building"）。',
       whatNowTitle: "下一步",
       workspaceBackupTitle: "工作區備份",

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -141,10 +141,6 @@ const inspectWindowsGatewayFirewall = vi.hoisted(() =>
 vi.mock("../commands/onboard-helpers.js", () => ({
   probeGatewayReachable,
   resolveAdvertisedControlUiLinks,
-  resolveControlUiLinks: vi.fn(() => ({
-    httpUrl: "http://127.0.0.1:18789",
-    wsUrl: "ws://127.0.0.1:18789",
-  })),
   resolveLocalControlUiProbeLinks,
   waitForGatewayReachable,
 }));
@@ -1541,6 +1537,9 @@ describe("finalizeSetupWizard", () => {
 
   it("never prints the reusable Gateway token during classic onboarding", async () => {
     const prompter = createLaterPrompter();
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+    const runtime = { log: runtimeLog, error: runtimeError, exit: vi.fn() };
     probeGatewayReachable.mockResolvedValue({ ok: true });
 
     await finalizeSetupWizard({
@@ -1563,17 +1562,21 @@ describe("finalizeSetupWizard", () => {
         tailscaleMode: "off",
       },
       prompter,
-      runtime: createRuntime(),
+      runtime,
     });
 
-    const output = vi
-      .mocked(prompter.note)
-      .mock.calls.map((call) => call.join("\n"))
+    const terminalOutput = [prompter.note, prompter.outro]
+      .flatMap((writer) => vi.mocked(writer).mock.calls.flat())
       .join("\n");
-    expect(output).toContain("http://127.0.0.1:18789");
-    expect(output).toContain("openclaw dashboard --no-open");
-    expect(output).not.toContain("session-token");
-    expect(output).not.toContain("#token=");
+    const runtimeOutput = [runtimeLog, runtimeError]
+      .flatMap((writer) => writer.mock.calls.flat())
+      .join("\n");
+    expect(terminalOutput).toContain("http://127.0.0.1:18789");
+    expect(terminalOutput).toContain("openclaw dashboard --no-open");
+    for (const output of [terminalOutput, runtimeOutput]) {
+      expect(output).not.toContain("session-token");
+      expect(output).not.toContain("#token=");
+    }
   });
 
   it("stops after a scheduled restart instead of reinstalling the service", async () => {

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -139,15 +139,6 @@ const inspectWindowsGatewayFirewall = vi.hoisted(() =>
 );
 
 vi.mock("../commands/onboard-helpers.js", () => ({
-  buildOnboardingControlUiUrl: (params: {
-    httpUrl: string;
-    authMode?: "token" | "password";
-    token?: string;
-    suppressTokenOutput?: boolean;
-  }) =>
-    params.authMode === "token" && params.token && !params.suppressTokenOutput
-      ? `${params.httpUrl}#token=${encodeURIComponent(params.token)}`
-      : params.httpUrl,
   probeGatewayReachable,
   resolveAdvertisedControlUiLinks,
   resolveControlUiLinks: vi.fn(() => ({
@@ -1548,8 +1539,9 @@ describe("finalizeSetupWizard", () => {
     expect(gatewayServiceInstall).not.toHaveBeenCalled();
   });
 
-  it("suppresses token-bearing onboarding output when requested", async () => {
+  it("never prints the reusable Gateway token during classic onboarding", async () => {
     const prompter = createLaterPrompter();
+    probeGatewayReachable.mockResolvedValue({ ok: true });
 
     await finalizeSetupWizard({
       flow: "advanced",
@@ -1558,8 +1550,7 @@ describe("finalizeSetupWizard", () => {
         authChoice: "skip",
         installDaemon: false,
         skipHealth: true,
-        skipUi: true,
-        suppressGatewayTokenOutput: true,
+        skipUi: false,
       },
       baseConfig: {},
       nextConfig: {},
@@ -1580,6 +1571,7 @@ describe("finalizeSetupWizard", () => {
       .mock.calls.map((call) => call.join("\n"))
       .join("\n");
     expect(output).toContain("http://127.0.0.1:18789");
+    expect(output).toContain("openclaw dashboard --no-open");
     expect(output).not.toContain("session-token");
     expect(output).not.toContain("#token=");
   });

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -23,7 +23,6 @@ import { resolveGatewayInstallToken } from "../commands/gateway-install-token.js
 import { formatHealthCheckFailure } from "../commands/health-format.js";
 import { healthCommand } from "../commands/health.js";
 import {
-  buildOnboardingControlUiUrl,
   probeGatewayReachable,
   waitForGatewayReachable,
   resolveAdvertisedControlUiLinks,
@@ -507,7 +506,6 @@ export async function finalizeSetupWizard(
   options: FinalizeOnboardingOptions,
 ): Promise<{ launchedTui: boolean }> {
   const { flow, opts, baseConfig, nextConfig, settings, prompter, runtime } = options;
-  const suppressGatewayTokenOutput = opts.suppressGatewayTokenOutput === true;
   let gatewayProbe: { ok: boolean; detail?: string } = { ok: true };
   let resolvedGatewayPassword = "";
   let sessionGateway: import("../gateway/server.js").GatewayServer | undefined;
@@ -668,12 +666,6 @@ export async function finalizeSetupWizard(
       basePath: controlUiBasePath,
       tlsEnabled: nextConfig.gateway?.tls?.enabled === true,
     });
-    const authedUrl = buildOnboardingControlUiUrl({
-      httpUrl: displayLinks.httpUrl,
-      authMode: settings.authMode,
-      token: settings.gatewayToken,
-      suppressTokenOutput: suppressGatewayTokenOutput,
-    });
     if (gateway.status !== "failed" && (opts.skipHealth || !gatewayProbe.ok)) {
       gatewayProbe = await probeGatewayReachable({
         url: probeLinks.wsUrl,
@@ -766,14 +758,6 @@ export async function finalizeSetupWizard(
     await prompter.note(
       [
         dashboardReady ? t("wizard.finalize.webUiUrl", { url: displayLinks.httpUrl }) : undefined,
-        dashboardReady &&
-        !opts.skipUi &&
-        gatewayProbe.ok &&
-        settings.authMode === "token" &&
-        settings.gatewayToken &&
-        !suppressGatewayTokenOutput
-          ? t("wizard.finalize.webUiWithTokenUrl", { url: authedUrl })
-          : undefined,
         t("wizard.finalize.gatewayWsUrl", { url: displayLinks.wsUrl }),
         gatewayStatusLine,
         ...windowsFirewallLines,
@@ -820,11 +804,9 @@ export async function finalizeSetupWizard(
           t("wizard.finalize.gatewayTokenGenerate", {
             command: formatCliCommand("openclaw doctor --generate-gateway-token"),
           }),
-          suppressGatewayTokenOutput ? undefined : t("wizard.finalize.dashboardTokenMemory"),
           t("wizard.finalize.dashboardOpenAnytime", {
             command: formatCliCommand("openclaw dashboard --no-open"),
           }),
-          suppressGatewayTokenOutput ? undefined : t("wizard.finalize.dashboardTokenPrompt"),
         ].filter(Boolean);
         await prompter.note(tokenNotes.join("\n"), "Token");
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where classic onboarding could print a reusable Gateway token inside a dashboard URL, including through a dead headless SSH formatter path. Token-bearing terminal output is easy to retain in terminal transcripts, logs, recordings, and support bundles.

## Why This Change Was Made

Classic onboarding now prints only the uncredentialed Control UI URL and the existing `openclaw dashboard --no-open` recovery command. The obsolete authenticated-URL builder, unused SSH token parameter, and token-specific onboarding copy are deleted. Maintainer security review explicitly accepts the token-free classic handoff because the published contract already promises a clean link and a short-lived dashboard bootstrap.

The separate dashboard command is unchanged. Its backward-compatible JSON `url`, short-lived one-time `browserUrl`, and browser pairing behavior remain covered. This PR is AI-assisted.

## User Impact

Operators no longer receive reusable Gateway credentials in classic onboarding or headless SSH output. They still receive a plain dashboard URL and a supported recovery command. Dashboard integrations retain their structured JSON handoff.

## Evidence

Exact head: `bad68a070478b92f11594e984648d9aa0e64f65f`, rebased onto `origin/main` `27cb5d021fd1f7d8dd408871645038318609ce0a`.

- Pre-fix synthetic-sentinel reproduction: the no-reusable-credential contract failed with both `classicLeaks: true` and `sshLeaks: true` (exit 42). No real credential was read or printed.
- Source-blind operator validation: two real interactive classic QuickStart runs completed without printing the reusable sentinel, `#token=`, or reusable-token labels; both CLI help surfaces use the new handoff wording. Two isolated live dashboard probes retained the legacy structured URL fields and distinct one-time `browserUrl` shape without printing either synthetic sentinel or full URLs.
- Focused onboarding/dashboard/CLI proof: 8 files across 4 Vitest shards, 236/236 tests passed.
- `pnpm check:changed`: passed for the selected `core`, `coreTests`, and `docs` lanes, including formatting, typechecking, lint, dependency/boundary guards, dead exports, import cycles, and repository ratchets.
- `pnpm docs:list` and `pnpm check:docs`: passed; 6,514 internal links checked with 0 broken links and 1,176 config examples validated.
- Fresh exact-head Codex autoreview: clean, with no accepted/actionable findings.
- Exact-head CI: [run 32078160453](https://github.com/openclaw/openclaw/actions/runs/32078160453) completed green; the repository watcher reported `GREEN` for this head.
- LOC: production +3/-60 (net -57); tests +18/-23 (net -5); docs +1/-1 (net 0); total +22/-84 across 9 files.

Contributor credit is preserved: the first repair commit is authored by Amp (`amp@ampcode.com`), followed by Peter's maintainer cleanup commit.
