### PR TITLE
fix(ci): keep synced Testbox candidate checkouts clean

### DIFF
--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3741,21 +3741,21 @@ function injectFullCheckoutLeaseReclaim(commandArgs: string[]) {
   return normalizedArgs;
 }
 
-function injectRemoteTestboxCi(commandArgs: string[], providerName: string) {
+function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: string) {
   if (commandArgs[0] !== "run" || canonicalProviderName(providerName) !== "blacksmith-testbox") {
     return commandArgs;
   }
-  const normalizedArgs = [...commandArgs];
-  const { start } = parseRunInvocation(help.text, normalizedArgs);
-  if (start < 0) {
-    return normalizedArgs;
+  const invocation = parseRunInvocation(help.text, commandArgs);
+  if (invocation.start < 0) {
+    return commandArgs;
   }
-  if (hasOption(normalizedArgs, "--shell")) {
-    normalizedArgs[start] = `export CI=true; ${normalizedArgs[start]}`;
-  } else {
-    normalizedArgs.splice(start, 0, "env", "CI=true");
-  }
-  return normalizedArgs;
+  const snapshot = hasOption(commandArgs, "--no-sync")
+    ? ""
+    : `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; `;
+  return replaceRunCommandWithShell(
+    invocation,
+    `${snapshot}export CI=true; ${renderRunShellCommand(invocation)}`,
+  );
 }
 
 function applyRunTransforms(
@@ -3807,7 +3807,7 @@ function applyRunTransforms(
   invocation = parseRunInvocation(help.text, transformedArgs);
   transformedArgs = injectRemotePosixHydratedNodeModulesBootstrap(invocation);
   return {
-    args: injectRemoteTestboxCi(transformedArgs, options.provider),
+    args: injectRemoteTestboxBootstrap(transformedArgs, options.provider),
     wsl2ScriptBootstrap,
   };
 }

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -66,6 +66,7 @@ const defaultGitResponses: Record<string, { status?: number; stdout?: string; st
   [GIT_CONFIG_SPARSE_KEY]: { stdout: "false\n" },
   [GIT_SPARSE_LIST_KEY]: { status: 1 },
 };
+const remoteTestboxBootstrap = `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; export CI=true;`;
 
 function makeFakeCrabbox(helpText: string): string {
   const cached = fakeCrabboxBinDirs.get(helpText);
@@ -1680,7 +1681,7 @@ describe("scripts/crabbox-wrapper", () => {
       "tbx_owned",
       "--shell",
       "--",
-      `export CI=true; ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
+      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -1897,7 +1898,7 @@ describe("scripts/crabbox-wrapper", () => {
       "blue-hermit",
       "--shell",
       "--",
-      `export CI=true; ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
+      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -1917,7 +1918,7 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--shell",
       "--",
-      `export CI=true; ${remotePosixHydratedModulesBootstrap} cd packages && pnpm install && pnpm build`,
+      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} cd packages && pnpm install && pnpm build`,
     ]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers testing an unpushed candidate branch on Blacksmith Testbox could reach release-package preflight with candidate files represented as tracked working-tree changes under a different `HEAD`, causing the valid test run to stop before any scenario executed.

## Why This Change Was Made

The Testbox command bootstrap now records a local commit when delegated sync changed the remote checkout, making `HEAD` and the synced candidate tree agree before source-SHA-sensitive checks run. `--no-sync` reuse remains untouched, and the existing remote `CI=true` behavior is preserved.

## User Impact

Maintainers can run package, Docker, and upgrade validation from local candidate branches without adding one-off remote commit commands. Production LOC is net zero; this changes only CI tooling.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts` — 239/239 passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/crabbox-wrapper.mts test/scripts/crabbox-wrapper.test.ts` — passed after formatting.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/crabbox-wrapper.mts` — 0 warnings/errors.
- Live Blacksmith Testbox `tbx_01m05xrjmrcemkdfvc667eznzx` synced this uncommitted patch and proved both a clean tracked tree and `remote-testbox-sync` at `HEAD`: https://github.com/openclaw/openclaw/actions/runs/31965084810
- Autoreview: clean, no accepted/actionable findings.
