### PR TITLE
fix(tasks): skip session sweep when the cron store is unreadable

### DIFF
--- a/src/commands/tasks-session-registry-maintenance.test.ts
+++ b/src/commands/tasks-session-registry-maintenance.test.ts
@@ -1,0 +1,78 @@
+// Covers the session-registry sweep's cron-store failure behavior: an
+// unreadable cron store must skip the sweep, not prune running transcripts.
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetConfigRuntimeState } from "../config/config.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { runSessionRegistryMaintenance } from "./tasks-session-registry-maintenance.js";
+
+const mocks = vi.hoisted(() => ({
+  cronStoreLoadError: undefined as Error | undefined,
+}));
+
+vi.mock("../cron/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cron/store.js")>();
+  return {
+    ...actual,
+    loadCronJobsStoreSync: (storePath: string) => {
+      if (mocks.cronStoreLoadError) {
+        throw mocks.cronStoreLoadError;
+      }
+      return actual.loadCronJobsStoreSync(storePath);
+    },
+  };
+});
+
+describe("runSessionRegistryMaintenance", () => {
+  afterEach(() => {
+    mocks.cronStoreLoadError = undefined;
+    resetConfigRuntimeState();
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("skips the sweep instead of pruning when the cron store is unreadable", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-session-registry-maintenance-" },
+      async (state) => {
+        resetConfigRuntimeState();
+        const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+        const staleCronKey = "agent:main:cron:maybe-running:run:old-run";
+        await replaceSessionEntry(
+          { sessionKey: staleCronKey, storePath },
+          { sessionId: "maybe-running", updatedAt: Date.now() - 8 * 24 * 60 * 60_000 },
+        );
+        mocks.cronStoreLoadError = new Error("SQLITE_CORRUPT: database disk image is malformed");
+
+        const summary = await runSessionRegistryMaintenance({ apply: true });
+
+        expect(summary.skippedReason).toContain("cron store unreadable");
+        expect(summary.pruned).toBe(0);
+        // The possibly-running cron transcript survives until cron facts are readable.
+        expect(loadSessionEntry({ sessionKey: staleCronKey, storePath })).toBeDefined();
+      },
+    );
+  });
+
+  it("prunes stale rows when the cron store is readable", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-session-registry-maintenance-" },
+      async (state) => {
+        resetConfigRuntimeState();
+        const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+        const staleKey = "agent:main:cron:done-job:run:old-run";
+        await replaceSessionEntry(
+          { sessionKey: staleKey, storePath },
+          { sessionId: "old-run", updatedAt: Date.now() - 8 * 24 * 60 * 60_000 },
+        );
+
+        const summary = await runSessionRegistryMaintenance({ apply: true });
+
+        expect(summary.skippedReason).toBeUndefined();
+        expect(summary.pruned).toBe(1);
+        expect(loadSessionEntry({ sessionKey: staleKey, storePath })).toBeUndefined();
+      },
+    );
+  });
+});

