### PR TITLE
fix: doctor shows progress during long migrations

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -4,6 +4,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { readAgentRosterProperty, tryResolveSoleAgentId } from "../agents/agent-scope-config.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { withProgress } from "../cli/progress.js";
 import { configIncludeOwnsAgentRoster } from "../config/agent-roster-provenance.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
@@ -158,12 +159,24 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   prompter?: DoctorPrompter;
 }) {
   const shouldRepair = params.options.repair === true || params.options.yes === true;
-  const preflight = await runDoctorConfigPreflight({
-    repairPrefixedConfig: shouldRepair,
-    recoverCorruptTargetStore: shouldRepair,
-    doctorOnlyStateMigrations: shouldRepair,
-    preparePluginMetadataSnapshot: true,
-  });
+  const preflight = await withProgress(
+    {
+      label: "Checking OpenClaw state…",
+      enabled: params.options.nonInteractive !== true && params.options.json !== true,
+      delayMs: 200,
+    },
+    (progress) =>
+      runDoctorConfigPreflight({
+        repairPrefixedConfig: shouldRepair,
+        recoverCorruptTargetStore: shouldRepair,
+        doctorOnlyStateMigrations: shouldRepair,
+        preparePluginMetadataSnapshot: true,
+        measure: async (name, run) => {
+          progress.setLabel(`${name.slice(name.lastIndexOf(".") + 1).replaceAll("-", " ")}…`);
+          return await run();
+        },
+      }),
+  );
   const snapshot = preflight.snapshot;
   const baseCfg = preflight.baseConfig;
   const pluginMetadataSnapshotState: DoctorPluginMetadataSnapshotState = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` during an upgrade could see no terminal activity for a long time while large state migrations were still making progress.

## Why This Change Was Made

Wrap the existing doctor config preflight in the shared CLI progress reporter and feed it the preflight's existing measurement stage names. Progress stays off for JSON and explicitly non-interactive invocations, and the shared wrapper always clears it on success or failure.

## User Impact

Interactive doctor runs now show the current migration stage instead of appearing hung during high-volume upgrades. Machine-readable and non-interactive output remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-config-flow.test.ts`: 63 passed
- `pnpm exec oxlint --type-aware --type-check --deny-warnings src/commands/doctor-config-flow.ts`: 0 warnings, 0 errors
- `pnpm exec oxfmt --check src/commands/doctor-config-flow.ts`: clean
- Codex autoreview: clean, overall correctness 0.99