### PR TITLE
fix(cli): explain empty directory lookups

### DIFF
--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -55,15 +55,27 @@ openclaw message send --channel slack --target user:U012ABCDEF --message "hello"
 openclaw directory self --channel zalouser
 ```
 
-A channel may legitimately return no self identity, including channels that only expose peer or
-group directories. This is a successful empty result (exit code `0`), not a failed lookup. The text
-output names the queried channel and account and explains that the plugin returned no identity. In
-JSON mode, the result is structured so scripts can distinguish it from an error:
+A channel may legitimately return no self identity. This is a successful empty result (exit code
+`0`), not a failed lookup. Channels without a self resolver report that the channel does not expose
+a self identity, without suggesting account troubleshooting:
 
 ```json
 {
   "status": "unavailable",
   "channel": "telegram",
+  "accountId": "default",
+  "reason": "self-identity-unsupported"
+}
+```
+
+When a channel implements self lookup but returns no identity, the text output names the channel and
+account and suggests checking its configuration and authentication. JSON callers can distinguish
+that case by its reason:
+
+```json
+{
+  "status": "unavailable",
+  "channel": "msteams",
   "accountId": "default",
   "reason": "plugin-returned-no-self-identity"
 }

--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -18,7 +18,9 @@ Results are meant to be pasted into other commands, especially `openclaw message
 - `--account <id>`: account id (default: channel default)
 - `--json`: output JSON
 
-Default (non-JSON) output is `id` (and sometimes `name`) separated by a tab.
+Default output renders IDs and names in a table. Empty list results name the channel and account
+that were queried; JSON list output uses an empty array (`[]`). Failures exit nonzero and use an
+`{ "error": "..." }` object in JSON mode.
 
 ## Notes
 
@@ -51,6 +53,20 @@ openclaw message send --channel slack --target user:U012ABCDEF --message "hello"
 
 ```bash
 openclaw directory self --channel zalouser
