### PR TITLE
fix(browser): support Chrome Web Store native bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Chrome Web Store native bootstrap:** pre-register the exact official Store origin alongside deterministic unpacked IDs, detect Store installs without granting path ownership, and migrate only inspect-proven owned registrations.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Chrome Web Store native bootstrap:** pre-register the exact official Store origin alongside deterministic unpacked IDs, detect Store installs without granting path ownership, and migrate only inspect-proven owned registrations.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -150,16 +150,13 @@ openclaw browser extension cdp
 openclaw browser extension cdp --json
 ```
 
-- `extension install` copies the bundled runtime into a stable state-directory
-  path and pre-registers its deterministic, origin-locked native bootstrap host
-  in existing Chrome-family user-data roots. Launch Chrome, run this command,
-  and use **Load unpacked** only after it prints the stable path. The command
-  waits while Chrome records that exact path, then verifies the recorded ID
-  against Chromium's path-derived ID. **Load unpacked** is the only manual
-  action in normal setup.
-- `extension status` reports the installed copy, detected IDs/profiles,
-  owned-registration health, and whether manual setup is required. JSON output
-  never includes a pairing string or relay key.
+- `extension install` pre-registers the origin-locked native bootstrap host in
+  existing Chrome-family user-data roots. Run it first, then
+  [add OpenClaw from the Chrome Web Store](https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig).
+  The stable **Load unpacked** path remains available as a development fallback.
+- `extension status` reports Store discovery separately from approved unpacked
+  IDs and paths, plus owned-registration health and whether manual setup is
+  required. JSON output never includes a pairing string or relay key.
 - `extension uninstall-host` removes only verified OpenClaw-owned native-host
   manifests and launchers. It does not remove the extension from Chrome.
 - `extension path` is read-only. It prints the stable installed copy when
@@ -194,8 +191,8 @@ Setup, security model, and recovery steps: [Chrome extension](/tools/chrome-exte
 
 If the extension already attempted automatic setup before the native host
 existed, Chromium retains that miss for the running browser process. Restart
-Chrome once, then repeat the ordered install flow; popup retries alone cannot
-recover that existing process.
+Chrome once, run `extension install`, then reopen the Store extension; popup
+retries alone cannot recover that existing process.
 
 ## Tabs
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -366,8 +366,10 @@ That stages grounded durable candidates into the short-term dreaming store while
     When a stable Chrome extension copy and owned native-host registration already
     exist, doctor reports registration drift. `openclaw doctor --fix` may repair
     that owned registration, but it never installs the host for every OpenClaw
-    user and never overwrites a foreign same-name manifest or launcher. Use
-    `openclaw browser extension install` for the initial setup.
+    user and never overwrites a foreign same-name manifest or launcher. For
+    initial setup, run `openclaw browser extension install` first, then add the
+    official Chrome Web Store extension. The unpacked stable path is a
+    development fallback.
 
     Doctor also audits the host-local Chrome MCP path when you use `defaultProfile: "user"` or a configured `existing-session` profile:
 

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -272,6 +272,10 @@ plus deterministic development origins in canonical order. The Store identity
 is a fixed product trust grant, not proof that an arbitrary path is
 OpenClaw-owned.
 
+Install the official Chrome Web Store build for normal use. Only load unpacked
+development copies you trust: Chrome can give a key-matched unpacked build the
+same extension identity and native-host access.
+
 The unpacked development ID calculation matches Chromium's
 `crx_file::id_util::GenerateIdForPath`: hash the canonical absolute path's raw
 bytes with SHA-256 (native UTF-16LE path bytes on Windows, with only a lowercase

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -32,33 +32,38 @@ a script launcher or registry key without a proven binary framing path.
 
 ## Install
 
-Launch Chrome, then run this command before loading the extension:
+Launch Chrome, then pre-register the native host before adding the extension:
 
 ```bash
 openclaw browser extension install
 ```
 
-Keep the command running. It copies the bundled extension to a stable
-OpenClaw-owned directory, predicts the unpacked extension ID from that exact
-path, and pre-registers an origin-locked native host in existing Chrome-family
-user-data roots. Only after pre-registration succeeds does it print the stable
-path to load.
+Keep the command running. It pre-registers an origin-locked native host for the
+exact official Chrome Web Store identity and for OpenClaw's deterministic
+development IDs. After pre-registration succeeds, add
+[OpenClaw from the Chrome Web Store](https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig).
 
-Chrome does not let a normal CLI silently install an unpacked extension. This
-one step is unavoidable:
+The extension pairs on its first native call; you do not need to open its
+popup, reload it, or restart Chrome during a normal first-time setup. The
+installer then reads the profile's `Secure Preferences` and verifies the exact
+Store ID independently from any extension path.
+
+For extension development, the command also copies the bundled extension to a
+stable OpenClaw-owned directory. Use that unpacked copy only as a development
+fallback:
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode**.
 3. Click **Load unpacked**.
 4. Select the path printed by the command.
 
-Leave the install command running while you complete those steps. The extension
-pairs on its first native call; you do not need to open its popup, reload the
-extension, or restart Chrome during a normal first-time setup. The installer
-then reads the profile's `Secure Preferences` and verifies that Chrome loaded
-the approved realpath under the predicted ID.
+Leave the install command running while completing either Store or development
+setup. For unpacked development, the installer verifies that Chrome loaded the
+approved realpath under its predicted deterministic ID.
 
-The installer accepts an ID only when all of these are true:
+The installer recognizes the official Store installation only by the exact
+Foundation Store ID. That identity never makes a recorded path OpenClaw-owned.
+For unpacked development, it accepts an ID only when all of these are true:
 
 - the ID matches Chrome's 32-character extension ID format;
 - Chrome records the install location as unpacked;
@@ -76,9 +81,10 @@ Use a different bounded wait when needed:
 openclaw browser extension install --wait-ms 60000
 ```
 
-For automation, use `--json`. The result includes the stable copy, discovered
-IDs and profiles, native-host registration health, and whether manual setup is
-required. It never includes a relay key or pairing string.
+For automation, use `--json`. The result reports Store discovery separately
+from approved unpacked IDs and paths, plus native-host registration health and
+whether manual setup is required. It never includes a relay key or pairing
+string.
 
 ## Use it
 
@@ -177,8 +183,8 @@ Remove only OpenClaw-owned native-host manifests and launchers:
 openclaw browser extension uninstall-host
 ```
 
-This does not remove the unpacked extension from Chrome. Use
-`chrome://extensions` for that. It also does not delete the stable extension
+This does not remove the Store or unpacked extension from Chrome. Use
+`chrome://extensions` for that. It also does not delete the stable development
 copy or an existing relay key.
 
 `openclaw browser extension path` is read-only. It prints the stable installed
