### PR TITLE
fix(tui): report each reconnect failure instead of freezing on the first

### DIFF
--- a/src/tui/gateway-chat.reconnect-errors.test.ts
+++ b/src/tui/gateway-chat.reconnect-errors.test.ts
@@ -1,0 +1,66 @@
+// Covers TUI connect-error reporting across reconnect close cycles.
+import { describe, expect, it, vi } from "vitest";
+
+type CapturedClientCallbacks = {
+  onConnectError?: (error: Error) => void;
+  onClose?: (code: number, reason: string) => void;
+  onHelloOk?: (hello: unknown) => void;
+};
+
+const capturedClientOptions = vi.hoisted(() => ({
+  current: undefined as CapturedClientCallbacks | undefined,
+}));
+
+vi.mock("../gateway/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/client.js")>();
+  class RecordingGatewayClient {
+    constructor(options: CapturedClientCallbacks) {
+      capturedClientOptions.current = options;
+    }
+    stopAndWait(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+  return { ...actual, GatewayClient: RecordingGatewayClient };
+});
+
+const { GatewayChatClient } = await import("./gateway-chat.js");
+
+function connectChatClient() {
+  const chat = new GatewayChatClient({ url: "ws://127.0.0.1:1" });
+  const callbacks = capturedClientOptions.current;
+  if (!callbacks) {
+    throw new Error("expected GatewayChatClient to construct a gateway client");
+  }
+  return { chat, callbacks };
+}
+
+describe("GatewayChatClient reconnect errors", () => {
+  it("reports a distinct connect error after each close cycle", () => {
+    const { chat, callbacks } = connectChatClient();
+    const connectErrors: string[] = [];
+    const disconnects: string[] = [];
+    chat.onConnectError = (error) => connectErrors.push(error.message);
+    chat.onDisconnected = (reason) => disconnects.push(reason);
+
+    callbacks.onConnectError?.(new Error("connection refused"));
+    callbacks.onClose?.(1006, "connect failed");
+    callbacks.onConnectError?.(new Error("pairing required"));
+
+    expect(connectErrors).toEqual(["connection refused", "pairing required"]);
+    // The close that follows a reported connect error stays suppressed so the
+    // TUI shows one cause per cycle, not a redundant disconnect line.
+    expect(disconnects).toEqual([]);
+  });
+
+  it("dedupes repeated connect errors within one close cycle", () => {
+    const { chat, callbacks } = connectChatClient();
+    const connectErrors: string[] = [];
+    chat.onConnectError = (error) => connectErrors.push(error.message);
+
+    callbacks.onConnectError?.(new Error("connection refused"));
+    callbacks.onConnectError?.(new Error("connection refused"));
+
+    expect(connectErrors).toEqual(["connection refused"]);
+  });
+});

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -103,12 +103,16 @@ describe("GatewayChatClient", () => {
       expect(connectError.details).toEqual({ code: "PAIRING_REQUIRED", requestId: "pair-1" });
       expect(onDisconnected).not.toHaveBeenCalled();
 
+      // The close above ended that socket's cycle, so the next attempt's
+      // failure is a new socket and must be reported, not deduped forever.
       const retryError = new Error("retry failed");
       options.onConnectError?.(retryError);
-      expect(onConnectError).toHaveBeenCalledOnce();
+      expect(onConnectError).toHaveBeenNthCalledWith(2, retryError);
+      options.onConnectError?.(new Error("duplicate within the retry socket"));
+      expect(onConnectError).toHaveBeenCalledTimes(2);
       options.onHelloOk?.({});
       options.onConnectError?.(retryError);
-      expect(onConnectError).toHaveBeenNthCalledWith(2, retryError);
+      expect(onConnectError).toHaveBeenNthCalledWith(3, retryError);
 
       options.onHelloOk?.({});
       onDisconnected.mockClear();

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -229,6 +229,11 @@ export class GatewayChatClient implements TuiBackend {
           this.resolveReady = resolve;
         });
         if (this.pendingConnectError && this.onConnectError) {
+          // Dedupe is per close-cycle: clearing here lets the next reconnect
+          // attempt report its own failure cause. Holding the guard until a
+          // successful hello froze the TUI on the first error forever (e.g. a
+          // later pairing-required failure and its approval hint never showed).
+          this.pendingConnectError = undefined;
           return;
         }
         this.onDisconnected?.(reason);


### PR DESCRIPTION
## What Problem This Solves

The TUI gateway client dedupes connect errors with a `pendingConnectError` guard that only a successful hello clears. Against a gateway that keeps failing for *different* reasons — connection refused first, then pairing-required once the gateway comes up — every error after the first is swallowed. The operator never sees the pairing approval hint ("Approve it in that gateway's Control UI…"), so the TUI silently retries forever with a stale error on screen. Doctrine class: action path ending with no visible outcome.

## Why This Change Was Made

Root cause: the dedupe scope was per-connection-lifetime instead of per-close-cycle. `notifyConnectError` early-returns while `pendingConnectError` is set, and only `onHelloOk` cleared it — but a client that never reaches hello never clears it. The `onClose` handler already has the suppression branch that eats the redundant disconnect after a reported connect error; clearing the guard there makes dedupe exactly one-report-per-close-cycle: repeated errors within a cycle stay deduped, each new reconnect attempt reports its own cause.

## User Impact

A TUI started against a down or unpaired gateway now shows each distinct failure cause as it happens, including the pairing-required message with its approval instructions, instead of freezing on the first "connection refused".

## Evidence

- New `src/tui/gateway-chat.reconnect-errors.test.ts`: second distinct connect error after a close cycle is delivered (fails pre-fix — second error swallowed), repeated errors within one cycle stay deduped, and the post-error close stays suppressed.
- `node scripts/run-vitest.mjs run src/tui/gateway-chat.reconnect-errors.test.ts src/tui/gateway-chat.connection.test.ts src/tui/gateway-chat.scopes.test.ts` — all pass (41 tests).
- `tsgo` core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- Prod LOC: +5 (guard clear + invariant comment), test +66.
