### PR TITLE
fix(media): discover whisper.cpp models instead of a test fixture path

### DIFF
--- a/src/media-understanding/local-audio.test.ts
+++ b/src/media-understanding/local-audio.test.ts
@@ -43,6 +43,47 @@ describe("local audio selection", () => {
     });
   });
 
+  it("discovers installed whisper models and prefers non-tiny over the tiny fixture", async () => {
+    const tempDir = tempDirs.make("openclaw-local-audio-");
+    const commandPath = path.join(tempDir, "whisper-cli");
+    await fs.writeFile(commandPath, "#!/bin/sh\n");
+    await fs.chmod(commandPath, 0o755);
+
+    const selection = await inspectLocalAudioSelection({
+      env: { PATH: tempDir },
+      platform: process.platform,
+      arch: process.arch,
+      inspectLinkedLibraries: async () => null,
+      listDirectory: async (dirPath) =>
+        dirPath === "/opt/homebrew/share/whisper-cpp"
+          ? ["for-tests-ggml-tiny.bin", "ggml-tiny.bin", "ggml-base.en.bin", "notes.txt"]
+          : [],
+    });
+
+    const whisper = selection.candidates.find((candidate) => candidate.id === "whisper-cli");
+    expect(whisper?.ready).toBe(true);
+    expect(whisper?.entry?.args).toContain("/opt/homebrew/share/whisper-cpp/ggml-base.en.bin");
+  });
+
+  it("reports whisper as not ready when no ggml model is installed", async () => {
+    const tempDir = tempDirs.make("openclaw-local-audio-");
+    const commandPath = path.join(tempDir, "whisper-cli");
+    await fs.writeFile(commandPath, "#!/bin/sh\n");
+    await fs.chmod(commandPath, 0o755);
+
+    const selection = await inspectLocalAudioSelection({
+      env: { PATH: tempDir },
+      platform: process.platform,
+      arch: process.arch,
+      inspectLinkedLibraries: async () => null,
+      listDirectory: async () => [],
+    });
+
+    const whisper = selection.candidates.find((candidate) => candidate.id === "whisper-cli");
+    expect(whisper?.ready).toBe(false);
+    expect(whisper?.reason).toBe("model file not found");
+  });
+
   it("does not resolve auto-detected commands from empty PATH entries", async () => {
     const tempDir = tempDirs.make("openclaw-local-audio-");
     const modelPath = path.join(tempDir, "whisper.bin");

--- a/src/media-understanding/local-audio.ts
+++ b/src/media-understanding/local-audio.ts
@@ -35,7 +35,45 @@ type InspectionOptions = {
   checkExecutable?: (filePath: string, platform: NodeJS.Platform) => Promise<boolean>;
   resolveRealpath?: (filePath: string) => Promise<string>;
   inspectLinkedLibraries?: (filePath: string, platform: NodeJS.Platform) => Promise<string | null>;
+  listDirectory?: (dirPath: string) => Promise<string[]>;
 };
+
+const WHISPER_CPP_MODEL_DIRS = [
+  "/opt/homebrew/share/whisper-cpp",
+  "/usr/local/share/whisper-cpp",
+  "/usr/share/whisper-cpp",
+];
+
+async function listDirectoryEntries(dirPath: string): Promise<string[]> {
+  try {
+    return await fs.readdir(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Picks an installed ggml whisper.cpp model without hardcoding a filename.
+ * Larger models transcribe better, so prefer non-tiny when several exist;
+ * WHISPER_CPP_MODEL remains the explicit override.
+ */
+async function discoverWhisperCppModel(
+  listDirectory: (dirPath: string) => Promise<string[]>,
+): Promise<string | null> {
+  for (const dir of WHISPER_CPP_MODEL_DIRS) {
+    const models = (await listDirectory(dir))
+      .filter((name) => name.startsWith("ggml-") && name.endsWith(".bin"))
+      .toSorted((a, b) => {
+        const tinyA = a.includes("tiny") ? 1 : 0;
+        const tinyB = b.includes("tiny") ? 1 : 0;
+        return tinyA - tinyB || a.localeCompare(b);
+      });
+    if (models[0]) {
+      return path.join(dir, models[0]);
+    }
+  }
+  return null;
+}
 
 const binaryCache = new Map<string, Promise<string | null>>();
 const libraryCache = new Map<string, Promise<string | null>>();
@@ -282,10 +320,11 @@ export async function inspectLocalAudioSelection(
   );
 
   const envModel = env.WHISPER_CPP_MODEL?.trim();
-  const defaultWhisperModel = "/opt/homebrew/share/whisper-cpp/for-tests-ggml-tiny.bin";
   const whisperModel =
-    envModel && (await optionalPathExists(envModel)) ? envModel : defaultWhisperModel;
-  const whisperReady = Boolean(whisperCommand) && (await optionalPathExists(whisperModel));
+    envModel && (await optionalPathExists(envModel))
+      ? envModel
+      : await discoverWhisperCppModel(options.listDirectory ?? listDirectoryEntries);
+  const whisperReady = Boolean(whisperCommand) && Boolean(whisperModel);
   const whisperBackend = whisperCommand
     ? await inspectWhisperBackend({
         command: whisperCommand,
@@ -320,7 +359,8 @@ export async function inspectLocalAudioSelection(
   ];
   const whisperArgs = [
     "-m",
-    whisperModel,
+    // Args are only executed when whisperReady, which requires a model.
+    whisperModel ?? "",
     "-otxt",
     "-of",
     "{{OutputBase}}",


### PR DESCRIPTION
## What Problem This Solves

The auto local-STT selection hardcoded `/opt/homebrew/share/whisper-cpp/for-tests-ggml-tiny.bin` — a CI provisioning artifact — as the production whisper.cpp model default. Two silent failure modes:

1. A real user with `brew install whisper-cpp` and properly downloaded ggml models got `ready: false` ("model file not found") because that exact test-fixture filename doesn't exist — voice notes silently fell through to no local transcription despite a working transcriber being installed.
2. Machines provisioned by OpenClaw's own test setup **did** have the file, so real user audio was transcribed with the worst-quality tiny model, with nothing recording that a test artifact was selected.

## Why This Change Was Made

Replace the fixture literal with discovery: scan the standard whisper-cpp install dirs (`/opt/homebrew/share/whisper-cpp`, `/usr/local/share/whisper-cpp`, `/usr/share/whisper-cpp`) for `ggml-*.bin`, preferring non-tiny models (larger = better transcription), deterministic name order within a tier. `WHISPER_CPP_MODEL` remains the explicit override. "Model file not found" now genuinely means no model is installed. The `listDirectory` seam is injected for tests, matching the module's existing `resolveBinary`/`checkExecutable` injection pattern.

## User Impact

`brew install whisper-cpp` + any downloaded ggml model now works out of the box for local voice-note transcription; test fixtures no longer leak into production model selection.

## Evidence

- Two new regressions: discovery prefers `ggml-base.en.bin` over tiny + fixture names (fails pre-fix — old code picked the fixture literal), and no-models → `ready: false` with the existing reason string.
- `node scripts/run-vitest.mjs run src/media-understanding` — 62 files, 934/944 pass (10 pre-existing skips).
- tsgo core green.
- LOC: prod +44/−4 (discovery helper + injected seam), test +41. Growth justified: replaces a broken constant with the capability it pretended to provide.
- Codex autoreview (gpt-5.6-sol, high): clean, 0.99.
