### PR TITLE
fix(cli): report unknown subcommands even with --help

### DIFF
--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -2,6 +2,11 @@
 import type { Command, Option } from "commander";
 
 const activeErrorCommandByRoot = new WeakMap<Command, Command>();
+const lazyCommands = new WeakSet<Command>();
+
+export function markCommanderLazyCommand(command: Command): void {
+  lazyCommands.add(command);
+}
 
 function getCommandHierarchy(command: Command): Command[] {
   const hierarchy: Command[] = [];
@@ -82,6 +87,30 @@ function getRootCommand(command: Command): Command {
     root = root.parent;
   }
   return root;
+}
+
+/** Classify a possible child token only after Commander owns its active command node. */
+export function getCommanderSubcommandFact(
+  command: Command,
+  args: readonly string[],
+): { kind: "defer" } | { kind: "unknown"; name: string } | undefined {
+  const firstArgument = command.args[0];
+  const matchesChild = command.commands.some(
+    (child) => child.name() === firstArgument || child.aliases().includes(firstArgument ?? ""),
+  );
+  if (
+    command.registeredArguments.length > 0 ||
+    firstArgument === undefined ||
+    firstArgument.startsWith("-") ||
+    matchesChild
+  ) {
+    return undefined;
+  }
+  const helpRequested = args.includes("-h") || args.includes("--help");
+  if (helpRequested && lazyCommands.has(command)) {
+    return { kind: "defer" };
+  }
+  return command.commands.length > 0 ? { kind: "unknown", name: firstArgument } : undefined;
 }
 
 /** Scope the exact Commander node synchronously emitting an error. */

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -13,13 +13,17 @@ async function parseLazyGroupError(params: {
   argv: string[];
   group: string;
   subcommands: Array<{ name: string; aliases?: string[] }>;
-}): Promise<{ error: CommanderError; output: string }> {
+}): Promise<{ error: CommanderError; output: string; stdout: string }> {
   const originalArgv = process.argv;
   process.argv = ["node", "openclaw", ...params.argv];
   let output = "";
+  let stdout = "";
   try {
     const program = new OpenClawCommand().name("openclaw").exitOverride();
     program.configureOutput({
+      writeOut: (value) => {
+        stdout += value;
+      },
       writeErr: (value) => {
         output += value;
       },
@@ -50,7 +54,7 @@ async function parseLazyGroupError(params: {
 
     const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(CommanderError);
-    return { error: error as CommanderError, output };
+    return { error: error as CommanderError, output, stdout };
   } finally {
     process.argv = originalArgv;
   }
@@ -101,6 +105,34 @@ describe("formatCliParseErrorOutput", () => {
     expect(output).toBe(
       'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli\n',
     );
+  });
+
+  it("reports an unmatched lazy subcommand before --help can hide it", async () => {
+    const { error, output, stdout } = await parseLazyGroupError({
+      argv: ["sessions", "lst", "--help"],
+      group: "sessions",
+      subcommands: [{ name: "list" }, { name: "cleanup" }],
+    });
+
+    expect(error.code).toBe("commander.unknownCommand");
+    expect(error.exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(output).toBe(
+      'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("loads a real lazy subcommand before showing its help", async () => {
+    const { error, output, stdout } = await parseLazyGroupError({
+      argv: ["sessions", "list", "--help"],
+      group: "sessions",
+      subcommands: [{ name: "list" }, { name: "cleanup" }],
+    });
+
+    expect(error.code).toBe("commander.helpDisplayed");
+    expect(error.exitCode).toBe(0);
+    expect(output).toBe("");
+    expect(stdout).toContain("Usage: openclaw sessions list [options]");
   });
 
   it("suggests aliases from the live child command tree", async () => {

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -118,6 +118,31 @@ describe("configureProgramHelp", () => {
     }
   }
 
+  async function parseHelp(argv: string[]) {
+    process.argv = ["node", "openclaw", ...argv];
+    let stdout = "";
+    let stderr = "";
+    const program = new OpenClawCommand().enablePositionalOptions().exitOverride();
+    configureProgramHelp(program, testProgramContext);
+    program.configureOutput({
+      writeOut: (value) => {
+        stdout += value;
+      },
+      writeErr: (value) => {
+        stderr += value;
+      },
+    });
+    const plugins = program.command("plugins").description("Manage plugins");
+    plugins
+      .command("list")
+      .description("List plugins")
+      .action(() => {});
+
+    const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(CommanderError);
+    return { error: error as CommanderError, stderr, stdout };
+  }
+
   it("adds root help hint and marks commands with subcommands", () => {
     process.argv = ["node", "openclaw", "--help"];
     const program = makeProgramWithCommands();
@@ -144,6 +169,24 @@ describe("configureProgramHelp", () => {
     expect(options?.mode).toBe("default");
     expect(help).toContain("Examples:");
     expect(help).toContain("https://docs.openclaw.ai/cli");
+  });
+
+  it("keeps valid root, group, subcommand, short, and help-command output successful", async () => {
+    const rootHelp = await parseHelp(["--help"]);
+    const shortHelp = await parseHelp(["-h"]);
+    const groupHelp = await parseHelp(["plugins", "--help"]);
+    const subcommandHelp = await parseHelp(["plugins", "list", "--help"]);
+    const helpCommand = await parseHelp(["help", "plugins"]);
+
+    for (const result of [rootHelp, shortHelp, groupHelp, subcommandHelp, helpCommand]) {
+      expect(result.error.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+    }
+    expect(rootHelp.error.code).toBe("commander.helpDisplayed");
+    expect(shortHelp.stdout).toBe(rootHelp.stdout);
+    expect(groupHelp.stdout).toContain("Usage: openclaw plugins [options] [command]");
+    expect(subcommandHelp.stdout).toContain("Usage: openclaw plugins list [options]");
+    expect(helpCommand.stdout).toBe(groupHelp.stdout);
   });
 
   it("formats parse errors from the exact Commander command path", async () => {

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -2,17 +2,14 @@
 import { Command, type ErrorOptions } from "commander";
 import { getCommanderSubcommandFact, setCommanderErrorCommand } from "./commander-parse-facts.js";
 
-type CommanderHelpInternals = Command & {
-  _outputHelpIfRequested(args: string[]): void;
-};
-
-/* oxlint-disable eslint/no-underscore-dangle -- The identifier is Commander 15.0.0's own hook name; package.json pins that exact version. */
-/* oxlint-disable typescript/unbound-method -- Commander omits the hook from its types; the call site restores the receiver. */
-// SAFETY: Commander 15.0.0's runtime class defines this pinned private hook with the signature exposed above.
-const commanderOutputHelpIfRequested = (Command.prototype as CommanderHelpInternals)
-  ._outputHelpIfRequested;
-/* oxlint-enable typescript/unbound-method */
-/* oxlint-enable eslint/no-underscore-dangle */
+// Commander 15 declares this help hook only in its runtime class, not its types.
+// Declaring it here lets the subclass override and delegate through `super`
+// instead of re-binding a captured prototype method.
+declare module "commander" {
+  interface Command {
+    _outputHelpIfRequested(args: string[]): void;
+  }
+}
 
 export class OpenClawCommand extends Command {
   override createCommand(name?: string): Command {
@@ -30,7 +27,7 @@ export class OpenClawCommand extends Command {
 
   // Commander 15 checks this internal hook before dispatching actions.
   // Defer only marked lazy placeholders so their real command tree can decide.
-  _outputHelpIfRequested(args: string[]): void {
+  override _outputHelpIfRequested(args: string[]): void {
     const subcommandFact = getCommanderSubcommandFact(this, args);
     if (subcommandFact?.kind === "defer") {
       return;
@@ -40,6 +37,7 @@ export class OpenClawCommand extends Command {
         code: "commander.unknownCommand",
       });
     }
-    commanderOutputHelpIfRequested.call(this, args);
+    // oxlint-disable-next-line eslint/no-underscore-dangle -- Commander 15.0.0 owns this hook name; package.json pins that exact version.
+    super._outputHelpIfRequested(args);
   }
 }

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -1,6 +1,14 @@
 // Commander subclass that preserves the exact failing command for parse-error guidance.
 import { Command, type ErrorOptions } from "commander";
-import { setCommanderErrorCommand } from "./commander-parse-facts.js";
+import { getCommanderSubcommandFact, setCommanderErrorCommand } from "./commander-parse-facts.js";
+
+type CommanderHelpInternals = Command & {
+  _outputHelpIfRequested(args: string[]): void;
+};
+
+// SAFETY: Commander 15 owns this prototype method; the adapter preserves its receiver and args.
+const commanderOutputHelpIfRequested = (Command.prototype as CommanderHelpInternals)
+  ._outputHelpIfRequested;
 
 export class OpenClawCommand extends Command {
   override createCommand(name?: string): Command {
@@ -8,25 +16,26 @@ export class OpenClawCommand extends Command {
   }
 
   override error(message: string, errorOptions?: ErrorOptions): never {
-    const firstArgument = this.args[0];
-    // Commander checks a parent action before its unknown-command branch.
-    // Reclassify only zero-argument parents so genuine leaf excess stays intact.
-    const isUnknownSubcommand =
-      errorOptions?.code === "commander.excessArguments" &&
-      this.registeredArguments.length === 0 &&
-      this.commands.length > 0 &&
-      firstArgument !== undefined &&
-      !this.commands.some(
-        (command) => command.name() === firstArgument || command.aliases().includes(firstArgument),
-      );
     const restoreErrorCommand = setCommanderErrorCommand(this);
     try {
-      return super.error(
-        isUnknownSubcommand ? `error: unknown command '${firstArgument}'` : message,
-        isUnknownSubcommand ? { ...errorOptions, code: "commander.unknownCommand" } : errorOptions,
-      );
+      return super.error(message, errorOptions);
     } finally {
       restoreErrorCommand();
     }
+  }
+
+  // Commander 15 checks this internal hook before dispatching actions.
+  // Defer only marked lazy placeholders so their real command tree can decide.
+  _outputHelpIfRequested(args: string[]): void {
+    const subcommandFact = getCommanderSubcommandFact(this, args);
+    if (subcommandFact?.kind === "defer") {
+      return;
+    }
+    if (subcommandFact?.kind === "unknown") {
+      this.error(`error: unknown command '${subcommandFact.name}'`, {
+        code: "commander.unknownCommand",
+      });
+    }
+    commanderOutputHelpIfRequested.call(this, args);
   }
 }

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -8,6 +8,7 @@ type CommanderHelpInternals = Command & {
 
 /* oxlint-disable eslint/no-underscore-dangle -- The identifier is Commander 15.0.0's own hook name; package.json pins that exact version. */
 /* oxlint-disable typescript/unbound-method -- Commander omits the hook from its types; the call site restores the receiver. */
+// SAFETY: Commander 15.0.0's runtime class defines this pinned private hook with the signature exposed above.
 const commanderOutputHelpIfRequested = (Command.prototype as CommanderHelpInternals)
   ._outputHelpIfRequested;
 /* oxlint-enable typescript/unbound-method */

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -6,9 +6,12 @@ type CommanderHelpInternals = Command & {
   _outputHelpIfRequested(args: string[]): void;
 };
 
-// SAFETY: Commander 15 owns this prototype method; the adapter preserves its receiver and args.
+/* oxlint-disable eslint/no-underscore-dangle -- The identifier is Commander 15.0.0's own hook name; package.json pins that exact version. */
+/* oxlint-disable typescript/unbound-method -- Commander omits the hook from its types; the call site restores the receiver. */
 const commanderOutputHelpIfRequested = (Command.prototype as CommanderHelpInternals)
   ._outputHelpIfRequested;
+/* oxlint-enable typescript/unbound-method */
+/* oxlint-enable eslint/no-underscore-dangle */
 
 export class OpenClawCommand extends Command {
   override createCommand(name?: string): Command {

--- a/src/cli/program/register-lazy-command.ts
+++ b/src/cli/program/register-lazy-command.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import { reparseProgramFromActionCommand } from "./action-reparse.js";
 import { removeCommandByName } from "./command-tree.js";
+import { markCommanderLazyCommand } from "./commander-parse-facts.js";
 
 type RegisterLazyCommandParams = {
   program: Command;
@@ -25,6 +26,7 @@ export function registerLazyCommand({
   register,
 }: RegisterLazyCommandParams): void {
   const placeholder = program.command(name).description(description);
+  markCommanderLazyCommand(placeholder);
   for (const option of options ?? []) {
     placeholder.option(option.flags, option.description);
   }

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -208,6 +208,7 @@ describe("production lint suppressions", () => {
         "src/cli/cli-utils.ts|typescript/no-unnecessary-type-parameters|1",
         "src/cli/command-options.ts|typescript/no-unnecessary-type-parameters|1",
         "src/cli/plugins-cli-test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/cli/program/openclaw-command.ts|eslint/no-underscore-dangle|1",
         "src/cli/test-runtime-capture.ts|typescript/no-unnecessary-type-parameters|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

Adding `--help` to a mistyped nested command made Commander print the parent group's help and exit 0. The invalid token disappeared, so `openclaw sessions lst --help` looked like successful help for a valid command instead of reporting that `lst` does not exist.

## Why This Change Was Made

Commander 15 checks its internal help hook before dispatching command actions and before its unknown-command branch. That ordering is especially important for OpenClaw's lazy placeholders: the placeholder must run its action and load the real child tree before OpenClaw can decide whether the token is a real subcommand.

The OpenClaw Commander adapter now records lazy placeholders, defers only their early help check, and classifies the token after the real tree has loaded. Unknown tokens then use the same canonical unknown-command formatter as the no-help form. Real child commands continue to render their own help normally. This keeps lazy registration lazy and adds no per-group command lists.

Production LOC: +56/-16 (net +40) | Tests: +77/-2

## User Impact

`<group> <unknown> --help` now names the invalid subcommand, suggests a nearby real command when available, points to the parent group's help, and exits 1. Root, parent, real-subcommand, short-form, and `help <command>` output remain byte-identical and exit 0.

## Evidence

### Built-dist before and after

Both builds used source base `715c379fd949a9a77224a590e8d9016f88b62d0c`, `OPENCLAW_SKIP_CHANNELS=1`, and an isolated temporary `OPENCLAW_STATE_DIR` on Blacksmith Testbox `tbx_01m05rnzy10cbmgnebpvqgjhc8` (Actions run https://github.com/openclaw/openclaw/actions/runs/31960660687).

```text
BEFORE
$ openclaw sessions lst --help
OpenClaw 2026.8.1 (715c379) — All your chats, one OpenClaw.
Usage: openclaw sessions [options] [command]
[parent sessions help]
[exit 0]

AFTER
$ openclaw sessions lst --help
OpenClaw sessions has no command "lst".
Did you mean this?
  openclaw sessions list
Try: openclaw sessions --help
Docs: https://docs.openclaw.ai/cli
[exit 1]
```

```text
BEFORE
$ openclaw memory bogusxyz --help
OpenClaw 2026.8.1 (715c379) — All your chats, one OpenClaw.
Usage: openclaw memory [options] [command]
[parent memory help]
[exit 0]

AFTER
$ openclaw memory bogusxyz --help
OpenClaw memory has no command "bogusxyz".
Try: openclaw memory --help
Docs: https://docs.openclaw.ai/cli
[exit 1]
```

The normalized nested help form is consistent too:

```text
$ openclaw help sessions bogusxyz
OpenClaw sessions has no command "bogusxyz".
Try: openclaw sessions --help
Docs: https://docs.openclaw.ai/cli
[exit 1]
```

### Valid help is byte-identical

| Invocation | Before | After | stdout SHA-256 |
| --- | ---: | ---: | --- |
| `openclaw sessions list --help` | exit 0 | exit 0 | `fd5e681456d8993d9d1d6bbbf9e17219fc932e1f3142eb9dc7f050ffed5f04bc` |
| `openclaw sessions --help` | exit 0 | exit 0 | `e8aca473eb906102b4f673a51539abe20b5ad05ce6cb5438aefb31c5098089f1` |
| `openclaw --help` | exit 0 | exit 0 | `6d0e4f8f41eade80f0a9876c1b77c67cc7b388dd4b620fe462394f216e1a38ad` |
| `openclaw -h` | exit 0 | exit 0 | `6d0e4f8f41eade80f0a9876c1b77c67cc7b388dd4b620fe462394f216e1a38ad` |
| `openclaw help sessions` | exit 0 | exit 0 | `e8aca473eb906102b4f673a51539abe20b5ad05ce6cb5438aefb31c5098089f1` |

Every valid case also had empty stderr before and after.

### Tests and review

- Pre-fix regression: `reports an unmatched lazy subcommand before --help can hide it` failed with received `commander.helpDisplayed`, expected `commander.unknownCommand`.
- `node scripts/run-vitest.mjs src/cli/program` — 63 files, 1,117 tests passed.
- `pnpm build` — passed; no ineffective dynamic-import warning.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs` selected `core, coreTests`, accepted the new assertion-safety comment, then stopped on unrelated shrink-only baseline drift already present on `origin/main`: `src/state/control-ui-device-auth-migration.ts: 0 < 1` and `ui/src/lib/nodes/index.ts: 3 < 4`. This PR does not touch those files or the protected baseline.
