### PR TITLE
fix(audit): inherit supervisor markers in audit worker database options

### DIFF
--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -9,6 +9,8 @@ import {
   openOpenClawStateDatabase,
   registerOpenClawStateDatabaseLifecycleListener,
 } from "../state/openclaw-state-db.js";
+import { claimOpenClawStateOwnership } from "../state/openclaw-state-ownership-operations.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { listAuditEvents, recordAuditEvent } from "./audit-event-store.js";
 import type { AuditEventInput } from "./audit-event-types.js";
 import { createAuditEventWriter } from "./audit-event-writer.js";
@@ -173,6 +175,46 @@ afterEach(() => {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("audit event writer", () => {
+  it("preserves external supervision for claimed state writes", async () => {
+    const stateDir = tempDirs.make("openclaw-audit-writer-external-");
+    const supervisedDatabase = {
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_SUPERVISOR_MODE: "external",
+      },
+    };
+    claimOpenClawStateOwnership("gateway-test-supervisor", supervisedDatabase);
+    closeOpenClawStateDatabaseForTest();
+    const write = async (runId: string, supervisorMode: string | undefined) => {
+      const errors: string[] = [];
+      await withEnvAsync({ OPENCLAW_SUPERVISOR_MODE: supervisorMode }, async () => {
+        const writer = createAuditEventWriter({ stateDir, onError: (error) => errors.push(error) });
+        await writer.ready;
+        expect(writer.record({ ...input(), sourceId: `${runId}:1:started`, runId })).toBe(true);
+        await writer.stop();
+      });
+      return errors;
+    };
+
+    const supervisedErrors = await write("supervised-run", "external");
+    expect(supervisedErrors).toEqual([]);
+    expect(
+      listAuditEvents({ database: supervisedDatabase, limit: 10 }).events.map(
+        (event) => event.runId,
+      ),
+    ).toEqual(["supervised-run"]);
+    closeOpenClawStateDatabaseForTest();
+
+    const unmarkedErrors = await write("unmarked-run", undefined);
+    expect(unmarkedErrors.some((error) => error.includes("gateway-test-supervisor"))).toBe(true);
+    expect(
+      listAuditEvents({ database: supervisedDatabase, limit: 10 }).events.map(
+        (event) => event.runId,
+      ),
+    ).toEqual(["supervised-run"]);
+  });
+
   it("keeps progress absent while disabled and routes enabled progress off audit_events", async () => {
     const stateDir = tempDirs.make("openclaw-audit-writer-");
     const database = { env: { OPENCLAW_STATE_DIR: stateDir } };

--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -6,6 +6,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { claimOpenClawStateOwnership } from "../state/openclaw-state-ownership-operations.js";
 import { listAuditEvents, recordAuditEvent } from "./audit-event-store.js";
 import type { AuditEventInput } from "./audit-event-types.js";
 import { createAuditEventWriter } from "./audit-event-writer.js";
@@ -790,5 +791,61 @@ describe("audit event worker", () => {
     expect(
       inspectExecutionIdentityRun({ runId: "after-key-loss" }, database).identity,
     ).toMatchObject({ state: "unknown", reasonCode: "run_not_found" });
+  });
+
+  it("inherits the Gateway's OPENCLAW_SUPERVISOR_MODE marker across the worker boundary when external ownership is claimed", async () => {
+    const stateDir = tempDirs.make("openclaw-audit-writer-supervised-");
+    const supervisorEnv = { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_SUPERVISOR_MODE: "external" };
+    claimOpenClawStateOwnership("gateway-supervisor", { env: supervisorEnv });
+    closeOpenClawStateDatabaseForTest();
+    const previousSupervisorMode = process.env.OPENCLAW_SUPERVISOR_MODE;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_SUPERVISOR_MODE = "external";
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const errors: string[] = [];
+    const writer = createAuditEventWriter({
+      stateDir,
+      onError: (error) => errors.push(error),
+    });
+    try {
+      await writer.ready;
+      const eventInput: AuditEventInput = {
+        sourceId: "supervised-worker-run:1:started",
+        sourceSequence: 1,
+        occurredAt: Date.now(),
+        kind: "agent_run",
+        action: "agent.run.started",
+        status: "started",
+        actorType: "agent",
+        actorId: "main",
+        agentId: "main",
+        runId: "supervised-worker-run",
+      };
+      expect(writer.record(eventInput)).toBe(true);
+      await writer.stop();
+      expect(errors).toEqual([]);
+      expect(errors.some((error) => error.includes("OpenClawStateExternalOwnershipError"))).toBe(
+        false,
+      );
+      const database = {
+        env: { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_SUPERVISOR_MODE: "external" },
+      };
+      expect(
+        listAuditEvents({ database, limit: 10 }).events.some(
+          (event) => event.runId === "supervised-worker-run",
+        ),
+      ).toBe(true);
+    } finally {
+      if (previousSupervisorMode === undefined) {
+        delete process.env.OPENCLAW_SUPERVISOR_MODE;
+      } else {
+        process.env.OPENCLAW_SUPERVISOR_MODE = previousSupervisorMode;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
   });
 });

--- a/src/audit/audit-event-writer.ts
+++ b/src/audit/audit-event-writer.ts
@@ -88,7 +88,7 @@ function executionIdentityFailureMessage(error: unknown): string {
   return "audit execution identity persistence failed";
 }
 
-/** Start one bounded queue on the current process's cached shared-state connection owner. */
+/** Start one bounded queue; retain the owner environment or claimed state rejects its writes. */
 export function createAuditEventWriter(
   options: {
     stateDir?: string;
@@ -98,7 +98,7 @@ export function createAuditEventWriter(
   } = {},
 ): AuditEventWriter {
   const database = {
-    env: { OPENCLAW_STATE_DIR: options.stateDir ?? resolveStateDir(process.env) },
+    env: { ...process.env, OPENCLAW_STATE_DIR: options.stateDir ?? resolveStateDir(process.env) },
   };
   const maxPending = Math.max(1, Math.floor(options.maxPending ?? MAX_PENDING_AUDIT_EVENTS));
   const queue: AuditWriterRequest[] = [];

--- a/src/audit/audit-event-writer.worker.ts
+++ b/src/audit/audit-event-writer.worker.ts
@@ -28,7 +28,12 @@ if (!parentPort || !stateDir) {
   throw new Error("audit event writer requires a parent port and state directory");
 }
 const port = parentPort;
-const database = { env: { OPENCLAW_STATE_DIR: stateDir } };
+// Spread `process.env` so the worker thread inherits supervisor markers
+// (e.g. OPENCLAW_SUPERVISOR_MODE=external) alongside the explicitly
+// forwarded OPENCLAW_STATE_DIR. Otherwise the reduced env would fence the
+// Gateway's own audit writer out of state it is meant to protect.
+// See: https://github.com/openclaw/openclaw/issues/123691
+const database = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
 
 function executionIdentityFailureMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Fixes #123691

## What Problem This Solves

Gateways that use the documented durable external ownership mode could not persist audit events. The Gateway accepted each event into its queue, but SQLite rejected the queue as an unmarked writer.

## Root Cause

The process-owned audit queue replaced its database environment with an object that contained only `OPENCLAW_STATE_DIR`. This dropped the inherited `OPENCLAW_SUPERVISOR_MODE=external` marker before state ownership admission.

## Fix

The audit queue now preserves the process environment when it overrides the state directory. The ownership layer remains unchanged, so unmarked writers still fail before mutation.

## Evidence

The same disposable claimed-database scenario ran against current `main` at `3399dd67b7e` and this head at `35e7446c4ea`.

| Scenario | Current main | This PR |
| --- | --- | --- |
| Marked queue accepts the event | Yes | Yes |
| Marked queue ownership errors | 9 | 0 |
| Marked event persisted | No | Yes |
| Unmarked queue rejected | Yes | Yes |
| Unmarked event persisted | No | No |

Focused regression proof:

```text
node scripts/run-vitest.mjs src/audit/audit-event-writer.test.ts src/state/openclaw-state-ownership.test.ts
Test Files  2 passed (2)
Tests  35 passed (35)
```

The focused formatter, linter, repository ratchets, database-first guard, import-cycle guard, and other permitted changed-scope guards pass. Hosted CI owns type checks and builds for this change.

## Production LOC

Production is line-count neutral: `+2/-2`. Regression coverage is `+42/-0`.

Co-authored-by: Kailigithub <12250313+Kailigithub@users.noreply.github.com>
