### PR TITLE
fix(cli): fail absent service start and restart

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -600,7 +600,7 @@ openclaw gateway restart
   </Accordion>
   <Accordion title="Lifecycle behavior">
     - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
-    - If no managed service is installed and no eligible unmanaged Gateway is running, `gateway start` and `gateway restart` print install hints and exit nonzero. Run `openclaw gateway install` first. Stopping an absent service remains a successful no-op.
+    - If no managed service is installed, `gateway start` prints install hints and exits nonzero. `gateway restart` can first recover an installed-but-unloaded LaunchAgent or a verified unmanaged Gateway; if neither a managed service nor recovery handles the action, it prints the same hints and exits nonzero. Stopping an absent service remains a successful no-op.
     - If `gateway start` or `gateway restart` needs to repair a stale service definition, the command refuses when the invoking shell resolves a different state directory, config path, or port than the installed service. Match or unset the conflicting environment overrides, or use `openclaw gateway install --force` to retarget the service intentionally.
     - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
     - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -600,6 +600,7 @@ openclaw gateway restart
   </Accordion>
   <Accordion title="Lifecycle behavior">
     - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
+    - If no managed service is installed and no eligible unmanaged Gateway is running, `gateway start` and `gateway restart` print install hints and exit nonzero. Run `openclaw gateway install` first. Stopping an absent service remains a successful no-op.
     - If `gateway start` or `gateway restart` needs to repair a stale service definition, the command refuses when the invoking shell resolves a different state directory, config path, or port than the installed service. Match or unset the conflicting environment overrides, or use `openclaw gateway install --force` to retarget the service intentionally.
     - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
     - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -164,6 +164,9 @@ openclaw node uninstall
 Use `openclaw node run` for a foreground node host (no service).
 
 Service commands accept `--json` for machine-readable output.
+`node start` and `node restart` print install hints and exit nonzero when no
+managed node service is installed; run `openclaw node install` first. Stopping
+an absent service remains a successful no-op.
 
 The node host retries Gateway restart and network closes in-process. If the
 Gateway reports a terminal token/password/bootstrap auth pause, the node host

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -234,23 +234,39 @@ describe("runServiceRestart token drift", () => {
     expectUnsupportedServiceCheckFailure();
   });
 