+```
+
+A channel may legitimately return no self identity, including channels that only expose peer or
+group directories. This is a successful empty result (exit code `0`), not a failed lookup. The text
+output names the queried channel and account and explains that the plugin returned no identity. In
+JSON mode, the result is structured so scripts can distinguish it from an error:
+
+```json
+{
+  "status": "unavailable",
+  "channel": "telegram",
+  "accountId": "default",
+  "reason": "plugin-returned-no-self-identity"
+}
 ```
 
 ## Peers (contacts/users)

--- a/src/channels/plugins/directory-adapters.test.ts
+++ b/src/channels/plugins/directory-adapters.test.ts
@@ -13,6 +13,12 @@ describe("directory adapters", () => {
     await expect(adapter.self?.({ cfg: {}, runtime: {} as never })).resolves.toBeNull();
   });
 
+  it("defaults an explicitly undefined self to the null resolver", async () => {
+    const adapter = createChannelDirectoryAdapter({ self: undefined });
+    expect(adapter.self).toBe(nullChannelDirectorySelf);
+    await expect(adapter.self?.({ cfg: {}, runtime: {} as never })).resolves.toBeNull();
+  });
+
   it("preserves provided resolvers", async () => {
     const adapter = createChannelDirectoryAdapter({
       listPeers: async () => [{ kind: "user", id: "u-1" }],

--- a/src/channels/plugins/directory-adapters.ts
+++ b/src/channels/plugins/directory-adapters.ts
@@ -19,8 +19,8 @@ export function createChannelDirectoryAdapter(
   } = {},
 ): ChannelDirectoryAdapter {
   return {
-    self: params.self ?? nullChannelDirectorySelf,
     ...params,
+    self: params.self ?? nullChannelDirectorySelf,
   };
 }
 

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -1,6 +1,7 @@
 // Directory CLI tests cover directory command registration and plugin-backed lookups.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { registerDirectoryCli } from "./directory-cli.js";
 
 const runtimeState = await vi.hoisted(async () => {
@@ -192,7 +193,7 @@ describe("registerDirectoryCli", () => {
         "--json",
       ],
     },
-  ])("explains an unavailable self identity in $mode mode", async ({ mode, args }) => {
+  ])("explains an empty implemented self lookup in $mode mode", async ({ mode, args }) => {
     const self = vi.fn().mockResolvedValue(null);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: { "demo-directory": {} } },
@@ -215,10 +216,57 @@ describe("registerDirectoryCli", () => {
       });
     } else {
       const output = runtimeState.runtimeLogs.join("\n");
-      expect(output).toContain('channel "demo-directory"');
-      expect(output).toContain('account "account-1"');
-      expect(output).toContain("returned no self identity");
-      expect(output).toContain("did not provide a reason");
+      expect(output).toBe(
+        'No self identity was returned for channel "demo-directory", account "account-1". Verify the account is configured and authenticated, then retry.',
+      );
+    }
+    expect(runtimeState.defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      mode: "human",
+      args: ["directory", "self", "--channel", "demo-directory", "--account", "account-1"],
+    },
+    {
+      mode: "JSON",
+      args: [
+        "directory",
+        "self",
+        "--channel",
+        "demo-directory",
+        "--account",
+        "account-1",
+        "--json",
+      ],
+    },
+  ])("explains an unsupported self lookup in $mode mode", async ({ mode, args }) => {
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: { "demo-directory": {} } },
+      channelId: "demo-directory",
+      plugin: {
+        id: "demo-directory",
+        directory: { self: nullChannelDirectorySelf },
+      },
+      configChanged: false,
+    });
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+
+    await program.parseAsync(args, { from: "user" });
+
+    if (mode === "JSON") {
+      expect(runtimeState.defaultRuntime.writeJson).toHaveBeenCalledWith({
+        status: "unavailable",
+        channel: "demo-directory",
+        accountId: "account-1",
+        reason: "self-identity-unsupported",
+      });
+    } else {
+      expect(runtimeState.runtimeLogs.join("\n")).toBe(
+        'Channel "demo-directory" does not expose a self identity.',
+      );
     }
     expect(runtimeState.defaultRuntime.exit).not.toHaveBeenCalled();
   });

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -175,6 +175,54 @@ describe("registerDirectoryCli", () => {
     });
   });
 
+  it.each([
+    {
+      mode: "human",
+      args: ["directory", "self", "--channel", "demo-directory", "--account", "account-1"],
+    },
+    {
+      mode: "JSON",
+      args: [
+        "directory",
+        "self",
+        "--channel",
+        "demo-directory",
+        "--account",
+        "account-1",
+        "--json",
+      ],
+    },
+  ])("explains an unavailable self identity in $mode mode", async ({ mode, args }) => {
+    const self = vi.fn().mockResolvedValue(null);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: { "demo-directory": {} } },
+      channelId: "demo-directory",
+      plugin: { id: "demo-directory", directory: { self } },
+      configChanged: false,
+    });
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+
+    await program.parseAsync(args, { from: "user" });
+
+    if (mode === "JSON") {
+      expect(runtimeState.defaultRuntime.writeJson).toHaveBeenCalledWith({
+        status: "unavailable",
+        channel: "demo-directory",
+        accountId: "account-1",
+        reason: "plugin-returned-no-self-identity",
+      });
+    } else {
+      const output = runtimeState.runtimeLogs.join("\n");
+      expect(output).toContain('channel "demo-directory"');
+      expect(output).toContain('account "account-1"');
+      expect(output).toContain("returned no self identity");
+      expect(output).toContain("did not provide a reason");
+    }
+    expect(runtimeState.defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
   it("prefers live directory list readers when available", async () => {
     const listPeers = vi.fn().mockResolvedValue([{ id: "user:config", kind: "user" }]);
     const listPeersLive = vi.fn().mockResolvedValue([{ id: "user:live", kind: "user" }]);
@@ -242,6 +290,67 @@ describe("registerDirectoryCli", () => {
     expect(runtimeState.defaultRuntime.log).toHaveBeenCalledWith(
       JSON.stringify([{ id: "channel:config", kind: "group" }], null, 2),
     );
+  });
+
+  it.each([
+    {
+      label: "peers",
+      args: ["directory", "peers", "list", "--channel", "demo-directory", "--account", "account-1"],
+      expected: "No peers found",
+    },
+    {
+      label: "groups",
+      args: [
+        "directory",
+        "groups",
+        "list",
+        "--channel",
+        "demo-directory",
+        "--account",
+        "account-1",
+      ],
+      expected: "No groups found",
+    },
+    {
+      label: "group members",
+      args: [
+        "directory",
+        "groups",
+        "members",
+        "--channel",
+        "demo-directory",
+        "--account",
+        "account-1",
+        "--group-id",
+        "group-1",
+      ],
+      expected: 'No group members found for group "group-1"',
+    },
+  ])("names the query context for empty $label", async ({ args, expected }) => {
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: { "demo-directory": {} } },
+      channelId: "demo-directory",
+      plugin: {
+        id: "demo-directory",
+        directory: {
+          listPeers: vi.fn().mockResolvedValue([]),
+          listGroups: vi.fn().mockResolvedValue([]),
+          listGroupMembers: vi.fn().mockResolvedValue([]),
+        },
+      },
+      configChanged: false,
+    });
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+
+    await program.parseAsync(args, { from: "user" });
+
+    const output = runtimeState.runtimeLogs.join("\n");
+    expect(output).toContain(expected);
+    expect(output).toContain('channel "demo-directory"');
+    expect(output).toContain('account "account-1"');
+    expect(runtimeState.defaultRuntime.exit).not.toHaveBeenCalled();
   });
 
   it("sanitizes plugin directory entries only for terminal output", async () => {

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import {
   getTerminalTableWidth,
   renderTerminalSafeTable,
@@ -38,6 +39,12 @@ function buildRows(entries: Array<{ id: string; name?: string | undefined }>) {
     ID: entry.id,
     Name: normalizeOptionalString(entry.name) ?? "",
   }));
+}
+
+function formatDirectoryScope(channelId: string, accountId: string): string {
+  const channel = JSON.stringify(sanitizeTerminalText(channelId));
+  const account = JSON.stringify(sanitizeTerminalText(accountId));
+  return `channel ${channel}, account ${account}`;
 }
 
 function printDirectoryList(params: {
@@ -140,11 +147,12 @@ export function registerDirectoryCli(program: Command) {
           cfg,
           channel: opts.channel ?? null,
         });
-    const channelId = selection.channel;
+    const selectedChannelId = selection.channel;
     const plugin = selection.plugin;
     if (!plugin) {
-      throw new Error(`Unsupported channel: ${String(channelId)}`);
+      throw new Error(`Unsupported channel: ${String(selectedChannelId)}`);
     }
+    const channelId = selectedChannelId ?? plugin.id;
     const accountId =
       normalizeOptionalString(opts.account) || resolveChannelDefaultAccountId({ plugin, cfg });
     return { cfg, channelId, accountId, plugin };
@@ -186,7 +194,11 @@ export function registerDirectoryCli(program: Command) {
       defaultRuntime.writeJson(result);
       return;
     }
-    printDirectoryList({ title: params.title, emptyMessage: params.emptyMessage, entries: result });
+    printDirectoryList({
+      title: params.title,
+      emptyMessage: `${params.emptyMessage} for ${formatDirectoryScope(channelId, accountId)}.`,
+      entries: result,
+    });
   };
 
   const runDirectoryAction = async (opts: { json?: unknown }, action: () => Promise<void>) => {
@@ -215,12 +227,25 @@ export function registerDirectoryCli(program: Command) {
           throw new Error(`Channel ${channelId} does not support directory self`);
         }
         const result = await fn({ cfg, accountId, runtime: defaultRuntime });
-        if (opts.json) {
-          defaultRuntime.writeJson(result);
+        if (!result) {
+          if (opts.json) {
+            defaultRuntime.writeJson({
+              status: "unavailable",
+              channel: channelId,
+              accountId,
+              reason: "plugin-returned-no-self-identity",
+            });
+          } else {
+            defaultRuntime.log(
+              theme.muted(
+                `The channel plugin returned no self identity for ${formatDirectoryScope(channelId, accountId)}. It did not provide a reason; verify the account is configured and authenticated, then retry. Some channels do not expose a self identity.`,
+              ),
+            );
+          }
           return;
         }
-        if (!result) {
-          defaultRuntime.log(theme.muted("Not available."));
+        if (opts.json) {
+          defaultRuntime.writeJson(result);
           return;
         }
         const tableWidth = getTerminalTableWidth();
@@ -249,7 +274,7 @@ export function registerDirectoryCli(program: Command) {
           action: "listPeers",
           unsupported: "peers",
           title: "Peers",
-          emptyMessage: "No peers found.",
+          emptyMessage: "No peers found",
         });
       }),
     );
@@ -265,7 +290,7 @@ export function registerDirectoryCli(program: Command) {
           action: "listGroups",
           unsupported: "groups",
           title: "Groups",
-          emptyMessage: "No groups found.",
+          emptyMessage: "No groups found",
         });
       }),
     );
@@ -305,7 +330,7 @@ export function registerDirectoryCli(program: Command) {
         }
         printDirectoryList({
           title: "Group Members",
-          emptyMessage: "No group members found.",
+          emptyMessage: `No group members found for group ${JSON.stringify(sanitizeTerminalText(groupId))}, ${formatDirectoryScope(channelId, accountId)}.`,
           entries: result,
         });
       }),

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -12,6 +12,7 @@ import {
   renderTerminalSafeTable,
 } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
@@ -228,17 +229,22 @@ export function registerDirectoryCli(program: Command) {
         }
         const result = await fn({ cfg, accountId, runtime: defaultRuntime });
         if (!result) {
+          const unsupported = fn === nullChannelDirectorySelf;
           if (opts.json) {
             defaultRuntime.writeJson({
               status: "unavailable",
               channel: channelId,
               accountId,
-              reason: "plugin-returned-no-self-identity",
+              reason: unsupported
+                ? "self-identity-unsupported"
+                : "plugin-returned-no-self-identity",
             });
           } else {
             defaultRuntime.log(
               theme.muted(
-                `The channel plugin returned no self identity for ${formatDirectoryScope(channelId, accountId)}. It did not provide a reason; verify the account is configured and authenticated, then retry. Some channels do not expose a self identity.`,
+                unsupported
+                  ? `Channel ${JSON.stringify(sanitizeTerminalText(channelId))} does not expose a self identity.`
+                  : `No self identity was returned for ${formatDirectoryScope(channelId, accountId)}. Verify the account is configured and authenticated, then retry.`,
               ),
             );
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw directory self` reported only `Not available.` (or bare `null` with `--json`) when a channel returned no self identity. The command exited successfully but did not identify the queried channel/account, explain the non-outcome, or give scripts a structured result distinct from an error.

