### PR TITLE
fix(config): render actionable validation errors

### DIFF
--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -2,7 +2,7 @@ import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-c
 import type { ConfigFileSnapshot } from "../config/config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
-import { attachConfigIssueDiagnostics } from "../config/issue-location.js";
+import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -61,15 +61,7 @@ export async function loadValidConfig(
     return snapshot;
   }
   runtime.error(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`);
-  const displayIssues = attachConfigIssueDiagnostics(snapshot.issues, {
-    raw: snapshot.raw,
-    parsed: snapshot.parsed,
-    effective: snapshot.sourceConfig,
-    configPath: snapshot.path,
-    formatPathForDisplay: true,
-    includeReceivedValueHint: true,
-  });
-  for (const line of formatConfigIssueLines(displayIssues, "-", { normalizeRoot: true })) {
+  for (const line of renderConfigValidationIssueLines(snapshot)) {
     runtime.error(line);
   }
   runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -4,7 +4,7 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
-import { attachConfigIssueDiagnostics } from "../config/issue-location.js";
+import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { CONFIG_PATH, resolveConfigPath } from "../config/paths.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
@@ -332,18 +332,8 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
       if (opts.json) {
         writeRuntimeJson(runtime, { valid: false, path: outputPath, issues });
       } else {
-        const displayIssues = attachConfigIssueDiagnostics(issues, {
-          raw: snapshot.raw,
-          parsed: snapshot.parsed,
-          effective: snapshot.sourceConfig,
-          configPath: snapshot.path,
-          formatPathForDisplay: true,
-          includeReceivedValueHint: true,
-        });
         runtime.error(danger(`OpenClaw config is invalid: ${shortPath}`));
-        for (const line of formatConfigIssueLines(displayIssues, danger("×"), {
-          normalizeRoot: true,
-        })) {
+        for (const line of renderConfigValidationIssueLines(snapshot, danger("×"))) {
           runtime.error(`  ${line}`);
         }
         runtime.error("");

--- a/src/cli/daemon-cli/lifecycle-action-preflight.test.ts
+++ b/src/cli/daemon-cli/lifecycle-action-preflight.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 });
 
 async function withIsolatedLifecycleState(
-  run: (params: { agentDir: string }) => Promise<void>,
+  run: (params: { agentDir: string; configPath: string }) => Promise<void>,
 ): Promise<void> {
   await withTestDir({ prefix: "openclaw-lifecycle-action-preflight-" }, async (root) => {
     const stateDir = path.join(root, "state");
@@ -23,7 +23,7 @@ async function withIsolatedLifecycleState(
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
     resetConfigRuntimeState();
-    await run({ agentDir });
+    await run({ agentDir, configPath });
     await expect(fs.access(path.join(stateDir, "state", "openclaw.sqlite"))).rejects.toMatchObject({
       code: "ENOENT",
     });
@@ -62,6 +62,28 @@ describe("getServiceActionPreflightFailure", () => {
     async (action) => {
       await withIsolatedLifecycleState(async () => {
         await expect(getServiceActionPreflightFailure(action)).resolves.toBeNull();
+      });
+    },
+  );
+
+  it.each(["start", "restart"] as const)(
+    "renders actionable invalid-config diagnostics before %s",
+    async (action) => {
+      await withIsolatedLifecycleState(async ({ configPath }) => {
+        await fs.writeFile(
+          configPath,
+          '{\n  meta: { lastTouchedVersion: "9999.1.1" },\n  gateway: { mode: "nope" },\n}\n',
+        );
+        resetConfigRuntimeState();
+
+        const failure = await getServiceActionPreflightFailure(action);
+
+        expect(failure?.message).toContain(
+          'openclaw.json:3 — gateway.mode: Invalid input (allowed: "local", "remote"), got: "nope"',
+        );
+        expect(failure?.message).toContain(
+          "Config was last written by OpenClaw 9999.1.1, but you are running",
+        );
       });
     },
   );

--- a/src/cli/daemon-cli/lifecycle-action-preflight.ts
+++ b/src/cli/daemon-cli/lifecycle-action-preflight.ts
@@ -4,7 +4,7 @@ import {
 } from "../../agents/auth-profiles/legacy-source-diagnostic.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { resolveFutureConfigActionBlock } from "../../config/future-version-guard.js";
-import { formatConfigIssueLines } from "../../config/issue-format.js";
+import { renderConfigValidationIssueLines } from "../../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../../config/recovery-policy.js";
 import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
 import { collectCandidateAgentDirs } from "../../secrets/runtime-fast-path.js";
@@ -75,7 +75,7 @@ export async function getServiceActionPreflightFailure(
     if (snapshot.exists && !snapshot.valid) {
       const message =
         snapshot.issues.length > 0
-          ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+          ? renderConfigValidationIssueLines(snapshot, "").join("\n")
           : "Unknown validation issue.";
       return {
         message,

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -7,6 +7,7 @@ import { note } from "../../../packages/terminal-core/src/note.js";
 import type { ConfigSnapshotReadMeasure } from "../../config/io.js";
 import { ExitError } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
+import { VERSION } from "../../version.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
 
@@ -28,12 +29,15 @@ vi.mock("../../config/config.js", () => ({
   setRuntimeConfigSnapshot: setRuntimeConfigSnapshotMock,
 }));
 
-type ConfigIssue = { path: string; message: string };
+type ConfigIssue = { path: string; pathSegments?: Array<string | number>; message: string };
 
 function makeSnapshot() {
   return {
     exists: false,
     valid: true,
+    raw: null as string | null,
+    parsed: {},
+    sourceConfig: {},
     issues: [] as ConfigIssue[],
     warnings: [] as ConfigIssue[],
     legacyIssues: [] as ConfigIssue[],
@@ -676,7 +680,7 @@ describe("ensureConfigReady", () => {
     }
 
     expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
-    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(undefined, undefined);
+    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(undefined, {});
   });
 
   it("exits for invalid config on non-allowlisted commands", async () => {
@@ -695,6 +699,56 @@ describe("ensureConfigReady", () => {
     ]);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("renders unknown keys and received values with the shared source diagnostics", async () => {
+    setInvalidSnapshot({
+      raw: '{\n  "meta": { "migrations": { "futureMarker": true } },\n  "gateway": { "port": "nope" }\n}',
+      parsed: {
+        meta: { migrations: { futureMarker: true } },
+        gateway: { port: "nope" },
+      },
+      sourceConfig: {
+        meta: { migrations: { futureMarker: true } },
+        gateway: { port: "nope" },
+      },
+      issues: [
+        {
+          path: "meta",
+          pathSegments: ["meta"],
+          message: 'Unrecognized key: "migrations"',
+        },
+        {
+          path: "gateway.port",
+          pathSegments: ["gateway", "port"],
+          message: "Invalid input: expected number",
+        },
+      ],
+    });
+
+    const runtime = await runEnsureConfigReady(["message"]);
+    const output = plainErrorCalls(runtime).join("\n");
+
+    expect(output).toContain('  - openclaw.json:2 — meta: Unrecognized key: "migrations"');
+    expect(output).toContain(
+      '  - openclaw.json:3 — gateway.port: Invalid input: expected number, got: "nope"',
+    );
+  });
+
+  it.each([
+    { touchedVersion: "9999.1.1", expected: true },
+    { touchedVersion: VERSION, expected: false },
+  ])(
+    "shows a config version-skew hint only for newer writers ($touchedVersion)",
+    async ({ touchedVersion, expected }) => {
+      setInvalidSnapshot({ sourceConfig: { meta: { lastTouchedVersion: touchedVersion } } });
+
+      const runtime = await runEnsureConfigReady(["message"]);
+      const output = plainErrorCalls(runtime).join("\n");
+      const hint = `Config was last written by OpenClaw ${touchedVersion}, but you are running ${VERSION} — upgrade or re-run setup.`;
+
+      expect(output.includes(hint)).toBe(expected);
+    },
+  );
 
   it("runs doctor and retries the config guard once after consent", async () => {
     writeLegacyTaskSidecarMarker(useTempOpenClawHome());

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -325,11 +325,12 @@ export async function ensureConfigReady(
         subcommandName &&
         ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName))
     : false;
-  const { formatConfigIssueLines } = await import("../../config/issue-format.js");
+  const [{ formatConfigIssueLines }, { renderConfigValidationIssueLines }] = await Promise.all([
+    import("../../config/issue-format.js"),
+    import("../../config/issue-location.js"),
+  ]);
   const issues =
-    snapshot.exists && !snapshot.valid
-      ? formatConfigIssueLines(snapshot.issues, "-", { normalizeRoot: true })
-      : [];
+    snapshot.exists && !snapshot.valid ? renderConfigValidationIssueLines(snapshot) : [];
   const legacyIssues =
     snapshot.legacyIssues.length > 0 ? formatConfigIssueLines(snapshot.legacyIssues, "-") : [];
 
@@ -420,9 +421,7 @@ export async function ensureConfigReady(
           })
         ).snapshot;
         if (retrySnapshot.exists && !retrySnapshot.valid) {
-          const retryIssues = formatConfigIssueLines(retrySnapshot.issues, "-", {
-            normalizeRoot: true,
-          });
+          const retryIssues = renderConfigValidationIssueLines(retrySnapshot);
           throw createInvalidConfigError(
             retrySnapshot.path,
             retryIssues.join("\n") || "Unknown validation issue.",

--- a/src/commands/config-validation.test.ts
+++ b/src/commands/config-validation.test.ts
@@ -115,8 +115,12 @@ describe("requireValidConfig", () => {
 
   it("blocks invalid config before emitting compatibility advice", async () => {
     readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
       exists: true,
       valid: false,
+      raw: "{}",
+      parsed: {},
+      sourceConfig: {},
       config: {},
       issues: [{ path: "routing.allowFrom", message: "Legacy key" }],
     });
@@ -134,8 +138,12 @@ describe("requireValidConfig", () => {
 
   it("replaces doctor fix advice for plugin packaging compiled-output failures", async () => {
     readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
       exists: true,
       valid: false,
+      raw: "{}",
+      parsed: {},
+      sourceConfig: {},
       config: {},
       issues: [
         {
@@ -167,8 +175,12 @@ describe("requireValidConfig", () => {
 
   it("keeps doctor fix advice for normal invalid config failures", async () => {
     readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
       exists: true,
       valid: false,
+      raw: "{}",
+      parsed: {},
+      sourceConfig: {},
       config: {},
       issues: [{ path: "gateway.mode", message: "Expected 'local' or 'remote'" }],
       legacyIssues: [],

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -6,7 +6,7 @@ import {
   type OpenClawConfig,
   readConfigFileSnapshot,
 } from "../config/config.js";
-import { formatConfigIssueLines } from "../config/issue-format.js";
+import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
@@ -33,7 +33,7 @@ export async function requireValidConfigFileSnapshot(
   if (snapshot.exists && !snapshot.valid) {
     const issues =
       snapshot.issues.length > 0
-        ? formatConfigIssueLines(snapshot.issues, "-").join("\n")
+        ? renderConfigValidationIssueLines(snapshot).join("\n")
         : "Unknown validation issue.";
     runtime.error(`OpenClaw config is invalid: ${snapshot.path}\n${issues}`);
     runtime.error(

--- a/src/config/io.invalid-config.ts
+++ b/src/config/io.invalid-config.ts
@@ -2,9 +2,9 @@
  * Shared invalid-config formatting, logging, and error helpers for config reads and mutations.
  * All terminal-facing text is sanitized here so callers can reuse the same failure surface.
  */
-import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import type { DedupeCache } from "../infra/dedupe.js";
 import { extractErrorCode } from "../infra/errors.js";
+import { formatConfigIssueLines } from "./issue-format.js";
 
 /** Minimal validation issue shape accepted from schema and mutation validation paths. */
 type ConfigValidationIssueLike = {
@@ -14,13 +14,7 @@ type ConfigValidationIssueLike = {
 
 /** Formats validation issues as terminal-safe bullet lines for config load failures. */
 export function formatInvalidConfigDetails(issues: ConfigValidationIssueLike[]): string {
-  return issues
-    .map(
-      (issue) =>
-        // Validation paths/messages can contain user config text; sanitize before terminal output.
-        `- ${sanitizeTerminalText(issue.path || "<root>")}: ${sanitizeTerminalText(issue.message)}`,
-    )
-    .join("\n");
+  return formatConfigIssueLines(issues, "-", { normalizeRoot: true }).join("\n");
 }
 
 /** Builds the one-line invalid-config prefix plus preformatted validation details. */

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -1,16 +1,37 @@
 import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
-import { attachConfigIssueDiagnostics } from "./issue-location.js";
+import { renderConfigValidationIssueLines } from "./issue-location.js";
+import type { ConfigFileSnapshot, ConfigValidationIssue } from "./types.js";
 
 type PathSegment = string | number;
 
-function formatConfigIssuePath(pathSegments: PathSegment[]): string {
+function renderIssue(params: {
+  issue: ConfigValidationIssue;
+  raw: string | null;
+  parsed: unknown;
+  effective: unknown;
+}): string {
   return (
-    attachConfigIssueDiagnostics(
-      [{ path: pathSegments.join("."), pathSegments, message: "Invalid input" }],
-      { raw: null, parsed: {}, effective: {}, formatPathForDisplay: true },
-    )[0]?.path ?? ""
+    renderConfigValidationIssueLines(
+      {
+        issues: [params.issue],
+        raw: params.raw,
+        parsed: params.parsed,
+        sourceConfig: params.effective as ConfigFileSnapshot["sourceConfig"],
+        path: "/tmp/openclaw.json",
+      },
+      "",
+    )[0] ?? ""
   );
+}
+
+function formatConfigIssuePath(pathSegments: PathSegment[]): string {
+  return renderIssue({
+    issue: { path: pathSegments.join("."), pathSegments, message: "Invalid input" },
+    raw: null,
+    parsed: {},
+    effective: {},
+  }).replace(/: Invalid input$/, "");
 }
 
 function resolveConfigIssueLineInRaw(raw: string, pathSegments: PathSegment[]): number | undefined {
@@ -20,10 +41,14 @@ function resolveConfigIssueLineInRaw(raw: string, pathSegments: PathSegment[]): 
   } catch {
     // Malformed or empty text cannot own a source location.
   }
-  return attachConfigIssueDiagnostics(
-    [{ path: pathSegments.join("."), pathSegments, message: "Invalid input" }],
-    { raw, parsed, effective: parsed },
-  )[0]?.line;
+  const rendered = renderIssue({
+    issue: { path: pathSegments.join("."), pathSegments, message: "Invalid input" },
+    raw,
+    parsed,
+    effective: parsed,
+  });
+  const match = rendered.match(/^openclaw\.json:(\d+) — /);
+  return match?.[1] ? Number(match[1]) : undefined;
 }
 
 function appendReceivedValueHint(message: string, pathValue: string, value: unknown): string {
@@ -36,14 +61,14 @@ function appendReceivedValueHint(message: string, pathValue: string, value: unkn
     current = child;
   }
   current[pathSegments.at(-1) ?? ""] = value;
-  return (
-    attachConfigIssueDiagnostics([{ path: pathValue, pathSegments, message }], {
-      raw: JSON5.stringify(root),
-      parsed: root,
-      effective: root,
-      includeReceivedValueHint: true,
-    })[0]?.message ?? message
-  );
+  const rendered = renderIssue({
+    issue: { path: pathValue, pathSegments, message },
+    raw: JSON5.stringify(root),
+    parsed: root,
+    effective: root,
+  });
+  const issueText = rendered.split(" — ").at(-1) ?? rendered;
+  return issueText.slice(issueText.indexOf(": ") + 2);
 }
 
 describe("formatConfigIssuePath", () => {
@@ -57,8 +82,8 @@ describe("formatConfigIssuePath", () => {
     expect(formatConfigIssuePath(["a", 0, "b", 1])).toBe("a[0].b[1]");
   });
 
-  it("returns empty string for empty path", () => {
-    expect(formatConfigIssuePath([])).toBe("");
+  it("normalizes an empty path to the root marker", () => {
+    expect(formatConfigIssuePath([])).toBe("<root>");
   });
 
   it("handles all-string path", () => {
@@ -288,260 +313,99 @@ describe("appendReceivedValueHint", () => {
   });
 });
 
-describe("attachConfigIssueDiagnostics", () => {
-  const issue = (
-    pathSegments: Array<string | number>,
-    message: string,
-    extra: { allowedValues?: string[] } = {},
-  ) => ({ path: pathSegments.join("."), pathSegments, message, ...extra });
-  const raw = [
-    "{",
-    '  "agents": {',
-    '    "list": [',
-    '      { "tools": { "profile": "none" } }',
-    "    ]",
-    "  }",
-    "}",
-  ].join("\n");
-
-  const parsed = {
-    agents: { list: [{ tools: { profile: "none" } }] },
-  };
-
-  it("preserves internal path by default", () => {
-    const issues = attachConfigIssueDiagnostics(
-      [
-        issue(
-          ["agents", "list", 0, "tools", "profile"],
-          'Invalid input (allowed: "minimal", "coding")',
-          {
-            allowedValues: ["minimal", "coding"],
-          },
-        ),
-      ],
-      { raw, parsed, effective: parsed, configPath: "/tmp/openclaw.json" },
-    );
-
-    expect(issues[0]?.path).toBe("agents.list.0.tools.profile");
-    expect(issues[0]?.message).toBe('Invalid input (allowed: "minimal", "coding")');
-    expect(issues[0]?.line).toBe(4);
-    expect(issues[0]?.sourceFile).toBe("openclaw.json");
+describe("renderConfigValidationIssueLines", () => {
+  const issue = (pathSegments: PathSegment[], message: string): ConfigValidationIssue => ({
+    path: pathSegments.join("."),
+    pathSegments,
+    message,
   });
 
-  it("formats display path when requested", () => {
-    const issues = attachConfigIssueDiagnostics(
-      [
-        issue(
+  it("combines display paths, source locations, and received values", () => {
+    const raw = [
+      "{",
+      '  "agents": {',
+      '    "list": [',
+      '      { "tools": { "profile": "none" } }',
+      "    ]",
+      "  }",
+      "}",
+    ].join("\n");
+    const config = { agents: { list: [{ tools: { profile: "none" } }] } };
+
+    expect(
+      renderIssue({
+        issue: issue(
           ["agents", "list", 0, "tools", "profile"],
           'Invalid input (allowed: "minimal", "coding")',
-          {
-            allowedValues: ["minimal", "coding"],
-          },
         ),
-      ],
-      {
         raw,
-        parsed,
-        effective: parsed,
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
+        parsed: config,
+        effective: config,
+      }),
+    ).toBe(
+      'openclaw.json:4 — agents.list[0].tools.profile: Invalid input (allowed: "minimal", "coding"), got: "none"',
     );
-
-    expect(issues[0]?.path).toBe("agents.list[0].tools.profile");
-    expect(issues[0]?.message).toContain('got: "none"');
-    expect(issues[0]?.line).toBe(4);
   });
 
-  it("handles empty raw gracefully", () => {
-    const issues = attachConfigIssueDiagnostics([issue(["foo"], "error")], {
-      raw: null,
-      parsed: {},
-      effective: {},
-      configPath: "/tmp/openclaw.json",
-    });
-
-    expect(issues[0]?.line).toBeUndefined();
-    expect(issues[0]?.sourceFile).toBeUndefined();
-  });
-
-  it("handles $include'd paths gracefully (navigator returns undefined)", () => {
-    const issues = attachConfigIssueDiagnostics(
-      [
-        issue(
+  it("omits locations and received values for included config", () => {
+    const config = { models: { providers: { openai: { api: "bad" } } } };
+    expect(
+      renderIssue({
+        issue: issue(
           ["models", "providers", "openai", "api"],
           'Invalid input (allowed: "openai-chatgpt")',
         ),
-      ],
-      {
-        raw: ["{", '  "$include": "./models.json"', "}"].join("\n"),
-        parsed: { models: { providers: { openai: { api: "bad" } } } },
-        effective: { models: { providers: { openai: { api: "bad" } } } },
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    // Path exists in parsed but not in raw — no line number, no received value
-    expect(issues[0]?.line).toBeUndefined();
-    expect(issues[0]?.sourceFile).toBeUndefined();
-    expect(issues[0]?.message).toBe('Invalid input (allowed: "openai-chatgpt")');
-  });
-
-  it("preserves numeric record keys (not array indices)", () => {
-    const issues = attachConfigIssueDiagnostics(
-      [issue(["plugins", "entries", "123", "config", "mode"], 'Invalid input (allowed: "good")')],
-      {
-        raw: [
-          "{",
-          '  "plugins": {',
-          '    "entries": {',
-          '      "123": { "config": { "mode": "bad" } }',
-          "    }",
-          "  }",
-          "}",
-        ].join("\n"),
-        parsed: { plugins: { entries: { "123": { config: { mode: "bad" } } } } },
-        effective: { plugins: { entries: { "123": { config: { mode: "bad" } } } } },
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    expect(issues[0]?.path).toBe("plugins.entries.123.config.mode");
-    expect(issues[0]?.message).toBe('Invalid input (allowed: "good")');
-    expect(issues[0]?.line).toBe(4);
-  });
-
-  it("preserves non-canonical numeric record keys", () => {
-    const recordConfig = { records: { "01": { mode: "bad" }, "1": { mode: "good" } } };
-    const issues = attachConfigIssueDiagnostics(
-      [issue(["records", "01", "mode"], "Invalid input")],
-      {
-        raw: '{ records: { "01": { mode: "bad" }, "1": { mode: "good" } } }',
-        parsed: recordConfig,
-        effective: recordConfig,
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    expect(issues[0]).toMatchObject({
-      path: "records.01.mode",
-      message: 'Invalid input, got: "bad"',
-      line: 1,
-    });
+        raw: '{ "$include": "./models.json" }',
+        parsed: config,
+        effective: config,
+      }),
+    ).toBe('models.providers.openai.api: Invalid input (allowed: "openai-chatgpt")');
   });
 
   it("uses structured paths to distinguish dotted keys from nested keys", () => {
-    const dottedConfig = { "foo.bar": "literal", foo: { bar: "nested" } };
-    const params = {
-      raw: ['{ "foo.bar": "literal",', '  foo: { bar: "nested" } }'].join("\n"),
-      parsed: dottedConfig,
-      effective: dottedConfig,
-      configPath: "/tmp/openclaw.json",
-      formatPathForDisplay: true,
-      includeReceivedValueHint: true,
-    };
+    const config = { "foo.bar": "literal", foo: { bar: "nested" } };
+    const raw = ['{ "foo.bar": "literal",', '  foo: { bar: "nested" } }'].join("\n");
 
     expect(
-      attachConfigIssueDiagnostics([issue(["foo.bar"], "Invalid input")], params)[0],
-    ).toMatchObject({
-      message: 'Invalid input, got: "literal"',
-      line: 1,
-    });
+      renderIssue({
+        issue: issue(["foo.bar"], "Invalid input"),
+        raw,
+        parsed: config,
+        effective: config,
+      }),
+    ).toBe('openclaw.json:1 — foo.bar: Invalid input, got: "literal"');
     expect(
-      attachConfigIssueDiagnostics([issue(["foo", "bar"], "Invalid input")], params)[0],
-    ).toMatchObject({
-      message: 'Invalid input, got: "nested"',
-      line: 2,
-    });
-  });
-
-  it("does not let existing values steal missing dotted or nested paths", () => {
-    const dottedConfig = { "foo.bar": "literal", foo: {} };
-    const params = {
-      raw: ['{ "foo.bar": "literal",', "  foo: {} }"].join("\n"),
-      parsed: dottedConfig,
-      effective: dottedConfig,
-      configPath: "/tmp/openclaw.json",
-      formatPathForDisplay: true,
-      includeReceivedValueHint: true,
-    };
-
-    expect(attachConfigIssueDiagnostics([issue(["foo", "bar"], "Required")], params)[0]).toEqual(
-      issue(["foo", "bar"], "Required"),
-    );
-    const nestedOnly = { foo: { bar: "nested" } };
-    expect(
-      attachConfigIssueDiagnostics([issue(["foo.bar"], "Required")], {
-        ...params,
-        raw: '{ foo: { bar: "nested" } }',
-        parsed: nestedOnly,
-        effective: nestedOnly,
-      })[0],
-    ).toEqual(issue(["foo.bar"], "Required"));
+      renderIssue({
+        issue: issue(["foo", "bar"], "Invalid input"),
+        raw,
+        parsed: config,
+        effective: config,
+      }),
+    ).toBe('openclaw.json:2 — foo.bar: Invalid input, got: "nested"');
   });
 
   it("omits values changed by environment substitution", () => {
-    const envRaw = raw.replace('"none"', '"${PROFILE}"');
-    const issues = attachConfigIssueDiagnostics(
-      [issue(["agents", "list", 0, "tools", "profile"], "Invalid input")],
-      {
-        raw: envRaw,
-        parsed: { agents: { list: [{ tools: { profile: "${PROFILE}" } }] } },
-        effective: { agents: { list: [{ tools: { profile: "none" } }] } },
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    expect(issues[0]?.message).toBe("Invalid input");
-    expect(issues[0]?.line).toBe(4);
+    expect(
+      renderIssue({
+        issue: issue(["gateway", "bind"], "Invalid input"),
+        raw: '{ gateway: { bind: "${BIND}" } }',
+        parsed: { gateway: { bind: "${BIND}" } },
+        effective: { gateway: { bind: "lan" } },
+      }),
+    ).toBe("openclaw.json:1 — gateway.bind: Invalid input");
   });
 
-  it("omits arbitrary plugin-owned values", () => {
-    const pluginConfig = {
-      plugins: { entries: { custom: { config: { accessCode: "private" } } } },
+  it.each(["custom", "vendor.plugin"])("omits plugin-owned values for %s", (pluginId) => {
+    const config = {
+      plugins: { entries: { [pluginId]: { config: { accessCode: "private" } } } },
     };
-    const issues = attachConfigIssueDiagnostics(
-      [issue(["plugins", "entries", "custom", "config", "accessCode"], "Invalid input")],
-      {
-        raw: '{ plugins: { entries: { custom: { config: { accessCode: "private" } } } } }',
-        parsed: pluginConfig,
-        effective: pluginConfig,
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    expect(issues[0]?.message).toBe("Invalid input");
-    expect(issues[0]?.line).toBe(1);
-  });
-
-  it("omits plugin-owned values when the plugin id contains dots", () => {
-    const pluginConfig = {
-      plugins: { entries: { "vendor.plugin": { config: { sessionValue: "private" } } } },
-    };
-    const issues = attachConfigIssueDiagnostics(
-      [issue(["plugins", "entries", "vendor.plugin", "config", "sessionValue"], "Invalid input")],
-      {
-        raw: '{ plugins: { entries: { "vendor.plugin": { config: { sessionValue: "private" } } } } }',
-        parsed: pluginConfig,
-        effective: pluginConfig,
-        configPath: "/tmp/openclaw.json",
-        formatPathForDisplay: true,
-        includeReceivedValueHint: true,
-      },
-    );
-
-    expect(issues[0]?.message).toBe("Invalid input");
-    expect(issues[0]?.line).toBe(1);
+    expect(
+      renderIssue({
+        issue: issue(["plugins", "entries", pluginId, "config", "accessCode"], "Invalid input"),
+        raw: JSON5.stringify(config),
+        parsed: config,
+        effective: config,
+      }),
+    ).toBe(`openclaw.json:1 — plugins.entries.${pluginId}.config.accessCode: Invalid input`);
   });
 });

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,9 +1,12 @@
 import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import JSON5 from "json5";
+import { VERSION } from "../version.js";
+import { formatConfigIssueLines } from "./issue-format.js";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
-import type { ConfigValidationIssue } from "./types.js";
+import type { ConfigFileSnapshot, ConfigValidationIssue } from "./types.js";
 import { isSecretRef } from "./types.secrets.js";
+import { shouldWarnOnTouchedVersion } from "./version.js";
 
 type ConfigIssuePathSegment = string | number;
 
@@ -336,7 +339,7 @@ type ConfigIssueDiagnostics = ConfigValidationIssue & {
   sourceFile?: string;
 };
 
-export function attachConfigIssueDiagnostics(
+function attachConfigIssueDiagnostics(
   issues: readonly ConfigValidationIssue[],
   params: AttachConfigIssueDiagnosticsParams,
 ): ConfigIssueDiagnostics[] {
@@ -367,4 +370,27 @@ export function attachConfigIssueDiagnostics(
       ...(line === undefined ? {} : { line, sourceFile }),
     };
   });
+}
+
+/** Render invalid config issues with source locations, received values, and version-skew advice. */
+export function renderConfigValidationIssueLines(
+  snapshot: Pick<ConfigFileSnapshot, "issues" | "raw" | "parsed" | "sourceConfig" | "path">,
+  marker = "-",
+): string[] {
+  const issues = attachConfigIssueDiagnostics(snapshot.issues, {
+    raw: snapshot.raw,
+    parsed: snapshot.parsed,
+    effective: snapshot.sourceConfig,
+    configPath: snapshot.path,
+    formatPathForDisplay: true,
+    includeReceivedValueHint: true,
+  });
+  const lines = formatConfigIssueLines(issues, marker, { normalizeRoot: true });
+  const touchedVersion = snapshot.sourceConfig.meta?.lastTouchedVersion;
+  return shouldWarnOnTouchedVersion(VERSION, touchedVersion)
+    ? [
+        ...lines,
+        `Config was last written by OpenClaw ${touchedVersion}, but you are running ${VERSION} — upgrade or re-run setup.`,
+      ]
+    : lines;
 }

--- a/src/gateway/server-startup-config-helpers.ts
+++ b/src/gateway/server-startup-config-helpers.ts
@@ -8,7 +8,7 @@ import {
   type ReadConfigFileSnapshotWithPluginMetadataResult,
   readConfigFileSnapshotWithPluginMetadata,
 } from "../config/io.js";
-import { formatConfigIssueLines } from "../config/issue-format.js";
+import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import {
   retainLegacyDefaultAgentId,
   tryGetLegacyDefaultAgentId,
@@ -56,7 +56,7 @@ export function assertValidGatewayStartupConfigSnapshot(
   }
   const issues =
     snapshot.issues.length > 0
-      ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+      ? renderConfigValidationIssueLines(snapshot, "").join("\n")
       : "Unknown validation issue.";
   const recoveryHint =
     options.includeDoctorHint && isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -484,6 +484,32 @@ describe("gateway startup config validation", () => {
     );
   });
 
+  it("renders actionable diagnostics for invalid config written by a newer version", async () => {
+    const rawConfig = {
+      meta: { lastTouchedVersion: "9999.1.1" },
+      gateway: { mode: "nope" },
+    };
+    const invalidSnapshot = buildInvalidConfigSnapshot({
+      rawConfig,
+      config: rawConfig as OpenClawConfig,
+      issues: [
+        {
+          path: "gateway.mode",
+          pathSegments: ["gateway", "mode"],
+          message: 'Invalid input (allowed: "local", "remote")',
+        },
+      ],
+    });
+    vi.mocked(configIo.readConfigFileSnapshot).mockResolvedValueOnce(invalidSnapshot);
+
+    await expectStartupRejects(
+      new RegExp(
+        'openclaw-startup-recovery\\.json:1 — gateway\\.mode: Invalid input \\(allowed: "local", "remote"\\), got: "nope".*Config was last written by OpenClaw 9999\\.1\\.1, but you are running',
+        "s",
+      ),
+    );
+  });
+
   it("does not suggest doctor repair for plugin packaging compiled-output failures", async () => {
     const rawConfig = pluginSlotRawConfig("local");
     const invalidSnapshot = buildInvalidConfigSnapshot({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running an older OpenClaw against a config written by a newer release received validation failures that were too vague to repair and gave no indication that version skew might be the cause.

Verified live reproduction: an operator running Homebrew openclaw 2026.7.1-2 against a config last written by 2026.8.1 saw `OpenClaw config is invalid: meta/agents/gateway.nodes Invalid input` — path fragments with no offending key name and no hint — while the newer binary's `config validate` on the SAME file said valid-with-warning. The keys involved post-date the old release: `meta.migrations.modelPolicyAllowlist`, `gateway.nodes.commands`, and retired `agents.entries.*.default`.

There were two real weaknesses: strict unknown-key rejections collapsed to bare `Invalid input` without the offending key, and nothing suggested version skew even though `meta.lastTouchedVersion` was already available.

## Why This Change Was Made

CLI, service-lifecycle, and direct Gateway-startup invalid-config failure paths now use one canonical renderer. It preserves structured issue paths, adds the config filename and source line when the value is in the root file, safely includes the received scalar value, and appends a version-skew line only when the shared OpenClaw version comparator proves that the config writer is newer.

The comparison degrades safely: missing or unparsable `meta.lastTouchedVersion` values produce no hint, same-release and correction-release families do not mis-fire, and prerelease ordering continues through the existing shared comparator. Machine-readable JSON output remains on the existing normalized issue-object path and does not gain display text or change shape.

The prepared patch was production +42/-41 (net +1), tests net -70. After applying ClawSweeper's service-lifecycle and Gateway-startup boundary moves, the final diff is production +46/-45 (net +1), tests +233/-255 (net -22). The production increase is the canonical rendering boundary itself; duplicated per-caller formatting was removed, and the former diagnostic helper is now private.

## User Impact

Operators now see actionable invalid-config output such as the exact file and line, the full offending path, and the received value. When an older binary reads a config written by a newer OpenClaw, the error also recommends upgrading or rerunning setup instead of leaving the operator to infer version skew.

JSON consumers are unaffected.

## Evidence

- Fresh autoreview on the rebased final diff: clean, no accepted/actionable findings.
- Focused config/CLI, service-lifecycle, and Gateway-startup proof: `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle-action-preflight.test.ts src/gateway/server-startup-config.recovery.test.ts src/config/issue-location.test.ts src/config/io.invalid-config.test.ts src/config/version.test.ts src/commands/config-validation.test.ts src/cli/program/config-guard.test.ts src/cli/config-cli.test.ts` — 352 tests passed across 4 shards.
- Changed gate: `node scripts/check-changed.mjs` — passed via the documented high-capacity local fallback after no remote provider was ready.
- Black-box `openclaw config validate` against an isolated invalid config written by `9999.1.1`: emitted `newer.json5:3 — gateway.mode: Invalid input (allowed: "local", "remote"), got: "nope"` plus the newer-writer hint.
- The same black-box check with `2026.8.1`, missing version metadata, and garbage version metadata emitted no skew hint.
- Black-box `openclaw config validate --json` retained exactly the top-level keys `issues`, `path`, and `valid`; the issue remained a normalized object with `path`, `message`, and `allowedValues`.
- ClawSweeper follow-up: service-action and Gateway-startup invalid snapshots now use the same renderer, with focused newer-writer boundary tests for both paths.

AI-assisted: the final diff was independently reviewed with the repository autoreview workflow, and the observable CLI behavior was validated source-blind against the contract above.