@@ -261,12 +267,17 @@ OpenClaw-owned mode-`0700` directory. Manifests are mode `0600`; the launcher is
 owner-executable. Symlinks, foreign ownership, unsafe modes, path traversal,
 wildcard origins, and foreign same-name registrations fail closed.
 
-The unpacked ID calculation matches Chromium's
+The managed manifest authorizes the exact Foundation Chrome Web Store origin
+plus deterministic development origins in canonical order. The Store identity
+is a fixed product trust grant, not proof that an arbitrary path is
+OpenClaw-owned.
+
+The unpacked development ID calculation matches Chromium's
 `crx_file::id_util::GenerateIdForPath`: hash the canonical absolute path's raw
 bytes with SHA-256 (native UTF-16LE path bytes on Windows, with only a lowercase
 drive letter uppercased), keep the first 16 digest bytes, then map hexadecimal
-digits `0` through `f` to letters `a` through `p`. The extension manifest has no
-`key`; registration authorizes only exact IDs derived from approved
+digits `0` through `f` to letters `a` through `p`. The unpacked extension
+manifest has no `key`; only these development IDs depend on approved
 OpenClaw-owned realpaths.
 
 The relay itself uses connection-bound HMAC proofs. The persistent per-host key
@@ -281,8 +292,8 @@ openclaw doctor
 ```
 
 - **No extension ID detected:** keep Chrome running, rerun `extension install`,
-  and use **Load unpacked** only after the command says native bootstrap is
-  ready and prints the stable path.
+  then add the official Store extension. Use **Load unpacked** only as a
+  development fallback after the command says native bootstrap is ready.
 - **Extension was loaded before native setup:** restart Chrome once to clear its
   cached native-host miss, then rerun the ordered install flow.
 - **Waiting for local OpenClaw:** run `extension status`; install or repair the

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -166,7 +166,8 @@ Chromium caches the first missing-native-host result for the running browser
 process. If an existing extension already attempted automatic setup before the
 native host was installed, restart Chrome once (a full browser-process reload).
 Retrying from the popup or Settings cannot clear that process-level miss.
-Normal setup avoids it by pre-registering the host before **Load unpacked**.
+Normal setup avoids it by pre-registering the host before adding or reopening
+the Store extension. For development, pre-register before **Load unpacked**.
 
 ## Status and removal
 

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -26,6 +26,7 @@ const runE2E =
   process.env.OPENCLAW_BROWSER_EXTENSION_E2E === "1" &&
   (process.platform === "linux" || process.platform === "darwin");
 const cleanups: Array<() => Promise<void>> = [];
+const STORE_ORIGIN = "chrome-extension://kcdjddhmeafeomebliikmbpblkmkfoig/";
 
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).toReversed()) {
@@ -249,6 +250,8 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         ]
           .toSorted()
           .map((id) => `chrome-extension://${id}/`);
+        expectedOrigins.push(STORE_ORIGIN);
+        expectedOrigins.sort();
         const relevantManifestPaths = chromeProductRoots(deps)
           .filter((productRoot) => productRoot.userDataDir === userDataDir)
           .map((productRoot) =>
@@ -392,6 +395,19 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         ) {
           throw new Error("native host did not use the custom installation context");
         }
+        const storeHostProbe = spawnSync(manifest.path, [STORE_ORIGIN], {
+          input: requestFrame,
+          env: browserEnv,
+          timeout: 30_000,
+        });
+        expect(
+          storeHostProbe.status,
+          `Store native host exit=${storeHostProbe.status} signal=${storeHostProbe.signal} stderr=${storeHostProbe.stderr.toString("utf8")}`,
+        ).toBe(0);
+        expect(decodeSingleNativeResponse(storeHostProbe.stdout)).toMatchObject({
+          ok: true,
+          nonce: "BwcHBwcHBwcHBwcHBwcHBw",
+        });
         process.stderr.write("[browser-extension-e2e] launcher probe passed\n");
 
         await expect

--- a/extensions/browser/src/browser/extension-install-layout.ts
+++ b/extensions/browser/src/browser/extension-install-layout.ts
@@ -26,6 +26,7 @@ export type DiscoveredChromeExtension = {
   extensionId: string;
   extensionPath: string;
 };
