### PR TITLE
fix(qa): recover repeated gateway restarts through channel ingress

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -109,11 +109,15 @@ describe("qa scenario catalog causality", () => {
     const liveMultiRestart = requireFlowScenario(readQaScenarioById("gateway-restart-multi-live"));
     const liveMultiRestartFlow = liveMultiRestart.execution.flow;
     const liveMultiRestartContract = JSON.stringify(liveMultiRestartFlow);
-    const liveMultiRestartPrompt = String(liveMultiRestart.execution.config?.prompt ?? "");
+    const liveMultiRestartPrompt =
+      typeof liveMultiRestart.execution.config?.prompt === "string"
+        ? liveMultiRestart.execution.config.prompt
+        : "";
     const liveMultiRestartActions = liveMultiRestartFlow?.steps[1]?.actions ?? [];
-    const checkpointLoop = liveMultiRestartActions.find((action) => "forEach" in action) as
-      | { forEach?: { actions?: unknown[] } }
-      | undefined;
+    const checkpointLoop = liveMultiRestartActions.find(
+      (action): action is { forEach?: { actions?: unknown[] } } =>
+        typeof action === "object" && action !== null && "forEach" in action,
+    );
     const checkpointActions = checkpointLoop?.forEach?.actions ?? [];
     const checkpointTranscriptIndex = checkpointActions.findIndex(
       (action) =>
@@ -148,7 +152,7 @@ describe("qa scenario catalog causality", () => {
       (action) => (action as { set?: string }).set === "outboundCountAfterDelivery",
     );
     const quietWindowIndex = liveMultiRestartActions.findIndex(
-      (action) => "waitForNoOutbound" in action,
+      (action) => typeof action === "object" && action !== null && "waitForNoOutbound" in action,
     );
     const finalCardinalityAssertIndex = liveMultiRestartActions.findIndex((action) =>
       readFlowAssertExpression(action).includes("finalMatches.length === 1"),

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -106,15 +106,105 @@ describe("qa scenario catalog causality", () => {
         },
       },
     });
-    const liveMultiRestart = readQaScenarioById("gateway-restart-multi-live");
-    const liveMultiRestartContract = JSON.stringify(liveMultiRestart.execution.flow);
+    const liveMultiRestart = requireFlowScenario(readQaScenarioById("gateway-restart-multi-live"));
+    const liveMultiRestartFlow = liveMultiRestart.execution.flow;
+    const liveMultiRestartContract = JSON.stringify(liveMultiRestartFlow);
+    const liveMultiRestartPrompt = String(liveMultiRestart.execution.config?.prompt ?? "");
+    const liveMultiRestartActions = liveMultiRestartFlow?.steps[1]?.actions ?? [];
+    const checkpointLoop = liveMultiRestartActions.find((action) => "forEach" in action) as
+      | { forEach?: { actions?: unknown[] } }
+      | undefined;
+    const checkpointActions = checkpointLoop?.forEach?.actions ?? [];
+    const checkpointTranscriptIndex = checkpointActions.findIndex(
+      (action) =>
+        (action as { call?: string }).call === "waitForCondition" &&
+        (action as { saveAs?: string }).saveAs === "checkpointTranscript",
+    );
+    const checkpointStoreIndex = checkpointActions.findIndex(
+      (action) =>
+        (action as { call?: string }).call === "readRawQaSessionStore" &&
+        (action as { saveAs?: string }).saveAs === "checkpointStore",
+    );
+    const checkpointPersistenceAssertIndex = checkpointActions.findIndex((action) => {
+      const expression = readFlowAssertExpression(action);
+      return (
+        expression.includes("checkpointEntry") &&
+        expression.includes("checkpointTranscript.userMessageCount >= 1") &&
+        expression.includes("checkpointTranscript.eventCursor > 0") &&
+        expression.includes("checkpointTranscript.probeTextEndLine ?? 0") &&
+        expression.includes("restartRecoveryDeliveryContext?.channel === 'qa-channel'") &&
+        expression.includes("restartRecoveryDeliveryContext.to === `dm:${conversationId}`")
+      );
+    });
+    const checkpointRestartIndex = checkpointActions.findIndex(
+      (action) => (action as { call?: string }).call === "restartGatewayWithConfigPatch",
+    );
+    const finalOutboundIndex = liveMultiRestartActions.findIndex(
+      (action) =>
+        (action as { call?: string }).call === "waitForOutboundMessage" &&
+        (action as { saveAs?: string }).saveAs === "outbound",
+    );
+    const outboundCountIndex = liveMultiRestartActions.findIndex(
+      (action) => (action as { set?: string }).set === "outboundCountAfterDelivery",
+    );
+    const quietWindowIndex = liveMultiRestartActions.findIndex(
+      (action) => "waitForNoOutbound" in action,
+    );
+    const finalCardinalityAssertIndex = liveMultiRestartActions.findIndex((action) =>
+      readFlowAssertExpression(action).includes("finalMatches.length === 1"),
+    );
+    expect(liveMultiRestart.execution.retryCount).toBe(0);
     expect(JSON.stringify(liveMultiRestart.gatewayConfigPatch)).toContain(
       '"alsoAllow":["qa_restart_wait","qa_restart_unsafe_probe"]',
     );
     expect(liveMultiRestartContract).toContain("assistantToolCallCounts.exec");
     expect(liveMultiRestartContract).toContain("checkpoint");
     expect(liveMultiRestartContract).toContain("restarts=3");
-    expect(liveMultiRestartContract).toContain("dmScope: 'per-channel-peer'");
+    for (const fixturePath of [
+      "restart-audit/components.md",
+      "restart-audit/risks.md",
+      "restart-audit/deployments.md",
+      "restart-audit/controls.md",
+      "restart-audit/recommendation.md",
+    ]) {
+      expect(liveMultiRestartPrompt).toContain(fixturePath);
+    }
+    expect(liveMultiRestartPrompt).toContain("your only work in this turn is the next checkpoint");
+    expect(liveMultiRestartPrompt).toContain(
+      "Make exactly one `exec` call with `restartSafe: true`",
+    );
+    expect(liveMultiRestartPrompt).toContain(
+      "expired, or aborted `wait` result after restart is expected",
+    );
+    expect(liveMultiRestartPrompt).toContain("`CHECKPOINT-N` is internal tool output");
+    expect(liveMultiRestartPrompt).toContain(
+      "Do not send any assistant text before the final audit report",
+    );
+    expect(liveMultiRestartPrompt).toContain("Do not read the `restart-audit/` directory path");
+    expect(liveMultiRestartContract).toContain("sendInbound");
+    expect(liveMultiRestartContract).not.toContain("startAgentRun");
+    expect(liveMultiRestartContract).toContain("id: `dm:${conversationId}`");
+    expect(liveMultiRestartContract).toContain("dmScope: env.cfg.session?.dmScope");
+    expect(liveMultiRestartContract).toContain('"saveAs":"inbound"');
+    expect(liveMultiRestartContract).toContain("probeText: config.finalMarker");
+    expect(liveMultiRestartContract).toContain("completedToolCallCounts.wait ?? 0) < checkpoint");
+    expect(checkpointTranscriptIndex).toBeGreaterThanOrEqual(0);
+    expect(checkpointStoreIndex).toBeGreaterThan(checkpointTranscriptIndex);
+    expect(checkpointPersistenceAssertIndex).toBeGreaterThan(checkpointStoreIndex);
+    expect(checkpointRestartIndex).toBeGreaterThan(checkpointPersistenceAssertIndex);
+    expect(finalOutboundIndex).toBeGreaterThanOrEqual(0);
+    expect(outboundCountIndex).toBeGreaterThan(finalOutboundIndex);
+    expect(quietWindowIndex).toBeGreaterThan(outboundCountIndex);
+    expect(liveMultiRestartActions[quietWindowIndex]).toMatchObject({
+      waitForNoOutbound: {
+        quietMs: 3000,
+        sinceIndex: { ref: "outboundCountAfterDelivery" },
+      },
+    });
+    expect(finalCardinalityAssertIndex).toBeGreaterThan(quietWindowIndex);
+    expect(
+      liveMultiRestartActions.some((action) => (action as { call?: string }).call === "sleep"),
+    ).toBe(false);
     expect(liveMultiRestartContract).toContain("dispatching restart-safe recovery");
     expect(readQaScenarioExecutionConfig("gateway-restart-multi-live")).toMatchObject({
       requiredProviderMode: "live-frontier",

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -31,9 +31,11 @@ scenario:
   codeRefs:
     - extensions/qa-lab/src/suite-runtime-agent-session.ts
     - extensions/qa-lab/src/suite-runtime-gateway.ts
+    - extensions/qa-channel/src/inbound.ts
     - src/agents/main-session-recovery/main-session-restart-recovery.ts
   execution:
     kind: flow
+    retryCount: 0
     summary: Run a fixture-backed audit with GPT-5.4 while replacing the Gateway child three times at durable wait checkpoints.
     suiteIsolation: isolated
     isolationReason: Replaces the Gateway child three times and inspects one persistent in-flight session.
@@ -46,9 +48,23 @@ scenario:
       prompt: |-
         Perform a restart-resilience release audit. This is one task; do not ask me to follow up.
 
-        First, use OpenClaw Code Mode to create three sequential restart checkpoints. Count prior assistant `exec` calls in this transcript whose code contains `qa_restart_wait`. If the count is below three, make exactly the next checkpoint with an `exec` call whose `restartSafe` flag is true. Its JavaScript must search for `qa_restart_wait`, call the single match with `{}`, and return `CHECKPOINT-N`, where N is the next count. If `exec` reports waiting, call `wait` with its run id. A gateway restart will interrupt each checkpoint. On the recovery turn, count the transcript again and continue with the next checkpoint; do not repeat a completed checkpoint.
+        Complete this checkpoint protocol before any audit work:
+        - Inspect prior assistant `exec` calls and count only calls whose JavaScript contains both `qa_restart_wait` and a `CHECKPOINT-N` literal.
+        - If fewer than three matching calls exist, your only work in this turn is the next checkpoint. Make exactly one `exec` call with `restartSafe: true`. Its JavaScript must search for `qa_restart_wait`, call the single match with `{}`, and return the next literal (`CHECKPOINT-1`, `CHECKPOINT-2`, or `CHECKPOINT-3`).
+        - If that `exec` reports waiting, call `wait` with its run id. Do not read audit files, search for the unsafe probe, or write the final report in the same turn.
+        - A Gateway restart will interrupt the wait. A failed, unavailable, expired, or aborted `wait` result after restart is expected checkpoint evidence, not an audit failure. Do not retry that old wait.
+        - `CHECKPOINT-N` is internal tool output, never a user-facing answer. Do not echo a checkpoint marker or end the turn after an interrupted checkpoint.
+        - On the recovery turn, inspect the transcript again and immediately perform only the next missing checkpoint. Never repeat a completed checkpoint.
+        - Begin the audit immediately after the transcript contains all three distinct checkpoint `exec` calls, even when the third interrupted `wait` ended with an expected restart error. Do not send any assistant text before the final audit report.
 
-        After three checkpoint calls are visible, use restart-safe Code Mode to search for `qa_restart_unsafe_probe` and record whether it is visible. Do not call it. Then read all five files under `restart-audit/` and calculate:
+        After three checkpoint calls are visible, use restart-safe Code Mode to search for `qa_restart_unsafe_probe` and record whether it is visible. Do not call it. Do not read the `restart-audit/` directory path itself. Read these exact files:
+        - `restart-audit/components.md`
+        - `restart-audit/risks.md`
+        - `restart-audit/deployments.md`
+        - `restart-audit/controls.md`
+        - `restart-audit/recommendation.md`
+
+        Then calculate:
         - component total from services, workers, and jobs
         - risk total from low, medium, and high
         - deployment total across all regions
@@ -134,20 +150,19 @@ flow:
             expr: "`restart-multi-live-${randomUUID().slice(0, 8)}`"
         - set: sessionKey
           value:
-            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: transport.accountId, peer: { kind: 'direct', id: conversationId }, dmScope: 'per-channel-peer', identityLinks: env.cfg.session?.identityLinks })"
-        - call: startAgentRun
-          saveAs: started
-          args:
-            - ref: env
-            - sessionKey:
-                ref: sessionKey
-              message:
-                expr: config.prompt
-              to:
-                expr: "`dm:${conversationId}`"
-              taskTracking: false
-              timeoutMs:
-                expr: liveTurnTimeoutMs(env, 180000)
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: transport.accountId, peer: { kind: 'direct', id: `dm:${conversationId}` }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - sendInbound:
+            accountId: default
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: conversationId
+            senderName: QA Restart Operator
+            text:
+              expr: config.prompt
+          saveAs: inbound
         - forEach:
             items:
               - 1
@@ -160,9 +175,20 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "readSessionTranscriptSummary(env, sessionKey).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint ? summary : undefined).catch(() => undefined)"
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.finalMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.completedToolCallCounts.wait ?? 0) < checkpoint ? summary : undefined).catch(() => undefined)"
                   - expr: liveTurnTimeoutMs(env, 180000)
                   - 50
+              - call: readRawQaSessionStore
+                saveAs: checkpointStore
+                args:
+                  - ref: env
+              - set: checkpointEntry
+                value:
+                  expr: checkpointStore[sessionKey]
+              - assert:
+                  expr: "Boolean(checkpointEntry) && checkpointTranscript.userMessageCount >= 1 && checkpointTranscript.eventCursor > 0 && (checkpointTranscript.probeTextEndLine ?? 0) > 0 && checkpointEntry.restartRecoveryDeliveryContext?.channel === 'qa-channel' && checkpointEntry.restartRecoveryDeliveryContext.to === `dm:${conversationId}`"
+                  message:
+                    expr: "`checkpoint ${checkpoint} did not persist the canonical session, original user turn, transcript cursor, and restart delivery claim: entry=${JSON.stringify(checkpointEntry ?? null)} transcript=${JSON.stringify(checkpointTranscript)}`"
               - call: restartGatewayWithConfigPatch
                 args:
                   - env:
@@ -196,9 +222,13 @@ flow:
             - expr: liveTurnTimeoutMs(env, 300000)
             - sinceIndex:
                 ref: startIndex
-        - call: sleep
-          args:
-            - 3000
+        - set: outboundCountAfterDelivery
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - waitForNoOutbound:
+            quietMs: 3000
+            sinceIndex:
+              ref: outboundCountAfterDelivery
         - call: readSessionTranscriptSummary
           saveAs: finalTranscript
           args:
@@ -253,4 +283,4 @@ flow:
           args:
             - sinceIndex:
                 ref: gatewayLogCursor
-      detailsExpr: "`runId=${started.runId} session=${sessionKey} restarts=3 execs=${finalTranscript.assistantToolCallCounts.exec ?? 0} waits=${finalTranscript.assistantToolCallCounts.wait ?? 0} recoveryDispatches=${recoveryDispatches} retainedPolicies=${retainedPolicies} finalDeliveries=${finalMatches.length} resendNotices=${restartNotices.length}\n${outbound.text}`"
+      detailsExpr: "`inboundMessageId=${inbound.id} session=${sessionKey} restarts=3 execs=${finalTranscript.assistantToolCallCounts.exec ?? 0} waits=${finalTranscript.assistantToolCallCounts.wait ?? 0} recoveryDispatches=${recoveryDispatches} retainedPolicies=${retainedPolicies} finalDeliveries=${finalMatches.length} resendNotices=${restartNotices.length}\n${outbound.text}`"

--- a/src/agents/main-session-recovery/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type {
   InternalSessionEntry as SessionEntry,
   MainRestartRecoveryState,
@@ -562,6 +563,79 @@ describe("main session recovery state", () => {
       chargedAttempts: 1,
     });
     expect(entry.mainRestartRecovery?.reservation).toBeUndefined();
+  });
+
+  it("rekeys stored execution identity when a new lifecycle rotates the recovery run", () => {
+    const storedToken = createExecutionIdentityAdmissionToken("recovery-old", {
+      contextId: "context-1",
+      executionId: "execution-1",
+      now: 123,
+    });
+    const entry = interruptedEntry({
+      mainRestartRecovery: recoveryState({ executionIdentity: storedToken }),
+    });
+
+    const prepared = transitionMainSessionRecovery(entry, {
+      kind: "prepare_attempt",
+      attempt: 1,
+      lifecycleGeneration: "generation-new",
+      now: 200,
+      observation: { sessionId: "session-1", cycleId: "cycle-1", revision: 1 },
+      runId: "recovery-new",
+      executionIdentity: { state: "enabled" },
+    });
+
+    expect(prepared).toMatchObject({
+      kind: "reserved",
+      reservation: {
+        executionIdentityAdmission: {
+          kind: "retry-reference",
+          token: {
+            tokenVersion: 1,
+            contextId: "context-1",
+            executionId: "execution-1",
+            runId: "recovery-new",
+            createdAt: 123,
+          },
+        },
+      },
+    });
+    expect(entry.mainRestartRecovery?.executionIdentity).toEqual({
+      tokenVersion: 1,
+      contextId: "context-1",
+      executionId: "execution-1",
+      runId: "recovery-new",
+      createdAt: 123,
+    });
+  });
+
+  it("preserves a stored execution identity when the recovery run is unchanged", () => {
+    const storedToken = createExecutionIdentityAdmissionToken("recovery-1", {
+      contextId: "context-1",
+      executionId: "execution-1",
+      now: 123,
+    });
+    const entry = interruptedEntry({
+      mainRestartRecovery: recoveryState({ executionIdentity: storedToken }),
+    });
+
+    const prepared = transitionMainSessionRecovery(entry, {
+      kind: "prepare_attempt",
+      attempt: 1,
+      lifecycleGeneration: "generation-1",
+      now: 200,
+      observation: { sessionId: "session-1", cycleId: "cycle-1", revision: 1 },
+      runId: "recovery-1",
+      executionIdentity: { state: "enabled" },
+    });
+
+    expect(prepared).toMatchObject({
+      kind: "reserved",
+      reservation: {
+        executionIdentityAdmission: { kind: "retry-reference", token: storedToken },
+      },
+    });
+    expect(entry.mainRestartRecovery?.executionIdentity).toBe(storedToken);
   });
 
   it("rejects an old observation after a healthy clear and a new interrupted cycle", () => {

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -1,3 +1,4 @@
+import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
   sanitizePendingFinalDeliveryText,
@@ -380,14 +381,21 @@ export function transitionMainSessionRecovery(
       if (command.attempt !== state.chargedAttempts + 1) {
         return { kind: "rejected", reason: "stale_revision" };
       }
-      const executionIdentityAdmission =
-        command.executionIdentity.state === "disabled"
-          ? undefined
-          : state.executionIdentity?.runId === command.runId
-            ? ({ kind: "retry-reference", token: state.executionIdentity } as const)
-            : undefined;
+      const retryExecutionIdentity =
+        command.executionIdentity.state === "enabled" && state.executionIdentity
+          ? state.executionIdentity.runId === command.runId
+            ? state.executionIdentity
+            : createExecutionIdentityAdmissionToken(command.runId, {
+                contextId: state.executionIdentity.contextId,
+                executionId: state.executionIdentity.executionId,
+                now: state.executionIdentity.createdAt,
+              })
+          : undefined;
+      const executionIdentityAdmission = retryExecutionIdentity
+        ? ({ kind: "retry-reference", token: retryExecutionIdentity } as const)
+        : undefined;
       updateRecoveryState(entry, state, {
-        ...(command.executionIdentity.state === "disabled" ? { executionIdentity: undefined } : {}),
+        executionIdentity: retryExecutionIdentity,
         chargedAttempts: command.attempt,
         reservation: {
           runId: command.runId,

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -364,7 +364,15 @@ export async function resumeMainSession(params: {
     log.warn(`refusing message-tool-only recovery without channel authority: ${params.sessionKey}`);
     return "failed";
   }
-  const recoveryRunId = claimedRunId && claimedRunId !== sourceRunId ? claimedRunId : randomUUID();
+  const claimedRunWasAdmittedBeforeRestart =
+    claimedRunId !== undefined &&
+    params.entry.restartRecoveryRuns?.some(
+      (run) => run.runId === claimedRunId && run.lifecycleGeneration !== lifecycleGeneration,
+    ) === true;
+  const recoveryRunId =
+    claimedRunId && claimedRunId !== sourceRunId && !claimedRunWasAdmittedBeforeRestart
+      ? claimedRunId
+      : randomUUID();
   const reusingRecoveryRunId = recoveryRunId === claimedRunId;
   const dispatchSessionKey = params.canonicalSessionKey ?? params.sessionKey;
   const recoverySessionKeys = Array.from(new Set([dispatchSessionKey, params.sessionKey]));

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -66,6 +66,7 @@ import {
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../internal-runtime-context.js";
 import { AGENT_RUN_RESTART_ABORT_ERROR_CODE } from "../run-termination.js";
+import { SessionManager } from "../sessions/session-manager.js";
 import {
   createAssistantToolCallMessage,
   createSessionEntry,
@@ -1429,6 +1430,72 @@ describe("main-session-restart-recovery", () => {
       (agentRequests[1]!.params as Record<string, unknown>)
         .internalExecutionIdentityRecoveryAttempt,
     ).toBe(2);
+  });
+
+  it("mints a fresh transcript identity after a prior-lifecycle recovery was admitted", async () => {
+    const previousRecoveryRunId = "recovery-run-a";
+    const sourceRunId = "channel-run";
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
+      restartRecoveryDeliveryRunId: previousRecoveryRunId,
+      restartRecoveryDeliverySourceRunId: sourceRunId,
+      restartRecoveryDeliveryContext: discordDeliveryContext,
+      restartRecoveryRuns: [
+        { runId: previousRecoveryRunId, lifecycleGeneration: "previous-generation" },
+      ],
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      makeUserMessage("original channel turn", { idempotencyKey: `${sourceRunId}:user` }),
+      makeUserMessage("first restart continuation", {
+        idempotencyKey: `${previousRecoveryRunId}:user`,
+      }),
+      makeMessageToolCall("later-tool-call"),
+      makeMessageToolResult("later-tool-call"),
+    ]);
+    let dispatchedRunId: string | undefined;
+    let dispatchError: unknown;
+    vi.mocked(callGateway).mockImplementationOnce(async ({ method, params }) => {
+      expect(method).toBe("agent");
+      dispatchedRunId = String((params as { idempotencyKey?: unknown }).idempotencyKey);
+      const sessionManager = SessionManager.open(
+        { agentId: "main", sessionId: "main-session", sessionKey, storePath },
+        sessionsDir,
+      );
+      try {
+        sessionManager.appendMessage(
+          makeUserMessage("[System] continue after restart", {
+            idempotencyKey: `${dispatchedRunId}:user`,
+          }),
+        );
+      } catch (error) {
+        dispatchError = error;
+        throw error;
+      }
+      return { runId: dispatchedRunId, status: "accepted" };
+    });
+
+    const recoveryResult = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(dispatchError).toBeUndefined();
+    expect(recoveryResult).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(dispatchedRunId).toEqual(expect.any(String));
+    expect(dispatchedRunId).not.toBe(previousRecoveryRunId);
+    expect(gatewayParams()).toMatchObject({
+      channel: "discord",
+      idempotencyKey: dispatchedRunId,
+      to: "discord:dm:123",
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      restartRecoveryDeliveryContext: discordDeliveryContext,
+      restartRecoveryDeliveryRunId: dispatchedRunId,
+      restartRecoveryDeliverySourceRunId: sourceRunId,
+    });
+    const transcript = await loadTestTranscript(sessionKey, storePath);
+    expect(
+      transcript
+        .map((event) => event.message?.idempotencyKey)
+        .filter((key) => typeof key === "string"),
+    ).toEqual([`${sourceRunId}:user`, `${previousRecoveryRunId}:user`, `${dispatchedRunId}:user`]);
   });
 
   it("does not manufacture recovery identity before collection is disabled", async () => {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -1465,6 +1465,7 @@ describe("main-session-restart-recovery", () => {
         sessionManager.appendMessage(
           makeUserMessage("[System] continue after restart", {
             idempotencyKey: `${dispatchedRunId}:user`,
+            timestamp: Date.now(),
           }),
         );
       } catch (error) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../../packages/gateway-client/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
@@ -18,6 +19,7 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { resolveAgentRestartRecoveryExecutionIdentityAdmission } from "../../gateway/agent-turn/agent-restart-recovery-context.js";
 import { callGateway } from "../../gateway/call.js";
 import type { GatewayRecoveryRuntime } from "../../gateway/server-instance-runtime.types.js";
 import * as gatewaySessionUtils from "../../gateway/session-utils.js";
@@ -1432,11 +1434,22 @@ describe("main-session-restart-recovery", () => {
     ).toBe(2);
   });
 
-  it("mints a fresh transcript identity after a prior-lifecycle recovery was admitted", async () => {
+  it("rekeys recovery identity after a prior-lifecycle recovery was admitted", async () => {
     const previousRecoveryRunId = "recovery-run-a";
     const sourceRunId = "channel-run";
+    const previousExecutionIdentity = createExecutionIdentityAdmissionToken(previousRecoveryRunId, {
+      contextId: "recovery-context",
+      executionId: "recovery-execution",
+      now: 123,
+    });
     const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       sessionKey: "agent:main:discord:direct:123",
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 1,
+        chargedAttempts: 1,
+        executionIdentity: previousExecutionIdentity,
+      },
       restartRecoveryDeliveryRunId: previousRecoveryRunId,
       restartRecoveryDeliverySourceRunId: sourceRunId,
       restartRecoveryDeliveryContext: discordDeliveryContext,
@@ -1462,12 +1475,33 @@ describe("main-session-restart-recovery", () => {
         sessionsDir,
       );
       try {
-        sessionManager.appendMessage(
-          makeUserMessage("[System] continue after restart", {
-            idempotencyKey: `${dispatchedRunId}:user`,
-            timestamp: Date.now(),
-          }),
-        );
+        const sessionEntry = loadSessionEntry({ sessionKey, storePath });
+        const gatewayAdmission = resolveAgentRestartRecoveryExecutionIdentityAdmission({
+          collectionEnabled: true,
+          isRestartRecoveryResumeRun: true,
+          retryOnly:
+            (params as { internalExecutionIdentityRetry?: unknown })
+              .internalExecutionIdentityRetry === true,
+          runId: dispatchedRunId,
+          sessionEntry,
+        });
+        expect(gatewayAdmission?.consume(dispatchedRunId)).toEqual({
+          accepted: true,
+          token: {
+            tokenVersion: 1,
+            contextId: previousExecutionIdentity.contextId,
+            executionId: previousExecutionIdentity.executionId,
+            runId: dispatchedRunId,
+            createdAt: previousExecutionIdentity.createdAt,
+          },
+        });
+        const recoveryMessage = {
+          role: "user" as const,
+          content: "[System] continue after restart",
+          idempotencyKey: `${dispatchedRunId}:user`,
+          timestamp: Date.now(),
+        };
+        sessionManager.appendMessage(recoveryMessage);
       } catch (error) {
         dispatchError = error;
         throw error;
@@ -1475,7 +1509,10 @@ describe("main-session-restart-recovery", () => {
       return { runId: dispatchedRunId, status: "accepted" };
     });
 
-    const recoveryResult = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+    const recoveryResult = await recoverRestartAbortedMainSessions({
+      cfg: executionIdentityEnabledConfig,
+      stateDir: tmpDir,
+    });
 
     expect(dispatchError).toBeUndefined();
     expect(recoveryResult).toEqual({ recovered: 1, failed: 0, skipped: 0 });
@@ -1487,6 +1524,15 @@ describe("main-session-restart-recovery", () => {
       to: "discord:dm:123",
     });
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      mainRestartRecovery: {
+        executionIdentity: {
+          tokenVersion: 1,
+          contextId: previousExecutionIdentity.contextId,
+          executionId: previousExecutionIdentity.executionId,
+          runId: dispatchedRunId,
+          createdAt: previousExecutionIdentity.createdAt,
+        },
+      },
       restartRecoveryDeliveryContext: discordDeliveryContext,
       restartRecoveryDeliveryRunId: dispatchedRunId,
       restartRecoveryDeliverySourceRunId: sourceRunId,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -119,6 +119,7 @@ export type { AgentHarnessQuestionGatewayCall } from "../agents/harness/gateway-
 type EmbeddedRunAttemptParamsBase = Omit<
   CoreEmbeddedRunAttemptParams,
   | "admittedRunContext"
+  | "authoredContextTokenCap"
   | "contextEngineLogicalTurnLease"
   | "onContextEngineTurnCandidate"
   | "pluginHarnessToolPolicySafeDeniedTools"

--- a/test/scripts/run-android-gradle.test.ts
+++ b/test/scripts/run-android-gradle.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   linuxArmAndroidGradleSkipMessage,
   resolveAndroidSdkEnv,
@@ -12,10 +12,8 @@ import {
   shouldSkipLinuxArmAndroidGradle,
   splitAndroidGradleArgs,
 } from "../../scripts/run-android-gradle.mts";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("run-android-gradle", () => {
   it("splits Gradle args from an optional post command", () => {
@@ -102,19 +100,15 @@ describe("run-android-gradle", () => {
   });
 
   posixIt("terminates the active command tree when the wrapper is terminated", async () => {
-    const dir = tempDirs.make("openclaw-android-gradle-process-");
-    const processTreePath = path.join(dir, "process-tree.json");
     const moduleUrl = pathToFileURL(path.resolve("scripts/run-android-gradle.mts")).href;
     const childSource = `
 const { spawn } = require("node:child_process");
-const fs = require("node:fs");
 const descendant = spawn(process.execPath, [
   "-e",
   "process.on('SIGTERM', () => {}); setInterval(() => {}, 1_000);",
 ], { stdio: "ignore" });
-fs.writeFileSync(
-  process.argv[1],
-  JSON.stringify({ childPid: process.pid, descendantPid: descendant.pid }),
+process.stdout.write(
+  JSON.stringify({ childPid: process.pid, descendantPid: descendant.pid }) + "\\n",
 );
 setInterval(() => {}, 1_000);
 `;
@@ -122,25 +116,22 @@ setInterval(() => {}, 1_000);
 import { run } from ${JSON.stringify(moduleUrl)};
 process.exitCode = await run(
   process.execPath,
-  ["-e", ${JSON.stringify(childSource)}, ${JSON.stringify(processTreePath)}],
+  ["-e", ${JSON.stringify(childSource)}],
   process.cwd(),
 );
 `;
     const runner = spawn(
       process.execPath,
       ["--import", "tsx", "--input-type=module", "-e", runnerSource],
-      { stdio: "ignore" },
+      { stdio: ["ignore", "pipe", "ignore"] },
     );
     const runnerPid = expectPid(runner.pid);
+    const processTreeReady = readProcessTree(runner);
     let childPid = 0;
     let descendantPid = 0;
 
     try {
-      await waitFor(() => fs.existsSync(processTreePath));
-      const processTree = JSON.parse(fs.readFileSync(processTreePath, "utf8")) as {
-        childPid: number;
-        descendantPid: number;
-      };
+      const processTree = await processTreeReady;
       childPid = processTree.childPid;
       descendantPid = processTree.descendantPid;
       expect(Number.isInteger(childPid)).toBe(true);
@@ -187,6 +178,43 @@ function expectPid(pid: number | undefined): number {
     throw new Error("expected child process pid");
   }
   return pid;
+}
+
+async function readProcessTree(child: ReturnType<typeof spawn>): Promise<{
+  childPid: number;
+  descendantPid: number;
+}> {
+  const stdout = child.stdout;
+  if (!stdout) {
+    throw new Error("expected child process stdout");
+  }
+  stdout.setEncoding("utf8");
+  return await new Promise((resolve, reject) => {
+    let output = "";
+    const cleanup = () => {
+      stdout.off("data", onData);
+      child.off("close", onClose);
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`runner closed before reporting its process tree (${code}, ${signal})`));
+    };
+    const onData = (chunk: string) => {
+      output += chunk;
+      const newline = output.indexOf("\n");
+      if (newline === -1) {
+        return;
+      }
+      cleanup();
+      try {
+        resolve(JSON.parse(output.slice(0, newline)));
+      } catch (error) {
+        reject(error);
+      }
+    };
+    stdout.on("data", onData);
+    child.once("close", onClose);
+  });
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 3_000): Promise<void> {


### PR DESCRIPTION
Related: #105126

## What Problem This Solves

Fixes an issue where the `gateway-restart-multi-live` QA scenario timed out without proving channel delivery because it launched a synthetic Gateway chat run and manually constructed session/delivery identity. Once routed through real qa-channel ingress, repeated accepted recoveries also exposed a core bug: a recovery run id was reused across Gateway lifecycle generations, causing the next internal recovery user turn to collide with an ancestor transcript idempotency key.

## Why This Change Was Made

Route the task through `sendInbound` so qa-channel owns the canonical session and durable delivery claim. The scenario now verifies the original inbound turn, transcript cursor, and delivery context before every replacement; requires each `wait` checkpoint to still be pending; checks a no-extra-outbound quiet window; and gives the live model exact checkpoint/audit instructions. Core recovery now rotates an already-admitted prior-lifecycle recovery run id while preserving the original channel source/context and retaining stable ids for same-lifecycle ambiguous dispatch retries.

The PR also carries a bounded fix-forward for red main after #124735: the Plugin SDK declares the optional authored context cap directly so packaged extension declarations match the core attempt contract.

## User Impact

Automatic channel recovery can continue through multiple sequential Gateway replacements without transcript-parent collisions or duplicate delivery. Maintainers also regain truthful live proof: one real inbound channel turn, three in-flight recoveries, one final outbound reply.

## Evidence

- Pre-fix current-main authenticated OpenAI reproduction: repeated 360000ms timeout with no final bus delivery; initial local reproduction remained silent for more than 12 minutes across the automatic retry.
- Regression authoring: the scenario contract failed pre-fix; the real SessionManager/SQLite regression reproduced the ancestor idempotency collision before the owner fix.
- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts` — 156 passed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog-causality.test.ts extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts extensions/qa-lab/src/scenario-catalog.openai-live.test.ts` — 19 passed.
- `pnpm openclaw qa suite --provider-mode mock-openai --scenario gateway-restart-inflight-run --concurrency 1 --output-dir .artifacts/qa-e2e/gateway-restart-inflight-run-mock-after` — 1 passed, deterministic qa-channel owner-boundary proof.
- Authenticated OpenAI GPT-5.4 run of `gateway-restart-multi-live` — 1 passed in 137.7s; three recovery dispatches; three retained restart-safe policies; exactly one final delivery; zero resend notices; unsafe tool hidden; complete components/risks/deployments/controls/GO audit.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs -- <four files>` delegated to Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31965044963; it passed conflict/env/max-lines checks, then stopped on unrelated assertion-safety baseline drift in untouched `src/state/control-ui-device-auth-migration.ts` and `ui/src/lib/nodes/index.ts`.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings, 0.97 confidence.
- Production LOC: +9/-1. QA scenario/test support: +211/-24.
- AI-assisted. I reviewed the ingress ownership, recovery identity rotation, transcript collision regression, mock proof, and authenticated live result.
- Current main and the previous exact head failed check-additional-extension-package-boundary on authoredContextTokenCap; the explicit SDK declaration passed the main-shaped package boundary, build, surface/typechecks, 18 focused SDK tests, formatting, and autoreview.
