### PR TITLE
fix: show config paths in doctor migration notices

### DIFF
--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -1,7 +1,7 @@
 // Doctor config preflight tests cover last-known-good snapshots and config snapshot promotion.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyCliProfileEnv } from "../cli/profile.js";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
 import { writeConfigHealthStateToStore } from "../config/io.health-state.js";
@@ -17,6 +17,10 @@ import {
   runDoctorConfigPreflight,
   shouldSkipPluginValidationForDoctorConfigPreflight,
 } from "./doctor-config-preflight.js";
+
+const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: noteMock }));
 
 type ConfigHealthDatabase = Pick<OpenClawStateKyselyDatabase, "config_health_entries">;
 
@@ -72,6 +76,25 @@ async function seedLastKnownGood(
 describe("runDoctorConfigPreflight", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+    noteMock.mockClear();
+  });
+
+  it("renders legacy context-budget notices with their config paths", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        models: { providers: { openai: { contextTokens: 64_000 } } },
+      });
+
+      await runDoctorConfigPreflight({
+        migrateState: false,
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+      });
+
+      const output = noteMock.mock.calls.map(([message]) => message).join("\n");
+      expect(output).toContain("- models.providers.openai.contextTokens:");
+      expect(output).not.toContain("- : ");
+    });
   });
 
   it("supports non-observing config reads", async () => {

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -136,12 +136,12 @@ export function normalizeCompatibilityConfigValues(
   if (options.sourceConfigBeforeMigrations === undefined) {
     const migration = migrateLegacyContextBudgetConfig(cfg);
     contextBudgetConfig = migration.config;
-    changes.push(...migration.changes);
-    contextBudgetWarnings = migration.warnings;
+    changes.push(...migration.changes.map(({ message }) => message));
+    contextBudgetWarnings = migration.warnings.map(({ message }) => message);
   } else {
     const migration = migrateLegacyContextBudgetConfig(options.sourceConfigBeforeMigrations);
-    changes.push(...migration.changes);
-    contextBudgetWarnings = migration.warnings;
+    changes.push(...migration.changes.map(({ message }) => message));
+    contextBudgetWarnings = migration.warnings.map(({ message }) => message);
   }
   const reservedMcpServerNames = migrateReservedMcpServerNames(
     contextBudgetConfig,

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -175,13 +175,14 @@ describe("config io paths", () => {
         expect.stringContaining("models.providers.<provider>.models[].contextTokens"),
       );
       expect(snapshot.warnings).toContainEqual({
-        path: "",
+        path: "agents.defaults.contextTokens",
         message: "Removed agents.defaults.contextTokens.",
       });
       expect(snapshot.warnings).toContainEqual({
-        path: "",
+        path: "agents.defaults.contextTokens",
         message: expect.stringContaining("models.providers.<provider>.models[].contextTokens"),
       });
+      expect(snapshot.warnings).not.toContainEqual(expect.objectContaining({ path: "" }));
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(raw);
     });
   });

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -79,8 +79,8 @@ export function loadConfigFromContext(
       );
     }
     for (const diagnostic of [
-      ...contextBudgetMigration.changes,
-      ...contextBudgetMigration.warnings,
+      ...contextBudgetMigration.changes.map(({ message }) => message),
+      ...contextBudgetMigration.warnings.map(({ message }) => message),
       ...rosterMigration.diagnostics,
     ]) {
       deps.logger.warn(`Config (${configPath}): ${diagnostic}`);

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -179,8 +179,8 @@ export async function readConfigFileSnapshotInternal(
     );
     const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config);
     envVarWarnings.push(
-      ...contextBudgetMigration.changes.map((message) => ({ path: "", message })),
-      ...contextBudgetMigration.warnings.map((message) => ({ path: "", message })),
+      ...contextBudgetMigration.changes,
+      ...contextBudgetMigration.warnings,
       ...rosterMigration.diagnostics.map((message) => ({ path: "agents.entries", message })),
     );
     const effectiveConfigRaw = rosterMigration.config;

--- a/src/config/legacy.context-budget.test.ts
+++ b/src/config/legacy.context-budget.test.ts
@@ -44,10 +44,26 @@ describe("legacy context-budget config migration", () => {
       { contextTokens: 8_000, contextWindow: 16_000 },
     ]);
     expect(migrated.changes).toEqual([
-      "models.providers.example.contextTokens → models.providers.example.models[0].contextTokens.",
-      "Removed models.providers.example.contextTokens after baking it into explicit model entries.",
-      "models.providers.example.contextWindow → models.providers.example.models[0].contextWindow.",
-      "Removed models.providers.example.contextWindow after baking it into explicit model entries.",
+      {
+        path: "models.providers.example.contextTokens",
+        message:
+          "models.providers.example.contextTokens → models.providers.example.models[0].contextTokens.",
+      },
+      {
+        path: "models.providers.example.contextTokens",
+        message:
+          "Removed models.providers.example.contextTokens after baking it into explicit model entries.",
+      },
+      {
+        path: "models.providers.example.contextWindow",
+        message:
+          "models.providers.example.contextWindow → models.providers.example.models[0].contextWindow.",
+      },
+      {
+        path: "models.providers.example.contextWindow",
+        message:
+          "Removed models.providers.example.contextWindow after baking it into explicit model entries.",
+      },
     ]);
     expect(migrated.warnings).toEqual([]);
   });
