### PR TITLE
feat(voice-call): sessionScope "main" routes calls into the agent main session

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -105,7 +105,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
           provider: "twilio", // or "telnyx" | "plivo" | "mock"
           fromNumber: "+15550001234", // or TWILIO_FROM_NUMBER for Twilio
           toNumber: "+15550005678",
-          sessionScope: "per-phone", // per-phone | per-call
+          sessionScope: "per-phone", // per-phone | per-call | main
           numbers: {
             "+15550009999": {
               inboundGreeting: "Silver Fox Cards, how can I help?",
@@ -237,12 +237,19 @@ each carrier call should start with fresh context, for example reception,
 booking, IVR, or Google Meet bridge flows where the same phone number may
 represent different meetings.
 
-Voice Call stores generated session keys under the configured agent namespace
-(`agent:<agentId>:voice:*`). Raw explicit integration keys resolve into the
-same namespace: a canonical `agent:<configuredAgentId>:*` key keeps that
-owner and honors core `session.mainKey`/global-scope aliasing; foreign or
-malformed `agent:*` input is scoped as an opaque key under the configured
-agent; `global` and `unknown` remain global sentinels.
+Set `sessionScope: "main"` to route every call into the configured agent's main
+session. This honors the core `session.mainKey` setting and resolves to
+`global` when core `session.scope` is `"global"`. Raw call turns then share
+history with the agent's primary session, so use this only when that shared
+context is intentional.
+
+For `per-phone` and `per-call`, Voice Call stores generated session keys under
+the configured agent namespace (`agent:<agentId>:voice:*`). Raw explicit
+integration keys resolve into the same namespace: a canonical
+`agent:<configuredAgentId>:*` key keeps that owner and honors core
+`session.mainKey`/global-scope aliasing; foreign or malformed `agent:*` input
+is scoped as an opaque key under the configured agent; `global` and `unknown`
+remain global sentinels.
 
 ## Realtime voice conversations
 
@@ -267,7 +274,7 @@ Current runtime behavior:
 - `realtime.fastContext.enabled` is default-off. When enabled, Voice Call first searches indexed memory/session context for the consult question and returns authorized snippets to the realtime model within `realtime.fastContext.timeoutMs` before falling back to the full consult agent only if `realtime.fastContext.fallbackToConsult` is true. The active memory plugin authorizes session-transcript hits; plugins without that capability fail closed for session hits while ordinary memory hits remain available.
 - If `realtime.provider` points at an unregistered provider, or no realtime voice provider is registered at all, Voice Call logs a warning and skips realtime media instead of failing the whole plugin.
 - `inboundPolicy` must not be `"disabled"` when `realtime.enabled` is true; `validateProviderConfig` rejects that combination.
-- Consult session keys reuse the stored call session when available, then fall back to the configured `sessionScope` (`per-phone` by default, or `per-call` for isolated calls).
+- Consult session keys reuse the stored call session when available, then fall back to the configured `sessionScope` (`per-phone` by default, `per-call` for isolated calls, or `main` for the configured agent's main session).
 
 ### Tool policy
 

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -38,7 +38,7 @@ Put under `plugins.entries.voice-call.config`:
   provider: "twilio", // or "telnyx" | "plivo" | "mock"
   fromNumber: "+15550001234",
   toNumber: "+15550005678",
-  sessionScope: "per-phone", // or "per-call"
+  sessionScope: "per-phone", // or "per-call" | "main"
 
   twilio: {
     accountSid: "ACxxxxxxxx",
@@ -104,7 +104,7 @@ Notes:
 - Runtime accepts canonical config only. If older configs still use `provider: "log"`, `twilio.from`, or legacy `streaming.*` OpenAI keys, run `openclaw doctor --fix` to rewrite them.
 - advanced webhook, streaming, and tunnel notes: `https://docs.openclaw.ai/plugins/voice-call`
 - `responseModel` is optional. When unset, voice responses use the runtime default model.
-- `sessionScope` defaults to `per-phone`, preserving caller memory across calls. Use `per-call` for reception, booking, IVR, and bridge flows where each carrier call should start fresh.
+- `sessionScope` defaults to `per-phone`, preserving caller memory across calls. Use `per-call` for reception, booking, IVR, and bridge flows where each carrier call should start fresh. Use `main` to share the configured agent's main session, honoring core `session.mainKey` and global scope.
 - `realtime.consultThinkingLevel` is optional. When set, it overrides the thinking level used by the model behind realtime `openclaw_agent_consult` calls.
 - `realtime.consultFastMode` is optional. When set, it toggles fast mode for realtime `openclaw_agent_consult` calls.
 

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -242,7 +242,7 @@
     },
     "sessionScope": {
       "label": "Session Scope",
-      "help": "Use per-phone to preserve caller memory across calls, or per-call to isolate every call into a fresh voice session."
+      "help": "Use per-phone to preserve caller memory, per-call to isolate every call, or main to share the configured agent's main session."
     },
     "responseModel": {
       "label": "Response Model",
@@ -933,7 +933,7 @@
       },
       "sessionScope": {
         "type": "string",
-        "enum": ["per-phone", "per-call"]
+        "enum": ["per-phone", "per-call", "main"]
       },
       "responseModel": {
         "type": "string"

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -469,11 +469,54 @@ describe("resolveVoiceCallConfig session routing", () => {
     ).toBe("agent:main:voice:call:call-123");
   });
 
-  it("scopes explicit voice session keys by configured agent", () => {
+  it.each([
+    {
+      name: "the default core session",
+      agentId: undefined,
+      coreSession: undefined,
+      expected: "agent:main:main",
+    },
+    {
+      name: "a custom core main key",
+      agentId: undefined,
+      coreSession: { mainKey: "work" },
+      expected: "agent:main:work",
+    },
+    {
+      name: "global core scope",
+      agentId: undefined,
+      coreSession: { scope: "global" as const },
+      expected: "global",
+    },
+    {
+      name: "a configured agent",
+      agentId: "ops",
+      coreSession: undefined,
+      expected: "agent:ops:main",
+    },
+  ])("routes main-scoped calls to $name", ({ agentId, coreSession, expected }) => {
     const config = resolveVoiceCallConfig({
       enabled: true,
       provider: "mock",
-      sessionScope: "per-call",
+      sessionScope: "main",
+      agentId,
+    });
+
+    expect(
+      resolveVoiceCallSessionKey({
+        config,
+        callId: "call-123",
+        phone: "+1 (555) 000-1111",
+        coreSession,
+      }),
+    ).toBe(expected);
+  });
+
+  it("lets an explicit session key override main scope", () => {
+    const config = resolveVoiceCallConfig({
+      enabled: true,
+      provider: "mock",
+      sessionScope: "main",
     });
 
     expect(

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -202,7 +202,7 @@ export type WebhookSecurityConfig = z.infer<typeof VoiceCallWebhookSecurityConfi
 const CallModeSchema = z.enum(["notify", "conversation"]);
 export type CallMode = z.infer<typeof CallModeSchema>;
 
-const VoiceCallSessionScopeSchema = z.enum(["per-phone", "per-call"]);
+const VoiceCallSessionScopeSchema = z.enum(["per-phone", "per-call", "main"]);
 
 const OutboundConfigSchema = z
   .object({
@@ -731,6 +731,13 @@ export function resolveVoiceCallSessionKey(params: {
     return resolveVoiceCallAgentSessionKey({
       config: params.config,
       sessionKey: explicit,
+      coreSession: params.coreSession,
+    });
+  }
+  if (params.config.sessionScope === "main") {
+    return resolveVoiceCallAgentSessionKey({
+      config: params.config,
+      sessionKey: "main",
       coreSession: params.coreSession,
     });
   }

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -3,19 +3,25 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
+import type { CallManagerContext } from "./manager/context.js";
 import { persistCallRecord } from "./manager/store.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import { CallRecordSchema } from "./types.js";
 import type {
+  CallRecord,
   GetCallStatusInput,
   GetCallStatusResult,
   HangupCallInput,
   InitiateCallInput,
   InitiateCallResult,
+  NormalizedEvent,
   PlayTtsInput,
   ProviderWebhookParseResult,
   StartListeningInput,
@@ -158,5 +164,157 @@ export function makePersistedCall(
     transcript: [],
     processedEventIds: [],
     ...overrides,
+  };
+}
+
+export const EVENT_MANAGER_REPLAY_KEY_LIMIT = 10_000;
+
+export function createEventManagerHarness() {
+  const contexts: CallManagerContext[] = [];
+
+  function installStateRuntime(shouldFail?: () => boolean): void {
+    setVoiceCallStateRuntime({
+      state: {
+        resolveStateDir: () => "",
+        openKeyedStore: (() => {
+          throw new Error("openKeyedStore is not used by voice-call event tests");
+        }) as never,
+        openSyncKeyedStore: (options: OpenKeyedStoreOptions) => {
+          if (shouldFail?.()) {
+            throw new Error("synthetic SQLite persistence failure");
+          }
+          return createPluginStateSyncKeyedStoreForTests("voice-call", options);
+        },
+        openChannelIngressQueue: (() => {
+          throw new Error("openChannelIngressQueue is not used by voice-call event tests");
+        }) as never,
+        openChannelIngressDrain: (() => {
+          throw new Error("openChannelIngressDrain is not used by voice-call event tests");
+        }) as never,
+      },
+    });
+  }
+
+  function setup(): void {
+    resetPluginStateStoreForTests();
+    installStateRuntime();
+  }
+
+  function cleanup(): void {
+    for (const ctx of contexts.splice(0)) {
+      for (const timer of ctx.maxDurationTimers.values()) {
+        clearTimeout(timer);
+      }
+      ctx.maxDurationTimers.clear();
+      for (const waiter of ctx.transcriptWaiters.values()) {
+        clearTimeout(waiter.timeout);
+      }
+      ctx.transcriptWaiters.clear();
+      fs.rmSync(ctx.storePath, { recursive: true, force: true });
+    }
+    resetPluginStateStoreForTests();
+  }
+
+  function createContext(overrides: Partial<CallManagerContext> = {}): CallManagerContext {
+    const storePath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-events-test-"));
+    const ctx: CallManagerContext = {
+      activeCalls: new Map(),
+      providerCallIdMap: new Map(),
+      processedEventIds: new Set(),
+      rejectedProviderCallIds: new Map(),
+      provider: null,
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+      }),
+      storePath,
+      webhookUrl: null,
+      activeTurnCalls: new Set(),
+      transcriptWaiters: new Map(),
+      maxDurationTimers: new Map(),
+      initialMessageInFlight: new Set(),
+      ...overrides,
+    };
+    contexts.push(ctx);
+    return ctx;
+  }
+
+  function createProvider(overrides: Partial<VoiceCallProvider> = {}): VoiceCallProvider {
+    return {
+      name: "plivo",
+      verifyWebhook: () => ({ ok: true }),
+      parseWebhookEvent: () => ({ events: [] }),
+      initiateCall: async () => ({ providerCallId: "provider-call-id", status: "initiated" }),
+      hangupCall: async () => {},
+      playTts: async () => {},
+      startListening: async () => {},
+      stopListening: async () => {},
+      getCallStatus: async () => ({ status: "in-progress", isTerminal: false }),
+      ...overrides,
+    };
+  }
+
+  function createInboundDisabledConfig() {
+    return VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+      inboundPolicy: "disabled",
+    });
+  }
+
+  function createInboundInitiatedEvent(params: {
+    id: string;
+    providerCallId: string;
+    from: string;
+  }): NormalizedEvent {
+    return {
+      id: params.id,
+      type: "call.initiated",
+      callId: params.providerCallId,
+      providerCallId: params.providerCallId,
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: params.from,
+      to: "+15550000000",
+    };
+  }
+
+  function createRejectingInboundContext(): {
+    ctx: CallManagerContext;
+    hangupCalls: HangupCallInput[];
+  } {
+    const hangupCalls: HangupCallInput[] = [];
+    const provider = createProvider({
+      hangupCall: async (input: HangupCallInput): Promise<void> => {
+        hangupCalls.push(input);
+      },
+    });
+    const ctx = createContext({
+      config: createInboundDisabledConfig(),
+      provider,
+    });
+    return { ctx, hangupCalls };
+  }
+
+  function requireFirstActiveCall(ctx: CallManagerContext): CallRecord {
+    const call = [...ctx.activeCalls.values()][0];
+    if (!call) {
+      throw new Error("expected one active call");
+    }
+    return call;
+  }
+
+  return {
+    cleanup,
+    createContext,
+    createInboundDisabledConfig,
+    createInboundInitiatedEvent,
+    createProvider,
+    createRejectingInboundContext,
+    installStateRuntime,
+    requireFirstActiveCall,
+    setup,
   };
 }

--- a/extensions/voice-call/src/manager/events.inbound.test.ts
+++ b/extensions/voice-call/src/manager/events.inbound.test.ts
@@ -1,0 +1,319 @@
+// Voice Call tests cover inbound event policy and routing behavior.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VoiceCallConfigSchema } from "../config.js";
+import {
+  createEventManagerHarness,
+  EVENT_MANAGER_REPLAY_KEY_LIMIT,
+} from "../manager.test-harness.js";
+import type { AnswerCallInput, CallRecord, NormalizedEvent } from "../types.js";
+import { processEvent } from "./events.js";
+
+const {
+  cleanup,
+  createContext,
+  createInboundDisabledConfig,
+  createInboundInitiatedEvent,
+  createProvider,
+  createRejectingInboundContext,
+  installStateRuntime,
+  requireFirstActiveCall,
+  setup,
+} = createEventManagerHarness();
+
+beforeEach(() => {
+  setup();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("processEvent (functional inbound calls)", () => {
+  it.each(["created", "rejected"] as const)(
+    "does not publish %s inbound calls before SQLite persistence succeeds",
+    (kind) => {
+      let failPersistence = true;
+      installStateRuntime(() => failPersistence);
+      const { ctx, hangupCalls } = createRejectingInboundContext();
+      ctx.config.inboundPolicy = kind === "created" ? "open" : "disabled";
+      const event = createInboundInitiatedEvent({
+        id: `event-durable-${kind}`,
+        providerCallId: `provider-durable-${kind}`,
+        from: "+15550000002",
+      });
+
+      expect(() => processEvent(ctx, event)).toThrow("synthetic SQLite persistence failure");
+      expect(ctx.activeCalls.size).toBe(0);
+      expect(ctx.providerCallIdMap.size).toBe(0);
+      expect(ctx.rejectedProviderCallIds.size).toBe(0);
+      expect(ctx.processedEventIds.size).toBe(0);
+      expect(hangupCalls).toHaveLength(0);
+
+      failPersistence = false;
+      expect(processEvent(ctx, event)).toEqual({ kind: "processed" });
+      expect(ctx.activeCalls.size).toBe(kind === "created" ? 1 : 0);
+      expect(hangupCalls).toHaveLength(kind === "rejected" ? 1 : 0);
+    },
+  );
+
+  it("calls provider hangup when rejecting inbound call", () => {
+    const { ctx, hangupCalls } = createRejectingInboundContext();
+    const event = createInboundInitiatedEvent({
+      id: "evt-1",
+      providerCallId: "prov-1",
+      from: "+15559999999",
+    });
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(hangupCalls).toHaveLength(1);
+    expect(hangupCalls[0]).toEqual({
+      callId: "prov-1",
+      providerCallId: "prov-1",
+      reason: "hangup-bot",
+    });
+  });
+
+  it("does not call hangup when provider is null", () => {
+    const ctx = createContext({
+      config: createInboundDisabledConfig(),
+      provider: null,
+    });
+    const event = createInboundInitiatedEvent({
+      id: "evt-2",
+      providerCallId: "prov-2",
+      from: "+15551111111",
+    });
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+  });
+
+  it("calls hangup only once for duplicate events for same rejected call", () => {
+    const { ctx, hangupCalls } = createRejectingInboundContext();
+    const event1 = createInboundInitiatedEvent({
+      id: "evt-init",
+      providerCallId: "prov-dup",
+      from: "+15552222222",
+    });
+    const event2: NormalizedEvent = {
+      id: "evt-ring",
+      type: "call.ringing",
+      callId: "prov-dup",
+      providerCallId: "prov-dup",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15552222222",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event1);
+    processEvent(ctx, event2);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(hangupCalls).toEqual([
+      {
+        callId: "prov-dup",
+        providerCallId: "prov-dup",
+        reason: "hangup-bot",
+      },
+    ]);
+  });
+
+  it("answers accepted inbound calls when the provider requires an answer command", () => {
+    const answerCalls: AnswerCallInput[] = [];
+    const provider = createProvider({
+      answerCall: async (input: AnswerCallInput): Promise<void> => {
+        answerCalls.push(input);
+      },
+    });
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "telnyx",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+        telnyx: {
+          apiKey: "KEY123",
+          connectionId: "CONN456",
+        },
+        skipSignatureVerification: true,
+      }),
+      provider,
+    });
+    const event = createInboundInitiatedEvent({
+      id: "evt-answer",
+      providerCallId: "call-control-1",
+      from: "+15552222222",
+    });
+
+    processEvent(ctx, event);
+
+    const call = requireFirstActiveCall(ctx);
+    expect(answerCalls).toEqual([
+      {
+        callId: call.callId,
+        providerCallId: "call-control-1",
+      },
+    ]);
+  });
+
+  it("removes active call even when hangup rejects", () => {
+    const provider = createProvider({
+      hangupCall: async (): Promise<void> => {
+        throw new Error("provider down");
+      },
+    });
+    const ctx = createContext({
+      config: createInboundDisabledConfig(),
+      provider,
+    });
+    const event = createInboundInitiatedEvent({
+      id: "evt-fail",
+      providerCallId: "prov-fail",
+      from: "+15553333333",
+    });
+
+    processEvent(ctx, event);
+    expect(ctx.activeCalls.size).toBe(0);
+  });
+
+  it("preserves inbound direction for auto-registered inbound calls", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+    });
+    const event: NormalizedEvent = {
+      id: "evt-inbound-dir",
+      type: "call.initiated",
+      callId: "CA-inbound-789",
+      providerCallId: "CA-inbound-789",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15554444444",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(1);
+    const call = requireFirstActiveCall(ctx);
+    expect(call.direction).toBe("inbound");
+  });
+
+  it.each([
+    {
+      sessionScope: "per-call",
+      coreSession: undefined,
+      expectedSessionKey: (call: CallRecord) => `agent:main:voice:call:${call.callId}`,
+    },
+    {
+      sessionScope: "main",
+      coreSession: { mainKey: "work" },
+      expectedSessionKey: () => "agent:main:work",
+    },
+  ])(
+    "assigns $sessionScope session keys to inbound calls",
+    ({ sessionScope, coreSession, expectedSessionKey }) => {
+      const ctx = createContext({
+        config: VoiceCallConfigSchema.parse({
+          enabled: true,
+          provider: "plivo",
+          fromNumber: "+15550000000",
+          inboundPolicy: "open",
+          sessionScope,
+        }),
+        coreSession,
+      });
+      const event: NormalizedEvent = {
+        id: "evt-inbound-session-scope",
+        type: "call.initiated",
+        callId: "CA-inbound-session-scope",
+        providerCallId: "CA-inbound-session-scope",
+        timestamp: Date.now(),
+        direction: "inbound",
+        from: "+15554444444",
+        to: "+15550000000",
+      };
+
+      processEvent(ctx, event);
+
+      const call = requireFirstActiveCall(ctx);
+      expect(call.sessionKey).toBe(expectedSessionKey(call));
+    },
+  );
+
+  it("applies per-number inbound greeting and stores the matched route key", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+        inboundGreeting: "Hello from global.",
+        numbers: {
+          "+15550002222": {
+            agentId: "cards",
+            inboundGreeting: "Silver Fox Cards, how can I help?",
+          },
+        },
+      }),
+    });
+    const event: NormalizedEvent = {
+      id: "evt-inbound-number-route",
+      type: "call.initiated",
+      callId: "CA-inbound-number-route",
+      providerCallId: "CA-inbound-number-route",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15554444444",
+      to: "+1 (555) 000-2222",
+    };
+
+    processEvent(ctx, event);
+
+    const call = requireFirstActiveCall(ctx);
+    expect(call.metadata?.initialMessage).toBe("Silver Fox Cards, how can I help?");
+    expect(call.metadata?.numberRouteKey).toBe("+15550002222");
+    expect(call.agentId).toBe("cards");
+  });
+
+  it("bounds rejected provider calls while retaining hangup-once behavior", () => {
+    const rejectedProviderCallIds = new Map<string, symbol>(
+      Array.from(
+        { length: EVENT_MANAGER_REPLAY_KEY_LIMIT },
+        (_, index) => [`provider-${index}`, Symbol(`provider-${index}`)] as const,
+      ),
+    );
+    const { ctx, hangupCalls } = createRejectingInboundContext();
+    ctx.rejectedProviderCallIds = rejectedProviderCallIds;
+
+    processEvent(
+      ctx,
+      createInboundInitiatedEvent({
+        id: "evt-rejected-new",
+        providerCallId: "provider-new",
+        from: "+15552222222",
+      }),
+    );
+    processEvent(
+      ctx,
+      createInboundInitiatedEvent({
+        id: "evt-rejected-new-replay",
+        providerCallId: "provider-new",
+        from: "+15552222222",
+      }),
+    );
+
+    expect(ctx.rejectedProviderCallIds.size).toBe(EVENT_MANAGER_REPLAY_KEY_LIMIT);
+    expect(ctx.rejectedProviderCallIds.has("provider-0")).toBe(false);
+    expect(ctx.rejectedProviderCallIds.has("provider-new")).toBe(true);
+    expect(hangupCalls).toHaveLength(1);
+  });
+});

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -763,37 +763,36 @@ describe("processEvent (functional)", () => {
       coreSession: { mainKey: "work" },
       expectedSessionKey: () => "agent:main:work",
     },
-  ])("assigns $sessionScope session keys to inbound calls", ({
-    sessionScope,
-    coreSession,
-    expectedSessionKey,
-  }) => {
-    const ctx = createContext({
-      config: VoiceCallConfigSchema.parse({
-        enabled: true,
-        provider: "plivo",
-        fromNumber: "+15550000000",
-        inboundPolicy: "open",
-        sessionScope,
-      }),
-      coreSession,
-    });
-    const event: NormalizedEvent = {
-      id: "evt-inbound-session-scope",
-      type: "call.initiated",
-      callId: "CA-inbound-session-scope",
-      providerCallId: "CA-inbound-session-scope",
-      timestamp: Date.now(),
-      direction: "inbound",
-      from: "+15554444444",
-      to: "+15550000000",
-    };
+  ])(
+    "assigns $sessionScope session keys to inbound calls",
+    ({ sessionScope, coreSession, expectedSessionKey }) => {
+      const ctx = createContext({
+        config: VoiceCallConfigSchema.parse({
+          enabled: true,
+          provider: "plivo",
+          fromNumber: "+15550000000",
+          inboundPolicy: "open",
+          sessionScope,
+        }),
+        coreSession,
+      });
+      const event: NormalizedEvent = {
+        id: "evt-inbound-session-scope",
+        type: "call.initiated",
+        callId: "CA-inbound-session-scope",
+        providerCallId: "CA-inbound-session-scope",
+        timestamp: Date.now(),
+        direction: "inbound",
+        from: "+15554444444",
+        to: "+15550000000",
+      };
 
-    processEvent(ctx, event);
+      processEvent(ctx, event);
 
-    const call = requireFirstActiveCall(ctx);
-    expect(call.sessionKey).toBe(expectedSessionKey(call));
-  });
+      const call = requireFirstActiveCall(ctx);
+      expect(call.sessionKey).toBe(expectedSessionKey(call));
+    },
+  );
 
   it("applies per-number inbound greeting and stores the matched route key", () => {
     const ctx = createContext({

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -752,15 +752,31 @@ describe("processEvent (functional)", () => {
     expect(call.direction).toBe("inbound");
   });
 
-  it("assigns per-call session keys to inbound calls when configured", () => {
+  it.each([
+    {
+      sessionScope: "per-call",
+      coreSession: undefined,
+      expectedSessionKey: (call: CallRecord) => `agent:main:voice:call:${call.callId}`,
+    },
+    {
+      sessionScope: "main",
+      coreSession: { mainKey: "work" },
+      expectedSessionKey: () => "agent:main:work",
+    },
+  ])("assigns $sessionScope session keys to inbound calls", ({
+    sessionScope,
+    coreSession,
+    expectedSessionKey,
+  }) => {
     const ctx = createContext({
       config: VoiceCallConfigSchema.parse({
         enabled: true,
         provider: "plivo",
         fromNumber: "+15550000000",
         inboundPolicy: "open",
-        sessionScope: "per-call",
+        sessionScope,
       }),
+      coreSession,
     });
     const event: NormalizedEvent = {
       id: "evt-inbound-session-scope",
@@ -776,7 +792,7 @@ describe("processEvent (functional)", () => {
     processEvent(ctx, event);
 
     const call = requireFirstActiveCall(ctx);
-    expect(call.sessionKey).toBe(`agent:main:voice:call:${call.callId}`);
+    expect(call.sessionKey).toBe(expectedSessionKey(call));
   });
 
   it("applies per-number inbound greeting and stores the matched route key", () => {

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -1,23 +1,16 @@
 // Voice Call tests cover events plugin behavior.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  createPluginStateSyncKeyedStoreForTests,
-  resetPluginStateStoreForTests,
-} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema } from "../config.js";
+import {
+  createEventManagerHarness,
+  EVENT_MANAGER_REPLAY_KEY_LIMIT,
+} from "../manager.test-harness.js";
 import type { VoiceCallProvider } from "../providers/base.js";
-import { setVoiceCallStateRuntime } from "../runtime-state.js";
-import type { AnswerCallInput, CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
-import type { CallManagerContext } from "./context.js";
+import type { CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
 import { processEvent } from "./events.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
 
-const MANAGER_REPLAY_KEY_LIMIT = 10_000;
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
   return {
@@ -46,143 +39,26 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
   };
 });
 
-const contexts: CallManagerContext[] = [];
-
-function installStateRuntime(shouldFail?: () => boolean): void {
-  setVoiceCallStateRuntime({
-    state: {
-      resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call event tests");
-      }) as never,
-      openSyncKeyedStore: (options: OpenKeyedStoreOptions) => {
-        if (shouldFail?.()) {
-          throw new Error("synthetic SQLite persistence failure");
-        }
-        return createPluginStateSyncKeyedStoreForTests("voice-call", options);
-      },
-      openChannelIngressQueue: (() => {
-        throw new Error("openChannelIngressQueue is not used by voice-call event tests");
-      }) as never,
-      openChannelIngressDrain: (() => {
-        throw new Error("openChannelIngressDrain is not used by voice-call event tests");
-      }) as never,
-    },
-  });
-}
+const {
+  cleanup,
+  createContext,
+  createInboundInitiatedEvent,
+  createProvider,
+  createRejectingInboundContext,
+  installStateRuntime,
+  requireFirstActiveCall,
+  setup,
+} = createEventManagerHarness();
 
 beforeEach(() => {
-  resetPluginStateStoreForTests();
-  installStateRuntime();
+  setup();
 });
 
-afterEach(async () => {
-  for (const ctx of contexts.splice(0)) {
-    for (const timer of ctx.maxDurationTimers.values()) {
-      clearTimeout(timer);
-    }
-    ctx.maxDurationTimers.clear();
-    for (const waiter of ctx.transcriptWaiters.values()) {
-      clearTimeout(waiter.timeout);
-    }
-    ctx.transcriptWaiters.clear();
-    fs.rmSync(ctx.storePath, { recursive: true, force: true });
-  }
-  resetPluginStateStoreForTests();
+afterEach(() => {
+  cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
-
-function createContext(overrides: Partial<CallManagerContext> = {}): CallManagerContext {
-  const storePath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-events-test-"));
-  const ctx: CallManagerContext = {
-    activeCalls: new Map(),
-    providerCallIdMap: new Map(),
-    processedEventIds: new Set(),
-    rejectedProviderCallIds: new Map(),
-    provider: null,
-    config: VoiceCallConfigSchema.parse({
-      enabled: true,
-      provider: "plivo",
-      fromNumber: "+15550000000",
-    }),
-    storePath,
-    webhookUrl: null,
-    activeTurnCalls: new Set(),
-    transcriptWaiters: new Map(),
-    maxDurationTimers: new Map(),
-    initialMessageInFlight: new Set(),
-    ...overrides,
-  };
-  contexts.push(ctx);
-  return ctx;
-}
-
-function createProvider(overrides: Partial<VoiceCallProvider> = {}): VoiceCallProvider {
-  return {
-    name: "plivo",
-    verifyWebhook: () => ({ ok: true }),
-    parseWebhookEvent: () => ({ events: [] }),
-    initiateCall: async () => ({ providerCallId: "provider-call-id", status: "initiated" }),
-    hangupCall: async () => {},
-    playTts: async () => {},
-    startListening: async () => {},
-    stopListening: async () => {},
-    getCallStatus: async () => ({ status: "in-progress", isTerminal: false }),
-    ...overrides,
-  };
-}
-
-function createInboundDisabledConfig() {
-  return VoiceCallConfigSchema.parse({
-    enabled: true,
-    provider: "plivo",
-    fromNumber: "+15550000000",
-    inboundPolicy: "disabled",
-  });
-}
-
-function createInboundInitiatedEvent(params: {
-  id: string;
-  providerCallId: string;
-  from: string;
-}): NormalizedEvent {
-  return {
-    id: params.id,
-    type: "call.initiated",
-    callId: params.providerCallId,
-    providerCallId: params.providerCallId,
-    timestamp: Date.now(),
-    direction: "inbound",
-    from: params.from,
-    to: "+15550000000",
-  };
-}
-
-function createRejectingInboundContext(): {
-  ctx: CallManagerContext;
-  hangupCalls: HangupCallInput[];
-} {
-  const hangupCalls: HangupCallInput[] = [];
-  const provider = createProvider({
-    hangupCall: async (input: HangupCallInput): Promise<void> => {
-      hangupCalls.push(input);
-    },
-  });
-  const ctx = createContext({
-    config: createInboundDisabledConfig(),
-    provider,
-  });
-  return { ctx, hangupCalls };
-}
-
-function requireFirstActiveCall(ctx: CallManagerContext) {
-  const call = [...ctx.activeCalls.values()][0];
-  if (!call) {
-    throw new Error("expected one active call");
-  }
-  return call;
-}
 
 describe("processEvent (functional)", () => {
   it.each(["speech", "answered", "terminal"] as const)(
@@ -248,137 +124,6 @@ describe("processEvent (functional)", () => {
       expect(ctx.activeCalls.has(call.callId)).toBe(kind !== "terminal");
     },
   );
-
-  it.each(["created", "rejected"] as const)(
-    "does not publish %s inbound calls before SQLite persistence succeeds",
-    (kind) => {
-      let failPersistence = true;
-      installStateRuntime(() => failPersistence);
-      const { ctx, hangupCalls } = createRejectingInboundContext();
-      ctx.config.inboundPolicy = kind === "created" ? "open" : "disabled";
-      const event = createInboundInitiatedEvent({
-        id: `event-durable-${kind}`,
-        providerCallId: `provider-durable-${kind}`,
-        from: "+15550000002",
-      });
-
-      expect(() => processEvent(ctx, event)).toThrow("synthetic SQLite persistence failure");
-      expect(ctx.activeCalls.size).toBe(0);
-      expect(ctx.providerCallIdMap.size).toBe(0);
-      expect(ctx.rejectedProviderCallIds.size).toBe(0);
-      expect(ctx.processedEventIds.size).toBe(0);
-      expect(hangupCalls).toHaveLength(0);
-
-      failPersistence = false;
-      expect(processEvent(ctx, event)).toEqual({ kind: "processed" });
-      expect(ctx.activeCalls.size).toBe(kind === "created" ? 1 : 0);
-      expect(hangupCalls).toHaveLength(kind === "rejected" ? 1 : 0);
-    },
-  );
-
-  it("calls provider hangup when rejecting inbound call", () => {
-    const { ctx, hangupCalls } = createRejectingInboundContext();
-    const event = createInboundInitiatedEvent({
-      id: "evt-1",
-      providerCallId: "prov-1",
-      from: "+15559999999",
-    });
-
-    processEvent(ctx, event);
-
-    expect(ctx.activeCalls.size).toBe(0);
-    expect(hangupCalls).toHaveLength(1);
-    expect(hangupCalls[0]).toEqual({
-      callId: "prov-1",
-      providerCallId: "prov-1",
-      reason: "hangup-bot",
-    });
-  });
-
-  it("does not call hangup when provider is null", () => {
-    const ctx = createContext({
-      config: createInboundDisabledConfig(),
-      provider: null,
-    });
-    const event = createInboundInitiatedEvent({
-      id: "evt-2",
-      providerCallId: "prov-2",
-      from: "+15551111111",
-    });
-
-    processEvent(ctx, event);
-
-    expect(ctx.activeCalls.size).toBe(0);
-  });
-
-  it("calls hangup only once for duplicate events for same rejected call", () => {
-    const { ctx, hangupCalls } = createRejectingInboundContext();
-    const event1 = createInboundInitiatedEvent({
-      id: "evt-init",
-      providerCallId: "prov-dup",
-      from: "+15552222222",
-    });
-    const event2: NormalizedEvent = {
-      id: "evt-ring",
-      type: "call.ringing",
-      callId: "prov-dup",
-      providerCallId: "prov-dup",
-      timestamp: Date.now(),
-      direction: "inbound",
-      from: "+15552222222",
-      to: "+15550000000",
-    };
-
-    processEvent(ctx, event1);
-    processEvent(ctx, event2);
-
-    expect(ctx.activeCalls.size).toBe(0);
-    expect(hangupCalls).toEqual([
-      {
-        callId: "prov-dup",
-        providerCallId: "prov-dup",
-        reason: "hangup-bot",
-      },
-    ]);
-  });
-
-  it("answers accepted inbound calls when the provider requires an answer command", () => {
-    const answerCalls: AnswerCallInput[] = [];
-    const provider = createProvider({
-      answerCall: async (input: AnswerCallInput): Promise<void> => {
-        answerCalls.push(input);
-      },
-    });
-    const ctx = createContext({
-      config: VoiceCallConfigSchema.parse({
-        enabled: true,
-        provider: "telnyx",
-        fromNumber: "+15550000000",
-        inboundPolicy: "open",
-        telnyx: {
-          apiKey: "KEY123",
-          connectionId: "CONN456",
-        },
-        skipSignatureVerification: true,
-      }),
-      provider,
-    });
-    const event = createInboundInitiatedEvent({
-      id: "evt-answer",
-      providerCallId: "call-control-1",
-      from: "+15552222222",
-    });
-
-    processEvent(ctx, event);
-
-    const call = requireFirstActiveCall(ctx);
-    expect(answerCalls).toEqual([
-      {
-        callId: call.callId,
-        providerCallId: "call-control-1",
-      },
-    ]);
-  });
 
   it("updates providerCallId map when provider ID changes", () => {
     const now = Date.now();
@@ -658,26 +403,6 @@ describe("processEvent (functional)", () => {
     vi.useRealTimers();
   });
 
-  it("removes active call even when hangup rejects", () => {
-    const provider = createProvider({
-      hangupCall: async (): Promise<void> => {
-        throw new Error("provider down");
-      },
-    });
-    const ctx = createContext({
-      config: createInboundDisabledConfig(),
-      provider,
-    });
-    const event = createInboundInitiatedEvent({
-      id: "evt-fail",
-      providerCallId: "prov-fail",
-      from: "+15553333333",
-    });
-
-    processEvent(ctx, event);
-    expect(ctx.activeCalls.size).toBe(0);
-  });
-
   it("auto-registers externally-initiated outbound-api calls with correct direction", () => {
     const ctx = createContext();
     const event: NormalizedEvent = {
@@ -723,110 +448,6 @@ describe("processEvent (functional)", () => {
     expect(hangupCalls).toHaveLength(0);
     const call = requireFirstActiveCall(ctx);
     expect(call.direction).toBe("outbound");
-  });
-
-  it("preserves inbound direction for auto-registered inbound calls", () => {
-    const ctx = createContext({
-      config: VoiceCallConfigSchema.parse({
-        enabled: true,
-        provider: "plivo",
-        fromNumber: "+15550000000",
-        inboundPolicy: "open",
-      }),
-    });
-    const event: NormalizedEvent = {
-      id: "evt-inbound-dir",
-      type: "call.initiated",
-      callId: "CA-inbound-789",
-      providerCallId: "CA-inbound-789",
-      timestamp: Date.now(),
-      direction: "inbound",
-      from: "+15554444444",
-      to: "+15550000000",
-    };
-
-    processEvent(ctx, event);
-
-    expect(ctx.activeCalls.size).toBe(1);
-    const call = requireFirstActiveCall(ctx);
-    expect(call.direction).toBe("inbound");
-  });
-
-  it.each([
-    {
-      sessionScope: "per-call",
-      coreSession: undefined,
-      expectedSessionKey: (call: CallRecord) => `agent:main:voice:call:${call.callId}`,
-    },
-    {
-      sessionScope: "main",
-      coreSession: { mainKey: "work" },
-      expectedSessionKey: () => "agent:main:work",
-    },
-  ])(
-    "assigns $sessionScope session keys to inbound calls",
-    ({ sessionScope, coreSession, expectedSessionKey }) => {
-      const ctx = createContext({
-        config: VoiceCallConfigSchema.parse({
-          enabled: true,
-          provider: "plivo",
-          fromNumber: "+15550000000",
-          inboundPolicy: "open",
-          sessionScope,
-        }),
-        coreSession,
-      });
-      const event: NormalizedEvent = {
-        id: "evt-inbound-session-scope",
-        type: "call.initiated",
-        callId: "CA-inbound-session-scope",
-        providerCallId: "CA-inbound-session-scope",
-        timestamp: Date.now(),
-        direction: "inbound",
-        from: "+15554444444",
-        to: "+15550000000",
-      };
-
-      processEvent(ctx, event);
-
-      const call = requireFirstActiveCall(ctx);
-      expect(call.sessionKey).toBe(expectedSessionKey(call));
-    },
-  );
-
-  it("applies per-number inbound greeting and stores the matched route key", () => {
-    const ctx = createContext({
-      config: VoiceCallConfigSchema.parse({
-        enabled: true,
-        provider: "plivo",
-        fromNumber: "+15550000000",
-        inboundPolicy: "open",
-        inboundGreeting: "Hello from global.",
-        numbers: {
-          "+15550002222": {
-            agentId: "cards",
-            inboundGreeting: "Silver Fox Cards, how can I help?",
-          },
-        },
-      }),
-    });
-    const event: NormalizedEvent = {
-      id: "evt-inbound-number-route",
-      type: "call.initiated",
-      callId: "CA-inbound-number-route",
-      providerCallId: "CA-inbound-number-route",
-      timestamp: Date.now(),
-      direction: "inbound",
-      from: "+15554444444",
-      to: "+1 (555) 000-2222",
-    };
-
-    processEvent(ctx, event);
-
-    const call = requireFirstActiveCall(ctx);
-    expect(call.metadata?.initialMessage).toBe("Silver Fox Cards, how can I help?");
-    expect(call.metadata?.numberRouteKey).toBe("+15550002222");
-    expect(call.agentId).toBe("cards");
   });
 
   it("deduplicates by dedupeKey even when event IDs differ", () => {
@@ -886,7 +507,7 @@ describe("processEvent (functional)", () => {
   it("bounds committed replay keys in both manager and persisted call owners", () => {
     const now = Date.now();
     const managerKeys = Array.from(
-      { length: MANAGER_REPLAY_KEY_LIMIT },
+      { length: EVENT_MANAGER_REPLAY_KEY_LIMIT },
       (_, index) => `manager-${index}`,
     );
     const callKeys = Array.from({ length: MAX_CALL_REPLAY_KEYS }, (_, index) => `call-${index}`);
@@ -917,7 +538,7 @@ describe("processEvent (functional)", () => {
 
     const call = ctx.activeCalls.get("call-bounded");
     expect(result).toEqual({ kind: "processed" });
-    expect(ctx.processedEventIds.size).toBe(MANAGER_REPLAY_KEY_LIMIT);
+    expect(ctx.processedEventIds.size).toBe(EVENT_MANAGER_REPLAY_KEY_LIMIT);
     expect(ctx.processedEventIds.has("manager-0")).toBe(false);
     expect(ctx.processedEventIds.has("evt-bounded-new")).toBe(true);
     expect(call?.processedEventIds).toHaveLength(MAX_CALL_REPLAY_KEYS);
@@ -933,39 +554,6 @@ describe("processEvent (functional)", () => {
         digits: "1",
       }),
     ).toEqual({ kind: "ignored" });
-  });
-
-  it("bounds rejected provider calls while retaining hangup-once behavior", () => {
-    const rejectedProviderCallIds = new Map<string, symbol>(
-      Array.from(
-        { length: MANAGER_REPLAY_KEY_LIMIT },
-        (_, index) => [`provider-${index}`, Symbol(`provider-${index}`)] as const,
-      ),
-    );
-    const { ctx, hangupCalls } = createRejectingInboundContext();
-    ctx.rejectedProviderCallIds = rejectedProviderCallIds;
-
-    processEvent(
-      ctx,
-      createInboundInitiatedEvent({
-        id: "evt-rejected-new",
-        providerCallId: "provider-new",
-        from: "+15552222222",
-      }),
-    );
-    processEvent(
-      ctx,
-      createInboundInitiatedEvent({
-        id: "evt-rejected-new-replay",
-        providerCallId: "provider-new",
-        from: "+15552222222",
-      }),
-    );
-
-    expect(ctx.rejectedProviderCallIds.size).toBe(MANAGER_REPLAY_KEY_LIMIT);
-    expect(ctx.rejectedProviderCallIds.has("provider-0")).toBe(false);
-    expect(ctx.rejectedProviderCallIds.has("provider-new")).toBe(true);
-    expect(hangupCalls).toHaveLength(1);
   });
 
   it("keeps retryable call.error events replayable", () => {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -31,6 +31,7 @@ type EventContext = Pick<
   | "rejectedProviderCallIds"
   | "provider"
   | "config"
+  | "coreSession"
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
@@ -104,6 +105,7 @@ function createWebhookCall(params: {
       config: effectiveConfig,
       callId,
       phone: params.direction === "outbound" ? params.to : params.from,
+      coreSession: params.ctx.coreSession,
     }),
     agentId: normalizeAgentId(effectiveConfig.agentId),
     startedAt: Date.now(),


### PR DESCRIPTION
## What Problem This Solves

Voice Call supports inbound calls, but every call lands in a dedicated `agent:<agentId>:voice:*` session (`sessionScope: "per-phone"` or `"per-call"`). Operators who want their phone calls to continue the agent's primary conversation — call in, talk about what the main session has been working on, and have the next desktop message see that exchange — had no way to route calls there. The plumbing already existed for explicit integration keys (which honor core `session.mainKey` and global-scope aliasing), but no config surface reached it.

## Why This Change Was Made

`sessionScope` gains a third value, `"main"`, that resolves generated call session keys through the existing `resolveVoiceCallAgentSessionKey` path with the canonical `main` alias. That reuses the exact main-session canonicalization core already owns (`session.mainKey` override, `"global"` scope collapse) instead of introducing a parallel resolution path. The inbound webhook call-record path now forwards the manager's `coreSession` (it was the only `resolveVoiceCallSessionKey` caller not passing it), so inbound and outbound calls resolve identically. Explicit session keys still take precedence; `per-phone` and `per-call` behavior is unchanged.

## User Impact

Operators can set `plugins.entries.voice-call.config.sessionScope: "main"` to have phone calls (inbound and outbound) share the configured agent's main session, including realtime-voice `openclaw_agent_consult` runs, which reuse the stored call session key. Default behavior is unchanged (`per-phone`). Docs describe the new value and warn that raw call turns then share history with the primary session.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call/src/config.test.ts` — 42 passed, including new table-driven cases: default core session → `agent:main:main`, `session.mainKey` override honored, `session.scope: "global"` → `global`, custom agent → `agent:ops:main`, explicit key still wins over main scope.
- `node scripts/run-vitest.mjs extensions/voice-call/src/manager/events.test.ts` — 31 passed, including a new inbound-webhook regression asserting the accepted call record's `sessionKey` is the canonical main key under `sessionScope: "main"`.
- Full plugin suite `node scripts/run-vitest.mjs extensions/voice-call` — 59 files, 645 tests passed.
- `pnpm tsgo:extensions` and `pnpm tsgo:test:extensions` — clean.
- Production TypeScript delta: +9 lines (enum value, one resolution branch, one context field plumb).
- Docs: `docs/plugins/voice-call.md` session-scope section + realtime consult note; plugin manifest enum/help aligned (`openclaw.plugin.json`, `README.md`).
