### PR TITLE
fix(ci): prevent healthy Crabbox readiness checks from timing out

### DIFF
--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -54,9 +54,6 @@ type DoctorResult = { ok: boolean; provider: string; checks: DoctorCheck[] };
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CRABBOX_METADATA_PROBE_TIMEOUT_MS = 5_000;
-// Crabbox gives a provider doctor check 10s; the wrapper must outlive that
-// contract or it can kill a valid diagnostic before Crabbox reports readiness.
-const CRABBOX_DOCTOR_TIMEOUT_MS = 15_000;
 const MAX_TIMING_JSON_LINE_CHARS = 1024 * 1024;
 const REMOTE_CHANGED_GATE_BUNDLE_FILE = ".openclaw-crabbox-changed-gate.bundle";
 // A cold Crabbox (first call after an upgrade, or one on a loaded machine) can
@@ -439,7 +436,7 @@ function buildBatchCommandLine(command: string, commandArgs: string[]) {
 function checkedOutput(
   command: string,
   commandArgs: string[],
-  timeoutMs = resolveMetadataProbeTimeoutMs(process.env),
+  timeoutMs: number | null = resolveMetadataProbeTimeoutMs(process.env),
 ) {
   const invocation = spawnInvocation(command, commandArgs, process.env, process.platform);
   const result = spawnSync(invocation.command, invocation.args, {
@@ -447,7 +444,7 @@ function checkedOutput(
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    timeout: timeoutMs,
+    ...(timeoutMs === null ? {} : { timeout: timeoutMs }),
     killSignal: "SIGKILL",
   });
   const timedOut = result.error?.name === "Error" && result.signal === "SIGKILL";
@@ -874,7 +871,8 @@ function crabboxProviderReadiness(provider: string, version: string, context: Ta
     doctorArgs.push("--windows-mode", context.windowsMode);
   }
   doctorArgs.push("--json");
-  const doctor = checkedOutput(binary, doctorArgs, CRABBOX_DOCTOR_TIMEOUT_MS);
+  // Crabbox owns the provider deadlines; wait for it to serialize the final stdout document.
+  const doctor = checkedOutput(binary, doctorArgs, null);
   const result = parseDoctorResult(doctor.stdout, canonicalProvider, doctor.status);
   const managed = ["aws", "azure", "daytona"].includes(canonicalProvider);
   const broker = result?.checks.find((check) => check.check === "broker");

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -107,6 +107,7 @@ async function main() {
   if (args[0] === "run" && args[1] === "--help") { process.stdout.write(helpText); return; }
   if (args[0] === "doctor") {
     const provider = optionValue("provider"); const target = optionValue("target"); const windowsMode = optionValue("windows-mode");
+    if (process.env.OPENCLAW_FAKE_CRABBOX_DOCTOR_PROGRESS) process.stderr.write(process.env.OPENCLAW_FAKE_CRABBOX_DOCTOR_PROGRESS + "\n");
     await wait(Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_DOCTOR_DELAY_MS || "0", 10));
     if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_DOCTOR_TARGET && target !== process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_DOCTOR_TARGET) { process.stderr.write("doctor target mismatch: got=" + target + "\n"); process.exit(64); }
     if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_DOCTOR_WINDOWS_MODE && windowsMode !== process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_DOCTOR_WINDOWS_MODE) { process.stderr.write("doctor windows mode mismatch: got=" + windowsMode + "\n"); process.exit(64); }
@@ -1201,14 +1202,17 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("aws");
   });
 
-  it("allows a provider-scoped doctor to use its full dependency timeout", () => {
+  it("lets doctor own its timeout and parses machine output from stdout", () => {
     const { output } = runSuccessfulBrokerWrapper(["run", "--provider", "aws", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_DOCTOR_DELAY_MS: "5500" },
-      timeoutMs: 20_000,
+      env: {
+        OPENCLAW_FAKE_CRABBOX_DOCTOR_DELAY_MS: "250",
+        OPENCLAW_FAKE_CRABBOX_DOCTOR_PROGRESS: "checking provider readiness",
+      },
+      nodePreload: testTimingPreload({ spawnTimeoutMs: 100 }),
     });
 
     expect(output.args).toContain("aws");
-  }, 20_000);
+  });
 
   it("probes native Windows readiness with the requested target context", () => {
     const { output, result } = runSuccessfulBrokerWrapper(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where direct AWS readiness could false-fail as `invalid doctor JSON` when a healthy `crabbox doctor --provider aws --target linux --json` needed more than 15 seconds to complete. The doctor process was killed before it could serialize its valid final stdout JSON.

## Why This Change Was Made

The wrapper no longer imposes a duplicate process deadline on provider doctor checks and instead lets Crabbox own provider deadlines and final JSON serialization. Stdout-only JSON parsing, schema and status validation, broker checks, provider selection, and all readiness policy remain unchanged. The duplicate wrapper timeout came from https://github.com/openclaw/openclaw/pull/119700; this patch removes only that competing deadline.

## User Impact

Operators can run AWS-backed changed-file and live proof without healthy readiness checks false-failing solely because doctor takes over 15 seconds. This does not weaken provider policy or readiness validation.

## Evidence

AI-assisted; I understand and reviewed the change.

- Focused regression: `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts` — 239/239 passed. It emits stderr progress, delays the final stdout JSON, and caps only child calls that pass a timeout, proving doctor now waits for Crabbox.
- Live direct AWS one-shot wrapper run — provider `aws`, lease `cbx_ed932b5a2ee6`, run `run_47b958bab036`, remote output `openclaw-crabbox-live-ok`, exit 0, `leaseStopped:true`: https://crabbox.openclaw.ai/portal/runs/run_47b958bab036
- Complete AWS-pinned changed-file gate: `CRABBOX_PROVIDER=aws node scripts/check-changed.mjs -- scripts/crabbox-wrapper.mts test/scripts/crabbox-wrapper.test.ts` — provider `aws`, lease `cbx_08f2a4ce81ca`, run `run_c548ee58c256`, all prescribed format/type/lint/guards passed, exit 0, `leaseStopped:true`: https://crabbox.openclaw.ai/portal/runs/run_c548ee58c256
- Structured autoreview: clean, with no accepted/actionable findings.
- `git diff --check`: clean.
- Production/tooling LOC: +4/-6 (net -2). Tests: +8/-4 (net +4).
