### PR TITLE
docs(docker): warn against single-file binding openclaw.json

### DIFF
--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -180,15 +180,17 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 # - "./openclaw.json:/home/node/.openclaw/openclaw.json"
 ```
 
-Docker pins a file bind to one inode. OpenClaw writes `openclaw.json` with a
-sibling temp file plus rename, which publishes a new inode. After that replace,
-a file-bound container can keep reading the old file while the host path points
-at the new one, so config edits look like a no-op.
+A Docker file bind attaches the mount-time inode, not the path name. OpenClaw
+writes `openclaw.json` with `@openclaw/fs-safe` `replaceFileAtomic`: a sibling
+temp file plus rename. The config writer also sets
+`copyFallbackOnPermissionError: true`, which falls back to copy-replace only
+on `EPERM`/`EEXIST`. Either path publishes a new inode. The file-bound
+container can keep reading the old inode while the host path points at the
+new one, so config edits look like a no-op.
 
-Do not treat a specific errno or `openclaw doctor` as the signal. The config
-writer enables a permission-error copy fallback, so a failed rename does not
-always mean config cannot be saved. Doctor "config drift" is for
-supervisor/service files, not a bind-mounted `openclaw.json`.
+Do not treat a specific Docker errno or `openclaw doctor` as the signal. A
+failed rename can still save via that copy fallback. Doctor "config drift"
+is for supervisor/service files, not a bind-mounted `openclaw.json`.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -165,6 +165,34 @@ truth. Long-lived state must survive restarts, rebuilds, and reboots.
 | Node and OS packages | Container filesystem                | Docker image                | Rebuilt with the image; do not install at runtime                          |
 | Docker container     | Ephemeral                           | Restartable                 | Safe to replace after mounted state is verified                            |
 
+## Common pitfall: never file-bind `openclaw.json`
+
+Mount the gateway state **as a directory**, never as a single file. The repo
+`docker-compose.yml` already does this:
+
+```yaml
+# Supported: whole state directory.
+- "${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/node/.openclaw"
+```
+
+```yaml
+# Unsupported: single-file bind. Do not use this.
+# - "./openclaw.json:/home/node/.openclaw/openclaw.json"
+```
+
+Docker pins a file bind to one inode. OpenClaw writes `openclaw.json` with a
+sibling temp file plus rename, which publishes a new inode. After that replace,
+a file-bound container can keep reading the old file while the host path points
+at the new one, so config edits look like a no-op.
+
+Do not treat a specific errno or `openclaw doctor` as the signal. The config
+writer enables a permission-error copy fallback, so a failed rename does not
+always mean config cannot be saved. Doctor "config drift" is for
+supervisor/service files, not a bind-mounted `openclaw.json`.
+
+Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
+inside that directory.
+
 ## Update OpenClaw
 
 For a source-built image:

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -181,16 +181,16 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 ```
 
 A Docker file bind attaches the mount-time inode, not the path name. OpenClaw
-writes `openclaw.json` with `@openclaw/fs-safe` `replaceFileAtomic`: a sibling
-temp file plus rename. The config writer also sets
-`copyFallbackOnPermissionError: true`, which falls back to copy-replace only
-on `EPERM`/`EEXIST`. Either path publishes a new inode. The file-bound
-container can keep reading the old inode while the host path points at the
-new one, so config edits look like a no-op.
+never rewrites `openclaw.json` in place: it writes a sibling temp file and
+renames it over the target, and its permission-error fallback removes and
+recreates the file instead. Both paths publish a new inode, so a file-bound
+container keeps reading the old one while the host path points at the new
+one — config edits look like a no-op.
 
 Do not treat a specific Docker errno or `openclaw doctor` as the signal. A
