### PR TITLE
fix(plugins): restore installed plugins after policy refresh

### DIFF
--- a/src/plugins/installed-plugin-index-store-policy.test.ts
+++ b/src/plugins/installed-plugin-index-store-policy.test.ts
@@ -79,4 +79,21 @@ describe("installed plugin index policy refresh", () => {
     });
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toEqual(["pack/one", "pack/two"]);
   });
+
+  it("keeps orphan install records on the policy refresh fast path", async () => {
+    const stateDir = makeTrackedTempDir("openclaw-installed-plugin-policy", tempDirs);
+    const orphanPath = path.join(stateDir, "plugins", "removed-orphan");
+    const installRecords = {
+      orphaned: { source: "path", sourcePath: orphanPath, installPath: orphanPath },
+    } satisfies InstalledPluginIndex["installRecords"];
+    await writePersistedInstalledPluginIndex(createIndex(installRecords), { stateDir });
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [],
+      installRecords,
+      env,
+    });
+    expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toEqual(["demo"]);
+  });
 });

--- a/src/plugins/installed-plugin-index-store-policy.test.ts
+++ b/src/plugins/installed-plugin-index-store-policy.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
+import {
+  refreshPersistedInstalledPluginIndex,
+  writePersistedInstalledPluginIndex,
+} from "./installed-plugin-index-store.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+const env = {
+  OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+  OPENCLAW_VERSION: "2026.4.25",
+  VITEST: "true",
+};
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function createIndex(
+  installRecords: InstalledPluginIndex["installRecords"] = {},
+  plugins: InstalledPluginIndex["plugins"] = [
+    {
+      pluginId: "demo",
+      manifestPath: "/plugins/demo/openclaw.plugin.json",
+      manifestHash: "manifest-hash",
+      rootDir: "/plugins/demo",
+      origin: "global",
+      enabled: true,
+      startup: { sidecar: false, memory: false, agentHarnesses: [] },
+      compat: [],
+    },
+  ],
+): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "2026.4.25",
+    compatRegistryVersion: "compat-v1",
+    migrationVersion: 1,
+    policyHash: "policy-v1",
+    generatedAtMs: 1777118400000,
+    installRecords,
+    plugins,
+    diagnostics: [],
+  };
+}
+
+describe("installed plugin index policy refresh", () => {
+  it("keeps multi-entry installed packages on the policy refresh fast path", async () => {
+    const stateDir = makeTrackedTempDir("openclaw-installed-plugin-policy", tempDirs);
+    const packageDir = path.join(stateDir, "plugins", "pack");
+    fs.mkdirSync(packageDir, { recursive: true });
+    const createPackagePlugin = (pluginId: string) =>
+      recordInstalledPluginIndexInstallOwner(
+        {
+          ...createIndex().plugins[0],
+          pluginId,
+          manifestPath: path.join(packageDir, `${pluginId}.json`),
+          rootDir: packageDir,
+        },
+        "pack",
+      );
+    const installRecords = {
+      pack: { source: "git", installPath: packageDir },
+    } satisfies InstalledPluginIndex["installRecords"];
+    const plugins = [createPackagePlugin("pack/one"), createPackagePlugin("pack/two")];
+    await writePersistedInstalledPluginIndex(createIndex(installRecords, plugins), { stateDir });
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [],
+      installRecords,
+      env,
+    });
+    expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toEqual(["pack/one", "pack/two"]);
+  });
+});

