### PR TITLE
fix(gateway): gate session.tool mirrors behind session subscriptions

### DIFF
--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -164,6 +164,38 @@ describe("collaboration event scope guards", () => {
     expect(unsubscribed.socket.events).toEqual([]);
   });
 
+  it("suppresses session.tool mirrors for scoped clients without a matching subscription", () => {
+    const subscribed = makeClient("subscribed", "operator", ["operator.read"]);
+    const otherSession = makeClient("other-session", "operator", ["operator.read"]);
+    const unscoped = makeClient("unscoped", "operator", ["operator.read"]);
+    for (const entry of [subscribed, otherSession]) {
+      entry.client.connect.caps = [GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS];
+    }
+    const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
+    sessionMessageSubscribers.subscribe(subscribed.client.connId, "agent:main:main");
+    sessionMessageSubscribers.subscribe(otherSession.client.connId, "agent:main:other");
+    const { broadcastToConnIds } = createGatewayBroadcaster({
+      clients: new Set([subscribed.client, otherSession.client, unscoped.client]),
+      sessionMessageSubscribers,
+    });
+
+    // Mirrors the server-chat session.tool fanout: targeted at all session
+    // subscribers, session identity carried in the payload.
+    broadcastToConnIds(
+      "session.tool",
+      { sessionKey: "agent:main:main", tool: { name: "exec", args: { command: "ls" } } },
+      new Set(["subscribed", "other-session", "unscoped"]),
+      { dropIfSlow: true },
+    );
+
+    expect(subscribed.socket.events).toEqual(["session.tool"]);
+    // The scoped client subscribed to a different session must not receive
+    // another session's tool args via the mirror event.
+    expect(otherSession.socket.events).toEqual([]);
+    // Unscoped Control UI clients keep full fanout.
+    expect(unscoped.socket.events).toEqual(["session.tool"]);
+  });
+
   it("delivers prepared global observer audiences exactly once", () => {
     const main = makeClient("main", "operator", ["operator.read"]);
     const legacy = makeClient("legacy", "operator", ["operator.read"]);

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -99,6 +99,10 @@ const SESSION_SUBSCRIPTION_EVENTS = new Set([
   "chat",
   "chat.side_result",
   "session.observer",
+  // Mirrors the raw agent tool event (full args/result snapshots) onto
+  // session subscribers; omitting it here would hand scoped clients the
+  // exact payload the registry gate suppresses on the `agent` event.
+  "session.tool",
 ]);
 
 function serializeFrameField(name: "payload" | "stateVersion", value: unknown): string {


### PR DESCRIPTION
## What Problem This Solves

`session.tool` mirrors the raw agent tool event — full tool args and result snapshots — onto session subscribers so operator UIs attaching mid-run can render live tool cards. But the event name was missing from `SESSION_SUBSCRIPTION_EVENTS`, the allowlist that scopes session-bearing broadcasts for clients with the session-scoped-events cap (and browser copilot clients). A scoped client subscribed to one session's messages therefore received **every** session's tool payloads through the mirror — the exact data the registry gate correctly suppresses on the raw `agent` event. The gate's own comment promises "opt-in scoped clients never receive session-bearing broadcasts without an authoritative registry key"; `session.observer` was added to the set for precisely this mirror-event class, and `session.tool` carries strictly more data.

## Why This Change Was Made

Root cause: the gate is an allowlist and the newer mirror event never joined it. The fix is one set entry with an invariant comment. The payload already carries `sessionKey` (server-chat spreads it into `agentPayload`), so `resolveBroadcastSessionScope` keys the registry check without any producer change, and unscoped Control UI clients keep full fanout per the existing design.

## User Impact

Session-scoped clients (browser copilot, cap-gated integrations) no longer see tool arguments and results from sessions they did not subscribe to. No change for regular Control UI clients.

## Evidence

- New regression in `src/gateway/server-broadcast.board.test.ts` drives the server-chat-style targeted `session.tool` fanout: scoped client subscribed to the same session receives it, scoped client on a different session receives nothing, unscoped client keeps full fanout — fails pre-fix (cross-session leak).
- `node scripts/run-vitest.mjs run src/gateway/server-broadcast.board.test.ts src/gateway/server-chat.agent-events.test.ts` — 161 tests pass.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +4 −0 (set entry + comment), test +32.
