### PR TITLE
fix(tasks): cancel subagents through gateway

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -327,15 +327,40 @@ describe("tasks commands", () => {
     });
   });
 
-  it("routes cron task cancellation through the live gateway before local fallback", async () => {
+  it.each([
+    {
+      label: "Cron",
+      runtime: "cron",
+      ownerKey: "",
+      scopeKind: "system",
+      childSessionKey: "agent:main:cron:nightly-gmail-sync",
+      runId: "cron:nightly-gmail-sync:123",
+    },
+    {
+      label: "ACP",
+      runtime: "acp",
+      ownerKey: "agent:jarvis:main",
+      scopeKind: "session",
+      childSessionKey: "agent:codex:acp:child",
+      runId: "run-acp-cancel",
+    },
+    {
+      label: "Subagent",
+      runtime: "subagent",
+      ownerKey: "agent:jarvis:main",
+      scopeKind: "session",
+      childSessionKey: "agent:worker:subagent:child",
+      runId: "run-subagent-cancel",
+    },
+  ] as const)("routes $label task cancellation through the live gateway", async (testCase) => {
     await withTaskCommandStateDir(async () => {
       const task = createTaskRecord({
-        runtime: "cron",
-        sourceId: "nightly-gmail-sync",
-        ownerKey: "",
-        scopeKind: "system",
-        runId: "cron:nightly-gmail-sync:123",
-        task: "Nightly Gmail sync",
+        runtime: testCase.runtime,
+        ownerKey: testCase.ownerKey,
+        scopeKind: testCase.scopeKind,
+        childSessionKey: testCase.childSessionKey,
+        runId: testCase.runId,
+        task: `Cancel ${testCase.label} child`,
         status: "running",
         deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
@@ -345,7 +370,7 @@ describe("tasks commands", () => {
         cancelled: true,
         task: {
           taskId: task.taskId,
-          runtime: "cron",
+          runtime: testCase.runtime,
           runId: task.runId,
         },
       });
@@ -361,48 +386,7 @@ describe("tasks commands", () => {
         }),
       );
       expect(runtime.log).toHaveBeenCalledWith(
-        `Cancelled ${task.taskId} (cron) run cron:nightly-gmail-sync:123.`,
-      );
-      expect(runtime.error).not.toHaveBeenCalled();
-      expect(runtime.exit).not.toHaveBeenCalled();
-    });
-  });
-
-  it("routes ACP task cancellation through the live gateway before local fallback", async () => {
-    await withTaskCommandStateDir(async () => {
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
-        childSessionKey: "agent:codex:acp:child",
-        runId: "run-acp-cancel",
-        task: "Cancel ACP child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-      });
-      mocks.callGateway.mockResolvedValueOnce({
-        found: true,
-        cancelled: true,
-        task: {
-          taskId: task.taskId,
-          runtime: "acp",
-          runId: task.runId,
-        },
-      });
-      const runtime = createRuntime();
-
-      await tasksCancelCommand({ lookup: task.taskId }, runtime);
-
-      expect(mocks.callGateway).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "tasks.cancel",
-          params: { taskId: task.taskId },
-          timeoutMs: 5_000,
-        }),
-      );
-      expect(runtime.log).toHaveBeenCalledWith(
-        `Cancelled ${task.taskId} (acp) run run-acp-cancel.`,
+        `Cancelled ${task.taskId} (${testCase.runtime}) run ${testCase.runId}.`,
       );
       expect(runtime.error).not.toHaveBeenCalled();
       expect(runtime.exit).not.toHaveBeenCalled();
@@ -457,38 +441,54 @@ describe("tasks commands", () => {
     },
   );
 
-  it("fails ACP task cancellation loudly when the live gateway is unavailable", async () => {
-    await withTaskCommandStateDir(async () => {
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
-        childSessionKey: "agent:codex:acp:child",
-        runId: "run-acp-cancel-gateway-down",
-        task: "Cancel ACP child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
+  it.each([
+    {
+      label: "ACP",
+      runtime: "acp",
+      childSessionKey: "agent:codex:acp:child",
+      runId: "run-acp-cancel-gateway-down",
+    },
+    {
+      label: "Subagent",
+      runtime: "subagent",
+      childSessionKey: "agent:worker:subagent:child",
+      runId: "run-subagent-cancel-gateway-down",
+    },
+  ] as const)(
+    "fails $label task cancellation loudly when the live gateway is unavailable",
+    async (testCase) => {
+      await withTaskCommandStateDir(async () => {
+        const task = createTaskRecord({
+          runtime: testCase.runtime,
+          ownerKey: "agent:jarvis:main",
+          scopeKind: "session",
+          childSessionKey: testCase.childSessionKey,
+          runId: testCase.runId,
+          task: `Cancel ${testCase.label} child`,
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+        });
+        mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+        const runtime = createRuntime();
+
+        await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+        expect(mocks.callGateway).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "tasks.cancel",
+            params: { taskId: task.taskId },
+            timeoutMs: 5_000,
+          }),
+        );
+        expect(runtime.error).toHaveBeenCalledWith(
+          `${testCase.runtime.toUpperCase()} task cancellation requires the live Gateway tasks.cancel path: gateway unavailable`,
+        );
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(runtime.log).not.toHaveBeenCalled();
       });
-      mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
-      const runtime = createRuntime();
-
-      await tasksCancelCommand({ lookup: task.taskId }, runtime);
-
-      expect(mocks.callGateway).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "tasks.cancel",
-          params: { taskId: task.taskId },
-          timeoutMs: 5_000,
-        }),
-      );
-      expect(runtime.error).toHaveBeenCalledWith(
-        "ACP task cancellation requires the live Gateway tasks.cancel path: gateway unavailable",
-      );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(runtime.log).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it("explains stale running tasks retained by backing sessions in maintenance JSON", async () => {
     await withTaskCommandStateDir(async (state) => {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -98,7 +98,7 @@ type GatewayTaskCancelResult = {
 async function tryCancelGatewayOwnedTaskViaGateway(
   task: TaskRecord,
 ): Promise<GatewayTaskCancelResult | null> {
-  if (task.runtime !== "cron" && task.runtime !== "acp") {
+  if (task.runtime === "cli") {
     return null;
   }
   try {
@@ -109,16 +109,16 @@ async function tryCancelGatewayOwnedTaskViaGateway(
       timeoutMs: 5_000,
     });
   } catch (error) {
-    if (task.runtime === "acp") {
-      const detail = error instanceof Error ? error.message : String(error);
-      return {
-        found: true,
-        cancelled: false,
-        reason: `ACP task cancellation requires the live Gateway tasks.cancel path: ${detail}`,
-        task,
-      };
+    if (task.runtime === "cron") {
+      return null;
     }
-    return null;
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      found: true,
+      cancelled: false,
+      reason: `${task.runtime.toUpperCase()} task cancellation requires the live Gateway tasks.cancel path: ${detail}`,
+      task,
+    };
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users cancelling a running subagent through `openclaw tasks cancel` would receive `Subagent task not found`, even though the Gateway owned and could cancel the task.

## Why This Change Was Made

Gateway-owned task runtimes now use the canonical Gateway `tasks.cancel` path. CLI tasks remain local, and cron tasks retain their existing local fallback when the Gateway is unavailable. Existing cron and ACP coverage is consolidated into table-driven cases that also protect subagent behavior.

## User Impact

Operators can cancel running subagent tasks through the tasks CLI using the task ID, child-session key, or run ID, with failures reported from the authoritative Gateway path instead of a misleading local lookup miss.

## Evidence

- Pre-fix regression proof with the production change stashed: 2 subagent cancellation cases failed.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/commands/tasks.test.ts` — 27 tests passed.
- Changed-surface gate: `node scripts/check-changed.mjs` — passed. Configured remote providers were unavailable, so the repository wrapper used its documented local fallback.
- Live QA campaign repro: `tasks cancel` on a running subagent returned `Subagent task not found` for task ID, child-session key, and run ID lookup forms, while Gateway `tasks.cancel` successfully cancelled the same task.
- Production LOC: +10/-10 (net 0). Tests: +80/-80 (net 0).
- Fresh autoreview: clean, with no accepted or actionable findings.
