### PR TITLE
fix(qa): honor model fast-mode defaults when flag is omitted

### DIFF
--- a/extensions/qa-lab/src/cli.test.ts
+++ b/extensions/qa-lab/src/cli.test.ts
@@ -49,6 +49,7 @@ const {
   runQaCoverageReportCommand,
   runQaJsonlReplayCommand,
   runQaLabSelfCheckCommand,
+  runQaManualLaneCommand,
   runQaProfileCommand,
   runQaProviderServerCommand,
   runQaSuiteCommand,
@@ -65,6 +66,7 @@ const {
   runQaCoverageReportCommand: vi.fn(),
   runQaJsonlReplayCommand: vi.fn(),
   runQaLabSelfCheckCommand: vi.fn(),
+  runQaManualLaneCommand: vi.fn(),
   runQaProfileCommand: vi.fn(),
   runQaProviderServerCommand: vi.fn(),
   runQaSuiteCommand: vi.fn(),
@@ -123,6 +125,7 @@ vi.mock("./cli.runtime.js", () => ({
   runQaCoverageReportCommand,
   runQaJsonlReplayCommand,
   runQaLabSelfCheckCommand,
+  runQaManualLaneCommand,
   runQaProfileCommand,
   runQaProviderServerCommand,
   runQaSuiteCommand,
@@ -141,6 +144,7 @@ describe("qa cli registration", () => {
     runQaCoverageReportCommand.mockReset();
     runQaJsonlReplayCommand.mockReset();
     runQaLabSelfCheckCommand.mockReset();
+    runQaManualLaneCommand.mockReset();
     runQaProfileCommand.mockReset();
     runQaProviderServerCommand.mockReset();
     runQaSuiteCommand.mockReset();
@@ -880,7 +884,7 @@ describe("qa cli registration", () => {
       providerMode: "live-frontier",
       primaryModel: undefined,
       alternateModel: undefined,
-      fastMode: false,
+      fastMode: undefined,
       allowFailures: false,
       scenarioIds: [],
       listScenarios: false,
@@ -888,6 +892,20 @@ describe("qa cli registration", () => {
       credentialSource: undefined,
       credentialRole: undefined,
     });
+  });
+
+  it.each([
+    ["suite", ["qa", "suite"]],
+    ["profile", ["qa", "run", "--qa-profile", "smoke-ci"]],
+    ["manual", ["qa", "manual", "--message", "hello"]],
+  ])("preserves omitted --fast intent for %s runs", async (_name, args) => {
+    await program.parseAsync(["node", "openclaw", ...args]);
+
+    const call =
+      runQaSuiteCommand.mock.calls[0]?.[0] ??
+      runQaProfileCommand.mock.calls[0]?.[0] ??
+      runQaManualLaneCommand.mock.calls[0]?.[0];
+    expect(call?.fastMode).toBeUndefined();
   });
 
   it("forwards --list-scenarios for telegram runs", async () => {

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -435,7 +435,7 @@ export function registerQaLabCli(program: Command) {
       false,
     )
     .option("--fail-fast", "Stop after the first failed QA scenario")
-    .option("--fast", "Enable provider fast mode where supported", false);
+    .option("--fast", "Enable provider fast mode where supported");
   qaRun.action(async (opts: QaRunCliOptions, command: Command) => {
     validateQaRunMode(opts, command);
     if (opts.qaProfile?.trim()) {
@@ -497,7 +497,7 @@ export function registerQaLabCli(program: Command) {
       false,
     )
     .option("--fail-fast", "Stop after the first failed QA scenario")
-    .option("--fast", "Enable provider fast mode where supported", false)
+    .option("--fast", "Enable provider fast mode where supported")
     .option(
       "--thinking <level>",
       "Suite thinking default: off|minimal|low|medium|high|xhigh|adaptive|max",
@@ -738,7 +738,7 @@ export function registerQaLabCli(program: Command) {
     .option("--provider-mode <mode>", formatQaProviderModeHelp(), DEFAULT_QA_LIVE_PROVIDER_MODE)
     .option("--model <ref>", "Primary provider/model ref (defaults by provider mode)")
     .option("--alt-model <ref>", "Alternate provider/model ref")
-    .option("--fast", "Enable provider fast mode where supported", false)
+    .option("--fast", "Enable provider fast mode where supported")
     .option("--timeout-ms <ms>", "Override agent.wait timeout", (value: string) =>
       parseQaCliPositiveIntegerOption(value, "--timeout-ms"),
     )

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -107,7 +107,7 @@ function createSharedLiveTransportQaCliRegistration(
         .option("--model <ref>", "Primary provider/model ref")
         .option("--alt-model <ref>", "Alternate provider/model ref")
         .option("--scenario <id>", params.scenarioHelp, collectStringOption, [])
-        .option("--fast", "Enable provider fast mode where supported", false);
+        .option("--fast", "Enable provider fast mode where supported");
 
       if (params.allowFailuresHelp) {
         command.option("--allow-failures", params.allowFailuresHelp, false);

--- a/extensions/qa-lab/src/providers/live-frontier/index.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/index.ts
@@ -39,7 +39,7 @@ export const liveFrontierProviderDefinition: QaProviderDefinition = {
   resolveModelParams: ({ modelRef, fastMode, thinkingDefault }) => ({
     transport: "sse",
     openaiWsWarmup: false,
-    ...(fastMode === true || isQaFastModeModelRef(modelRef) ? { fastMode: true } : {}),
+    ...((fastMode ?? isQaFastModeModelRef(modelRef)) ? { fastMode: true } : {}),
     ...(thinkingDefault ? { thinking: thinkingDefault } : {}),
   }),
   resolveTurnTimeoutMs: ({ fallbackMs, modelRef }) => {

--- a/extensions/qa-lab/src/suite-model-selection.test.ts
+++ b/extensions/qa-lab/src/suite-model-selection.test.ts
@@ -1,5 +1,7 @@
 // QA Lab tests cover suite model-pair resolution.
 import { describe, expect, it } from "vitest";
+import { buildQaGatewayConfig } from "./qa-gateway-config.js";
+import { buildQaSuiteSummaryJson } from "./suite-artifacts.js";
 import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
 
 describe("resolveRequestedQaSuiteModels", () => {
@@ -29,4 +31,39 @@ describe("resolveRequestedQaSuiteModels", () => {
       alternateModel: "openai/gpt-5.6-terra",
     });
   });
+
+  it.each([
+    [undefined, true],
+    [true, true],
+    [false, false],
+  ] as const)(
+    "keeps effective fast mode aligned between live-frontier config and summary for input %s",
+    (fastMode, expectedFastMode) => {
+      const selection = resolveRequestedQaSuiteModels({
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-sol",
+        fastMode,
+        scenarios: [],
+      });
+      const config = buildQaGatewayConfig({
+        bind: "loopback",
+        gatewayPort: 18789,
+        gatewayToken: "test-token",
+        workspaceDir: "/tmp/qa-workspace",
+        ...selection,
+      });
+      const summary = buildQaSuiteSummaryJson({
+        ...selection,
+        scenarios: [],
+        startedAt: new Date("2026-08-16T00:00:00.000Z"),
+        finishedAt: new Date("2026-08-16T00:00:01.000Z"),
+        concurrency: 1,
+      });
+
+      expect(config.agents?.defaults?.models?.[selection.primaryModel]?.params?.fastMode).toBe(
+        expectedFastMode ? true : undefined,
+      );
+      expect(summary.run.fastMode).toBe(expectedFastMode);
+    },
+  );
 });

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -336,7 +336,7 @@ function registerLiveTransportQaCli(
     .option("--model <ref>", "Primary provider/model ref")
     .option("--alt-model <ref>", "Alternate provider/model ref")
     .option("--scenario <id>", params.scenarioHelp, collectLiveTransportQaStringOption, [])
-    .option("--fast", "Enable provider fast mode where supported", false);
+    .option("--fast", "Enable provider fast mode where supported");
 
   if (params.allowFailuresHelp) {
     command.option("--allow-failures", params.allowFailuresHelp, false);

--- a/src/plugin-sdk/qa-runtime.test.ts
+++ b/src/plugin-sdk/qa-runtime.test.ts
@@ -181,6 +181,10 @@ describe("plugin-sdk qa-runtime", () => {
       })
       .register(qa);
 
+    await qa.parseAsync(["node", "openclaw", "telegram"]);
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ fastMode: undefined }));
+    run.mockClear();
+
     await qa.parseAsync([
       "node",
       "openclaw",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators running suite, profile, manual, or live-transport commands without `--fast` would have that omission collapsed to `false`, preventing live-frontier model defaults from selecting fast mode. Explicit programmatic `false` could also be overridden by the model default, making generated Gateway config disagree with the run summary.

## Why This Change Was Made

The QA CLI now preserves the existing tri-state contract (`undefined`, `true`, or `false`) instead of inventing a false default. Live-frontier resolves omitted values from the selected model while retaining an explicit false, and the plugin SDK mirror uses the same parser behavior.

## User Impact

QA runs now use the selected live-frontier model's intended fast-mode default when the flag is omitted. Callers that explicitly disable fast mode continue to get standard mode, and run summaries match the effective Gateway configuration.

## Evidence

- Exact head: `ab22ac8afeff5c9bb0002d9c28e675ac0bd418d0`.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.test.ts extensions/qa-lab/src/suite-model-selection.test.ts src/plugin-sdk/qa-runtime.test.ts`
  - 86 focused tests passed across the QA extension and plugin SDK shards.
- Added behavior coverage for omitted CLI intent across suite/profile/manual paths, the live-transport plugin SDK seam, and effective config/summary agreement for omitted, true, and false values.
- Targeted oxlint: zero warnings/errors; oxfmt and `git diff --check` passed.
- The rebased commit is patch-identical to the previously tested candidate.
- Fresh authenticated Codex autoreview found no findings (`patch is correct`, confidence 0.99).
- Independent exact-head review found no P0-P2 findings and confirmed the parser/provider split is the owner-boundary fix.

AI-assisted: yes — produced and independently checked during an Amp Auto QA campaign. I understand the QA parser, provider-default, config, and summary behavior changed here.
