### PR TITLE
fix(skills): report missing ClawHub skills as not found

### DIFF
--- a/src/skills/lifecycle/clawhub-install-core.ts
+++ b/src/skills/lifecycle/clawhub-install-core.ts
@@ -8,7 +8,11 @@ import {
   normalizeClawHubSha256Integrity,
   type ClawHubDownloadResult,
 } from "../../infra/clawhub-artifacts.js";
-import { isDefaultClawHubBaseUrl, resolveClawHubBaseUrl } from "../../infra/clawhub-client.js";
+import {
+  ClawHubRequestError,
+  isDefaultClawHubBaseUrl,
+  resolveClawHubBaseUrl,
+} from "../../infra/clawhub-client.js";
 import {
   type ClawHubTrustErrorCode,
   ensureClawHubPackageTrustAcknowledged,
@@ -184,6 +188,32 @@ export async function resolveInstallVersion(params: {
     throw new Error(`Skill "${params.slug}" has no installable version.`);
   }
   return { detail, version };
+}
+
+function formatClawHubSkillInstallError(error: unknown, slug: string): string {
+  if (!(error instanceof ClawHubRequestError)) {
+    return formatErrorMessage(error);
+  }
+  const skillPath = `/api/v1/skills/${encodeURIComponent(slug)}`;
+  if (
+    error.status === 404 &&
+    (error.requestPath.endsWith(skillPath) || error.requestPath.endsWith(`${skillPath}/install`))
+  ) {
+    return `Skill "${slug}" not found. Run \`openclaw skills list\` to see available skills.`;
+  }
+  if (error.status === 401) {
+    return `ClawHub authentication failed while installing skill "${slug}". Authenticate with ClawHub and try again.`;
+  }
+  if (error.status === 403) {
+    return `ClawHub denied access while installing skill "${slug}". Check your ClawHub access and try again.`;
+  }
+  if (error.status === 429) {
+    return `ClawHub rate limit reached while installing skill "${slug}". Wait and try again later.`;
+  }
+  if (error.status >= 500) {
+    return `ClawHub is temporarily unavailable while installing skill "${slug}". Try again later.`;
+  }
+  return `ClawHub could not install skill "${slug}". Check the skill reference and try again.`;
 }
 
 function normalizeGitHubSourcePath(raw: string): string {
@@ -683,6 +713,6 @@ export async function performClawHubSkillInstall(
       await archive.cleanup().catch(() => undefined);
     }
   } catch (err) {
-    return { ok: false, error: formatErrorMessage(err) };
+    return { ok: false, error: formatClawHubSkillInstallError(err, params.slug) };
   }
 }

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -79,6 +79,8 @@ vi.mock("../../state/claw-package-adoption.js", () => ({
   markClawPackageIndependentlyOwned: markClawPackageIndependentlyOwnedMock,
 }));
 
