### PR TITLE
fix(mcp): make Codex approval dead ends actionable

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -397,6 +397,12 @@ openclaw mcp add memory \
   --approval approve
 ```
 
+For an existing saved server, update only its approval mode:
+
+```bash
+openclaw mcp configure memory --approval approve
+```
+
 The flag writes `codex.defaultToolsApprovalMode`, which accepts `auto`,
 `prompt`, or `approve`. `approve` bypasses per-call approval for every tool on
 that server, so use it only for trusted servers. `mcp probe` and `mcp doctor
@@ -438,7 +444,7 @@ Notes:
 - `probe` connects and reports tool counts, resources/prompts support, list-change support, and diagnostics.
 - `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags. Use `--approval auto|prompt|approve` to set the Codex tool approval mode.
 - `set` expects one JSON object value on the command line.
-- `configure` updates enablement, tool filters, timeouts, OAuth, TLS, and parallel-tool-call hints without replacing the whole server definition. Add `--probe` to verify the updated server before saving.
+- `configure` updates enablement, tool filters, timeouts, OAuth, TLS, Codex approval mode, and parallel-tool-call hints without replacing the whole server definition. Add `--probe` to verify the updated server before saving.
 - `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs.
 - `login` runs the OAuth flow for HTTP servers configured with `auth: "oauth"`. For a loopback redirect, OpenClaw listens for the browser callback and completes login automatically. The printed `--code` command remains the fallback for remote, headless, or unreachable callbacks.
 - `logout` clears stored OAuth credentials for the named server without removing the saved server definition.

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -383,16 +383,33 @@ Those saved definitions are for runtimes that OpenClaw launches or configures la
 
 Runtime adapters may normalize this shared registry into the shape their downstream client expects. For example, embedded OpenClaw consumes OpenClaw `transport` values directly, while Claude Code and Gemini receive CLI-native `type` values such as `http`, `sse`, or `stdio`.
 
-Codex app-server also honors an optional `codex` block on each server. This is
-OpenClaw projection metadata for Codex app-server threads only; it does not
-change ACP sessions, generic Codex harness config, or other runtime adapters.
-Use non-empty `codex.agents` to project a server only into specific OpenClaw
-agent ids. Empty, blank, or invalid agent lists are rejected by config
-validation and omitted by the runtime projection path instead of becoming
-global. Use `codex.defaultToolsApprovalMode` (`auto`, `prompt`, or `approve`)
-to emit Codex's native `default_tools_approval_mode` for a trusted server.
-OpenClaw strips the `codex` metadata before handing the native `mcp_servers`
-config to Codex.
+### Codex tool approvals
+
+Codex app-server approval-gates tools that have no MCP safety annotations when
+the server uses the default `auto` mode. Interactive turns can approve those
+calls in the Control UI. For a server you trust, set the mode while adding it:
+
+```bash
+openclaw mcp add memory \
+  --command npx \
+  --arg -y \
+  --arg @modelcontextprotocol/server-memory \
+  --approval approve
+```
+
+The flag writes `codex.defaultToolsApprovalMode`, which accepts `auto`,
+`prompt`, or `approve`. `approve` bypasses per-call approval for every tool on
+that server, so use it only for trusted servers. `mcp probe` and `mcp doctor
+--probe` warn when a server remains in `auto` mode and none of its tools has
+safety annotations.
+
+The optional `codex` block is OpenClaw projection metadata for Codex app-server
+threads only; it does not change ACP sessions, generic Codex harness config, or
+other runtime adapters. Use non-empty `codex.agents` to project a server only
+into specific OpenClaw agent ids. Empty, blank, or invalid agent lists are
+rejected by config validation and omitted by the runtime projection path
+instead of becoming global. OpenClaw strips the `codex` metadata before handing
+the native `mcp_servers` config to Codex.
 
 ### Saved MCP server definitions
 
@@ -419,7 +436,7 @@ Notes:
 - `status` classifies configured transports without connecting. `--verbose` includes resolved launch, timeout, OAuth, filter, and parallel-call details, including when stored OAuth tokens require additional authorization. Credential-bearing stdio arguments are redacted in text and JSON output.
 - `doctor` performs static checks without connecting. Add `--probe` when the command should also verify that enabled servers connect.
 - `probe` connects and reports tool counts, resources/prompts support, list-change support, and diagnostics.
