### PR TITLE
fix(agents): prevent side-effect replay after restart

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
+import { buildRestartRecoveryTerminalDeliveryEvidence } from "../agent-command-restart-recovery.js";
 import { createAgentRunRestartAbortError } from "../run-termination.js";
 import { deliverAgentCommandResult } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -764,6 +765,48 @@ describe("deliverAgentCommandResult payload normalization", () => {
       },
     ]);
     expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "deterministic approval prompt",
+      result: { didSendDeterministicApprovalPrompt: true },
+      field: "didSendDeterministicApprovalPrompt",
+      expected: true,
+    },
+    {
+      name: "accepted session spawn",
+      result: {
+        acceptedSessionSpawns: [
+          { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+        ],
+      },
+      field: "acceptedSessionSpawns",
+      expected: [{ runId: "child-run", childSessionKey: "agent:main:subagent:child" }],
+    },
+    {
+      name: "successful cron add",
+      result: { successfulCronAdds: 1 },
+      field: "successfulCronAdds",
+      expected: 1,
+    },
+  ])("preserves $name as restart-unsafe delivery evidence", async ({ result, field, expected }) => {
+    const onDeliveryResult = vi.fn();
+    const delivered = await deliverAgentCommandResultForTest({
+      omitReplyTarget: true,
+      opts: { deliver: false },
+      payloads: [],
+      result,
+      onDeliveryResult,
+    });
+
+    expect(delivered).toHaveProperty(field, expected);
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(delivered);
+    expect(buildRestartRecoveryTerminalDeliveryEvidence(delivered)).toEqual({
+      captured: true,
+      restartUnsafeSideEffectsDetected: true,
+    });
   });
 
   it("does not automatically redeliver text and media already sent to the same target", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -111,6 +111,9 @@ type AgentCommandDeliveryResult = {
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];
+  didSendDeterministicApprovalPrompt?: true;
+  acceptedSessionSpawns?: NonNullable<RunResult["acceptedSessionSpawns"]>;
+  successfulCronAdds?: number;
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
 };
@@ -209,6 +212,11 @@ function buildDeliveryResult(params: {
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
 }): AgentCommandDeliveryResult {
+  const successfulCronAdds = params.result.successfulCronAdds;
+  const hasSuccessfulCronAdds =
+    typeof successfulCronAdds === "number" &&
+    Number.isFinite(successfulCronAdds) &&
+    successfulCronAdds > 0;
   return {
     payloads: params.payloads,
     meta: params.meta,
@@ -222,6 +230,13 @@ function buildDeliveryResult(params: {
     ...(hasNonEmptyArray(params.result.messagingToolSentTargets)
       ? { messagingToolSentTargets: params.result.messagingToolSentTargets }
       : {}),
+    ...(params.result.didSendDeterministicApprovalPrompt === true
+      ? { didSendDeterministicApprovalPrompt: true }
+      : {}),
+    ...(hasNonEmptyArray(params.result.acceptedSessionSpawns)
+      ? { acceptedSessionSpawns: params.result.acceptedSessionSpawns }
+      : {}),
+    ...(hasSuccessfulCronAdds ? { successfulCronAdds } : {}),
     ...(params.deliverySucceeded !== undefined
       ? { deliverySucceeded: params.deliverySucceeded }
       : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restarting after an agent sent a deterministic approval prompt, accepted a child-session spawn, or added a cron job could make the completed run look replay-safe. Recovery could then replay the run and duplicate an already-committed side effect.

## Why This Change Was Made

The embedded runner already records these three owner-produced facts, and restart recovery already classifies them as unsafe. This change preserves them through the ordinary `AgentCommandDeliveryResult` producer boundary so the existing terminal evidence projector receives the complete facts instead of reconstructing them downstream.

## User Impact

After a restart, OpenClaw no longer replays runs whose ordinary delivery path already committed an approval prompt, accepted session spawn, or cron addition.

Production LOC: +15/-0 | Tests: +43/-0

AI-assisted; the implementation and proof were reviewed against the full affected delivery and restart-recovery path.

## Evidence

- Pre-fix regression: the three new table cases failed with each expected field `undefined` on the ordinary delivery result (`3 failed, 54 passed` in `delivery.test.ts`).
- `node scripts/run-vitest.mjs src/agents/command/delivery.test.ts src/agents/agent-command-restart-recovery.test.ts` — 74 tests passed across both shards.
- `node scripts/check-changed.mjs -- src/agents/command/delivery.ts src/agents/command/delivery.test.ts` — passed the complete `core, coreTests` typecheck, lint, guard, dead-export, and import-cycle plan on Blacksmith Testbox `tbx_01m05wj9h3tac2k9nhcnjr1z06` ([run](https://github.com/openclaw/openclaw/actions/runs/31964052082)).
- Codex autoreview (`gpt-5.6-sol`, high reasoning) — clean, no accepted/actionable findings.
- `git diff --check` — passed.

A live gateway restart was not run; the requested deterministic owner-boundary regression exercises the exact ordinary callback path that previously discarded the facts.
