### PR TITLE
fix(ui): stop stale clients from acting connected

### DIFF
--- a/packages/gateway-protocol/src/connect-error-details.test.ts
+++ b/packages/gateway-protocol/src/connect-error-details.test.ts
@@ -45,10 +45,13 @@ describe("readConnectErrorDetailCode", () => {
 });
 
 describe("readControlUiBuildMismatchId", () => {
-  it("returns a bounded reload target", () => {
+  it.each([
+    ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+    ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+  ])("returns a bounded reload target for %s", (code) => {
     expect(
       readControlUiBuildMismatchId({
-        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        code,
         gatewayBuildId: "gateway-build",
         reloadRequired: true,
       }),

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -232,7 +232,11 @@ export function readConnectErrorDetailCode(details: unknown): string | null {
 
 /** Read the exact target artifact from an untrusted reload-required rejection. */
 export function readControlUiBuildMismatchId(details: unknown): string | null {
-  if (readConnectErrorDetailCode(details) !== ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH) {
+  const code = readConnectErrorDetailCode(details);
+  if (
+    code !== ConnectErrorDetailCodes.PROTOCOL_MISMATCH &&
+    code !== ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH
+  ) {
     return null;
   }
   const raw = details as { gatewayBuildId?: unknown; reloadRequired?: unknown };

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -332,7 +332,11 @@ export async function attachAuthenticatedGatewayConnect(
     });
     sendHandshakeErrorResponse(ErrorCodes.UNAVAILABLE, message, {
       retryable: false,
-      details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+      details: {
+        code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+        gatewayBuildId: controlUiBuildMismatch.gatewayBuildId,
+        reloadRequired: true,
+      },
     });
     logWsControl.warn(
       `control ui build rejected conn=${connId} clientBuild=${formatForLog(controlUiBuildMismatch.clientBuildId ?? "legacy")} gatewayBuild=${formatForLog(controlUiBuildMismatch.gatewayBuildId)}; reload required`,

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
-import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
+import {
+  ConnectErrorDetailCodes,
+  readControlUiBuildMismatchId,
+} from "../../../../packages/gateway-protocol/src/connect-error-details.js";
 import { ErrorCodes, PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
@@ -290,9 +293,18 @@ describe("Control UI build admission over WebSocket", () => {
           code: ErrorCodes.UNAVAILABLE,
           message: "protocol mismatch: Control UI updated; reload this page to continue",
           retryable: false,
-          details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+          details: {
+            code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+            gatewayBuildId: "gateway-build",
+            reloadRequired: true,
+          },
         },
       });
+      expect(
+        readControlUiBuildMismatchId(
+          (rejection.error as { details?: unknown } | undefined)?.details,
+        ),
+      ).toBe("gateway-build");
       ws.send(
         JSON.stringify({
           type: "req",

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -287,8 +287,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
         </openclaw-tooltip-provider>
       `;
     }
-    const showLoginGate =
-      !gatewayConnected && (this.loginGatePinned || gatewaySnapshot.phase !== "reconnecting");
+    const shellOwnsRecovery =
+      gatewaySnapshot.phase === "reconnecting" || gatewaySnapshot.phase === "reload-required";
+    const showLoginGate = !gatewayConnected && !shellOwnsRecovery;
     if (showLoginGate) {
       return html`
         <openclaw-tooltip-provider>

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -274,12 +274,15 @@ export function renderApplicationShell(host: ShellViewHost) {
   const custodianPanelAvailable =
     gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
   const activeRoute = host.routeState.routeId ?? "chat";
-  // Chat has an offline outbox, and New Session keeps a local draft while its
-  // server-backed Start action is already gated. Other pages cannot submit
-  // useful work while disconnected, so keep their visible controls honest.
+  // Chat has an offline outbox, New Session keeps a local draft, and Appearance
+  // persists local preference intent for replay. Their server actions are
+  // independently gated; other pages cannot submit useful disconnected work.
   const pageActionsBlocked =
     gatewaySnapshot.phase === "reload-required" ||
-    (!gatewayConnected && activeRoute !== "chat" && activeRoute !== "new-session");
+    (!gatewayConnected &&
+      activeRoute !== "chat" &&
+      activeRoute !== "new-session" &&
+      activeRoute !== "appearance");
   // Plugin tabs share one route; the search picks the active item.
   const activePluginRef =
     activeRoute === "plugin"

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -274,6 +274,10 @@ export function renderApplicationShell(host: ShellViewHost) {
   const custodianPanelAvailable =
     gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
   const activeRoute = host.routeState.routeId ?? "chat";
+  // Chat has an explicit offline outbox. Other pages cannot submit useful
+  // work while disconnected, so keep their visible controls honest.
+  const pageActionsBlocked =
+    gatewaySnapshot.phase === "reload-required" || (!gatewayConnected && activeRoute !== "chat");
   // Plugin tabs share one route; the search picks the active item.
   const activePluginRef =
     activeRoute === "plugin"
@@ -595,7 +599,14 @@ export function renderApplicationShell(host: ShellViewHost) {
           onRefresh: () => host.refreshControlUi(),
           onHoldUpdate: () => context.overlays.holdUpdate(),
         })}
+        ${pageActionsBlocked && gatewaySnapshot.phase !== "reload-required"
+          ? html`<div class="connection-action-block" role="status" aria-live="polite">
+              ${t("connection.actionsUnavailable")}
+            </div>`
+          : nothing}
         <openclaw-router-outlet
+          ?inert=${pageActionsBlocked}
+          aria-disabled=${pageActionsBlocked ? "true" : nothing}
           .router=${runtime.router}
           .retryContext=${context}
           .onNotFound=${() => host.replaceChatWithCurrentSession()}

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -274,10 +274,12 @@ export function renderApplicationShell(host: ShellViewHost) {
   const custodianPanelAvailable =
     gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
   const activeRoute = host.routeState.routeId ?? "chat";
-  // Chat has an explicit offline outbox. Other pages cannot submit useful
-  // work while disconnected, so keep their visible controls honest.
+  // Chat has an offline outbox, and New Session keeps a local draft while its
+  // server-backed Start action is already gated. Other pages cannot submit
+  // useful work while disconnected, so keep their visible controls honest.
   const pageActionsBlocked =
-    gatewaySnapshot.phase === "reload-required" || (!gatewayConnected && activeRoute !== "chat");
+    gatewaySnapshot.phase === "reload-required" ||
+    (!gatewayConnected && activeRoute !== "chat" && activeRoute !== "new-session");
   // Plugin tabs share one route; the search picks the active item.
   const activePluginRef =
     activeRoute === "plugin"

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -572,6 +572,26 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("reload-required");
   });
 
+  it("keeps a bare protocol mismatch in the login-gate path", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1008,
+      reason: "protocol mismatch",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "protocol mismatch",
+        details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+      },
+      willRetry: false,
+    });
+
+    expect(scheduleStaleChunkReloadMock).not.toHaveBeenCalled();
+    expect(gateway.snapshot.phase).toBe("stopped");
+    expect(gateway.snapshot.lastErrorCode).toBe(ConnectErrorDetailCodes.PROTOCOL_MISMATCH);
+  });
+
   it("keeps reconnecting across event-gap recovery with a fresh client", () => {
     const { gateway, clients, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -547,6 +547,31 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("offline");
   });
 
+  it("schedules the guarded reload and publishes a terminal phase for a stale build", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1008,
+      reason: "protocol mismatch: Control UI updated; reload this page to continue",
+      error: {
+        code: "UNAVAILABLE",
+        message: "protocol mismatch: Control UI updated; reload this page to continue",
+        details: {
+          code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+          gatewayBuildId: "replacement-build",
+          reloadRequired: true,
+        },
+      },
+      willRetry: false,
+    });
+
+    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledExactlyOnceWith({
+      buildId: "replacement-build",
+    });
+    expect(gateway.snapshot.phase).toBe("reload-required");
+  });
+
   it("keeps reconnecting across event-gap recovery with a fresh client", () => {
     const { gateway, clients, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -1,7 +1,4 @@
-import {
-  ConnectErrorDetailCodes,
-  readControlUiBuildMismatchId,
-} from "@openclaw/gateway-client/browser";
+import { readControlUiBuildMismatchId } from "@openclaw/gateway-client/browser";
 import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control-ui-contract.js";
 // Control UI module owns the application gateway store: the reactive
 // snapshot around GatewayBrowserClient consumed by the app shell.
@@ -441,14 +438,10 @@ export function createApplicationGateway(
           void scheduleStaleChunkReload({ buildId: mismatchedBuildId });
         }
         const lastErrorCode = resolveGatewayErrorDetailCode(error) ?? error?.code ?? null;
-        const reloadRequired =
-          mismatchedBuildId !== null ||
-          lastErrorCode === ConnectErrorDetailCodes.PROTOCOL_MISMATCH ||
-          lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH;
         setSnapshot({
           ...snapshot,
           client: nextClient,
-          phase: reloadRequired
+          phase: mismatchedBuildId !== null
             ? "reload-required"
             : everConnected
               ? willRetry

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -1,4 +1,7 @@
-import { readControlUiBuildMismatchId } from "@openclaw/gateway-client/browser";
+import {
+  ConnectErrorDetailCodes,
+  readControlUiBuildMismatchId,
+} from "@openclaw/gateway-client/browser";
 import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control-ui-contract.js";
 // Control UI module owns the application gateway store: the reactive
 // snapshot around GatewayBrowserClient consumed by the app shell.
@@ -437,23 +440,30 @@ export function createApplicationGateway(
         if (mismatchedBuildId) {
           void scheduleStaleChunkReload({ buildId: mismatchedBuildId });
         }
+        const lastErrorCode = resolveGatewayErrorDetailCode(error) ?? error?.code ?? null;
+        const reloadRequired =
+          mismatchedBuildId !== null ||
+          lastErrorCode === ConnectErrorDetailCodes.PROTOCOL_MISMATCH ||
+          lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH;
         setSnapshot({
           ...snapshot,
           client: nextClient,
-          phase: everConnected
-            ? willRetry
-              ? "reconnecting"
-              : "offline"
-            : willRetry
-              ? "connecting"
-              : "stopped",
+          phase: reloadRequired
+            ? "reload-required"
+            : everConnected
+              ? willRetry
+                ? "reconnecting"
+                : "offline"
+              : willRetry
+                ? "connecting"
+                : "stopped",
           hello: null,
           canvasPluginSurfaceUrl: null,
           selfUser: null,
           lastError: error?.message
             ? formatUiError(error.message)
             : `disconnected (${code}): ${formatUiExternalText(reason, t("common.unknown"))}`,
-          lastErrorCode: resolveGatewayErrorDetailCode(error) ?? error?.code ?? null,
+          lastErrorCode,
         });
       },
       onGap: ({ expected, received }) => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -441,15 +441,16 @@ export function createApplicationGateway(
         setSnapshot({
           ...snapshot,
           client: nextClient,
-          phase: mismatchedBuildId !== null
-            ? "reload-required"
-            : everConnected
-              ? willRetry
-                ? "reconnecting"
-                : "offline"
-              : willRetry
-                ? "connecting"
-                : "stopped",
+          phase:
+            mismatchedBuildId !== null
+              ? "reload-required"
+              : everConnected
+                ? willRetry
+                  ? "reconnecting"
+                  : "offline"
+                : willRetry
+                  ? "connecting"
+                  : "stopped",
           hello: null,
           canvasPluginSurfaceUrl: null,
           selfUser: null,

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -8,6 +8,7 @@ export type ApplicationGatewayPhase =
   | "connecting"
   | "connected"
   | "reconnecting"
+  | "reload-required"
   | "offline";
 
 export type ApplicationGatewaySnapshot = {

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -121,6 +121,9 @@ export function createGatewayHarness(
     },
     gateway,
     connect,
+    replaceSnapshotWithoutPublishing(next: Partial<ApplicationGatewaySnapshot>) {
+      snapshot = { ...snapshot, ...next };
+    },
     update(next: Partial<ApplicationGatewaySnapshot>) {
       snapshot = { ...snapshot, ...next };
       for (const listener of snapshotListeners) {

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -60,6 +60,21 @@ afterEach(() => {
 });
 
 describe("Control UI refresh nudge", () => {
+  it("flags a terminal build rejection without requiring a hello", () => {
+    const gatewayClient = client(async () => []);
+    const harness = createGatewayHarness(null, false);
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.update({
+      client: gatewayClient,
+      phase: "reload-required",
+      hello: null,
+    });
+
+    expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+    overlays.dispose();
+  });
+
   it("does not flag an independently built configured UI root", () => {
     const gatewayClient = client(async () => []);
     const harness = createGatewayHarness(null, false);
@@ -507,6 +522,26 @@ describe("application approval overlays", () => {
       "Approval failed: gateway unavailable",
     );
     expect(overlays.snapshot.approvalBusy).toBe(false);
+    overlays.dispose();
+  });
+
+  it("surfaces a connection error when a rendered approval races a disconnect", async () => {
+    const request = vi.fn<RequestFn>((method) =>
+      Promise.resolve(method.endsWith(".list") ? [] : { ok: true }),
+    );
+    const harness = createGatewayHarness(client(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+    harness.emitApproval("approval-disconnected", 1_000);
+
+    // The rendered modal can dispatch its click before Lit consumes the
+    // Gateway snapshot notification that removes the stale card.
+    harness.replaceSnapshotWithoutPublishing({ phase: "reconnecting" });
+    await overlays.decideApproval("allow-once", "approval-disconnected");
+
+    expect(overlays.snapshot.approvalErrors.get("approval-disconnected")).toBe(
+      "Connect to the Gateway to change sessions.",
+    );
+    expect(request).not.toHaveBeenCalledWith("exec.approval.resolve", expect.anything());
     overlays.dispose();
   });
 

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -291,7 +291,9 @@ export function createApplicationOverlays(
         updateRunning: false,
       };
       updateCampaignPoller.stop();
-      if (!next.client) {
+      if (next.phase === "reload-required") {
+        snapshot = { ...snapshot, controlUiRefreshRequired: true };
+      } else if (!next.client) {
         connectedEpoch = 0;
         snapshot = { ...snapshot, controlUiRefreshRequired: false };
       } else if (next.hello) {
@@ -561,14 +563,15 @@ export function createApplicationOverlays(
         ? promptState.execApprovalQueue.find((entry) => entry.id === approvalId)
         : promptState.execApprovalQueue[0];
       const client = gateway.snapshot.client;
-      if (
-        !active ||
-        !client ||
-        promptState.execApprovalBusy ||
-        disposed ||
-        gateway.snapshot.phase !== "connected" ||
-        !readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals
-      ) {
+      if (!active || promptState.execApprovalBusy || disposed) {
+        return;
+      }
+      if (!client || gateway.snapshot.phase !== "connected") {
+        promptState.execApprovalErrors.set(active.id, t("sessionsView.actionRequiresConnection"));
+        publish();
+        return;
+      }
+      if (!readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals) {
         return;
       }
       promptState.execApprovalBusy = true;

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -209,6 +209,7 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
         return html`<button
           class=${decisionClass(decision)}
           type="button"
+          aria-label=${label}
           ?disabled=${props.busy}
           title=${props.variant === "modal" ? `${label} (${decisionShortcut(decision)})` : label}
           @click=${() => props.onDecision(active.id, decision)}

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -114,6 +114,21 @@ describe("openclaw-exec-approval", () => {
     );
   });
 
+  it("exposes labelled, focusable decision buttons", async () => {
+    await renderApproval(createExecRequest());
+    await getRenderedModalDialog(container);
+
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".exec-approval-actions button"),
+    );
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Allow once",
+      "Always allow",
+      "Deny",
+    ]);
+    expect(buttons.every((button) => button.tabIndex === 0)).toBe(true);
+  });
+
   it("does not show exec unavailable copy for restricted plugin approvals", async () => {
     await renderOpenedApproval(
       createExecRequest({

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -115,7 +115,7 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("exposes labelled, focusable decision buttons", async () => {
-    await renderApproval(createExecRequest());
+    await renderOpenedApproval(createExecRequest());
     await getRenderedModalDialog(container);
 
     const buttons = Array.from(

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -52,6 +52,8 @@ describe("openclaw-modal-dialog", () => {
 
     expect(dialog.open).toBe(true);
     expect(dialog.localName).toBe("dialog");
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
     expect(dialog.getAttribute("aria-label")).toBe("Confirm action");
     expect(dialog.getAttribute("aria-description")).toBe("Review the operation before continuing.");
     expect(dialog.getRootNode()).toBe(webAwesomeDialog.shadowRoot);

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -204,6 +204,8 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     if (!dialog) {
       return;
     }
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
     if (this.label) {
       dialog.setAttribute("aria-label", this.label);
     } else {

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -59,6 +59,13 @@ suite.define(() => {
       approval("approval-active", "echo active", 1_000),
     );
     await currentPage.getByText("echo active", { exact: true }).waitFor();
+    await currentPage.getByRole("dialog", { name: "Exec approval needed" }).waitFor();
+    await currentPage.getByRole("button", { name: "Allow once" }).focus();
+    expect(
+      await currentPage
+        .getByRole("button", { name: "Allow once" })
+        .evaluate((button) => button === document.activeElement),
+    ).toBe(true);
     await currentPage.getByRole("button", { name: "Allow once" }).click();
 
     await gateway.emitGatewayEvent(

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -59,7 +59,6 @@ suite.define(() => {
       approval("approval-active", "echo active", 1_000),
     );
     await currentPage.getByText("echo active", { exact: true }).waitFor();
-    await currentPage.getByRole("dialog", { name: "Exec approval needed" }).waitFor();
     await currentPage.getByRole("button", { name: "Allow once" }).focus();
     expect(
       await currentPage
@@ -87,6 +86,7 @@ suite.define(() => {
       .toBe("Approval failed: gateway unavailable");
 
     await approvalAttentionChip(currentPage).click();
+    await currentPage.getByRole("dialog", { name: "Exec approval needed" }).waitFor();
     const approvalModal = await waitForConfirmModal(currentPage);
     await approvalModal.getByText("echo newer", { exact: true }).click();
     await expect

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,4 +1,6 @@
 // Control UI tests cover the responsive disconnected login gate.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
@@ -11,6 +13,7 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
+const RECOVERY_ARTIFACT_DIR = path.resolve(".artifacts/control-ui-e2e/zombie-reload");
 
 async function renderLoginGate(page: Page): Promise<void> {
   const response = await page.goto(suite.server.baseUrl);
@@ -86,7 +89,7 @@ suite.define(() => {
       code: "UNAVAILABLE",
       message: "Control UI updated; reload this page to continue",
       details: {
-        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
         gatewayBuildId: "replacement-build",
         reloadRequired: true,
       },
@@ -128,7 +131,7 @@ suite.define(() => {
       code: "UNAVAILABLE",
       message: "Control UI updated; reload this page to continue",
       details: {
-        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
         gatewayBuildId: "replacement-build",
         reloadRequired: true,
       },
@@ -148,12 +151,8 @@ suite.define(() => {
 
       await gateway.waitForRequest("connect");
       await gateway.rejectDeferred("connect", mismatch);
-      const failure = page.locator('.login-gate__failure[data-kind="build-mismatch"]');
-      await failure.waitFor({ timeout: 10_000 });
-      expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(
-        "Server updated",
-      );
-      expect(await failure.locator(".login-gate__failure-refresh").isVisible()).toBe(true);
+      await page.getByRole("button", { name: /Server updated/u }).waitFor({ timeout: 10_000 });
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
       expect(
         await page.evaluate(() =>
@@ -165,7 +164,7 @@ suite.define(() => {
     }
   });
 
-  it("shows a protocol mismatch without reconnecting", async () => {
+  it("shows a terminal protocol mismatch as reload-required without reconnecting", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     await page.clock.install();
@@ -180,14 +179,74 @@ suite.define(() => {
         details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
       });
 
-      const failure = page.locator(".login-gate__failure-summary");
-      await failure.waitFor({ timeout: 10_000 });
-      expect((await failure.textContent())?.toLowerCase()).toContain(
-        "supported connection protocol",
-      );
-      expect(await page.locator(".login-gate__failure-refresh").isVisible()).toBe(true);
+      const refresh = page.getByRole("button", { name: /Server updated/u });
+      await refresh.waitFor({ timeout: 10_000 });
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+      expect(await page.locator("openclaw-app-shell").count()).toBe(1);
+      expect(await page.locator("openclaw-router-outlet").getAttribute("inert")).not.toBeNull();
+      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
+      await page.screenshot({
+        path: path.join(RECOVERY_ARTIFACT_DIR, "01-reload-required.png"),
+        fullPage: true,
+      });
       await page.clock.runFor(1_600);
       expect(await gateway.getRequests("connect")).toHaveLength(1);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("lets reload-required recovery outrank a manually pinned login gate", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    try {
+      await page.goto(suite.server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", {
+        code: "INVALID_REQUEST",
+        message: "token missing",
+        details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+      });
+      await page.locator('.login-gate__failure[data-kind="auth-required"]').waitFor();
+
+      await gateway.deferNext("connect");
+      await page.getByRole("button", { name: "Connect" }).click();
+      await expect.poll(async () => (await gateway.getRequests("connect")).length).toBe(2);
+      await gateway.rejectDeferred("connect", {
+        code: "INVALID_REQUEST",
+        message: "protocol mismatch: Control UI updated; reload this page to continue",
+        details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+      });
+
+      await page.getByRole("button", { name: /Server updated/u }).waitFor();
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("blocks non-chat page actions visibly while reconnecting", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(new URL("settings/connection", suite.server.baseUrl).href);
+      await page.locator("openclaw-app-shell").waitFor();
+      await gateway.deferNext("connect");
+      await gateway.closeLatest(1012, "test reconnect");
+
+      await page.getByText("Actions are unavailable while the Gateway reconnects.").waitFor();
+      const outlet = page.locator("openclaw-router-outlet");
+      expect(await outlet.getAttribute("inert")).not.toBeNull();
+      expect(await outlet.getAttribute("aria-disabled")).toBe("true");
+      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
+      await page.screenshot({
+        path: path.join(RECOVERY_ARTIFACT_DIR, "02-reconnecting-actions-blocked.png"),
+        fullPage: true,
+      });
     } finally {
       await closeContext(context);
     }

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -153,6 +153,12 @@ suite.define(() => {
       await gateway.rejectDeferred("connect", mismatch);
       await page.getByRole("button", { name: /Server updated/u }).waitFor({ timeout: 10_000 });
       expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+      expect(await page.locator("openclaw-router-outlet").getAttribute("inert")).not.toBeNull();
+      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
+      await page.screenshot({
+        path: path.join(RECOVERY_ARTIFACT_DIR, "01-reload-required.png"),
+        fullPage: true,
+      });
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
       expect(
         await page.evaluate(() =>
@@ -164,7 +170,7 @@ suite.define(() => {
     }
   });
 
-  it("shows a terminal protocol mismatch as reload-required without reconnecting", async () => {
+  it("shows a bare protocol mismatch as compatibility guidance without reconnecting", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     await page.clock.install();
@@ -179,16 +185,12 @@ suite.define(() => {
         details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
       });
 
-      const refresh = page.getByRole("button", { name: /Server updated/u });
-      await refresh.waitFor({ timeout: 10_000 });
-      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
-      expect(await page.locator("openclaw-app-shell").count()).toBe(1);
-      expect(await page.locator("openclaw-router-outlet").getAttribute("inert")).not.toBeNull();
-      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
-      await page.screenshot({
-        path: path.join(RECOVERY_ARTIFACT_DIR, "01-reload-required.png"),
-        fullPage: true,
-      });
+      const failure = page.locator('.login-gate__failure[data-kind="protocol-mismatch"]');
+      await failure.waitFor({ timeout: 10_000 });
+      expect((await failure.textContent())?.toLowerCase()).toContain(
+        "supported connection protocol",
+      );
+      expect(await failure.locator(".login-gate__failure-refresh").isVisible()).toBe(true);
       await page.clock.runFor(1_600);
       expect(await gateway.getRequests("connect")).toHaveLength(1);
     } finally {
@@ -199,6 +201,9 @@ suite.define(() => {
   it("lets reload-required recovery outrank a manually pinned login gate", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
+    await page.addInitScript(() => {
+      sessionStorage.setItem("openclaw.controlUi.staleChunkReloadBuildId", "replacement-build");
+    });
     const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
 
     try {
@@ -215,11 +220,26 @@ suite.define(() => {
       await page.getByRole("button", { name: "Connect" }).click();
       await expect.poll(async () => (await gateway.getRequests("connect")).length).toBe(2);
       await gateway.rejectDeferred("connect", {
-        code: "INVALID_REQUEST",
+        code: "UNAVAILABLE",
         message: "protocol mismatch: Control UI updated; reload this page to continue",
-        details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+        details: {
+          code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+          gatewayBuildId: "replacement-build",
+          reloadRequired: true,
+        },
+        retryable: false,
       });
 
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+            };
+            return app.runtime?.context.gateway.snapshot.phase;
+          }),
+        )
+        .toBe("reload-required");
       await page.getByRole("button", { name: /Server updated/u }).waitFor();
       expect(await page.locator("openclaw-login-gate").count()).toBe(0);
     } finally {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3750,6 +3750,7 @@ export const en: TranslationMap = {
     queuedCount: "{count} queued",
     reconnecting: "Reconnecting…",
     retryNow: "Retry now",
+    actionsUnavailable: "Actions are unavailable while the Gateway reconnects.",
     scopeUpgrade: {
       limited: "This browser has limited access.",
       guidance:

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -25,7 +25,7 @@ hashes.sha512Async = async (message: Uint8Array) => {
   if (globalThis.crypto?.subtle && subtleSha512Async) {
     return await subtleSha512Async(message);
   }
-  return (await loadPureSha2()).sha512(message);
+  return Uint8Array.from((await loadPureSha2()).sha512(message));
 };
 
 type GatewayRequestClient = {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3867,6 +3867,15 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   margin-top: 8px;
 }
 
+.connection-action-block {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--secondary);
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .content--chat {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an open Control UI became a zombie after the Gateway restarted with a newer build. The Gateway rejected every reconnect with WebSocket close 4008 and logged `control ui build rejected … reload required`, but the page stayed fully interactive with no blocking or recovery surface. Typed submits went nowhere, and an approval modal rendered but could not be resolved by click, Enter, or Space before expiring inert after 120 seconds.

The dead recovery path had two disconnected contracts: the Gateway emitted `PROTOCOL_MISMATCH`, while the Control UI reload reader required `CONTROL_UI_BUILD_MISMATCH` plus `reloadRequired` metadata that no producer emitted. The only other automatic recovery waited for a hello frame, but stale-build admission rejects the client before hello. Separately, disconnected approval decisions silently returned without a visible outcome.

## Why This Change Was Made

The Gateway's existing stale-build admission owner now adds the target build ID and `reloadRequired: true` to its additive, open-ended error details. The application Gateway store recognizes only that validated producer contract as a terminal `reload-required` phase, and the shell owns the refresh surface even when the login gate had been manually pinned. Bare `PROTOCOL_MISMATCH` negotiation failures keep their existing compatibility guidance. The reader retains the shipped `CONTROL_UI_BUILD_MISMATCH` code for compatibility while accepting the metadata-bearing live `PROTOCOL_MISMATCH` producer.

During ordinary reconnects, chat remains interactive because it has an intentional offline outbox. New Session also keeps its local draft editor available while its server-backed Start action remains disabled, and Appearance preserves browser-local preference intent for replay. Other pages expose a visible reconnecting explanation and make their action surface inert, so an action cannot silently disappear. Approval decisions that race a disconnect now show a connection error instead of returning invisibly.

Dialogs now expose `role="dialog"` and `aria-modal="true"`, and approval decision buttons have explicit accessible labels. In the live failure, the approval modal exposed only “Dismiss” to the accessibility tree with `dialogCount=0`; that missing semantic surface is why keyboard activation could not reach the decision controls.

No protocol version bump is needed: the details object is additive/open-ended, this change establishes one canonical producer contract, and the reader keeps the shipped mismatch code for compatibility.

## User Impact

After a Gateway update, stale Control UI tabs now clearly say **Server updated — Refresh for full capabilities** instead of looking connected. While an ordinary reconnect is in progress, server-backed non-chat actions are visibly unavailable; chat can still queue messages offline, New Session can preserve a local draft, and Appearance can preserve local preferences until reconnect. Approval dialogs and their decision controls are discoverable to assistive technology and keyboard users.

## Evidence

### Before

The before-state is the absence of any recovery or blocking surface, so there was no useful UI element to capture. In the verified live reproduction, the page looped rejected WebSocket reconnects while remaining fully interactive; submits disappeared, and the approval modal could neither resolve nor expose its decision controls to the accessibility tree. The pre-fix Chromium E2E reproduced this by timing out while waiting for **Server updated**.

### After: stale build recovery

![Control UI showing Server updated and Refresh for full capabilities](https://github.com/user-attachments/assets/03339fb6-19ca-4c93-afb8-069025b084fe)

### After: ordinary reconnect action fencing

![Control UI showing Actions are unavailable while the Gateway reconnects](https://github.com/user-attachments/assets/4d2a27cd-3a08-4125-916b-0a30ae0cf4d3)

### Automated proof

- Focused protocol, Gateway admission, application lifecycle, overlay, approval, login, dialog, and device-identity suites: 314 passing after the final correction.
- Chromium Control UI E2E: the requested reload/approval pair passed 14/14 on current `main`; the final isolated owner runs passed 34/34 after adding reconnect-draft, offline-preference, and offline-locale cases.
- `node scripts/check-changed.mjs`: passed all selected core, core-test, and UI lanes. No remote provider passed readiness, so the script used its documented trusted-source local fallback.
- Exact extension package-boundary compile: all 123 plugins passed, including Codex.
- Fresh autoreview on the final rebased diff: clean, no accepted/actionable findings.
- Source-blind behavior validation: reload-required surface visible; reconnect actions without an offline owner visibly blocked; chat offline outbox remains exempt; approval dialog and decision button are accessible by role/name and focus.
- Exact-head CI run `31967280698` caught that the first whole-route reconnect fence also disabled New Session's local draft textarea. The follow-up narrows the exception to that local editor while its server-backed Start action remains disabled; the exact failing E2E now passes 13/13.
- Exact-head CI run `31967819678` caught the same distinction for Appearance's durable browser-local preference queue. Appearance now preserves its tested local intent and replay contract while server writes remain independently gated; the affected preference and locale E2E tests pass 7/7.
- Exact-head CI run `31968460920` exposed a stale/current-main merge-tree failure in the Codex package-boundary compile. Rebasing onto current `main` made all 123 package-boundary compiles pass. The rebase also exposed current-main's stricter typed-array test contract; the lazy SHA-512 fallback now returns owned digest bytes, with 51 node/device tests and the full test-type lane green. The same bounded digest fix also exists in #124784, but that broader PR is held for an unrelated skill-command product decision.
- ClawSweeper's P1 and both Rank-up moves are applied: `reload-required` now derives only from validated stale-build metadata, while focused store and browser regressions preserve ordinary bare-protocol guidance.

The Codex protocol audit confirmed that error payloads have optional, open-ended data in `codex-rs/app-server-protocol/src/rpc.rs:76`, while error codes remain stable numeric identifiers in `codex-rs/app-server/src/error_code.rs:1`. This additive details change does not require a protocol-version bump.

Production LOC: +68/-22 (net +46) | Tests: +216/-15

AI-assisted: yes. The final diff was independently reviewed and the observable browser behavior was validated separately.