-  it("prints the container restart hint when restart is requested for a not-loaded service", async () => {
+  it("fails restart with the container hint when no service is installed", async () => {
     service.isLoaded.mockResolvedValue(false);
     vi.stubEnv("OPENCLAW_CONTAINER_HINT", "openclaw-demo-container");
 
-    await runServiceRestart({
-      serviceNoun: "Gateway",
-      service,
-      renderStartHints: () => [
-        "Restart the container or the service that manages it for openclaw-demo-container.",
-        "openclaw gateway install",
-      ],
-      opts: { json: false },
-    });
+    await expect(
+      runServiceRestart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [
+          "Restart the container or the service that manages it for openclaw-demo-container.",
+          "openclaw gateway install",
+        ],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
 
-    expect(lifecycleRuntimeLogs).toContain("Gateway service not loaded.");
-    expect(lifecycleRuntimeLogs).toContain(
-      "Start with: Restart the container or the service that manages it for openclaw-demo-container.",
+    const payload = readJsonLog<{
+      action?: string;
+      ok?: boolean;
+      error?: string;
+      hints?: string[];
+      hintItems?: Array<{ kind: string; text: string }>;
+    }>();
+    expect(payload).toMatchObject({
+      action: "restart",
+      ok: false,
+      error: "Gateway service not loaded.",
+    });
+    expect(payload.hints).toContain(
+      "Restart the container or the service that manages it for openclaw-demo-container.",
+    );
+    expect(payload.hintItems).toContainEqual(
+      expect.objectContaining({ kind: "container-restart" }),
     );
   });
 
@@ -862,25 +878,27 @@ describe("runServiceRestart token drift", () => {
     expect(payload.error).toContain("launchctl kickstart failed: permission denied");
   });
 
-  it("falls back to not-loaded hints when start finds no install artifacts", async () => {
+  it("fails start with install hints when no service is installed", async () => {
     service.isLoaded.mockResolvedValue(false);
     service.readCommand.mockResolvedValue(null);
 
-    await runServiceStart({
-      serviceNoun: "Gateway",
-      service,
-      renderStartHints: () => ["openclaw gateway install"],
-      opts: { json: true },
-    });
+    await expect(
+      runServiceStart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => ["openclaw gateway install"],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
 
     const payload = readJsonLog<{
       ok?: boolean;
-      result?: string;
+      error?: string;
       hints?: string[];
       hintItems?: Array<{ kind: string; text: string }>;
     }>();
-    expect(payload.ok).toBe(true);
-    expect(payload.result).toBe("not-loaded");
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("Gateway service not loaded.");
     expect(payload.hints?.includes("openclaw gateway install")).toBe(true);
     expect(
       payload.hintItems?.some(

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -94,30 +94,16 @@ function mergeWarnings(
   return combined.length > 0 ? combined : undefined;
 }
 
-async function handleServiceNotLoaded(params: {
+async function failServiceNotLoaded(params: {
   serviceNoun: string;
   service: GatewayService;
-  loaded: boolean;
   renderStartHints: () => string[];
-  json: boolean;
-  emit: ReturnType<typeof createDaemonActionContext>["emit"];
+  fail: ReturnType<typeof createDaemonActionContext>["fail"];
 }) {
   const hints = filterContainerGenericHints(
     await maybeAugmentSystemdHints(params.renderStartHints()),
   );
-  params.emit({
-    ok: true,
-    result: "not-loaded",
-    message: `${params.serviceNoun} service ${params.service.notLoadedText}.`,
-    hints,
-    service: buildDaemonServiceSnapshot(params.service, params.loaded),
-  });
-  if (!params.json) {
-    defaultRuntime.log(`${params.serviceNoun} service ${params.service.notLoadedText}.`);
-    for (const hint of hints) {
-      defaultRuntime.log(`Start with: ${hint}`);
-    }
-  }
+  params.fail(`${params.serviceNoun} service ${params.service.notLoadedText}.`, hints);
 }
 
 async function resolveServiceLoadedOrFail(params: {
@@ -277,13 +263,11 @@ export async function runServiceStart(params: {
       params.expectedPort,
     );
     if (startResult.outcome === "missing-install") {
-      await handleServiceNotLoaded({
+      await failServiceNotLoaded({
         serviceNoun: params.serviceNoun,
         service: params.service,
-        loaded: startResult.state.loaded,
         renderStartHints: params.renderStartHints,
-        json,
-        emit,
+        fail,
       });
       return;
     }
@@ -560,13 +544,11 @@ export async function runServiceRestart(params: {
       return false;
     }
     if (!handledRecovery) {
-      await handleServiceNotLoaded({
+      await failServiceNotLoaded({
         serviceNoun: params.serviceNoun,
         service: params.service,
-        loaded,
         renderStartHints: params.renderStartHints,
-        json,
-        emit,
+        fail,
       });
       return false;
     }


### PR DESCRIPTION
AI-assisted: yes. The implementation, proof, and landing review were performed with Codex under maintainer direction.

## What Problem This Solves

Fixes an issue where operators running `openclaw gateway start`, `gateway restart`, `node start`, or `node restart` against an absent managed service received exit 0 and `ok: true`, even though no authoritative service instance performed the requested mutation.

Stopping an absent service remains the intentional idempotent success.

## Why This Change Was Made

The shared lifecycle core now routes the authoritative `startGatewayService(...).outcome === "missing-install"` result and restart's unhandled owner-recovery result through the existing action failure owner. This preserves Gateway-specific launchd, systemd, unmanaged-listener, and external-supervisor recovery paths, while Node intentionally continues to supply no recovery callback.

The previous helper duplicated success emission and human logging. Replacing it with the shared failure owner removes 18 net production lines and avoids a parallel output/exit path.

Non-goals: this PR does not change external-supervisor JSON behavior, Node-specific hint wording, configuration baselines, assertion-safety baselines, protocols, auth, or service identity.

## User Impact

Gateway and Node `start`/`restart` now exit nonzero and return actionable install hints when no managed service exists and no documented recovery succeeds. Human output sends the error to stderr and tips to stdout; `--json` emits exactly one `ok: false` document. Existing installed, already-running, stopped, launchd-repair, systemd, unmanaged Gateway recovery, and absent-stop behavior remains intact.

## Evidence

Exact branch identity:

- Base: `337933509d623cb68f2b3fbb9ebeb3641901dab7`
- Head: `504229db0e64252d3ad39dd9e30e7158a23649da`
- Original frozen baseline: `5ce012619463149a1f81243298f27ec69111ba54`
- Original and rebased patch IDs: `0d48ede9e7200aef00b236d88e192bc2647f47ba`
- Required exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31964531082 (success)

Pre-fix boundary regression against the frozen baseline:

```text
node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle-core.test.ts
Test Files  1 failed (1)
Tests       2 failed | 33 passed (35)
restart resolved false instead of exiting 1
start resolved undefined instead of exiting 1
```

Current-head focused proof:

```text
node scripts/run-vitest.mjs \
  src/daemon/service.test.ts \
  src/cli/daemon-cli/lifecycle-core.test.ts \
  src/cli/daemon-cli/lifecycle.test.ts \
  src/cli/daemon-cli/lifecycle.external-supervision.test.ts \
  src/cli/daemon-cli/launchd-recovery.test.ts \
  src/cli/daemon-cli/response.test.ts \
  src/daemon/runtime-hints.test.ts \
  src/daemon/systemd-hints.test.ts
# 135 passed on macOS
```

On isolated AWS Crabbox lease `cbx_c962e1d41d86`:

```text
corepack pnpm build
# passed

corepack pnpm test \
  src/daemon/service.test.ts \
  src/cli/daemon-cli/lifecycle-core.test.ts \
  src/cli/daemon-cli/lifecycle.test.ts \
  src/cli/daemon-cli/lifecycle.external-supervision.test.ts \
  src/cli/daemon-cli/launchd-recovery.test.ts \
  src/cli/daemon-cli/response.test.ts \
  src/cli/node-cli/daemon.test.ts \
  src/daemon/runtime-hints.test.ts \
  src/daemon/systemd-hints.test.ts
# 163 passed on Linux
```

Source-blind built CLI proof used the exact current-head `dist/entry.js` artifact:

- Gateway and Node `start`, `restart`, and `stop` in human and JSON modes on macOS and Linux: 24 cases total.
- Absent start/restart: exit 1, human error on stderr plus tips on stdout, or one JSON `ok:false` document.
- Absent stop: exit 0 and one JSON `ok:true,result:"not-loaded"` document.
- Real isolated launchd: install, RPC-ready, already running, installed-but-unloaded re-bootstrap, restart, uninstall, absent stop, cleanup.
- Real isolated systemd: Gateway and Node install, already running, stop/start, restart, uninstall, cleanup.

Static and docs proof:

```text
node --import tsx scripts/run-oxlint-shards.mts --only=core
# 0 warnings, 0 errors

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/autoqa150-land-core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.config-cli.json --builders 1
node --import tsx scripts/check-import-cycles.ts
# 0 runtime value cycles

corepack pnpm docs:list
corepack pnpm format:docs:check docs/cli/gateway.md docs/cli/node.md
corepack pnpm docs:check-mdx
corepack pnpm docs:check-links
corepack pnpm docs:check-config-examples
# passed; 0 broken links
```

Git-backed Testbox proof: `tbx_01m05sr5pxy281bmhnephbkxng`, Actions run `31961593693`. Lint, production types, test types, cycles, and diff passed before `check:changed` reached unrelated baseline shrink entries in `src/state/control-ui-device-auth-migration.ts` and `ui/src/lib/nodes/index.ts`. The candidate changes none of those paths. `config:docs:check` likewise reports pre-existing current-main count/hash drift; this PR does not fold in separately owned baseline work.

Fresh Codex autoreview against `origin/main` reported no findings and `patch is correct` with 0.99 confidence. A second review of the ClawSweeper-driven documentation clarification also reported no findings at 0.99 confidence.

ClawSweeper's P2 documentation finding was applied: the Gateway lifecycle text now distinguishes managed-only `gateway start` from restart's installed-LaunchAgent and verified-unmanaged recovery paths. No production or test code changed after the full build, source-blind matrix, and platform proof.

LOC classification:

- Production TypeScript: `+7/-25` (net `-18`)
- Tests: `+41/-23` (net `+18`)
- Docs: `+4/-0`
- Total: `+52/-48`
