### PR TITLE
chore: keep beta validation fixtures release-aware

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -927,7 +927,7 @@ describe("update-cli", () => {
     readPackageVersion.mockResolvedValue("2.0.0");
 
     mockPackageInstallStatus(tempDir);
-    primeNpmChannelTag("latest", "0.0.1");
+    primeNpmChannelTag(isBetaTag(VERSION) ? "beta" : "latest", "0.0.1");
     vi.mocked(runGatewayUpdate).mockResolvedValue({
       status: "ok",
       mode: "npm",
@@ -5421,7 +5421,9 @@ describe("update-cli", () => {
     expect(postCoreSpawn?.[1]).toEqual([entryPath, "update", "--no-restart", "--yes"]);
     expect(postCoreSpawn?.[2].stdio).toBe("inherit");
     expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE).toBe("1");
-    expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE_CHANNEL).toBe("stable");
+    expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE_CHANNEL).toBe(
+      isBetaTag(VERSION) ? "beta" : "stable",
+    );
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expect(getLogOutput()).not.toContain("already-current");
   });

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -39,6 +39,16 @@ function expectedClawHubInstallSpec(spec: string): string {
   }).installSpec;
 }
 
+function expectedCodexInstallSpec(): string {
+  return resolveNpmInstallSpecsForUpdateChannel({
+    spec: "@openclaw/codex",
+    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
+    officialPackageName: "@openclaw/codex",
+    coreVersion: VERSION,
+    versionBoundToCore: true,
+  }).installSpec;
+}
+
 function currentOpenClawReleaseBase(): string {
   return VERSION.replace(/-(?:alpha|beta)\.[1-9]\d*$/u, "");
 }
@@ -2332,7 +2342,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: `@openclaw/codex@${VERSION}`,
+      spec: expectedCodexInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2351,7 +2361,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(result.repairedPluginIds).toEqual(["codex"]);
@@ -2394,7 +2404,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     expect(mocks.resolveProviderInstallCatalogEntries).toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: `@openclaw/codex@${VERSION}`,
+      spec: expectedCodexInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2410,7 +2420,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
     ]);
     expect(result.warnings).toStrictEqual([]);
   });
