### PR TITLE
fix(channels): resolve registered plugins before agent workspace

### DIFF
--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -123,6 +123,7 @@ describe("registerDirectoryCli", () => {
     const installArgs = firstRecordArg(mocks.resolveInstallableChannelPlugin);
     expect(installArgs.rawChannel).toBe("demo-directory");
     expect(installArgs.allowInstall).toBe(true);
+    expect(installArgs.preferRegisteredPlugin).toBe(true);
     expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(1);
     const replaceArgs = firstRecordArg(mocks.replaceConfigFile);
     expect(replaceArgs.nextConfig).toEqual({

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -120,6 +120,7 @@ export function registerDirectoryCli(program: Command) {
           runtime: defaultRuntime,
           rawChannel: explicitChannel,
           allowInstall: true,
+          preferRegisteredPlugin: true,
           supports: (plugin) => Boolean(plugin.directory),
         })
       : null;

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -107,6 +107,7 @@ describe("resolveInstallableChannelPlugin", () => {
       runtime: {} as never,
       rawChannel: "telegram",
       allowInstall: true,
+      preferRegisteredPlugin: true,
       supports: (plugin) => Boolean(plugin.directory),
     });
 
@@ -137,6 +138,7 @@ describe("resolveInstallableChannelPlugin", () => {
         runtime: {} as never,
         rawChannel: "workspace-channel",
         allowInstall: false,
+        preferRegisteredPlugin: true,
       }),
     ).rejects.toThrow("agent selection required");
 

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -78,12 +78,71 @@ function firstMockArg(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown
 describe("resolveInstallableChannelPlugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
+    mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.getChannelPlugin.mockReturnValue(undefined);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValue({
       cfg: {},
       installed: false,
     });
+  });
+
+  it("returns a registered plugin before resolving a multi-agent workspace owner", async () => {
+    const registeredPlugin = {
+      ...createPlugin("telegram"),
+      directory: { self: vi.fn() },
+    } as ChannelPlugin;
+    mocks.getChannelPlugin.mockReturnValue(registeredPlugin);
+    mocks.resolveDefaultAgentId.mockImplementation(() => {
+      throw new Error("agent selection required");
+    });
+
+    const result = await resolveInstallableChannelPlugin({
+      cfg: {
+        agents: {
+          list: [{ id: "alpha" }, { id: "beta" }],
+        },
+      },
+      runtime: {} as never,
+      rawChannel: "telegram",
+      allowInstall: true,
+      supports: (plugin) => Boolean(plugin.directory),
+    });
+
+    expect(result).toMatchObject({
+      channelId: "telegram",
+      plugin: registeredPlugin,
+      configChanged: false,
+      pluginInstalled: false,
+      supportsRequestedCapability: true,
+    });
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
+    expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+  });
+
+  it("still requires a workspace owner before resolving an unregistered plugin", async () => {
+    mocks.resolveDefaultAgentId.mockImplementation(() => {
+      throw new Error("agent selection required");
+    });
+
+    await expect(
+      resolveInstallableChannelPlugin({
+        cfg: {
+          agents: {
+            list: [{ id: "alpha" }, { id: "beta" }],
+          },
+        },
+        runtime: {} as never,
+        rawChannel: "workspace-channel",
+        allowInstall: false,
+      }),
+    ).rejects.toThrow("agent selection required");
+
+    expect(mocks.getChannelPlugin).toHaveBeenCalledWith("workspace-channel");
+    expect(mocks.resolveDefaultAgentId).toHaveBeenCalledTimes(1);
+    expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
   });
 
   it("ignores untrusted workspace channel shadows during setup resolution", async () => {

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   listChannelPluginCatalogEntries: vi.fn(),
   getChannelPluginCatalogEntry: vi.fn(),
   getChannelPlugin: vi.fn(),
+  getLoadedChannelPlugin: vi.fn(),
   loadChannelSetupPluginRegistrySnapshotForChannel: vi.fn(),
   ensureChannelSetupPluginInstalled: vi.fn(),
   createClackPrompter: vi.fn(() => ({}) as never),
@@ -26,6 +27,7 @@ vi.mock("../../channels/plugins/catalog.js", () => ({
 
 vi.mock("../../channels/plugins/index.js", () => ({
   getChannelPlugin: mocks.getChannelPlugin,
+  getLoadedChannelPlugin: mocks.getLoadedChannelPlugin,
   normalizeChannelId: (value: unknown) => (typeof value === "string" ? value.trim() || null : null),
 }));
 
@@ -81,6 +83,7 @@ describe("resolveInstallableChannelPlugin", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
     mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.getLoadedChannelPlugin.mockReturnValue(undefined);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValue({
       cfg: {},
@@ -93,7 +96,7 @@ describe("resolveInstallableChannelPlugin", () => {
       ...createPlugin("telegram"),
       directory: { self: vi.fn() },
     } as ChannelPlugin;
-    mocks.getChannelPlugin.mockReturnValue(registeredPlugin);
+    mocks.getLoadedChannelPlugin.mockReturnValue(registeredPlugin);
     mocks.resolveDefaultAgentId.mockImplementation(() => {
       throw new Error("agent selection required");
     });
@@ -119,8 +122,35 @@ describe("resolveInstallableChannelPlugin", () => {
       supportsRequestedCapability: true,
     });
     expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("telegram");
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
     expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
     expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+  });
+
+  it("requires a workspace owner before falling back to an unloaded bundled plugin", async () => {
+    mocks.getChannelPlugin.mockReturnValue(createPlugin("telegram"));
+    mocks.resolveDefaultAgentId.mockImplementation(() => {
+      throw new Error("agent selection required");
+    });
+
+    await expect(
+      resolveInstallableChannelPlugin({
+        cfg: {
+          agents: {
+            list: [{ id: "alpha" }, { id: "beta" }],
+          },
+        },
+        runtime: {} as never,
+        rawChannel: "telegram",
+        allowInstall: false,
+        preferRegisteredPlugin: true,
+      }),
+    ).rejects.toThrow("agent selection required");
+
+    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("telegram");
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveDefaultAgentId).toHaveBeenCalledTimes(1);
   });
 
   it("still requires a workspace owner before resolving an unregistered plugin", async () => {
@@ -142,7 +172,8 @@ describe("resolveInstallableChannelPlugin", () => {
       }),
     ).rejects.toThrow("agent selection required");
 
-    expect(mocks.getChannelPlugin).toHaveBeenCalledWith("workspace-channel");
+    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("workspace-channel");
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
     expect(mocks.resolveDefaultAgentId).toHaveBeenCalledTimes(1);
     expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
   });

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -123,6 +123,19 @@ export async function resolveInstallableChannelPlugin(params: {
 }): Promise<ResolveInstallableChannelPluginResult> {
   const supports = params.supports ?? (() => true);
   let nextCfg = params.cfg;
+  const directChannelId = params.channelId ?? normalizeChannelId(params.rawChannel);
+  const registeredPlugin = directChannelId ? getChannelPlugin(directChannelId) : undefined;
+  if (directChannelId && registeredPlugin) {
+    return {
+      cfg: nextCfg,
+      channelId: directChannelId,
+      plugin: registeredPlugin,
+      configChanged: false,
+      pluginInstalled: false,
+      supportsRequestedCapability: supports(registeredPlugin),
+    };
+  }
+
   const workspaceDir = resolveWorkspaceDir(nextCfg, params.agentId);
   const catalogEntry =
     (params.rawChannel
@@ -135,7 +148,7 @@ export async function resolveInstallableChannelPlugin(params: {
         })
       : undefined);
   const channelId =
-    params.channelId ??
+    directChannelId ??
     resolveResolvedChannelId({
       rawChannel: params.rawChannel,
       catalogEntry,

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -5,7 +5,11 @@ import {
   listRawChannelPluginCatalogEntries,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import {
+  getChannelPlugin,
+  getLoadedChannelPlugin,
+  normalizeChannelId,
+} from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -127,7 +131,7 @@ export async function resolveInstallableChannelPlugin(params: {
   const directChannelId = params.channelId ?? normalizeChannelId(params.rawChannel);
   const registeredPlugin =
     params.preferRegisteredPlugin && directChannelId
-      ? getChannelPlugin(directChannelId)
+      ? getLoadedChannelPlugin(directChannelId)
       : undefined;
   if (params.preferRegisteredPlugin && directChannelId && registeredPlugin) {
     return {

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -118,14 +118,18 @@ export async function resolveInstallableChannelPlugin(params: {
   channelId?: ChannelId;
   agentId?: string;
   allowInstall?: boolean;
+  preferRegisteredPlugin?: boolean;
   prompter?: WizardPrompter;
   supports?: (plugin: ChannelPlugin) => boolean;
 }): Promise<ResolveInstallableChannelPluginResult> {
   const supports = params.supports ?? (() => true);
   let nextCfg = params.cfg;
   const directChannelId = params.channelId ?? normalizeChannelId(params.rawChannel);
-  const registeredPlugin = directChannelId ? getChannelPlugin(directChannelId) : undefined;
-  if (directChannelId && registeredPlugin) {
+  const registeredPlugin =
+    params.preferRegisteredPlugin && directChannelId
+      ? getChannelPlugin(directChannelId)
+      : undefined;
+  if (params.preferRegisteredPlugin && directChannelId && registeredPlugin) {
     return {
       cfg: nextCfg,
       channelId: directChannelId,


### PR DESCRIPTION
Closes #124679

## What Problem This Solves

`openclaw directory` could not use an explicitly selected, already registered channel plugin in a multi-agent installation. The shared installable-channel resolver tried to choose a default agent workspace before checking the active channel registry, so `AgentSelectionRequiredError` aborted directory lookups even though no workspace discovery or installation was needed.

## Why This Change Was Made

The directory CLI now explicitly opts into resolving an exact registered channel before workspace-scoped catalog work. Other users of the shared resolver, including channel login and logout, keep their existing catalog/install snapshot sequence. Unregistered plugins remain on the explicit-owner path.

## User Impact

Users with multiple configured agents can run directory commands such as `openclaw directory self --channel telegram` when that channel is already registered. Unregistered workspace plugins still require an explicit system-agent owner before discovery or installation.

## Evidence

- Real CLI proof on Node 24.15.0 used an isolated temporary state/config with `agents.ownership="explicit"`, two agents with no default owner, and the repo IRC plugin loaded through `plugins.load.paths`; no live account, credential, or network connection was used.
- `OPENCLAW_STATE_DIR=<temp> OPENCLAW_CONFIG_PATH=<temp>/openclaw.json pnpm openclaw directory groups list --channel irc --json` exited 0 and returned the configured `#proof-room` group through the real plugin directory adapter.
- The same command with `--channel missing-proof-channel` exited 1 with `Multiple agents are configured, but this operation has no explicit owner`, proving unresolved plugins still use the workspace-owner gate.
- Current-main reconciliation: merge head `d879c3d520204c4cbfcdf4d02f4c729370a22a5b` combines business head `19286d4b7aa6410f8065e74da22beee619007d47` with frozen `upstream/main` `47399310a08e67c926875a3da8252467585dac6e`. The PR-owned delta remains the same four files (`+117/-2`) while preserving main's explicit `agentId` workspace resolver and the directory-only registered-plugin fast path.
- Node 24.15.0: `node scripts/run-vitest.mjs src/commands/channel-setup/channel-plugin-resolution.test.ts` (8/8 passed) and `node scripts/run-vitest.mjs src/cli/directory-cli.test.ts src/cli/channel-auth.test.ts` (45/45 passed).
- Focused oxfmt passed on all four changed files. Focused oxlint passed with `config/tsconfig/oxlint.core.json`; `git diff --check 47399310a08e67c926875a3da8252467585dac6e..HEAD` passed.
- Fresh local autoreview on the reconciled head reported no accepted/actionable findings and judged the patch correct (confidence 0.98).
- Prior exact-head GitHub CI completed on `fe6d29ae9c0b7907f2b7fc21e88620181f3bab19` without failures. Exact merge-head CI started in [run 32094322651](https://github.com/openclaw/openclaw/actions/runs/32094322651); this body records the immediate post-push snapshot and does not claim a terminal result.

## AI Assistance

AI assistance was used for source analysis, implementation, tests, real CLI validation, and PR drafting. The contributor reviewed the final diff and validation evidence.\n\n### Identity refresh (2026-08-20)\n\n- Metadata-only history rewrite: new head `a7c783ed51ab8c1d7e8ee23d209a96c5370ec9db`; all rewritten commits now use `Leon-SK668 <0668001470@xydigit.com>` for both author and committer. Commit trees, messages, timestamps, parent structure, and the PR business diff are unchanged.\n- No product code or proof claim changed in this refresh. Existing focused tests/CI/review evidence remains behaviorally applicable to the unchanged tree; this new head is available for the normal exact-head checks.\n