### PR TITLE
fix(cli): avoid exposing provider env values in parse errors

### DIFF
--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -161,7 +161,7 @@ function parseProviderEnvEntries(
   for (const entry of entries) {
     const separator = entry.indexOf("=");
     if (separator <= 0) {
-      throw new Error("--provider-env expects KEY=VALUE entries.");
+      throw new Error("--provider-env expects KEY=*** entries.");
     }
     const key = entry.slice(0, separator).trim();
     if (!key) {

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -161,11 +161,11 @@ function parseProviderEnvEntries(
   for (const entry of entries) {
     const separator = entry.indexOf("=");
     if (separator <= 0) {
-      throw new Error(`--provider-env expects KEY=VALUE entries (received: "${entry}").`);
+      throw new Error("--provider-env expects KEY=VALUE entries.");
     }
     const key = entry.slice(0, separator).trim();
     if (!key) {
-      throw new Error(`--provider-env key must not be empty (received: "${entry}").`);
+      throw new Error("--provider-env key must not be empty.");
     }
     env[key] = entry.slice(separator + 1);
   }

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -133,31 +133,6 @@ async function withExecDryRunConfigHarness(
 }
 
 describe("config cli integration", () => {
-  it.each([
-    ["=SYNTHETIC_PROVIDER_ENV_SECRET", "--provider-env expects KEY=*** entries."],
-    ["   =SYNTHETIC_PROVIDER_ENV_SECRET", "--provider-env key must not be empty."],
-  ])("keeps malformed provider env values out of CLI output", async (entry, message) => {
-    const secret = "SYNTHETIC_PROVIDER_ENV_SECRET";
-    const runtime = createTestRuntime();
-
-    await expect(
-      runConfigSet({
-        path: "secrets.providers.runner",
-        cliOptions: {
-          providerSource: "exec",
-          providerCommand: "/usr/bin/env",
-          providerEnv: [entry],
-          dryRun: true,
-        },
-        runtime: runtime.runtime,
-      }),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(runtime.logs.join("\n")).not.toContain(secret);
-    expect(runtime.errors.join("\n")).not.toContain(secret);
-    expect(runtime.errors).toStrictEqual([message]);
-  });
-
   it("accepts plugin hook conversation-access policy via config set", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-plugin-hooks-"));
     const configPath = path.join(tempDir, "openclaw.json");

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -133,6 +133,31 @@ async function withExecDryRunConfigHarness(
 }
 
 describe("config cli integration", () => {
+  it.each([
+    ["=SYNTHETIC_PROVIDER_ENV_SECRET", "--provider-env expects KEY=*** entries."],
+    ["   =SYNTHETIC_PROVIDER_ENV_SECRET", "--provider-env key must not be empty."],
+  ])("keeps malformed provider env values out of CLI output", async (entry, message) => {
+    const secret = "SYNTHETIC_PROVIDER_ENV_SECRET";
+    const runtime = createTestRuntime();
+
+    await expect(
+      runConfigSet({
+        path: "secrets.providers.runner",
+        cliOptions: {
+          providerSource: "exec",
+          providerCommand: "/usr/bin/env",
+          providerEnv: [entry],
+          dryRun: true,
+        },
+        runtime: runtime.runtime,
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtime.logs.join("\n")).not.toContain(secret);
+    expect(runtime.errors.join("\n")).not.toContain(secret);
+    expect(runtime.errors).toStrictEqual([message]);
+  });
+
   it("accepts plugin hook conversation-access policy via config set", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-plugin-hooks-"));
     const configPath = path.join(tempDir, "openclaw.json");

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1995,6 +1995,43 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
+    it.each([
+      [
+        "leading equals",
+        "=SYNTHETIC_PROVIDER_ENV_SECRET",
+        "--provider-env expects KEY=*** entries.",
+      ],
+      [
+        "whitespace key",
+        "   =SYNTHETIC_PROVIDER_ENV_SECRET",
+        "--provider-env key must not be empty.",
+      ],
+    ])("does not disclose provider env values for a %s entry", async (_name, entry, message) => {
+      const secret = "SYNTHETIC_PROVIDER_ENV_SECRET";
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "secrets.providers.runner",
+          "--provider-source",
+          "exec",
+          "--provider-command",
+          "/usr/bin/env",
+          "--provider-env",
+          entry,
+          "--dry-run",
+        ]),
+      ).rejects.toThrow(message);
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(JSON.stringify(mockLog.mock.calls)).not.toContain(secret);
+      expect(JSON.stringify(mockWriteStdout.mock.calls)).not.toContain(secret);
+      expect(JSON.stringify(mockError.mock.calls)).not.toContain(secret);
+      expectErrorIncludes(message);
+    });
+
     it("runs resolvability checks in builder dry-run mode without writing", async () => {
       setGatewaySnapshot({ providers: { default: { source: "env" } } });
 

--- a/src/config/io.audit.test.ts
+++ b/src/config/io.audit.test.ts
@@ -378,6 +378,11 @@ describe("config io audit helpers", () => {
       expected: ["openclaw", "--password", "***"],
     },
     {
+      name: "password alias covered by the secret suffix matcher",
+      argv: ["openclaw", "--passwd", "fake"],
+      expected: ["openclaw", "--passwd", "***"],
+    },
+    {
       name: "secret flag without a value",
       argv: ["openclaw", "--token"],
       expected: ["openclaw", "--token"],
@@ -474,6 +479,16 @@ describe("config io audit helpers", () => {
         '[{"path":"channels.slack.token","value":"secret-value"}]',
       ],
       expected: ["openclaw", "config", "set", "--batch-json", "***"],
+    },
+    {
+      name: "config provider env assignment",
+      argv: ["openclaw", "config", "set", "--provider-env", "KEY=secret-value"],
+      expected: ["openclaw", "config", "set", "--provider-env", "***"],
+    },
+    {
+      name: "inline config provider env assignment",
+      argv: ["openclaw", "config", "set", "--provider-env=KEY=secret-value"],
+      expected: ["openclaw", "config", "set", "--provider-env=***"],
     },
   ])("redacts $name in persisted audit process info", ({ argv, expected }) => {
     expect(createAuditRecordBase("/tmp/openclaw.json", argv).argv).toEqual(expected);

--- a/src/config/redact-argv.ts
+++ b/src/config/redact-argv.ts
@@ -9,7 +9,7 @@ const SECRET_FLAG_NAMES = new Set([
   "--apikey",
   "--secret",
   "--password",
-  "--passwd",
+  "--provider-env",
   "--auth-token",
   "--access-token",
   "--refresh-token",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed `--provider-env` entries could repeat the full assignment, including credential material, in config CLI errors. Valid provider assignments could also retain the flag value in config-audit argv snapshots.

## Why This Change Was Made

The provider-entry parser now returns fixed, input-free diagnostics while preserving the invalid field/shape guidance. The canonical argv redactor treats `--provider-env` as credential-bearing in separate and inline forms before audit persistence. Valid `KEY=VALUE` parsing and provider configuration are unchanged.

This is AI-assisted. Maintainer security review accepts the parser and audit-owner repair; it adds no config, default, protocol, permission, or compatibility surface.

## User Impact

Operators still receive actionable errors for malformed provider environment flags, but credential values no longer appear in the shipped CLI's stdout/stderr or persisted config-audit argv. The command exits before reading or writing configuration.

## Evidence

Exact head: `55f624d8ecf` rebased onto current mainline commit `389fed29cf1a5c0f900ed0a379d7598b1b58aacf`.

- Pre-fix real CLI reproduction with an isolated nonexistent config path: both malformed shapes exited 1 with `leaksSynthetic:true`; no real credential was read or printed.
- Exact-head shipped-entrypoint proof on Testbox: both shapes exited 1 with `leaksSynthetic:false` and `actionableMessage:true`. The `pnpm` development wrapper was excluded from this assertion because pnpm echoes its own argv before OpenClaw starts; installed OpenClaw uses `openclaw.mjs` directly.
- Focused parser/output/audit suites: 222/222 passed.
- Blacksmith Testbox `tbx_01m092cvban913awj8jg0fe5ap`, run https://github.com/openclaw/openclaw/actions/runs/32082433605: selected `core` and `coreTests` changed lanes passed, including typecheck, lint, boundary/dependency guards, dead exports, import cycles, database-first, and security guards. The shallow Testbox checkout skipped only the merge-base comparison for the env-var budget; the absolute budget passed 501/501 and exact-head CI owns the full PR gate.
- Fresh Codex autoreview: clean, no accepted/actionable findings. The review's lower-priority `--passwd` question is covered by a regression proving the canonical secret-suffix matcher still redacts it.
- `git diff --check`: clean.
- LOC: production +3/-3 (net 0); tests +52/-0; 4 files.

Provenance: the reflective parser messages were introduced by #113248 (`eac10a01d5a4`) on 2026-07-24, authored and merged by @steipete.