--- a/src/commands/tasks-session-registry-maintenance.ts
+++ b/src/commands/tasks-session-registry-maintenance.ts
@@ -1,0 +1,109 @@
+// Session-registry sweep for `openclaw tasks maintenance`: prunes stale task
+// session rows while preserving transcripts owned by running cron jobs.
+import { getRuntimeConfig } from "../config/config.js";
+import {
+  resolveAllAgentSessionStoreTargetsSync,
+  runSessionRegistryMaintenanceForStore,
+} from "../config/sessions.js";
+import { normalizeCronLaneSegment } from "../cron/service/task-runs.js";
+import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
+import { formatErrorMessage } from "../infra/errors.js";
+
+const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
+
+type SessionRegistryMaintenanceStoreSummary = {
+  agentId: string;
+  storePath: string;
+  beforeCount: number;
+  afterCount: number;
+  pruned: number;
+  preservedRunning: number;
+};
+
+export type SessionRegistryMaintenanceSummary = {
+  retentionMs: number;
+  runningCronJobs: number;
+  pruned: number;
+  stores: SessionRegistryMaintenanceStoreSummary[];
+  /** Set when the sweep did not run; pruning without cron facts would archive live transcripts. */
+  skippedReason?: string;
+};
+
+function resolveExplicitCronSessionSegment(sessionKey: string | undefined): string | undefined {
+  const match = /^(?:agent:[^:]+:)?cron:([^:]+)$/u.exec(sessionKey?.trim() ?? "");
+  return match?.[1]?.toLowerCase();
+}
+
+type RunningCronJobIds =
+  | { ok: true; ids: Set<string>; count: number }
+  | { ok: false; reason: string };
+
+function readRunningCronJobIds(): RunningCronJobIds {
+  try {
+    const cronStorePath = resolveCronJobsStorePath();
+    const runningJobs = loadCronJobsStoreSync(cronStorePath).jobs.filter(
+      (job) => typeof job.state?.runningAtMs === "number",
+    );
+    return {
+      ok: true,
+      // A running job may have been retargeted after its session was created. Keep both historical
+      // shapes; the registry has no producer metadata, so retaining an ambiguous alias is safer
+      // than pruning a live transcript.
+      ids: new Set(
+        runningJobs.flatMap((job) => [
+          job.id.toLowerCase(),
+          normalizeCronLaneSegment(job.id, "job"),
+          ...(job.sessionTarget !== "main" && job.sessionKey
+            ? [resolveExplicitCronSessionSegment(job.sessionKey)].filter(
+                (segment): segment is string => segment !== undefined,
+              )
+            : []),
+        ]),
+      ),
+      count: runningJobs.length,
+    };
+  } catch (err) {
+    // An unreadable cron store must not look like "no running jobs": the
+    // session sweep would then archive transcripts of jobs that are running.
+    return { ok: false, reason: formatErrorMessage(err) };
+  }
+}
+
+export async function runSessionRegistryMaintenance(params: {
+  apply: boolean;
+}): Promise<SessionRegistryMaintenanceSummary> {
+  const cfg = getRuntimeConfig();
+  const runningCronJobs = readRunningCronJobIds();
+  if (!runningCronJobs.ok) {
+    return {
+      retentionMs: SESSION_REGISTRY_RETENTION_MS,
+      runningCronJobs: 0,
+      pruned: 0,
+      stores: [],
+      skippedReason: `cron store unreadable: ${runningCronJobs.reason}`,
+    };
+  }
+  const stores: SessionRegistryMaintenanceStoreSummary[] = [];
+  for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: params.apply,
+      retentionMs: SESSION_REGISTRY_RETENTION_MS,
+      runningCronJobIds: runningCronJobs.ids,
+      storePath: target.storePath,
+    });
+    stores.push({
+      agentId: target.agentId,
+      storePath: target.storePath,
+      beforeCount: result.beforeCount,
+      afterCount: result.afterCount,
+      pruned: result.pruned,
+      preservedRunning: result.preservedRunning,
+    });
+  }
+  return {
+    retentionMs: SESSION_REGISTRY_RETENTION_MS,
+    runningCronJobs: runningCronJobs.count,
+    pruned: stores.reduce((total, store) => total + store.pruned, 0),
+    stores,
+  };
+}

--- a/src/commands/tasks-session-registry-maintenance.ts
+++ b/src/commands/tasks-session-registry-maintenance.ts
@@ -20,7 +20,7 @@ type SessionRegistryMaintenanceStoreSummary = {
   preservedRunning: number;
 };
 
