### PR TITLE
fix(memory): fail corrupted index commands

### DIFF
--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -312,14 +312,17 @@ export async function runMemoryPromote(
       }
       let candidates: Awaited<ReturnType<typeof rankShortTermPromotionCandidates>>;
       try {
+        const gatherAllForApply = Boolean(opts.apply);
         candidates = await rankShortTermPromotionCandidates({
           workspaceDir,
-          limit: opts.limit,
-          minScore: opts.minScore ?? dreaming.minScore,
-          minRecallCount: opts.minRecallCount ?? dreaming.minRecallCount,
-          minUniqueQueries: opts.minUniqueQueries ?? dreaming.minUniqueQueries,
+          limit: gatherAllForApply ? undefined : opts.limit,
+          minScore: gatherAllForApply ? 0 : (opts.minScore ?? dreaming.minScore),
+          minRecallCount: gatherAllForApply ? 0 : (opts.minRecallCount ?? dreaming.minRecallCount),
+          minUniqueQueries: gatherAllForApply
+            ? 0
+            : (opts.minUniqueQueries ?? dreaming.minUniqueQueries),
           recencyHalfLifeDays: dreaming.recencyHalfLifeDays,
-          maxAgeDays: dreaming.maxAgeDays,
+          maxAgeDays: gatherAllForApply ? undefined : dreaming.maxAgeDays,
           includePromoted: Boolean(opts.includePromoted),
         });
       } catch (err) {
@@ -364,6 +367,7 @@ export async function runMemoryPromote(
                 reconciledExisting: applyResult.reconciledExisting,
                 memoryPath: applyResult.memoryPath,
                 appliedCandidates: applyResult.appliedCandidates,
+                rejectedCandidates: applyResult.rejectedCandidates,
               }
             : undefined,
         });
@@ -408,6 +412,11 @@ export async function runMemoryPromote(
         lines.push("");
       }
       if (applyResult) {
+        for (const rejection of applyResult.rejectedCandidates) {
+          const candidate = rejection.candidate;
+          const source = `${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}`;
+          lines.push(warn(`Skipped ${source}: ${rejection.reason}.`));
+        }
         if (applyResult.applied > 0) {
           lines.push(
             success(
@@ -419,7 +428,7 @@ export async function runMemoryPromote(
               `appended=${applyResult.appended} reconciledExisting=${applyResult.reconciledExisting}`,
             ),
           );
-        } else {
+        } else if (applyResult.rejectedCandidates.length === 0) {
           lines.push(warn("No candidates met apply criteria."));
         }
       }

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -350,6 +350,22 @@ export async function runMemoryPromote(
           return;
         }
       }
+      const outputLimit =
+        typeof opts.limit === "number" && Number.isFinite(opts.limit)
+          ? Math.max(0, Math.floor(opts.limit))
+          : candidates.length;
+      const rejectedCandidates = applyResult
+        ? applyResult.rejectedCandidates.slice(
+            0,
+            Math.max(0, outputLimit - applyResult.appliedCandidates.length),
+          )
+        : [];
+      const outputCandidates = applyResult
+        ? [
+            ...applyResult.appliedCandidates,
+            ...rejectedCandidates.map((rejection) => rejection.candidate),
+          ]
+        : candidates;
       const storePath = resolveShortTermRecallStorePath(workspaceDir);
       const lockPath = resolveShortTermRecallLockPath(workspaceDir);
       const audit = await auditShortTermPromotionArtifacts({ workspaceDir });
@@ -359,7 +375,7 @@ export async function runMemoryPromote(
           storePath,
           lockPath,
           audit,
-          candidates,
+          candidates: outputCandidates,
           apply: applyResult
             ? {
                 applied: applyResult.applied,
@@ -367,7 +383,7 @@ export async function runMemoryPromote(
                 reconciledExisting: applyResult.reconciledExisting,
                 memoryPath: applyResult.memoryPath,
                 appliedCandidates: applyResult.appliedCandidates,
-                rejectedCandidates: applyResult.rejectedCandidates,
+                rejectedCandidates,
               }
             : undefined,
         });
