### PR TITLE
fix(ci): keep QA evidence output repo-relative

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -624,9 +624,10 @@ jobs:
         working-directory: selected
         run: |
           set -euo pipefail
-          output_dir="${GITHUB_WORKSPACE}/selected/.artifacts/qa-e2e/profile-${QA_PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/${QA_SHARD_ID}"
-          mkdir -p "$output_dir"
-          echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
+          qa_output_dir=".artifacts/qa-e2e/profile-${QA_PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/${QA_SHARD_ID}"
+          published_output_dir="${GITHUB_WORKSPACE}/selected/${qa_output_dir}"
+          mkdir -p "$qa_output_dir"
+          echo "output_dir=${published_output_dir}" >> "$GITHUB_OUTPUT"
           mapfile -t scenario_ids < <(jq -er '.[]' <<<"$SCENARIO_IDS_JSON")
           scenario_args=()
           for scenario_id in "${scenario_ids[@]}"; do
@@ -664,7 +665,7 @@ jobs:
               --qa-profile "$QA_PROFILE" \
               --concurrency 3 \
               --fast \
-              --output-dir "$output_dir" \
+              --output-dir "$qa_output_dir" \
               "${scenario_args[@]}" \
             3>&2 2>"$timeout_supervisor_fifo" || qa_exit_code=$?
 
@@ -680,7 +681,7 @@ jobs:
             echo "::warning::QA profile '${QA_PROFILE}' timed out after 110 minutes and was terminated; partial evidence will still be uploaded."
           fi
 
-          QA_EXIT_CODE="$qa_exit_code" TIMEOUT_OUTCOME="$timeout_outcome" OUTPUT_DIR="$output_dir" \
+          QA_EXIT_CODE="$qa_exit_code" TIMEOUT_OUTCOME="$timeout_outcome" OUTPUT_DIR="$published_output_dir" \
             node --input-type=module <<'NODE'
           import fs from "node:fs";
           import path from "node:path";

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7769,12 +7769,16 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(runProfileStep.run).toContain("--concurrency 3");
     expect(runProfileStep.run).toContain("--fast");
+    expect(runProfileStep.run).toContain('qa_output_dir=".artifacts/qa-e2e/');
     expect(runProfileStep.run).toContain(
-      'output_dir="${GITHUB_WORKSPACE}/selected/.artifacts/qa-e2e/',
+      'published_output_dir="${GITHUB_WORKSPACE}/selected/${qa_output_dir}"',
     );
-    expect(runProfileStep.run).toContain('mkdir -p "$output_dir"');
-    expect(runProfileStep.run.indexOf('mkdir -p "$output_dir"')).toBeLessThan(
-      runProfileStep.run.indexOf('echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"'),
+    expect(runProfileStep.run).toContain('mkdir -p "$qa_output_dir"');
+    expect(runProfileStep.run).toContain('echo "output_dir=${published_output_dir}"');
+    expect(runProfileStep.run).toContain('--output-dir "$qa_output_dir"');
+    expect(runProfileStep.run).toContain('OUTPUT_DIR="$published_output_dir"');
+    expect(runProfileStep.run.indexOf('mkdir -p "$qa_output_dir"')).toBeLessThan(
+      runProfileStep.run.indexOf('echo "output_dir=${published_output_dir}"'),
     );
     expect(runProfileStep.run).toContain(
       "LC_ALL=C timeout --verbose --signal=TERM --kill-after=30s 110m",


### PR DESCRIPTION
Related: #124612

## What Problem This Solves

Fixes an issue where every sharded QA maturity-evidence job exited before running scenarios because the QA CLI received an absolute `--output-dir`, which its repo-containment contract rejects.

## Why This Change Was Made

The workflow now passes a repository-relative path to the QA CLI while separately publishing the corresponding absolute path for artifact upload, evidence validation, and run-status handling. Both paths resolve to the same shard directory under the selected checkout.

## User Impact

The eight-shard maturity scorecard workflow can execute scenarios instead of failing during CLI startup. Artifact upload and aggregation continue to use the exact shard output directory.

**AI-assisted:** Yes.

## Evidence

- Failing protected rollout: https://github.com/openclaw/openclaw/actions/runs/31965426505
- Representative failure: `--output-dir must be a relative path inside the repo root.`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 119 passed, 2 platform-skipped.
- `node --import tsx scripts/check-workflows.mts`, actionlint, zizmor, formatting, and `git diff --check` passed.
- Mandatory structured autoreview reported no accepted/actionable findings.
