### PR TITLE
fix(doctor): stop reporting a fully configured Telegram setup as first-time setup

### DIFF
--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover doctor plugin behavior.
+import type { ChannelDoctorEmptyAllowlistAccountContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { telegramDoctor } from "./doctor.js";
@@ -815,6 +816,69 @@ describe("telegram doctor", () => {
 
     expect((await collectPreviewWarnings(cfg, {})).join("\n")).not.toContain(
       "TELEGRAM_BOT_TOKEN is absent",
+    );
+  });
+});
+
+describe("telegram doctor empty allowlist extra warnings", () => {
+  function collectExtraWarnings(
+    context: Partial<ChannelDoctorEmptyAllowlistAccountContext>,
+  ): string[] {
+    const collect = telegramDoctor.collectEmptyAllowlistExtraWarnings;
+    if (!collect) {
+      throw new Error("expected Telegram empty allowlist extra warning collector");
+    }
+    return collect({
+      account: { groupPolicy: "allowlist" },
+      channelName: "telegram",
+      dmPolicy: "pairing",
+      prefix: "channels.telegram",
+      ...context,
+    });
+  }
+
+  it("skips parent-scope first-time guidance when every account configures groups", () => {
+    const warnings = collectExtraWarnings({
+      childAccounts: [
+        { groups: { "-1001": { requireMention: true } } },
+        { groups: { "-1002": { requireMention: true } } },
+      ],
+      effectiveAllowFrom: ["166534209"],
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps first-time guidance when one account still lacks groups", () => {
+    const warnings = collectExtraWarnings({
+      childAccounts: [{ groups: { "-1001": { requireMention: true } } }, {}],
+    });
+
+    expect(warnings.join("\n")).toContain("first-time setup mode");
+  });
+
+  it("keeps first-time guidance when no accounts are configured", () => {
+    const warnings = collectExtraWarnings({ childAccounts: [] });
+
+    expect(warnings.join("\n")).toContain("first-time setup mode");
+  });
+
+  it("keeps first-time guidance when child accounts are withheld", () => {
+    // The scanner withholds childAccounts when an implicit runtime account
+    // inherits the container scope, so its group routing is still unconfigured.
+    const warnings = collectExtraWarnings({});
+
+    expect(warnings.join("\n")).toContain("first-time setup mode");
+  });
+
+  it("keeps account-scope first-time guidance untouched", () => {
+    const warnings = collectExtraWarnings({
+      parent: { groupPolicy: "allowlist" },
+      prefix: "channels.telegram.accounts.default",
+    });
+
+    expect(warnings.join("\n")).toContain(
+      "channels.telegram.accounts.default: Telegram is in first-time setup mode.",
     );
   });
 });

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -516,11 +516,23 @@ function hasConfiguredGroups(account: DoctorAccountRecord, parent?: DoctorAccoun
 function collectTelegramGroupPolicyWarnings(params: {
   account: DoctorAccountRecord;
   prefix: string;
+  childAccounts?: DoctorAccountRecord[];
   effectiveAllowFrom?: DoctorAllowFromList;
   dmPolicy?: string;
   parent?: DoctorAccountRecord;
 }): string[] {
   if (!hasConfiguredGroups(params.account, params.parent)) {
+    // The parent container scope carries no groups of its own once every active
+    // account defines them. Group routing already works, so first-time setup
+    // guidance here would be a false positive; per-account scopes still warn.
+    // `parent` is undefined only on that container scope.
+    if (
+      !params.parent &&
+      params.childAccounts?.length &&
+      params.childAccounts.every((child) => hasConfiguredGroups(child, params.account))
+    ) {
+      return [];
+    }
     const effectiveDmPolicy = params.dmPolicy ?? "pairing";
     const dmSetupLine =
       effectiveDmPolicy === "pairing"
@@ -560,6 +572,7 @@ function collectTelegramEmptyAllowlistExtraWarnings(
       undefined) === "allowlist"
     ? collectTelegramGroupPolicyWarnings({
         account,
+        childAccounts: params.childAccounts,
         dmPolicy: params.dmPolicy,
         effectiveAllowFrom: params.effectiveAllowFrom as DoctorAllowFromList | undefined,
         parent,

--- a/src/channels/bundled-channel-catalog-read.test.ts
+++ b/src/channels/bundled-channel-catalog-read.test.ts
@@ -46,6 +46,7 @@ vi.mock("../infra/openclaw-root.js", () => ({
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import {
+  findBundledChannelCatalogId,
   findBundledChannelCatalogMetadata,
   listBundledChannelCatalogEntries,
 } from "./bundled-channel-catalog-read.js";
@@ -258,6 +259,10 @@ describe("listBundledChannelCatalogEntries", () => {
       approvalFlags: ["native"],
       doctorCapabilities: { openDmRequiresAllowFromWildcard: false },
     });
+    expect(findBundledChannelCatalogId("qqbot")).toBe("qqbot");
+    expect(findBundledChannelCatalogId("QQBOT")).toBe("qqbot");
+    expect(findBundledChannelCatalogId("not-a-real-channel")).toBeUndefined();
+    expect(findBundledChannelCatalogId("")).toBeUndefined();
   });
 
   it("finds doctor capabilities from the generated catalog when the package is excluded", () => {

--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -165,15 +165,24 @@ export function listBundledChannelCatalogEntries(): BundledChannelCatalogEntry[]
   );
 }
 
-/** Finds bundled or generated channel metadata by id or alias. */
-export function findBundledChannelCatalogMetadata(
-  channelId: string,
-): PluginPackageChannel | undefined {
+function findBundledChannelCatalogEntry(channelId: string): BundledChannelCatalogEntry | undefined {
   const normalized = normalizeOptionalLowercaseString(channelId);
   if (!normalized) {
     return undefined;
   }
   return listBundledChannelCatalogEntries().find(
     (entry) => entry.id === normalized || entry.aliases.includes(normalized),
-  )?.channel;
+  );
+}
+
+/** Finds bundled or generated channel metadata by id or alias. */
+export function findBundledChannelCatalogMetadata(
+  channelId: string,
+): PluginPackageChannel | undefined {
+  return findBundledChannelCatalogEntry(channelId)?.channel;
+}
+
+/** Resolves a channel id or alias to its canonical bundled catalog id. */
+export function findBundledChannelCatalogId(channelId: string): string | undefined {
+  return findBundledChannelCatalogEntry(channelId)?.id;
 }

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -471,6 +471,16 @@ export type ChannelDoctorSequenceResult = {
 export type ChannelDoctorEmptyAllowlistAccountContext = {
   account: Record<string, unknown>;
   channelName: string;
+  /**
+   * Active child accounts, set only on the parent container scope
+   * (`channels.<id>`) and only when it is a pure container: at least one active
+   * account under `accounts`, and every runtime account configured there.
+   * Channels use it to skip setup guidance that the per-account scopes already
+   * cover. Left undefined when there are no active accounts, or when an
+   * implicit runtime account inherits this scope and so has no scope of its own
+   * to warn on. When present it is always non-empty.
+   */
+  childAccounts?: Array<Record<string, unknown>>;
   dmPolicy?: string;
   effectiveAllowFrom?: Array<string | number>;
   parent?: Record<string, unknown>;

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -11,6 +11,20 @@ const channelPluginMocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(() => undefined),
 }));
 
+// Doctor runs without starting channels, so the plugin registry can still be
+// empty. This flag reproduces that state without unregistering real channels.
+const registryState = vi.hoisted(() => ({ forceUnregistered: false }));
+
+const readOnlyMocks = vi.hoisted(() => ({
+  resolveReadOnlyChannelPluginsForConfig: vi.fn(() => ({ plugins: [] })),
+}));
+
+vi.mock("../../channels/plugins/read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: (
+    ...args: Parameters<typeof readOnlyMocks.resolveReadOnlyChannelPluginsForConfig>
+  ) => readOnlyMocks.resolveReadOnlyChannelPluginsForConfig(...args),
+}));
+
 vi.mock("../../channels/plugins/bundled.js", () => ({
   getBundledChannelPlugin: channelPluginMocks.getBundledChannelPlugin,
 }));
@@ -19,10 +33,23 @@ vi.mock("../../channels/plugins/index.js", () => ({
   getChannelPlugin: channelPluginMocks.getChannelPlugin,
 }));
 
+vi.mock("../../channels/registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../channels/registry.js")>();
+  return {
+    ...actual,
+    normalizeAnyChannelId: (raw?: string | null) =>
+      registryState.forceUnregistered ? null : actual.normalizeAnyChannelId(raw),
+  };
+});
+
 describe("doctor channel capabilities", () => {
   beforeEach(() => {
     channelPluginMocks.getBundledChannelPlugin.mockReset().mockReturnValue(undefined);
     channelPluginMocks.getChannelPlugin.mockReset().mockReturnValue(undefined);
+    registryState.forceUnregistered = false;
+    readOnlyMocks.resolveReadOnlyChannelPluginsForConfig.mockReset().mockReturnValue({
+      plugins: [],
+    });
   });
 
   it("returns canonical top-level route semantics from googlechat plugin metadata", () => {
@@ -138,5 +165,46 @@ describe("doctor channel capabilities", () => {
       configured: ["work"],
       runtime: ["default", "work"],
     });
+  });
+
+  it("resolves account ids through the bundled catalog when no channel is registered", () => {
+    registryState.forceUnregistered = true;
+    channelPluginMocks.getBundledChannelPlugin.mockReturnValue({
+      config: {
+        listAccountIds: () => ["default", "work"],
+        resolveAccount: (_cfg: unknown, accountId?: string | null) => ({ accountId }),
+      },
+    } as never);
+
+    expect(resolveDoctorChannelAccountIds("telegram", {}, ["default"])).toEqual({
+      configured: ["default"],
+      runtime: ["default", "work"],
+    });
+  });
+
+  it("resolves account ids for a configured external plugin through the read-only loader", () => {
+    registryState.forceUnregistered = true;
+    readOnlyMocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [
+        {
+          id: "acme-chat",
+          config: {
+            listAccountIds: () => ["default", "team"],
+            resolveAccount: (_cfg: unknown, accountId?: string | null) => ({ accountId }),
+          },
+        },
+      ],
+    } as never);
+
+    expect(resolveDoctorChannelAccountIds("acme-chat", {}, ["default"])).toEqual({
+      configured: ["default"],
+      runtime: ["default", "team"],
+    });
+  });
+
+  it("still returns undefined for channels no loader can resolve", () => {
+    registryState.forceUnregistered = true;
+
+    expect(resolveDoctorChannelAccountIds("not-a-real-channel", {}, ["default"])).toBeUndefined();
   });
 });

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -1,8 +1,13 @@
-import { findBundledChannelCatalogMetadata } from "../../channels/bundled-channel-catalog-read.js";
+import {
+  findBundledChannelCatalogId,
+  findBundledChannelCatalogMetadata,
+} from "../../channels/bundled-channel-catalog-read.js";
 // Doctor capability lookup for channel-specific policy and migration behavior.
 import { getBundledChannelPlugin } from "../../channels/plugins/bundled.js";
 import type { ChannelDmAllowFromMode } from "../../channels/plugins/dm-access.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginPackageChannelDoctorCapabilities } from "../../plugins/manifest.js";
