### PR TITLE
fix(onboard): run channel hooks after config is saved

### DIFF
--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -90,7 +90,12 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     import("../agents.config.js"),
     loadOnboardChannels(),
   ]);
-  const postWriteHooks = onboardChannels.createChannelOnboardingPostWriteHookCollector();
+  const channelSetup = onboardChannels.createChannelSetupTransaction({
+    runtime,
+    ...(params.beforePersistentEffect
+      ? { beforePersistentEffect: params.beforePersistentEffect }
+      : {}),
+  });
   let selection: ChannelChoice[] = [];
   const accountIds: Partial<Record<ChannelChoice, string>> = {};
   const resolvedPlugins = new Map<ChannelChoice, ChannelSetupPlugin>();
@@ -105,9 +110,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
       ? { beforePersistentEffect: params.beforePersistentEffect }
       : {}),
     ...(params.deferDeviceLinkToClient ? { deferDeviceLinkToClient: true } : {}),
-    onPostWriteHook: (hook) => {
-      postWriteHooks.collect(hook);
-    },
+    onPostWriteHook: (hook) => channelSetup.onPostWriteHook(hook),
     promptAccountIds: true,
     deferStatusUntilSelection: true,
     skipStatusNote: true,
@@ -122,28 +125,21 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     },
   });
   const commitWizardConfig = async (config: OpenClawConfig) => {
-    await params.beforePersistentEffect?.();
-    const committed = await commitConfigWithPendingPluginInstalls({
-      nextConfig: config,
-      ...(baseHash !== undefined ? { baseHash } : {}),
-    });
-    if (committed.movedInstallRecords) {
-      await refreshPluginRegistryAfterConfigMutation({
-        config: committed.config,
-        reason: "source-changed",
-        installRecords: committed.installRecords,
-        logger: { warn: (message) => runtime.log(message) },
+    return await channelSetup.commit(config, async (configToCommit) => {
+      const committed = await commitConfigWithPendingPluginInstalls({
+        nextConfig: configToCommit,
+        ...(baseHash !== undefined ? { baseHash } : {}),
       });
-    }
-    await onboardChannels.runCollectedChannelOnboardingPostWriteHooks({
-      hooks: postWriteHooks.drain(),
-      cfg: committed.config,
-      runtime,
-      ...(params.beforePersistentEffect
-        ? { beforePersistentEffect: params.beforePersistentEffect }
-        : {}),
+      if (committed.movedInstallRecords) {
+        await refreshPluginRegistryAfterConfigMutation({
+          config: committed.config,
+          reason: "source-changed",
+          installRecords: committed.installRecords,
+          logger: { warn: (message) => runtime.log(message) },
+        });
+      }
+      return committed.config;
     });
-    return committed.config;
   };
   if (selection.length === 0) {
     if (nextConfig !== cfg) {

--- a/src/commands/onboard-channels.post-write.test.ts
+++ b/src/commands/onboard-channels.post-write.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   createChannelOnboardingPostWriteHook,
-  createChannelOnboardingPostWriteHookCollector,
-  runCollectedChannelOnboardingPostWriteHooks,
+  createChannelSetupTransaction,
 } from "./onboard-channels.js";
 import { createExitThrowingRuntime } from "./test-wizard-helpers.js";
 
@@ -20,8 +19,8 @@ describe("setupChannels post-write hooks", () => {
     const adapter = {
       afterConfigWritten,
     };
-    const collector = createChannelOnboardingPostWriteHookCollector();
     const runtime = createExitThrowingRuntime();
+    const transaction = createChannelSetupTransaction({ runtime });
     const hook = createChannelOnboardingPostWriteHook({
       accountId: "acct-1",
       adapter,
@@ -32,16 +31,13 @@ describe("setupChannels post-write hooks", () => {
     if (!hook) {
       throw new Error("expected post-write hook");
     }
-    collector.collect(hook);
+    transaction.onPostWriteHook(hook);
 
     expect(afterConfigWritten).not.toHaveBeenCalled();
 
-    await runCollectedChannelOnboardingPostWriteHooks({
-      hooks: collector.drain(),
-      cfg,
-      runtime,
-    });
+    const committed = await transaction.commit(cfg, async () => cfg);
 
+    expect(committed).toBe(cfg);
     expect(afterConfigWritten).toHaveBeenCalledWith({
       previousCfg,
       cfg,
@@ -52,24 +48,35 @@ describe("setupChannels post-write hooks", () => {
 
   it("logs onboarding post-write hook failures without aborting", async () => {
     const runtime = createExitThrowingRuntime();
-
-    await runCollectedChannelOnboardingPostWriteHooks({
-      hooks: [
-        {
-          channel: "telegram",
-          accountId: "acct-1",
-          run: async () => {
-            throw new Error("hook failed");
-          },
-        },
-      ],
-      cfg: {} as OpenClawConfig,
-      runtime,
+    const transaction = createChannelSetupTransaction({ runtime });
+    transaction.onPostWriteHook({
+      channel: "telegram",
+      accountId: "acct-1",
+      run: async () => {
+        throw new Error("hook failed");
+      },
     });
+
+    await transaction.commit({} as OpenClawConfig, async (config) => config);
 
     expect(runtime.error).toHaveBeenCalledWith(
       'Channel telegram post-setup warning for "acct-1": hook failed',
     );
     expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("does not run hooks when config persistence fails", async () => {
+    const runtime = createExitThrowingRuntime();
+    const hook = vi.fn();
+    const transaction = createChannelSetupTransaction({ runtime });
+    transaction.onPostWriteHook({ channel: "matrix", accountId: "ops", run: hook });
+
+    await expect(
+      transaction.commit({} as OpenClawConfig, async () => {
+        throw new Error("write failed");
+      }),
+    ).rejects.toThrow("write failed");
+
+    expect(hook).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,7 +1,7 @@
 /** Re-export seam for channel onboarding flow helpers. */
 export {
   createChannelOnboardingPostWriteHook,
-  createChannelOnboardingPostWriteHookCollector,
+  createChannelSetupTransaction,
   runCollectedChannelOnboardingPostWriteHooks,
   setupChannels,
 } from "../flows/channel-setup.js";

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -55,17 +55,36 @@ import {
   resolveQuickstartDefault,
 } from "./channel-setup.status.js";
 
-export function createChannelOnboardingPostWriteHookCollector() {
+export function createChannelSetupTransaction(params: {
+  runtime: RuntimeEnv;
+  beforePersistentEffect?: () => Promise<void>;
+}) {
   const hooks = new Map<string, ChannelOnboardingPostWriteHook>();
+  const runPostWriteHooks = async (cfg: OpenClawConfig) => {
+    await runCollectedChannelOnboardingPostWriteHooks({
+      hooks: [...hooks.values()],
+      cfg,
+      runtime: params.runtime,
+      ...(params.beforePersistentEffect
+        ? { beforePersistentEffect: params.beforePersistentEffect }
+        : {}),
+    });
+    hooks.clear();
+  };
   return {
-    collect(hook: ChannelOnboardingPostWriteHook) {
+    onPostWriteHook(hook: ChannelOnboardingPostWriteHook) {
       hooks.set(`${hook.channel}:${hook.accountId}`, hook);
     },
-    drain(): ChannelOnboardingPostWriteHook[] {
-      const next = [...hooks.values()];
-      hooks.clear();
-      return next;
+    async commit(
+      nextConfig: OpenClawConfig,
+      write: (config: OpenClawConfig) => Promise<OpenClawConfig>,
+    ): Promise<OpenClawConfig> {
+      await params.beforePersistentEffect?.();
+      const committedConfig = await write(nextConfig);
+      await runPostWriteHooks(committedConfig);
+      return committedConfig;
     },
+    runPostWriteHooks,
   };
 }
 

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -668,7 +668,6 @@ describe("SystemAgentChatEngine runtime", () => {
 
     expect(stopped.text).toContain("Telegram setup stopped");
     expect(mocks.writeWizardConfigFile).toHaveBeenCalledOnce();
-    expect(mocks.runCollectedChannelOnboardingPostWriteHooks).toHaveBeenCalledOnce();
     expect(hook.run).not.toHaveBeenCalled();
   });
 });
@@ -710,11 +709,12 @@ describe("hosted channel post-write hooks", () => {
       { channels: { matrix: { enabled: true } } },
       { allowConfigSizeDrop: false, baseHash: "hook-base-hash" },
     );
-    expect(mocks.runCollectedChannelOnboardingPostWriteHooks).toHaveBeenCalledWith({
-      hooks: [hook],
+    expect(hook.run).toHaveBeenCalledWith({
       cfg: committed,
       runtime: expect.any(Object),
-      beforePersistentEffect: expect.any(Function),
     });
+    expect(mocks.writeWizardConfigFile.mock.invocationCallOrder[0]).toBeLessThan(
+      hook.run.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 });

--- a/src/system-agent/hosted-setup.runtime.ts
+++ b/src/system-agent/hosted-setup.runtime.ts
@@ -86,38 +86,36 @@ export async function runHostedChannelSetup(
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
   runtime?: RuntimeEnv,
 ): Promise<HostedSetupCompletion> {
-  const {
-    createChannelOnboardingPostWriteHookCollector,
-    runCollectedChannelOnboardingPostWriteHooks,
-    setupChannels,
-  } = await import("../commands/onboard-channels.js");
-  const postWriteHooks = createChannelOnboardingPostWriteHookCollector();
+  const { createChannelSetupTransaction, setupChannels } =
+    await import("../commands/onboard-channels.js");
+  let channelSetup: ReturnType<typeof createChannelSetupTransaction>;
   return await runHostedSetup({
     label: "Channel setup",
     runtime,
     beforePersistentApply,
-    run: async ({ baseConfig, runtime: setupRuntime }) => ({
-      nextConfig: await setupChannels(baseConfig, setupRuntime, prompter, {
-        initialSelection: [channel],
-        forceAllowFromChannels: [channel],
-        allowIMessageInstall: true,
-        allowSignalInstall: true,
-        deferStatusUntilSelection: true,
-        quickstartDefaults: true,
-        skipDmPolicyPrompt: true,
-        skipConfirm: true,
+    run: async ({ baseConfig, runtime: setupRuntime }) => {
+      channelSetup = createChannelSetupTransaction({
+        runtime: setupRuntime,
         beforePersistentEffect: async () => await beforePersistentApply(setupRuntime),
-        onPostWriteHook: (hook) => postWriteHooks.collect(hook),
-      }),
-      afterWrite: async (committedConfig) => {
-        await runCollectedChannelOnboardingPostWriteHooks({
-          hooks: postWriteHooks.drain(),
-          cfg: committedConfig,
-          runtime: setupRuntime,
+      });
+      return {
+        nextConfig: await setupChannels(baseConfig, setupRuntime, prompter, {
+          initialSelection: [channel],
+          forceAllowFromChannels: [channel],
+          allowIMessageInstall: true,
+          allowSignalInstall: true,
+          deferStatusUntilSelection: true,
+          quickstartDefaults: true,
+          skipDmPolicyPrompt: true,
+          skipConfirm: true,
           beforePersistentEffect: async () => await beforePersistentApply(setupRuntime),
-        });
-      },
-    }),
+          onPostWriteHook: (hook) => channelSetup.onPostWriteHook(hook),
+        }),
+        afterWrite: async (committedConfig) => {
+          await channelSetup.runPostWriteHooks(committedConfig);
+        },
+      };
+    },
   });
 }
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -343,7 +343,8 @@ function expectMockCallArgNotNull(
   }
 }
 
-vi.mock("../commands/onboard-channels.js", () => ({
+vi.mock("../commands/onboard-channels.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commands/onboard-channels.js")>()),
   setupChannels,
 }));
 
@@ -2291,6 +2292,56 @@ describe("runSetupWizard", () => {
         quickstartDefaults: true,
       },
       "channel setup options",
+    );
+  });
+
+  it("persists classic channel setup before hooks and Gateway finalization", async () => {
+    const beforeConfig = { agents: { defaults: { workspace: "/tmp/workspace" } } };
+    const configured = {
+      ...beforeConfig,
+      channels: { matrix: { accounts: { ops: { enabled: true } } } },
+    } satisfies OpenClawConfig;
+    const hook = vi.fn();
+    const isConfiguredWrite = (value: OpenClawConfig) =>
+      value.channels?.matrix?.accounts?.ops?.enabled === true;
+    setupChannels.mockImplementationOnce(async (_cfg, _runtime, _prompter, options) => {
+      const setupOptions = options as {
+        onPostWriteHook?: (value: {
+          channel: "matrix";
+          accountId: string;
+          run: typeof hook;
+        }) => void;
+      };
+      setupOptions.onPostWriteHook?.({ channel: "matrix", accountId: "ops", run: hook });
+      return configured;
+    });
+    readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot(beforeConfig));
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      createRuntime(),
+      buildWizardPrompter({}),
+    );
+
+    const configuredWriteIndex = replaceConfigFile.mock.calls.findIndex(([params]) =>
+      isConfiguredWrite(params.nextConfig),
+    );
+    expect(configuredWriteIndex).toBeGreaterThanOrEqual(0);
+    expect(replaceConfigFile.mock.invocationCallOrder[configuredWriteIndex]).toBeLessThan(
+      hook.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(hook).toHaveBeenCalledWith({ cfg: configured, runtime: expect.any(Object) });
+    expect(hook.mock.invocationCallOrder[0]).toBeLessThan(
+      finalizeSetupWizard.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
   });
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -602,7 +602,9 @@ async function runSetupWizardOnce(
     await prompter.note(t("wizard.setup.skipChannels"), t("wizard.setup.channelsTitle"));
   } else {
     const { listChannelPlugins } = await import("../channels/plugins/index.js");
-    const { setupChannels } = await import("../commands/onboard-channels.js");
+    const { createChannelSetupTransaction, setupChannels } =
+      await import("../commands/onboard-channels.js");
+    const channelSetup = createChannelSetupTransaction({ runtime });
     const quickstartAllowFromChannels =
       flow === "quickstart"
         ? listChannelPlugins()
@@ -618,12 +620,19 @@ async function runSetupWizardOnce(
       skipConfirm: flow === "quickstart",
       quickstartDefaults: flow === "quickstart",
       secretInputMode: opts.secretInputMode,
+      onPostWriteHook: (hook) => channelSetup.onPostWriteHook(hook),
     });
+    nextConfig = await channelSetup.commit(
+      nextConfig,
+      async (config) => await writeSetupConfigFile(config, { allowConfigSizeDrop: false }),
+    );
   }
 
-  nextConfig = await writeSetupConfigFile(nextConfig, {
-    allowConfigSizeDrop: false,
-  });
+  if (opts.skipChannels) {
+    nextConfig = await writeSetupConfigFile(nextConfig, {
+      allowConfigSizeDrop: false,
+    });
+  }
   let onboardingTarget = resolveOnboardingAgentTarget(nextConfig);
   const { logConfigUpdated } = await loadConfigLoggingModule();
   logConfigUpdated(runtime);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel onboarding could run plugin post-write hooks before the completed channel configuration was durably committed, so hooks could observe stale config or leave side effects after a failed write.

## Why This Change Was Made

Channel setup now owns one transaction that collects account hooks, commits the final config, and only then drains hooks against the committed config. The classic wizard, hosted setup, and `channels add` all use that canonical ordering while preserving their existing persistence and authority checks.

## User Impact

Channel setup hooks now consistently see the committed configuration across classic onboarding, hosted onboarding, and `channels add`; failed config writes do not run hooks.

## Evidence

- Node 24.19.0: 123 focused tests passed across `channels.add`, onboarding post-write hooks, hosted setup, and classic setup (46 + 3 + 15 + 59).
- `oxfmt --check` passed on all 8 changed files.
- Type-aware `oxlint` passed with 0 warnings and 0 errors.
- `git diff --check` passed.
- TruffleHog pre-review scan passed for verified/unknown findings.
- Live GitHub duplicate search found no matching open issue or PR.
- `check-changed` classification attempted; remote Crabbox routing was unavailable in this orb, so exact-head hosted CI is the broad gate.
- Independent manual review: no P0-P2 findings; canonical transaction is the best abstraction versus duplicating hook ordering in each caller.

## AI Assistance

Implementation and publication were performed with AI assistance. Codex autoreview was unavailable because the Codex executable is not installed; its mandatory TruffleHog preflight completed cleanly before that failure. No agent transcript is included.
