### PR TITLE
fix(tui): close stale prompts after session restore

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -26,7 +26,9 @@ export async function disposeActiveTuiFixtures(): Promise<void> {
   }
 }
 
-export async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
+export async function startTuiFixture(
+  opts: { env?: NodeJS.ProcessEnv; rememberedSessionKey?: string } = {},
+) {
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-"));
   const scriptPath = await writeTuiPtyFixtureScript(tempDir);
   const logPath = path.join(tempDir, "fixture-log.jsonl");
@@ -36,6 +38,12 @@ export async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
     env: {
       OPENCLAW_THEME: "dark",
       OPENCLAW_TUI_PTY_LOG_PATH: logPath,
+      ...(opts.rememberedSessionKey
+        ? {
+            OPENCLAW_STATE_DIR: tempDir,
+            OPENCLAW_TUI_PTY_REMEMBERED_SESSION_KEY: opts.rememberedSessionKey,
+          }
+        : {}),
       NO_COLOR: undefined,
       ...opts.env,
     },
@@ -68,6 +76,9 @@ export async function writeTuiPtyFixtureScript(dir: string) {
   const outboundPayloadsModuleUrl = pathToFileURL(
     path.join(process.cwd(), "src/infra/outbound/payloads.ts"),
   ).href;
+  const lastSessionModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/tui/tui-last-session.ts"),
+  ).href;
   await writeFile(
     scriptPath,
     `
@@ -76,12 +87,15 @@ export async function writeTuiPtyFixtureScript(dir: string) {
       import { buildEmbeddedRunPayloads } from ${JSON.stringify(payloadsModuleUrl)};
       import { getReplyPayloadMetadata } from ${JSON.stringify(replyPayloadModuleUrl)};
       import { normalizeReplyPayloadsForDelivery } from ${JSON.stringify(outboundPayloadsModuleUrl)};
+      import { buildTuiLastSessionScopeKey, writeTuiLastSessionKey } from ${JSON.stringify(lastSessionModuleUrl)};
       import type { TuiBackend } from ${JSON.stringify(tuiModuleUrl.replace("/tui.ts", "/tui-backend.ts"))};
       import { runTui } from ${JSON.stringify(tuiModuleUrl)};
 
       const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
       const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
       const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
+      const rememberedSessionKey = process.env.OPENCLAW_TUI_PTY_REMEMBERED_SESSION_KEY;
+      const preRestoreOverlay = process.env.OPENCLAW_TUI_PTY_PRE_RESTORE_OVERLAY;
       const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
       const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
       let verboseLevel = process.env.OPENCLAW_TUI_PTY_VERBOSE_LEVEL;
@@ -504,7 +518,9 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           record("listSessions", {
             purpose: opts?.includeDerivedTitles ? "picker" : "refresh",
           });
-          const sessions = enablePickerFixture
+          const sessions = rememberedSessionKey
+            ? [sessionEntry(rememberedSessionKey)]
+            : enablePickerFixture
             ? [
                 sessionEntry("main"),
                 {
@@ -659,6 +675,16 @@ export async function writeTuiPtyFixtureScript(dir: string) {
       }
 
       async function main() {
+        if (rememberedSessionKey) {
+          await writeTuiLastSessionKey({
+            scopeKey: buildTuiLastSessionScopeKey({
+              connectionUrl: "pty-fixture://local",
+              agentId: "main",
+              sessionScope: "per-sender",
+            }),
+            sessionKey: rememberedSessionKey,
+          });
+        }
         await runTui({
           backend: new FixtureBackend(),
           config: {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -311,6 +311,39 @@ describe.sequential("TUI PTY harness", () => {
     expect(taskRefreshIndex).toBeLessThan(historyLoadIndex);
   });
 
+  it.each([
+    ["plugin approval", "plugin-approval", "workspace skill approval: Default session approval"],
+    ["task suggestion", "task-suggestion", "Suggested follow-up: Default session task"],
+  ] as const)(
+    "closes a pre-restore %s after adopting the remembered session",
+    async (_label, preRestoreOverlay, stalePrompt) => {
+      const rememberedSessionKey = "agent:main:remembered";
+      const restoreFixture = await startTuiFixture({
+        rememberedSessionKey,
+        env: { OPENCLAW_TUI_PTY_PRE_RESTORE_OVERLAY: preRestoreOverlay },
+      });
+      try {
+        await restoreFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "loadHistory" &&
+            objectFieldEquals(entry, "sessionKey", rememberedSessionKey),
+          STARTUP_TIMEOUT_MS,
+        );
+        const rows = await waitForSynchronizedFrameRows(
+          restoreFixture.run,
+          (frameRows) =>
+            frameRows.some((row) => row.includes("session remembered")) &&
+            frameRows.some((row) => row.includes("local ready | idle")),
+          STARTUP_TIMEOUT_MS,
+        );
+        expect(rows.join("\n")).not.toContain(stalePrompt);
+      } finally {
+        await restoreFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
   it(
     "drives the real TUI terminal loop through typed and fragmented Unicode input",
     async () => {

--- a/src/tui/tui-pty-subscription-fixture-test-support.ts
+++ b/src/tui/tui-pty-subscription-fixture-test-support.ts
@@ -1,6 +1,7 @@
 // Keeps bounded session-subscription failure injection outside the shared PTY fixture.
 export const TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT = `
   private sessionSubscriptionAttempts = 0;
+  private preRestoreOverlayEmitted = false;
 
   async subscribeSessionEvents() {
     record("subscribeSessionEvents");
@@ -8,6 +9,44 @@ export const TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT = `
     if (this.sessionSubscriptionAttempts++ < configuredFailures) {
       record("subscribeSessionFailure");
       throw new Error("fixture session subscription unavailable");
+    }
+    if (!this.preRestoreOverlayEmitted && preRestoreOverlay) {
+      this.preRestoreOverlayEmitted = true;
+      if (preRestoreOverlay === "plugin-approval") {
+        pendingPluginApproval = {
+          id: "plugin:pre-restore",
+          request: {
+            title: "Default session approval",
+            description: "This prompt must close when remembered-session restore changes identity.",
+            pluginId: "workspace-skills",
+            severity: "warning",
+            toolName: "skill_workshop",
+            allowedDecisions: ["allow-once", "deny"],
+            sessionKey: "agent:main:main",
+          },
+          createdAtMs: Date.now(),
+          expiresAtMs: Date.now() + 120_000,
+        };
+        this.onEvent?.({
+          event: "plugin.approval.requested",
+          payload: pendingPluginApproval,
+        });
+      } else if (preRestoreOverlay === "task-suggestion") {
+        pendingTaskSuggestion = {
+          id: "task_pre_restore",
+          title: "Default session task",
+          prompt: "This prompt must close when remembered-session restore changes identity.",
+          tldr: "It belongs to the abandoned default session.",
+          cwd: "/repo/project",
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          createdAt: Date.now(),
+        };
+        this.onEvent?.({
+          event: "task.suggestion",
+          payload: { action: "created", suggestion: pendingTaskSuggestion },
+        });
+      }
     }
     return { subscribed: true };
   }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -729,19 +729,15 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   const sessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   const sessionMainKey = normalizeMainKey(config.session?.mainKey);
   const configuredDefaultAgentId = tryResolveDefaultAgentId(config);
-  let currentAgentId = resolveInitialTuiAgentId({
+  const initialAgentId = resolveInitialTuiAgentId({
     cfg: config,
     fallbackAgentId: configuredDefaultAgentId,
     initialSessionInput,
     agentId: opts.agentId,
   });
-  const agentDefaultId = configuredDefaultAgentId ?? currentAgentId;
+  const agentDefaultId = configuredDefaultAgentId ?? initialAgentId;
   const agentNames = new Map<string, string>();
-  let currentSessionKey = "";
   let rememberedSessionApplied = false;
-  let currentSessionId: string | null = null;
-  const sessionGenerations = new Map<string, number>();
-  const sessionIds = new Map<string, string>();
   let connectionGeneration = 0;
   let wasDisconnected = false;
   let remediationShown = false;
@@ -765,62 +761,74 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   let invalidateSessionRunOwnership: () => void = () => undefined;
   let retireHistoryAbsentRun: (_runId: string) => void = () => undefined;
 
-  const currentSessionGenerationKey = (): string =>
-    JSON.stringify([currentAgentId, currentSessionKey]);
-  const readCurrentSessionGeneration = () =>
-    sessionGenerations.get(currentSessionGenerationKey()) ?? 0;
-  const writeCurrentSessionGeneration = (value: number) => {
-    sessionGenerations.set(currentSessionGenerationKey(), value);
-  };
-
-  const state: TuiStateAccess = {
+  const state = {
     agentDefaultId,
     sessionMainKey,
     sessionScope,
     agents: [],
+    sessionIdentity: {
+      agentId: initialAgentId,
+      sessionKey: resolveTuiSessionSelection({
+        raw: initialSessionInput,
+        cfg: config,
+        sessionScope,
+        currentAgentId: initialAgentId,
+        sessionMainKey,
+      }).key,
+      sessionId: null as string | null,
+      epochs: new Map<string, [sessionId: string | undefined, generation: number]>(),
+    },
+    currentSessionGenerationKey() {
+      return JSON.stringify([this.sessionIdentity.agentId, this.sessionIdentity.sessionKey]);
+    },
     get currentAgentId() {
-      return currentAgentId;
+      return this.sessionIdentity.agentId;
     },
     set currentAgentId(value) {
-      if (currentAgentId === value) {
+      if (this.sessionIdentity.agentId === value) {
         return;
       }
-      currentAgentId = value;
+      this.sessionIdentity.agentId = value;
       invalidateSessionRunOwnership();
       pluginApprovals?.sessionChanged();
       taskSuggestions?.sessionChanged();
     },
     get currentSessionKey() {
-      return currentSessionKey;
+      return this.sessionIdentity.sessionKey;
     },
     set currentSessionKey(value) {
-      currentSessionKey = value;
+      this.sessionIdentity.sessionKey = value;
       pluginApprovals?.sessionChanged();
       taskSuggestions?.sessionChanged();
     },
     get currentSessionId() {
-      return currentSessionId;
+      return this.sessionIdentity.sessionId;
     },
     set currentSessionId(value) {
       if (value) {
-        const generationKey = currentSessionGenerationKey();
-        const previousSessionId = sessionIds.get(generationKey);
+        const generationKey = this.currentSessionGenerationKey();
+        const previous = this.sessionIdentity.epochs.get(generationKey);
+        const previousSessionId = previous?.[0];
         // The first ID binds an unresolved selection; reset/replacement owners bump explicitly.
-        if (previousSessionId && previousSessionId !== value) {
-          writeCurrentSessionGeneration(readCurrentSessionGeneration() + 1);
-        }
-        sessionIds.set(generationKey, value);
+        const generation =
+          (previous?.[1] ?? 0) + (previousSessionId && previousSessionId !== value ? 1 : 0);
+        this.sessionIdentity.epochs.set(generationKey, [value, generation]);
       }
-      currentSessionId = value;
+      this.sessionIdentity.sessionId = value;
     },
     get sessionGeneration() {
-      return readCurrentSessionGeneration();
+      return this.sessionIdentity.epochs.get(this.currentSessionGenerationKey())?.[1] ?? 0;
     },
     set sessionGeneration(value) {
-      writeCurrentSessionGeneration(Math.max(readCurrentSessionGeneration(), value));
+      const generationKey = this.currentSessionGenerationKey();
+      const previous = this.sessionIdentity.epochs.get(generationKey);
+      this.sessionIdentity.epochs.set(generationKey, [
+        previous?.[0],
+        Math.max(previous?.[1] ?? 0, value),
+      ]);
     },
-    activeChatRunId: null,
-    pendingSubmit: null,
+    activeChatRunId: null as TuiStateAccess["activeChatRunId"],
+    pendingSubmit: null as TuiStateAccess["pendingSubmit"],
     historyLoaded: false,
     sessionInfo: { ...emptySessionInfoDefaults },
     initialSessionApplied: false,
@@ -830,7 +838,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     showThinking: false,
     connectionStatus: isLocalMode ? "starting local runtime" : "connecting",
     activityStatus: "idle",
-    statusTimeout: null,
+    statusTimeout: null as TuiStateAccess["statusTimeout"],
     lastCtrlCAt: 0,
   };
 
@@ -1007,9 +1015,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     });
   };
 
-  currentSessionKey = resolveSessionSelection(initialSessionInput).key;
-
-  const buildLastSessionScopeKeyFor = (sessionKey = currentSessionKey) => {
+  const buildLastSessionScopeKeyFor = (sessionKey = state.currentSessionKey) => {
     const parsed = parseAgentSessionKey(sessionKey);
     return buildTuiLastSessionScopeKey({
       connectionUrl: client.connection.url,
@@ -1045,7 +1051,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     }
     const rememberedSelection = remembered ? resolveSessionSelection(remembered) : null;
     const rememberedKey = rememberedSelection?.key ?? null;
-    if (!rememberedKey || rememberedKey === currentSessionKey) {
+    if (!rememberedKey || rememberedKey === state.currentSessionKey) {
       rememberedSessionApplied = true;
       return;
     }
@@ -1078,16 +1084,16 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       currentAgentId: state.currentAgentId,
       sessions: sessions.sessions,
     });
-    if (!restored || restored === currentSessionKey) {
+    if (!restored || restored === state.currentSessionKey) {
       return;
     }
-    currentSessionKey = restored;
+    state.currentSessionKey = restored;
     updateHeader();
     updateFooter();
   };
 
   const updateHeader = () => {
-    const sessionLabel = formatSessionKey(currentSessionKey);
+    const sessionLabel = formatSessionKey(state.currentSessionKey);
     const agentLabel = formatAgentLabel(state.currentAgentId);
     const title = opts.title ?? "openclaw tui";
     const text = `${title} - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel}`;
@@ -1345,7 +1351,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     : undefined;
 
   const updateFooter = () => {
-    const sessionKeyLabel = formatSessionKey(currentSessionKey);
+    const sessionKeyLabel = formatSessionKey(state.currentSessionKey);
     const sessionLabel = state.sessionInfo.displayName
       ? `${sessionKeyLabel} (${state.sessionInfo.displayName})`
       : sessionKeyLabel;
@@ -1369,7 +1375,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     client,
     chatLog,
     getAgentId: () => state.currentAgentId,
-    getSessionKey: () => currentSessionKey,
+    getSessionKey: () => state.currentSessionKey,
     openOverlay,
     closeOverlay,
     requestRender: () => tui.requestRender(),
@@ -1387,7 +1393,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     if (!initialSessionInput) {
       return null;
     }
-    return currentAgentId;
+    return state.currentAgentId;
   })();
   const sessionActions = createSessionActions({
     client,
@@ -1437,8 +1443,8 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   const taskSuggestions = createTuiTaskSuggestionController({
     client,
     chatLog,
-    getAgentId: () => currentAgentId,
-    getSessionKey: () => currentSessionKey,
+    getAgentId: () => state.currentAgentId,
+    getSessionKey: () => state.currentSessionKey,
     openOverlay,
     closeOverlay,
     requestRender: () => tui.requestRender(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relaunching the TUI into a remembered session could keep seeing a plugin-approval or task-suggestion prompt from the initial default session.

## Why This Change Was Made

Session identity now lives in one state-owned record, and all runtime identity changes—including remembered-session restoration—flow through the state accessors that invalidate session-bound overlays and run generations. Initialization writes the record before observers exist; the backend remains a consumer of captured identity rather than a second owner.

## User Impact

After the TUI restores a remembered session, only prompts belonging to that active session remain actionable and visible.

## Evidence

- Pre-fix real-PTY regression: both new remembered-session cases failed because the default-session plugin approval and task suggestion remained visible under the restored-session header.
- Post-fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-harness.e2e.test.ts -t "closes a pre-restore"` — 2 passed.
- Requested TUI suite: `node scripts/run-vitest.mjs run src/tui --configLoader runner` — 44 files, 1,179 tests passed.
- Core production and core-test TypeScript checks passed.
- Targeted oxlint, formatting, and `git diff --check` passed.
- Codex autoreview (Sol/high): clean, no accepted/actionable findings.

Production LOC: +51/-45 (net +6) for the state ownership boundary. Tests/test support: +100/-2.
