### PR TITLE
test(azure-speech): make voices timeout proof deterministic

### DIFF
--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -3,6 +3,7 @@
 // the real fetch abort path without depending on Azure latency.
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listAzureSpeechVoices } from "./tts.js";
 
@@ -39,8 +40,13 @@ describe("listAzureSpeechVoices timeout", () => {
     { timeout: 2_000 },
     async () => {
       let requestCount = 0;
-      const server = createServer((_req, _res) => {
+      let notifyRequest = () => {};
+      const requestReceived = new Promise<void>((resolve) => {
+        notifyRequest = resolve;
+      });
+      const server = createServer((_request, _response) => {
         requestCount += 1;
+        notifyRequest();
       });
 
       const port = await listenLocal(server);
@@ -56,26 +62,32 @@ describe("listAzureSpeechVoices timeout", () => {
       );
 
       const startedAt = Date.now();
-      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      let watchdog: ReturnType<typeof setRealTimeout> | undefined;
 
       try {
-        await expect(
-          Promise.race([
-            listAzureSpeechVoices({
-              apiKey: "not-a-real",
-              baseUrl: "https://custom.example.com",
-              timeoutMs: 100,
-            }),
-            new Promise<never>((_, reject) => {
-              watchdog = setTimeout(() => reject(new Error("voices list did not time out")), 1_000);
-            }),
-          ]),
-        ).rejects.toThrow(/aborted|timeout|timed out/i);
-        expect(Date.now() - startedAt).toBeLessThan(1_000);
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        const watchdogPromise = new Promise<never>((_, reject) => {
+          watchdog = setRealTimeout(() => reject(new Error("voices list did not time out")), 1_000);
+        });
+        const request = Promise.race([
+          listAzureSpeechVoices({
+            apiKey: "not-a-real",
+            baseUrl: "https://custom.example.com",
+            timeoutMs: 100,
+          }),
+          watchdogPromise,
+        ]);
+        const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+
+        await Promise.race([requestReceived, watchdogPromise]);
         expect(requestCount).toBe(1);
+        await vi.advanceTimersByTimeAsync(100);
+        await rejection;
+        expect(Date.now() - startedAt).toBeLessThan(1_000);
       } finally {
+        vi.useRealTimers();
         if (watchdog) {
-          clearTimeout(watchdog);
+          clearRealTimeout(watchdog);
         }
         await closeServer(server);
       }

--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -1,3 +1,4 @@
+import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listInworldVoices } from "./tts.js";
@@ -14,9 +15,14 @@ describe("listInworldVoices live timeout", () => {
     { timeout: 2_000 },
     async () => {
       let requestCount = 0;
+      let notifyRequest = () => {};
+      const requestReceived = new Promise<void>((resolve) => {
+        notifyRequest = resolve;
+      });
       await withServer(
         (request) => {
           requestCount += 1;
+          notifyRequest();
           request.resume();
         },
         async (baseUrl) => {
@@ -27,14 +33,35 @@ describe("listInworldVoices live timeout", () => {
             }) as unknown as typeof globalThis.fetch,
           );
 
-          await expect(
-            listInworldVoices({
-              apiKey: "test-key",
-              baseUrl: "https://custom.inworld.example.com",
-              timeoutMs: 250,
-            }),
-          ).rejects.toThrow(/aborted|timeout|timed out/i);
-          expect(requestCount).toBe(1);
+          let watchdog: ReturnType<typeof setRealTimeout> | undefined;
+          try {
+            vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+            const watchdogPromise = new Promise<never>((_, reject) => {
+              watchdog = setRealTimeout(
+                () => reject(new Error("voices list did not time out")),
+                1_000,
+              );
+            });
+            const request = Promise.race([
+              listInworldVoices({
+                apiKey: "test-key",
+                baseUrl: "https://custom.inworld.example.com",
+                timeoutMs: 250,
+              }),
+              watchdogPromise,
+            ]);
+            const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+
+            await Promise.race([requestReceived, watchdogPromise]);
+            expect(requestCount).toBe(1);
+            await vi.advanceTimersByTimeAsync(250);
+            await rejection;
+          } finally {
+            vi.useRealTimers();
+            if (watchdog) {
+              clearRealTimeout(watchdog);
+            }
+          }
         },
       );
     },


### PR DESCRIPTION
Related: #124684

## What Problem This Solves

Fixes an issue where the Azure Speech voice-timeout integration test could fail on a loaded runner even though the request timed out correctly. The 100 ms abort could fire before the loopback connection reached the server handler, leaving the request count at zero and making the test race the request it was trying to observe.

Observed in CI job `checks-node-changed-extensions-config-2`: `extensions/azure-speech/voices-timeout.test.ts:75` expected `requestCount` to be 1 but received 0.

## Why This Change Was Made

The tests now hold only the timeout timers, start the real loopback request, await an explicit server-receipt promise under the existing real 1 s watchdog, and then advance the configured timeout exactly. This keeps the original 100 ms Azure budget and 250 ms Inworld budget while proving both dispatch and abort deterministically.

The sibling sweep found the same author and same race shape in Inworld, so that test uses the same proof. Mattermost already awaits server receipt, and Telegram receives response headers before testing its body deadline.

There is no production defect. `fetchWithSsrFGuard` intentionally starts the timeout before DNS/SSRF preflight so the entire guarded operation is bounded, and the Azure caller has no behavior that depends on distinguishing a pre-dispatch timeout from an unanswered request. Production code and timeout defaults are unchanged.

AI-assisted: yes.

## User Impact

No runtime behavior changes. CI retains the full timeout contract without a scheduler-sensitive request-arrival race.

## Evidence

- Pre-fix CI evidence: `checks-node-changed-extensions-config-2` failed at the request-count assertion with expected 1, received 0.
- Repeat proof: 20/20 consecutive runs of `node scripts/run-vitest.mjs extensions/azure-speech/voices-timeout.test.ts extensions/inworld/voices-timeout.test.ts` passed (2 tests per run).
- Azure Speech suite: `node scripts/run-vitest.mjs extensions/azure-speech` passed (4 files, 23 tests).
- Changed gate: `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01m05pfjh7yfprgj9m3qvgt83a` (exit 0): https://github.com/openclaw/openclaw/actions/runs/31958741117
- Formatting and patch integrity: `oxfmt` and `git diff --check` passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` reported no accepted/actionable findings.
