### PR TITLE
fix(ui): open file changes from branch diff marker

### DIFF
--- a/ui/src/e2e/chat-pull-requests.e2e.test.ts
+++ b/ui/src/e2e/chat-pull-requests.e2e.test.ts
@@ -204,9 +204,31 @@ describeControlUiE2e("session pull request chips", () => {
     const context = await newBrowserContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD],
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "sessions.diff",
+        SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+      ],
       methodResponses: {
         [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+        "sessions.diff": {
+          sessionKey: "main",
+          root: "/tmp/checkout",
+          branch: "claude/cloud-workers-live-events",
+          baseRef: "main",
+          files: [
+            {
+              path: "src/app.ts",
+              status: "modified",
+              additions: 2819,
+              deletions: 205,
+              patch: "@@ -1 +1 @@\n-old\n+new\n",
+            },
+          ],
+          additions: 2819,
+          deletions: 205,
+        },
       },
     });
     await page.goto(`${server.baseUrl}chat`);
@@ -239,6 +261,11 @@ describeControlUiE2e("session pull request chips", () => {
     // Locale-formatted diff stats, sized like the PR the branch would open.
     await expect.poll(() => row.locator(".chat-pr__additions").textContent()).toBe("+2,819");
     await expect.poll(() => row.locator(".chat-pr__deletions").textContent()).toBe("−205");
+    const diffMarker = row.getByRole("button", { name: "Show session changes" });
+    await expect.poll(() => diffMarker.count()).toBe(1);
+    await diffMarker.click();
+    await expect.poll(() => page.locator(".session-diff").count()).toBe(1);
+    await expect.poll(() => page.locator(".session-diff__filename").textContent()).toBe("app.ts");
     // While rate limited "no PR found" is unreliable, so the warning shows.
     await expect.poll(() => row.locator(".chat-pr__warning").count()).toBe(1);
     const create = row.locator(".chat-pr__create");

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -452,6 +452,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
         this.requestUpdate();
       },
       onDismissPullRequest: this.dismissSessionPullRequest,
+      onOpenDiff: catalogKey ? undefined : sessionWorkspace.onOpenDiff,
       taskSuggestionBusyIds: this.taskSuggestionBusyIds,
       sessionSuggestions: multiIdentity ? this.sessionSuggestions : [],
       sessionSuggestionRole: this.sessionSuggestionRole,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -256,6 +256,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     pullRequestsExpanded?: boolean;
     onExpandPullRequests?: () => void;
     onDismissPullRequest?: (pullRequest: ControlUiSessionPullRequest) => void;
+    onOpenDiff?: () => void;
   };
 
 export function renderChat(props: ChatProps) {
@@ -525,6 +526,7 @@ export function renderChat(props: ChatProps) {
                     expanded: props.pullRequestsExpanded === true,
                     onExpand: () => props.onExpandPullRequests?.(),
                     onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
+                    onOpenDiff: props.onOpenDiff,
                   })}
                   ${renderChatSessionSuggestions({
                     suggestions: props.sessionSuggestions ?? [],

--- a/ui/src/pages/chat/components/chat-pull-requests.ts
+++ b/ui/src/pages/chat/components/chat-pull-requests.ts
@@ -188,16 +188,28 @@ function visibleChatPullRequests(
   };
 }
 
-function renderDiffStats(item: { additions?: number; deletions?: number }) {
+function renderDiffStats(
+  item: { additions?: number; deletions?: number },
+  onOpenDiff?: () => void,
+) {
   if (typeof item.additions !== "number" && typeof item.deletions !== "number") {
     return nothing;
   }
-  return html`
-    <span class="chat-pr__diff">
-      <span class="chat-pr__additions">+${formatDiffCount(item.additions ?? 0)}</span>
-      <span class="chat-pr__deletions">−${formatDiffCount(item.deletions ?? 0)}</span>
-    </span>
+  const content = html`
+    <span class="chat-pr__additions">+${formatDiffCount(item.additions ?? 0)}</span>
+    <span class="chat-pr__deletions">−${formatDiffCount(item.deletions ?? 0)}</span>
   `;
+  if (onOpenDiff) {
+    return html`<button
+      class="chat-pr__diff chat-pr__diff--button"
+      type="button"
+      aria-label=${t("chat.sessionDiff.show")}
+      @click=${onOpenDiff}
+    >
+      ${content}
+    </button>`;
+  }
+  return html` <span class="chat-pr__diff">${content}</span> `;
 }
 
 function renderRateLimitWarning() {
@@ -215,7 +227,11 @@ function renderRateLimitWarning() {
 // branch is unpushed the gateway omits createUrl — the row then just reports
 // the session's local changed files. While rate limited, "no PR found" is
 // unreliable, so the warning stays visible here.
-function renderBranchRow(branch: ControlUiSessionBranch, rateLimited: boolean) {
+function renderBranchRow(
+  branch: ControlUiSessionBranch,
+  rateLimited: boolean,
+  onOpenDiff?: () => void,
+) {
   return html`
     <article class="chat-pr" data-state="branch">
       <span class="chat-pr__link chat-pr__link--static">
@@ -224,7 +240,7 @@ function renderBranchRow(branch: ControlUiSessionBranch, rateLimited: boolean) {
         <span class="chat-pr__branch">${branch.branch}</span>
       </span>
       <span class="chat-pr__meta">
-        ${renderDiffStats(branch)} ${rateLimited ? renderRateLimitWarning() : nothing}
+        ${renderDiffStats(branch, onOpenDiff)} ${rateLimited ? renderRateLimitWarning() : nothing}
         ${branch.createUrl
           ? html`
               <a
@@ -250,6 +266,7 @@ export function renderChatPullRequests(props: {
   expanded: boolean;
   onExpand: () => void;
   onDismiss: (pullRequest: ControlUiSessionPullRequest) => void;
+  onOpenDiff?: () => void;
 }) {
   if (props.pullRequests.length === 0 && !props.branch) {
     return nothing;
@@ -257,7 +274,7 @@ export function renderChatPullRequests(props: {
   const { visible, hiddenCount } = visibleChatPullRequests(props.pullRequests, props.expanded);
   return html`
     <div class="chat-prs" aria-live="polite">
-      ${props.branch ? renderBranchRow(props.branch, props.rateLimited) : nothing}
+      ${props.branch ? renderBranchRow(props.branch, props.rateLimited, props.onOpenDiff) : nothing}
       ${visible.map((pullRequest) => {
         const merged = pullRequest.state === "merged";
         return html`

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2168,6 +2168,13 @@ button.chat-reply-preview--message:disabled {
   font: 12px/1.4 var(--mono);
 }
 
+.chat-pr__diff--button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: var(--cursor-action);
+}
+
 .chat-pr__additions {
   color: var(--ok);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing local branch changes in chat could see the addition/deletion marker but could not open the file-diff sidebar from it.

## Why This Change Was Made

The pre-PR branch marker now reuses the existing session-diff opener when that capability is available. Historical pull-request statistics remain noninteractive because they do not represent the current checkout.

## User Impact

Users can click the `+… −…` marker beside the current branch to inspect changed files and patches in the existing sidebar.

## Evidence

- Pre-fix Chromium regression: expected the branch diff marker to expose the “Show session changes” button, received no button.
- Post-fix Control UI E2E: `ui/src/e2e/chat-pull-requests.e2e.test.ts` — 2 passed.
- Component coverage: `ui/src/pages/chat/components/chat-pull-requests.test.ts` — 16 passed.
- Visual browser proof recorded before click and after the `app.ts` diff sidebar opened.
- Format, UI typecheck, UI test types, oxlint, stylelint, and `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
