### PR TITLE
fix(ui): keep Control UI device identity working on plain-HTTP origins

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -692,7 +692,7 @@ The Control UI generates device identity with pure-JS Ed25519, so pairing works 
 
 - Token/password auth does not replace browser device identity: HTTP browsers still pair with a signed device key, which never crosses the wire. Prefer HTTPS (for example, Tailscale Serve) — plaintext transport still exposes the page and the shared secret to on-path attackers.
 - `gateway.controlUi.dangerouslyDisableDeviceAuth`: retired break-glass input, now fully inert. Control UI browsers pair through the normal device flow; `openclaw doctor --fix` removes the legacy key.
-- Separately, successful `gateway.auth.mode: "trusted-proxy"` authentication can admit **operator** Control UI sessions without device identity. This does not extend to node-role Control UI sessions.
+- Separately, successful `gateway.auth.mode: "trusted-proxy"` authentication can admit **operator** Control UI sessions without device identity when the browser cannot supply one. Browsers that can mint an identity (any origin, including plain HTTP) follow the normal pairing flow instead — automatic with `deviceAutoApprove`, otherwise a one-time approval. This does not extend to node-role Control UI sessions.
 
 ### Insecure/dangerous flags
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -688,9 +688,9 @@ Trusted proxy headers do not make node device pairing automatically trusted - `g
 
 ### Control UI over HTTP
 
-The Control UI needs a secure context (HTTPS or localhost) to generate device identity.
+The Control UI generates device identity with pure-JS Ed25519, so pairing works on any origin, including plain HTTP.
 
-- Token/password auth does not replace browser device identity over remote plain HTTP. Use HTTPS (for example, Tailscale Serve) or open the UI on `127.0.0.1` from the Gateway host.
+- Token/password auth does not replace browser device identity: HTTP browsers still pair with a signed device key, which never crosses the wire. Prefer HTTPS (for example, Tailscale Serve) — plaintext transport still exposes the page and the shared secret to on-path attackers.
 - `gateway.controlUi.dangerouslyDisableDeviceAuth`: retired break-glass input, now fully inert. Control UI browsers pair through the normal device flow; `openclaw doctor --fix` removes the legacy key.
 - Separately, successful `gateway.auth.mode: "trusted-proxy"` authentication can admit **operator** Control UI sessions without device identity. This does not extend to node-role Control UI sessions.
 

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -203,7 +203,7 @@ Enabling this option delegates new browser device enrollment entirely to the rev
 
 ## Control UI pairing behavior
 
-When `gateway.auth.mode = "trusted-proxy"` is active and the request passes trusted-proxy checks, Control UI WebSocket sessions can connect without device pairing identity.
+Browsers attach a device identity on every origin, including plain HTTP, so first connects follow the standard pairing flow: automatic approval when [`deviceAutoApprove`](#automatic-device-approval) is enabled, otherwise a one-time approval on the Gateway host. When `gateway.auth.mode = "trusted-proxy"` is active and the request passes trusted-proxy checks, only Control UI sessions from browsers that cannot supply a device identity at all are admitted device-less.
 
 Scope implications:
 

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -208,7 +208,7 @@ When `gateway.auth.mode = "trusted-proxy"` is active and the request passes trus
 Scope implications:
 
 - Device-less Control UI WebSocket sessions cannot self-declare permissions. OpenClaw clears their requested scope list to `[]`, then applies any matching server-side `identityScopes` grant after proxy identity verification.
-- If methods fail with `missing scope` after a successful WebSocket connect, use HTTPS so the browser can generate device identity and complete pairing. See [Control UI insecure HTTP](/web/control-ui#insecure-http).
+- If methods fail with `missing scope` after a successful WebSocket connect, reload so the browser pairs its device identity, or approve the pending device request. See [Control UI insecure HTTP](/web/control-ui#insecure-http).
 
 Reverse-proxy scope capping: if your proxy sends `x-openclaw-scopes` on the Control UI WebSocket upgrade request, OpenClaw caps device enrollment or upgrade requests and the final union of device-authorized and identity-granted session scopes. This header does not grant scopes; it only narrows authority. When `deviceAutoApprove.enabled` is true, the cap also limits the persistent device grant written by [automatic device approval](#automatic-device-approval).
 
@@ -537,7 +537,7 @@ Separate, non-trusted-proxy-specific findings also apply whenever Control UI is 
 
     Fix:
 
-    - For Control UI, use HTTPS so the browser can generate device identity and complete pairing.
+    - For Control UI, reload the dashboard so the browser generates device identity and completes pairing (works over HTTP too).
     - For custom automation, use device identity/pairing, the reserved direct-local `gateway-client` backend helper path, or [admin HTTP RPC](/plugins/admin-http-rpc).
     - Do not add the retired `gateway.controlUi.dangerouslyDisableDeviceAuth` key to current config; it is ignored and `openclaw doctor --fix` removes it.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -661,13 +661,15 @@ Tokenless Serve auth assumes the gateway host is trusted. If untrusted local cod
 
 ## Insecure HTTP
 
-If you open the dashboard over plain HTTP (`http://<lan-ip>` or `http://<tailscale-ip>`), the browser runs in a **non-secure context** and blocks WebCrypto. OpenClaw rejects token/password Control UI connections without device identity; a shared secret cannot replace browser identity.
+Opening the dashboard over plain HTTP (`http://<lan-ip>` or `http://<tailscale-ip>`) works: device identity is generated and signed with pure-JS Ed25519, so pairing does not depend on WebCrypto or a secure context. The signing key never leaves the browser, which makes it the one credential a plaintext transport cannot leak — unlike the shared token, which any on-path observer of an HTTP connection can read.
+
+Plain HTTP remains a downgraded transport: an active attacker on the path can modify the page and capture anything in it. Prefer HTTPS wherever possible — Tailscale Serve gives you a real certificate with no configuration — and treat HTTP as a LAN-only convenience. Browsers also withhold secure-context features (for example passkeys) on HTTP, and Chrome's Local Network Access rules increasingly restrict plaintext local requests.
 
 The supported device-less exception is successful operator Control UI auth
 through `gateway.auth.mode: "trusted-proxy"`. There is no persistent config
 switch that disables device identity.
 
