### PR TITLE
fix(matrix): edit expired exec approvals instead of redacting (#113263)

### DIFF
--- a/extensions/matrix/src/approval-handler.runtime.test.ts
+++ b/extensions/matrix/src/approval-handler.runtime.test.ts
@@ -600,4 +600,74 @@ describe("matrixApprovalNativeRuntime", () => {
       ].join("\n"),
     });
   });
+
+  it("redacts expired exec approvals by default (back-compat)", async () => {
+    const result = await matrixApprovalNativeRuntime.presentation.buildExpiredResult({
+      cfg: {} as never,
+      accountId: "default",
+      context: { client: {} as never },
+      request: {
+        id: "req-1",
+        request: { command: "echo hi" },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        phase: "expired",
+        title: "Exec Approval Required",
+        metadata: [],
+        commandText: "echo hi",
+      } as never,
+      entry: {} as never,
+    });
+
+    expect(result).toEqual({ kind: "delete" });
+  });
+
+  it("edits expired exec approvals in place when onExpire is 'edit'", async () => {
+    const result = await matrixApprovalNativeRuntime.presentation.buildExpiredResult({
+      cfg: {
+        channels: {
+          matrix: {
+            accounts: {
+              default: {
+                execApprovals: { onExpire: "edit" },
+              },
+            },
+          },
+        },
+      } as never,
+      accountId: "default",
+      context: { client: {} as never },
+      request: {
+        id: "req-1",
+        request: { command: "echo hi" },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        phase: "expired",
+        title: "Exec Approval Required",
+        metadata: [],
+        commandText: "echo hi",
+      } as never,
+      entry: {} as never,
+    });
+
+    expect(result).toEqual({
+      kind: "update",
+      payload: [
+        "Exec approval: Expired (no decision within the approval window)",
+        "",
+        "Command",
+        "```",
+        "echo hi",
+        "```",
+      ].join("\n"),
+    });
+  });
 });

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -1,6 +1,7 @@
 // Matrix plugin module implements approval handler behavior.
 import type {
   ChannelApprovalCapabilityHandlerContext,
+  ExpiredApprovalView,
   PendingApprovalView,
   ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
@@ -377,6 +378,18 @@ function buildMarkdownCodeBlock(text: string): string {
   return [fence, text, fence].join("\n");
 }
 
+function buildExpiredApprovalText(view: ExpiredApprovalView): string {
+  if (view.approvalKind === "plugin") {
+    return "Exec approval: Expired (no decision within the approval window)";
+  }
+  return [
+    "Exec approval: Expired (no decision within the approval window)",
+    "",
+    "Command",
+    buildMarkdownCodeBlock(view.commandText),
+  ].join("\n");
+}
+
 export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<
   PendingApprovalContent,
   PreparedMatrixTarget,
@@ -419,7 +432,17 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
       kind: "update",
       payload: buildResolvedApprovalText(view),
     }),
-    buildExpiredResult: () => ({ kind: "delete" }),
+    buildExpiredResult: ({ cfg, accountId, context, view }) => {
+      const resolved = resolveHandlerContext({ cfg, accountId, context });
+      const onExpire = resolved
+        ? resolveMatrixAccount({ cfg: cfg as CoreConfig, accountId: resolved.accountId }).config
+            .execApprovals?.onExpire
+        : undefined;
+      if (onExpire === "edit") {
+        return { kind: "update", payload: buildExpiredApprovalText(view) };
+      }
+      return { kind: "delete" };
+    },
   },
   transport: {
     prepareTarget: ({ cfg, accountId, context, plannedTarget }) => {

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -43,6 +43,10 @@ const matrixExecApprovalsSchema = z
     agentFilter: z.array(z.string()).optional(),
     sessionFilter: z.array(z.string()).optional(),
     target: z.enum(["dm", "channel", "both"]).optional(),
+    // Default "redact" preserves existing behavior; "edit" rewrites the
+    // prompt in-place (matching the resolved-approval path) instead of
+    // leaving a delete tombstone once the approval TTL elapses.
+    onExpire: z.enum(["redact", "edit"]).optional(),
   })
   .optional();
 

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -87,6 +87,8 @@ type MatrixExecApprovalConfig = {
   sessionFilter?: string[];
   /** Where approval prompts should go. Default: dm. */
   target?: MatrixExecApprovalTarget;
+  /** On TTL expiry, edit the prompt in-place instead of redacting it. Default: redact. */
+  onExpire?: "redact" | "edit";
 };
 
 export type MatrixStreamingMode = "partial" | "quiet" | "progress" | "off";


### PR DESCRIPTION
## Problem

When a pending Matrix exec approval hits the 30-minute TTL, the handler always redacts the prompt (`buildExpiredResult: () => ({ kind: "delete" })`), leaving a "message deleted" tombstone. Reviewers lose visibility into what was requested and when it timed out. Resolved approvals already use `kind: "update"` (in-place edit) via `buildResolvedApprovalText`, so the delete-on-expiry path is an asymmetry, not an intentional design choice.

Fixes #113263, which documents a production case: 54 of 60 approval prompts in one room export were self-redacted after exactly 30 minutes.

## Fix

- Add `channels.matrix.execApprovals.onExpire: "redact" | "edit"` to the Matrix config schema. Default is `"redact"` — no behavior change unless explicitly opted in.
- When `onExpire: "edit"`, `buildExpiredResult` returns `{ kind: "update", payload: buildExpiredApprovalText(view) }` instead of `{ kind: "delete" }`, reusing the same `updateEntry` transport path already used for resolved approvals.
- New `buildExpiredApprovalText` helper mirrors `buildResolvedApprovalText`'s structure (title + command code block), reusing the existing `buildMarkdownCodeBlock` fence-escaping helper.
- Reaction-binding cleanup is unaffected — `unbindPending` already runs before `buildExpiredResult` is called in `finalizeExpired`, so this is orthogonal to the edit/delete decision.

## Scope / limitations

- Only exec approvals get a rich edit body (title + command). Plugin approvals on the edit path currently fall back to a simple title-only message; could be extended later if there's demand.
- No config change is needed to keep existing behavior — `onExpire` defaults to `"redact"`.

## Testing

- Added two tests to `approval-handler.runtime.test.ts`: default redact-on-expiry (regression guard) and edit-on-expiry when `onExpire: "edit"` is set.
- `npx vitest run extensions/matrix/src/approval-handler.runtime.test.ts` — 9/9 passing.
- `./node_modules/.bin/oxlint` on all changed files — 0 warnings/errors.
- Confirmed the one pre-existing `tsc --noEmit -p tsconfig.extensions.json` error (`system-agent/chat-turn-router.ts`) is present on a clean `upstream/main` checkout too — unrelated to this change.
