### PR TITLE
fix(cli): align agent exec with system agent owner

### DIFF
--- a/src/commands/agent-exec.agent-owner.test.ts
+++ b/src/commands/agent-exec.agent-owner.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import { resolveSqliteScope } from "../config/sessions/session-accessor.sqlite-scope.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { agentExecCommand } from "./agent-exec.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("agent exec owner selection", () => {
+  it.each([
+    {
+      name: "a migrated legacy default",
+      config: {
+        agents: {
+          entries: {
+            alpha: { default: true },
+            beta: {},
+          },
+        },
+      },
+    },
+    {
+      name: "the canonical system-agent owner",
+      config: {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "alpha" } },
+          entries: { alpha: {}, beta: {} },
+        },
+      },
+    },
+  ])("uses $name for the run and its SQLite store scope", async ({ config }) => {
+    const configRoot = tempDirs.make("openclaw-agent-exec-default-agent-");
+    const configPath = path.join(configRoot, "openclaw.json");
+    await fs.writeFile(configPath, JSON.stringify(config), "utf8");
+    const runAgent = vi.fn(async (options: Record<string, unknown>) => {
+      const requestedAgentId = typeof options.agentId === "string" ? options.agentId : "main";
+      const sessionId = String(options.sessionId);
+      const storePath = resolveSessionStorePathCore(undefined, {
+        agentId: "alpha",
+        env: process.env,
+      });
+
+      // Exercise the production guard that rejects keys owned by another agent.
+      expect(() =>
+        resolveSqliteScope({
+          agentId: requestedAgentId,
+          defaultAgentId: "alpha",
+          env: process.env,
+          sessionKey: `agent:${requestedAgentId}:explicit:${sessionId}`,
+          storePath,
+        }),
+      ).not.toThrow();
+      expect(requestedAgentId).toBe("alpha");
+      return {
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 1 },
+      };
+    });
+
+    const result = await agentExecCommand("inspect", { config: configPath }, runtime, { runAgent });
+
+    expect(result.envelope.error).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+    expect(runAgent).toHaveBeenCalledOnce();
+  });
+});

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -629,7 +629,11 @@ export async function agentExecCommand(
     const pluginInstallRoots = pluginInstallContext?.resolvePluginInstallRoots();
     const timeout = normalizeTimeoutSeconds(opts.timeout);
     const fallbacks = normalizeFallbacks(opts.model, opts.fallback);
-    const { resolveDefaultAgentDir } = await import("../agents/agent-scope-config.js");
+    const {
+      resolveAgentDir,
+      resolveSystemAgentTargetAgentId,
+      tryResolveLegacyCompatibilityAgentId,
+    } = await import("../agents/agent-scope-config.js");
     // Resolve from the inherited config, not `{}`: the default agent may declare
     // its own `agentDir`, and that is where its stored auth profiles live. This
     // reads `baseConfig` rather than `runConfig` because the run config
@@ -637,7 +641,15 @@ export async function agentExecCommand(
     // credential ownership must still follow the operator's configuration.
     // Computed before the environment repoints the state dir so the unconfigured
     // case still resolves against the real one.
-    const storedAuthAgentDir = resolveDefaultAgentDir(baseConfig);
+    const execAgentId =
+      tryResolveLegacyCompatibilityAgentId(baseConfig) ??
+      resolveSystemAgentTargetAgentId(baseConfig, undefined, {
+        surface: "agent exec",
+        hint: "Set agents.defaults.systemAgent.agentId.",
+      });
+    // Auth, session keys, and SQLite ownership must share one resolved owner.
+    // Splitting these paths can select an agent's store but emit a `main` key.
+    const storedAuthAgentDir = resolveAgentDir(baseConfig, execAgentId);
     restoreEnvironment = setAgentExecEnvironment({ stateDir, cwd });
     runtimePaths = await import("../config/paths.js");
     runtimePaths.pinRuntimePaths();
@@ -692,6 +704,7 @@ export async function agentExecCommand(
         {
           message: prompt,
           sessionId,
+          agentId: execAgentId,
           workspaceDir: cwd,
           cwd,
           model: opts.model,


### PR DESCRIPTION
## What Problem This Solves

Fixes #119750.

`openclaw agent exec` selected the configured agent's SQLite store but omitted the run `agentId`. In an explicit multi-agent install whose system owner is not `main`, the generated `agent:main:explicit:*` session key therefore failed the store ownership guard before the model was called.

## Why This Change Was Made

The command now resolves one execution owner at its entry point and uses it for both the stored-auth directory and the embedded run. Freshly migrated legacy defaults reuse the existing migration owner; canonical configurations use `agents.defaults.systemAgent.agentId`.

This keeps auth, session-key construction, and SQLite ownership on one canonical agent without weakening the guard, adding an `--agent` option, or adding a compatibility path to steady-state runtime.

## User Impact

`agent exec` now completes normally when a valid explicit multi-agent configuration assigns system work to an agent other than `main`. Ambiguous multi-agent configurations still fail with guidance to set `agents.defaults.systemAgent.agentId`.

## Evidence

Exact head: `9500f7fec698b773e39e169dd387be2fabae15f9`.

- `node scripts/run-vitest.mjs src/commands/agent-exec.agent-owner.test.ts` under Node 24.15.0 - 2 tests passed for migrated legacy and canonical explicit-owner configurations.
- Real CLI run on the exact head used the repository mock OpenAI Responses server with canonical owner `alpha`: `agent exec --config <redacted> --state-dir <redacted> --cwd <redacted> --timeout 60 --json ...` returned `ok: true`, `final: OPENCLAW_AGENT_EXEC_OWNER_OK`, provider `openai`, model `gpt-5.5`.
- The mock server received exactly one `/v1/responses` request, proving execution crossed the provider boundary.
- The retained per-agent SQLite database was `agents/alpha/agent/openclaw-agent.sqlite`; its newest session key was `agent:alpha:explicit:95deebaf-e9d4-4405-ae66-b5cea3eb7113`.
- The exact-head source build completed, including bundled plugin control-plane verification.
- `pnpm exec oxfmt --check src/commands/agent-exec.ts src/commands/agent-exec.agent-owner.test.ts` - passed.
- `pnpm exec oxlint src/commands/agent-exec.ts src/commands/agent-exec.agent-owner.test.ts` - passed.
- Fresh autoreview at P1 scope: clean, no P0/P1 findings, overall correctness 0.90.
- Surface: 2 files, +95/-2.

## AI Assistance

AI-assisted: yes. The final diff was tested through the real CLI and independently autoreviewed. No sanitized transcript artifact is attached.