+export type DiscoveredChromeStoreExtension = Omit<DiscoveredChromeExtension, "extensionPath">;
 export type ExtensionInstallDeps = {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
@@ -310,12 +311,14 @@ async function approvedRealpaths(paths: readonly string[]): Promise<string[]> {
   return [...new Set(resolved.filter((value): value is string => value !== null))];
 }
 
-/** Discover unpacked OpenClaw IDs from exact Secure Preferences path records. */
+/** Discover exact Store identity separately from approved unpacked path records. */
 export async function discoverChromeExtensionIds(params: {
   approvedDirs: readonly string[];
+  storeExtensionId?: string;
   deps?: ExtensionInstallDeps;
 }): Promise<{
   discovered: DiscoveredChromeExtension[];
+  storeDiscovered: DiscoveredChromeStoreExtension[];
   issues: string[];
   identityMismatches: string[];
 }> {
@@ -325,6 +328,7 @@ export async function discoverChromeExtensionIds(params: {
     (await approvedRealpaths(params.approvedDirs)).map((value) => comparablePath(value, platform)),
   );
   const discovered: DiscoveredChromeExtension[] = [];
+  const storeDiscovered: DiscoveredChromeStoreExtension[] = [];
   const issues: string[] = [];
   const identityMismatches: string[] = [];
   for (const root of chromeProductRoots(deps)) {
@@ -374,7 +378,26 @@ export async function discoverChromeExtensionIds(params: {
           ) {
             continue;
           }
-          const entry = rawEntry as { location?: unknown; path?: unknown };
+          const entry = rawEntry as {
+            from_webstore?: unknown;
+            location?: unknown;
+            path?: unknown;
+          };
+          if (
+            extensionId === params.storeExtensionId &&
+            entry.from_webstore === true &&
+            entry.location !== UNPACKED_MANIFEST_LOCATION
+          ) {
+            storeDiscovered.push({
+              product: root.product,
+              browser: root.label,
+              userDataDir: root.userDataDir,
+              profile: profileEntry.name,
+              securePreferencesPath,
+              extensionId,
+            });
+            continue;
+          }
           if (entry.location !== UNPACKED_MANIFEST_LOCATION || typeof entry.path !== "string") {
             continue;
           }
@@ -415,8 +438,19 @@ export async function discoverChromeExtensionIds(params: {
       entry,
     ]),
   );
+  const uniqueStore = new Map(
+    storeDiscovered.map((entry) => [
+      `${entry.product}\0${entry.profile}\0${entry.extensionId}`,
+      entry,
+    ]),
+  );
   return {
     discovered: [...unique.values()].toSorted((a, b) =>
+      `${a.product}/${a.profile}/${a.extensionId}`.localeCompare(
+        `${b.product}/${b.profile}/${b.extensionId}`,
+      ),
+    ),
+    storeDiscovered: [...uniqueStore.values()].toSorted((a, b) =>
       `${a.product}/${a.profile}/${a.extensionId}`.localeCompare(
         `${b.product}/${b.profile}/${b.extensionId}`,
       ),

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./extension-install.js";
 
 const ID_A = "abcdefghijklmnopabcdefghijklmnop";
+const FOUNDATION_STORE_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
 // Changed-file CI runs source tests without dist; full-build lanes exercise the real native host.
 const BUILT_NATIVE_HOST_PATH = path.resolve("dist/extensions/browser/native-host-entry.js");
 const tempRoots: string[] = [];
@@ -82,6 +83,29 @@ async function writeSecurePreferences(params: {
     mode: 0o600,
   });
   return file;
+}
+
+async function rewriteRegistrationOrigins(manifestPath: string, origins: string[]) {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
+    path: string;
+    allowed_origins: string[];
+  };
+  const launcher = await fs.readFile(manifest.path, "utf8");
+  const replacement = origins.map((origin) => ` '--expected-origin' '${origin}'`).join("");
+  const nextLauncher = launcher.replace(
+    /(?: '--expected-origin' 'chrome-extension:\/\/[a-p]{32}\/')+ "\$@"/u,
+    `${replacement} "$@"`,
+  );
+  if (nextLauncher === launcher) {
+    throw new Error("launcher origins were not replaced");
+  }
+  await fs.writeFile(manifest.path, nextLauncher, { mode: 0o700 });
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify({ ...manifest, allowed_origins: origins })}\n`,
+    { mode: 0o600 },
+  );
+  return manifest;
 }
 
 afterEach(async () => {
@@ -296,6 +320,11 @@ describe("Secure Preferences discovery", () => {
       profile: "Default",
       entries: {
         [installedId]: { location: 4, path: installed, manifest: { name: "Not OpenClaw" } },
+        [FOUNDATION_STORE_ID]: {
+          location: 1,
+          from_webstore: true,
+          path: path.join(value.root, "foreign-store-lookalike"),
+        },
         ["p".repeat(32)]: { location: 1, path: installed, manifest: { name: "OpenClaw" } },
       },
     });
@@ -304,12 +333,14 @@ describe("Secure Preferences discovery", () => {
       profile: "Profile 1",
       entries: {
         [bundledId]: { location: 4, path: value.bundledDir },
+        [FOUNDATION_STORE_ID]: { location: 1, from_webstore: false },
         ["o".repeat(32)]: { location: 4, path: path.join(value.root, "lookalike") },
       },
     });
 
     const result = await discoverChromeExtensionIds({
       approvedDirs: [installed, value.bundledDir],
+      storeExtensionId: FOUNDATION_STORE_ID,
       deps: value.deps,
     });
 
@@ -322,6 +353,13 @@ describe("Secure Preferences discovery", () => {
         generateChromeExtensionIdForPath(entry.extensionPath, value.deps.platform),
       );
     }
+    expect(result.storeDiscovered).toEqual([
+      expect.objectContaining({
+        profile: "Default",
+        extensionId: FOUNDATION_STORE_ID,
+      }),
+    ]);
+    expect(result.discovered.map((entry) => entry.extensionId)).not.toContain(FOUNDATION_STORE_ID);
   });
 
   it("rejects a recorded ID that does not match the canonical approved path", async () => {
@@ -533,7 +571,9 @@ describe("native host registration", () => {
               allowed_origins: string[];
             };
             expect(preRegistration.allowed_origins).toEqual(
-              [installedId, bundledId].toSorted().map((id) => `chrome-extension://${id}/`),
+              [installedId, bundledId, FOUNDATION_STORE_ID]
+                .toSorted()
+                .map((id) => `chrome-extension://${id}/`),
             );
             wroteProfile = true;
             await writeSecurePreferences({
@@ -552,10 +592,11 @@ describe("native host registration", () => {
     const registration = status.registrations.find((entry) => entry.product === "chromium");
     expect(registration).toMatchObject({
       state: "owned",
-      extensionIds: [installedId, bundledId].toSorted(),
+      extensionIds: [installedId, bundledId, FOUNDATION_STORE_ID].toSorted(),
     });
     const manifest = await fs.readFile(registration?.manifestPath ?? "", "utf8");
     expect(manifest).toContain(`chrome-extension://${installedId}/`);
+    expect(manifest).toContain(`chrome-extension://${FOUNDATION_STORE_ID}/`);
     expect(manifest).not.toMatch(/[0-9a-f]{64}/u);
     expect(JSON.stringify(status)).not.toMatch(/pairingString|token|Bearer/u);
     if (process.platform !== "win32") {
@@ -563,7 +604,7 @@ describe("native host registration", () => {
       const launcherPath = (JSON.parse(manifest) as { path: string }).path;
       expect((await fs.stat(launcherPath)).mode & 0o777).toBe(0o700);
       const launcher = await fs.readFile(launcherPath, "utf8");
-      const expectedOrigins = [installedId, bundledId]
+      const expectedOrigins = [installedId, bundledId, FOUNDATION_STORE_ID]
         .toSorted()
         .map((id) => `chrome-extension://${id}/`);
       expect(launcher.match(/chrome-extension:\/\/[a-p]{32}\//gu)?.toSorted()).toEqual(
@@ -571,6 +612,40 @@ describe("native host registration", () => {
       );
       expect(launcher).not.toMatch(/pairingString|Bearer|#[A-Za-z0-9_-]{20}/u);
     }
+  });
+
+  it("treats the exact Store record as installed without approving its recorded path", async () => {
+    const value = await fixture();
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    const arbitraryPath = path.join(value.root, "not-an-owned-extension-path");
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: {
+        [FOUNDATION_STORE_ID]: {
+          location: 1,
+          from_webstore: true,
+          path: arbitraryPath,
+        },
+      },
+    });
+
+    const status = await installChromeExtensionBootstrap({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      waitMs: 1_000,
+      deps: value.deps,
+    });
+
+    expect(status.discovered).toEqual([]);
+    expect(status.storeDiscovered).toEqual([
+      expect.objectContaining({ extensionId: FOUNDATION_STORE_ID, profile: "Default" }),
+    ]);
+    expect(status.approvedPaths).not.toContain(arbitraryPath);
+    expect(status.manualSetupRequired).toBe(false);
   });
 
   it("refuses to overwrite or remove a foreign manifest with the same host name", async () => {
@@ -678,13 +753,9 @@ describe("native host registration", () => {
       allowed_origins: string[];
     };
     const extraOrigin = `chrome-extension://${"p".repeat(32)}/`;
-    await fs.writeFile(
+    await rewriteRegistrationOrigins(
       manifestPath,
-      `${JSON.stringify({
-        ...manifest,
-        allowed_origins: [...manifest.allowed_origins, extraOrigin].toSorted(),
-      })}\n`,
-      { mode: 0o600 },
+      [...manifest.allowed_origins, extraOrigin].toSorted(),
     );
 
     status = await browserExtensionStatus({ bundledDir: value.bundledDir, deps: value.deps });
@@ -708,6 +779,49 @@ describe("native host registration", () => {
     const removal = await uninstallChromeExtensionNativeHosts({ deps: value.deps });
     expect(removal.refused).toEqual([]);
     expect(removal.removed).toHaveLength(2);
+  });
+
+  it("refuses malformed and unsafe owned launchers", async () => {
+    const mutations =
+      process.platform === "win32"
+        ? (["malformed"] as const)
+        : (["malformed", "unsafe-mode"] as const);
+    for (const mutation of mutations) {
+      const value = await fixture();
+      const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+      const installedId = await predictedId(installed, value.deps.platform);
+      const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+      if (!chrome) {
+        throw new Error("missing Chrome fixture root");
+      }
+      await writeSecurePreferences({
+        userDataDir: chrome.userDataDir,
+        profile: "Default",
+        entries: { [installedId]: { location: 4, path: installed } },
+      });
+      const status = await installChromeExtensionBootstrap({
+        bundledDir: value.bundledDir,
+        pluginRoot: value.pluginRoot,
+        waitMs: 1_000,
+        deps: value.deps,
+      });
+      const manifestPath =
+        status.registrations.find((entry) => entry.product === "chrome")?.manifestPath ?? "";
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as { path: string };
+      if (mutation === "malformed") {
+        await fs.appendFile(manifest.path, "# unexpected launcher content\n");
+      } else {
+        await fs.chmod(manifest.path, 0o744);
+      }
+
+      const repair = await repairOwnedChromeExtensionNativeHosts({
+        bundledDir: value.bundledDir,
+        pluginRoot: value.pluginRoot,
+        deps: value.deps,
+      });
+      expect(repair.changes, mutation).toEqual([]);
+      expect(repair.warnings.join("\n"), mutation).toContain("native host repair refused");
+    }
   });
 
   it("uninstalls owned registrations and reports Windows as manual_required", async () => {
@@ -747,7 +861,60 @@ describe("native host registration", () => {
     });
   });
 
-  it("refuses owned-path ID drift even when the native host moved", async () => {
+  it("migrates one stale path-derived slot while adding the Store origin", async () => {
+    const value = await fixture();
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    const installedId = await predictedId(installed, value.deps.platform);
+    const bundledId = await predictedId(value.bundledDir, value.deps.platform);
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: { [installedId]: { location: 4, path: installed } },
+    });
+    const status = await installChromeExtensionBootstrap({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      waitMs: 1_000,
+      deps: value.deps,
+    });
+    const manifestPath =
+      status.registrations.find((entry) => entry.product === "chrome")?.manifestPath ?? "";
+    const staleId = "o".repeat(32);
+    await rewriteRegistrationOrigins(
+      manifestPath,
+      [installedId, staleId].toSorted().map((id) => `chrome-extension://${id}/`),
+    );
+
+    const repair = await repairOwnedChromeExtensionNativeHosts({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      deps: value.deps,
+    });
+
+    expect(repair).toEqual({
+      changes: ["Repaired Google Chrome OpenClaw native messaging registration."],
+      warnings: [],
+    });
+    const repaired = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
+      path: string;
+      allowed_origins: string[];
+    };
+    const expectedOrigins = [installedId, bundledId, FOUNDATION_STORE_ID]
+      .toSorted()
+      .map((id) => `chrome-extension://${id}/`);
+    expect(repaired.allowed_origins).toEqual(expectedOrigins);
+    expect(
+      (await fs.readFile(repaired.path, "utf8"))
+        .match(/chrome-extension:\/\/[a-p]{32}\//gu)
+        ?.toSorted(),
+    ).toEqual(expectedOrigins);
+  });
+
+  it("refuses path-origin cardinality and no-overlap drift", async () => {
     const value = await fixture();
     const installed = await installStableChromeExtension(value.bundledDir, value.deps);
     const installedId = await predictedId(installed, value.deps.platform);
@@ -772,14 +939,7 @@ describe("native host registration", () => {
       path: string;
       allowed_origins: string[];
     };
-    await fs.writeFile(
-      manifestPath,
-      `${JSON.stringify({
-        ...firstManifest,
-        allowed_origins: [`chrome-extension://${installedId}/`],
-      })}\n`,
-      { mode: 0o600 },
-    );
+    await rewriteRegistrationOrigins(manifestPath, [`chrome-extension://${installedId}/`]);
     const movedNativeHost = path.join(value.root, "moved", "native-host-entry.js");
     await fs.mkdir(path.dirname(movedNativeHost), { recursive: true });
     await fs.writeFile(movedNativeHost, "export {};\n", { mode: 0o600 });
@@ -790,6 +950,17 @@ describe("native host registration", () => {
     });
     expect(repair.changes).toEqual([]);
     expect(repair.warnings.join("\n")).toContain("native host repair refused");
+    await rewriteRegistrationOrigins(
+      manifestPath,
+      ["o".repeat(32), "p".repeat(32)].toSorted().map((id) => `chrome-extension://${id}/`),
+    );
+    const noOverlapRepair = await repairOwnedChromeExtensionNativeHosts({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      deps: { ...value.deps, nativeHostPath: movedNativeHost },
+    });
+    expect(noOverlapRepair.changes).toEqual([]);
+    expect(noOverlapRepair.warnings.join("\n")).toContain("native host repair refused");
     status = await browserExtensionStatus({
       bundledDir: value.bundledDir,
       deps: { ...value.deps, nativeHostPath: movedNativeHost },

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -25,8 +25,9 @@ const BROWSER_EXTENSION_INSTALL_WAIT_DEFAULT_MS = 30_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MIN_MS = 1_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MAX_MS = 120_000;
 const NATIVE_HOST_DESCRIPTION = "OpenClaw browser extension bootstrap";
-// This exact Foundation Store identity is trusted as a caller, never as proof
-// that an arbitrary extension path is OpenClaw-owned.
+// Chrome authorizes native messaging by extension ID. This trust grant intentionally
+// includes user-loaded unpacked builds that preserve the Store ID; those builds must be trusted.
+// The ID is never proof that an arbitrary extension path is OpenClaw-owned.
 const FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
 export const FOUNDATION_CHROME_WEB_STORE_URL = `https://chromewebstore.google.com/detail/openclaw/${FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID}`;
 

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -9,6 +9,7 @@ import {
   type ChromeProductRoot,
   discoverChromeExtensionIds,
   type DiscoveredChromeExtension,
+  type DiscoveredChromeStoreExtension,
   ensurePrivateDirectory,
   type ExtensionInstallDeps,
   generateChromeExtensionIdForPath,
@@ -24,6 +25,10 @@ const BROWSER_EXTENSION_INSTALL_WAIT_DEFAULT_MS = 30_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MIN_MS = 1_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MAX_MS = 120_000;
 const NATIVE_HOST_DESCRIPTION = "OpenClaw browser extension bootstrap";
+// This exact Foundation Store identity is trusted as a caller, never as proof
+// that an arbitrary extension path is OpenClaw-owned.
+const FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
+export const FOUNDATION_CHROME_WEB_STORE_URL = `https://chromewebstore.google.com/detail/openclaw/${FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID}`;
 
 type NativeHostRegistrationStatus = {
   product: ChromeProduct;
@@ -41,6 +46,7 @@ type BrowserExtensionStatus = {
   bundledPath: string;
   approvedPaths: string[];
   discovered: DiscoveredChromeExtension[];
+  storeDiscovered: DiscoveredChromeStoreExtension[];
   registrations: NativeHostRegistrationStatus[];
   manualSetupRequired: boolean;
   issues: string[];
@@ -92,10 +98,82 @@ function launcherPathForManifest(manifestPath: string, deps: ExtensionInstallDep
   return path.join(nativeMessagingRoot(deps), `${BROWSER_NATIVE_HOST_NAME}.${suffix}.sh`);
 }
 
+function expectedExtensionIds(extensionIds: string[]): string[] {
+  return [...new Set([...extensionIds, FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID])].toSorted();
+}
+
 function expectedOriginsForExtensionIds(extensionIds: string[]): string[] {
-  return [...new Set(extensionIds)]
-    .toSorted()
-    .map((extensionId) => `chrome-extension://${extensionId}/`);
+  return expectedExtensionIds(extensionIds).map(
+    (extensionId) => `chrome-extension://${extensionId}/`,
+  );
+}
+
+function pathDerivedExtensionIds(extensionIds: string[]): string[] {
+  return extensionIds.filter(
+    (extensionId) => extensionId !== FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID,
+  );
+}
+
+function isSafeOriginMigration(existingIds: string[], desiredPathIds: string[]): boolean {
+  const existingPathIds = pathDerivedExtensionIds(existingIds).toSorted();
+  const desiredIds = [...new Set(desiredPathIds)].toSorted();
+  if (JSON.stringify(existingPathIds) === JSON.stringify(desiredIds)) {
+    return true;
+  }
+  const removed = existingPathIds.filter((id) => !desiredIds.includes(id));
+  const added = desiredIds.filter((id) => !existingPathIds.includes(id));
+  const overlap = existingPathIds.some((id) => desiredIds.includes(id));
+  return (
+    existingPathIds.length === desiredIds.length &&
+    removed.length === 1 &&
+    added.length === 1 &&
+    overlap
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function launcherMatchesOrigins(params: {
+  content: string;
+  manifestPath: string;
+  launcherPath: string;
+  origins: string[];
+}): boolean {
+  const quotedValue = String.raw`'(?:[^'\r\n]|'"'"')*'`;
+  const command = [
+    quotedValue,
+    quotedValue,
+    escapeRegExp(shellQuote("--manifest")),
+    escapeRegExp(shellQuote(params.manifestPath)),
+    escapeRegExp(shellQuote("--launcher")),
+    escapeRegExp(shellQuote(params.launcherPath)),
+    ...params.origins.flatMap((origin) => [
+      escapeRegExp(shellQuote("--expected-origin")),
+      escapeRegExp(shellQuote(origin)),
+    ]),
+  ].join(" ");
+  const pattern = new RegExp(
+    `^#!/bin/sh\\n${escapeRegExp(OWNED_LAUNCHER_MARKER)}\\nexport OPENCLAW_STATE_DIR=${quotedValue}\\n(?:export OPENCLAW_CONFIG_PATH=${quotedValue}\\n)?exec ${command} "\\$@"\\n$`,
+    "u",
+  );
+  return pattern.test(params.content);
+}
+
+async function assertPrivateNativeHostFile(
+  target: string,
+  executable: boolean,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  await assertOwnedPath(target, "file");
+  if (platform === "win32") {
+    return;
+  }
+  const mode = (await fs.lstat(target)).mode & 0o777;
+  if ((mode & 0o077) !== 0 || (executable && (mode & 0o100) === 0)) {
+    throw new Error("native host file has unsafe mode");
+  }
 }
 
 async function resolveLauncherInstall(params: {
@@ -138,7 +216,7 @@ async function resolveLauncherInstall(params: {
 async function inspectRegistration(
   root: ChromeProductRoot,
   deps: ExtensionInstallDeps,
-  expectedExtensionIds?: string[],
+  expectedPathExtensionIds?: string[],
 ): Promise<NativeHostRegistrationStatus> {
   const manifestPath = path.join(root.nativeManifestDir, `${BROWSER_NATIVE_HOST_NAME}.json`);
   if (!(await pathInfo(manifestPath))) {
@@ -151,7 +229,7 @@ async function inspectRegistration(
     };
   }
   try {
-    await assertOwnedPath(manifestPath, "file");
+    await assertPrivateNativeHostFile(manifestPath, false, deps.platform ?? process.platform);
     const parsed: unknown = JSON.parse(await fs.readFile(manifestPath, "utf8"));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error("manifest is not an object");
@@ -174,15 +252,15 @@ async function inspectRegistration(
       };
     }
     const exactKeys = ["name", "description", "path", "type", "allowed_origins"];
+    const stringOrigins = origins.filter((origin): origin is string => typeof origin === "string");
     const validOrigins =
       origins.length > 0 &&
-      origins.every(
-        (origin) =>
-          typeof origin === "string" && /^chrome-extension:\/\/[a-p]{32}\/$/u.test(origin),
-      ) &&
+      origins.length === stringOrigins.length &&
+      stringOrigins.every((origin) => /^chrome-extension:\/\/[a-p]{32}\/$/u.test(origin)) &&
       new Set(origins).size === origins.length;
-    const expectedOrigins = expectedExtensionIds
-      ? expectedOriginsForExtensionIds(expectedExtensionIds)
+    const canonicalOrigins = [...stringOrigins].toSorted();
+    const expectedOrigins = expectedPathExtensionIds
+      ? expectedOriginsForExtensionIds(expectedPathExtensionIds)
       : null;
     if (
       Object.keys(manifest).length !== exactKeys.length ||
@@ -190,13 +268,20 @@ async function inspectRegistration(
       (manifest as { description?: unknown }).description !== NATIVE_HOST_DESCRIPTION ||
       (manifest as { type?: unknown }).type !== "stdio" ||
       !validOrigins ||
+      JSON.stringify(origins) !== JSON.stringify(canonicalOrigins) ||
       (expectedOrigins !== null && JSON.stringify(origins) !== JSON.stringify(expectedOrigins))
     ) {
       throw new Error("native host manifest does not contain exact allowed origins");
     }
-    await assertOwnedPath(expectedLauncher, "file");
-    if (!(await fs.readFile(expectedLauncher, "utf8")).includes(OWNED_LAUNCHER_MARKER)) {
-      throw new Error("launcher ownership marker is missing");
+    await assertPrivateNativeHostFile(expectedLauncher, true, deps.platform ?? process.platform);
+    const launcherMatches = launcherMatchesOrigins({
+      content: await fs.readFile(expectedLauncher, "utf8"),
+      manifestPath,
+      launcherPath: expectedLauncher,
+      origins: stringOrigins,
+    });
+    if (!launcherMatches) {
+      throw new Error("native host launcher and manifest origins do not match");
     }
     return {
       product: root.product,
@@ -225,9 +310,18 @@ async function installRegistration(params: {
 }): Promise<NativeHostRegistrationStatus> {
   const { root, extensionIds, deps } = params;
   const manifestPath = path.join(root.nativeManifestDir, `${BROWSER_NATIVE_HOST_NAME}.json`);
-  const existing = await inspectRegistration(root, deps, extensionIds);
+  const existing = await inspectRegistration(root, deps);
   if (existing.state === "foreign" || existing.state === "invalid") {
     throw new Error(`Refusing to overwrite ${existing.state} native host: ${manifestPath}`);
+  }
+  const desiredOrigins = expectedOriginsForExtensionIds(extensionIds);
+  if (
+    existing.state === "owned" &&
+    JSON.stringify(existing.extensionIds.map((id) => `chrome-extension://${id}/`)) !==
+      JSON.stringify(desiredOrigins) &&
+    !isSafeOriginMigration(existing.extensionIds, extensionIds)
+  ) {
+    throw new Error(`Refusing to overwrite owned native host with unexpected allowed origins`);
   }
   await ensurePrivateDirectory(nativeMessagingRoot(deps));
   await ensurePrivateDirectory(root.nativeManifestDir);
@@ -299,7 +393,7 @@ export function normalizeExtensionInstallWaitMs(value: unknown): number {
   return parsed;
 }
 
-/** Copy, pre-register deterministic IDs, then verify Chrome's recorded identity. */
+/** Copy, pre-register Store plus deterministic IDs, then verify Chrome's recorded identity. */
 export async function installChromeExtensionBootstrap(params: {
   bundledDir: string;
   pluginRoot: string;
@@ -343,7 +437,7 @@ export async function installChromeExtensionBootstrap(params: {
   }
   if (preRegisteredRoots > 0) {
     params.onProgress?.(
-      `Native bootstrap is ready. In Chrome, use chrome://extensions → Developer mode → Load unpacked → ${installed}`,
+      `Native bootstrap is ready. Add OpenClaw from the Chrome Web Store: ${FOUNDATION_CHROME_WEB_STORE_URL}. For development, load unpacked from ${installed}.`,
     );
   } else {
     preRegistrationIssues.push(
@@ -361,17 +455,23 @@ export async function installChromeExtensionBootstrap(params: {
   const deadline = now() + waitMs;
   let discovery = await discoverChromeExtensionIds({
     approvedDirs: approvedPaths,
+    storeExtensionId: FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID,
     deps,
   });
   let announcedWait = false;
-  while (discovery.discovered.length === 0 && now() < deadline) {
+  while (
+    discovery.discovered.length === 0 &&
+    discovery.storeDiscovered.length === 0 &&
+    now() < deadline
+  ) {
     if (!announcedWait) {
-      params.onProgress?.("Waiting for Chrome to verify the unpacked OpenClaw extension…");
+      params.onProgress?.("Waiting for Chrome to verify the OpenClaw extension…");
       announcedWait = true;
     }
     await sleep(Math.min(500, Math.max(1, deadline - now())));
     discovery = await discoverChromeExtensionIds({
       approvedDirs: approvedPaths,
+      storeExtensionId: FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID,
       deps,
     });
   }
@@ -396,7 +496,11 @@ export async function browserExtensionStatus(params: {
   const approvedPaths = installedCopy.owned
     ? await approvedInstallRealpaths(installedPath, bundledPath)
     : [bundledPath];
-  const discovery = await discoverChromeExtensionIds({ approvedDirs: approvedPaths, deps });
+  const discovery = await discoverChromeExtensionIds({
+    approvedDirs: approvedPaths,
+    storeExtensionId: FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID,
+    deps,
+  });
   const predictedIds = [
     ...new Set(
       approvedPaths.map((candidate) => generateChromeExtensionIdForPath(candidate, platform)),
@@ -409,9 +513,9 @@ export async function browserExtensionStatus(params: {
           chromeProductRoots(deps).map((root) => inspectRegistration(root, deps, predictedIds)),
         );
   const missingRegistration = chromeProductRoots(deps).some((root) => {
-    const productWasDiscovered = discovery.discovered.some(
-      (entry) => entry.product === root.product,
-    );
+    const productWasDiscovered =
+      discovery.discovered.some((entry) => entry.product === root.product) ||
+      discovery.storeDiscovered.some((entry) => entry.product === root.product);
     if (!productWasDiscovered) {
       return false;
     }
@@ -419,7 +523,8 @@ export async function browserExtensionStatus(params: {
     const registration = registrations.find((entry) => entry.manifestPath === manifestPath);
     return (
       registration?.state !== "owned" ||
-      JSON.stringify(registration.extensionIds) !== JSON.stringify(predictedIds)
+      JSON.stringify(registration.extensionIds) !==
+        JSON.stringify(expectedExtensionIds(predictedIds))
     );
   });
   return {
@@ -429,11 +534,12 @@ export async function browserExtensionStatus(params: {
     bundledPath: path.resolve(params.bundledDir),
     approvedPaths,
     discovered: discovery.discovered,
+    storeDiscovered: discovery.storeDiscovered,
     registrations,
     manualSetupRequired:
       platform === "win32" ||
       (installedCopy.present && !installedCopy.owned) ||
-      discovery.discovered.length === 0 ||
+      (discovery.discovered.length === 0 && discovery.storeDiscovered.length === 0) ||
       discovery.identityMismatches.length > 0 ||
       missingRegistration,
     issues: [
@@ -515,7 +621,10 @@ export async function repairOwnedChromeExtensionNativeHosts(params: {
     return { changes: [], warnings: [] };
   }
   const before = await browserExtensionStatus({ bundledDir: params.bundledDir, deps });
-  if (!before.installedCopy.owned || before.discovered.length === 0) {
+  if (
+    !before.installedCopy.owned ||
+    (before.discovered.length === 0 && before.storeDiscovered.length === 0)
+  ) {
     return { changes: [], warnings: [] };
   }
   const changes: string[] = [];
@@ -527,8 +636,10 @@ export async function repairOwnedChromeExtensionNativeHosts(params: {
     .toSorted();
   for (const root of chromeProductRoots(deps)) {
     const manifestPath = path.join(root.nativeManifestDir, `${BROWSER_NATIVE_HOST_NAME}.json`);
-    const registration = before.registrations.find((entry) => entry.manifestPath === manifestPath);
-    const productWasDiscovered = before.discovered.some((entry) => entry.product === root.product);
+    const registration = await inspectRegistration(root, deps);
+    const productWasDiscovered =
+      before.discovered.some((entry) => entry.product === root.product) ||
+      before.storeDiscovered.some((entry) => entry.product === root.product);
     if (!productWasDiscovered) {
       continue;
     }
@@ -542,6 +653,13 @@ export async function repairOwnedChromeExtensionNativeHosts(params: {
       continue;
     }
     try {
+      const idsAreCurrent =
+        JSON.stringify(registration.extensionIds) ===
+        JSON.stringify(expectedExtensionIds(predictedIds));
+      if (!idsAreCurrent && !isSafeOriginMigration(registration.extensionIds, predictedIds)) {
+        warnings.push(`${root.label} native host repair refused: unexpected allowed origins`);
+        continue;
+      }
       const launcher = await resolveLauncherInstall({
         manifestPath,
         pluginRoot: params.pluginRoot,
@@ -549,8 +667,6 @@ export async function repairOwnedChromeExtensionNativeHosts(params: {
         deps,
       });
       await assertOwnedPath(launcher.path, "file");
-      const idsAreCurrent =
-        JSON.stringify(registration.extensionIds) === JSON.stringify(predictedIds);
       const launcherIsCurrent = (await fs.readFile(launcher.path, "utf8")) === launcher.content;
       if (idsAreCurrent && launcherIsCurrent) {
         continue;

--- a/extensions/browser/src/browser/extension-native-host.test.ts
+++ b/extensions/browser/src/browser/extension-native-host.test.ts
@@ -12,6 +12,7 @@ import {
 
 const EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop";
 const ORIGIN = `chrome-extension://${EXTENSION_ID}/`;
+const STORE_ORIGIN = "chrome-extension://kcdjddhmeafeomebliikmbpblkmkfoig/";
 const OTHER_ORIGIN = `chrome-extension://${"p".repeat(32)}/`;
 const NONCE = Buffer.alloc(16, 7).toString("base64url");
 const PAIRING = `ws://127.0.0.1:18799/extension#${relayTestKey(1)}`;
@@ -234,6 +235,35 @@ describe("native host origin and topology boundary", () => {
     const result = await invokeHost();
     expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, pairingString: PAIRING });
     expect(result.writes).toHaveLength(1);
+  });
+
+  it("accepts the exact Store caller when launcher args and manifest match", async () => {
+    const fixture = await nativeFixture();
+    const expectedOrigins = [ORIGIN, STORE_ORIGIN].toSorted();
+    await fs.writeFile(
+      fixture.manifestPath,
+      `${JSON.stringify({
+        name: "ai.openclaw.browser_bootstrap",
+        description: "OpenClaw browser extension bootstrap",
+        path: fixture.launcherPath,
+        type: "stdio",
+        allowed_origins: expectedOrigins,
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const result = await invokeHost({
+      ...fixture,
+      callerOrigin: STORE_ORIGIN,
+      expectedOrigins,
+    });
+
+    expect(result.response).toEqual({
+      v: 1,
+      ok: true,
+      nonce: NONCE,
+      pairingString: PAIRING,
+    });
   });
 
   it("rejects a wrong extension origin", async () => {

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -33,12 +33,12 @@ describe("browser extension pairing Gateway URL", () => {
     resetRuntimeCapture();
   });
 
-  it("prints Load unpacked only after native pre-registration is ready", async () => {
+  it("prints the Store CTA only after native pre-registration is ready", async () => {
     installMocks.installChromeExtensionBootstrap.mockImplementation(
       async (params: Parameters<typeof installChromeExtensionBootstrap>[0]) => {
         params.onProgress?.("Pre-registered the native host for Chromium.");
         params.onProgress?.(
-          "Native bootstrap is ready. In Chrome, use chrome://extensions → Developer mode → Load unpacked → /stable/openclaw-extension",
+          "Native bootstrap is ready. Add OpenClaw from the Chrome Web Store. For development, load unpacked from /stable/openclaw-extension.",
         );
         return {
           platform: "linux",
@@ -57,6 +57,7 @@ describe("browser extension pairing Gateway URL", () => {
               extensionPath: "/stable/openclaw-extension",
             },
           ],
+          storeDiscovered: [],
           registrations: [],
           manualSetupRequired: false,
           issues: [],
@@ -75,9 +76,9 @@ describe("browser extension pairing Gateway URL", () => {
     const output = logSpy.mock.calls.map(([message]) => String(message));
     expect(output[0]).toContain("Preparing");
     expect(output.findIndex((message) => message.includes("Pre-registered"))).toBeLessThan(
-      output.findIndex((message) => message.includes("Load unpacked")),
+      output.findIndex((message) => message.includes("Chrome Web Store")),
     );
-    expect(output.at(-1)).toContain("deterministic extension identity verified");
+    expect(output.at(-1)).toContain("extension identity verified");
   });
 
   it("rejects path-rewriting proxy prefixes for strict v2 resource binding", async () => {

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -1,12 +1,13 @@
 /**
- * `openclaw browser extension` CLI: install the unpacked Chrome extension,
- * register its native bootstrap host, and retain advanced manual pairing.
+ * `openclaw browser extension` CLI: register the Store and development extension
+ * native bootstrap host, and retain advanced manual pairing.
  */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import {
   browserExtensionStatus,
+  FOUNDATION_CHROME_WEB_STORE_URL,
   installChromeExtensionBootstrap,
   normalizeExtensionInstallWaitMs,
   resolveChromeExtensionLoadPath,
@@ -160,11 +161,11 @@ export function registerBrowserExtensionCommands(
 
   extension
     .command("install")
-    .description("Install the stable extension copy and register its native bootstrap host")
+    .description("Register the native bootstrap host for Store and development installs")
     .option("--json", "Print a machine-readable status report")
     .option(
       "--wait-ms <ms>",
-      "How long to wait after pre-registration for Chrome to verify the unpacked extension",
+      "How long to wait after pre-registration for Chrome to verify the extension",
       String(30_000),
     )
     .action(async (opts) => {
@@ -175,7 +176,7 @@ export function registerBrowserExtensionCommands(
           const bundledDir = resolveChromeExtensionDir(pluginRoot);
           if (opts.json !== true) {
             defaultRuntime.log(
-              info("Preparing the OpenClaw Chrome extension. Keep Chrome running…"),
+              info("Preparing the OpenClaw Chrome native bootstrap. Keep Chrome running…"),
             );
           }
           const status = await installChromeExtensionBootstrap({
@@ -196,10 +197,10 @@ export function registerBrowserExtensionCommands(
                 ? theme.warn(
                     status.platformSupport === "manual_required"
                       ? "Automatic native bootstrap is not supported on this platform; use Settings for manual pairing."
-                      : "Automatic setup was not verified. Keep Chrome running, rerun install, and use Load unpacked only after the command says native bootstrap is ready. If this extension already attempted setup before the host existed, restart Chrome once before retrying.",
+                      : `Automatic setup was not verified. Run install before adding OpenClaw from ${FOUNDATION_CHROME_WEB_STORE_URL}. Use Load unpacked only as a development fallback after pre-registration. If this extension already attempted setup before the host existed, restart Chrome once before retrying.`,
                   )
                 : info(
-                    `Native host and deterministic extension identity verified for ${status.discovered.length} profile registration(s). The extension connects automatically.`,
+                    `Native host and extension identity verified for ${status.discovered.length + status.storeDiscovered.length} profile registration(s). The extension connects automatically.`,
                   ),
             );
           }
@@ -230,8 +231,9 @@ export function registerBrowserExtensionCommands(
         defaultRuntime.log(
           [
             `Extension copy: ${status.installedCopy.owned ? "installed" : "bundled fallback"}`,
+            `Store:          ${status.storeDiscovered.length > 0 ? status.storeDiscovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile})`).join(", ") : "not detected"}`,
+            `Development:    ${status.discovered.length > 0 ? status.discovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile})`).join(", ") : "none detected"}`,
             `Load unpacked:  ${status.installedCopy.owned ? status.installedCopy.path : status.bundledPath}`,
-            `Chrome IDs:     ${status.discovered.length > 0 ? status.discovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile})`).join(", ") : "none detected"}`,
             `Native hosts:   ${status.registrations.filter((entry) => entry.state === "owned").length} owned`,
             `Setup:          ${status.manualSetupRequired ? "manual action required" : "automatic bootstrap ready"}`,
           ].join("\n"),

--- a/extensions/browser/src/doctor-browser.ts
+++ b/extensions/browser/src/doctor-browser.ts
@@ -18,6 +18,7 @@ import {
 import { DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME, resolveBrowserConfig } from "./browser/config.js";
 import {
   browserExtensionStatus,
+  FOUNDATION_CHROME_WEB_STORE_URL,
   repairOwnedChromeExtensionNativeHosts,
 } from "./browser/extension-install.js";
 import { listSystemProfiles } from "./browser/system-profiles.js";
@@ -272,7 +273,8 @@ export async function noteChromeMcpBrowserReadiness(
           [
             "- The Chrome extension native bootstrap is not fully registered.",
             `- Run ${formatCliCommand("openclaw browser extension status --json")} for the redacted registration report.`,
-            `- Run ${formatCliCommand("openclaw browser extension install")} after loading the printed unpacked directory.`,
+            `- Run ${formatCliCommand("openclaw browser extension install")} before adding OpenClaw from ${FOUNDATION_CHROME_WEB_STORE_URL}.`,
+            "- Load unpacked from the printed stable path only as a development fallback.",
           ].join("\n"),
           "Browser extension bootstrap",
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing the already-published official Chrome Web Store extension v2.2.0 would be rejected by OpenClaw's native bootstrap because the managed native-host registration authorized only deterministic unpacked-path IDs. This blocks automatic local pairing during a fleet rollout even though the Store extension still uses the current one-shot native bootstrap and Browser Relay Authentication v2.

Official listing: https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig

## Why This Change Was Made

The installer now treats the exact Foundation Store ID as one explicit product identity and emits its origin alongside the approved deterministic unpacked origins in canonical order. Store discovery is reported separately from path-derived discovery and never adds a Store-recorded path to `approvedPaths`.

Owned-registration migration remains deliberately narrow: exact OpenClaw manifest and launcher structure, ownership, modes, and origin equality must be proven before adding the Store origin or replacing one overlapping stale path-derived slot. Foreign extras, wildcards, malformed launchers, unsafe modes, mismatches, arbitrary cardinality, and no-overlap replacements remain refused.

The native host, native Port lifecycle, Gateway-wakeup pairing, relay server/lifecycle, auth protocol, custody behavior, All tabs default, browser-node behavior, and manual/direct-remote paths are unchanged.

## User Impact

Operators can run `openclaw browser extension install` first to pre-register the native host, then add the official Store extension and receive automatic local pairing. The stable unpacked path remains available as a development fallback.

This is intended to unblock the official v2.2.0 Store rollout across managed hosts without requiring the incompatible host-owned relay redesign.

## Evidence

- Live CRX inspection: exact Store ID resolves to OpenClaw v2.2.0 with the expected MV3/nativeMessaging permission set.
- Pre-fix regression: the existing installer test failed because the generated manifest contained only two unpacked origins and omitted `chrome-extension://kcdjddhmeafeomebliikmbpblkmkfoig/`.
- Focused tests: 77 passed across installer, native host, CLI, and Doctor; the opt-in Chromium file skipped in the non-E2E pass.
- Real Chromium E2E: `pnpm test:e2e:browser-extension` passed, covering pre-registration, unpacked load, Secure Preferences identity, one-shot auto-pair, Gateway wakeup, All tabs, tab revocation, and exact unpacked + Store caller launcher probes.
- Extension production/test typechecks: `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` passed.
- Build/package/docs: `pnpm build`, `pnpm test:extensions:package-boundary` (123 plugins), and `pnpm check:docs` passed.
- Changed gate: `pnpm check:changed` passed for `extensions`, `extensionTests`, and `docs`.
- Targeted format/lint and `git diff --check` passed.
- TruffleHog clean; final Codex autoreview clean through P1 with no findings.
- Production LOC: +195/-41 (net +154), required for the Store identity/discovery capability and the inspect-proven migration security boundary. Tests: +240/-22. Docs: +48/-38. Release-note context is carried in this PR body per repository policy.

AI-assisted: yes. The implementation and proof were reviewed with the repository's Codex autoreview workflow.