-failed rename can still save via that copy fallback. Doctor "config drift"
-is for supervisor/service files, not a bind-mounted `openclaw.json`.
+failed rename can still save through that fallback, and doctor's config-drift
+checks cover service and MCP configuration, not a bind-mounted
+`openclaw.json`.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -180,17 +180,16 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 # - "./openclaw.json:/home/node/.openclaw/openclaw.json"
 ```
 
-A Docker file bind attaches the mount-time inode, not the path name. OpenClaw
-never rewrites `openclaw.json` in place: it writes a sibling temp file and
-renames it over the target, and its permission-error fallback removes and
-recreates the file instead. Both paths publish a new inode, so a file-bound
-container keeps reading the old one while the host path points at the new
-one — config edits look like a no-op.
+A single-file bind follows the file the host path pointed at when the container
+started, not the path itself. OpenClaw never edits `openclaw.json` in place:
+every config write publishes a replacement file. So the first host-side save
+leaves the container reading the file it was bound to while the host path
+already points at the new one, and further edits look like a no-op inside the
+container.
 
-Do not treat a specific Docker errno or `openclaw doctor` as the signal. A
-failed rename can still save through that fallback, and doctor's config-drift
-checks cover service and MCP configuration, not a bind-mounted
-`openclaw.json`.
+Nothing reports this. The host-side save succeeds, and `openclaw doctor` checks
+service and MCP configuration drift, not whether a bind-mounted `openclaw.json`
+still resolves to the file the host is writing.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -181,13 +181,13 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 ```
 
 A single-file bind follows the file the host path pointed at when the container
-started, not the path itself. OpenClaw never edits `openclaw.json` in place:
-every OpenClaw config write publishes a replacement file. Divergence happens
-only when a host tool replaces that source file after the container starts.
-The container then keeps reading the file it was bound to while the host path
-already points at the new one, so later replacement saves look like a no-op
-inside the container. An in-place edit of the same file does not create that
-divergence.
+started, not the path itself. Ordinary OpenClaw config saves publish a
+replacement file rather than editing that inode in place. Prefix recovery can
+write the canonical path directly. Divergence happens when a host tool
+replaces that source file after the container starts: the container keeps
+reading the file it was bound to, while the host path already points at the
+new one, so later replacement saves look like a no-op inside the container.
+An in-place edit of the same file does not create that divergence.
 
 Nothing reports a stale bind. A replacement save on the host succeeds, and
 `openclaw doctor` checks service and MCP configuration drift, not whether a

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -182,14 +182,16 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 
 A single-file bind follows the file the host path pointed at when the container
 started, not the path itself. OpenClaw never edits `openclaw.json` in place:
-every config write publishes a replacement file. So the first host-side save
-leaves the container reading the file it was bound to while the host path
-already points at the new one, and further edits look like a no-op inside the
-container.
+every OpenClaw config write publishes a replacement file. Divergence happens
+only when a host tool replaces that source file after the container starts.
+The container then keeps reading the file it was bound to while the host path
+already points at the new one, so later replacement saves look like a no-op
+inside the container. An in-place edit of the same file does not create that
+divergence.
 
-Nothing reports this. The host-side save succeeds, and `openclaw doctor` checks
-service and MCP configuration drift, not whether a bind-mounted `openclaw.json`
-still resolves to the file the host is writing.
+Nothing reports a stale bind. A replacement save on the host succeeds, and
+`openclaw doctor` checks service and MCP configuration drift, not whether a
+bind-mounted `openclaw.json` still resolves to the file the host is writing.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -79,8 +79,8 @@ from the provider guide.
 ## Bake required binaries into the image
 
 Installing binaries inside a running container is a trap: anything installed
-at runtime is lost on restart. Bake every external binary a skill needs into
-the image at build time.
+at runtime is lost when the container is recreated. Bake every external binary
+a skill needs into the image at build time.
 
 The examples below cover three binaries only, alphabetically:
 
