### PR TITLE
fix: large Telegram videos lose width/height and play with a wrong aspect ratio

### DIFF
--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -12,6 +12,23 @@ vi.mock("./ffmpeg-exec.js", () => ({
   runFfprobe,
 }));
 
+// Lets timing tests simulate the wall-clock cost of staging the retry file.
+const stagingHook = vi.hoisted(() => ({ onWrite: null as null | (() => void) }));
+
+vi.mock("../infra/private-temp-workspace.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../infra/private-temp-workspace.js")>();
+  const withTempWorkspace: typeof real.withTempWorkspace = async (options, fn) =>
+    await real.withTempWorkspace(options, async (workspace) => {
+      const originalWrite = workspace.write.bind(workspace);
+      workspace.write = async (name, data) => {
+        stagingHook.onWrite?.();
+        return await originalWrite(name, data);
+      };
+      return await fn(workspace);
+    });
+  return { ...real, withTempWorkspace };
+});
+
 let testDir = "";
 let songPath = "";
 let clipPath = "";
@@ -46,6 +63,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   runFfprobe.mockReset();
+  stagingHook.onWrite = null;
 });
 
 async function probeMediaFile(filePath: string, kind: MediaProbeKind): Promise<MediaProbeResult> {
@@ -324,7 +342,7 @@ describe("probeVideoDimensions", () => {
     await expect(fs.access(path.dirname(failedPath))).rejects.toThrow();
   });
 
-  it("carries the remaining probe budget into the temp-file retry", async () => {
+  it("carries the deadline remainder after staging into the temp-file retry", async () => {
     const buffer = Buffer.from("slow pipe video");
     let now = 1_000_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -333,13 +351,37 @@ describe("probeVideoDimensions", () => {
         now += 4000;
         throw new Error("pipe:0: Invalid data found when processing input");
       });
+      stagingHook.onWrite = () => {
+        now += 2000;
+      };
       runFfprobe.mockResolvedValueOnce(
         JSON.stringify({ streams: [{ codec_type: "video", width: 640, height: 480 }] }),
       );
 
       await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 640, height: 480 });
       expect(runFfprobe).toHaveBeenCalledTimes(2);
-      expect(runFfprobe).toHaveBeenLastCalledWith(expect.any(Array), { timeoutMs: 6000 });
+      // 10s budget - 4s pipe probe - 2s staging = 4s left for the retry.
+      expect(runFfprobe).toHaveBeenLastCalledWith(expect.any(Array), { timeoutMs: 4000 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("skips the file probe when staging exhausts the shared deadline", async () => {
+    const buffer = Buffer.from("slow staging video");
+    let now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      runFfprobe.mockImplementationOnce(async () => {
+        now += 4000;
+        throw new Error("pipe:0: Invalid data found when processing input");
+      });
+      stagingHook.onWrite = () => {
+        now += 7000;
+      };
+
+      await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+      expect(runFfprobe).toHaveBeenCalledTimes(1);
     } finally {
       nowSpy.mockRestore();
     }

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -315,9 +315,51 @@ describe("probeVideoDimensions", () => {
     });
 
     await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
-    expect(filePaths).toHaveLength(1);
-    await expect(fs.access(filePaths[0])).rejects.toThrow();
-    await expect(fs.access(path.dirname(filePaths[0]))).rejects.toThrow();
+    const failedPath = filePaths[0];
+    expect(failedPath).toBeDefined();
+    if (!failedPath) {
+      return;
+    }
+    await expect(fs.access(failedPath)).rejects.toThrow();
+    await expect(fs.access(path.dirname(failedPath))).rejects.toThrow();
+  });
+
+  it("carries the remaining probe budget into the temp-file retry", async () => {
+    const buffer = Buffer.from("slow pipe video");
+    let now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      runFfprobe.mockImplementationOnce(async () => {
+        now += 4000;
+        throw new Error("pipe:0: Invalid data found when processing input");
+      });
+      runFfprobe.mockResolvedValueOnce(
+        JSON.stringify({ streams: [{ codec_type: "video", width: 640, height: 480 }] }),
+      );
+
+      await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 640, height: 480 });
+      expect(runFfprobe).toHaveBeenCalledTimes(2);
+      expect(runFfprobe).toHaveBeenLastCalledWith(expect.any(Array), { timeoutMs: 6000 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("skips the temp-file retry when the pipe probe exhausted the budget", async () => {
+    const buffer = Buffer.from("timed out video");
+    let now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      runFfprobe.mockImplementationOnce(async () => {
+        now += 10_000;
+        throw new Error("ffprobe timed out");
+      });
+
+      await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+      expect(runFfprobe).toHaveBeenCalledTimes(1);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("keeps concurrent fallback probes isolated in separate workspaces", async () => {

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -277,35 +277,72 @@ describe("probeVideoDimensions", () => {
 
   it("falls back to a seekable temp file when the pipe probe yields no dimensions", async () => {
     const buffer = Buffer.from("moov-at-end video");
+    let probed: { args: string[]; content: Buffer } | undefined;
     runFfprobe.mockRejectedValueOnce(new Error("pipe:0: Invalid data found when processing input"));
-    runFfprobe.mockResolvedValueOnce(
-      JSON.stringify({ streams: [{ codec_type: "video", width: 1920, height: 1080 }] }),
-    );
+    runFfprobe.mockImplementationOnce(async (args: string[]) => {
+      probed = { args, content: await fs.readFile(args.at(-1) as string) };
+      return JSON.stringify({ streams: [{ codec_type: "video", width: 1920, height: 1080 }] });
+    });
 
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 1920, height: 1080 });
     expect(runFfprobe).toHaveBeenCalledTimes(2);
-    expect(runFfprobe).toHaveBeenLastCalledWith(
-      [
-        "-v",
-        "error",
-        "-protocol_whitelist",
-        "fd",
-        "-show_entries",
-        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
-        "-of",
-        "json",
-        "-fd",
-        "0",
-        "fd:",
-      ],
-      { stdinFileDescriptor: expect.any(Number) },
-    );
+    expect(probed?.args).toEqual([
+      "-v",
+      "error",
+      "-protocol_whitelist",
+      "file",
+      "-show_entries",
+      "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
+      "-of",
+      "json",
+      expect.stringContaining("video-probe-"),
+    ]);
+    expect(probed?.content.equals(buffer)).toBe(true);
+    const probedPath = probed?.args.at(-1) as string;
+    await expect(fs.access(probedPath)).rejects.toThrow();
+    await expect(fs.access(path.dirname(probedPath))).rejects.toThrow();
   });
 
-  it("returns undefined when both the pipe and the temp-file probe fail", async () => {
+  it("returns undefined and still cleans up when the temp-file probe fails too", async () => {
     const buffer = Buffer.from("not a video");
-    runFfprobe.mockRejectedValue(new Error("pipe:0: Invalid data found when processing input"));
+    const filePaths: string[] = [];
+    runFfprobe.mockImplementation(async (args: string[]) => {
+      const target = args.at(-1) as string;
+      if (target !== "pipe:0") {
+        filePaths.push(target);
+      }
+      throw new Error("Invalid data found when processing input");
+    });
 
     await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+    expect(filePaths).toHaveLength(1);
+    await expect(fs.access(filePaths[0])).rejects.toThrow();
+    await expect(fs.access(path.dirname(filePaths[0]))).rejects.toThrow();
+  });
+
+  it("keeps concurrent fallback probes isolated in separate workspaces", async () => {
+    const bufferA = Buffer.from("video payload A");
+    const bufferB = Buffer.from("video payload B");
+    runFfprobe.mockImplementation(async (args: string[]) => {
+      const target = args.at(-1) as string;
+      if (target === "pipe:0") {
+        throw new Error("Invalid data found when processing input");
+      }
+      const written = await fs.readFile(target);
+      if (written.equals(bufferA)) {
+        return JSON.stringify({ streams: [{ codec_type: "video", width: 100, height: 200 }] });
+      }
+      if (written.equals(bufferB)) {
+        return JSON.stringify({ streams: [{ codec_type: "video", width: 300, height: 400 }] });
+      }
+      throw new Error(`unexpected probe payload at ${target}`);
+    });
+
+    const [a, b] = await Promise.all([
+      probeVideoDimensions(bufferA),
+      probeVideoDimensions(bufferB),
+    ]);
+    expect(a).toEqual({ width: 100, height: 200 });
+    expect(b).toEqual({ width: 300, height: 400 });
   });
 });

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -274,4 +274,38 @@ describe("probeVideoDimensions", () => {
       { input: buffer },
     );
   });
+
+  it("falls back to a seekable temp file when the pipe probe yields no dimensions", async () => {
+    const buffer = Buffer.from("moov-at-end video");
+    runFfprobe.mockRejectedValueOnce(new Error("pipe:0: Invalid data found when processing input"));
+    runFfprobe.mockResolvedValueOnce(
+      JSON.stringify({ streams: [{ codec_type: "video", width: 1920, height: 1080 }] }),
+    );
+
+    await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 1920, height: 1080 });
+    expect(runFfprobe).toHaveBeenCalledTimes(2);
+    expect(runFfprobe).toHaveBeenLastCalledWith(
+      [
+        "-v",
+        "error",
+        "-protocol_whitelist",
+        "fd",
+        "-show_entries",
+        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
+        "-of",
+        "json",
+        "-fd",
+        "0",
+        "fd:",
+      ],
+      { stdinFileDescriptor: expect.any(Number) },
+    );
+  });
+
+  it("returns undefined when both the pipe and the temp-file probe fail", async () => {
+    const buffer = Buffer.from("not a video");
+    runFfprobe.mockRejectedValue(new Error("pipe:0: Invalid data found when processing input"));
+
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+  });
 });

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { MediaKind } from "@openclaw/media-core/constants";
 import {
   asPositiveSafeInteger as parsePositiveInteger,
@@ -261,5 +263,39 @@ type VideoDimensions = {
 /** Probes a video buffer while preserving the existing public media-runtime API. */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
   const { width, height } = (await probeMediaSource({ kind: "buffer", buffer }, "video")) ?? {};
-  return width && height ? { width, height } : undefined;
+  if (width && height) {
+    return { width, height };
+  }
+  return await probeVideoDimensionsFromTempFile(buffer);
+}
+
+/**
+ * MP4s whose moov atom trails the mdat (and other non-streamable layouts) cannot
+ * be parsed from the non-seekable stdin pipe, so large videos silently lose their
+ * dimensions and Telegram renders them with a wrong aspect ratio (#97826).
+ * Retry from a seekable temp file before degrading to absent fields.
+ */
+async function probeVideoDimensionsFromTempFile(
+  buffer: Buffer,
+): Promise<VideoDimensions | undefined> {
+  let tempDir: string | undefined;
+  try {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-video-probe-"));
+    const tempPath = path.join(tempDir, "probe.bin");
+    await fs.writeFile(tempPath, buffer);
+    const handle = await fs.open(tempPath, "r");
+    try {
+      const { width, height } =
+        (await probeMediaSource({ kind: "fileDescriptor", fd: handle.fd }, "video")) ?? {};
+      return width && height ? { width, height } : undefined;
+    } finally {
+      await handle.close().catch(() => {});
+    }
+  } catch {
+    return undefined;
+  } finally {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
 }

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -279,11 +279,10 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
   }
   // The retry shares one deadline with the pipe probe so a failing video can
   // never delay delivery beyond the single-probe budget.
-  const remainingMs = deadlineMs - Date.now();
-  if (remainingMs <= 0) {
+  if (Date.now() >= deadlineMs) {
     return undefined;
   }
-  return await probeVideoDimensionsFromTempFile(buffer, remainingMs);
+  return await probeVideoDimensionsFromTempFile(buffer, deadlineMs);
 }
 
 /**
@@ -296,13 +295,19 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
  */
 async function probeVideoDimensionsFromTempFile(
   buffer: Buffer,
-  timeoutMs: number,
+  deadlineMs: number,
 ): Promise<VideoDimensions | undefined> {
   try {
     return await withTempWorkspace(
       { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "video-probe-" },
       async (workspace) => {
         const filePath = await workspace.write("probe-input.bin", buffer);
+        // Staging a large buffer costs real time; recompute what is left of the
+        // shared deadline after the write so the probe cannot overrun it.
+        const timeoutMs = deadlineMs - Date.now();
+        if (timeoutMs <= 0) {
+          return undefined;
+        }
         const { width, height } =
           (await probeMediaSource({ kind: "filePath", filePath }, "video", { timeoutMs })) ?? {};
         return width && height ? { width, height } : undefined;

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -8,6 +8,7 @@ import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/rec
 import { withTempWorkspace } from "../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
+import { MEDIA_FFPROBE_TIMEOUT_MS } from "./ffmpeg-limits.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
 
@@ -271,11 +272,18 @@ type VideoDimensions = {
 
 /** Probes a video buffer while preserving the existing public media-runtime API. */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
+  const deadlineMs = Date.now() + MEDIA_FFPROBE_TIMEOUT_MS;
   const { width, height } = (await probeMediaSource({ kind: "buffer", buffer }, "video")) ?? {};
   if (width && height) {
     return { width, height };
   }
-  return await probeVideoDimensionsFromTempFile(buffer);
+  // The retry shares one deadline with the pipe probe so a failing video can
+  // never delay delivery beyond the single-probe budget.
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) {
+    return undefined;
+  }
+  return await probeVideoDimensionsFromTempFile(buffer, remainingMs);
 }
 
 /**
@@ -288,6 +296,7 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
  */
 async function probeVideoDimensionsFromTempFile(
   buffer: Buffer,
+  timeoutMs: number,
 ): Promise<VideoDimensions | undefined> {
   try {
     return await withTempWorkspace(
@@ -295,7 +304,7 @@ async function probeVideoDimensionsFromTempFile(
       async (workspace) => {
         const filePath = await workspace.write("probe-input.bin", buffer);
         const { width, height } =
-          (await probeMediaSource({ kind: "filePath", filePath }, "video")) ?? {};
+          (await probeMediaSource({ kind: "filePath", filePath }, "video", { timeoutMs })) ?? {};
         return width && height ? { width, height } : undefined;
       },
     );

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import type { MediaKind } from "@openclaw/media-core/constants";
 import {
   asPositiveSafeInteger as parsePositiveInteger,
   asSafeIntegerInRange,
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { withTempWorkspace } from "../infra/private-temp-workspace.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
@@ -43,7 +43,10 @@ type MediaProbeBatchOptions = {
   maxProbes: number;
 };
 
-type FfprobeSource = { kind: "fileDescriptor"; fd: number } | { kind: "buffer"; buffer: Buffer };
+type FfprobeSource =
+  | { kind: "fileDescriptor"; fd: number }
+  | { kind: "buffer"; buffer: Buffer }
+  | { kind: "filePath"; filePath: string };
 
 function parseDurationMs(value: unknown): number | undefined {
   if (typeof value !== "number" && typeof value !== "string") {
@@ -130,8 +133,7 @@ function parseFfprobeMediaMetadata(
   };
 }
 
-function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
-  const isFileDescriptor = protocol === "fd";
+function buildFfprobeMetadataArgs(protocol: "fd" | "pipe" | "file", filePath?: string): string[] {
   return [
     "-v",
     "error",
@@ -141,8 +143,11 @@ function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
     "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
     "-of",
     "json",
-    ...(isFileDescriptor ? ["-fd", "0"] : []),
-    isFileDescriptor ? "fd:" : "pipe:0",
+    ...(protocol === "fd"
+      ? ["-fd", "0", "fd:"]
+      : protocol === "pipe"
+        ? ["pipe:0"]
+        : [filePath ?? ""]),
   ];
 }
 
@@ -162,15 +167,19 @@ async function probeMediaSource(
   kind: MediaProbeKind,
   options: MediaProbeOptions = {},
 ): Promise<PlaybackMediaProbeResult | null> {
-  const runProbe = async (protocol: "fd" | "pipe") =>
+  const runProbe = async (protocol: "fd" | "pipe" | "file") =>
     await runFfprobe(
-      buildFfprobeMetadataArgs(protocol),
+      buildFfprobeMetadataArgs(protocol, source.kind === "filePath" ? source.filePath : undefined),
       source.kind === "buffer"
         ? { input: source.buffer, ...options }
-        : { stdinFileDescriptor: source.fd, ...options },
+        : source.kind === "fileDescriptor"
+          ? { stdinFileDescriptor: source.fd, ...options }
+          : { ...options },
     );
   try {
-    const stdout = await runProbe(source.kind === "fileDescriptor" ? "fd" : "pipe");
+    const stdout = await runProbe(
+      source.kind === "fileDescriptor" ? "fd" : source.kind === "filePath" ? "file" : "pipe",
+    );
     return parseFfprobeMediaMetadata(stdout, kind);
   } catch (error) {
     if (source.kind === "fileDescriptor" && isMissingFdProtocolError(error)) {
@@ -270,32 +279,27 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
 }
 
 /**
- * MP4s whose moov atom trails the mdat (and other non-streamable layouts) cannot
- * be parsed from the non-seekable stdin pipe, so large videos silently lose their
- * dimensions and Telegram renders them with a wrong aspect ratio (#97826).
- * Retry from a seekable temp file before degrading to absent fields.
+ * Probing a buffer through stdin can fail even for valid videos: ffprobe may
+ * exit before draining the non-seekable pipe (typical once a large MP4's moov
+ * atom is parsed), so the write aborts and dimensions silently go absent —
+ * Telegram then renders the video with a wrong aspect ratio (#97826). Retry
+ * from a seekable file inside the hardened temp workspace before giving up;
+ * a plain path stays seekable even where ffprobe lacks the `fd` protocol.
  */
 async function probeVideoDimensionsFromTempFile(
   buffer: Buffer,
 ): Promise<VideoDimensions | undefined> {
-  let tempDir: string | undefined;
   try {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-video-probe-"));
-    const tempPath = path.join(tempDir, "probe.bin");
-    await fs.writeFile(tempPath, buffer);
-    const handle = await fs.open(tempPath, "r");
-    try {
-      const { width, height } =
-        (await probeMediaSource({ kind: "fileDescriptor", fd: handle.fd }, "video")) ?? {};
-      return width && height ? { width, height } : undefined;
-    } finally {
-      await handle.close().catch(() => {});
-    }
+    return await withTempWorkspace(
+      { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "video-probe-" },
+      async (workspace) => {
+        const filePath = await workspace.write("probe-input.bin", buffer);
+        const { width, height } =
+          (await probeMediaSource({ kind: "filePath", filePath }, "video")) ?? {};
+        return width && height ? { width, height } : undefined;
+      },
+    );
   } catch {
     return undefined;
-  } finally {
-    if (tempDir) {
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
   }
 }


### PR DESCRIPTION
Closes #97826

## What Problem This Solves

Fixes an issue where Telegram recipients of large agent-sent videos would see them stretched or squashed: `sendVideo` went out without `width`/`height`, so clients guessed the aspect ratio. Small videos were unaffected, which made the distortion look random to operators.

## Why This Change Was Made

`probeVideoDimensions()` feeds the video buffer to ffprobe through non-seekable stdin, and any failure on that path silently degrades to "no dimensions". Two failure modes matter here:

1. **Proven (see Evidence):** a container without any ffprobe binary — the docker-slim images don't bundle ffmpeg — makes every probe degrade silently. Filed separately as #125252 since it is the failure we could reproduce end-to-end.
2. **Reported but environment-dependent:** the pipe-probe failure this PR's fallback targets (#97826, also assumed by #113047/#113520). Full transparency: I could **not** reproduce it in any environment I have access to — macOS ffprobe 7.1/8.0, Debian bookworm apt ffmpeg, and a BtbN static build all parse both faststart and trailing-moov MP4s up to 158 MB from a real non-seekable pipe. The fallback is therefore defense-in-depth for the environments where that failure does occur, at zero cost to the healthy path (it only runs when the pipe probe yields nothing).

This change keeps the zero-copy pipe probe as the fast path and, only when it yields no dimensions, retries once from a file inside the hardened temp workspace (`withTempWorkspace` over `resolvePreferredOpenClawTmpDir()`, same pattern as `audio-transcode.ts`). The retry probes by trusted file path, which stays seekable even on ffprobe builds without the `fd` protocol. Both probes share a single `MEDIA_FFPROBE_TIMEOUT_MS` deadline: the retry only receives the remaining budget and is skipped entirely when the pipe probe exhausted it, so a failing video can never delay a Telegram send beyond the pre-existing single-probe budget. No new dependencies, no behavior change when the pipe probe succeeds.

On diff size: the net line growth beyond the fallback itself comes from extending `probeMediaSource` with a third source kind (`filePath`) so the retry reuses the canonical ffprobe argument builder and JSON parsing instead of duplicating them, plus the deadline plumbing above.

Deliberately scoped as a narrow subset of #113520 (same seekable-file idea — credit to its author): it touches only `src/media/media-probe.ts`, so it does not overlap the gateway/webchat rework that PR is blocked on.

## User Impact

Large Telegram videos (up to the Bot API's 50 MB upload cap) now arrive with correct width/height and play undistorted on desktop and mobile. Operators no longer need the send-as-document workaround that preserved the aspect ratio at the cost of inline playback.

## Evidence

- Seven focused unit tests: the fallback engages only when the pipe probe yields no dimensions and the probed temp file contains exactly the caller's bytes; the workspace is removed after success and failure (asserted via `fs.access` rejections); concurrent probes stay isolated in separate workspaces; the retry shares one deadline with the pipe probe and the remainder is **recomputed after staging the file** (4s probe + 2s staging → 4s retry), with skips covered both when the pipe probe and when staging exhaust the deadline. All 17 media-probe tests pass; `oxfmt --check`, oxlint, and `tsgo:core:test` are clean locally.
- **Real-behavior canary (production deployment, real Telegram sends):** I built this branch into an image and sent the same 44 MB MP4 through a live Telegram gateway four ways, then read the stored `video.width/height` back from the Bot API (via the `forwardMessage` response). Results:

  | Send | Build | ffprobe in container | Stored dimensions |
  |---|---|---|---|
  | 1 | current release | absent | 320×320 (wrong — distorted playback) |
  | 2 | this PR branch | absent | 320×320 (expected: no prober available) |
  | 3 | current release | present | 1920×1080 ✓ |
  | 4 | this PR branch | present | 1920×1080 ✓ (no regression) |

  Two honest caveats. First: with ffprobe present, the pipe probe succeeded for this file in this environment (Debian static ffmpeg build), so I could not trigger the pipe-failure live — that failure mode is environment-dependent, as discussed in #97826 and reproduced by others in #113520; the fallback path is covered by the unit tests above. Second, an operator-relevant diagnosis from the same canary run: a container without any ffprobe binary produces exactly the user-visible symptom of this issue (silent 320×320), because `requireSystemBin("ffprobe")` throws and every probe degrades to absent fields. Our own deployment turned out to be in that state (docker-slim images don't bundle ffmpeg). Filed as #125252 with the full evidence.
