### PR TITLE
perf(test): reuse Gateway for hosted wizard exits

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -835,20 +835,22 @@ module.exports = {
     },
   );
 
-  it.each([
-    { flow: "setup", exitCode: 0, status: "done" },
-    { flow: "setup", exitCode: 23, status: "error" },
-    { flow: "channels", exitCode: 0, status: "done" },
-    { flow: "channels", exitCode: 23, status: "error" },
-  ] as const)(
-    "keeps the authenticated Gateway alive after a $flow wizard exits $exitCode",
+  it(
+    "keeps the authenticated Gateway alive after all hosted wizard exits",
     { timeout: GATEWAY_E2E_TIMEOUT_MS },
-    async ({ flow, exitCode, status }) => {
+    async () => {
+      const testCases = [
+        { flow: "setup", exitCode: 0, status: "done" },
+        { flow: "setup", exitCode: 23, status: "error" },
+        { flow: "channels", exitCode: 0, status: "done" },
+        { flow: "channels", exitCode: 23, status: "error" },
+      ] as const;
       const { envSnapshot, tempHome } = await setupGatewayTempHome({
-        prefix: `openclaw-wizard-${flow}-exit-home-`,
+        prefix: "openclaw-wizard-contained-exit-home-",
         minimalGateway: true,
       });
       const wizardToken = nextGatewayId("wiz-contained-exit");
+      let exitCode = 0;
       const port = await getGatewayE2ePortBlock();
       const server = await startGatewayServer(port, {
         bind: "loopback",
@@ -875,23 +877,27 @@ module.exports = {
       });
 
       try {
-        const start = await client.request<WizardStartResult>(
-          "wizard.start",
-          flow === "channels" ? { flow } : { mode: "local" },
-        );
-        expect(start).toMatchObject({ done: false, status: "running" });
-        expect(start.step?.id).toBeTruthy();
+        for (const testCase of testCases) {
+          exitCode = testCase.exitCode;
+          const label = `${testCase.flow} wizard exit ${exitCode}`;
+          const start = await client.request<WizardStartResult>(
+            "wizard.start",
+            testCase.flow === "channels" ? { flow: testCase.flow } : { mode: "local" },
+          );
+          expect(start, label).toMatchObject({ done: false, status: "running" });
+          expect(start.step?.id, label).toBeTruthy();
 
-        const result = await client.request<WizardNextResult>("wizard.next", {
-          sessionId: start.sessionId,
-          answer: { stepId: start.step?.id, value: null },
-        });
-        expect(result).toMatchObject({ done: true, status });
-        if (exitCode !== 0) {
-          expect(result.error).toContain(String(exitCode));
+          const result = await client.request<WizardNextResult>("wizard.next", {
+            sessionId: start.sessionId,
+            answer: { stepId: start.step?.id, value: null },
+          });
+          expect(result, label).toMatchObject({ done: true, status: testCase.status });
+          if (exitCode !== 0) {
+            expect(result.error, label).toContain(String(exitCode));
+          }
+          expect(processExit, label).not.toHaveBeenCalled();
+          await expect(client.request("health", {}), label).resolves.toBeDefined();
         }
-        expect(processExit).not.toHaveBeenCalled();
-        await expect(client.request("health", {})).resolves.toBeDefined();
       } finally {
         processExit.mockRestore();
         await disconnectGatewayClient(client);

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -835,78 +835,69 @@ module.exports = {
     },
   );
 
-  it(
-    "keeps the authenticated Gateway alive after all hosted wizard exits",
-    { timeout: GATEWAY_E2E_TIMEOUT_MS },
-    async () => {
-      const testCases = [
-        { flow: "setup", exitCode: 0, status: "done" },
-        { flow: "setup", exitCode: 23, status: "error" },
-        { flow: "channels", exitCode: 0, status: "done" },
-        { flow: "channels", exitCode: 23, status: "error" },
-      ] as const;
-      const { envSnapshot, tempHome } = await setupGatewayTempHome({
-        prefix: "openclaw-wizard-contained-exit-home-",
-        minimalGateway: true,
-      });
-      const wizardToken = nextGatewayId("wiz-contained-exit");
-      let exitCode = 0;
-      const port = await getGatewayE2ePortBlock();
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token: wizardToken },
-        controlUiEnabled: false,
-        wizardRunner: async (_opts, runtime, prompter) => {
-          await prompter.outro("wizard complete");
-          runtime.exit(exitCode);
-        },
-        channelWizardRunner: async (_opts, runtime, prompter) => {
-          await prompter.outro("channel wizard complete");
-          runtime.exit(exitCode);
-        },
-      });
-      const client = await connectGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token: wizardToken,
-        clientDisplayName: "vitest-wizard-contained-exit",
-      });
-      // Intercept an actual host exit so the fail-first Gateway test cannot
-      // terminate its Vitest worker before reporting the regression.
-      const processExit = vi.spyOn(process, "exit").mockImplementation((code) => {
-        throw new Error(`Gateway process exit ${code}`);
-      });
+  it("contains hosted wizard exits", { timeout: GATEWAY_E2E_TIMEOUT_MS }, async () => {
+    const { envSnapshot, tempHome } = await setupGatewayTempHome({
+      prefix: "openclaw-wizard-contained-exit-home-",
+      minimalGateway: true,
+    });
+    const wizardToken = nextGatewayId("wiz-contained-exit");
+    let exitCode = 0;
+    const port = await getGatewayE2ePortBlock();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token: wizardToken },
+      controlUiEnabled: false,
+      wizardRunner: async (_opts, runtime, prompter) => {
+        await prompter.outro("wizard complete");
+        runtime.exit(exitCode);
+      },
+      channelWizardRunner: async (_opts, runtime, prompter) => {
+        await prompter.outro("channel wizard complete");
+        runtime.exit(exitCode);
+      },
+    });
+    const client = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token: wizardToken,
+    });
+    // Intercept an actual host exit so the fail-first Gateway test cannot
+    // terminate its Vitest worker before reporting the regression.
+    const processExit = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Gateway process exit ${code}`);
+    });
 
-      try {
-        for (const testCase of testCases) {
-          exitCode = testCase.exitCode;
-          const label = `${testCase.flow} wizard exit ${exitCode}`;
+    try {
+      for (const flow of ["setup", "channels"] as const) {
+        for (const nextExitCode of [0, 23] as const) {
+          exitCode = nextExitCode;
+          const status = exitCode === 0 ? "done" : "error";
           const start = await client.request<WizardStartResult>(
             "wizard.start",
-            testCase.flow === "channels" ? { flow: testCase.flow } : { mode: "local" },
+            flow === "channels" ? { flow } : { mode: "local" },
           );
-          expect(start, label).toMatchObject({ done: false, status: "running" });
-          expect(start.step?.id, label).toBeTruthy();
+          expect(start).toMatchObject({ done: false, status: "running" });
+          expect(start.step?.id).toBeTruthy();
 
           const result = await client.request<WizardNextResult>("wizard.next", {
             sessionId: start.sessionId,
             answer: { stepId: start.step?.id, value: null },
           });
-          expect(result, label).toMatchObject({ done: true, status: testCase.status });
+          expect(result).toMatchObject({ done: true, status });
           if (exitCode !== 0) {
-            expect(result.error, label).toContain(String(exitCode));
+            expect(result.error).toContain(String(exitCode));
           }
-          expect(processExit, label).not.toHaveBeenCalled();
-          await expect(client.request("health", {}), label).resolves.toBeDefined();
+          expect(processExit).not.toHaveBeenCalled();
+          await expect(client.request("health", {})).resolves.toBeDefined();
         }
-      } finally {
-        processExit.mockRestore();
-        await disconnectGatewayClient(client);
-        await server.close({ reason: "wizard runtime isolation E2E complete" });
-        await removeGatewayTempHome(tempHome);
-        envSnapshot.restore();
       }
-    },
-  );
+    } finally {
+      processExit.mockRestore();
+      await disconnectGatewayClient(client);
+      await server.close({ reason: "wizard runtime isolation E2E complete" });
+      await removeGatewayTempHome(tempHome);
+      envSnapshot.restore();
+    }
+  });
 
   it(
     "routes wizard.start flow channels to the channel wizard runner",


### PR DESCRIPTION
## What Problem This Solves

The authenticated Gateway wizard E2E matrix started a fresh temp home, Gateway server, and WebSocket client for each of four setup/channels × success/error cases. Those repeated lifecycles dominated the behavior proof even though the contract is independent wizard-session isolation inside one long-lived Gateway.

## Why This Change Was Made

Reuse one authenticated Gateway and client across four sequential wizard sessions while preserving every flow/outcome combination. Each case still proves the session result, nonzero exit error text, that `process.exit` was not called, and that the Gateway remains healthy afterward.

The direct handler-owner matrix in `src/gateway/server-methods/wizard.test.ts` remains unchanged. A production mutation that swallowed every `ExitError` made the consolidated E2E fail on the nonzero setup session, proving that error semantics remain protected.

## User Impact

No production behavior changes. The targeted test file becomes materially faster and consumes less CPU, reducing feedback time and CI load without weakening authenticated WebSocket coverage.

Controlled same-Testbox A/B (`tbx_01m05ezsh2rtkax8c8c0n9q0ps`, one excluded warmup, two retained samples per state, one Vitest worker, distinct filesystem module caches):

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 17.86s | 15.99s | -1.87s (-10.5%) |
| Vitest | 17.45s | 15.54s | -1.91s (-10.9%) |
| Test body | 11.66s | 9.81s | -1.85s (-15.9%) |
| CPU user+sys | 25.51s | 22.25s | -3.26s (-12.8%) |

Imports were effectively flat. RSS was noisy, so this PR makes no memory claim.

## Evidence

- Full Gateway E2E + wizard owner suite: 14/14 and 18/18 passed on Blacksmith Testbox `tbx_01m05tbke0nymtd00teryccrm6`: https://github.com/openclaw/openclaw/actions/runs/31962126654
- Complete changed gate passed on the same Testbox after the protected baseline correction: provider `blacksmith-testbox`, 10m11s, all checks green.
- Current rebased branch: assertion-safety ratchet, targeted oxlint, formatting/diff checks all pass.
- Fresh structured Codex autoreview after the final rebase: clean, 0.99 confidence.
- Production LOC: +0/-0. Test LOC: +59/-62.