@@ -85,18 +90,41 @@ function readResolvedAccountId(account: unknown): string | undefined {
   return typeof accountId === "string" && accountId ? accountId : undefined;
 }
 
+function findReadOnlyChannelPlugin(
+  cfg: OpenClawConfig,
+  channelName: string,
+): ChannelPlugin | undefined {
+  try {
+    const { plugins } = resolveReadOnlyChannelPluginsForConfig(cfg, {
+      includePersistedAuthState: false,
+      includeSetupFallbackPlugins: true,
+    });
+    return plugins.find((plugin) => plugin.id === channelName);
+  } catch {
+    // Doctor stays conservative when configured plugins cannot be loaded.
+    return undefined;
+  }
+}
+
 /** Resolve configured and runtime account ids through the channel plugin's own semantics. */
 export function resolveDoctorChannelAccountIds(
   channelName: string,
   cfg: OpenClawConfig,
   configuredAccountIds: string[],
 ): DoctorChannelAccountIds | undefined {
-  const channelId = normalizeAnyChannelId(channelName);
-  if (!channelId) {
-    return undefined;
-  }
+  // The plugin registry is only populated once channels start. Doctor inspects
+  // config without starting them, so fall back to the bundled catalog instead of
+  // treating every channel as unknown and returning undefined for all of them.
+  const channelId = normalizeAnyChannelId(channelName) ?? findBundledChannelCatalogId(channelName);
   try {
-    const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
+    const plugin =
+      (channelId
+        ? (getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId))
+        : undefined) ??
+      // Configured external plugins are absent from both the registry and the
+      // bundled catalog, so reuse the config-driven loader doctor already uses
+      // to find their adapters.
+      findReadOnlyChannelPlugin(cfg, channelName);
     if (!plugin) {
       return undefined;
     }

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -1,5 +1,6 @@
 // Channel doctor tests cover shared channel health checks and repair hints.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import { normalizeResolvedSecretInputString } from "../../../config/types.secrets.js";
 import {
   collectChannelDoctorCompatibilityMutations,
@@ -9,6 +10,7 @@ import {
   collectChannelDoctorStaleConfigMutations,
   createChannelDoctorEmptyAllowlistPolicyHooks,
 } from "./channel-doctor.js";
+import { scanEmptyAllowlistPolicyWarnings } from "./empty-allowlist-scan.js";
 
 const mocks = vi.hoisted(() => ({
   getLoadedChannelPlugin: vi.fn(),
@@ -33,6 +35,20 @@ vi.mock("../../../channels/plugins/bundled.js", () => ({
   getBundledChannelSetupPlugin: (...args: Parameters<typeof mocks.getBundledChannelSetupPlugin>) =>
     mocks.getBundledChannelSetupPlugin(...args),
 }));
+
+// Account-id resolution itself is covered by channel-capabilities.test.ts; here we
+// only pin that the scanner forwards childAccounts through the hooks to adapters.
+vi.mock("../channel-capabilities.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../channel-capabilities.js")>();
+  return {
+    ...actual,
+    resolveDoctorChannelAccountIds: (
+      _channelName: string,
+      _cfg: unknown,
+      configuredAccountIds: string[],
+    ) => ({ configured: configuredAccountIds, runtime: configuredAccountIds }),
+  };
+});
 
 vi.mock("../../../channels/plugins/read-only.js", () => ({
   resolveReadOnlyChannelPluginsForConfig: (
@@ -404,6 +420,39 @@ describe("channel doctor compatibility mutations", () => {
       READ_ONLY_CHANNEL_DOCTOR_OPTIONS,
     );
     expect(collectEmptyAllowlistExtraWarnings.mock.calls[0]?.[0]).not.toHaveProperty("cfg");
+  });
+
+  it("forwards container-scope child accounts through the empty allowlist hooks", () => {
+    const collectEmptyAllowlistExtraWarnings = vi.fn(
+      (_context: ChannelDoctorEmptyAllowlistAccountContext): string[] => [],
+    );
+    const cfg = {
+      channels: {
+        matrix: {
+          groupPolicy: "allowlist",
+          accounts: {
+            work: { groups: { "!room:example.org": {} } },
+          },
+        },
+      },
+    };
+    const env = { OPENCLAW_HOME: "/tmp/openclaw-test-home" };
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [{ id: "matrix", doctor: { collectEmptyAllowlistExtraWarnings } }],
+    });
+
+    const hooks = createChannelDoctorEmptyAllowlistPolicyHooks({ cfg: cfg as never, env });
+    scanEmptyAllowlistPolicyWarnings(cfg as never, {
+      doctorFixCommand: "openclaw doctor --fix",
+      ...hooks,
+    });
+
+    const contexts = collectEmptyAllowlistExtraWarnings.mock.calls.map(([context]) => context);
+    const parent = contexts.find((context) => context.prefix === "channels.matrix");
+    const account = contexts.find((context) => context.prefix === "channels.matrix.accounts.work");
+
+    expect(parent?.childAccounts).toHaveLength(1);
+    expect(account?.childAccounts).toBeUndefined();
   });
 
   it("reuses empty allowlist doctor entries across per-account hooks", () => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -1,5 +1,6 @@
 // Empty allowlist scan tests cover doctor detection of unconfigured sender allowlists.
 import { describe, expect, it, vi } from "vitest";
+import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./empty-allowlist-scan.js";
 
 vi.mock("../channel-capabilities.js", () => ({
@@ -101,6 +102,32 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings).toContain(
       '- channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.groupAllowFrom or channels.telegram.allowFrom, or set groupPolicy to "open".',
     );
+  });
+
+  it("suppresses the parent groupAllowFrom warning for any channel whose accounts all resolve", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          signal: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              work: { groupAllowFrom: ["signal:group:work"] },
+              personal: { groupAllowFrom: ["signal:group:personal"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(
+      warnings.some(
+        (warning) =>
+          warning.includes('channels.signal.groupPolicy is "allowlist"') &&
+          warning.includes("groupAllowFrom"),
+      ),
+    ).toBe(false);
   });
 
   it("keeps parent groupAllowFrom warning when an implicit default account is active", () => {
@@ -234,5 +261,62 @@ describe("doctor empty allowlist policy scan", () => {
     expect(extraWarningsForAccount).toHaveBeenCalledTimes(1);
     const [warningOptions] = extraWarningsForAccount.mock.calls[0] ?? [];
     expect(warningOptions?.prefix).toBe("channels.signal");
+  });
+
+  it("exposes active child accounts to the parent container scope only", () => {
+    const extraWarningsForAccount = vi.fn(
+      (_context: ChannelDoctorEmptyAllowlistAccountContext): string[] => [],
+    );
+
+    scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+            accounts: {
+              default: { dmPolicy: "allowlist" },
+              retired: { enabled: false, dmPolicy: "allowlist" },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix", extraWarningsForAccount },
+    );
+
+    const contexts = extraWarningsForAccount.mock.calls.map(([context]) => context);
+    const parent = contexts.find((context) => context?.prefix === "channels.telegram");
+    const account = contexts.find(
+      (context) => context?.prefix === "channels.telegram.accounts.default",
+    );
+
+    expect(parent?.childAccounts).toHaveLength(1);
+    expect(account?.childAccounts).toBeUndefined();
+  });
+
+  it("withholds child accounts when an implicit runtime account inherits the parent scope", () => {
+    const extraWarningsForAccount = vi.fn(
+      (_context: ChannelDoctorEmptyAllowlistAccountContext): string[] => [],
+    );
+
+    scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          "qa-channel": {
+            baseUrl: "https://qa.example",
+            dmPolicy: "allowlist",
+            accounts: {
+              work: { dmPolicy: "allowlist" },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix", extraWarningsForAccount },
+    );
+
+    const parent = extraWarningsForAccount.mock.calls
+      .map(([context]) => context)
+      .find((context) => context?.prefix === "channels.qa-channel");
+
+    expect(parent?.childAccounts).toBeUndefined();
   });
 });

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -42,7 +42,10 @@ export function scanEmptyAllowlistPolicyWarnings(
     prefix: string,
     channelName: string,
     parent?: DoctorAccountRecord,
-    options: { suppressGroupAllowlistWarning?: boolean } = {},
+    options: {
+      suppressGroupAllowlistWarning?: boolean;
+      childAccounts?: DoctorAccountRecord[];
+    } = {},
   ) => {
     const accountDm = asNullableRecord(account.dm);
     const parentDm = asNullableRecord(parent?.dm);
@@ -77,6 +80,7 @@ export function scanEmptyAllowlistPolicyWarnings(
         ...params.extraWarningsForAccount({
           account,
           channelName,
+          childAccounts: options.childAccounts,
           dmPolicy,
           effectiveAllowFrom,
           parent,
@@ -139,6 +143,11 @@ export function scanEmptyAllowlistPolicyWarnings(
       });
 
     checkAccount(channelConfig, `channels.${channelName}`, channelName, undefined, {
+      // Left undefined unless this scope is a pure container: an implicit
+      // runtime account inherits it and has no scope of its own to warn on, and
+      // with no active accounts there is no per-account scope to defer to.
+      childAccounts:
+        hasImplicitActiveAccount || activeAccounts.length === 0 ? undefined : activeAccounts,
       suppressGroupAllowlistWarning: suppressParentGroupAllowlistWarning,
     });
 


### PR DESCRIPTION
Closes #124705

## What Problem This Solves

Fixes an issue where operators running Telegram with multiple accounts would see
`openclaw doctor` report the channel as unconfigured, even though every account already
lists its groups and the bots reply in those groups normally:

```
- channels.telegram: Telegram is in first-time setup mode. DMs use pairing mode, so new
  senders must start a chat and be approved before regular messages are accepted. Group
  messages stay blocked until you add allowed chats under channels.telegram.groups ...
```

The warning tells operators their group messages are blocked when they are not, and points
at `channels.telegram.groups` — a key that multi-account setups intentionally leave empty
because each account carries its own `groups`. Doctor is what people reach for when
something looks broken, so a permanent false alarm there costs trust in every other line
it prints.

## Why This Change Was Made

There are two layers here, and the first one reaches past Telegram.

**Layer 1 — doctor could not resolve any channel's accounts.**
`resolveDoctorChannelAccountIds` resolves the channel through `normalizeAnyChannelId`,
which only knows channels present in the plugin *registry*. Doctor inspects config without
starting channels, so that registry is empty and the function returned `undefined` for
every channel. That makes `hasImplicitActiveAccount` unconditionally `true`, which means
`suppressParentGroupAllowlistWarning` — added in #93434 for exactly this class of
parent-scope false positive — has been permanently `false` in production. Its tests pass
because they run where the registry is populated.

Doctor was already inconsistent with itself: `channel-doctor.ts` locates the Telegram
adapter through `resolveReadOnlyChannelPluginsForConfig` (config-driven, registry-free), so
the warning is produced, while `channel-capabilities.ts` needs the registry, so the data
that would suppress it is missing. `getDoctorChannelCapabilities` already sidesteps this by
consulting the bundled catalog first. Account resolution now falls back the same way
doctor already does elsewhere — the bundled catalog for bundled channels, and the
config-driven read-only plugin loader for configured external ones — so both halves of
doctor agree on which channels exist, third-party channels included.

**Layer 2 — the parent container scope is checked as if it were an account.**
`scanEmptyAllowlistPolicyWarnings` calls `checkAccount(channelConfig, "channels.telegram",
…, parent: undefined)`. Once `accounts` are in use that scope holds no `groups` of its own,
so Telegram's first-time guidance fires there while both account scopes stay silent. The
scanner's existing suppression signal reaches `collectEmptyAllowlistPolicyWarningsForAccount`
but not the channel-supplied `extraWarningsForAccount` hook, which is where that guidance
comes from. The parent scope now carries its active child accounts in the existing
`ChannelDoctorEmptyAllowlistAccountContext` as an optional `childAccounts` field, and
Telegram skips first-time guidance only when every active account defines `groups`.

The field is **additive**. The hook keeps being invoked on exactly the scopes it is invoked
on today, and a channel plugin that ignores `childAccounts` behaves exactly as before, so
no existing plugin — bundled or external — changes behavior without opting in.

`childAccounts` is withheld when `hasImplicitActiveAccount` is true — the same guard #93434
applied. A container-level `botToken`/`tokenFile`/`$TELEGRAM_BOT_TOKEN` synthesizes an
implicit `default` runtime account that inherits this scope and has no scope of its own to
warn on, so its group routing really is unconfigured and the container keeps owning that
guidance. It is also withheld when there are no active accounts, so when present it is
always non-empty. Deciding this in the scanner rather than in the adapter keeps the
account-resolution data and the guard in one place.

Non-goals: setups with no `accounts` block keep the existing warning verbatim, accounts
that genuinely lack `groups` keep warning at their own scope, and no authorization or
routing behavior changes — this only affects what doctor prints.

**Blast radius, stated plainly.** Layer 1 is broader than the Telegram symptom that led
here. Because `resolveDoctorChannelAccountIds` previously returned `undefined` for every
channel, `suppressParentGroupAllowlistWarning` was dead for every channel. This change
makes that suppression live across all channels at once. It only fires when every active
account genuinely resolves a `groupAllowFrom` (or `allowFrom` under the fallback
capability), so operators lose no real warning — but reviewers should weigh it as a
cross-channel behavior change, not a Telegram-only one. `empty-allowlist-scan.test.ts`
covers a non-Telegram channel on both sides of that boundary.

## User Impact

Operators running multiple Telegram accounts get a clean `openclaw doctor` run instead of a
standing false alarm, and real first-time setups still get the guidance they need, reported
at the account scope that actually needs fixing. Beyond Telegram, doctor can now resolve
channel accounts at all during a normal run, which is what #93434's suppression needed to
work in the first place.

## Evidence

**Measured on the real CLI, not just tests.** Built the repo and ran `node openclaw.mjs
doctor` against a live 6-account Telegram config. Temporary instrumentation confirmed the
root cause before the fix:

```
TMPDIAG2 channelId=null
TMPDIAG  telegram accountIds=undefined implicit=true active=6
```

Each layer was then reverted independently and the CLI rebuilt, which shows both are
required:

| Applied | `first-time setup` warnings in real `doctor` output |
|---|---|
| neither | 1 |
| layer 1 only | 1 |
| both | **0** |

No other Telegram warnings changed; the remaining ones are unrelated (dead-lettered ingress
events).

**Red/green, production change reverted per layer.** Reverting only
`src/commands/doctor/channel-capabilities.ts`:

```
× resolves account ids through the bundled catalog when no channel is registered
AssertionError: expected undefined to deeply equal { configured: [ 'default' ], …(1) }
```

Reverting only `extensions/telegram/src/doctor.ts`:

```
× skips parent-scope first-time guidance when every account configures groups
AssertionError: expected [ Array(1) ] to deeply equal []
```

Reverting only `src/commands/doctor/shared/empty-allowlist-scan.ts`:

```
× exposes active child accounts to the parent container scope only
AssertionError: Target cannot be null or undefined.
```

**Test lanes:**

| Lane | Result |
|---|---|
| commands lane (all doctor tests) | 319 files, 4117 passed, 4 skipped |
| `test:channels` | 100 files, 1122 passed |
| `test:contracts:plugins` | 42 files, 1039 passed |
| `test:contracts:channels` | 4 shards, all passed |
| `test:extension telegram` | 212 chunks, 3593 passed, 0 failed |
| `pnpm check` | green except `assertion SAFETY comment ratchet` |

The one `pnpm check` failure is pre-existing and unrelated: it reports
`src/gateway/server.auth.control-ui.pairing.suite.ts: 6 < 11` (a baseline larger than the
real count). Stashing this change and rerunning produces byte-identical output, so it
reproduces on `main` untouched.

New coverage pins both layers: account ids resolve through the bundled catalog when no
channel is registered, resolve a configured external plugin through the read-only loader,
and still return `undefined` when no loader can identify the channel;
first-time guidance is skipped only when every active account configures `groups`, and is
preserved when one account lacks them, when there is no `accounts` block, when
`childAccounts` is withheld for an implicit runtime account, and at account scope.

*Prepared with AI assistance (Claude Code).*
