### PR TITLE
test(upgrade): drop retired agent context assertion

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -414,11 +414,6 @@ function assertConfigSurvived() {
       config.agents?.entries?.ops ?? legacyAgents.find((agent) => agent?.id === "ops");
     assert(mainAgent, "main agent missing");
     assert(opsAgent, "ops agent missing");
-    if (hasCoverage(coverage)) {
-      assert(config.agents?.defaults?.contextTokens === 64000, "default contextTokens changed");
-    } else {
-      assert(mainAgent.contextTokens === 64000, "main agent contextTokens changed");
-    }
     if (!hasCoverage(coverage) || !coverage.skippedIntents?.includes("agent-modern-preferences")) {
       assert(opsAgent.fastModeDefault === true, "ops fastModeDefault changed");
     }


### PR DESCRIPTION
## Summary

- remove the upgrade-survivor assertion for retired agent-level `contextTokens`
- keep survivor coverage focused on supported settings instead of treating Doctor cleanup as data loss

## Verification

- `node scripts/run-vitest.mjs test/scripts/upgrade-survivor-assertions.test.ts` (21 passed)
- targeted oxfmt and oxlint passed
- published `openclaw@2026.7.1-2` → candidate Testbox matrix passed 7/7 scenarios: base, Feishu, bootstrap persona, channel restoration, tilde log path, meeting-transcript SQLite, and cron authority
- autoreview clean (patch correctness 0.99)

Production LOC: -5.