-- `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags.
+- `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags. Use `--approval auto|prompt|approve` to set the Codex tool approval mode.
 - `set` expects one JSON object value on the command line.
 - `configure` updates enablement, tool filters, timeouts, OAuth, TLS, and parallel-tool-call hints without replacing the whole server definition. Add `--probe` to verify the updated server before saving.
 - `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs.
@@ -590,6 +607,8 @@ Use `--json` for scripts and dashboards. Field sets can grow over time, so consu
         "docs": {
           "launch": "streamable-http https://mcp.example.com/mcp",
           "tools": 2,
+          "codexApprovalMode": "auto",
+          "approvalHint": "tools have no safety annotations; calls will require interactive approval",
           "resources": true,
           "listChanged": {
             "tools": true,
@@ -603,7 +622,7 @@ Use `--json` for scripts and dashboards. Field sets can grow over time, so consu
     }
     ```
 
-    `probe --json` opens a live MCP client session and prints its result directly; unlike `status`/`doctor`, the output has no top-level `path` field. `resources` and `prompts` keys are present only when the server actually advertises that capability (a server without prompts omits the `prompts` key rather than reporting `false`). The command prints the complete result before exiting nonzero when diagnostics are present or a selected enabled server did not connect, so automation can inspect partial successes. Use `probe` for reachability and capability proof, not for static config audits.
+    `probe --json` opens a live MCP client session and prints its result directly; unlike `status`/`doctor`, the output has no top-level `path` field. Each server includes its effective `codexApprovalMode`; `approvalHint` appears when that mode is `auto` and the discovered tools have no safety annotations. `resources` and `prompts` keys are present only when the server actually advertises that capability (a server without prompts omits the `prompts` key rather than reporting `false`). The command prints the complete result before exiting nonzero when diagnostics are present or a selected enabled server did not connect, so automation can inspect partial successes. Use `probe` for reachability and capability proof, not for static config audits.
 
   </Accordion>
 </AccordionGroup>
@@ -634,6 +653,9 @@ Example config shape:
         "toolFilter": {
           "include": ["search_*"],
           "exclude": ["admin_*"]
+        },
+        "codex": {
+          "defaultToolsApprovalMode": "approve"
         }
       }
     }

--- a/src/agents/harness/native-hook-relay-permissions.ts
+++ b/src/agents/harness/native-hook-relay-permissions.ts
@@ -50,6 +50,8 @@ const MAX_APPROVAL_DESCRIPTION_LENGTH = 700;
 const MAX_PERMISSION_APPROVALS_PER_WINDOW = 12;
 const PERMISSION_APPROVAL_WINDOW_MS = 60_000;
 const MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES = 512;
