### PR TITLE
fix(auto-reply): reject redeliveries without recreating drained queues

### DIFF
--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -15,6 +15,7 @@ import {
   installQueueRuntimeErrorSilencer,
 } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
+import { getExistingFollowupQueue } from "./queue/state.js";
 
 installQueueRuntimeErrorSilencer();
 
@@ -250,6 +251,47 @@ describe("followup queue deduplication", () => {
       clearSessionQueues([key]);
       resetRecentQueuedMessageIdDedupe();
     }
+  });
+
+  it("does not leave an empty registry entry when rejecting a redelivery after the queue drained", async () => {
+    const key = `test-dedup-registry-leak-${Date.now()}`;
+    const { calls, done, runFollowup } = createFollowupCollector();
+
+    expect(
+      enqueueFollowupRun(
+        key,
+        createRun({
+          prompt: "original",
+          messageId: "leak-1",
+          originatingChannel: "discord",
+          originatingTo: "channel:123",
+        }),
+        collectSettings,
+      ),
+    ).toBe(true);
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+    // Let the drain finish and self-delete the empty queue from the registry.
+    await vi.waitFor(() => {
+      expect(getExistingFollowupQueue(key)).toBeUndefined();
+    });
+    expect(calls).toHaveLength(1);
+
+    // A provider redelivery of the same message must be rejected without
+    // recreating a registry entry that nothing would ever delete again.
+    expect(
+      enqueueFollowupRun(
+        key,
+        createRun({
+          prompt: "original (redelivery)",
+          messageId: "leak-1",
+          originatingChannel: "discord",
+          originatingTo: "channel:123",
+        }),
+        collectSettings,
+      ),
+    ).toBe(false);
+    expect(getExistingFollowupQueue(key)).toBeUndefined();
   });
 
   it("does not collide recent message-id keys when routing contains delimiters", async () => {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -139,11 +139,14 @@ export function enqueueFollowupRun(
   if (options.steerCandidate) {
     run.steerAnchor = true;
   }
-  const queue = getFollowupQueue(key, settings);
+  // Peek before getFollowupQueue: rejecting a redelivery after the original
+  // queue drained and self-deleted must not recreate an empty registry entry,
+  // which nothing would ever delete again.
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
   if (recentMessageIdKey && peekRecentQueueMessageId(recentMessageIdKey)) {
     return false;
   }
+  const queue = getFollowupQueue(key, settings);
 
   const dedupe =
     dedupeMode === "none"


### PR DESCRIPTION
## What Problem This Solves

`enqueueFollowupRun` called `getFollowupQueue()` — which inserts a new `FollowupQueueState` into the process-global `FOLLOWUP_QUEUES` registry — *before* the recent-message-id dedupe peek. A provider redelivery (Discord/Signal redelivering the same message id within the 5-minute dedupe TTL) arriving after the original queue had drained and self-deleted would recreate the registry entry, get rejected by the peek, and leave an empty `FollowupQueueState` (AbortController, item arrays, WeakSets) in the global map forever: registry entries are only deleted when a drain finishes with no pending work, and a queue that never receives an item never drains. Long-lived gateways leaked one state object per redelivered session key.

## Why This Change Was Made

Root cause: mutation-before-validation ordering. The dedupe key derivation (`buildRecentMessageIdKey`) only needs the run and the queue key, not the queue object, so the peek now runs first and the registry entry is created only for work that passes redelivery dedupe. One reorder, no new state or branches.

## User Impact

No more unbounded registry growth from provider redeliveries on long-lived gateways. No behavior change for admitted messages.

## Evidence

- New regression in `src/auto-reply/reply/queue.dedupe.test.ts`: drains a queue to registry self-deletion, replays the same message id, asserts rejection **and** that no registry entry reappears — fails pre-fix (entry recreated), passes post-fix.
- `node scripts/run-vitest.mjs run src/auto-reply/reply/queue` — 8 files, 32 tests pass; dedupe suite 15/15.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +4 −1 (reorder + invariant comment), test +42.
