### PR TITLE
feat(ui): surface approvals passively and redesign the approval card

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -2141,7 +2141,7 @@ describe("Codex app-server approval bridge", () => {
     });
 
     expect(gatewayRequestPayload().description).toBe(
-      "Command: pnpm test --watch extensions/codex/src/app-server\nSession: agent:main:session-1",
+      "Command: pnpm test --watch extensions/codex/src/app-server",
     );
     findApprovalEvent(params, {
       status: "pending",
@@ -2196,9 +2196,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(gatewayRequestPayload().description).toBe(
-      "Command: prefix VISIBLE suffix\nSession: agent:main:session-1",
-    );
+    expect(gatewayRequestPayload().description).toBe("Command: prefix VISIBLE suffix");
     findApprovalEvent(params, { command: "prefix VISIBLE suffix" });
   });
 
@@ -2219,9 +2217,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(gatewayRequestPayload().description).toBe(
-      "Command: echo safe cod.exe hidden done\nSession: agent:main:session-1",
-    );
+    expect(gatewayRequestPayload().description).toBe("Command: echo safe cod.exe hidden done");
     findApprovalEvent(params, { command: "echo safe cod.exe hidden done" });
   });
 
@@ -2245,7 +2241,7 @@ describe("Codex app-server approval bridge", () => {
     });
 
     expect(gatewayRequestPayload().description).toBe(
-      "Command: [preview truncated or unsafe content omitted]\nSession: agent:main:session-1",
+      "Command: [preview truncated or unsafe content omitted]",
     );
     const omittedEvent = findApprovalEvent(params, {});
     expect(omittedEvent.commandPreviewOmitted).toBe(true);