+const MCP_APPROVAL_UNAVAILABLE_REASON =
+  'MCP tool approval timed out (no operator connected). Approve in the Control UI, or set mcp.servers.<id>.codex.defaultToolsApprovalMode:"approve" for trusted servers.';
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 const {
@@ -214,6 +216,12 @@ export async function runNativeHookRelayPermissionRequest(params: {
     }
     if (decision === "deny") {
       return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");
+    }
+    if (decision === "unavailable" && request.toolName.startsWith("mcp__")) {
+      return params.adapter.renderPermissionDecisionResponse(
+        "deny",
+        MCP_APPROVAL_UNAVAILABLE_REASON,
+      );
     }
   } catch (error) {
     log.warn(
@@ -507,7 +515,7 @@ async function requestNativeHookRelayPermissionApproval(
   );
   const approvalId = requestResult?.id;
   if (!approvalId) {
-    return "defer";
+    return "unavailable";
   }
   let decision: string | null | undefined;
   if (Object.hasOwn(requestResult ?? {}, "decision")) {
@@ -531,7 +539,7 @@ async function requestNativeHookRelayPermissionApproval(
   if (decision === PluginApprovalResolutions.DENY) {
     return "deny";
   }
-  return "defer";
+  return "unavailable";
 }
 
 async function waitForNativeHookRelayApprovalDecision(params: {

--- a/src/agents/harness/native-hook-relay-permissions.ts
+++ b/src/agents/harness/native-hook-relay-permissions.ts
@@ -217,7 +217,7 @@ export async function runNativeHookRelayPermissionRequest(params: {
     if (decision === "deny") {
       return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");
     }
-    if (decision === "unavailable" && request.toolName.startsWith("mcp__")) {
+    if (decision === "timed-out" && request.toolName.startsWith("mcp__")) {
       return params.adapter.renderPermissionDecisionResponse(
         "deny",
         MCP_APPROVAL_UNAVAILABLE_REASON,
@@ -515,7 +515,7 @@ async function requestNativeHookRelayPermissionApproval(
   );
   const approvalId = requestResult?.id;
   if (!approvalId) {
-    return "unavailable";
+    return "defer";
   }
   let decision: string | null | undefined;
   if (Object.hasOwn(requestResult ?? {}, "decision")) {
@@ -528,7 +528,10 @@ async function requestNativeHookRelayPermissionApproval(
     });
     // Bind the verdict to the request that parked this call. A stale or
     // misrouted reply must never release a different tool gate.
-    decision = waitResult?.id === approvalId ? waitResult.decision : undefined;
+    if (!waitResult || waitResult.id !== approvalId) {
+      return "defer";
+    }
+    decision = waitResult.decision;
   }
   if (decision === PluginApprovalResolutions.ALLOW_ONCE) {
     return "allow";
@@ -539,7 +542,7 @@ async function requestNativeHookRelayPermissionApproval(
   if (decision === PluginApprovalResolutions.DENY) {
     return "deny";
   }
-  return "unavailable";
+  return decision == null ? "timed-out" : "defer";
 }
 
 async function waitForNativeHookRelayApprovalDecision(params: {

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -195,6 +195,7 @@ export type NativeHookRelayProviderAdapter = {
 export type NativeHookRelayPermissionApprovalResult =
   | NativeHookRelayPermissionDecision
   | "allow-always"
+  | "unavailable"
   | "defer";
 
 export type ActiveNativeHookRelayRegistration = NativeHookRelayRegistration & {

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -195,7 +195,7 @@ export type NativeHookRelayProviderAdapter = {
 export type NativeHookRelayPermissionApprovalResult =
   | NativeHookRelayPermissionDecision
   | "allow-always"
-  | "unavailable"
+  | "timed-out"
   | "defer";
 
 export type ActiveNativeHookRelayRegistration = NativeHookRelayRegistration & {

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -40,6 +40,54 @@ describe("native hook relay approval wait handling", () => {
     expect(result.stdout).toContain("mcp.servers.<id>.codex.defaultToolsApprovalMode");
   });
 
+  it("defers an MCP tool when no approval id is created", async () => {
+    mockCallGatewayTool.mockResolvedValueOnce({ status: "unavailable" });
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "mcp__memory__create_entities",
+          tool_input: { entities: [] },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    expect(mockCallGatewayTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers an MCP tool when waitDecision returns a different approval id", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-request", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:other-approval", decision: null });
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "mcp__memory__create_entities",
+          tool_input: { entities: [] },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
   it("defers when waitDecision reports a stale approval id", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-stale", status: "accepted" })

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -15,6 +15,31 @@ afterEach(() => {
 });
 
 describe("native hook relay approval wait handling", () => {
+  it("explains how to unblock an MCP tool when approval times out", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-timeout", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-timeout", decision: null });
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+
+    const result = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        tool_name: "mcp__memory__create_entities",
+        tool_input: { entities: [] },
+      },
+    });
+
+    expect(result.stdout).toContain("MCP tool approval timed out");
+    expect(result.stdout).toContain("mcp.servers.<id>.codex.defaultToolsApprovalMode");
+  });
+
   it("defers when waitDecision reports a stale approval id", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-stale", status: "accepted" })

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -70,6 +70,8 @@ describe("mcp cli", () => {
         "--connect-timeout",
         "3",
         "--parallel",
+        "--approval",
+        "approve",
         "--no-probe",
       ]);
 
@@ -85,6 +87,7 @@ describe("mcp cli", () => {
         requestTimeoutMs: 12_000,
         connectionTimeoutMs: 3_000,
         supportsParallelToolCalls: true,
+        codex: { defaultToolsApprovalMode: "approve" },
       });
     });
   });
@@ -735,6 +738,60 @@ describe("mcp cli", () => {
         diagnostics: [],
       });
       expect(lastErrorLine()).toBe("");
+    });
+  });
+
+  it("warns when auto-approved Codex MCP tools have no safety annotations", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand(["mcp", "set", "memory", JSON.stringify({ command: process.execPath })]);
+      setCreateSessionMcpRuntimeOverride((params) => ({
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        configFingerprint: "cli-probe-approval-hint",
+        createdAt: 0,
+        lastUsedAt: 0,
+        getCatalog: async () => ({
+          version: 1,
+          generatedAt: Date.now(),
+          servers: {
+            memory: {
+              serverName: "memory",
+              launchSummary: process.execPath,
+              toolCount: 1,
+              codexApprovalMode: "auto",
+            },
+          },
+          tools: [
+            {
+              serverName: "memory",
+              safeServerName: "memory",
+              toolName: "create_entities",
+              inputSchema: { type: "object" },
+              fallbackDescription: "Create entities",
+              codexAnnotations: {},
+            },
+          ],
+          diagnostics: [],
+        }),
+        peekCatalog: () => null,
+        markUsed: () => {},
+        callTool: async () => ({ content: [] }),
+        dispose: async () => {},
+      }));
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "probe", "memory"]);
+      expect(mockLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+        "tools have no safety annotations; calls will require interactive approval",
+      );
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "doctor", "memory", "--probe"]);
+      expect(mockLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+        "tools have no safety annotations; calls will require interactive approval",
+      );
     });
   });
 

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -92,6 +92,31 @@ describe("mcp cli", () => {
     });
   });
 
+  it("updates approval mode without replacing saved Codex metadata", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        JSON.stringify({
+          command: process.execPath,
+          codex: { agents: ["docs-agent"], defaultToolsApprovalMode: "auto" },
+        }),
+      ]);
+
+      await runMcpCommand(["mcp", "configure", "docs", "--approval", "approve"]);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        command: process.execPath,
+        codex: { agents: ["docs-agent"], defaultToolsApprovalMode: "approve" },
+      });
+    });
+  });
+
   it("rejects hexadecimal MCP timeout options before writing configuration", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1172,6 +1172,7 @@ export function registerMcpCli(program: Command) {
     .option("--clear-timeouts", "Clear request and connection timeout overrides", false)
     .option("--parallel", "Mark this server safe for concurrent tool calls")
     .option("--no-parallel", "Clear the concurrent tool-call marker")
+    .option("--approval <mode>", "Codex MCP tool approval mode: auto, prompt, or approve")
     .option("--auth <mode>", "HTTP auth mode: oauth")
     .option("--clear-auth", "Clear auth and OAuth metadata", false)
     .option("--oauth-scope <scope>", "OAuth scope")
@@ -1195,6 +1196,7 @@ export function registerMcpCli(program: Command) {
           connectTimeout?: string;
           clearTimeouts?: boolean;
           parallel?: boolean;
+          approval?: string;
           auth?: string;
           clearAuth?: boolean;
           oauthScope?: string;
@@ -1263,6 +1265,10 @@ export function registerMcpCli(program: Command) {
         } else if (opts.parallel === false) {
           delete next.supportsParallelToolCalls;
           delete next.supports_parallel_tool_calls;
+        }
+        const approvalMode = parseMcpApprovalModeOption(opts.approval);
+        if (approvalMode) {
+          next.codex = { ...next.codex, defaultToolsApprovalMode: approvalMode };
         }
         if (opts.clearAuth) {
           delete next.auth;

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -31,6 +31,7 @@ import {
 import { resolveMcpTransportConfig } from "../agents/mcp-transport-config.js";
 import { parseConfigValue } from "../auto-reply/reply/config-value.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
+import type { McpCodexToolApprovalMode } from "../config/types.mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
@@ -101,6 +102,19 @@ function parsePositiveNumberOption(value: string | undefined, label: string): nu
   return parsed;
 }
 
+function parseMcpApprovalModeOption(
+  value: string | undefined,
+): McpCodexToolApprovalMode | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const mode = normalizeLowercaseStringOrEmpty(value);
+  if (mode !== "auto" && mode !== "prompt" && mode !== "approve") {
+    fail('--approval must be "auto", "prompt", or "approve".');
+  }
+  return mode;
+}
+
 function parseOAuthConfig(opts: {
   scope?: string;
   redirectUrl?: string;
@@ -163,6 +177,8 @@ type McpDoctorServerResult = {
 };
 
 const MCP_DOCTOR_CONCURRENCY = 4;
+const MCP_CODEX_APPROVAL_ANNOTATION_HINT =
+  "tools have no safety annotations; calls will require interactive approval";
 
 const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",
@@ -364,23 +380,21 @@ async function collectMcpDoctorIssues(params: {
     server.enabled !== false &&
     !issues.some((entry) => entry.level === "error")
   ) {
-    const probeIssue = await probeMcpServerIssue({
+    const probeIssues = await probeMcpServerIssues({
       config: params.config,
       name,
       server,
     });
-    if (probeIssue) {
-      issues.push(probeIssue);
-    }
+    issues.push(...probeIssues);
   }
   return issues;
 }
 
-async function probeMcpServerIssue(params: {
+async function probeMcpServerIssues(params: {
   config: OpenClawConfig;
   name: string;
   server: Record<string, unknown>;
-}): Promise<McpDoctorIssue | null> {
+}): Promise<McpDoctorIssue[]> {
   const runtime = createSessionMcpRuntime({
     sessionId: "openclaw-cli-mcp-doctor",
     workspaceDir: process.cwd(),
@@ -394,14 +408,17 @@ async function probeMcpServerIssue(params: {
     const result = formatMcpProbeResult(await runtime.getCatalog());
     const diagnostic = result.diagnostics[0];
     if (diagnostic) {
-      return issue("error", `probe failed: ${diagnostic.message}`);
+      return [issue("error", `probe failed: ${diagnostic.message}`)];
     }
-    if (!result.servers[params.name]) {
-      return issue("error", "probe did not connect to this server");
+    const server = result.servers[params.name];
+    if (!server) {
+      return [issue("error", "probe did not connect to this server")];
     }
-    return null;
+    return server.approvalHint
+      ? [issue("info", `Codex approval mode: ${server.codexApprovalMode}; ${server.approvalHint}`)]
+      : [];
   } catch (err) {
-    return issue("error", `probe failed: ${formatErrorMessage(err)}`);
+    return [issue("error", `probe failed: ${formatErrorMessage(err)}`)];
   } finally {
     await runtime.dispose();
   }
@@ -496,31 +513,43 @@ function formatMcpProbeResult(
     servers: Object.fromEntries(
       Object.entries(catalog.servers)
         .toSorted(([a], [b]) => a.localeCompare(b))
-        .map(([name, server]) => [
-          name,
-          {
-            launch: server.launchSummary,
-            tools: server.toolCount,
-            ...(server.requestTimeoutMs ? { requestTimeoutMs: server.requestTimeoutMs } : {}),
-            ...(server.supportsParallelToolCalls
-              ? { supportsParallelToolCalls: server.supportsParallelToolCalls }
-              : {}),
-            ...(server.tools?.filteredCount ? { filteredTools: server.tools.filteredCount } : {}),
-            ...(server.resources ? { resources: true } : {}),
-            ...(server.prompts ? { prompts: true } : {}),
-            ...(server.tools?.listChanged ||
-            server.resources?.listChanged ||
-            server.prompts?.listChanged
-              ? {
-                  listChanged: {
-                    tools: server.tools?.listChanged === true,
-                    resources: server.resources?.listChanged === true,
-                    prompts: server.prompts?.listChanged === true,
-                  },
-                }
-              : {}),
-          },
-        ]),
+        .map(([name, server]) => {
+          const codexApprovalMode = server.codexApprovalMode ?? "auto";
+          const serverTools = catalog.tools.filter((tool) => tool.serverName === name);
+          const approvalHint =
+            codexApprovalMode === "auto" &&
+            serverTools.length > 0 &&
+            serverTools.every((tool) => Object.keys(tool.codexAnnotations ?? {}).length === 0)
+              ? MCP_CODEX_APPROVAL_ANNOTATION_HINT
+              : undefined;
+          return [
+            name,
+            {
+              launch: server.launchSummary,
+              tools: server.toolCount,
+              codexApprovalMode,
+              ...(approvalHint ? { approvalHint } : {}),
+              ...(server.requestTimeoutMs ? { requestTimeoutMs: server.requestTimeoutMs } : {}),
+              ...(server.supportsParallelToolCalls
+                ? { supportsParallelToolCalls: server.supportsParallelToolCalls }
+                : {}),
+              ...(server.tools?.filteredCount ? { filteredTools: server.tools.filteredCount } : {}),
+              ...(server.resources ? { resources: true } : {}),
+              ...(server.prompts ? { prompts: true } : {}),
+              ...(server.tools?.listChanged ||
+              server.resources?.listChanged ||
+              server.prompts?.listChanged
+                ? {
+                    listChanged: {
+                      tools: server.tools?.listChanged === true,
+                      resources: server.resources?.listChanged === true,
+                      prompts: server.prompts?.listChanged === true,
+                    },
+                  }
+                : {}),
+            },
+          ];
+        }),
     ),
     tools: projectedTools.map((tool) => tool.name).toSorted(),
     diagnostics: catalog.diagnostics ?? [],
@@ -815,8 +844,11 @@ export function registerMcpCli(program: Command) {
           defaultRuntime.log(`MCP probe (${loaded.path}):`);
           for (const [serverName, server] of Object.entries(result.servers)) {
             defaultRuntime.log(
-              `- ${serverName}: ${server.tools} tools${server.resources ? ", resources" : ""}${server.prompts ? ", prompts" : ""}`,
+              `- ${serverName}: ${server.tools} tools${server.resources ? ", resources" : ""}${server.prompts ? ", prompts" : ""}, Codex approval ${server.codexApprovalMode}`,
             );
+            if (server.approvalHint) {
+              defaultRuntime.log(`  i ${server.approvalHint}`);
+            }
           }
           for (const diagnostic of result.diagnostics) {
             defaultRuntime.log(`! ${diagnostic.serverName}: ${diagnostic.message}`);
@@ -931,6 +963,7 @@ export function registerMcpCli(program: Command) {
     .option("--timeout <seconds>", "Per-request timeout in seconds")
     .option("--connect-timeout <seconds>", "Connection timeout in seconds")
     .option("--parallel", "Mark this server safe for concurrent tool calls")
+    .option("--approval <mode>", "Codex MCP tool approval mode: auto, prompt, or approve")
     .option("--disabled", "Save the server disabled", false)
     .option("--ssl-verify <boolean>", "Verify HTTPS certificates: true or false")
     .option("--client-cert <path>", "HTTP mutual TLS client certificate path")
@@ -956,6 +989,7 @@ export function registerMcpCli(program: Command) {
           timeout?: string;
           connectTimeout?: string;
           parallel?: boolean;
+          approval?: string;
           disabled?: boolean;
           sslVerify?: string;
           clientCert?: string;
@@ -1021,6 +1055,10 @@ export function registerMcpCli(program: Command) {
         }
         if (opts.parallel) {
           server.supportsParallelToolCalls = true;
+        }
+        const approvalMode = parseMcpApprovalModeOption(opts.approval);
+        if (approvalMode) {
+          server.codex = { defaultToolsApprovalMode: approvalMode };
         }
         const requestTimeoutSeconds = parsePositiveNumberOption(opts.timeout, "--timeout");
         setOptionalField(

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1268,7 +1268,10 @@ export function registerMcpCli(program: Command) {
         }
         const approvalMode = parseMcpApprovalModeOption(opts.approval);
         if (approvalMode) {
-          next.codex = { ...next.codex, defaultToolsApprovalMode: approvalMode };
+          next.codex = {
+            ...(asRecord(next.codex) ?? {}),
+            defaultToolsApprovalMode: approvalMode,
+          };
         }
         if (opts.clearAuth) {
           delete next.auth;

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1269,7 +1269,7 @@ export function registerMcpCli(program: Command) {
         const approvalMode = parseMcpApprovalModeOption(opts.approval);
         if (approvalMode) {
           next.codex = {
-            ...(asRecord(next.codex) ?? {}),
+            ...asRecord(next.codex),
             defaultToolsApprovalMode: approvalMode,
           };
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex harness users adding a normal MCP server could hit an approval dead end on every tool call when that server omitted MCP safety annotations.

Verified live QA reproduced the default path: under the Codex harness, a server added with `mcp add` and no tool annotations makes every tool call approval-gated. A headless turn has no approver, so `plugin.approval.waitDecision` burns roughly 120 seconds and the model sees only `The call was rejected`. No hint points to the remedy, and `codex.defaultToolsApprovalMode` was reachable only by writing raw JSON through `mcp set`.

## Why This Change Was Made

The MCP CLI now exposes `--approval auto|prompt|approve` through both `mcp add` and the non-destructive `mcp configure` path. Live `mcp probe` / `mcp doctor --probe` results identify the effective Codex approval mode and warn when `auto` meets a server whose tools have no safety annotations. If a matching MCP approval request explicitly times out, the denial tells the model to use the Control UI or configure the trusted-server override.

The root cause is the combination of `resolveMcpCodexToolApprovalMode` defaulting to `auto` and `requiresMcpCodexToolApproval` treating missing annotations as approval-required in `src/agents/mcp-codex-tool-approval.ts`. The security default is **unchanged**: `auto` still defaults conservatively, and missing annotations still require approval. This change improves discoverability and dead-end messaging; it does not auto-approve a server.

The denial-text change is scoped to confirmed matching timeouts for `mcp__*` tools. Missing approval ids and stale or mismatched replies preserve the existing provider fallback. Exec/Bash and other native permission requests are unchanged. Updating a saved server merges only `codex.defaultToolsApprovalMode`, preserving `codex.agents` and all unrelated server metadata.

## User Impact

Operators can choose the existing Codex approval mode while adding or updating a trusted MCP server, see risky annotation-free defaults during probe/doctor, and get a concrete recovery path instead of waiting two minutes for an opaque rejection.

## Evidence

- Upstream Codex contract inspected directly: `codex-rs/core/src/mcp_tool_call.rs:1328` routes MCP approval through permission-request hooks, while `codex-rs/core/src/mcp_tool_call.rs:1857` converts elicitation decline to `Decline { message: None }`; decline metadata cannot carry this remediation to the model.
- MCP CLI: 25 focused tests passed, including non-destructive saved-server approval configuration with `codex.agents` preservation.
- Native hook: 122 focused tests passed, covering matching timeout, no-id fallback, mismatched-id fallback, and existing non-MCP fallback behavior.
- Built CLI: `mcp configure saved-server --approval approve` changed a saved mode from `auto` to `approve` while preserving `codex.agents`.
- `node scripts/check-changed.mjs` passed after the final conflict rebase.
- `pnpm build` passed after the final conflict rebase, including CLI bootstrap imports, unified bundles, runtime postbuild, Plugin SDK export validation, external plugin local dist, and Control UI build.
- `pnpm docs:list` passed.
- Source-blind built-CLI validation in isolated state proved add/configure persistence, saved metadata preservation, unchanged omission behavior, and invalid-mode errors.
- Final branch autoreview is clean with no accepted/actionable finding.
- Prepared MCP patch LOC (before review fixes), as requested: production +86/-39 (net +47), tests +82, docs +34/-12. The positive production delta is capability work: one public CLI flag, probe/doctor discovery and hinting, and actionable MCP-only denial text, scoped to `mcp__*` tools with exec/Bash behavior unchanged.
- Final PR LOC: runtime +98/-39 (net +59), tests +155, docs +41/-13. The additional runtime delta is the explicit timeout/fallback state boundary and non-destructive saved-server configuration.

During landing, exact-head CI exposed unrelated current-main cache and UI type failures. Their canonical fixes landed independently in #124800 and #124772, so both duplicates were dropped during rebase; this final diff is MCP-only.

AI-assisted: yes. The final diff, upstream contracts, tests, build, and user-visible CLI behavior were reviewed and verified after rebasing.
