### PR TITLE
fix(code-mode): advertise the nodes namespace only when the catalog has it

### DIFF
--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -30,7 +30,7 @@ import { ToolInputError } from "./tools/common.js";
 import { resolveEligibleNodeFromList } from "./tools/nodes-utils.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
-const CODE_MODE_NODES_TOOL_ID = "openclaw:core:nodes";
+export const CODE_MODE_NODES_TOOL_ID = "openclaw:core:nodes";
 
 type CodeModeNode = {
   id: string;

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -263,6 +263,27 @@ describe("Code Mode catalog and model-visible surface", () => {
     expect(parameters.properties).not.toHaveProperty("command");
   });
 
+  it("drops the nodes namespace hint when the run catalog cannot resolve it", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    const compacted = applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    // The compacted catalog is known and holds no openclaw:core:nodes entry
+    // (owner-only surfaces filter it); advertising the namespace anyway sends
+    // the model into guaranteed unknown-tool failures.
+    const execTool = expectDefined(compacted.tools[0], "exec tool test invariant");
+    expect(catalogRef.current?.entries.some((entry) => entry.id === "openclaw:core:nodes")).toBe(
+      false,
+    );
+    expect(execTool.description).not.toContain("paired Gateway nodes");
+  });
+
   it("keeps code-mode exec guidance compact without advertising unavailable namespaces", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     const compacted = applyCodeModeCatalog({

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -6,6 +6,7 @@ import { Type } from "typebox";
 import { getAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
+import { CODE_MODE_NODES_TOOL_ID } from "./code-mode-bridge.js";
 import {
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
@@ -145,8 +146,13 @@ function createCodeModeExecDescription(
   const swarmGuidance = swarmEnabled
     ? " Swarm globals `agents.run`, `phase`, and `log` are available; read `agents.d.ts` for types and orchestration idioms."
     : "";
+  // Nodes ride the owner-only core tool; advertising the namespace to a run
+  // whose catalog cannot resolve it turns the hint into hallucination bait.
+  const hasNodes = catalog?.some((entry) => entry.id === CODE_MODE_NODES_TOOL_ID) ?? false;
   const nodesGuidance =
-    "\n- nodes: paired Gateway nodes; nodes.list(), (await nodes.get(id)).invoke(command, params)\n";
+    !catalogKnown || hasNodes
+      ? "\n- nodes: paired Gateway nodes; nodes.list(), (await nodes.get(id)).invoke(command, params)\n"
+      : "";
   const skillsGuidance = ctx.codeModeSkills?.length
     ? " Skills are available through the async `skills` global: use `await skills.list()` and `await skills.read(name)`."
     : "";


### PR DESCRIPTION
## What Problem This Solves

The code-mode exec description advertised the `nodes` namespace unconditionally: "nodes: paired Gateway nodes; nodes.list(), (await nodes.get(id)).invoke(...)". But the nodes bridge resolves the owner-only `openclaw:core:nodes` tool (`GATEWAY_OWNER_ONLY_CORE_TOOLS`), which non-owner and policy-restricted runs filter out of the catalog. Every guest call then fails with "Unknown tool id ... Use tools.search to find a tool" — a recovery hint for a tool that provably does not exist in that run. Tool text naming gated capabilities is hallucination bait per the model-context doctrine; every sibling hint (API, MCP, swarm, skills) is already availability-gated.

## Why This Change Was Made

Gate `nodesGuidance` on the compacted catalog actually containing `openclaw:core:nodes`, following the exact sibling pattern (an unknown catalog keeps the hint, matching `mcpGuidance`).

## User Impact

Restricted code-mode runs stop burning execs on guaranteed unknown-tool failures chasing an advertised-but-absent namespace.

## Evidence

- New regression "drops the nodes namespace hint when the run catalog cannot resolve it" — fails pre-fix (stash-verified), passes post-fix; existing unknown-catalog test still pins the hint's presence there.
- `node scripts/run-vitest.mjs run src/agents/code-mode` — 2 shards, all pass (full code-mode suite).
- tsgo core green; no import cycle (bridge does not import code-mode.ts).
- LOC: prod +8/−2, test +21.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99.