@@ -59,12 +75,26 @@ describe("legacy context-budget config migration", () => {
 
     expect(migrated.config).toEqual({ models: { providers: { example: {} } } });
     expect(migrated.changes).toEqual([
-      "Removed models.providers.example.contextTokens.",
-      "Removed models.providers.example.contextWindow.",
+      {
+        path: "models.providers.example.contextTokens",
+        message: "Removed models.providers.example.contextTokens.",
+      },
+      {
+        path: "models.providers.example.contextWindow",
+        message: "Removed models.providers.example.contextWindow.",
+      },
     ]);
     expect(migrated.warnings).toEqual([
-      "models.providers.example.contextTokens had no explicit model entries to receive its value; use models.providers.<provider>.models[].contextTokens instead.",
-      "models.providers.example.contextWindow had no explicit model entries to receive its value; use models.providers.<provider>.models[].contextTokens instead.",
+      {
+        path: "models.providers.example.contextTokens",
+        message:
+          "models.providers.example.contextTokens had no explicit model entries to receive its value; use models.providers.<provider>.models[].contextTokens instead.",
+      },
+      {
+        path: "models.providers.example.contextWindow",
+        message:
+          "models.providers.example.contextWindow had no explicit model entries to receive its value; use models.providers.<provider>.models[].contextTokens instead.",
+      },
     ]);
   });
 