@@ -2491,13 +2501,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(mocks.resolveDirectBundledProviderPolicySurface).toHaveBeenCalledWith("openai");
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: `@openclaw/codex@${VERSION}`,
+      spec: expectedCodexInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
       mode: "update",
     });
     expect(result.changes).toEqual([
-      `Refreshed stale configured plugin "codex" from @openclaw/codex@${VERSION}.`,
+      `Refreshed stale configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
     ]);
     expectRecordFields(result.records.codex, {
       source: "npm",
@@ -2796,7 +2806,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: `@openclaw/codex@${VERSION}`,
+      spec: expectedCodexInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2812,7 +2822,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env,
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from @openclaw/codex@${VERSION}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(Object.keys(result.records)).toEqual(["codex"]);

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -827,18 +827,18 @@ describe("media store", () => {
         const nested = await storeResult.saveMediaBuffer(
           Buffer.from("old nested"),
           "text/plain",
-          path.join("remote-cache", "session-prune", "images"),
+          path.join("prune-chain", "session-prune", "images"),
         );
         const mediaDir = await storeResult.ensureMediaDir();
         const sessionDir = path.dirname(path.dirname(nested.path));
-        const remoteCacheDir = path.dirname(sessionDir);
+        const pruneChainDir = path.dirname(sessionDir);
         const past = Date.now() - 10_000;
         await fs.utimes(nested.path, past / 1000, past / 1000);
         return {
           removedFiles: [nested.path],
           preservedFiles: [],
-          removedDirs: [sessionDir],
-          preservedDirs: [remoteCacheDir, mediaDir],
+          removedDirs: [sessionDir, pruneChainDir],
+          preservedDirs: [mediaDir],
         };
       },
       run: async (storeValue: typeof import("./store.js")) =>

--- a/src/plugins/install-channel-specs.test.ts
+++ b/src/plugins/install-channel-specs.test.ts
@@ -75,19 +75,20 @@ describe("resolveNpmInstallSpecsForUpdateChannel", () => {
     });
   });
 
-  it("preserves beta behavior", () => {
+  it("preserves beta behavior for a version-bound plugin", () => {
     expect(
       resolveNpmInstallSpecsForUpdateChannel({
-        spec: "@openclaw/discord@latest",
+        spec: "@openclaw/codex@latest",
         updateChannel: "beta",
-        officialPackageName: "@openclaw/discord",
-        coreVersion: "2026.7.33",
+        officialPackageName: "@openclaw/codex",
+        coreVersion: "2026.8.1-beta.3",
+        versionBoundToCore: true,
       }),
     ).toEqual({
-      installSpec: "@openclaw/discord@beta",
-      recordSpec: "@openclaw/discord@latest",
-      fallbackSpec: "@openclaw/discord@latest",
-      fallbackLabel: "@openclaw/discord@beta",
+      installSpec: "@openclaw/codex@beta",
+      recordSpec: "@openclaw/codex@latest",
+      fallbackSpec: "@openclaw/codex@latest",
+      fallbackLabel: "@openclaw/codex@beta",
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves release validation failures that appear only when OpenClaw's `VERSION` is a beta build. Stable `main` passed because several fixtures hard-coded stable-only npm channel and Codex install expectations, while the media cleanup case reused the shared `remote-cache` subtree and could not prove ownership of its top-level directory.

## Why This Change Was Made

The fixtures now derive beta/stable expectations from `VERSION`, and Doctor's Codex assertions call the same update-channel plus version-bound install-spec resolver as production. Resolver coverage explicitly proves that a version-bound Codex plugin still installs from `@beta` on beta builds. The media cleanup case now owns a unique top-level subtree and asserts that the complete empty chain is removed while the media root survives.

The Codex package policy remains OpenClaw-owned: upstream Codex exposes and dispatches the `codex exec resume` CLI boundary (`codex-rs/cli/src/main.rs:128-132,1034-1049,2929-2944`; `codex-rs/exec/src/cli.rs:9-21,147-150,180-209`), OpenClaw invokes it from `extensions/codex/src/node-cli-sessions.ts:256-280`, and OpenClaw selects npm tags in `src/plugins/install-channel-specs.ts:38-75`.

This is an AI-assisted, test-only forward-port of release commit 514b04e3dd485ef1099384a62389e8ec9bb8f91a, adapted to current `main`. It changes no production code, generated files, baselines, snapshots, inventories, ignores, or changelog. No changelog entry is needed.

## User Impact

No runtime behavior changes. Maintainers get beta-aware release validation that catches real channel regressions without shared-state directory races.

## Evidence

- Pre-fix beta reproduction at 004606fb73bf0b1aadd00ef280435d30590a1c88:
  - the four-file focused run failed two CLI cases because production emitted `beta` while the fixture expected `stable`, and the downgrade fixture primed `latest` instead of exercising the beta channel;
  - the focused Doctor file failed eight cases because production resolved `@openclaw/codex@beta` while the fixtures expected the exact beta version.
- Pre-fix stable `main` at 66dc9d1c1e25a19fa8ca0b5c497a1165e27cf316 passed all four files (4 shards, 388 tests), demonstrating the stable-only blind spot.
- Post-fix: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/install-channel-specs.test.ts src/media/store.test.ts` — 4 shards, 388 tests passed.
- `node_modules/.bin/oxfmt --check` on all four files — passed.
- `node scripts/run-oxlint.mjs` on all four files — passed.
- `git diff --check` — passed.
- Changed gate: https://github.com/openclaw/openclaw/actions/runs/31961644592 passed conflict-marker, env-var-count, and max-lines guards, then stopped on unrelated moving-main assertion-safety baseline shrinkage in `src/state/control-ui-device-auth-migration.ts` and `ui/src/lib/nodes/index.ts`; neither file is touched here.
- Selected type lane: `corepack pnpm tsgo:core:test` passed on Testbox (wrapper exit 0): https://github.com/openclaw/openclaw/actions/runs/31961737916.
- Codex autoreview of the exact staged four-file tree reported no accepted or actionable findings.
- LOC: production +0/-0; tests +35/-22.