@@ -387,7 +403,7 @@ export async function runMemoryPromote(
       lines.push(`${heading("Short-Term Promotion Candidates")} ${muted(`(${agentId})`)}`);
       lines.push(`${muted("Recall store:")} ${shortenHomePath(storePath)}`);
       lines.push(muted(`Store health: ${formatAuditCounts(audit)}`));
-      for (const candidate of candidates) {
+      for (const candidate of outputCandidates) {
         lines.push(
           `${success(candidate.score.toFixed(3))} ${accent(`${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}`)}`,
         );
@@ -412,7 +428,7 @@ export async function runMemoryPromote(
         lines.push("");
       }
       if (applyResult) {
-        for (const rejection of applyResult.rejectedCandidates) {
+        for (const rejection of rejectedCandidates) {
           const candidate = rejection.candidate;
           const source = `${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}`;
           lines.push(warn(`Skipped ${source}: ${rejection.reason}.`));
@@ -428,7 +444,7 @@ export async function runMemoryPromote(
               `appended=${applyResult.appended} reconciledExisting=${applyResult.reconciledExisting}`,
             ),
           );
-        } else if (applyResult.rejectedCandidates.length === 0) {
+        } else if (rejectedCandidates.length === 0) {
           lines.push(warn("No candidates met apply criteria."));
         }
       }

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -360,11 +360,14 @@ export async function runMemoryPromote(
             Math.max(0, outputLimit - applyResult.appliedCandidates.length),
           )
         : [];
-      const outputCandidates = applyResult
-        ? [
-            ...applyResult.appliedCandidates,
-            ...rejectedCandidates.map((rejection) => rejection.candidate),
-          ]
+      const outputCandidateKeys = applyResult
+        ? new Set([
+            ...applyResult.appliedCandidates.map((candidate) => candidate.key),
+            ...rejectedCandidates.map((rejection) => rejection.candidate.key),
+          ])
+        : undefined;
+      const outputCandidates = outputCandidateKeys
+        ? candidates.filter((candidate) => outputCandidateKeys.has(candidate.key))
         : candidates;
       const storePath = resolveShortTermRecallStorePath(workspaceDir);
       const lockPath = resolveShortTermRecallLockPath(workspaceDir);

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -161,6 +161,7 @@ export function formatExtraPaths(workspaceDir: string, extraPaths: MemoryExtraPa
   });
 }
 async function withMemoryManagerForAgent(params: {
+  commandName: string;
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: MemoryManagerPurpose;
@@ -179,7 +180,14 @@ async function withMemoryManagerForAgent(params: {
   }
   await withManager<MemoryManager>({
     getManager: () => getMemorySearchManager(managerParams),
-    onMissing: (error) => defaultRuntime.log(error ?? "Memory search disabled."),
+    onMissing: (error) => {
+      if (!error?.trim()) {
+        defaultRuntime.log("Memory search disabled.");
+        return;
+      }
+      defaultRuntime.error(`${params.commandName} failed (${params.agentId}): ${error}`);
+      process.exitCode = 1;
+    },
     onCloseError: (err) =>
       defaultRuntime.error(`Memory manager close failed: ${formatErrorMessage(err)}`),
     close: async (manager) => {
@@ -207,6 +215,7 @@ export async function withMemoryCommand(params: {
     : [resolveAgent(cfg, params.agent)];
   for (const agentId of agentIds) {
     await withMemoryManagerForAgent({
+      commandName: params.commandName,
       cfg,
       agentId,
       purpose: params.purpose,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -2664,6 +2664,105 @@ describe("memory cli", () => {
     });
   });
 
+  it("preserves score order for mixed applied and rejected promotion output", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const relativePath = "memory/2026-04-03.md";
+      await writeDailyMemoryNote(workspaceDir, "2026-04-03", [
+        "High-score untrusted candidate.",
+        "Lower-score trusted candidate.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "candidate order",
+        results: [
+          {
+            path: relativePath,
+            startLine: 1,
+            endLine: 1,
+            score: 0.99,
+            snippet: "High-score untrusted candidate.",
+            source: "memory",
+            provenance: {
+              originClass: "untrusted",
+              sessionKind: "interactive",
+              observedAt: Date.now(),
+            },
+          },
+          {
+            path: relativePath,
+            startLine: 2,
+            endLine: 2,
+            score: 0.01,
+            snippet: "Lower-score trusted candidate.",
+            source: "memory",
+          },
+        ],
+      });
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "trusted candidate",
+        results: [
+          {
+            path: relativePath,
+            startLine: 2,
+            endLine: 2,
+            score: 0.01,
+            snippet: "Lower-score trusted candidate.",
+            source: "memory",
+          },
+        ],
+      });
+      const manager = {
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close: vi.fn(async () => {}),
+      };
+      const args = [
+        "promote",
+        "--apply",
+        "--limit",
+        "2",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "0",
+        "--min-unique-queries",
+        "0",
+      ];
+
+      mockManager(manager);
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli([...args, "--json"]);
+      const payload = firstWrittenJsonArg<{
+        candidates: Array<{ startLine: number }>;
+        apply: {
+          appliedCandidates: Array<{ startLine: number }>;
+          rejectedCandidates: Array<{ candidate: { startLine: number } }>;
+        };
+      }>(writeJson);
+      expect(payload?.candidates.map((candidate) => candidate.startLine)).toEqual([1, 2]);
+      expect(payload?.apply.appliedCandidates.map((candidate) => candidate.startLine)).toEqual([2]);
+      expect(
+        payload?.apply.rejectedCandidates.map((rejection) => rejection.candidate.startLine),
+      ).toEqual([1]);
+
+      const store = await shortTermTesting.readRecallStore(workspaceDir, new Date().toISOString());
+      for (const entry of Object.values(store.entries)) {
+        delete entry.promotedAt;
+      }
+      await shortTermTesting.writeRawRecallStore(workspaceDir, store);
+      await fs.rm(path.join(workspaceDir, "MEMORY.md"), { force: true });
+
+      mockManager(manager);
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(args);
+      const output = loggedOutput(log);
+      const rejectedIndex = output.indexOf(`${relativePath}:1-1`);
+      const appliedIndex = output.indexOf(`${relativePath}:2-2`);
+      expect(rejectedIndex).toBeGreaterThanOrEqual(0);
+      expect(rejectedIndex).toBeLessThan(appliedIndex);
+    });
+  });
+
   it("prints conceptual promotion signals", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const dayMs = 24 * 60 * 60 * 1000;

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -2598,10 +2598,11 @@ describe("memory cli", () => {
         "Rare trusted note remains below the apply signal threshold.",
         "Candidate: Durable action note. confidence: 0.90 evidence: memory/.dreams/session-corpus/day.txt:1-1 recalls: 3 status: staged",
       ]);
-      mockManager({
+      const manager = {
         status: () => makeMemoryStatus({ workspaceDir }),
         close: vi.fn(async () => {}),
-      });
+      };
+      mockManager(manager);
 
       const log = spyRuntimeLogs(defaultRuntime);
       await runMemoryCli([
@@ -2619,6 +2620,47 @@ describe("memory cli", () => {
       expectLogged(log, `Skipped ${relativePath}:2-2: signal threshold (1 < 2).`);
       expectLogged(log, `Skipped ${relativePath}:3-3: contamination filter after rehydration.`);
       expectNotLogged(log, "No candidates met apply criteria.");
+
+      log.mockClear();
+      mockManager(manager);
+      await runMemoryCli([
+        "promote",
+        "--apply",
+        "--limit",
+        "1",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "2",
+        "--min-unique-queries",
+        "0",
+      ]);
+      expect(loggedOutput(log).match(/^Skipped /gm)).toHaveLength(1);
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      mockManager(manager);
+      await runMemoryCli([
+        "promote",
+        "--apply",
+        "--limit",
+        "1",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "2",
+        "--min-unique-queries",
+        "0",
+        "--json",
+      ]);
+      const payload = firstWrittenJsonArg<{
+        candidates: unknown[];
+        apply: { appliedCandidates: unknown[]; rejectedCandidates: unknown[] };
+      }>(writeJson);
+      expect(payload?.candidates).toHaveLength(1);
+      expect([
+        ...(payload?.apply.appliedCandidates ?? []),
+        ...(payload?.apply.rejectedCandidates ?? []),
+      ]).toHaveLength(1);
     });
   });
 

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -3,9 +3,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import {
   firstWrittenJsonArg,
   spyRuntimeErrors,
@@ -143,6 +149,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   process.exitCode = undefined;
@@ -1572,6 +1579,64 @@ describe("memory cli", () => {
     expect(log).toHaveBeenCalledWith("Memory search disabled.");
   });
 
+  it.each([
+    ["index --force", ["index", "--force"]],
+    ["status --fix", ["status", "--fix"]],
+  ])("fails %s when the memory index has orphaned provenance", async (_label, args) => {
+    const stateDir = path.join(fixtureRoot, `corrupt-state-${workspaceCaseId++}`);
+    const workspaceDir = path.join(fixtureRoot, `corrupt-workspace-${workspaceCaseId++}`);
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const agentDatabase = openOpenClawAgentDatabase({ agentId: "main", env });
+    agentDatabase.db.exec(`
+      PRAGMA foreign_keys = OFF;
+      INSERT INTO memory_index_chunks (
+        id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
+      ) VALUES (
+        'orphaned-chunk', 'memory/orphan.md', 'memory', 1, 1,
+        'hash', 'none', 'orphaned memory', '[]', 1
+      );
+      INSERT INTO memory_index_chunk_provenance (
+        chunk_id, origin_class, session_kind, observed_at
+      ) VALUES ('orphaned-chunk', 'agent', 'unknown', 1);
+      DELETE FROM memory_index_chunks WHERE id = 'orphaned-chunk';
+      PRAGMA foreign_keys = ON;
+    `);
+    closeOpenClawAgentDatabasesForTest();
+
+    const cfg = {
+      memory: {
+        backend: "builtin",
+        search: {
+          provider: "none",
+          model: "",
+          rememberAcrossConversations: false,
+          sources: ["memory"],
+          store: { vector: { enabled: false } },
+          cache: { enabled: false },
+          sync: { watch: false, onSessionStart: false, onSearch: false },
+          query: { hybrid: { enabled: true } },
+        },
+      },
+      agents: {
+        defaults: { workspace: workspaceDir },
+        list: [{ id: "main", default: true }],
+      },
+      plugins: { enabled: false },
+    } as OpenClawConfig;
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    getRuntimeConfig.mockReturnValue(cfg);
+    const actualMemory =
+      await vi.importActual<typeof import("./memory/index.js")>("./memory/index.js");
+    getMemorySearchManager.mockImplementation(actualMemory.getMemorySearchManager);
+
+    const error = spyRuntimeErrors(defaultRuntime);
+    await runMemoryCli(args);
+
+    expect(resolveOpenClawAgentSqlitePath({ agentId: "main", env })).toBe(agentDatabase.path);
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("SQLite foreign_key_check failed"));
+  });
+
   it("logs backend unsupported message when index has no sync", async () => {
     const close = vi.fn(async () => {});
     mockManager({
@@ -2468,6 +2533,92 @@ describe("memory cli", () => {
       expectLogged(log, `Processed 1 candidate(s) for ${memoryPath}.`);
       expectLogged(log, "appended=1 reconciledExisting=0");
       expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("names the filter for each candidate rejected during promote apply", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const relativePath = "memory/2026-04-02.md";
+      await writeDailyMemoryNote(workspaceDir, "2026-04-02", [
+        "Untrusted router note must not become durable memory.",
+        "Rare trusted note remains below the apply signal threshold.",
+        "Durable action note.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "router note",
+        results: [
+          {
+            path: relativePath,
+            startLine: 1,
+            endLine: 1,
+            score: 0.99,
+            snippet: "Untrusted router note must not become durable memory.",
+            source: "memory",
+            provenance: {
+              originClass: "untrusted",
+              sessionKind: "interactive",
+              observedAt: Date.now(),
+            },
+          },
+          {
+            path: relativePath,
+            startLine: 2,
+            endLine: 2,
+            score: 0.99,
+            snippet: "Rare trusted note remains below the apply signal threshold.",
+            source: "memory",
+          },
+          {
+            path: relativePath,
+            startLine: 3,
+            endLine: 3,
+            score: 0.99,
+            snippet: "Durable action note.",
+            source: "memory",
+          },
+        ],
+      });
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "durable action",
+        results: [
+          {
+            path: relativePath,
+            startLine: 3,
+            endLine: 3,
+            score: 0.99,
+            snippet: "Durable action note.",
+            source: "memory",
+          },
+        ],
+      });
+      await writeDailyMemoryNote(workspaceDir, "2026-04-02", [
+        "Untrusted router note must not become durable memory.",
+        "Rare trusted note remains below the apply signal threshold.",
+        "Candidate: Durable action note. confidence: 0.90 evidence: memory/.dreams/session-corpus/day.txt:1-1 recalls: 3 status: staged",
+      ]);
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close: vi.fn(async () => {}),
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--apply",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "2",
+        "--min-unique-queries",
+        "0",
+      ]);
+
+      expectLogged(log, `Skipped ${relativePath}:1-1: origin filter (untrusted).`);
+      expectLogged(log, `Skipped ${relativePath}:2-2: signal threshold (1 < 2).`);
+      expectLogged(log, `Skipped ${relativePath}:3-3: contamination filter after rehydration.`);
+      expectNotLogged(log, "No candidates met apply criteria.");
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -285,43 +285,40 @@ export async function applyShortTermPromotions(
     // sacrifices trusted lines in a mixed file so untrusted text cannot promote.
     return withDailyFileQuarantine(authoritative, dailyProvenanceByPath);
   });
-  const selected = currentCandidates
-    .filter((candidate) => {
-      const latest = store.entries[candidate.key];
-      // Explicit untrusted/system origins never promote on ANY path (append or
-      // consolidation): recall frequency must never launder externally-derived
-      // content into MEMORY.md. Workspace memory files index as 'agent', so
-      // legitimate daily-note candidates stay eligible.
-      if (isPromotionOriginBlocked(candidate)) {
-        return false;
-      }
-      if (options.consolidation && (!latest || !isConsolidationCandidateEligible(candidate))) {
-        return false;
-      }
-      if (isContaminatedDreamingSnippet(candidate.snippet)) {
-        return false;
-      }
-      if (candidate.promotedAt) {
-        return false;
-      }
-      if (candidate.score < minScore) {
-        return false;
-      }
-      if (candidate.signalCount < minRecallCount) {
-        return false;
-      }
-      if (Math.max(candidate.uniqueQueries, candidate.recallDays.length) < minUniqueQueries) {
-        return false;
-      }
-      if (maxAgeDays >= 0 && candidate.ageDays > maxAgeDays) {
-        return false;
-      }
-      if (latest?.promotedAt) {
-        return false;
-      }
-      return true;
-    })
-    .slice(0, limit);
+  const rejectionReasons = new Map<string, string>();
+  const eligible = currentCandidates.filter((candidate) => {
+    const latest = store.entries[candidate.key];
+    const queryCount = Math.max(candidate.uniqueQueries, candidate.recallDays.length);
+    // Explicit untrusted/system origins never promote on ANY path (append or
+    // consolidation): recall frequency must never launder externally-derived
+    // content into MEMORY.md. Workspace memory files index as 'agent', so
+    // legitimate daily-note candidates stay eligible.
+    const reason = isPromotionOriginBlocked(candidate)
+      ? `origin filter (${candidate.provenance?.originClass})`
+      : options.consolidation && (!latest || !isConsolidationCandidateEligible(candidate))
+        ? "consolidation origin/session filter"
+        : isContaminatedDreamingSnippet(candidate.snippet)
+          ? "contamination filter"
+          : candidate.promotedAt || latest?.promotedAt
+            ? "already promoted"
+            : candidate.score < minScore
+              ? `score threshold (${candidate.score.toFixed(3)} < ${minScore})`
+              : candidate.signalCount < minRecallCount
+                ? `signal threshold (${candidate.signalCount} < ${minRecallCount})`
+                : queryCount < minUniqueQueries
+                  ? `query threshold (${queryCount} < ${minUniqueQueries})`
+                  : maxAgeDays >= 0 && candidate.ageDays > maxAgeDays
+                    ? `age threshold (${candidate.ageDays.toFixed(1)}d > ${maxAgeDays}d)`
+                    : undefined;
+    if (reason) {
+      rejectionReasons.set(candidate.key, reason);
+    }
+    return !reason;
+  });
+  const selected = eligible.slice(0, limit);
+  for (const candidate of eligible.slice(limit)) {
+    rejectionReasons.set(candidate.key, `selection limit (${limit})`);
+  }
 
   const rehydratedSelected: PromotionCandidate[] = [];
   const plannedSourceFingerprints = new Map<string, string>();
@@ -341,6 +338,15 @@ export async function applyShortTermPromotions(
     ) {
       rehydratedSelected.push(rehydrated);
       plannedSourceFingerprints.set(candidate.key, sourceFingerprintAfter);
+    } else {
+      rejectionReasons.set(
+        candidate.key,
+        !rehydrated
+          ? "source rehydration failed"
+          : sourceFingerprintBefore !== sourceFingerprintAfter
+            ? "source changed during apply"
+            : "contamination filter after rehydration",
+      );
     }
   }
 
@@ -351,6 +357,10 @@ export async function applyShortTermPromotions(
       appended: 0,
       reconciledExisting: 0,
       appliedCandidates: [],
+      rejectedCandidates: currentCandidates.map((candidate) => ({
+        candidate,
+        reason: rejectionReasons.get(candidate.key) ?? "candidate changed during apply",
+      })),
       compactedSections: 0,
       compactedDates: [],
     };
@@ -650,6 +660,12 @@ export async function applyShortTermPromotions(
     appended: appendedCandidates,
     reconciledExisting: alreadyWritten.length,
     appliedCandidates: committedCandidates,
+    rejectedCandidates: currentCandidates
+      .filter((candidate) => !committedCandidates.some((applied) => applied.key === candidate.key))
+      .map((candidate) => ({
+        candidate,
+        reason: rejectionReasons.get(candidate.key) ?? "candidate changed during apply",
+      })),
     compactedSections: compactedDates.length,
     compactedDates,
   };

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -213,6 +213,10 @@ export type ApplyShortTermPromotionsResult = {
   appended: number;
   reconciledExisting: number;
   appliedCandidates: PromotionCandidate[];
+  rejectedCandidates: Array<{
+    candidate: PromotionCandidate;
+    reason: string;
+  }>;
   /** Number of older promotion sections compacted out to honor the budget. */
   compactedSections: number;
   /** Dates of the compacted promotion sections, oldest first. */

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1774,6 +1774,7 @@ describe("short-term promotion", () => {
       });
 
       expect(applied.applied).toBe(0);
+      expect(applied.rejectedCandidates[0]?.reason).toContain("signal threshold");
     });
   });
 
@@ -1979,6 +1980,7 @@ describe("short-term promotion", () => {
       });
 
       expect(applied.applied).toBe(0);
+      expect(applied.rejectedCandidates[0]?.reason).toContain("age threshold");
       await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
     });
   });