-**Recommended fix:** use HTTPS (Tailscale Serve) or open the UI locally at `https://<magicdns>/` (Serve) or `http://127.0.0.1:18789/` (on the gateway host).
+**Recommended setup:** HTTPS via `https://<magicdns>/` (Tailscale Serve) or the UI locally at `http://127.0.0.1:18789/` (on the gateway host).
 
 <AccordionGroup>
   <Accordion title="Trusted-proxy note">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2366,6 +2366,9 @@ importers:
       '@noble/ed25519':
         specifier: 3.1.0
         version: 3.1.0
+      '@noble/hashes':
+        specifier: 2.2.0
+        version: 2.2.0
       '@novnc/novnc':
         specifier: 1.7.0
         version: 1.7.0

--- a/ui/config/control-ui-chunking.ts
+++ b/ui/config/control-ui-chunking.ts
@@ -59,11 +59,9 @@ export function controlUiStableChunkName(id: string): string | undefined {
     return "config-runtime";
   }
 
-  if (
-    moduleIdIncludesPackage(id, "@noble/ed25519") ||
-    moduleIdIncludesPackage(id, "@noble/hashes") ||
-    moduleIdIncludesPackage(id, "ipaddr.js")
-  ) {
+  // @noble/hashes stays out of this startup chunk deliberately: it is only
+  // dynamically imported as the insecure-context fallback digest provider.
+  if (moduleIdIncludesPackage(id, "@noble/ed25519") || moduleIdIncludesPackage(id, "ipaddr.js")) {
     return "gateway-runtime";
   }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "@modelcontextprotocol/ext-apps": "1.7.5",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@noble/ed25519": "3.1.0",
+    "@noble/hashes": "2.2.0",
     "@novnc/novnc": "1.7.0",
     "@openclaw/gateway-client": "workspace:*",
     "@openclaw/gateway-protocol": "workspace:*",

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -1042,7 +1042,9 @@ describe("GatewayBrowserClient", () => {
       phase: "hello",
       hasChallenge: true,
       usedFallback: false,
-      secureContext: true,
+      // The Node test host has no window, so the reported browser secure-context
+      // fact is false even though a device identity is present.
+      secureContext: false,
       hasDeviceIdentity: true,
       hasDevice: true,
       hasAuthToken: true,

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -168,6 +168,7 @@ type ConnectFrame = {
     caps?: string[];
     scopes?: string[];
     device?: {
+      id?: string;
       signedAt?: number;
     };
   };

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -312,8 +312,11 @@ function getLatestWebSocket(): MockWebSocket {
 }
 
 function stubInsecureCrypto() {
+  // Real insecure contexts keep randomUUID/getRandomValues; only crypto.subtle
+  // is gated to secure contexts.
   vi.stubGlobal("crypto", {
     randomUUID: () => "req-insecure",
+    getRandomValues: (array: Uint8Array) => array.fill(7),
   });
 }
 
@@ -1423,7 +1426,7 @@ describe("GatewayBrowserClient", () => {
     client.stop();
   });
 
-  it("uses a Gateway-owned recovery scope without browser crypto or client credentials", async () => {
+  it("uses a Gateway-owned recovery scope without shared credentials on an insecure context", async () => {
     localStorage.clear();
     stubInsecureCrypto();
     const onRecoveryScopeChange = vi.fn();
@@ -1450,7 +1453,8 @@ describe("GatewayBrowserClient", () => {
 
     await vi.waitFor(() => expect(onRecoveryScopeChange).toHaveBeenCalledOnce());
     expect(connectFrame.params?.auth).toBeUndefined();
-    expect(connectFrame.params?.device).toBeUndefined();
+    // Pure-JS signing keeps device identity available even without crypto.subtle.
+    expect(connectFrame.params?.device?.id).toBe("device-1");
     expect(client.recoveryScope).toBe("gateway-recovery-scope");
     expect(client.recoveryScopeReady).toBe(true);
     client.stop();
@@ -1625,7 +1629,7 @@ describe("GatewayBrowserClient", () => {
     });
   });
 
-  it("sends explicit shared token on insecure first connect without cached device fallback", async () => {
+  it("attaches device identity alongside an explicit shared token on an insecure context", async () => {
     stubInsecureCrypto();
     const client = new GatewayBrowserClient({
       url: "ws://gateway.example:18789",
@@ -1641,11 +1645,11 @@ describe("GatewayBrowserClient", () => {
       password: undefined,
       deviceToken: undefined,
     });
-    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
-    expect(signDevicePayloadMock).not.toHaveBeenCalled();
+    expect(connectFrame.params?.device?.id).toBe("device-1");
+    expect(signDevicePayloadMock).toHaveBeenCalled();
   });
 
-  it("sends explicit shared password on insecure first connect without cached device fallback", async () => {
+  it("attaches device identity alongside an explicit shared password on an insecure context", async () => {
     stubInsecureCrypto();
     const client = new GatewayBrowserClient({
       url: "ws://gateway.example:18789",
@@ -1661,8 +1665,8 @@ describe("GatewayBrowserClient", () => {
       password: "shared-password", // pragma: allowlist secret
       deviceToken: undefined,
     });
-    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
-    expect(signDevicePayloadMock).not.toHaveBeenCalled();
+    expect(connectFrame.params?.device?.id).toBe("device-1");
+    expect(signDevicePayloadMock).toHaveBeenCalled();
   });
 
   it("uses cached device tokens only when no explicit shared auth is provided", async () => {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -440,7 +440,7 @@ export class GatewayBrowserClient {
     const deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null =
       await loadOrCreateDeviceIdentity().catch(() => null);
     this.client.recordTiming("device-identity-ready", generation, undefined, {
-      secureContext: typeof window !== "undefined" && window.isSecureContext === true,
+      secureContext: typeof window !== "undefined" && window.isSecureContext,
       hasDeviceIdentity: deviceIdentity !== null,
     });
     if (deviceIdentity) {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -431,8 +431,9 @@ export class GatewayBrowserClient {
 
     // Device identity signs with pure-JS Ed25519, so it works on any origin,
     // including plain-HTTP LAN dashboards where crypto.subtle is unavailable.
-    // Blocked storage (for example some private-browsing modes) degrades to a
-    // device-less connect instead of failing the handshake.
+    // Blocked storage yields an ephemeral in-memory identity; only a failed
+    // mint (no WebCrypto RNG) degrades to a device-less connect instead of
+    // failing the handshake.
     let selectedAuth: GatewayConnectAuthSelection = {
       authToken: explicitGatewayToken,
       authPassword: explicitPassword,

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -429,21 +429,21 @@ export class GatewayBrowserClient {
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;
 
-    // crypto.subtle is only available in secure contexts (HTTPS, localhost).
-    // Token/password auth cannot replace browser device identity over plain HTTP.
-    const isSecureContext = typeof crypto !== "undefined" && Boolean(crypto.subtle);
-    let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
+    // Device identity signs with pure-JS Ed25519, so it works on any origin,
+    // including plain-HTTP LAN dashboards where crypto.subtle is unavailable.
+    // Blocked storage (for example some private-browsing modes) degrades to a
+    // device-less connect instead of failing the handshake.
     let selectedAuth: GatewayConnectAuthSelection = {
       authToken: explicitGatewayToken,
       authPassword: explicitPassword,
     };
-
-    if (isSecureContext) {
-      deviceIdentity = await loadOrCreateDeviceIdentity();
-      this.client.recordTiming("device-identity-ready", generation, undefined, {
-        secureContext: true,
-        hasDeviceIdentity: true,
-      });
+    const deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null =
+      await loadOrCreateDeviceIdentity().catch(() => null);
+    this.client.recordTiming("device-identity-ready", generation, undefined, {
+      secureContext: typeof window !== "undefined" && window.isSecureContext === true,
+      hasDeviceIdentity: deviceIdentity !== null,
+    });
+    if (deviceIdentity) {
       selectedAuth = this.selectConnectAuth({
         role,
         deviceId: deviceIdentity.deviceId,

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -72,6 +72,11 @@ export class GatewayRequestError extends GatewayProtocolRequestError {
   }
 }
 
+function browserSecureContext(): boolean {
+  const win = typeof window !== "undefined" ? window : undefined;
+  return win?.isSecureContext === true;
+}
+
 function isLoopbackIPv4Host(host: string): boolean {
   const octets = host.split(".");
   return (
@@ -399,7 +404,8 @@ export class GatewayBrowserClient {
 
   private connectPlanTimingPayload(plan: ConnectPlan): Partial<GatewayConnectTiming> {
     return {
-      secureContext: Boolean(plan.deviceIdentity),
+      // Device identity no longer implies a secure context; report the real fact.
+      secureContext: browserSecureContext(),
       hasDeviceIdentity: Boolean(plan.deviceIdentity),
       hasDevice: Boolean(plan.params.device),
       hasAuthToken: Boolean(plan.selectedAuth.authToken),
@@ -441,7 +447,7 @@ export class GatewayBrowserClient {
     const deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null =
       await loadOrCreateDeviceIdentity().catch(() => null);
     this.client.recordTiming("device-identity-ready", generation, undefined, {
-      secureContext: typeof window !== "undefined" && window.isSecureContext,
+      secureContext: browserSecureContext(),
       hasDeviceIdentity: deviceIdentity !== null,
     });
     if (deviceIdentity) {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -404,7 +404,6 @@ export class GatewayBrowserClient {
 
   private connectPlanTimingPayload(plan: ConnectPlan): Partial<GatewayConnectTiming> {
     return {
-      // Device identity no longer implies a secure context; report the real fact.
       secureContext: browserSecureContext(),
       hasDeviceIdentity: Boolean(plan.deviceIdentity),
       hasDevice: Boolean(plan.params.device),
@@ -435,26 +434,20 @@ export class GatewayBrowserClient {
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;
 
-    // Device identity signs with pure-JS Ed25519, so it works on any origin,
-    // including plain-HTTP LAN dashboards where crypto.subtle is unavailable.
-    // Blocked storage yields an ephemeral in-memory identity; only a failed
-    // mint (no WebCrypto RNG) degrades to a device-less connect instead of
-    // failing the handshake.
+    // Pure-JS Ed25519 signing keeps device identity working on any origin,
+    // including plain-HTTP dashboards without crypto.subtle; only a failed
+    // mint (no WebCrypto RNG) degrades to a device-less connect.
     let selectedAuth: GatewayConnectAuthSelection = {
       authToken: explicitGatewayToken,
       authPassword: explicitPassword,
     };
-    const deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null =
-      await loadOrCreateDeviceIdentity().catch(() => null);
+    const deviceIdentity = await loadOrCreateDeviceIdentity().catch(() => null);
     this.client.recordTiming("device-identity-ready", generation, undefined, {
       secureContext: browserSecureContext(),
       hasDeviceIdentity: deviceIdentity !== null,
     });
     if (deviceIdentity) {
-      selectedAuth = this.selectConnectAuth({
-        role,
-        deviceId: deviceIdentity.deviceId,
-      });
+      selectedAuth = this.selectConnectAuth({ role, deviceId: deviceIdentity.deviceId });
     }
     const scopes = resolveGatewayConnectScopes({
       requestedScopes: selectedAuth.authBootstrapToken

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -413,11 +413,40 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     }
   });
 
-  it("shows manual repair guidance without a signed browser device", async () => {
+  it("offers the admin upgrade without crypto.subtle", async () => {
     const context = await createContext();
     const page = await context.newPage();
     await page.addInitScript(() => {
       Object.defineProperty(globalThis.crypto, "subtle", {
+        configurable: true,
+        value: undefined,
+      });
+    });
+    const gateway = await installMockGateway(page, {
+      operatorScopes: LIMITED_SCOPES,
+      methodResponses: {
+        "device.scopes.requestUpgrade": { requestId: "upgrade-insecure" },
+      },
+    });
+
+    await page.goto(`${server.baseUrl}chat`);
+    // Pure-JS Ed25519 signs the device connect on insecure contexts, so the
+    // explicit upgrade path stays available instead of manual-only guidance.
+    await page.getByRole("button", { name: "Request admin" }).waitFor();
+    expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(0);
+  });
+
+  it("shows manual repair guidance when the browser cannot mint a device identity", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      // Without a WebCrypto RNG the identity mint fails and the client
+      // degrades to a device-less connect that cannot sign upgrade requests.
+      Object.defineProperty(globalThis.crypto, "subtle", {
+        configurable: true,
+        value: undefined,
+      });
+      Object.defineProperty(globalThis.crypto, "getRandomValues", {
         configurable: true,
         value: undefined,
       });

--- a/ui/src/lib/nodes/device-identity.insecure-context.test.ts
+++ b/ui/src/lib/nodes/device-identity.insecure-context.test.ts
@@ -51,6 +51,43 @@ describe("device identity on an insecure context", () => {
     ).resolves.toBe(true);
   });
 
+  it("keeps one stable identity per page lifetime when storage is blocked", async () => {
+    // The suite's default RNG stub is deterministic, which would mint identical
+    // keys and mask churn; every draw must differ for this regression to bite.
+    let draw = 0;
+    vi.stubGlobal("crypto", {
+      getRandomValues: (array: Uint8Array) => {
+        draw += 1;
+        for (let i = 0; i < array.length; i += 1) {
+          array[i] = (i * 37 + draw) % 256;
+        }
+        return array;
+      },
+    });
+    vi.stubGlobal("localStorage", undefined);
+    vi.resetModules();
+    const cold = await import("./index.ts");
+
+    const first = await cold.loadOrCreateDeviceIdentity();
+    const second = await cold.loadOrCreateDeviceIdentity();
+    expect(first.deviceId).toMatch(/^[0-9a-f]{64}$/);
+    expect(second.deviceId).toBe(first.deviceId);
+  });
+
+  it("still mints an identity when the store rejects writes", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    });
+    vi.resetModules();
+    const cold = await import("./index.ts");
+
+    const identity = await cold.loadOrCreateDeviceIdentity();
+    expect(identity.deviceId).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it("resolves the SHA-512 provider without crypto.subtle", async () => {
     expect(typeof hashes.sha512Async).toBe("function");
     const digest = await hashes.sha512Async?.(new Uint8Array([1, 2, 3]));

--- a/ui/src/lib/nodes/device-identity.insecure-context.test.ts
+++ b/ui/src/lib/nodes/device-identity.insecure-context.test.ts
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+// Plain-HTTP origins have no crypto.subtle; device identity must still mint,
+// fingerprint, and sign with the pure-JS paths so pairing works everywhere.
+import { hashes, verifyAsync } from "@noble/ed25519";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadOrCreateDeviceIdentity, signDevicePayload } from "./index.ts";
+
+function base64UrlDecode(value: string): Uint8Array {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const binary = atob(normalized);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+describe("device identity on an insecure context", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    // Real insecure contexts keep getRandomValues; only crypto.subtle is gated.
+    vi.stubGlobal("crypto", {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i += 1) {
+          array[i] = (i * 37 + 11) % 256;
+        }
+        return array;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("mints, persists, and signs a device identity without crypto.subtle", async () => {
+    expect(globalThis.crypto.subtle).toBeUndefined();
+
+    const identity = await loadOrCreateDeviceIdentity();
+    expect(identity.deviceId).toMatch(/^[0-9a-f]{64}$/);
+
+    // The identity round-trips from storage with a stable id.
+    const reloaded = await loadOrCreateDeviceIdentity();
+    expect(reloaded.deviceId).toBe(identity.deviceId);
+
+    const payload = "insecure-context-payload";
+    const signature = await signDevicePayload(identity.privateKey, payload);
+    await expect(
+      verifyAsync(
+        base64UrlDecode(signature),
+        new TextEncoder().encode(payload),
+        base64UrlDecode(identity.publicKey),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("resolves the SHA-512 provider without crypto.subtle", async () => {
+    expect(typeof hashes.sha512Async).toBe("function");
+    const digest = await hashes.sha512Async?.(new Uint8Array([1, 2, 3]));
+    expect(digest).toHaveLength(64);
+  });
+});

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -931,6 +931,11 @@ async function generateIdentity(): Promise<DeviceIdentity> {
   };
 }
 
+// Storage-blocked pages (for example private browsing) must still present one
+// stable device per page lifetime; minting a fresh key on every reconnect
+// would raise a new unpaired request each time and never retain approval.
+let sessionDeviceIdentity: DeviceIdentity | null = null;
+
 export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
   const storage = getSafeLocalStorage();
   try {
@@ -967,6 +972,9 @@ export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
     // Invalid local identity is replaced below.
   }
 
+  if (sessionDeviceIdentity) {
+    return sessionDeviceIdentity;
+  }
   const identity = await generateIdentity();
   const stored: StoredIdentity = {
     version: 1,
@@ -975,7 +983,12 @@ export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
     privateKey: identity.privateKey,
     createdAtMs: Date.now(),
   };
-  storage?.setItem(DEVICE_IDENTITY_STORAGE_KEY, JSON.stringify(stored));
+  try {
+    storage?.setItem(DEVICE_IDENTITY_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // A write-rejecting store still gets the in-memory identity below.
+  }
+  sessionDeviceIdentity = identity;
   return identity;
 }
 

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -1,7 +1,7 @@
 // Presentation-free by contract: confirmations and secret reveals belong to the owning
 // page, because native window.confirm/window.prompt silently answer in webviews with no
 // dialog bridge and would end the action with no outcome and no recorded reason.
-import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
+import { getPublicKeyAsync, hashes, signAsync, utils } from "@noble/ed25519";
 import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
@@ -14,6 +14,19 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import { cloneConfigObject, removePathValue, setPathValue } from "../config-form-utils.ts";
 // Shared Nodes operations used by the Control UI page and Gateway event hooks.
 import { formatUiError } from "../format-error.ts";
+
+// @noble/ed25519 defaults its SHA-512 to crypto.subtle, which browsers gate to
+// secure contexts. On plain-HTTP origins the pure-JS digests load lazily so
+// device identity keeps working there — the signing key is the one credential
+// that never crosses the wire — while secure contexts pay no startup bytes.
+const loadPureSha2 = () => import("@noble/hashes/sha2.js");
+const subtleSha512Async = hashes.sha512Async;
+hashes.sha512Async = async (message: Uint8Array) => {
+  if (globalThis.crypto?.subtle && subtleSha512Async) {
+    return await subtleSha512Async(message);
+  }
+  return (await loadPureSha2()).sha512(message);
+};
 
 type GatewayRequestClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
@@ -897,8 +910,14 @@ function bytesToHex(bytes: Uint8Array): string {
 }
 
 async function fingerprintPublicKey(publicKey: Uint8Array): Promise<string> {
-  const hash = await crypto.subtle.digest("SHA-256", publicKey.slice().buffer);
-  return bytesToHex(new Uint8Array(hash));
+  // Prefer the platform digest where the context provides it; the pure-JS
+  // fallback keeps identity working on plain-HTTP origins without subtle.
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle) {
+    const hash = await subtle.digest("SHA-256", publicKey.slice().buffer);
+    return bytesToHex(new Uint8Array(hash));
+  }
+  return bytesToHex((await loadPureSha2()).sha256(publicKey));
 }
 
 async function generateIdentity(): Promise<DeviceIdentity> {


### PR DESCRIPTION
## What Problem This Solves

Control UI device identity silently vanished on plain-HTTP origins. `@noble/ed25519` defaults its SHA-512 provider to `crypto.subtle`, which browsers gate to secure contexts, so an `http://<lan-ip>:18789` dashboard could not mint or sign a device identity. The connect path then explicitly skipped device identity on insecure contexts and fell back to shared-credential auth with a Gateway-owned recovery scope — no pairing row, no durable per-device grants, and the operator-facing docs claimed a secure context was required for pairing.

## Why This Change Was Made

The device signing key is the one credential that never crosses the wire (only nonce-bound signatures do), so HTTP + device pairing is strictly *stronger* than the old HTTP + token-only fallback — there was no security reason to keep the gate. The pure-JS digests already exist in the dependency tree's family (`@noble/hashes`, same author as the Ed25519 lib, which documents this exact wiring for non-subtle environments):

- `ui/src/lib/nodes/index.ts` wires `hashes.sha512Async` to prefer the platform digest and lazily import the pure-JS `sha512` only when `crypto.subtle` is absent; `fingerprintPublicKey` gets the same subtle-first/pure-JS-fallback shape for SHA-256.
- `ui/src/api/gateway.ts` drops the `isSecureContext` gate: every origin now loads/attaches a device identity, with blocked storage (some private-browsing modes) degrading to a device-less connect instead of failing the handshake.
- The fallback stays out of the startup bundle: `@noble/hashes` is deliberately excluded from the `gateway-runtime` startup chunk and loads as its own ~5.3 KiB lazy chunk only on insecure contexts. Perf gate passes: startup 334,789 B vs baseline 335,452 B (+1,056 tolerance) — net *under* baseline.

## User Impact

A LAN dashboard over plain HTTP now behaves like any other browser: it mints a device identity, raises a pairing request, and after one-time approval gets durable per-device scopes. Docs (`docs/web/control-ui.md`, `docs/gateway/security/index.md`, `docs/gateway/trusted-proxy-auth.md`) now describe this instead of claiming a secure context is required; HTTPS (Tailscale Serve) remains the recommendation for transport privacy since tokens/passwords still travel cleartext on HTTP.

## Evidence

- New regression suite `ui/src/lib/nodes/device-identity.insecure-context.test.ts` (jsdom, crypto stub without `subtle` but with `getRandomValues`, matching real insecure contexts): mints a 64-hex device id, round-trips storage, signature verifies via `verifyAsync`; SHA-512 provider resolves without subtle. **Fails on pre-fix code (2/2), passes post-fix.**
- `ui/src/api/gateway.node.test.ts` insecure-context tests rewritten: the connect frame now carries `device.id` and the signer is invoked on insecure contexts.
- Focused run post-rebase: `node scripts/run-vitest.mjs ui/src/lib/nodes/device-identity.insecure-context.test.ts ui/src/api/gateway.node.test.ts ui/src/lib/nodes/device-token.test.ts` → 3 files, 95 tests passed. Full UI suite (629 files) passed pre-rebase; `pnpm build` + `node scripts/ui.js build` green; Control UI perf gate green.
- **Live proof** (real Chromium via Playwright against a LAN-bound dev gateway on `http://10.21.40.134:29447`, isolated state dir, token auth): `window.isSecureContext === false`, `crypto.subtle` absent; identity minted in `localStorage`; pairing request raised; approved via `openclaw devices approve <id>` on the host; reload → fully connected dashboard. Device row shows all operator scopes granted.

Pairing card on the plain-HTTP origin (pre-approval):

![pairing required over HTTP](https://github.com/user-attachments/assets/1d961534-ee3d-4e37-95a7-39d9735adddf)

Connected dashboard after one-time CLI approval, same HTTP origin:

![connected dashboard over HTTP](https://github.com/user-attachments/assets/3b2928b5-c73b-4469-b6ec-05a0deb7c333)

Codex autoreview (`--mode branch --base origin/main`): clean, "patch is correct (0.98)", no accepted/actionable findings.

## Review findings addressed (ClawSweeper 82300d8)

**[P1] Trusted-proxy admission — accepted contract change, documented and covered.** Plain-HTTP trusted-proxy browsers previously slipped through the missing-device bypass into a device-less session: cleared scopes, "limited access" banner, and no upgrade path (a dead-end). With this PR they attach an identity and follow the same pairing flow HTTPS trusted-proxy deployments already live with today: automatic approval when `gateway.auth.trustedProxy.deviceAutoApprove` is enabled (the config designed for exactly this), otherwise a visible one-time approval with recorded pending state. The default-policy server boundary is already covered on `main` by `src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts` ("leaves trusted-proxy pairing unchanged when auto-approval is disabled": pairing-required error + recorded pending request), which plain-HTTP connects now join — no silent failure. Device-less admission remains for browsers that cannot mint an identity at all. `docs/gateway/trusted-proxy-auth.md` and `docs/gateway/security/index.md` now state this contract explicitly.

**[P1] Storage-blocked identity churn — fixed.** `loadOrCreateDeviceIdentity` now keeps one stable in-memory identity per page lifetime when storage is unavailable, and a write-rejecting store no longer fails the mint. Both regression tests fail pre-fix.

**[P2] secureContext timing fact — fixed.** Both timing sites now report the real `window.isSecureContext` via a shared `browserSecureContext()` helper instead of inferring it from device-identity presence.

**[low] @noble/hashes dependency review — verified.** Exact-pinned 2.2.0; zero runtime dependencies; no install scripts; author Paul Miller (same as the already-shipped `@noble/ed25519`, which documents this exact `hashes.sha512Async` wiring for non-subtle environments); published via GitHub Actions OIDC with a registry provenance attestation (`registry.npmjs.org/-/npm/v1/attestations/@noble%2fhashes@2.2.0`); registry tarball sha512 recomputed locally and it matches the `pnpm-lock.yaml` integrity exactly (`sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==`).
