### PR TITLE
fix(cli): accept agent names during setup

### DIFF
--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -522,6 +522,30 @@ describe("registerSetupCommand", () => {
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["guided", ["--wizard"]],
+    ["classic", ["--classic"]],
+    ["non-interactive", ["--non-interactive", "--accept-risk"]],
+  ])("forwards --agent-name through %s setup", async (_mode, modeArgs) => {
+    await runCli([
+      "setup",
+      ...modeArgs,
+      "--agent-name",
+      "robby",
+      "--workspace",
+      "/tmp/robby",
+      "--skip-bootstrap",
+    ]);
+
+    expect(lastWizardOptions()).toMatchObject({
+      agentName: "robby",
+      workspace: "/tmp/robby",
+      skipBootstrap: true,
+    });
+    expect(setupCommandMock).not.toHaveBeenCalled();
+    expect(runSystemAgentMock).not.toHaveBeenCalled();
+  });
+
   it("runs setup wizard command for migration import flags", async () => {
     await runCli([
       "setup",

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -139,6 +139,7 @@ async function runOnboardingEntry(
   await setupWizardCommand(
     {
       workspace: readStringValue(options.workspace),
+      agentName: readStringValue(options.agentName),
       nonInteractive: Boolean(options.nonInteractive),
       acceptRisk: Boolean(options.acceptRisk),
       classic: Boolean(options.classic),
@@ -206,6 +207,7 @@ export function registerSetupCommand(program: Command): void {
       "--workspace <dir>",
       "Workspace proposal for guided setup; persisted by baseline/classic/non-interactive setup",
     )
+    .option("--agent-name <name>", "Name for the first agent (default: main)")
     .option("--wizard", "Run interactive onboarding", false)
     .option(
       "--baseline",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw setup --agent-name <name>` would get an unknown-option error even though the equivalent onboarding entry point supports naming the first agent. This blocked scripted, classic, and guided setup flows from creating a named initial agent.

## Why This Change Was Made

The setup command now registers `--agent-name` and forwards it through the existing setup wizard options, matching the canonical onboarding path. Omitting the option preserves current behavior.

## User Impact

Users can name the first agent consistently whether they enter onboarding through `setup` or `onboard`, including guided, classic, and non-interactive setup.

## Evidence

- Before: `openclaw setup --agent-name robby` was rejected by Commander as an unknown option.
- Exact head: `8090ae97aba6fa0a95cbbefa6b601e8f6dc326ec`.
- `node scripts/run-vitest.mjs src/cli/program/register.setup.test.ts src/cli/program/register.onboard.test.ts src/commands/setup.test.ts`
  - 72 CLI setup/onboard tests passed.
  - 17 setup-command tests passed.
- Regression coverage exercises guided, classic, and non-interactive modes and verifies the same wizard contract.
- `git diff --check origin/main...HEAD` passed.
- Codex autoreview found no findings on the patch; the post-rebase commit is patch-equivalent.

AI-assisted: yes — produced and independently checked during an Amp Auto QA campaign. I understand the command registration and wizard-option flow changed here.