@@ -2023,6 +2025,7 @@ describe("short-term promotion", () => {
       });
 
       expect(applied.applied).toBe(0);
+      expect(applied.rejectedCandidates[0]?.reason).toBe("contamination filter");
       await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
     });
   });
@@ -2151,6 +2154,7 @@ describe("short-term promotion", () => {
         minUniqueQueries: 0,
       });
       expect(applied.applied).toBe(0);
+      expect(applied.rejectedCandidates[0]?.reason).toBe("origin filter (untrusted)");
       await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running memory index repair commands against an FK-corrupted index saw the SQLite `foreign_key_check` error but received exit code 0, so automation read a failed repair as success. It also fixes `memory promote --apply` silently dropping listed candidates behind a generic "No candidates met apply criteria" message.

## Why This Change Was Made

Memory-manager initialization failures now remain distinguishable from a normally disabled memory backend: non-empty initialization errors go to stderr and set exit code 1, while the intentional disabled path keeps its existing informational output. Promotion apply now gathers the bounded candidate set without pre-filtering, then keeps the real score, signal, query, age, provenance, contamination, and limit policy in `applyShortTermPromotions`, the owner that can report the exact rejection reason.

This reuses the existing memory-core manager/apply boundaries and adds no dependency or parallel policy path. The recall store already enforces a 512-entry retention cap, so complete rejection reporting remains bounded.

