### PR TITLE
fix(codex): honor node exec host selection

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -57,6 +57,11 @@ runtime allowlist disables native Code Mode and leaves the turn without an
 execution environment, OpenClaw keeps its policy-filtered `exec` and `process`
 tools available instead for direct, unsandboxed execution.
 
+When `tools.exec.host: "node"` or `/exec host=node` makes the node the session
+default, OpenClaw hides the Codex-native shell and exposes `node_exec` and
+`node_process` as the shell path. This keeps the configured execution host from
+silently falling back to the app-server or Gateway machine.
+
 This Codex-native feature is separate from
 [OpenClaw Code Mode](/tools/code-mode), an opt-in QuickJS-WASI runtime
 for generic OpenClaw runs with a different `exec` input shape. For the

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1100,10 +1100,12 @@ describe("Codex app-server dynamic tool build", () => {
       ask: "off",
     };
 
+    const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
-      nativeToolSurfaceEnabled: true,
+      nativeToolSurfaceEnabled,
     });
 
+    expect(nativeToolSurfaceEnabled).toBe(false);
     expect(tools.map((tool) => tool.name)).toEqual(["message", "node_exec", "node_process"]);
     const nodeExec = tools.find((tool) => tool.name === "node_exec");
     const nodeProcess = tools.find((tool) => tool.name === "node_process");
@@ -1160,12 +1162,18 @@ describe("Codex app-server dynamic tool build", () => {
         ],
       },
     } as never;
+    const runtimePolicyNativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
+      runtimePolicyParams,
+      undefined,
+      { agentId: "policy", runtimeSessionKey: "agent:policy:session-1" },
+    );
     const runtimePolicyTools = await buildDynamicToolsForTest(runtimePolicyParams, workspaceDir, {
       sandboxSessionKey: "agent:policy:session-1",
-      nativeToolSurfaceEnabled: true,
+      nativeToolSurfaceEnabled: runtimePolicyNativeToolSurfaceEnabled,
       sessionAgentId: "policy",
     });
 