+const { ClawHubRequestError } = await import("../../infra/clawhub-client.js");
+
 const {
   installSkillFromClawHub,
   preflightSkillFromClawHub,
@@ -352,6 +354,53 @@ describe("skills-clawhub", () => {
       slug: "agentreceipt",
       version: "1.0.0",
     });
+  });
+
+  it.each([
+    {
+      name: "maps missing install resolutions to the skills-info recovery message",
+      lookup: "install",
+      status: 404,
+      path: "/api/v1/skills/missing-skill/install",
+      body: "remote not-found detail",
+      expected:
+        'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+    },
+    {
+      name: "maps missing versioned skills to the skills-info recovery message",
+      lookup: "detail",
+      status: 404,
+      path: "/custom-clawhub/api/v1/skills/missing-skill",
+      body: "remote versioned not-found detail",
+      expected:
+        'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+    },
+    {
+      name: "keeps server failures distinct from missing skills",
+      lookup: "install",
+      status: 500,
+      path: "/api/v1/skills/missing-skill/install",
+      body: "remote-controlled server failure",
+      expected:
+        'ClawHub is temporarily unavailable while installing skill "missing-skill". Try again later.',
+    },
+  ] as const)("$name", async ({ lookup, status, path: requestPath, body, expected }) => {
+    const requestError = new ClawHubRequestError({ path: requestPath, status, body });
+    if (lookup === "detail") {
+      fetchClawHubSkillDetailMock.mockRejectedValueOnce(requestError);
+    } else {
+      fetchClawHubSkillInstallResolutionMock.mockRejectedValueOnce(requestError);
+    }
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "missing-skill",
+      ...(lookup === "detail" ? { version: "1.2.3" } : {}),
+    });
+
+    expect(result).toEqual({ ok: false, error: expected });
+    expect(result.ok ? "" : result.error).not.toContain("/api/v1/");
+    expect(result.ok ? "" : result.error).not.toContain(body);
   });
 
   it("installs skills-sh references via a ClawHub-approved pinned GitHub commit", async () => {
@@ -1885,6 +1934,37 @@ describe("skills-clawhub", () => {
       requestedReference: "skills-sh:openclaw/skills/weather",
       trustState: "not-scanned-by-clawhub",
     });
+  });
+
+  it("reports a tracked skill removed from ClawHub with the same recovery message", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-missing-update-");
+    await writeClawHubOriginFixture({
+      workspaceDir,
+      slug: "missing-skill",
+      installedVersion: "0.9.0",
+    });
+    const body = "remote update not-found detail";
+    fetchClawHubSkillInstallResolutionMock.mockRejectedValueOnce(
+      new ClawHubRequestError({
+        path: "/clawhub/api/v1/skills/missing-skill/install",
+        status: 404,
+        body,
+      }),
+    );
+
+    const results = await updateSkillsFromClawHub({
+      workspaceDir,
+      slug: "missing-skill",
+    });
+
+    expect(results).toEqual([
+      {
+        ok: false,
+        error:
+          'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+      },
+    ]);
+    expect(results[0]?.ok ? "" : results[0]?.error).not.toContain(body);
   });
 
   it("updates official publisher ClawHub skills without fetching security verdicts", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a missing ClawHub skill received an internal API path, HTTP status, and remote response body with no recovery step.

Before:

```text
$ openclaw skills install nonexistent-skill-xyz
ClawHub /api/v1/skills/nonexistent-skill-xyz/install failed (404): Skill not found
[exit 1]
```

The sibling commands already use domain language:

```text
Skill "nonexistent-skill-xyz" not found. Run `openclaw skills list` to see available skills.
Skill "nonexistent-skill-xyz" is not tracked as a ClawHub install.
Plugin not found: nonexistent-plugin. Run `openclaw plugins list` to see installed plugins, or `openclaw plugins search nonexistent-plugin` to look for installable plugins.
No ClawHub skills found.
```

## Why This Change Was Made

The skills lifecycle now maps structured `ClawHubRequestError` values at the install owner boundary. A 404 from either the skill detail lookup or install-resolution endpoint uses the existing `skills info` wording; other HTTP classes remain distinct and get safe recovery guidance without exposing the remote-controlled response body. Custom ClawHub base-path prefixes are supported, while artifact/download 404s are deliberately not mislabeled as a missing skill.

The plugin mapper was not promoted into shared infrastructure: it returns plugin-specific typed package/version codes, while skills returns a skill lifecycle result with requested-skill wording and a CLI next step. Promos likewise have command-specific return/throw semantics. Sharing those result shapes would add an adapter rather than consolidate ownership. `ClawHubRequestError.message` remains transport-shaped for logs and diagnostics; operator consumers should not print it verbatim.

### Consumer sweep

| Surface | Decision | Reason |
| --- | --- | --- |
| Skills install, unversioned | Changed | `/skills/:slug/install` 404 now names the skill and points to `skills list`; non-404 HTTP errors are status-class-specific and body-safe. |
| Skills install `--version` | Changed | `/skills/:slug` detail 404 uses the same canonical message. |
| Skills update, tracked | Changed through the same owner | Updates reuse the install lifecycle; a remotely removed tracked skill now gets the same recovery message. |
| Skills update, untracked | Left | Already returns `Skill "…" is not tracked as a ClawHub install.` without HTTP. |
| Skills search | Left | Empty results already say `No ClawHub skills found.` Endpoint failures are service failures, not no-match results. |
| Skills info | Left | Entirely local and already owns the canonical not-found wording. |
| Skills uninstall | Left | Local origin/lock/files only; no ClawHub request. |
| Plugins install/update | Left | Existing mapper owns typed package/version 404 outcomes and both commands share it; its result shape does not match skills. |
| Plugins search | Left | Empty results are already friendly; endpoint failures are service failures. |
| Plugins info/uninstall | Left | Local registry/config/files only; no ClawHub request. |
| Promos list/claim | Left | Both already map their 404s to promotion-specific answers and recovery. |
| Telemetry | Left | Install telemetry failures are swallowed and never reach operators. |

The sweep also found pre-existing raw non-404 transport-message debt in ClawHub search, plugin artifact/trust failures, skill trust/verification warnings, and promo non-404 propagation. Those paths have distinct product/security semantics and existing tests, so they are a named follow-up rather than being mixed into this missing-skill repair.

## User Impact

After:

```text
$ openclaw skills install nonexistent-skill-xyz
Skill "nonexistent-skill-xyz" not found. Run `openclaw skills list` to see available skills.
[exit 1]
```

The same output is observed for `skills install nonexistent-skill-xyz --version 1.2.3` and for a tracked skill that has been removed before `skills update`. Authentication, access-denied, rate-limit, server, and other failures do not become “not found.”

## Evidence

- Regression proved before the fix: both new lifecycle cases failed with the raw `ClawHub /api/v1/... failed (...)` message and remote body.
- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts src/cli/skills-cli.commands.test.ts` — 105 lifecycle tests and 77 CLI tests passed.
- `node scripts/check-changed.mjs` — passed on Testbox run https://github.com/openclaw/openclaw/actions/runs/31965533195, including core/test typechecks, lint, formatting, dead exports, import cycles, and selected architecture guards.
- `pnpm build` — passed from this worktree using the canonical checkout's existing dependency install; no dependency reconciliation.
- Built CLI live proof used a fresh `HOME`, isolated `OPENCLAW_STATE_DIR`, `OPENCLAW_SKIP_CHANNELS=1`, and no ClawHub auth config. Install, versioned install, and tracked update each exited 1 with only the canonical domain message.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- Production LOC: +32/-2 (net +30), for domain classification, remote-body isolation, and recovery guidance. Tests: +80/-0.

AI-assisted: yes.
