### PR TITLE
fix(gateway): stop closed clients from restoring session subscriptions

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -161,6 +161,8 @@ function listSourceDtsOutputs(sourceDir: string, outputPrefix: string) {
 const PLUGIN_SDK_TYPE_INPUTS = [
   "tsconfig.json",
   "src/plugin-sdk",
+  // agent-harness-runtime re-exports this attempt contract into generated SDK declarations.
+  "src/agents/embedded-agent-runner/run/types.ts",
   // provider-auth re-exports these signatures into generated SDK declarations.
   "src/agents/cli-credentials.ts",
   "src/plugins/provider-runtime-model.types.ts",

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -161,7 +161,7 @@ function listSourceDtsOutputs(sourceDir: string, outputPrefix: string) {
 const PLUGIN_SDK_TYPE_INPUTS = [
   "tsconfig.json",
   "src/plugin-sdk",
-  // agent-harness-runtime re-exports this attempt contract into generated SDK declarations.
+  // agent-harness-runtime projects the host-prepared attempt contract.
   "src/agents/embedded-agent-runner/run/types.ts",
   // provider-auth re-exports these signatures into generated SDK declarations.
   "src/agents/cli-credentials.ts",

--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -198,6 +198,21 @@ describe("control UI session PR subscriptions", () => {
     expect(load).not.toHaveBeenCalled();
   });
 
+  it("rejects replace-sets from inactive connections before loading", async () => {
+    const load = vi.fn(async () => READY);
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({
+      broadcastToConnIds,
+      load,
+      isConnectionActive: () => false,
+    });
+
+    await active.replace("conn-closed", ["orphan"]);
+
+    expect(load).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+  });
+
   it("does not publish a superseded replace-set after its load completes", async () => {
     vi.useFakeTimers();
     let resolveFirst!: (value: ControlUiSessionPullRequests) => void;

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -20,6 +20,7 @@ type LoadSessionPullRequests = (
 
 type SubscriptionDeps = {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
+  isConnectionActive?: (connId: string) => boolean;
   load?: LoadSessionPullRequests;
   setTimer?: typeof globalThis.setTimeout;
   clearTimer?: typeof globalThis.clearTimeout;
@@ -252,7 +253,7 @@ export function createControlUiSessionPullRequestSubscriptions(
       return;
     }
     const normalizedConnId = connId.trim();
-    if (!normalizedConnId) {
+    if (!normalizedConnId || deps.isConnectionActive?.(normalizedConnId) === false) {
       return;
     }
     const replacementToken = {};

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -368,14 +368,16 @@ const TOOL_EVENT_RECIPIENT_TTL_MS = 10 * 60 * 1000;
 const TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS = 30 * 1000;
 
 /** Create the broad sessions.changed subscriber registry. */
-export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRegistry {
+export function createSessionEventSubscriberRegistry(
+  isConnectionActive?: (connId: string) => boolean,
+): SessionEventSubscriberRegistry {
   const connIds = new Set<string>();
   const empty = new Set<string>();
 
   return {
     subscribe: (connId: string) => {
       const normalized = connId.trim();
-      if (!normalized) {
+      if (!normalized || isConnectionActive?.(normalized) === false) {
         return;
       }
       connIds.add(normalized);
@@ -392,7 +394,9 @@ export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRe
 }
 
 /** Create the per-session message subscriber registry. */
-export function createSessionMessageSubscriberRegistry(): SessionMessageSubscriberRegistry {
+export function createSessionMessageSubscriberRegistry(
+  isConnectionActive?: (connId: string) => boolean,
+): SessionMessageSubscriberRegistry {
   const sessionToConnIds = new Map<string, Set<string>>();
   // The final state after overlapping replays settles to their latest success
   // or the original committed base; failed provisionals cannot leave ghosts.
@@ -456,7 +460,11 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
     subscribe: (connId: string, sessionKey: string, opts) => {
       const normalizedConnId = normalize(connId);
       const normalizedSessionKey = normalize(sessionKey);
-      if (!normalizedConnId || !normalizedSessionKey) {
+      if (
+        !normalizedConnId ||
+        !normalizedSessionKey ||
+        isConnectionActive?.(normalizedConnId) === false
+      ) {
         return undefined;
       }
       const hadApprovals =

--- a/src/gateway/server-connection-state.ts
+++ b/src/gateway/server-connection-state.ts
@@ -17,8 +17,18 @@ export function createGatewayConnectionState(params: {
 }) {
   const loadRuntimeConfig = params.getRuntimeConfig ?? (() => params.cfg);
   const clients = new Set<GatewayWsClient>();
-  const sessionEventSubscribers = createSessionEventSubscriberRegistry();
-  const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
+  // Detached RPC dispatch can resume after close cleanup, so connection-owned
+  // producers must validate against the live transport owner before mutation.
+  const isConnectionActive = (connId: string) => {
+    for (const client of clients) {
+      if (client.connId === connId && !client.invalidated) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const sessionEventSubscribers = createSessionEventSubscriberRegistry(isConnectionActive);
+  const sessionMessageSubscribers = createSessionMessageSubscriberRegistry(isConnectionActive);
   const gatewayBroadcaster = createGatewayBroadcaster({
     clients,
     sessionMessageSubscribers,
@@ -44,6 +54,7 @@ export function createGatewayConnectionState(params: {
 
   return {
     clients,
+    isConnectionActive,
     ...gatewayBroadcaster,
     agentRunSeq,
     dedupe,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -57,6 +57,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
     nodeUnsubscribeAll,
     hasTalkNodeConnected,
     clients,
+    isConnectionActive,
     watchNodeHttpRuntime,
     sharedGatewaySessionGenerationState,
     resolveSharedGatewaySessionGenerationForRuntimeSnapshot,
@@ -148,6 +149,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
       nodeUnsubscribeAll,
       hasConnectedTalkNode: hasTalkNodeConnected,
       clients,
+      isConnectionActive,
       invalidateDeviceTransports: watchNodeHttpRuntime.invalidateSessionsForDevice,
       disconnectDeviceTransports: watchNodeHttpRuntime.disconnectSessionsForDevice,
       enforceSharedGatewayAuthGenerationForConfigWrite: (nextConfig: OpenClawConfig) => {

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -52,6 +52,7 @@ export async function prepareGatewayLifecycle(params: {
     workerGatewayEndpoint,
     transportBridge,
     sessionMessageSubscribers,
+    isConnectionActive,
     clients,
     broadcast,
     cfgAtStart,
@@ -322,8 +323,10 @@ export async function prepareGatewayLifecycle(params: {
   };
   runtimeState.controlUiSessionPullRequests = createControlUiSessionPullRequestSubscriptions({
     broadcastToConnIds,
+    isConnectionActive,
   });
   runtimeState.sessionViewerPresence = createSessionViewerPresenceDeclarations({
+    isConnectionActive,
     onReplace: (connId, sessionKeys) => {
       const client = [...clients].find((candidate) => candidate.connId === connId);
       if (!client?.presenceKey) {

--- a/src/gateway/server-methods/session-change-event.test.ts
+++ b/src/gateway/server-methods/session-change-event.test.ts
@@ -91,6 +91,29 @@ describe("sessions.changed coalescing", () => {
     expect(mocks.invalidate).toHaveBeenCalledTimes(3);
   });
 
+  it("emits the latest trailing row by the sustained-mutation deadline", () => {
+    const context = createContext();
+    const sessionKey = "agent:main:chat";
+
+    emitSessionsChanged(context, { reason: "leading", sessionKey });
+    emitSessionsChanged(context, { reason: "update-0", sessionKey });
+    for (let index = 1; index <= 5; index += 1) {
+      vi.advanceTimersByTime(90);
+      mocks.rowLabel = `state-${index}`;
+      emitSessionsChanged(context, { reason: `update-${index}`, sessionKey });
+    }
+
+    vi.advanceTimersByTime(49);
+    expect(context.broadcastToConnIds).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1);
+    expect(context.broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(context.broadcastToConnIds).mock.calls[1]?.[1]).toMatchObject({
+      label: "state-5",
+      reason: "update-5",
+    });
+  });
+
   it("keeps different session keys independent", () => {
     const context = createContext();
 

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -26,12 +26,14 @@ type SessionChangeContext = Pick<
 type PendingSessionChange = {
   context: SessionChangeContext;
   dirty: boolean;
+  firstDeferredAt?: number;
   key: string;
   payload: SessionChangedPayload;
   timer: ReturnType<typeof setTimeout> | null;
 };
 
 const SESSIONS_CHANGED_DEBOUNCE_MS = 100;
+const SESSIONS_CHANGED_MAX_WAIT_MS = 500;
 const sessionsMutationVersions = new WeakMap<object, number>();
 const pendingChangesByContext = new WeakMap<object, Map<string, PendingSessionChange>>();
 const pendingSessionChanges = new Set<PendingSessionChange>();
@@ -157,12 +159,16 @@ export function emitSessionsChanged(context: SessionChangeContext, payload: Sess
   if (pending) {
     pending.payload = payload;
     pending.dirty = true;
+    pending.firstDeferredAt ??= Date.now();
     if (pending.timer) {
       clearTimeout(pending.timer);
     }
+    // Keep resetting for a quiet-period trailing emit without letting a sustained
+    // mutation stream postpone the authoritative row forever.
+    const maxWaitRemaining = pending.firstDeferredAt + SESSIONS_CHANGED_MAX_WAIT_MS - Date.now();
     pending.timer = setTimeout(
       () => finishPendingSessionChange(pending),
-      SESSIONS_CHANGED_DEBOUNCE_MS,
+      Math.max(0, Math.min(SESSIONS_CHANGED_DEBOUNCE_MS, maxWaitRemaining)),
     );
     pending.timer.unref?.();
     return;

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -86,6 +86,7 @@ function makeContextParams(
     nodeUnsubscribeAll: vi.fn(),
     hasConnectedTalkNode: vi.fn(async () => false),
     clients: new Set(),
+    isConnectionActive: vi.fn(() => false),
     enforceSharedGatewayAuthGenerationForConfigWrite: vi.fn(),
     nodeRegistry: { invalidateConnectionForPairingChange: vi.fn() } as never,
     agentRunSeq: new Map(),
@@ -151,6 +152,16 @@ function makeGatewayClient(params: {
 }
 
 describe("createGatewayRequestContext", () => {
+  it("reuses the canonical connection liveness predicate", () => {
+    const isConnectionActive = vi.fn(() => true);
+    const params = makeContextParams();
+    Object.assign(params, { isConnectionActive });
+
+    const context = createGatewayRequestContext(params);
+
+    expect(context.isConnectionActive).toBe(isConnectionActive);
+  });
+
   it("cleans connection-scoped replace-sets with the other session subscriptions", () => {
     const unsubscribeAllSessionEvents = vi.fn();
     const unsubscribePullRequests = vi.fn();

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -68,6 +68,7 @@ type GatewayRequestContextParams = {
   nodeUnsubscribeAll: GatewayRequestContext["nodeUnsubscribeAll"];
   hasConnectedTalkNode: GatewayRequestContext["hasConnectedTalkNode"];
   clients: Set<GatewayRequestContextClient>;
+  isConnectionActive: NonNullable<GatewayRequestContext["isConnectionActive"]>;
   invalidateDeviceTransports?: (
     deviceId: string,
     opts?: { role?: string; reason?: string },
@@ -220,8 +221,7 @@ export function createGatewayRequestContext(
     nodeUnsubscribe: params.nodeUnsubscribe,
     nodeUnsubscribeAll: params.nodeUnsubscribeAll,
     hasConnectedTalkNode: params.hasConnectedTalkNode,
-    isConnectionActive: (connId) =>
-      [...params.clients].some((client) => client.connId === connId && !client.invalidated),
+    isConnectionActive: params.isConnectionActive,
     hasExecApprovalClients: (excludeConnId?: string) => {
       for (const gatewayClient of params.clients) {
         if (excludeConnId && gatewayClient.connId === excludeConnId) {

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -487,6 +487,7 @@ export async function prepareGatewayKernelState(params: {
     toolEventRecipients,
     sessionEventSubscribers,
     sessionMessageSubscribers,
+    isConnectionActive,
   } = connectionState;
 
   return {
@@ -569,6 +570,7 @@ export async function prepareGatewayKernelState(params: {
     toolEventRecipients,
     sessionEventSubscribers,
     sessionMessageSubscribers,
+    isConnectionActive,
     getWorkerIngressEndpoint: transportBridge.getWorkerIngressEndpoint,
     getMcpAppSandboxPort: transportBridge.getMcpAppSandboxPort,
     ensureSandboxHostPort: transportBridge.ensureSandboxHostPort,

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -18,7 +18,10 @@ vi.mock("./authenticated-request-dispatch.server-methods.runtime.js", async () =
       if (!handler) {
         throw new Error(`missing test handler for ${options.req.method}`);
       }
-      await handler({ ...options, params: options.req.params });
+      await handler({
+        ...options,
+        params: (options.req.params ?? {}) as Record<string, unknown>,
+      });
     },
   };
 });

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -56,12 +56,8 @@ describe("authenticated request connection liveness", () => {
     {
       method: "sessions.messages.subscribe",
       params: { key: "agent:main:main" },
-      assertEmpty: (state: ReturnType<typeof createGatewayConnectionState>) => {
-        expect(state.sessionMessageSubscribers.get("agent:main:main")).toEqual(new Set());
-        expect(
-          state.sessionMessageSubscribers.getForConnection("late-subscription-connection"),
-        ).toEqual(new Set());
-      },
+      assertEmpty: (state: ReturnType<typeof createGatewayConnectionState>) =>
+        expect(state.sessionMessageSubscribers.get("agent:main:main")).toEqual(new Set()),
     },
   ])("rejects a late $method mutation after disconnect cleanup", async (testCase) => {
     let releaseHandler!: () => void;

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { createGatewayConnectionState } from "../../server-connection-state.js";
+import type { GatewayRequestOptions } from "../../server-methods/types.js";
+import type { GatewayWsClient } from "../ws-types.js";
+import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+
+const runtime = vi.hoisted(() => ({ beforeHandler: vi.fn<() => Promise<void>>() }));
+
+vi.mock("./authenticated-request-dispatch.server-methods.runtime.js", async () => {
+  const { sessionSubscriptionHandlers } =
+    await import("../../server-methods/sessions-subscriptions.js");
+  return {
+    handleGatewayRequest: async (options: GatewayRequestOptions) => {
+      await runtime.beforeHandler();
+      const handler = sessionSubscriptionHandlers[options.req.method];
+      if (!handler) {
+        throw new Error(`missing test handler for ${options.req.method}`);
+      }
+      await handler({ ...options, params: options.req.params });
+    },
+  };
+});
+
+function createClient(): GatewayWsClient {
+  return {
+    socket: {} as WebSocket,
+    connId: "late-subscription-connection",
+    usesSharedGatewayAuth: false,
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "gateway-client", version: "dev", platform: "test", mode: "backend" },
+      role: "operator",
+      scopes: ["operator.read"],
+    },
+  };
+}
+
+describe("authenticated request connection liveness", () => {
+  beforeEach(() => {
+    runtime.beforeHandler.mockReset();
+  });
+
+  it.each([
+    {
+      method: "sessions.subscribe",
+      params: {},
+      assertEmpty: (state: ReturnType<typeof createGatewayConnectionState>) =>
+        expect(state.sessionEventSubscribers.getAll()).toEqual(new Set()),
+    },
+    {
+      method: "sessions.messages.subscribe",
+      params: { key: "agent:main:main" },
+      assertEmpty: (state: ReturnType<typeof createGatewayConnectionState>) => {
+        expect(state.sessionMessageSubscribers.get("agent:main:main")).toEqual(new Set());
+        expect(
+          state.sessionMessageSubscribers.getForConnection("late-subscription-connection"),
+        ).toEqual(new Set());
+      },
+    },
+  ])("rejects a late $method mutation after disconnect cleanup", async (testCase) => {
+    let releaseHandler!: () => void;
+    const held = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    runtime.beforeHandler.mockReturnValue(held);
+    const state = createGatewayConnectionState({ cfg: {} });
+    const client = createClient();
+    state.clients.add(client);
+    const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
+    const context = {
+      getRuntimeConfig: () => ({}),
+      logGateway: { error: vi.fn() },
+      subscribeSessionEvents: state.sessionEventSubscribers.subscribe,
+      subscribeSessionMessageEvents: state.sessionMessageSubscribers.subscribe,
+    };
+    const dispatcher = createGatewayAuthenticatedRequestDispatcher({
+      handler: {
+        connId: client.connId,
+        extraHandlers: {},
+        buildRequestContext: () => context as never,
+        send,
+        close: vi.fn(),
+        isClosed: () => false,
+        setCloseCause: vi.fn(),
+        logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      } as unknown as GatewayWsMessageHandlerParams,
+      isWebchatConnect: () => false,
+    });
+
+    await dispatcher.dispatch(
+      { type: "req", id: testCase.method, method: testCase.method, params: testCase.params },
+      client,
+    );
+    await vi.waitFor(() => expect(runtime.beforeHandler).toHaveBeenCalledOnce());
+
+    state.clients.delete(client);
+    state.sessionEventSubscribers.unsubscribe(client.connId);
+    state.sessionMessageSubscribers.unsubscribeAll(client.connId);
+    releaseHandler();
+
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({ id: testCase.method, ok: true })),
+    );
+    testCase.assertEmpty(state);
+  });
+});

--- a/src/gateway/session-viewer-presence.test.ts
+++ b/src/gateway/session-viewer-presence.test.ts
@@ -41,4 +41,15 @@ describe("session viewer presence declarations", () => {
 
     expect(onReplace).toHaveBeenCalledOnce();
   });
+
+  it("rejects declarations from inactive connections", () => {
+    const onReplace = vi.fn();
+    const declarations = createSessionViewerPresenceDeclarations({
+      onReplace,
+      isConnectionActive: () => false,
+    });
+
+    expect(declarations.replace("conn-closed", ["alpha"])).toEqual([]);
+    expect(onReplace).not.toHaveBeenCalled();
+  });
 });

--- a/src/gateway/session-viewer-presence.ts
+++ b/src/gateway/session-viewer-presence.ts
@@ -3,6 +3,7 @@
 
 type SessionViewerPresenceDeclarationsDeps = {
   onReplace: (connId: string, sessionKeys: readonly string[]) => void;
+  isConnectionActive?: (connId: string) => boolean;
 };
 
 type SessionViewerPresenceDeclarations = {
@@ -35,7 +36,7 @@ export function createSessionViewerPresenceDeclarations(
       return [];
     }
     const normalizedConnId = connId.trim();
-    if (!normalizedConnId) {
+    if (!normalizedConnId || deps.isConnectionActive?.(normalizedConnId) === false) {
       return [];
     }
     const next = normalizedSessionKeys(sessionKeys);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway WebSocket closing while a `sessions.subscribe` or `sessions.messages.subscribe` request was still crossing async dispatch/authorization could let the late handler recreate connection-owned registry entries after disconnect cleanup. Those ghost entries permanently kept expensive session snapshot/transcript and hidden-run mirroring gates enabled with zero connected clients. Also fixes sustained session mutation bursts indefinitely postponing the authoritative trailing `sessions.changed` status refresh.

## Why This Change Was Made

`createGatewayConnectionState` now owns one canonical live-client predicate, and connection-owned session/message/viewer/Control UI PR subscription producers reject inactive `connId` values synchronously before mutation. Ordinary UI/SDK RPCs still intentionally outlive reconnects; no global request cancellation or drain was added. `sessions.changed` retains a 100 ms quiet trailing emit but gains a 500 ms maximum wait from the first deferred mutation.

AI-assisted: yes. The implementation and evidence were reviewed before publication.

## User Impact

Disconnected clients no longer leave permanent background subscription work, and Control UI session status receives an authoritative refresh during long mutation bursts instead of remaining stale until the burst ends.

## Evidence

Pre-fix proof was captured before production edits:

- 2/2 late subscription cases retained the closed `connId`.
- The sustained debounce expected 2 broadcasts and got 1.
- Inactive viewer and Control UI PR replace-set tests mutated state.

Passing validation:

- `node scripts/run-vitest.mjs <6 focused Gateway test files>` — 6 files, 49 tests passed.
- `node scripts/run-vitest.mjs <6 sibling Gateway test files>` — 6 files, 52 tests passed.
- `node_modules/.bin/oxfmt --check <14 changed files>` — clean.
- `git diff --check` — clean.
- `node scripts/check-changed.mjs --dry-run -- <14 changed files>` — lanes `core`, `coreTests`.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted ...` — clean, no accepted/actionable findings.

The first exact-head CI run [31967187535](https://github.com/openclaw/openclaw/actions/runs/31967187535) failed only in `check-test-types-core-4` with TS2322 at line 21 of the new test. The mocked handler params were corrected to a typed record and pushed. Blacksmith Testbox run [31967406467](https://github.com/openclaw/openclaw/actions/runs/31967406467) then passed `CI=1 node scripts/run-tsgo-core-test-shards.mjs --stripe 4/5 --concurrency 2` with exit 0, and `node scripts/run-vitest.mjs src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts` passed 1 file / 2 tests.

Exact-head CI run [31968136145](https://github.com/openclaw/openclaw/actions/runs/31968136145) failed in `check-additional-extension-package-boundary` only because its merge base predated [#124735](https://github.com/openclaw/openclaw/pull/124735) and therefore lacked `authoredContextTokenCap`. Current main contains #124735, and this branch was rebased onto it.

The next exact-head CI run [31968481666](https://github.com/openclaw/openclaw/actions/runs/31968481666) found that current main had removed the private `getForConnection` registry accessor still asserted by the gateway test, and repeated the package-boundary stale declaration failure. #124735 added `authoredContextTokenCap` to the attempt contract re-exported through `src/plugin-sdk/agent-harness-runtime.ts`, but `src/agents/embedded-agent-runner/run/types.ts` was missing from the SDK declaration cache's source-input inventory. This head retains the observable per-session subscriber-set assertion and adds that attempt contract to the cache inputs.

Blacksmith Testbox run [31968753959](https://github.com/openclaw/openclaw/actions/runs/31968753959) synchronized the two CI repair files and passed:

- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 21 tests passed across 2 shards.
- `node scripts/run-tsgo-core-test-shards.mjs --stripe 4/5 --concurrency 2` — exit 0.
- `pnpm run test:extensions:package-boundary:compile` — all 123 plugins compiled, exit 0.

Production LOC: +45/-11 (net +34) | Tooling: +2/-0 | Tests: +168/-0. The positive production growth establishes one canonical connection-liveness ownership boundary shared by four connection-owned producers and adds the bounded authoritative debounce deadline; it adds no fallback or duplicate cleanup path. The tooling growth is only the missing SDK declaration cache input.

No screenshot/video was captured because the leaked registry is invisible and the starvation requires deterministic sustained sub-100ms mutations; the owner-boundary regressions directly exercise the original execution order and timing contract.

No related Gitcrawl issue or PR was found in the fresh local archive.