+    expect(runtimePolicyNativeToolSurfaceEnabled).toBe(false);
     expect(runtimePolicyTools.map((tool) => tool.name)).toEqual([
       "message",
       "node_exec",
@@ -1964,7 +1972,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
-  it("keeps Codex native tool surfaces when the effective exec target is node", () => {
+  it("disables Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     sessionParams.disableTools = false;
@@ -1975,16 +1983,16 @@ describe("Codex app-server dynamic tool build", () => {
       ask: "off",
     };
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(false);
 
     sessionParams.toolsAllow = ["*"];
-    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(false);
 
     const globalParams = createParams(path.join(tempDir, "global-session.jsonl"), workspaceDir);
     globalParams.disableTools = false;
     globalParams.config = { tools: { exec: { host: "node" } } } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(globalParams)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(globalParams)).toBe(false);
 
     const autoOverrideParams = createParams(
       path.join(tempDir, "auto-override-session.jsonl"),
@@ -2008,7 +2016,7 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(agentParams, undefined, {
         agentId: "main",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     const runtimePolicyParams = createParams(
       path.join(tempDir, "runtime-policy-session.jsonl"),
@@ -2026,7 +2034,7 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(false);
   });
 
   it("disables Codex native tool surfaces whenever an OpenClaw sandbox is active", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -554,6 +554,15 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (params.disableTools) {
     return false;
   }
+  if (
+    isCodexNativeExecutionBlockedByNodeExecHost(params, {
+      agentId: options.agentId,
+      runtimeSessionKey: options.runtimeSessionKey,
+      sandbox,
+    })
+  ) {
+    return false;
+  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -72,6 +72,8 @@ describe("resolveCodexNativeExecutionPolicy", () => {
       requestedExecHost: "node",
       effectiveExecHost: "node",
       node: "worker-1",
+      blockReason:
+        "OpenClaw exec host=node is active for this session. Codex app-server native execution cannot route shell, filesystem, MCP, or app-backed work through the selected OpenClaw node.",
     });
   });
 

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -184,6 +184,17 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("please now");
   });
 
+  it("parses identical exec directives deterministically", () => {
+    const input = "/exec host=node security=allowlist ask=always node=worker-1";
+    const first = extractExecDirective(input);
+
+    expect(Array.from({ length: 3 }, () => extractExecDirective(input))).toEqual([
+      first,
+      first,
+      first,
+    ]);
+  });
+
   it("captures invalid exec host values", () => {
     const res = extractExecDirective("/exec host=spaceship");
     expect(res.hasDirective).toBe(true);

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -111,6 +111,13 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     handleCommandsMock.mockResolvedValue(response);
     const commandName = body.slice(1).split(/\s+/, 1)[0] ?? "";
     const typing = createTypingController();
+    const resolvedConfig =
+      config ??
+      ({
+        session: {
+          store: path.join(tempDirs.make("openclaw-native-directive-"), "sessions.json"),
+        },
+      } as OpenClawConfig);
     const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: body,
@@ -132,22 +139,32 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
           body,
         },
       }),
-      cfg: markCompleteReplyConfig(
-        config ??
-          ({
-            session: {
-              store: path.join(tempDirs.make("openclaw-native-directive-"), "sessions.json"),
-            },
-          } as OpenClawConfig),
-      ),
+      cfg: markCompleteReplyConfig(resolvedConfig),
       agentId: "main",
       agentCfg: config?.agents?.defaults,
       commandAuthorized: true,
       typing,
     });
 
-    return { result, typing };
+    return { result, typing, storePath: resolvedConfig.session?.store };
   }
+
+  it("persists a native exec node selection before model dispatch", async () => {
+    const { result, storePath } = await resolveNativeDirectiveCommand(
+      "/exec host=node node=worker-1",
+    );
+
+    expect(result).toMatchObject({
+      handled: true,
+      reply: { text: expect.stringContaining("Exec defaults set (host=node, node=worker-1).") },
+    });
+    expect(
+      loadExactSessionEntry({
+        sessionKey: "agent:main:telegram:123",
+        storePath: storePath ?? "",
+      })?.entry,
+    ).toMatchObject({ execHost: "node", execNode: "worker-1" });
+  });
 
   it.each([
     { command: "/queue Can you diagnose this?", expected: 'Unrecognized queue mode "Can".' },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex harness sessions configured with `tools.exec.host: "node"`, or changed with `/exec host=node`, could still execute shell commands on the Codex app-server/Gateway host instead of the selected paired node.

The verified live reproduction set `/exec host=node node=<id>` and received the model-generated text `Execution host set to node <id>`, but the following command still ran on the Gateway. Across every attempt, the paired, approved, connected node host logged only `node host gateway connected`; the agent itself reported the Gateway hostname; and `session_nodes.entry_json` held no `execHost` or `execNode`. Config-level `tools.exec.host=node` behaved identically. The varied acknowledgements observed during reproduction were model-generated text, not canonical directive acknowledgements.

## Why This Change Was Made

The startup gate in `extensions/codex/src/app-server/dynamic-tool-build.ts:539` decided whether to enable Codex-native execution without consulting the canonical host resolution in `extensions/codex/src/app-server/native-execution-policy.ts:72`. That left Codex's local shell enabled even when the effective OpenClaw exec owner was a node.

The fix reuses that existing policy in the startup gate. Under an explicit node selection, OpenClaw now sends an empty Codex environment selection and exposes `node_exec` plus `node_process` as the sole shell path. The existing policy records the model-visible block reason in `extensions/codex/src/app-server/native-execution-policy.ts:97`, and native-only surfaces format it through `extensions/codex/src/app-server/sandbox-guard.ts:235` with the recovery choices: use a normal Codex harness turn on the node, or switch the exec host to Gateway.

This matches the upstream Codex contract checked directly at `../codex/codex-rs/core/src/thread_manager.rs:1769`, where an explicit environment list bypasses default local-environment selection, and `../codex/codex-rs/core/src/tools/spec_plan.rs:965`, where no selected environment means no native shell tools are registered.

`host=auto` behavior is unchanged: without a sandbox, Codex retains its native local shell while `node_exec` and `node_process` remain available for explicitly selected node work. Only explicit effective `host=node` disables native execution.

## User Impact

Operators can trust that an explicit node exec selection does not silently fall back to the app-server or Gateway machine. Node pairing, approvals, allowlists, and `host=auto` semantics are unchanged.

LOC: production +9, tests +55/-17, docs +5.

## Evidence

- Fresh autoreview on the rebased final diff: clean, no accepted/actionable findings (`patch is correct`, confidence 0.99).
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts` — 64 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts` — 120 passed across two shards.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-execution-policy.test.ts` — 9 passed.
- `node scripts/check-changed.mjs` — passed formatting, core/extension test types, extension production types, lint, dead-code, policy ratchets, database-first, sidecar, and import-cycle checks. The configured remote providers were unavailable on this host, so the repo wrapper used its approved trusted-source local fallback.
- `pnpm build` — passed, including unified dist, external plugin packages, runtime postbuild, Plugin SDK export checks, and Control UI build/sidecar guards.

Regression coverage verifies explicit per-turn overrides, session persistence, global configuration, agent-level policy, runtime session/agent resolution, the unchanged `auto` override, node-only dynamic tool exposure, and the user-facing native-execution block reason.