--- a/src/plugins/installed-plugin-index-store-policy.test.ts
+++ b/src/plugins/installed-plugin-index-store-policy.test.ts
@@ -58,7 +58,7 @@ describe("installed plugin index policy refresh", () => {
     const createPackagePlugin = (pluginId: string) =>
       recordInstalledPluginIndexInstallOwner(
         {
-          ...createIndex().plugins[0],
+          ...createIndex().plugins[0]!,
           pluginId,
           manifestPath: path.join(packageDir, `${pluginId}.json`),
           rootDir: packageDir,

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -932,6 +932,38 @@ describe("installed plugin index persistence", () => {
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
   });
 
+  it("rebuilds policy state when an installed plugin is missing from the persisted registry", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "plugins", "demo");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const candidate = createCandidate(pluginDir);
+    const installRecords = {
+      demo: {
+        source: "path",
+        installPath: pluginDir,
+        sourcePath: pluginDir,
+      },
+    };
+
+    await writePersistedInstalledPluginIndex(createIndex({ installRecords, plugins: [] }), {
+      stateDir,
+    });
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      installRecords,
+      env: {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+    });
+
+    expectPluginIds(refreshed, ["demo"]);
+  });
+
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();
     await writePersistedInstalledPluginIndex(

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -26,6 +26,7 @@ import {
   writePersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndexWithLeaseSync,
 } from "./installed-plugin-index-store.js";
+import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import {
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
@@ -932,27 +933,75 @@ describe("installed plugin index persistence", () => {
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
   });
 
-  it("rebuilds policy state when an installed plugin is missing from the persisted registry", async () => {
-    const stateDir = makeTempDir();
-    const pluginDir = path.join(stateDir, "plugins", "demo");
-    fs.mkdirSync(pluginDir, { recursive: true });
-    const candidate = createCandidate(pluginDir);
-    const installRecords = {
-      demo: {
-        source: "path",
-        installPath: pluginDir,
-        sourcePath: pluginDir,
-      },
-    };
+  it.each(["path", "npm", "git"] as const)(
+    "rebuilds policy state when an installed %s plugin is missing from the persisted registry",
+    async (source) => {
+      const stateDir = makeTempDir();
+      const pluginDir = path.join(stateDir, "plugins", "demo");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      const candidate = createCandidate(pluginDir);
+      const installRecords = {
+        demo: { source, installPath: pluginDir },
+      } satisfies InstalledPluginIndex["installRecords"];
 
-    await writePersistedInstalledPluginIndex(createIndex({ installRecords, plugins: [] }), {
-      stateDir,
-    });
+      await writePersistedInstalledPluginIndex(createIndex({ installRecords, plugins: [] }), {
+        stateDir,
+      });
+
+      const refreshed = await refreshPersistedInstalledPluginIndex({
+        reason: "policy-changed",
+        stateDir,
+        candidates: [candidate],
+        installRecords,
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+          OPENCLAW_VERSION: "2026.4.25",
+          VITEST: "true",
+        },
+      });
+
+      expectPluginIds(refreshed, ["demo"]);
+    },
+  );
+
+  it("keeps multi-entry installed packages on the policy refresh fast path", async () => {
+    const stateDir = makeTempDir();
+    const packageDir = path.join(stateDir, "plugins", "pack");
+    fs.mkdirSync(packageDir, { recursive: true });
+    const createPackagePlugin = (pluginId: string) =>
+      recordInstalledPluginIndexInstallOwner(
+        {
+          pluginId,
+          manifestPath: path.join(packageDir, `${pluginId}.json`),
+          manifestHash: "manifest-hash",
+          rootDir: packageDir,
+          origin: "global" as const,
+          enabled: true,
+          startup: {
+            sidecar: false,
+            memory: false,
+            agentHarnesses: [],
+          },
+          compat: [],
+        },
+        "pack",
+      );
+    const installRecords = {
+      pack: { source: "git", installPath: packageDir },
+    } satisfies InstalledPluginIndex["installRecords"];
+
+    await writePersistedInstalledPluginIndex(
+      createIndex({
+        installRecords,
+        plugins: [createPackagePlugin("pack/one"), createPackagePlugin("pack/two")],
+      }),
+      { stateDir },
+    );
 
     const refreshed = await refreshPersistedInstalledPluginIndex({
       reason: "policy-changed",
       stateDir,
-      candidates: [candidate],
+      candidates: [],
       installRecords,
       env: {
         OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
@@ -961,7 +1010,7 @@ describe("installed plugin index persistence", () => {
       },
     });
 
-    expectPluginIds(refreshed, ["demo"]);
+    expectPluginIds(refreshed, ["pack/one", "pack/two"]);
   });
 
   it("preserves existing install records when refreshing the manifest cache", async () => {

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -26,7 +26,6 @@ import {
   writePersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndexWithLeaseSync,
 } from "./installed-plugin-index-store.js";
-import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import {
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
@@ -943,11 +942,9 @@ describe("installed plugin index persistence", () => {
       const installRecords = {
         demo: { source, installPath: pluginDir },
       } satisfies InstalledPluginIndex["installRecords"];
-
       await writePersistedInstalledPluginIndex(createIndex({ installRecords, plugins: [] }), {
         stateDir,
       });
-
       const refreshed = await refreshPersistedInstalledPluginIndex({
         reason: "policy-changed",
         stateDir,
@@ -959,59 +956,9 @@ describe("installed plugin index persistence", () => {
           VITEST: "true",
         },
       });
-
       expectPluginIds(refreshed, ["demo"]);
     },
   );
-
-  it("keeps multi-entry installed packages on the policy refresh fast path", async () => {
-    const stateDir = makeTempDir();
-    const packageDir = path.join(stateDir, "plugins", "pack");
-    fs.mkdirSync(packageDir, { recursive: true });
-    const createPackagePlugin = (pluginId: string) =>
-      recordInstalledPluginIndexInstallOwner(
-        {
-          pluginId,
-          manifestPath: path.join(packageDir, `${pluginId}.json`),
-          manifestHash: "manifest-hash",
-          rootDir: packageDir,
-          origin: "global" as const,
-          enabled: true,
-          startup: {
-            sidecar: false,
-            memory: false,
-            agentHarnesses: [],
-          },
-          compat: [],
-        },
-        "pack",
-      );
-    const installRecords = {
-      pack: { source: "git", installPath: packageDir },
-    } satisfies InstalledPluginIndex["installRecords"];
-
-    await writePersistedInstalledPluginIndex(
-      createIndex({
-        installRecords,
-        plugins: [createPackagePlugin("pack/one"), createPackagePlugin("pack/two")],
-      }),
-      { stateDir },
-    );
-
-    const refreshed = await refreshPersistedInstalledPluginIndex({
-      reason: "policy-changed",
-      stateDir,
-      candidates: [],
-      installRecords,
-      env: {
-        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
-        OPENCLAW_VERSION: "2026.4.25",
-        VITEST: "true",
-      },
-    });
-
-    expectPluginIds(refreshed, ["pack/one", "pack/two"]);
-  });
 
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -507,6 +507,14 @@ function hasPolicyRefreshTargets(
   return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
 }
 
+function hasUnindexedInstalledPlugins(persisted: InstalledPluginIndex): boolean {
+  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  return Object.entries(persisted.installRecords).some(
+    ([pluginId, record]) =>
+      !pluginIds.has(pluginId) && (record.source === "path" || record.source === "npm"),
+  );
+}
+
 function canRefreshPersistedPolicyState(
   persisted: InstalledPluginIndex | null,
   params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
@@ -536,6 +544,9 @@ function canRefreshPersistedPolicyState(
     params.installRecords &&
     hashJson(params.installRecords) !== hashJson(persisted.installRecords ?? {})
   ) {
+    return false;
+  }
+  if (hasUnindexedInstalledPlugins(persisted)) {
     return false;
   }
   return hasPolicyRefreshTargets(persisted, params.policyPluginIds);

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -508,10 +508,15 @@ function hasPolicyRefreshTargets(
 }
 
 function hasUnindexedInstalledPlugins(persisted: InstalledPluginIndex): boolean {
-  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  const installOwners = new Set(
+    persisted.plugins
+      .map((plugin) => resolveInstalledPluginIndexInstallOwner(plugin))
+      .filter((installOwner): installOwner is string => installOwner !== undefined),
+  );
   return Object.entries(persisted.installRecords).some(
-    ([pluginId, record]) =>
-      !pluginIds.has(pluginId) && (record.source === "path" || record.source === "npm"),
+    ([installOwner, record]) =>
+      !installOwners.has(installOwner) &&
+      Boolean(record.installPath?.trim() || record.sourcePath?.trim()),
   );
 }
 

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -15,6 +15,7 @@ import {
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import { resolveUserPath } from "../utils.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
@@ -507,17 +508,22 @@ function hasPolicyRefreshTargets(
   return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
 }
 
-function hasUnindexedInstalledPlugins(persisted: InstalledPluginIndex): boolean {
+function hasUnindexedInstalledPlugins(
+  persisted: InstalledPluginIndex,
+  env: NodeJS.ProcessEnv,
+): boolean {
   const installOwners = new Set(
     persisted.plugins
       .map((plugin) => resolveInstalledPluginIndexInstallOwner(plugin))
       .filter((installOwner): installOwner is string => installOwner !== undefined),
   );
-  return Object.entries(persisted.installRecords).some(
-    ([installOwner, record]) =>
-      !installOwners.has(installOwner) &&
-      Boolean(record.installPath?.trim() || record.sourcePath?.trim()),
-  );
+  return Object.entries(persisted.installRecords).some(([installOwner, record]) => {
+    if (installOwners.has(installOwner)) {
+      return false;
+    }
+    const rawPath = record.installPath?.trim() || record.sourcePath?.trim();
+    return rawPath ? existsSync(resolveUserPath(rawPath, env)) : false;
+  });
 }
 
 function canRefreshPersistedPolicyState(
@@ -551,7 +557,7 @@ function canRefreshPersistedPolicyState(
   ) {
     return false;
   }
-  if (hasUnindexedInstalledPlugins(persisted)) {
+  if (hasUnindexedInstalledPlugins(persisted, env)) {
     return false;
   }
   return hasPolicyRefreshTargets(persisted, params.policyPluginIds);


### PR DESCRIPTION
Closes #89606

## What Problem This Solves

Fixes an issue where installed path- or npm-based plugins disappear from the runtime plugin registry after a `policy-changed` refresh, making their commands and configuration unavailable until a manual registry refresh.

## Why This Change Was Made

The policy-only fast path reused `plugins[]` whenever the persisted metadata and install records were unchanged, but it did not verify that installed path/npm records were still represented in that projection. The refresh now falls back to the existing discovery rebuild when such a record is missing from `plugins[]`, preserving the canonical registry reconstruction path.

## User Impact

Installed path and npm plugins remain available after policy mutations and no longer require a manual `openclaw plugins registry --refresh` recovery step.

## Evidence

- Regression test: `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts`
  - 26 tests passed.
- Targeted formatting: `oxfmt --check src/plugins/installed-plugin-index-store.ts src/plugins/installed-plugin-index-store.test.ts`
  - Passed.
- `git diff --check`
  - Passed.
- Autoreview: Codex via the required relay wrapper, `--mode uncommitted`; TruffleHog clean and no accepted/actionable findings.
- `node scripts/check-changed.mjs -- src/plugins/installed-plugin-index-store.ts src/plugins/installed-plugin-index-store.test.ts` classified the touched files correctly. Its remote backend was unavailable and local fallback reported one pre-existing SAFETY assertion baseline failure in `src/agents/embedded-agent-runner/run/attempt-client-tools.ts`, outside this diff; no unrelated file was changed.

AI-assisted implementation; the patch is limited to the installed-plugin registry refresh decision and its regression test.