@@ -83,9 +113,18 @@ describe("legacy context-budget config migration", () => {
       agents: { defaults: {}, entries: { ops: {}, writer: {} }, list: [{ id: "legacy" }] },
     });
     expect(migrated.changes).toEqual([
-      "Removed agents.defaults.contextTokens.",
-      "Removed agents.entries.ops.contextTokens.",
-      "Removed agents.list[0].contextTokens.",
+      {
+        path: "agents.defaults.contextTokens",
+        message: "Removed agents.defaults.contextTokens.",
+      },
+      {
+        path: "agents.entries.ops.contextTokens",
+        message: "Removed agents.entries.ops.contextTokens.",
+      },
+      {
+        path: "agents.list[0].contextTokens",
+        message: "Removed agents.list[0].contextTokens.",
+      },
     ]);
     expect(migrated.warnings).toHaveLength(3);
     expect(migrateLegacyContextBudgetConfig(migrated.config)).toEqual({

--- a/src/config/legacy.context-budget.ts
+++ b/src/config/legacy.context-budget.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { OpenClawConfig } from "./types.openclaw.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.openclaw.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -8,8 +8,8 @@ const MODEL_CONTEXT_TOKENS_REPLACEMENT = "models.providers.<provider>.models[].c
 type ContextBudgetConfigMigration<T = unknown> = {
   config: T;
   changed: boolean;
-  changes: string[];
-  warnings: string[];
+  changes: ConfigValidationIssue[];
+  warnings: ConfigValidationIssue[];
 };
 
 function hasLegacyContextBudgetConfig(root: JsonRecord): boolean {
@@ -45,53 +45,44 @@ function hasLegacyContextBudgetConfig(root: JsonRecord): boolean {
   );
 }
 
-function removeAgentContextTokens(root: JsonRecord, changes: string[], warnings: string[]): void {
+function removeAgentContextTokens(
+  root: JsonRecord,
+  changes: ConfigValidationIssue[],
+  warnings: ConfigValidationIssue[],
+): void {
   const agents = root.agents;
   if (!isRecord(agents)) {
     return;
   }
-  const defaults = agents.defaults;
-  if (isRecord(defaults) && Object.hasOwn(defaults, "contextTokens")) {
-    delete defaults.contextTokens;
-    changes.push("Removed agents.defaults.contextTokens.");
-    warnings.push(
-      `agents.defaults.contextTokens cannot be represented per model; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
-    );
-  }
+  const removeContextTokens = (record: unknown, path: string): void => {
+    if (!isRecord(record) || !Object.hasOwn(record, "contextTokens")) {
+      return;
+    }
+    delete record.contextTokens;
+    changes.push({ path, message: `Removed ${path}.` });
+    warnings.push({
+      path,
+      message: `${path} cannot be represented per model; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
+    });
+  };
+  removeContextTokens(agents.defaults, "agents.defaults.contextTokens");
   const entries = agents.entries;
   if (isRecord(entries)) {
     for (const [agentId, entry] of Object.entries(entries)) {
-      if (!isRecord(entry) || !Object.hasOwn(entry, "contextTokens")) {
-        continue;
-      }
-      delete entry.contextTokens;
-      const path = `agents.entries.${agentId}.contextTokens`;
-      changes.push(`Removed ${path}.`);
-      warnings.push(
-        `${path} cannot be represented per model; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
-      );
+      removeContextTokens(entry, `agents.entries.${agentId}.contextTokens`);
     }
   }
-  if (!Array.isArray(agents.list)) {
-    return;
-  }
-  for (const [index, entry] of agents.list.entries()) {
-    if (!isRecord(entry) || !Object.hasOwn(entry, "contextTokens")) {
-      continue;
+  if (Array.isArray(agents.list)) {
+    for (const [index, entry] of agents.list.entries()) {
+      removeContextTokens(entry, `agents.list[${index}].contextTokens`);
     }
-    delete entry.contextTokens;
-    const path = `agents.list[${index}].contextTokens`;
-    changes.push(`Removed ${path}.`);
-    warnings.push(
-      `${path} cannot be represented per model; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
-    );
   }
 }
 
 function migrateProviderContextBudgets(
   root: JsonRecord,
-  changes: string[],
-  warnings: string[],
+  changes: ConfigValidationIssue[],
+  warnings: ConfigValidationIssue[],
 ): void {
   const providers = isRecord(root.models) ? root.models.providers : undefined;
   if (!isRecord(providers)) {
@@ -112,17 +103,24 @@ function migrateProviderContextBudgets(
             continue;
           }
           model[key] = provider[key];
-          changes.push(`${sourcePath} → models.providers.${providerId}.models[${index}].${key}.`);
+          changes.push({
+            path: sourcePath,
+            message: `${sourcePath} → models.providers.${providerId}.models[${index}].${key}.`,
+          });
         }
         delete provider[key];
-        changes.push(`Removed ${sourcePath} after baking it into explicit model entries.`);
+        changes.push({
+          path: sourcePath,
+          message: `Removed ${sourcePath} after baking it into explicit model entries.`,
+        });
         continue;
       }
       delete provider[key];
-      changes.push(`Removed ${sourcePath}.`);
-      warnings.push(
-        `${sourcePath} had no explicit model entries to receive its value; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
-      );
+      changes.push({ path: sourcePath, message: `Removed ${sourcePath}.` });
+      warnings.push({
+        path: sourcePath,
+        message: `${sourcePath} had no explicit model entries to receive its value; use ${MODEL_CONTEXT_TOKENS_REPLACEMENT} instead.`,
+      });
     }
   }
 }
@@ -137,8 +135,8 @@ export function migrateLegacyContextBudgetConfig(raw: unknown): ContextBudgetCon
     return { config: raw, changed: false, changes: [], warnings: [] };
   }
   const next = structuredClone(raw);
-  const changes: string[] = [];
-  const warnings: string[] = [];
+  const changes: ConfigValidationIssue[] = [];
+  const warnings: ConfigValidationIssue[] = [];
   migrateProviderContextBudgets(next, changes, warnings);
   removeAgentContextTokens(next, changes, warnings);
   return changes.length > 0


### PR DESCRIPTION
Fixes #124703

## What Problem This Solves

Fixes an issue where operators running Doctor against legacy context-budget config saw migration notices rendered as `- : message`, hiding which config key each notice concerned.

## Why This Change Was Made

The context-budget migration now preserves the exact source config path on each change and warning. Snapshot/Doctor consumers keep those structured diagnostics, while existing plain-string consumers explicitly retain the message text.

## User Impact

Doctor now shows actionable paths such as `models.providers.openai.contextTokens` instead of an empty path prefix. Config migration behavior and persisted files are unchanged.

## Evidence

- Regression test failed before the fix with `- : Removed models.providers.openai.contextTokens.` and passes after the owner-boundary repair.
- `node scripts/run-vitest.mjs src/config/legacy.context-budget.test.ts src/config/io.compat.test.ts src/commands/doctor-config-preflight.test.ts src/commands/doctor-legacy-config.migrations.test.ts` — 107 tests passed across 2 shards.
- `git diff --check` — passed.
- Production LOC: +49/-51 (net -2); tests: +77/-12.
- Autoreview completed with no accepted/actionable findings.
- `node scripts/check-changed.mjs -- <touched files>` reached the core guard fan-out, then stopped on an unrelated shrink-only assertion baseline for `src/state/control-ui-device-auth-migration.ts` and `ui/src/lib/nodes/index.ts`; neither file or baseline is changed here.

AI-assisted: Codex.
