### PR TITLE
fix: honor context caps on Codex-routed models

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -255,6 +255,11 @@ agents. Codex compacts through its native app-server thread state, so
 OpenClaw ignores those local summarizer overrides at runtime, and
 `openclaw doctor --fix` removes them when the agent uses Codex.
 
+An authored `models.providers.*.models[].contextTokens` cap is forwarded to
+Codex thread start and resume as `model_context_window`. Codex clamps the value
+to the model's native maximum and derives automatic compaction from the capped
+window. When the model entry has no authored cap, OpenClaw sends no override.
+
 Lossless remains supported as a context engine for assembly, ingestion, and
 maintenance around Codex turns, configured through
 `plugins.slots.contextEngine: "lossless-claw"` and

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -88,6 +88,7 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     : params.modelId;
   const {
     authProfileId: _outerAuthProfileId,
+    authoredContextTokenCap: _outerAuthoredContextTokenCap,
     contextWindowInfo: _outerContextWindowInfo,
     contextTokenBudget: _outerContextTokenBudget,
     model: _outerModel,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -107,6 +107,8 @@ function createNetworkProxyThreadLifecycleAppServerOptions() {
 
 function createParams(sessionFile: string, workspaceDir: string) {
   const params = createRunAttemptParams(sessionFile, workspaceDir);
+  delete params.contextTokenBudget;
+  delete params.contextWindowInfo;
   params.disableTools = false;
   params.config = undefined;
   return params;

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -107,8 +107,6 @@ function createNetworkProxyThreadLifecycleAppServerOptions() {
 
 function createParams(sessionFile: string, workspaceDir: string) {
   const params = createRunAttemptParams(sessionFile, workspaceDir);
-  delete params.contextTokenBudget;
-  delete params.contextWindowInfo;
   params.disableTools = false;
   params.config = undefined;
   return params;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -64,6 +64,33 @@ describe("Codex incognito thread persistence", () => {
   });
 });
 
+describe("Codex context window config", () => {
+  it("forwards only a prepared cap on thread start and resume (#124702)", () => {
+    const appServer = createAppServerOptions() as never;
+    const capped = createAttemptParams({ provider: "openai" });
+    capped.contextTokenBudget = 32_000;
+    const uncapped = createAttemptParams({ provider: "openai" });
+    const build = (params: EmbeddedRunAttemptParams) => [
+      buildThreadStartParams(params, {
+        appServer,
+        cwd: "/repo",
+        dynamicTools: [],
+      }),
+      buildThreadResumeParams(params, {
+        appServer,
+        threadId: "thread-1",
+      }),
+    ];
+
+    for (const request of build(capped)) {
+      expect(request.config?.model_context_window).toBe(32_000);
+    }
+    for (const request of build(uncapped)) {
+      expect(request.config).not.toHaveProperty("model_context_window");
+    }
+  });
+});
+
 describe("Codex ring-zero thread config", () => {
   it("accepts upstream-shaped inactive rows for the disabled MCP names", async () => {
     const request = vi.fn(async () => ({

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -68,7 +68,7 @@ describe("Codex context window config", () => {
   it("forwards only a prepared cap on thread start and resume (#124702)", () => {
     const appServer = createAppServerOptions() as never;
     const capped = createAttemptParams({ provider: "openai" });
-    capped.contextTokenBudget = 32_000;
+    capped.authoredContextTokenCap = 32_000;
     const uncapped = createAttemptParams({ provider: "openai" });
     const build = (params: EmbeddedRunAttemptParams) => [
       buildThreadStartParams(params, {

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -442,9 +442,9 @@ export function buildCodexRuntimeThreadConfigForRun(
             options.hostSystemAgentActive,
             restrictedToolSurfaceMcpServerNames,
           ),
-      params.contextTokenBudget === undefined
+      params.authoredContextTokenCap === undefined
         ? undefined
-        : { model_context_window: params.contextTokenBudget },
+        : { model_context_window: params.authoredContextTokenCap },
     ) ?? baseConfig;
   if (params.bootstrapContextMode !== "lightweight") {
     return runtimeConfig;

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -442,6 +442,9 @@ export function buildCodexRuntimeThreadConfigForRun(
             options.hostSystemAgentActive,
             restrictedToolSurfaceMcpServerNames,
           ),
+      params.contextTokenBudget === undefined
+        ? undefined
+        : { model_context_window: params.contextTokenBudget },
     ) ?? baseConfig;
   if (params.bootstrapContextMode !== "lightweight") {
     return runtimeConfig;

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -131,6 +131,26 @@ function resolveConfiguredRuntimeModel(
     : undefined;
 }
 
+function readAuthoredModelContextTokens(model: ConfigModelEntry | undefined): number | undefined {
+  return typeof model?.contextTokens === "number" && model.contextTokens > 0
+    ? model.contextTokens
+    : undefined;
+}
+
+/** Returns only the per-model contextTokens value authored in OpenClaw config. */
+export function resolveAuthoredModelContextTokens(
+  params: Pick<ContextTokenResolutionParams, "cfg" | "provider" | "modelProvider" | "model">,
+): number | undefined {
+  const ref = resolveProviderModelRef(params);
+  const explicitProvider = params.provider?.trim();
+  if (!ref || !explicitProvider) {
+    return undefined;
+  }
+  return readAuthoredModelContextTokens(
+    resolveConfiguredRuntimeModel(params.cfg, explicitProvider, params.modelProvider, ref.model),
+  );
+}
+
 function resolveModelFamilyId(modelId: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return normalized.includes("/") ? (normalized.split("/").at(-1) ?? normalized) : normalized;
@@ -203,10 +223,7 @@ export function resolveContextTokensForModelFromCache(
     const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model, {
       claudeCli1M: effectiveContext1M === true,
     });
-    const configuredContextTokens =
-      typeof configuredModel?.contextTokens === "number" && configuredModel.contextTokens > 0
-        ? configuredModel.contextTokens
-        : undefined;
+    const configuredContextTokens = readAuthoredModelContextTokens(configuredModel);
     if (configuredContextTokens !== undefined) {
       return fixedContextWindow === undefined
         ? configuredContextTokens

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -152,17 +152,21 @@ describe("embedded run retry dispatch", () => {
     expect(mocks.settleRequesterAfterSessionSpawns).not.toHaveBeenCalled();
   });
 
-  it("forwards a prepared context cap to plugin harness params without a context engine (#124702)", async () => {
+  it("forwards effective and authored context facts without a context engine (#124702)", async () => {
     const cappedInput = makeDispatchInput({}, createEmbeddedRunReplayState());
-    cappedInput.runtime.contextTokenBudget = 32_000;
+    cappedInput.runtime.contextTokenBudget = 272_000;
+    cappedInput.runtime.authoredContextTokenCap = 32_000;
     const capped = await dispatchEmbeddedRunAttempt(cappedInput);
 
-    expect(capped.preparedAttempt.contextTokenBudget).toBe(32_000);
+    expect(capped.preparedAttempt.contextTokenBudget).toBe(272_000);
+    expect(capped.preparedAttempt.authoredContextTokenCap).toBe(32_000);
 
     const uncappedInput = makeDispatchInput({}, createEmbeddedRunReplayState());
+    uncappedInput.runtime.contextTokenBudget = 272_000;
     const uncapped = await dispatchEmbeddedRunAttempt(uncappedInput);
 
-    expect(uncapped.preparedAttempt).not.toHaveProperty("contextTokenBudget");
+    expect(uncapped.preparedAttempt.contextTokenBudget).toBe(272_000);
+    expect(uncapped.preparedAttempt).not.toHaveProperty("authoredContextTokenCap");
   });
 
   it.each([true, false])(

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -152,6 +152,19 @@ describe("embedded run retry dispatch", () => {
     expect(mocks.settleRequesterAfterSessionSpawns).not.toHaveBeenCalled();
   });
 
+  it("forwards a prepared context cap to plugin harness params without a context engine (#124702)", async () => {
+    const cappedInput = makeDispatchInput({}, createEmbeddedRunReplayState());
+    cappedInput.runtime.contextTokenBudget = 32_000;
+    const capped = await dispatchEmbeddedRunAttempt(cappedInput);
+
+    expect(capped.preparedAttempt.contextTokenBudget).toBe(32_000);
+
+    const uncappedInput = makeDispatchInput({}, createEmbeddedRunReplayState());
+    const uncapped = await dispatchEmbeddedRunAttempt(uncappedInput);
+
+    expect(uncapped.preparedAttempt).not.toHaveProperty("contextTokenBudget");
+  });
+
   it.each([true, false])(
     "settles accepted spawns before a late post-compaction abort (yielded: %s)",
     async (yieldDetected) => {

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -217,6 +217,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       preparedModelRuntime: runInput.preparedModelRuntime,
       contextEngine: nativeModelOwned ? undefined : contextEngine,
       contextTokenBudget: runtime.contextTokenBudget,
+      authoredContextTokenCap: runtime.authoredContextTokenCap,
       contextWindowInfo: runtime.contextWindowInfo,
       prompt,
       provider,

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -46,18 +46,17 @@ export function resolveEmbeddedRunEffectiveModel(
     runtimeModel: params.runtimeModel,
     nativeModelOwned: params.nativeModelOwned,
   });
-  if (params.agentHarnessId === OPENCLAW_AGENT_RUNTIME_ID) {
-    return resolved;
-  }
-  // Native transports own discovery and fixed-contract windows. Forward only
-  // the operator-authored cap so provider metadata cannot become a native override.
+  const authoredContextTokenCap =
+    params.agentHarnessId === OPENCLAW_AGENT_RUNTIME_ID
+      ? undefined
+      : resolveAuthoredModelContextTokens({
+          cfg: params.runParams.config,
+          provider: contextConfigProvider,
+          model: params.modelId,
+        });
   return {
     ...resolved,
-    contextTokenBudget: resolveAuthoredModelContextTokens({
-      cfg: params.runParams.config,
-      provider: contextConfigProvider,
-      model: params.modelId,
-    }),
+    ...(authoredContextTokenCap === undefined ? {} : { authoredContextTokenCap }),
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -1,4 +1,6 @@
 import type { Model } from "../../../llm/types.js";
+import { OPENCLAW_AGENT_RUNTIME_ID } from "../../agent-runtime-id.js";
+import { resolveAuthoredModelContextTokens } from "../../context-resolution.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
@@ -31,18 +33,32 @@ export function resolveEmbeddedRunEffectiveModel(
     nativeModelOwned: boolean;
   },
 ) {
-  return resolveEmbeddedRuntimeModelPolicy({
+  const contextConfigProvider = resolveContextConfigProviderForRuntime({
+    provider: params.modelConfigProvider,
+    runtimeId: params.agentHarnessId,
+    config: params.runParams.config,
+  });
+  const resolved = resolveEmbeddedRuntimeModelPolicy({
     cfg: params.runParams.config,
     provider: params.provider,
-    contextConfigProvider: resolveContextConfigProviderForRuntime({
-      provider: params.modelConfigProvider,
-      runtimeId: params.agentHarnessId,
-      config: params.runParams.config,
-    }),
+    contextConfigProvider,
     modelId: params.modelId,
     runtimeModel: params.runtimeModel,
     nativeModelOwned: params.nativeModelOwned,
   });
+  if (params.agentHarnessId === OPENCLAW_AGENT_RUNTIME_ID) {
+    return resolved;
+  }
+  // Native transports own discovery and fixed-contract windows. Forward only
+  // the operator-authored cap so provider metadata cannot become a native override.
+  return {
+    ...resolved,
+    contextTokenBudget: resolveAuthoredModelContextTokens({
+      cfg: params.runParams.config,
+      provider: contextConfigProvider,
+      model: params.modelId,
+    }),
+  };
 }
 
 function buildHarnessModelProvider(

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -298,10 +298,12 @@ export async function dispatchEmbeddedRunAttempt(input: {
     ...(runtime.contextEngine
       ? {
           contextEngine: runtime.contextEngine,
-          contextTokenBudget: runtime.contextTokenBudget,
           contextWindowInfo: runtime.contextWindowInfo,
         }
       : {}),
+    ...(runtime.contextTokenBudget === undefined
+      ? {}
+      : { contextTokenBudget: runtime.contextTokenBudget }),
     skillsSnapshot: params.skillsSnapshot,
     prompt: pluginHarnessPrompt ?? preparedExecApprovalContinuation.prompt,
     transcriptPrompt:

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -45,6 +45,7 @@ type AttemptRuntime = {
   preparedModelRuntime?: EmbeddedRunAttemptParams["preparedModelRuntime"];
   contextEngine?: EmbeddedRunAttemptParams["contextEngine"];
   contextTokenBudget?: number;
+  authoredContextTokenCap?: number;
   contextWindowInfo?: EmbeddedRunAttemptParams["contextWindowInfo"];
   prompt: string;
   provider: string;
@@ -304,6 +305,9 @@ export async function dispatchEmbeddedRunAttempt(input: {
     ...(runtime.contextTokenBudget === undefined
       ? {}
       : { contextTokenBudget: runtime.contextTokenBudget }),
+    ...(runtime.authoredContextTokenCap === undefined
+      ? {}
+      : { authoredContextTokenCap: runtime.authoredContextTokenCap }),
     skillsSnapshot: params.skillsSnapshot,
     prompt: pluginHarnessPrompt ?? preparedExecApprovalContinuation.prompt,
     transcriptPrompt:

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -105,6 +105,7 @@ export async function prepareEmbeddedRunRuntime(input: {
     });
   const initialResolvedRuntimeModel = resolveEffectiveModel(runtimeModel);
   let contextTokenBudget = initialResolvedRuntimeModel.contextTokenBudget;
+  let authoredContextTokenCap = initialResolvedRuntimeModel.authoredContextTokenCap;
   let contextWindowInfo = initialResolvedRuntimeModel.contextWindowInfo;
   let outerContextTokenMeta: { contextTokens?: number } =
     contextTokenBudget === undefined ? {} : { contextTokens: contextTokenBudget };
@@ -116,6 +117,7 @@ export async function prepareEmbeddedRunRuntime(input: {
     runtimeModel = candidate;
     effectiveModel = resolved.effectiveModel;
     contextTokenBudget = resolved.contextTokenBudget;
+    authoredContextTokenCap = resolved.authoredContextTokenCap;
     contextWindowInfo = resolved.contextWindowInfo;
     outerContextTokenMeta =
       contextTokenBudget === undefined ? {} : { contextTokens: contextTokenBudget };
@@ -572,6 +574,7 @@ export async function prepareEmbeddedRunRuntime(input: {
       pluginHarnessOwnsTransport,
       effectiveModel,
       contextTokenBudget,
+      authoredContextTokenCap,
       contextWindowInfo,
       outerContextTokenMeta,
       activePreparedAuthPlan,

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -6,6 +6,7 @@ import type { ModelDefinitionConfig } from "../../../config/types.models.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import { AGENT_HARNESS_SESSION_ID_LOCKED_MESSAGE } from "../../../sessions/agent-harness-session-key.js";
+import { resolveEmbeddedRunEffectiveModel } from "./model-harness.js";
 import {
   buildBeforeModelResolveAttachments,
   resolveAgentHarnessRunAdmissionError,
@@ -295,6 +296,30 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
       tokens: 272_000,
     });
     expect(result.effectiveModel.contextWindow).toBe(272_000);
+  });
+
+  it("prepares only an authored per-model cap for plugin-owned transports (#124702)", () => {
+    const resolve = (models: ModelDefinitionConfig[]) =>
+      resolveEmbeddedRunEffectiveModel({
+        runParams: {
+          config: {
+            models: { providers: { openai: { baseUrl: "https://api.openai.com/v1", models } } },
+          },
+        } as never,
+        provider: "openai",
+        modelConfigProvider: "openai",
+        modelId: "gpt-5.5",
+        agentHarnessId: "codex",
+        runtimeModel: createRuntimeModel(),
+        nativeModelOwned: false,
+      });
+
+    expect(resolve([createConfiguredModel({ contextTokens: 32_000 })]).contextTokenBudget).toBe(
+      32_000,
+    );
+    expect(
+      resolve([createConfiguredModel({ contextTokens: undefined })]).contextTokenBudget,
+    ).toBeUndefined();
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -298,7 +298,7 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
     expect(result.effectiveModel.contextWindow).toBe(272_000);
   });
 
-  it("prepares only an authored per-model cap for plugin-owned transports (#124702)", () => {
+  it("preserves the effective budget and adds an authored cap for plugin transports (#124702)", () => {
     const resolve = (models: ModelDefinitionConfig[]) =>
       resolveEmbeddedRunEffectiveModel({
         runParams: {
@@ -309,17 +309,18 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
         provider: "openai",
         modelConfigProvider: "openai",
         modelId: "gpt-5.5",
-        agentHarnessId: "codex",
+        agentHarnessId: "claude-cli",
         runtimeModel: createRuntimeModel(),
         nativeModelOwned: false,
       });
 
-    expect(resolve([createConfiguredModel({ contextTokens: 32_000 })]).contextTokenBudget).toBe(
-      32_000,
-    );
-    expect(
-      resolve([createConfiguredModel({ contextTokens: undefined })]).contextTokenBudget,
-    ).toBeUndefined();
+    const capped = resolve([createConfiguredModel({ contextTokens: 32_000 })]);
+    expect(capped.contextTokenBudget).toBe(32_000);
+    expect(capped.authoredContextTokenCap).toBe(32_000);
+
+    const discovered = resolve([]);
+    expect(discovered.contextTokenBudget).toBe(272_000);
+    expect(discovered).not.toHaveProperty("authoredContextTokenCap");
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -124,6 +124,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   contextEngine?: ContextEngine;
   /** Resolved model context window in tokens for assemble/compact budgeting. */
   contextTokenBudget?: number;
+  /** Per-model contextTokens cap authored by the operator; absent when none was authored. */
+  authoredContextTokenCap?: number;
   /** Source metadata for the resolved model context budget. */
   contextWindowInfo?: EmbeddedRunContextWindowInfo;
   /** Resolved API key for this run when runtime auth did not replace it. */


### PR DESCRIPTION
Fixes #124702

## What Problem This Solves

Fixes an issue where an authored per-model `contextTokens` cap was silently ignored when an OpenAI model routed through the Codex harness. Codex continued using its native window, so the configured cap and reported session window disagreed.

## Why This Change Was Made

Core preserves the generic effective `contextTokenBudget` for every harness and separately prepares an optional `authoredContextTokenCap` from the exact `models.providers.*.models[].contextTokens` value. The Codex plugin maps only that authored fact to `config.model_context_window` on both `thread/start` and `thread/resume`; uncapped models send no override. Usage projection remains unchanged because Codex already reports the resolved model window.

The upstream Codex contract was inspected directly at sibling checkout `../codex` commit `86b1123ff6b5d089a146be4e603a324cf454223a`:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:59-97` defines `ThreadStartParams.config` as per-thread JSON config overrides.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:327-383` confirms `ThreadResumeParams` also accepts `config`.
- `codex-rs/app-server/src/request_processors/thread_processor.rs:150-153` records that config overrides are ignored when rejoining a running thread, while `:3510-3514` applies them when a thread is freshly resumed.
- `codex-rs/core/src/config/mod.rs:639-640,1593-1596` carries `model_context_window` into `ModelsManagerConfig`.
- `codex-rs/models-manager/src/model_info.rs:25-33` clamps the override to the model's native maximum.
- `codex-rs/protocol/src/openai_models.rs:477-493` derives automatic compaction from the resolved capped window.

OpenClaw's existing token fuse in `extensions/codex/src/app-server/startup-binding.ts` already clears oversized bindings and forces a fresh thread when limits are exceeded. No session-row special case was added. The new prepared-attempt field is additive, optional, and documented as absent when the operator authored no cap.

## User Impact

Operators can use the same per-model `contextTokens` cap for OpenClaw and Codex-routed runs without changing the effective-budget contract used by Claude CLI, Gemini CLI, or external agent harnesses. Codex clamps oversized authored values to its native maximum, compacts against the resulting capped window, and reports that resolved window through the existing usage path.

## Evidence

- Red-before regressions showed the prepared cap missing at core dispatch and `model_context_window` absent from Codex start/resume requests.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/setup.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts src/plugin-sdk/agent-harness-runtime.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/run-attempt.test.ts` — 434 tests passed across 4 shards.
- `pnpm plugin-sdk:surface:check` — passed for all 144 public Plugin SDK subpaths.
- `pnpm build` — passed on AWS Crabbox run `run_8e5b93fcf9a9`; all 144 public Plugin SDK subpaths verified in the built declaration graph.
- `node scripts/check-changed.mjs -- <touched files>` — passed every guard through production/full-tree dead-export analysis; Daytona then killed only the script-export Knip subprocess for memory pressure before later lanes ran.
- `git diff --check` — passed.
- Production LOC: +59/-11 (net +48); tests: +70/-0; docs: +5/-0. The production growth is the authored-only config lookup, additive prepared-attempt contract, and explicit core-to-native transport boundary.
- Autoreview completed with no accepted/actionable findings.

AI-assisted: Codex.