The same context loss affected the human empty-result messages for `directory peers list`, `directory groups list`, and `directory groups members`.

## Why This Change Was Made

The nullable self result is an intentional channel-plugin contract, so this keeps exit code 0 for a completed lookup that returns no identity. Human output now names the channel and account, states that the plugin returned no identity without a reason, and gives a configuration/authentication next step. JSON emits a discriminated successful-empty object:

```json
{
  "status": "unavailable",
  "channel": "buzz",
  "accountId": "default",
  "reason": "plugin-returned-no-self-identity"
}
```

Thrown and unsupported lookups still exit 1 and emit `{ "error": "..." }`. Empty list JSON remains `[]`, while each human list message now names its channel/account (and group for member queries).

Reachability is not limited to unconfigured profiles: twelve bundled channels inherit the shared adapter's default callable `self` implementation, which returns `null` even when the channel is fully configured. Five bundled channels have custom self lookup behavior and can also return `null` under channel-specific conditions. The CLI therefore cannot safely infer “unauthenticated” from `null`; it reports the exact fact it owns instead.

AI-assisted: yes.

## User Impact

Operators can now tell exactly what `directory self` queried and why the command produced no identity. Scripts can distinguish a successful empty lookup from a failed lookup without parsing prose. Empty peer/group/member messages also retain the resolved query scope.