@@ -2536,9 +2532,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(gatewayRequestPayload().description).toBe(
-      "Reason: needs write access for /tmp please\nSession: agent:main:session-1",
-    );
+    expect(gatewayRequestPayload().description).toBe("Reason: needs write access for /tmp please");
     findApprovalEvent(params, {
       status: "unavailable",
       reason: "needs write access for /tmp please",

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -343,13 +343,7 @@ function buildApprovalContext(params: {
   const description =
     permissionLines.length > 0
       ? joinDescriptionLinesWithinLimit(permissionLines, PERMISSION_DESCRIPTION_MAX_LENGTH)
-      : [
-          subject,
-          ...commandDetailLines,
-          params.paramsForRun.sessionKey && `Session: ${params.paramsForRun.sessionKey}`,
-        ]
-          .filter(Boolean)
-          .join("\n");
+      : [subject, ...commandDetailLines].join("\n");
   return {
     kind,
     title,

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -137,7 +137,7 @@ class OpenClawShell
   readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
   @query("openclaw-command-palette") commandPalette: CommandPaletteElement | undefined;
   @query("openclaw-exec-approval")
-  approvalOverlay: (HTMLElement & { show(): void }) | undefined;
+  approvalOverlay: (HTMLElement & { show(): void; dialogOpen?: boolean }) | undefined;
   commandPaletteTarget: CommandPaletteTargetDetail | undefined;
   navDrawerTrigger: HTMLElement | null = null;
   // Desktop and modal navigation are two slots for the same live sidebar.

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -74,7 +74,7 @@ export interface ShellChromeHost extends HTMLElement {
   readonly desktopPanelElement: OptionalCustomElement;
   readonly execApprovalElement: OptionalCustomElement;
   readonly commandPalette: CommandPaletteElement | undefined;
-  readonly approvalOverlay: (HTMLElement & { show(): void }) | undefined;
+  readonly approvalOverlay: (HTMLElement & { show(): void; dialogOpen?: boolean }) | undefined;
   routeState: ShellRouteState;
   navDrawerOpen: boolean;
   desktopNavigationExpanded: boolean;
@@ -407,7 +407,7 @@ export class ShellChromeOwner {
     if (
       host.commandPalette?.isOpen ||
       overlaySnapshot?.devicePairSetupOpen ||
-      (overlaySnapshot?.approvalQueue.length ?? 0) > 0 ||
+      host.approvalOverlay?.dialogOpen === true ||
       document.querySelector("dialog[open]")
     ) {
       return true;

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -21,7 +21,6 @@ import type { ShellRouteState } from "./app-host-route-state.ts";
 import { resolveTerminalThemeMode } from "./app-root.ts";
 import { isBrowserPanelAvailable, isDesktopPanelAvailable } from "./app-shell-chrome.ts";
 import type { OutboxStoreRuntime, StoredOutboxScopeHost } from "./app-shell-gateway.ts";
-import { findInlineApproval } from "./approval-presentation.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
@@ -347,9 +346,6 @@ export function renderApplicationShell(host: ShellViewHost) {
   // its scrolling and pins the composer dock to the bottom.
   const chatLikeRoute = isSessionRouteId(activeRoute) || activeRoute === "new-session";
   const custodianRoute = activeRoute === "custodian";
-  const inlineApproval = isSessionRouteId(activeRoute)
-    ? findInlineApproval(overlaySnapshot.approvalQueue, host.activeSessionKey)
-    : null;
   if (!settingsTakeover) {
     Object.assign(host.navigationSidebar, {
       basePath: context.basePath,
@@ -649,7 +645,6 @@ export function renderApplicationShell(host: ShellViewHost) {
               busy: overlaySnapshot.approvalBusy,
               errors: overlaySnapshot.approvalErrors,
               nowMs: overlaySnapshot.approvalNowMs,
-              inlineApprovalId: inlineApproval?.id ?? null,
               onDecision: (
                 approvalId: string,
                 decision: Parameters<typeof context.overlays.decideApproval>[0],

--- a/ui/src/app/approval-presentation.test.ts
+++ b/ui/src/app/approval-presentation.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   deriveApprovalBadgeSnapshot,
   findInlineApproval,
-  modalApprovalQueue,
   sessionHasPendingApproval,
 } from "./approval-presentation.ts";
 import type { ExecApprovalRequest } from "./exec-approval.ts";
@@ -22,7 +21,7 @@ function approval(
 }
 
 describe("approval presentation", () => {
-  it("puts the oldest matching active-session request inline and suppresses only it", () => {
+  it("puts the oldest matching active-session request inline", () => {
     const queue = [
       approval("approval-1", { sessionKey: "agent:main:current" }),
       approval("approval-2", { sessionKey: "agent:main:other" }),
@@ -32,28 +31,22 @@ describe("approval presentation", () => {
     const inline = findInlineApproval(queue, "agent:main:current");
 
     expect(inline?.id).toBe("approval-1");
-    expect(modalApprovalQueue(queue, inline?.id).map((entry) => entry.id)).toEqual([
-      "approval-2",
-      "approval-3",
-    ]);
   });
 
-  it("keeps every request in the modal when the active session does not match", () => {
+  it("does not select an inline request when the active session does not match", () => {
     const queue = [approval("approval-1", { sessionKey: "agent:main:other" })];
 
     const inline = findInlineApproval(queue, "agent:main:current");
 
     expect(inline).toBeNull();
-    expect(modalApprovalQueue(queue, inline?.id)).toBe(queue);
   });
 
-  it("keeps catalog-session requests modal because catalog chat cannot render them inline", () => {
+  it("does not select catalog-session requests because catalog chat cannot render them inline", () => {
     const queue = [approval("approval-1", { sessionKey: "catalog:codex:host:thread" })];
 
     const inline = findInlineApproval(queue, "catalog:codex:host:thread");
 
     expect(inline).toBeNull();
-    expect(modalApprovalQueue(queue, inline?.id)).toBe(queue);
   });
 
   it("derives per-agent counts and per-session flags from one queue snapshot", () => {

--- a/ui/src/app/approval-presentation.ts
+++ b/ui/src/app/approval-presentation.ts
@@ -27,13 +27,6 @@ export function findInlineApproval(
   );
 }
 
-export function modalApprovalQueue(
-  queue: readonly ExecApprovalRequest[],
-  inlineApprovalId: string | null | undefined,
-): readonly ExecApprovalRequest[] {
-  return inlineApprovalId ? queue.filter((entry) => entry.id !== inlineApprovalId) : queue;
-}
-
 export function deriveApprovalBadgeSnapshot(
   queue: readonly ExecApprovalRequest[],
 ): ApprovalBadgeSnapshot {

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -1,0 +1,131 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecApprovalRequest } from "../app/exec-approval.ts";
+import { i18n } from "../i18n/index.ts";
+import { renderExecApprovalCard } from "./exec-approval-card.ts";
+
+let container: HTMLDivElement;
+
+function approval(overrides: Partial<ExecApprovalRequest> = {}): ExecApprovalRequest {
+  return {
+    id: "approval-1",
+    kind: "plugin",
+    request: {
+      command: "Codex approval",
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+    },
+    pluginTitle: "Codex approval",
+    pluginDescription: "Command: pnpm test",
+    pluginId: "codex",
+    createdAtMs: 1,
+    expiresAtMs: 61_000,
+    ...overrides,
+  };
+}
+
+function renderCard(request: ExecApprovalRequest, variant: "inline" | "modal" = "modal") {
+  render(
+    renderExecApprovalCard({
+      approval: request,
+      busy: false,
+      error: null,
+      nowMs: 1_000,
+      variant,
+      onDecision: vi.fn(),
+    }),
+    container,
+  );
+  return container.querySelector<HTMLElement>(".exec-approval-card");
+}
+
+describe("exec approval card", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["warn", "warning"],
+    ["warning", "warning"],
+    ["danger", "danger"],
+    ["critical", "danger"],
+    ["error", "danger"],
+    ["unknown", "info"],
+    [undefined, "info"],
+  ])("maps plugin severity %s to the %s accent", (pluginSeverity, expected) => {
+    const card = renderCard(approval({ pluginSeverity }));
+
+    expect(card?.classList.contains(`exec-approval-card--severity-${expected}`)).toBe(true);
+  });
+
+  it("always gives exec approvals the warning accent", () => {
+    const card = renderCard(
+      approval({
+        kind: "exec",
+        pluginSeverity: "critical",
+        request: { command: "pnpm test" },
+      }),
+    );
+
+    expect(card?.classList.contains("exec-approval-card--severity-warning")).toBe(true);
+  });
+
+  it("shows plugin and agent chips with session details in the modal", () => {
+    const card = renderCard(approval());
+    const details = card?.querySelector<HTMLDetailsElement>(".exec-approval-details");
+
+    expect(card?.querySelector('[data-approval-chip="plugin"]')?.textContent).toBe("codex");
+    expect(card?.querySelector('[data-approval-chip="agent"]')?.textContent).toBe("main");
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain("Session");
+    expect(details?.textContent).toContain("agent:main:session-1");
+    expect(card?.textContent).not.toContain("Severity");
+  });
+
+  it("keeps inline identity limited to the plugin chip", () => {
+    const card = renderCard(approval(), "inline");
+
+    expect(card?.querySelector('[data-approval-chip="plugin"]')?.textContent).toBe("codex");
+    expect(card?.querySelector('[data-approval-chip="agent"]')).toBeNull();
+    expect(card?.querySelector(".exec-approval-details")).toBeNull();
+    expect(card?.textContent).not.toContain("agent:main:session-1");
+  });
+
+  it("keeps host and cwd visible while collapsing lower-value exec metadata", () => {
+    const card = renderCard(
+      approval({
+        kind: "exec",
+        request: {
+          command: "pnpm test",
+          host: "gateway",
+          cwd: "/workspace",
+          resolvedPath: "/usr/bin/pnpm",
+          security: "allowlist",
+          ask: "on-request",
+          agentId: "main",
+          sessionKey: "agent:main:session-1",
+        },
+      }),
+      "inline",
+    );
+    const details = card?.querySelector<HTMLDetailsElement>(".exec-approval-details");
+
+    expect(card?.querySelector(".exec-approval-meta")?.textContent).toContain("gateway");
+    expect(card?.querySelector(".exec-approval-meta")?.textContent).toContain("/workspace");
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain("Resolved");
+    expect(details?.textContent).toContain("Security");
+    expect(details?.textContent).toContain("Ask");
+    expect(card?.querySelector('[data-approval-chip="agent"]')).toBeNull();
+    expect(card?.textContent).not.toContain("agent:main:session-1");
+  });
+});

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -1,4 +1,3 @@
-// Shared approval card keeps the inline surface independent from the lazy modal.
 import { html, nothing } from "lit";
 import { formatApprovalDisplayPath } from "../../../src/infra/approval-display-paths.ts";
 import type {
@@ -81,30 +80,47 @@ function renderCommandWithSpans(request: ExecApprovalRequestPayload) {
   return html`<div class="exec-approval-command mono">${parts}</div>`;
 }
 
-function renderExecBody(request: ExecApprovalRequestPayload) {
+function renderDetails(content: ReturnType<typeof html>) {
+  return html`<details class="exec-approval-details">
+    <summary>${t("execApproval.details")}</summary>
+    <div class="exec-approval-meta">${content}</div>
+  </details>`;
+}
+
+function renderChip(kind: "plugin" | "agent", id?: string | null) {
+  return id
+    ? html`<span class="exec-approval-chip mono" data-approval-chip=${kind}>${id}</span>`
+    : nothing;
+}
+
+function renderExecBody(
+  request: ExecApprovalRequestPayload,
+  variant: ExecApprovalCardProps["variant"],
+) {
   return html` ${renderCommandWithSpans(request)}
     <div class="exec-approval-meta">
       ${renderMetaRow(t("execApproval.labels.host"), request.host)}
-      ${renderMetaRow(t("execApproval.labels.agent"), request.agentId)}
-      ${renderMetaRow(t("execApproval.labels.session"), request.sessionKey)}
       ${renderMetaRow(t("execApproval.labels.cwd"), request.cwd, { path: true })}
+    </div>
+    ${renderDetails(html`
       ${renderMetaRow(t("execApproval.labels.resolved"), request.resolvedPath, { path: true })}
       ${renderMetaRow(t("execApproval.labels.security"), request.security)}
       ${renderMetaRow(t("execApproval.labels.ask"), request.ask)}
-    </div>`;
+      ${variant === "modal"
+        ? renderMetaRow(t("execApproval.labels.session"), request.sessionKey)
+        : nothing}
+    `)}`;
 }
 
-function renderPluginBody(active: ExecApprovalRequest) {
+function renderPluginBody(active: ExecApprovalRequest, variant: ExecApprovalCardProps["variant"]) {
   return html` ${active.pluginDescription
-      ? html`<pre class="exec-approval-command mono" style="white-space:pre-wrap">
-${active.pluginDescription}</pre>`
-      : nothing}
-    <div class="exec-approval-meta">
-      ${renderMetaRow(t("execApproval.labels.severity"), active.pluginSeverity)}
-      ${renderMetaRow(t("execApproval.labels.plugin"), active.pluginId)}
-      ${renderMetaRow(t("execApproval.labels.agent"), active.request.agentId)}
-      ${renderMetaRow(t("execApproval.labels.session"), active.request.sessionKey)}
-    </div>`;
+    ? html`<pre class="exec-approval-command mono">${active.pluginDescription}</pre>`
+    : nothing}
+  ${variant === "modal" && active.request.sessionKey
+    ? renderDetails(
+        html`${renderMetaRow(t("execApproval.labels.session"), active.request.sessionKey)}`,
+      )
+    : nothing}`;
 }
 
 function decisionLabel(decision: ExecApprovalDecision) {
@@ -149,15 +165,27 @@ export function approvalTitle(active: ExecApprovalRequest): string {
 export function renderExecApprovalCard(props: ExecApprovalCardProps) {
   const active = props.approval;
   const decisions = resolveApprovalDecisions(active);
-  const title = approvalTitle(active);
-  // A timer role preserves context without per-second aria-live announcements.
+  const rawSeverity = active.pluginSeverity?.trim().toLowerCase();
+  const severity =
+    active.kind === "exec" || rawSeverity === "warning" || rawSeverity === "warn"
+      ? "warning"
+      : rawSeverity === "danger" || rawSeverity === "critical" || rawSeverity === "error"
+        ? "danger"
+        : "info";
+  const pluginId = active.kind === "plugin" ? active.pluginId?.trim() : null;
+  const agentId = props.variant === "modal" ? active.request.agentId?.trim() : null;
   return html` <div
-    class="exec-approval-card exec-approval-card--${props.variant}"
+    class="exec-approval-card exec-approval-card--${props.variant} exec-approval-card--severity-${severity}"
     data-approval-id=${active.id}
   >
     <div class="exec-approval-header">
       <div>
-        <div class="exec-approval-title">${title}</div>
+        <div class="exec-approval-title">${approvalTitle(active)}</div>
+        ${pluginId || agentId
+          ? html`<div class="exec-approval-chips">
+              ${renderChip("plugin", pluginId)} ${renderChip("agent", agentId)}
+            </div>`
+          : nothing}
         <div class="exec-approval-sub exec-approval-countdown" role="timer">
           ${approvalRemainingLabel(active.expiresAtMs, props.nowMs)}
         </div>
@@ -168,7 +196,9 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
           </div>`
         : nothing}
     </div>
-    ${active.kind === "exec" ? renderExecBody(active.request) : renderPluginBody(active)}
+    ${active.kind === "exec"
+      ? renderExecBody(active.request, props.variant)
+      : renderPluginBody(active, props.variant)}
     ${active.kind === "exec" && !decisions.includes("allow-always")
       ? html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`
       : nothing}

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -314,6 +314,25 @@ describe("openclaw-exec-approval", () => {
     expect(container.querySelector("openclaw-modal-dialog")).not.toBeNull();
   });
 
+  // Settings Escape guards read this fact; a pending queue alone must not
+  // report an open dialog now that approvals surface passively.
+  it("records dialogOpen only while the dialog is explicitly open", async () => {
+    const { approval } = await renderApproval(createExecRequest());
+    const element = approval as LitElement & { show(): void; dialogOpen: boolean };
+    expect(element.dialogOpen).toBe(false);
+
+    element.show();
+    await approval.updateComplete;
+    expect(element.dialogOpen).toBe(true);
+
+    const { modal } = await getRenderedModalDialog(container);
+    modal.dispatchEvent(
+      new CustomEvent("modal-cancel", { bubbles: true, composed: true, cancelable: true }),
+    );
+    await approval.updateComplete;
+    expect(element.dialogOpen).toBe(false);
+  });
+
   it("opens the full queue only on demand", async () => {
     const queue = [
       createExecRequest({ id: "approval-inline" }),

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -30,7 +30,6 @@ async function renderApproval(
     busy: boolean;
     errors: ReadonlyMap<string, string>;
     nowMs: number;
-    inlineApprovalId: string | null;
     onDecision: ReturnType<typeof vi.fn>;
   }> = {},
 ) {
@@ -43,7 +42,6 @@ async function renderApproval(
         busy: overrides.busy ?? false,
         errors: overrides.errors ?? new Map(),
         nowMs: overrides.nowMs ?? Date.now(),
-        inlineApprovalId: overrides.inlineApprovalId ?? null,
         onDecision,
       }}
     ></openclaw-exec-approval>`,
@@ -55,6 +53,16 @@ async function renderApproval(
   }
   await approval.updateComplete;
   return { approval, onDecision };
+}
+
+async function renderOpenedApproval(
+  requestOrQueue: ExecApprovalRequest | ExecApprovalRequest[],
+  overrides: Parameters<typeof renderApproval>[1] = {},
+) {
+  const rendered = await renderApproval(requestOrQueue, overrides);
+  (rendered.approval as LitElement & { show(): void }).show();
+  await rendered.approval.updateComplete;
+  return rendered;
 }
 
 function chord(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
@@ -77,8 +85,14 @@ describe("openclaw-exec-approval", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not render a modal when an approval arrives", async () => {
+    await renderApproval(createExecRequest());
+
+    expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
+  });
+
   it("uses neutral unavailable copy for exec allow-always decisions", async () => {
-    await renderApproval(
+    await renderOpenedApproval(
       createExecRequest({
         request: {
           command: "echo hello",
@@ -101,7 +115,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("does not show exec unavailable copy for restricted plugin approvals", async () => {
-    await renderApproval(
+    await renderOpenedApproval(
       createExecRequest({
         id: "plugin-approval-1",
         kind: "plugin",
@@ -124,7 +138,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("renders the live expiry countdown as mm:ss", async () => {
-    await renderApproval(createExecRequest({ expiresAtMs: 90_500 }), { nowMs: 0 });
+    await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }), { nowMs: 0 });
     await getRenderedModalDialog(container);
 
     expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
@@ -141,7 +155,7 @@ describe("openclaw-exec-approval", () => {
         request: { command: "pnpm test", agentId: "worker" },
       }),
     ];
-    const { approval } = await renderApproval(queue);
+    const { approval } = await renderOpenedApproval(queue);
     await getRenderedModalDialog(container);
 
     expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
@@ -167,7 +181,7 @@ describe("openclaw-exec-approval", () => {
         request: { command: `${"a".repeat(60)}🙂 --with-extra-arguments` },
       }),
     ];
-    await renderApproval(queue);
+    await renderOpenedApproval(queue);
     await getRenderedModalDialog(container);
 
     expect(container.querySelector(".exec-approval-list__command")?.textContent).toBe(
@@ -176,7 +190,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("handles modal approval keyboard shortcuts", async () => {
-    const { onDecision } = await renderApproval(createExecRequest());
+    const { onDecision } = await renderOpenedApproval(createExecRequest());
     const { modal } = await getRenderedModalDialog(container);
 
     modal.dispatchEvent(chord("Enter"));
@@ -191,7 +205,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("ignores bare keys so stray typing cannot authorize a command", async () => {
-    const { onDecision } = await renderApproval(createExecRequest());
+    const { onDecision } = await renderOpenedApproval(createExecRequest());
     const { modal } = await getRenderedModalDialog(container);
 
     modal.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
@@ -203,7 +217,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("ignores auto-repeated shortcut keydown events", async () => {
-    const { onDecision } = await renderApproval(createExecRequest());
+    const { onDecision } = await renderOpenedApproval(createExecRequest());
     const { modal } = await getRenderedModalDialog(container);
 
     modal.dispatchEvent(chord("Enter", { repeat: true }));
@@ -215,7 +229,7 @@ describe("openclaw-exec-approval", () => {
   it("keeps the displayed approval pinned when an older request arrives", async () => {
     const newer = createExecRequest({ id: "approval-newer", createdAtMs: 2_000 });
     const older = createExecRequest({ id: "approval-older", createdAtMs: 1_000 });
-    const { approval } = await renderApproval([newer]);
+    const { approval } = await renderOpenedApproval([newer]);
     await getRenderedModalDialog(container);
     expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
       "approval-newer",
@@ -237,40 +251,12 @@ describe("openclaw-exec-approval", () => {
     );
   });
 
-  it("repins the modal card when its selection becomes inline", async () => {
-    const selected = createExecRequest({ id: "approval-selected", createdAtMs: 2_000 });
-    const displayedHead = createExecRequest({ id: "approval-head", createdAtMs: 1_000 });
-    const olderArrival = createExecRequest({ id: "approval-older", createdAtMs: 500 });
-    const { approval } = await renderApproval([displayedHead, selected]);
-    await getRenderedModalDialog(container);
-
-    container.querySelector<HTMLButtonElement>(".exec-approval-list__item")?.click();
-    await approval.updateComplete;
-    expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
-      "approval-selected",
-    );
-
-    await renderApproval([displayedHead, selected], { inlineApprovalId: selected.id });
-    await approval.updateComplete;
-    expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
-      "approval-head",
-    );
-
-    await renderApproval([olderArrival, displayedHead, selected], {
-      inlineApprovalId: selected.id,
-    });
-    await approval.updateComplete;
-    expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
-      "approval-head",
-    );
-  });
-
   it("guards shortcuts while busy, disallowed, or focused in text input", async () => {
     const restricted = createExecRequest({
       request: { command: "echo hello", allowedDecisions: ["allow-once", "deny"] },
     });
     const onDecision = vi.fn();
-    await renderApproval(restricted, { busy: true, onDecision });
+    await renderOpenedApproval(restricted, { busy: true, onDecision });
     let rendered = await getRenderedModalDialog(container);
     rendered.modal.dispatchEvent(chord("Enter"));
 
@@ -290,18 +276,10 @@ describe("openclaw-exec-approval", () => {
     expect(onDecision).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { reason: "a decision is in flight", busy: true, allowedDecisions: undefined },
-    { reason: "denial is unavailable", busy: false, allowedDecisions: ["allow-once"] as const },
-  ])("keeps the pending approval visible when $reason", async ({ busy, allowedDecisions }) => {
-    const { onDecision } = await renderApproval(
-      createExecRequest({
-        request: {
-          command: "echo hello",
-          ...(allowedDecisions ? { allowedDecisions: [...allowedDecisions] } : {}),
-        },
-      }),
-      { busy },
+  it("blocks dismissal while a decision is in flight", async () => {
+    const { onDecision } = await renderOpenedApproval(
+      createExecRequest({ request: { command: "echo hello" } }),
+      { busy: true },
     );
     const { modal } = await getRenderedModalDialog(container);
     const cancel = new CustomEvent("modal-cancel", {
@@ -315,42 +293,56 @@ describe("openclaw-exec-approval", () => {
     expect(onDecision).not.toHaveBeenCalled();
   });
 
-  it("suppresses the automatic modal for the inline request but opens it on demand", async () => {
-    const { approval } = await renderApproval(createExecRequest(), {
-      inlineApprovalId: "approval-1",
+  it("dismissal closes the view without deciding and the chip can reopen it", async () => {
+    const { approval, onDecision } = await renderOpenedApproval(
+      createExecRequest({ request: { command: "echo hello" } }),
+    );
+    const { modal } = await getRenderedModalDialog(container);
+    const cancel = new CustomEvent("modal-cancel", {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
     });
+
+    expect(modal.dispatchEvent(cancel)).toBe(true);
+    await approval.updateComplete;
+    expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
+    expect(onDecision).not.toHaveBeenCalled();
+
+    (approval as LitElement & { show(): void }).show();
+    await approval.updateComplete;
+    expect(container.querySelector("openclaw-modal-dialog")).not.toBeNull();
+  });
+
+  it("opens the full queue only on demand", async () => {
+    const queue = [
+      createExecRequest({ id: "approval-inline" }),
+      createExecRequest({ id: "approval-other", request: { command: "pnpm test" } }),
+    ];
+    const { approval } = await renderApproval(queue);
     expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
 
     (approval as LitElement & { show(): void }).show();
     await approval.updateComplete;
 
     expect(container.querySelector("openclaw-modal-dialog")).not.toBeNull();
-  });
-
-  it("keeps unrelated requests modal while one active-session request is inline", async () => {
-    await renderApproval(
-      [
-        createExecRequest({ id: "approval-inline" }),
-        createExecRequest({ id: "approval-other", request: { command: "pnpm test" } }),
-      ],
-      { inlineApprovalId: "approval-inline" },
-    );
-
-    await getRenderedModalDialog(container);
     expect(container.querySelector(".exec-approval-card")?.getAttribute("data-approval-id")).toBe(
-      "approval-other",
+      "approval-inline",
     );
+    expect(container.querySelectorAll(".exec-approval-list__item")).toHaveLength(1);
+    expect(container.querySelector(".exec-approval-queue")?.textContent?.trim()).toBe("2 pending");
   });
 
-  it("resets manual show-all after the approval queue drains", async () => {
-    let rendered = await renderApproval(createExecRequest(), { inlineApprovalId: "approval-1" });
-    (rendered.approval as LitElement & { show(): void }).show();
-    await rendered.approval.updateComplete;
+  it("closes and resets after the approval queue drains", async () => {
+    await renderOpenedApproval(createExecRequest());
     expect(container.querySelector("openclaw-modal-dialog")).not.toBeNull();
 
-    rendered = await renderApproval([], { inlineApprovalId: null });
+    let rendered = await renderApproval([]);
     await rendered.approval.updateComplete;
-    await renderApproval(createExecRequest(), { inlineApprovalId: "approval-1" });
+    expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
+
+    rendered = await renderApproval(createExecRequest());
+    await rendered.approval.updateComplete;
 
     expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
   });

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -102,6 +102,13 @@ class ExecApproval extends OpenClawLightDomContentsElement {
     void this.updateComplete.then(() => this.dialog?.show());
   }
 
+  /** Recorded fact for shell guards (settings Escape): the dialog renders in
+   * shadow DOM, so `document.querySelector("dialog[open]")` cannot see it, and
+   * a pending queue no longer implies a visible dialog. */
+  get dialogOpen(): boolean {
+    return this.explicitlyOpen && (this.props?.queue.length ?? 0) > 0;
+  }
+
   private handleKeydown(event: KeyboardEvent, active: ExecApprovalRequest): void {
     // A held chord auto-repeats: once a decision settles and the queue
     // advances, the repeat would apply the same decision to the next request.

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -1,8 +1,7 @@
-// Control UI modal queues approvals that are not currently inline in chat.
+// Control UI modal presents approvals after an explicit operator action.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, query, state } from "lit/decorators.js";
-import { modalApprovalQueue } from "../app/approval-presentation.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../app/exec-approval.ts";
 import { t } from "../i18n/index.ts";
 import { formatCountdown } from "../lib/format.ts";
@@ -22,7 +21,6 @@ type ExecApprovalProps = {
   busy: boolean;
   errors: ReadonlyMap<string, string>;
   nowMs: number;
-  inlineApprovalId?: string | null;
   onDecision: (approvalId: string, decision: ExecApprovalDecision) => void | Promise<void>;
 };
 
@@ -94,25 +92,14 @@ class ExecApproval extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: ExecApprovalProps;
   @query("openclaw-modal-dialog") private dialog?: OpenClawModalDialog;
   @state() private selectedApprovalId: string | null = null;
-  @state() private forceShowAll = false;
+  @state() private explicitlyOpen = false;
 
   show(): void {
-    this.forceShowAll = true;
-    void this.updateComplete.then(() => this.dialog?.show());
-  }
-
-  private displayedQueue(): readonly ExecApprovalRequest[] {
-    const props = this.props;
-    if (!props) {
-      return [];
+    if (!this.props?.queue.length) {
+      return;
     }
-    return this.forceShowAll
-      ? props.queue
-      : modalApprovalQueue(props.queue, props.inlineApprovalId);
-  }
-
-  private activeApproval(queue: readonly ExecApprovalRequest[]): ExecApprovalRequest | null {
-    return queue.find((entry) => entry.id === this.selectedApprovalId) ?? queue.at(0) ?? null;
+    this.explicitlyOpen = true;
+    void this.updateComplete.then(() => this.dialog?.show());
   }
 
   private handleKeydown(event: KeyboardEvent, active: ExecApprovalRequest): void {
@@ -132,34 +119,36 @@ class ExecApproval extends OpenClawLightDomContentsElement {
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     const previousProps = changedProperties.get("props") as ExecApprovalProps | undefined;
     if (previousProps?.queue.length && !this.props?.queue.length) {
-      this.forceShowAll = false;
+      this.explicitlyOpen = false;
       this.selectedApprovalId = null;
       return;
     }
     // Pin the presented request: late-arriving older approvals re-sort the
     // queue, and swapping the card mid-read (or mid-decision) could attach the
     // user's answer or a failure message to a request they never saw.
-    const displayedQueue = this.displayedQueue();
-    if (!displayedQueue.some((entry) => entry.id === this.selectedApprovalId)) {
-      this.selectedApprovalId = displayedQueue.at(0)?.id ?? null;
+    const queue = this.props?.queue ?? [];
+    if (!queue.some((entry) => entry.id === this.selectedApprovalId)) {
+      this.selectedApprovalId = queue.at(0)?.id ?? null;
     }
   }
 
   override render() {
     const props = this.props;
-    const queue = this.displayedQueue();
-    const active = this.activeApproval(queue);
-    if (!props || !active) {
+    const queue = props?.queue ?? [];
+    const active = queue.find((entry) => entry.id === this.selectedApprovalId) ?? queue.at(0);
+    if (!props || !this.explicitlyOpen || !active) {
       return nothing;
     }
-    const decisions = resolveApprovalDecisions(active);
     const handleCancel = (event: Event) => {
-      if (props.busy || !decisions.includes("deny")) {
-        // Dismissal must never hide an approval that cannot yet be resolved.
+      if (props.busy) {
+        // A decision is in flight; closing now would hide its error surface.
         event.preventDefault();
         return;
       }
-      void props.onDecision(active.id, "deny");
+      // Explicitly opened means dismissal is just closing the view: the queue
+      // stays pending and visible via the attention chip and session badges.
+      // Denying here would turn Esc into a silent destructive decision.
+      this.explicitlyOpen = false;
     };
     return html`
       <openclaw-modal-dialog

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -162,6 +162,11 @@ export const icons = {
     <path d="M16 3.13a4 4 0 0 1 0 7.75" />`),
   shieldCheck: strokeIcon(svg` <path d="M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V5l8-3 8 3z" />
     <path d="m9 12 2 2 4-4" />`),
+  shieldQuestion: strokeIcon(svg` <path
+      d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+    />
+    <path d="M9.1 9a3 3 0 0 1 5.82 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />`),
 
   // UI icons
   menu: strokeIcon(svg` <line x1="4" x2="20" y1="12" y2="12" />

--- a/ui/src/components/session-attention-presentation.ts
+++ b/ui/src/components/session-attention-presentation.ts
@@ -12,7 +12,7 @@ export function renderSessionAttentionIcon(attention: SidebarSessionAttention) {
     attention.kind === "question"
       ? icons.hand
       : attention.kind === "approval"
-        ? icons.key
+        ? icons.shieldQuestion
         : attention.kind === "agent"
           ? resolveSessionAttentionIcon(attention.icon)
           : icons.alertTriangle;

--- a/ui/src/components/sidebar-attention-items.ts
+++ b/ui/src/components/sidebar-attention-items.ts
@@ -57,7 +57,7 @@ export function buildSidebarAttentionItems(params: {
     items.push({
       kind: "pendingApproval",
       severity: "warning",
-      icon: "shieldCheck",
+      icon: "shieldQuestion",
       label: t(count === 1 ? "attention.pendingApproval" : "attention.pendingApprovals", {
         count: String(count),
       }),

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -179,7 +179,7 @@ describe("pending approval attention", () => {
       {
         kind: "pendingApproval",
         severity: "warning",
-        icon: "shieldCheck",
+        icon: "shieldQuestion",
         action: { kind: "openApprovals" },
       },
     ]);

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -1,8 +1,14 @@
 // Control UI E2E tests cover approval queue behavior through the Gateway WebSocket.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import type { Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  waitForConfirmModal,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -11,16 +17,24 @@ const suite = createControlUiE2eSuite({
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
 let page: Page | undefined;
-function approval(id: string, command: string, createdAtMs: number) {
+const activeSessionKey = "agent:main:main";
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "approval-flow");
+
+function approval(id: string, command: string, createdAtMs: number, sessionKey = activeSessionKey) {
   return {
     id,
     createdAtMs,
     expiresAtMs: Date.now() + 60_000,
-    request: { command },
+    request: { command, agentId: "main", sessionKey },
   };
 }
 
 const requireRecord = createRequireRecord("record", "expected-object-value");
+
+function approvalAttentionChip(currentPage: Page) {
+  return currentPage.locator("openclaw-sidebar-attention .sidebar-attention__open");
+}
 
 suite.define(() => {
   afterEach(async () => {
@@ -35,9 +49,9 @@ suite.define(() => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
-    const gateway = await installMockGateway(currentPage);
+    const gateway = await installMockGateway(currentPage, { sessionKey: activeSessionKey });
 
-    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(controlUiSessionUrl(suite.server?.baseUrl ?? "", activeSessionKey));
     await gateway.waitForRequest("sessions.list");
     await gateway.deferNext("exec.approval.resolve");
     await gateway.emitGatewayEvent(
@@ -51,7 +65,7 @@ suite.define(() => {
       "exec.approval.requested",
       approval("approval-newer", "echo newer", 2_000),
     );
-    await currentPage.getByText("echo newer", { exact: true }).waitFor();
+    await approvalAttentionChip(currentPage).waitFor();
     await gateway.rejectDeferred("exec.approval.resolve", {
       code: "UNAVAILABLE",
       message: "gateway unavailable",
@@ -65,14 +79,67 @@ suite.define(() => {
       )
       .toBe("Approval failed: gateway unavailable");
 
-    await currentPage.getByText("echo newer", { exact: true }).click();
+    await approvalAttentionChip(currentPage).click();
+    const approvalModal = await waitForConfirmModal(currentPage);
+    await approvalModal.getByText("echo newer", { exact: true }).click();
     await expect
-      .poll(() => currentPage.locator(".exec-approval-card").getAttribute("data-approval-id"))
+      .poll(() => approvalModal.locator(".exec-approval-card").getAttribute("data-approval-id"))
       .toBe("approval-newer");
-    await expect.poll(() => currentPage.locator(".exec-approval-error").count()).toBe(0);
+    await expect.poll(() => approvalModal.locator(".exec-approval-error").count()).toBe(0);
     await expect
-      .poll(() => currentPage.getByRole("button", { name: "Deny" }).isEnabled())
+      .poll(() => approvalModal.getByRole("button", { name: "Deny" }).isEnabled())
       .toBe(true);
+  });
+
+  it("keeps approvals passive until the sidebar attention chip opens the full queue", async () => {
+    if (captureUiProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      viewport: { height: 800, width: 1200 },
+      ...(captureUiProof
+        ? { recordVideo: { dir: proofDir, size: { height: 800, width: 1200 } } }
+        : {}),
+    });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, { sessionKey: activeSessionKey });
+
+    await currentPage.goto(controlUiSessionUrl(suite.server?.baseUrl ?? "", activeSessionKey));
+    await gateway.waitForRequest("sessions.list");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-inline", "echo inline", 1_000),
+    );
+
+    await currentPage
+      .locator('.chat-inline-approval [data-approval-id="approval-inline"]')
+      .waitFor();
+    expect(await currentPage.locator("openclaw-modal-dialog").count()).toBe(0);
+
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-other", "echo other", 2_000, "agent:main:other"),
+    );
+
+    await approvalAttentionChip(currentPage).waitFor();
+    expect(await currentPage.locator("openclaw-modal-dialog").count()).toBe(0);
+    expect(await currentPage.getByText("echo other", { exact: true }).count()).toBe(0);
+    if (captureUiProof) {
+      await currentPage.screenshot({ path: path.join(proofDir, "01-passive-attention.png") });
+    }
+
+    await approvalAttentionChip(currentPage).click();
+    const approvalModal = await waitForConfirmModal(currentPage);
+
+    await approvalModal.locator('[data-approval-id="approval-inline"]').waitFor();
+    await approvalModal.getByText("echo other", { exact: true }).waitFor();
+    await expect
+      .poll(() => approvalModal.locator(".exec-approval-queue").textContent())
+      .toContain("2 pending");
+    if (captureUiProof) {
+      await currentPage.screenshot({ path: path.join(proofDir, "02-open-queue.png") });
+    }
   });
 
   it("sends a typed approval command immediately while the active run waits", async () => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1761,6 +1761,7 @@ export const en: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Allow Always is unavailable for this command.",
     deny: "Deny",
+    details: "Details",
     labels: {
       host: "Host",
       agent: "Agent",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3238,12 +3238,14 @@ td.data-table-key-col {
    =========================================== */
 
 .exec-approval-card {
+  --exec-approval-accent: var(--border);
+
   width: 100%;
   max-height: inherit;
   display: flex;
   flex-direction: column;
-  background: var(--card);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--exec-approval-accent) 5%, var(--card));
+  border: 1px solid color-mix(in srgb, var(--exec-approval-accent) 45%, var(--border));
   border-radius: var(--radius-lg);
   padding: 20px;
   animation: scale-in 0.2s var(--ease-out);
@@ -3259,9 +3261,19 @@ td.data-table-key-col {
 
 .exec-approval-card--inline {
   padding: 14px 16px;
-  border-color: color-mix(in srgb, var(--warn) 45%, var(--border));
-  background: color-mix(in srgb, var(--warn) 5%, var(--card));
   animation: none;
+}
+
+.exec-approval-card--severity-info {
+  --exec-approval-accent: var(--border);
+}
+
+.exec-approval-card--severity-warning {
+  --exec-approval-accent: var(--warn);
+}
+
+.exec-approval-card--severity-danger {
+  --exec-approval-accent: var(--danger);
 }
 
 .exec-approval-header {
@@ -3282,13 +3294,25 @@ td.data-table-key-col {
   margin-top: 4px;
 }
 
-.exec-approval-queue {
+.exec-approval-queue,
+.exec-approval-chip {
   font-size: 12px; /* was 11px */
   font-weight: 500;
   color: var(--muted);
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 4px 10px;
+}
+
+.exec-approval-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 6px;
+}
+
+.exec-approval-chip {
+  padding: 2px 8px;
 }
 
 .exec-approval-command {
@@ -3332,6 +3356,21 @@ td.data-table-key-col {
   font-family: var(--mono);
   overflow-wrap: anywhere;
   text-align: right;
+}
+
+.exec-approval-details {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.exec-approval-details summary {
+  width: fit-content;
+  cursor: var(--cursor-action);
+}
+
+.exec-approval-details .exec-approval-meta {
+  margin-top: 8px;
 }
 
 .exec-approval-error {


### PR DESCRIPTION
## What Problem This Solves

Exec/plugin approvals had two UX problems:

1. **The modal ambushed the operator.** Any approval whose session was not the active chat auto-opened the centered, focus-stealing modal (`openclaw-modal-dialog` defaults `open`), while an approval for the viewed session rendered inline at the bottom of the chat. The same alert appeared in two different places depending on the route, and visibly "hopped" from the centered overlay to the bottom dock when navigating into the owning session. In split-pane layouts the shell (`host.activeSessionKey`) and the pane (`state.sessionKey`) could disagree, double-rendering one approval in both surfaces.
2. **The card buried the decision under a metadata table.** Severity rendered as a literal `Severity: warning` row while the card's amber tint was hardcoded and disconnected from the data; agent/session rows repeated identity the operator was already looking at; and the codex app-server bridge baked `Session: agent:…` into its description text, so the session key appeared twice on one card.

## Why This Change Was Made

Approvals should surface passively and be acted on deliberately. The session-row attention icon, agent badge counts, and the sidebar "N pending approvals" chip already record where approvals are pending; the auto-modal upstaged all of them and stole focus mid-typing. The attention icon also reused `icons.key`, which is the Secrets icon in config navigation, so it read as "credentials" rather than "needs your approval".

## User Impact

- Approvals never auto-open the modal. The owning session shows the inline card as before; every other approval surfaces via the session-row shield-question icon, agent badges, and the attention chip. Clicking the chip opens the modal with the **full** queue.
- Dismissing the explicitly opened modal (Esc/backdrop) now just closes it — previously dismissal **denied** the active request, which becomes a silent-destructive trap once the modal is opened voluntarily. Everything stays pending and reachable through the chip. Dismissal is still blocked while a decision is in flight.
- Card redesign: severity drives the accent color (neutral/amber/red via tokens); plugin and agent are header chips (agent only in the modal — the inline card lives inside its own session); the session key and low-value exec rows (Resolved/Security/Ask) sit behind a collapsed "Details" disclosure; Host and CWD stay visible.
- The codex bridge no longer duplicates the session key into description text; the approval envelope already carries `sessionKey`.
- Deletes the inline-vs-modal exclusion machinery (`modalApprovalQueue`, `inlineApprovalId`, `forceShowAll`), removing the split-pane double-render seam.

**Before** (auto-popped modal, metadata table):

![before](https://github.com/user-attachments/assets/61e8a563-9ede-49ba-8e98-28e1d1061833)

**After** (passive: inline card + chip, no modal):

![after-passive](https://github.com/user-attachments/assets/e94f740c-e2eb-4118-9dcb-0b341d374818)

**After** (chip-opened queue modal, chips + collapsed Details):

![after-modal](https://github.com/user-attachments/assets/d01a5620-7c2e-4022-81f4-71e9396ec008)

## Evidence

- New e2e regression (`ui/src/e2e/approval-flow.e2e.test.ts`): approval for the active session renders inline with **no** modal element; approval for another session surfaces only via the attention chip; chip click opens the modal with the full queue ("2 pending"). The no-auto-modal assertion fails on pre-change code.
- Component tests: explicit-open lifecycle (no render on queue arrival, `show()` opens full queue, drain resets), dismissal-closes-without-deciding + busy-blocks-dismissal, severity accent classes, chips, Details disclosure, no session text in the inline variant (`exec-approval.test.ts`, new `exec-approval-card.test.ts`).
- Bridge tests updated: description no longer contains `Session:` lines (`extensions/codex/src/app-server/approval-bridge.test.ts`, 87 passed).
- Focused runs green: 34 component tests, 87 bridge tests, 3 e2e. `tsgo:ui`, `tsgo:extensions`, `lint:ui:styles`, `ui:i18n:verify` (baseline unchanged), oxlint on touched files, `oxfmt --check` all pass locally. Remote `check:changed` was infra-unavailable during development (Azure core quota / Daytona memory tier / Blacksmith doctor) — local fallback per repo validation rules; exact-head CI on this PR is the authoritative gate.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted findings.
- Follow-up (next PR): align the standalone approval deep-link page (`ui/src/pages/approval/`) with the new card design and drop the then-unused `execApproval.labels.severity/plugin/agent` keys.