AI-assisted: yes.

## User Impact

Shell scripts can now trust `memory status --fix` and `memory index --force`: unrecovered index corruption prints the error on stderr and exits 1. Operators applying short-term promotions now see a per-candidate reason such as `signal threshold (1 < 2)` instead of a silent non-outcome.

## Evidence

Verified live QA reproduction before the fix:

- With an FK-corrupted memory index, `memory status --fix` and `memory index --force` printed the SQLite `foreign_key_check` error and exited 0, so failed repair was reported as success to scripts.
- `memory promote --apply` silently dropped listed candidates and printed only `No candidates met apply criteria`.

Built-CLI proof after the fix:

- Both corrupt-index commands print the unrecovered corruption on stderr and exit 1.
- Promotion apply prints `Skipped memory/2026-04-02.md:2-2: signal threshold (1 < 2).` for the rejected candidate.

Focused regression proof:

- Pre-fix: 2 failing tests (`expected exit 1, received undefined`).
- Post-fix: `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts extensions/memory-core/src/short-term-promotion.test.ts` — 2 files, 169 tests passed.
- Apply-limit regression coverage verifies both text and JSON return exactly one unique candidate outcome for `memory promote --apply --limit 1` while complete internal gathering still supplies rejection accounting.
- Mixed-outcome coverage verifies a higher-scored rejected candidate remains ahead of a lower-scored applied candidate in both JSON and human output.
- `node scripts/check-changed.mjs` — passed all selected extension production/test format, guard, typecheck, lint, dead-code, database-first, and import-cycle checks. Remote routing found no ready provider, so the repository wrapper used its documented local fallback.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — final whole-branch review clean, no accepted/actionable findings; overall correctness 0.99.

Performance check for complete apply-time candidate gathering (100 alternating warm runs of the real SQLite-backed `rankShortTermPromotionCandidates` path):

- 213 candidates: filtered/limited p50 2.802 ms and 2,806 KiB heap delta; unfiltered p50 2.844 ms and 2,952 KiB (+0.042 ms, +146 KiB).
- 500 candidates: filtered/limited p50 6.570 ms and 7,219 KiB heap delta; unfiltered p50 6.738 ms and 7,561 KiB (+0.168 ms, +342 KiB).
- The normal store is capped at 512 entries. A lower gather cap would omit tail candidates and therefore lose their rejection reasons; the existing retention cap is the correct bound.

Production LOC: +103/-46 (net +57) | Tests: +296/-0. The production growth is the concrete CLI capability: honest process failure semantics plus structured per-candidate rejection reporting, with the documented `--limit` and score-order contracts preserved across text and JSON. Threshold decisions remain consolidated in the existing apply owner instead of adding a second filtering policy.