-export type SessionRegistryMaintenanceSummary = {
+type SessionRegistryMaintenanceSummary = {
   retentionMs: number;
   runningCronJobs: number;
   pruned: number;

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -10,12 +10,6 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { parseCliEnumFilter } from "../cli/enum-filter.js";
 import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
-import {
-  resolveAllAgentSessionStoreTargetsSync,
-  runSessionRegistryMaintenanceForStore,
-} from "../config/sessions.js";
-import { normalizeCronLaneSegment } from "../cron/service/task-runs.js";
-import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
 import { cancelDetachedTaskRunById } from "../tasks/task-executor.js";
@@ -61,14 +55,13 @@ import {
   buildTaskSystemAuditFindings,
   type TaskSystemAuditFinding,
 } from "./tasks-audit-system.js";
+import { runSessionRegistryMaintenance } from "./tasks-session-registry-maintenance.js";
 
 const RUNTIME_PAD = 8;
 const STATUS_PAD = 10;
 const DELIVERY_PAD = 14;
 const ID_PAD = 10;
 const RUN_PAD = 10;
-const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
-
 const info = theme.info;
 
 function formatTaskLookupMiss(lookup: string): string {
@@ -131,85 +124,6 @@ async function tryCancelGatewayOwnedTaskViaGateway(
 
 function configureTaskMaintenanceFromConfig(): void {
   configureTaskRegistryMaintenance();
-}
-
-type SessionRegistryMaintenanceStoreSummary = {
-  agentId: string;
-  storePath: string;
-  beforeCount: number;
-  afterCount: number;
-  pruned: number;
-  preservedRunning: number;
-};
-
-type SessionRegistryMaintenanceSummary = {
-  retentionMs: number;
-  runningCronJobs: number;
-  pruned: number;
-  stores: SessionRegistryMaintenanceStoreSummary[];
-};
-
-function resolveExplicitCronSessionSegment(sessionKey: string | undefined): string | undefined {
-  const match = /^(?:agent:[^:]+:)?cron:([^:]+)$/u.exec(sessionKey?.trim() ?? "");
-  return match?.[1]?.toLowerCase();
-}
-
-function readRunningCronJobIds(): { ids: Set<string>; count: number } {
-  try {
-    const cronStorePath = resolveCronJobsStorePath();
-    const runningJobs = loadCronJobsStoreSync(cronStorePath).jobs.filter(
-      (job) => typeof job.state?.runningAtMs === "number",
-    );
-    return {
-      // A running job may have been retargeted after its session was created. Keep both historical
-      // shapes; the registry has no producer metadata, so retaining an ambiguous alias is safer
-      // than pruning a live transcript.
-      ids: new Set(
-        runningJobs.flatMap((job) => [
-          job.id.toLowerCase(),
-          normalizeCronLaneSegment(job.id, "job"),
-          ...(job.sessionTarget !== "main" && job.sessionKey
-            ? [resolveExplicitCronSessionSegment(job.sessionKey)].filter(
-                (segment): segment is string => segment !== undefined,
-              )
-            : []),
-        ]),
-      ),
-      count: runningJobs.length,
-    };
-  } catch {
-    return { ids: new Set(), count: 0 };
-  }
-}
-
-async function runSessionRegistryMaintenance(params: {
-  apply: boolean;
-}): Promise<SessionRegistryMaintenanceSummary> {
-  const cfg = getRuntimeConfig();
-  const runningCronJobs = readRunningCronJobIds();
-  const stores: SessionRegistryMaintenanceStoreSummary[] = [];
-  for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    const result = await runSessionRegistryMaintenanceForStore({
-      apply: params.apply,
-      retentionMs: SESSION_REGISTRY_RETENTION_MS,
-      runningCronJobIds: runningCronJobs.ids,
-      storePath: target.storePath,
-    });
-    stores.push({
-      agentId: target.agentId,
-      storePath: target.storePath,
-      beforeCount: result.beforeCount,
-      afterCount: result.afterCount,
-      pruned: result.pruned,
-      preservedRunning: result.preservedRunning,
-    });
-  }
-  return {
-    retentionMs: SESSION_REGISTRY_RETENTION_MS,
-    runningCronJobs: runningCronJobs.count,
-    pruned: stores.reduce((total, store) => total + store.pruned, 0),
-    stores,
-  };
 }
 
 function truncate(value: string, maxChars: number) {
@@ -720,7 +634,9 @@ export async function tasksMaintenanceCommand(
   );
   runtime.log(
     info(
-      `Session registry: ${sessionMaintenance.pruned} prune · ${sessionMaintenance.runningCronJobs} running automations`,
+      sessionMaintenance.skippedReason
+        ? `Session registry: sweep skipped (${sessionMaintenance.skippedReason})`
+        : `Session registry: ${sessionMaintenance.pruned} prune · ${sessionMaintenance.runningCronJobs} running automations`,
     ),
   );
   runtime.log(


### PR DESCRIPTION
## What Problem This Solves

`openclaw tasks maintenance --apply` runs a session-registry sweep that prunes stale task session rows but preserves transcripts owned by *running* cron jobs. The running-job set came from `readRunningCronJobIds()`, whose `catch` swallowed any cron-store load error and returned an **empty set** — indistinguishable from "no jobs are running". With a corrupt or locked cron store, the sweep then archived the transcripts of every running cron job. Destructive data loss triggered by an unrelated read failure, with no visible reason.

## Why This Change Was Made

Root cause: a failure outcome was collapsed into the success shape (empty set). Per the repo's closed-result conventions, the loader now returns a discriminated `ok/error` result. When the cron store is unreadable, the sweep is skipped entirely and the maintenance summary carries `skippedReason` — surfaced both in the JSON payload and the human-readable "Session registry: sweep skipped (…)" line, so the operator sees exactly why nothing was pruned and what to repair.

The sweep also moved into its own module, `tasks-session-registry-maintenance.ts`: `tasks.ts` was at its 700-line max-lines cap, and the sweep is a coherent standalone concept (cron facts → preserve keys → per-store prune). No `max-lines` suppression added, per repo policy.

## User Impact

A corrupt cron store no longer silently destroys running-job transcripts during maintenance; the operator gets an explicit skip reason instead.

## Evidence

- New colocated `tasks-session-registry-maintenance.test.ts`: with a throwing cron-store loader, apply-mode maintenance skips the sweep, reports `skippedReason`, and the possibly-running transcript survives — **fails on pre-fix semantics** (empty-set catch prunes it). Second test proves the readable-store path still prunes.
- `node scripts/run-vitest.mjs run src/commands/tasks-session-registry-maintenance.test.ts src/commands/tasks.test.ts src/commands/tasks-json.test.ts` — 36 tests pass.
- tsgo core + core-test shards, oxfmt, oxlint clean (max-lines resolved by the extraction, not suppressed).
- Codex autoreview: clean, 0.98 ("patch is correct").
- LOC: prod +113 −88 (mostly the module move; net new logic is the closed result + skip branch), test +78.