@@ -180,18 +180,12 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 # - "./openclaw.json:/home/node/.openclaw/openclaw.json"
 ```
 
-A single-file bind follows the file the host path pointed at when the container
-started, not the path itself. Ordinary OpenClaw config saves publish a
-replacement file rather than editing the existing file in place. Prefix
-recovery can write the canonical path directly. Divergence happens when a host
-tool replaces that source file after the container starts: the container keeps
-reading the file it was bound to, while the host path already points at the
-new one, so later replacement saves look like a no-op inside the container.
-An in-place edit of the same file does not create that divergence.
-
-Nothing reports a stale bind. A replacement save on the host succeeds, and
-`openclaw doctor` checks service and MCP configuration drift, not whether a
-bind-mounted `openclaw.json` still resolves to the file the host is writing.
+A single-file bind remains attached to the mounted file. Normal OpenClaw
+configuration saves replace `openclaw.json`. If a host-side save replaces the
+source of a single-file bind after the container starts, the container can keep
+reading the old file while the host path points to the new one. The host-side
+save can succeed without updating what the container sees. An edit that writes
+to the same file in place does not cause this divergence.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -182,9 +182,9 @@ Mount the gateway state **as a directory**, never as a single file. The repo
 
 A single-file bind follows the file the host path pointed at when the container
 started, not the path itself. Ordinary OpenClaw config saves publish a
-replacement file rather than editing that inode in place. Prefix recovery can
-write the canonical path directly. Divergence happens when a host tool
-replaces that source file after the container starts: the container keeps
+replacement file rather than editing the existing file in place. Prefix
+recovery can write the canonical path directly. Divergence happens when a host
+tool replaces that source file after the container starts: the container keeps
 reading the file it was bound to, while the host path already points at the
 new one, so later replacement saves look like a no-op inside the container.
 An in-place edit of the same file does not create that divergence.


### PR DESCRIPTION
## What Problem This Solves

Warn Docker operators to mount the whole OpenClaw state directory, matching the repository Compose layout. A host-side replacement of a single-file `openclaw.json` bind source can succeed while the running container continues reading the old file. The contributor observed this on a Synology NAS deployment.

## Why This Change Was Made

The warning distinguishes replacement saves from in-place edits and shows the supported directory mount. Normal configuration saves replace the file; prefix recovery can write in place. The maintainer follow-up preserves that distinction, simplifies the operator prose, and removes an unsupported blanket claim about stale-bind diagnostics.

The same page also incorrectly said that binaries installed at runtime disappear on restart. They disappear when the container is recreated; the build-time installation advice remains unchanged.

## User Impact

Docker operators get the supported directory-mount layout and an explanation of why host and container configuration can diverge. No runtime, configuration, or storage behavior changes.

## Evidence

- The contributor reports a real NAS incident where host and container configuration differed after a single-file bind. This is attributed incident evidence; the maintainer did not rerun that deployment.
- Both services in the current repository Compose file mount the whole state directory. The normal writer calls `replaceFileAtomic`; prefix recovery calls `fs.promises.writeFile`. Direct inspection of the pinned `@openclaw/fs-safe` 0.5.6 replacement and copy-fallback implementations confirmed the normal replacement contract.
- The mount-contract review request is addressed by Docker's [bind-mount documentation](https://docs.docker.com/engine/storage/bind-mounts/) and the upstream maintainer's [explanation of file replacement](https://github.com/moby/moby/issues/6011#issuecomment-47932248) and [recommendation to mount the parent directory](https://github.com/moby/moby/issues/6011#issuecomment-47933245). Docker's [storage documentation](https://docs.docker.com/engine/storage/) confirms the container-recreation boundary.
- The latest exact-head ClawSweeper review found no actionable patch defect and noted a three-way-merge limitation in its partial checkout. A data-only three-way merge of the changed page against main `572fe5b296a` completed without conflicts, preserving main’s frontmatter, RAM/build-stage guidance, and current SQLite persistence table. Trusted MDX and formatting checks also passed on that merged page.
- Trusted documentation tooling passed on the corrected page: documentation listing, MDX compilation, formatting with explicit trusted configuration, and complete-diff whitespace validation. No contributor code or configuration was executed locally.

Fresh complete-candidate Codex review found no accepted/actionable P0 findings. The reviewed maintainer commit is `9f6884c46539579c0d5b210e13c3227ea59250e5`, preserving the contributor’s latest commit as its direct parent. The published GitHub documentation blob matches the reviewed candidate exactly. [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33350853567) passed; [documentation CI](https://github.com/openclaw/openclaw/actions/runs/33350853588) passed on the same commit.

Thanks @ericcaiwx-star.