## Evidence

Before, from the reported built command:

```text
$ openclaw directory self
Not available.
[exit 0]

$ openclaw directory self --json
null
[exit 0]
```

The pre-fix regression run also captured all three sibling leaves:

```text
No peers found.
No groups found.
No group members found.
```

After `pnpm build`, using a fresh scratch profile, `OPENCLAW_SKIP_CHANNELS=1`, and free port 46187:

```text
$ openclaw directory self --channel buzz
The channel plugin returned no self identity for channel "buzz", account "default". It did not provide a reason; verify the account is configured and authenticated, then retry. Some channels do not expose a self identity.
[exit 0]

$ openclaw directory self --channel buzz --json
{
  "status": "unavailable",
  "channel": "buzz",
  "accountId": "default",
  "reason": "plugin-returned-no-self-identity"
}
[exit 0]

$ openclaw directory peers list --channel buzz
No peers found for channel "buzz", account "default".
[exit 0]

$ openclaw directory groups list --channel buzz
No groups found for channel "buzz", account "default".
[exit 0]

$ openclaw directory groups members --channel buzz --group-id room-1
No group members found for group "room-1", channel "buzz", account "default".
[exit 0]

$ openclaw directory self --channel signal --json
{
  "error": "Channel signal does not support directory self"
}
[exit 1]
```

Validation:

- Pre-fix `node scripts/run-vitest.mjs src/cli/directory-cli.test.ts`: 5 intended failures, 15 existing tests passed.
- Post-fix same command: 20/20 passed.
- `node scripts/check-changed.mjs`: passed core production/test typechecks, changed-file lint, formatting, import-cycle and boundary guards.
- `pnpm build`: passed on the final source; no ineffective dynamic imports.
- `pnpm check:docs`: 0 markdown issues, MDX clean, 6,495 internal links checked with 0 broken.
- Source-blind built-CLI validation: 4/4 contract clauses passed, including repeatable structured JSON and error/non-error discrimination.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings.

Production LOC: +35/-10 (net +25). Tests: +109/-0. Docs: +17/-1.
