### PR TITLE
fix(cli): allow hook toggles to select an agent

### DIFF
--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -57,10 +57,14 @@ Prints a ready/not-ready count summary; with hooks not ready, lists each with it
 ## Enable a hook
 
 ```bash
-openclaw hooks enable <name>
+openclaw hooks enable <name> [--agent <id>]
 ```
 
 Adds/updates `hooks.internal.entries.<name>.enabled = true` in config and also flips the `hooks.internal.enabled` master switch on (the gateway does not load any internal hook handler until at least one is configured). Fails if the hook does not exist, is plugin-managed, or is not eligible (missing requirements).
+
+`--agent <id>` selects the workspace used to discover the hook and is required
+when multiple agents are configured without an implicit owner. The persisted
+hook entry is global and applies wherever that hook key is discovered.
 
 Plugin-managed hooks show `plugin:<id>` in `hooks list` and cannot be enabled/disabled here; enable or disable the owning plugin instead.
 
@@ -69,7 +73,7 @@ Restart the gateway after enabling (macOS menu bar app restart, or restart your 
 ## Disable a hook
 
 ```bash
-openclaw hooks disable <name>
+openclaw hooks disable <name> [--agent <id>]
 ```
 
 Sets `hooks.internal.entries.<name>.enabled = false`. Restart the gateway afterward.

--- a/src/cli/hooks-cli.toggle.test.ts
+++ b/src/cli/hooks-cli.toggle.test.ts
@@ -127,9 +127,32 @@ const report: HookStatusReport = {
 const { registerHooksCli } = await import("./hooks-cli.js");
 
 function createHooksProgram(): Command {
-  const program = new Command();
+  const program = new Command().enablePositionalOptions();
   registerHooksCli(program);
   return program;
+}
+
+function configureExplicitFleet() {
+  const config = {
+    ...sourceConfig,
+    agents: {
+      ownership: "explicit" as const,
+      list: [
+        { id: "main", workspace: "/tmp/openclaw-main-workspace" },
+        { id: "research", workspace: "/tmp/openclaw-research-workspace" },
+      ],
+    },
+  };
+  mocks.getRuntimeConfig.mockReturnValue(config);
+  mocks.listAgentIds.mockReturnValue(["main", "research"]);
+  mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue(undefined);
+  mocks.resolveDefaultAgentId.mockImplementation(() => {
+    throw new Error("selection required");
+  });
+  mocks.resolveAgentWorkspaceDir.mockImplementation(
+    (_config: unknown, agentId: string) => `/tmp/openclaw-${agentId}-workspace`,
+  );
+  return config;
 }
 
 describe("hooks CLI metadata config keys", () => {
@@ -337,35 +360,62 @@ describe("hooks CLI metadata config keys", () => {
     }
   });
 
-  it("rejects a parent --agent for hook writes", async () => {
+  it.each([
+    ["enable", ["hooks", "--agent", "research", "enable", "display-name"], true],
+    ["enable", ["hooks", "enable", "display-name", "--agent", "research"], true],
+    ["disable", ["hooks", "--agent", "research", "disable", "display-name"], false],
+    ["disable", ["hooks", "disable", "display-name", "--agent", "research"], false],
+  ])("uses --agent for %s hook discovery", async (_label, argv, enabled) => {
+    const explicitFleet = configureExplicitFleet();
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      sourceConfig: explicitFleet,
+      hash: "config-hash",
+    });
+
+    await createHooksProgram().parseAsync(argv, { from: "user" });
+
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(explicitFleet, "research");
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        ...explicitFleet,
+        hooks: {
+          internal: {
+            enabled: true,
+            entries: {
+              "metadata-key": {
+                env: { HOOK_ENV: "preserved" },
+                enabled,
+              },
+            },
+          },
+        },
+      },
+      baseHash: "config-hash",
+    });
+  });
+
+  it("leaves config unchanged when the selected hook agent is invalid", async () => {
+    const explicitFleet = configureExplicitFleet();
+    const initialConfig = structuredClone(explicitFleet);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      sourceConfig: explicitFleet,
+      hash: "config-hash",
+    });
+
     await expect(
-      createHooksProgram().parseAsync(["hooks", "--agent", "research", "enable", "display-name"], {
+      createHooksProgram().parseAsync(["hooks", "enable", "display-name", "--agent", "retired"], {
         from: "user",
       }),
-    ).rejects.toThrow("does not support --agent");
+    ).rejects.toThrow("__exit__:1");
 
+    expect(capture.runtimeErrors.at(-1)).toContain('Unknown agent id "retired"');
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(explicitFleet).toEqual(initialConfig);
   });
 
   it("keeps the explicit owner in the offline hooks fallback", async () => {
-    const explicitFleet = {
-      agents: {
-        ownership: "explicit",
-        list: [
-          { id: "ops", workspace: "/tmp/openclaw-ops-workspace" },
-          { id: "research", workspace: "/tmp/openclaw-research-workspace" },
-        ],
-      },
-    };
-    mocks.getRuntimeConfig.mockReturnValue(explicitFleet);
-    mocks.listAgentIds.mockReturnValue(["ops", "research"]);
-    mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue(undefined);
-    mocks.resolveDefaultAgentId.mockImplementation(() => {
-      throw new Error("selection required");
-    });
-    mocks.resolveAgentWorkspaceDir.mockImplementation(
-      (_config: unknown, agentId: string) => `/tmp/openclaw-${agentId}-workspace`,
-    );
+    const explicitFleet = configureExplicitFleet();
 
     await createHooksProgram().parseAsync(["hooks", "list", "--agent", "research", "--json"], {
       from: "user",

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -146,14 +146,8 @@ async function loadHooksReport(agentId?: string): Promise<HookStatusReport> {
   }
 }
 
-function resolveHooksAgentOption(
-  command: Command | undefined,
-  opts?: { agent?: unknown },
-): string | undefined {
-  return (
-    resolveOptionFromCommand<string>(command, "agent") ??
-    (typeof opts?.agent === "string" ? opts.agent : undefined)
-  );
+function resolveHooksAgentOption(command: Command | undefined): string | undefined {
+  return resolveOptionFromCommand<string>(command, "agent");
 }
 
 function resolveHookForToggle(
@@ -560,11 +554,11 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
   return lines.join("\n");
 }
 
-async function enableHook(hookName: string): Promise<void> {
+async function enableHook(hookName: string, agentId?: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const hook = resolveHookForToggle(
-    buildHooksReport(config, resolveHooksReportTarget(config)),
+    buildHooksReport(config, resolveHooksReportTarget(config, agentId)),
     hookName,
     { requireEligible: true },
   );
@@ -584,11 +578,11 @@ async function enableHook(hookName: string): Promise<void> {
   );
 }
 
-async function disableHook(hookName: string): Promise<void> {
+async function disableHook(hookName: string, agentId?: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const hook = resolveHookForToggle(
-    buildHooksReport(config, resolveHooksReportTarget(config)),
+    buildHooksReport(config, resolveHooksReportTarget(config, agentId)),
     hookName,
   );
   const nextConfig = buildConfigWithHookEnabled({
@@ -624,7 +618,7 @@ export function registerHooksCli(program: Command): void {
     if (
       parentAgent &&
       actionCommand !== hooks &&
-      !new Set(["list", "info", "check"]).has(actionCommand.name())
+      !new Set(["list", "info", "check", "enable", "disable"]).has(actionCommand.name())
     ) {
       throw new Error(
         `openclaw hooks ${actionCommand.name()} does not support --agent; the option only selects an owner for read-only hook reports.`,
@@ -641,7 +635,7 @@ export function registerHooksCli(program: Command): void {
     .option("-v, --verbose", "Show more details including missing requirements", false)
     .action(async (opts: HooksListOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
+        const report = await loadHooksReport(resolveHooksAgentOption(command));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHooksList(report, { ...opts, json }), json);
       }),
@@ -654,7 +648,7 @@ export function registerHooksCli(program: Command): void {
     .option("--json", "Output as JSON", false)
     .action(async (name, opts: HookInfoOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
+        const report = await loadHooksReport(resolveHooksAgentOption(command));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHookInfo(report, name, { ...opts, json }), json);
         return report.hooks.some((hook) => hook.name === name || hook.hookKey === name) ? 0 : 1;
@@ -668,7 +662,7 @@ export function registerHooksCli(program: Command): void {
     .option("--json", "Output as JSON", false)
     .action(async (opts: HooksCheckOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
+        const report = await loadHooksReport(resolveHooksAgentOption(command));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHooksCheck(report, { ...opts, json }), json);
       }),
@@ -677,18 +671,20 @@ export function registerHooksCli(program: Command): void {
   hooks
     .command("enable <name>")
     .description("Enable a hook")
-    .action(async (name) =>
+    .option("--agent <id>", "Agent id whose workspace to inspect")
+    .action(async (name, _opts: { agent?: string }, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        await enableHook(name);
+        await enableHook(name, resolveHooksAgentOption(command));
       }),
     );
 
   hooks
     .command("disable <name>")
     .description("Disable a hook")
-    .action(async (name) =>
+    .option("--agent <id>", "Agent id whose workspace to inspect")
+    .action(async (name, _opts: { agent?: string }, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        await disableHook(name);
+        await disableHook(name, resolveHooksAgentOption(command));
       }),
     );
 
@@ -753,7 +749,7 @@ export function registerHooksCli(program: Command): void {
 
   hooks.action(async (opts: HooksListOptions, command: Command) =>
     runOneShotHooksCliAction(async () => {
-      const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
+      const report = await loadHooksReport(resolveHooksAgentOption(command));
       const json = hasJsonOutput(opts);
       writeHooksOutput(formatHooksList(report, { ...opts, json }), json);
     }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators with multiple explicitly owned agents could not enable or disable a workspace hook for a selected agent. The CLI told them to pass `--agent <id>`, but the toggle leaves rejected that option; the parent-position form could even persist the global config mutation before exiting with an error.

## Why This Change Was Made

Hook toggles now use the same agent-selection path as hook discovery, with `--agent <id>` declared on both toggle leaves so Commander accepts the option before or after the subcommand. Agent validation and workspace discovery happen before the config replacement, while the persisted hook entry remains intentionally global.

## User Impact

Operators can run either `openclaw hooks --agent <id> enable <hook>` or `openclaw hooks enable <hook> --agent <id>` (and the corresponding disable forms). Invalid agent ids fail with exit 1 and leave the config unchanged.

## Evidence

Verified live QA reproduction before the fix on a two-agent roster:

- `hooks enable <id>` said `Pass --agent <id>`.
- `hooks enable <id> --agent main` said `does not recognize option`.
- `hooks --agent main enable <id>` hard-errored `enable does not support --agent` after already persisting the config mutation (exit 1 with changed config).

Post-fix live QA:

- Both parent and leaf `--agent` positions work for enable and disable.
- An invalid agent exits 1 with the config hash unchanged.

Fresh local proof on commit `31561551ea9334cbd38a4b137fc5c875c7ae174c`:

- `node scripts/run-vitest.mjs src/cli/hooks-cli.toggle.test.ts src/cli/hooks-cli.test.ts src/cli/hooks-cli.process.test.ts`: 43 passing CLI tests plus 3 passing process-lifecycle tests.
- `node scripts/check-changed.mjs`: passed all selected core, core-test, and docs checks. Remote providers were unavailable, so the repository wrapper used its supported local fallback; the first local attempt timed out waiting for a live sibling lock, and the clean retry passed.
- Source-blind isolated CLI validation: parent-position enable and leaf-position disable exited 0 and changed the selected hook state; invalid agent `retired` exited 1 with identical before/after SHA-256 config hashes.
- Fresh autoreview: clean, no accepted/actionable findings.

LOC by ownership: production `+17/-21` (net `-4`), tests `+72/-22` (net `+50`), docs `+6/-2`.

AI-assisted implementation and validation; the final diff and behavior were independently reviewed.
