### PR TITLE
fix(onboard): acknowledge risk before resetting state

### DIFF
--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -15,6 +15,17 @@ behavior and outputs, see [CLI setup reference](/start/wizard-cli-reference).
 ## Flow details (local mode)
 
 <Steps>
+  <Step title="Risk acknowledgement">
+    - Interactive runs complete the risk acknowledgement before a requested
+      reset can move any state to Trash. Declining or canceling leaves state
+      untouched.
+    - First run (or any run before `wizard.securityAcknowledgedAt` is set)
+      asks you to confirm you understand that agents are powerful and full
+      system access is risky.
+    - `--non-interactive` requires `--accept-risk` explicitly; without it,
+      onboarding exits with an error instead of prompting.
+
+  </Step>
   <Step title="Reset (optional)">
     - `--reset` resets state before setup runs; without it, re-running onboarding
       keeps existing config and reuses it as defaults.
@@ -24,17 +35,6 @@ behavior and outputs, see [CLI setup reference](/start/wizard-cli-reference).
     - If the config file is invalid, onboarding stops and tells you to run
       `openclaw doctor` first, then re-run setup.
     - Reset moves state to Trash (never deletes directly).
-
-  </Step>
-  <Step title="Risk acknowledgement">
-    - First run (or any run before `wizard.securityAcknowledgedAt` is set)
-      asks you to confirm you understand that agents are powerful and full
-      system access is risky.
-    - `--non-interactive` requires `--accept-risk` explicitly; without it,
-      onboarding exits with an error instead of prompting.
-    - Interactive runs get a confirm prompt instead of the flag; declining
-      cancels setup.
-
   </Step>
   <Step title="Model/Auth">
     - **Anthropic API key**: uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -31,6 +31,12 @@ not install or modify anything on the remote host.
 ## Local flow details
 
 <Steps>
+  <Step title="Risk acknowledgement">
+    - Interactive onboarding asks for any required risk acknowledgement before
+      a requested reset. Declining or canceling leaves existing state untouched.
+    - Non-interactive onboarding requires `--accept-risk` and does not prompt.
+
+  </Step>
   <Step title="Existing config detection">
     - If `~/.openclaw/openclaw.json` exists, choose **Keep current values**, **Review and update**, or **Reset before setup**.
     - Re-running the wizard does not wipe anything unless you explicitly choose Reset (or pass `--reset`).

--- a/src/commands/onboard-interactive-runner.ts
+++ b/src/commands/onboard-interactive-runner.ts
@@ -10,14 +10,15 @@ export function hasInteractiveOnboardingTty(): boolean {
 export async function runInteractiveOnboarding(
   action: () => Promise<void>,
   runtime: RuntimeEnv,
-): Promise<void> {
+): Promise<boolean> {
   let exitCode: number | null = null;
   try {
     await action();
+    return true;
   } catch (error) {
     if (error instanceof WizardCancelledError) {
       exitCode = 1;
-      return;
+      return false;
     }
     throw error;
   } finally {

--- a/src/commands/onboard-interactive.test.ts
+++ b/src/commands/onboard-interactive.test.ts
@@ -2,11 +2,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
-import { runInteractiveSetup } from "./onboard-interactive.js";
+import {
+  acknowledgeInteractiveOnboardingRisk,
+  runInteractiveSetup,
+} from "./onboard-interactive.js";
 
 const mocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(() => ({ id: "prompter" })),
   runSetupWizard: vi.fn(async () => {}),
+  requireRiskAcknowledgement: vi.fn(async () => ({})),
   restoreTerminalState: vi.fn(),
 }));
 
@@ -16,6 +20,10 @@ vi.mock("../wizard/clack-prompter.js", () => ({
 
 vi.mock("../wizard/setup.js", () => ({
   runSetupWizard: mocks.runSetupWizard,
+}));
+
+vi.mock("../wizard/setup.shared.js", () => ({
+  requireRiskAcknowledgement: mocks.requireRiskAcknowledgement,
 }));
 
 vi.mock("../../packages/terminal-core/src/restore.js", () => ({
@@ -79,6 +87,44 @@ describe("runInteractiveSetup", () => {
     await expect(runInteractiveSetup({} as never, runtime)).rejects.toThrow("boom");
 
     expect(runtime.exit).not.toHaveBeenCalled();
+    expect(mocks.restoreTerminalState).toHaveBeenCalledWith("setup finish", {
+      resumeStdinIfPaused: false,
+    });
+  });
+});
+
+describe("acknowledgeInteractiveOnboardingRisk", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("completes one acknowledgement with the existing config", async () => {
+    const runtime = makeRuntime();
+    const config = { gateway: { port: 19_001 } };
+
+    await expect(
+      acknowledgeInteractiveOnboardingRisk({ reset: true }, config, runtime),
+    ).resolves.toBe(true);
+
+    expect(mocks.requireRiskAcknowledgement).toHaveBeenCalledOnce();
+    expect(mocks.requireRiskAcknowledgement).toHaveBeenCalledWith({
+      opts: { reset: true },
+      prompter: { id: "prompter" },
+      config,
+    });
+  });
+
+  it.each(["Ctrl-C", "EOF"])("maps %s cancellation before reset to exit 1", async () => {
+    const runtime = makeRuntime();
+    mocks.requireRiskAcknowledgement.mockRejectedValueOnce(
+      new WizardCancelledError("risk not accepted"),
+    );
+
+    await expect(acknowledgeInteractiveOnboardingRisk({ reset: true }, {}, runtime)).resolves.toBe(
+      false,
+    );
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.restoreTerminalState).toHaveBeenCalledWith("setup finish", {
       resumeStdinIfPaused: false,
     });

--- a/src/commands/onboard-interactive.ts
+++ b/src/commands/onboard-interactive.ts
@@ -4,15 +4,29 @@
  * It wires the Clack prompter to the setup wizard and restores terminal state
  * on every exit path so canceled setup cannot leave stdin paused.
  */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { runSetupWizard } from "../wizard/setup.js";
+import { requireRiskAcknowledgement } from "../wizard/setup.shared.js";
 import {
   hasInteractiveOnboardingTty,
   runInteractiveOnboarding,
 } from "./onboard-interactive-runner.js";
 import type { OnboardOptions } from "./onboard-types.js";
+
+/** Completes the interactive risk gate before a requested reset can move state. */
+export async function acknowledgeInteractiveOnboardingRisk(
+  opts: OnboardOptions,
+  config: OpenClawConfig,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<boolean> {
+  const prompter = createClackPrompter();
+  return await runInteractiveOnboarding(async () => {
+    await requireRiskAcknowledgement({ opts, prompter, config });
+  }, runtime);
+}
 
 /** Runs the interactive setup wizard and maps user cancellation to exit code 1. */
 export async function runInteractiveSetup(

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -21,6 +21,7 @@ type ProviderAuthMethodNonInteractiveValidationContext = Parameters<
 >[0];
 
 const mocks = vi.hoisted(() => ({
+  acknowledgeInteractiveOnboardingRisk: vi.fn(async () => true),
   runInteractiveSetup: vi.fn(async () => {}),
   runGuidedOnboarding: vi.fn(async () => {}),
   runNonInteractiveSetup: vi.fn(async () => {}),
@@ -85,6 +86,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./onboard-interactive.js", () => ({
+  acknowledgeInteractiveOnboardingRisk: mocks.acknowledgeInteractiveOnboardingRisk,
   runInteractiveSetup: mocks.runInteractiveSetup,
 }));
 
@@ -272,6 +274,37 @@ describe("setupWizardCommand", () => {
   });
 
   it.each([
+    ["classic", { reset: true, classic: true }],
+    ["guided", { reset: true }],
+  ] as const)("acknowledges risk before an interactive %s reset", async (_label, options) => {
+    const runtime = makeRuntime();
+
+    await setupWizardCommand(options, runtime);
+
+    expect(mocks.acknowledgeInteractiveOnboardingRisk).toHaveBeenCalledOnce();
+    expect(mocks.handleReset).toHaveBeenCalledOnce();
+    const acknowledgementOrder =
+      mocks.acknowledgeInteractiveOnboardingRisk.mock.invocationCallOrder[0];
+    const resetOrder = mocks.handleReset.mock.invocationCallOrder[0];
+    if (acknowledgementOrder === undefined || resetOrder === undefined) {
+      throw new Error("expected risk acknowledgement and reset calls");
+    }
+    expect(acknowledgementOrder).toBeLessThan(resetOrder);
+    const setup = options.classic ? mocks.runInteractiveSetup : mocks.runGuidedOnboarding;
+    expect(setup).toHaveBeenCalledWith(expect.objectContaining({ acceptRisk: true }), runtime);
+  });
+
+  it("leaves state untouched when interactive risk acknowledgement is declined", async () => {
+    const runtime = makeRuntime();
+    mocks.acknowledgeInteractiveOnboardingRisk.mockResolvedValueOnce(false);
+
+    await setupWizardCommand({ reset: true, classic: true }, runtime);
+
+    expect(mocks.handleReset).not.toHaveBeenCalled();
+    expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["guided", { reset: true }],
     ["classic", { reset: true, classic: true }],
   ] as const)("rejects headless %s onboarding before reset", async (_label, options) => {
@@ -298,6 +331,7 @@ describe("setupWizardCommand", () => {
     await setupWizardCommand({ reset: true, nonInteractive: true, acceptRisk: true }, runtime);
 
     expect(mocks.withSetupMigrationTargetLock).toHaveBeenCalledOnce();
+    expect(mocks.acknowledgeInteractiveOnboardingRisk).not.toHaveBeenCalled();
     expect(mocks.handleReset).toHaveBeenCalledOnce();
     expect(mocks.runNonInteractiveSetup).toHaveBeenCalledOnce();
     const lockOrder = mocks.withSetupMigrationTargetLock.mock.invocationCallOrder[0];
@@ -957,6 +991,7 @@ describe("setupWizardCommand", () => {
     expect(mocks.runGuidedOnboarding).toHaveBeenCalledOnce();
     expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
     expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.acknowledgeInteractiveOnboardingRisk).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -42,7 +42,10 @@ import {
 import { runGuidedOnboarding } from "./onboard-guided.js";
 import { DEFAULT_WORKSPACE, handleReset } from "./onboard-helpers.js";
 import { hasInteractiveOnboardingTty } from "./onboard-interactive-runner.js";
-import { runInteractiveSetup } from "./onboard-interactive.js";
+import {
+  acknowledgeInteractiveOnboardingRisk,
+  runInteractiveSetup,
+} from "./onboard-interactive.js";
 import { runNonInteractiveSetup } from "./onboard-non-interactive.js";
 import { resolveNonInteractiveApiKey as resolveNonInteractiveCredential } from "./onboard-non-interactive/api-keys.js";
 import { inferAuthChoiceFromFlags } from "./onboard-non-interactive/local/auth-choice-inference.js";
@@ -575,6 +578,7 @@ export async function setupWizardCommand(
       : runGuidedOnboarding;
 
   const runSetupAfterOptionalReset = async () => {
+    let setupOpts = normalizedOpts;
     if (normalizedOpts.reset) {
       const snapshot = await readConfigFileSnapshot();
       const baseConfig = snapshot.sourceConfig ?? (snapshot.valid ? snapshot.config : {});
@@ -642,12 +646,25 @@ export async function setupWizardCommand(
       if (!validateResetMigrationImport({ opts: normalizedOpts, runtime })) {
         return;
       }
+      if (!normalizedOpts.nonInteractive) {
+        const riskAccepted = await acknowledgeInteractiveOnboardingRisk(
+          normalizedOpts,
+          baseConfig,
+          runtime,
+        );
+        if (!riskAccepted) {
+          return;
+        }
+        // The canonical preflight already completed the one interactive risk
+        // gate. Carry that fact through setup so reset cannot cause a duplicate prompt.
+        setupOpts = { ...normalizedOpts, acceptRisk: true };
+      }
       // Reset is deliberately the final pre-dispatch step: no rejectable option
-      // checks may run after user state has moved to Trash.
+      // checks or interactive gates may run after user state moves to Trash.
       await handleReset(resetScope, workspaceDir, runtime);
     }
 
-    await runSetup(normalizedOpts, runtime);
+    await runSetup(setupOpts, runtime);
   };
   await withSetupMigrationTargetLock(resolveStateDir(), runSetupAfterOptionalReset);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where interactive onboarding with `--reset` could move existing configuration, credentials, sessions, and workspace state before showing the security and risk acknowledgement prompt.

## Why This Change Was Made

Interactive onboarding now completes the existing risk gate immediately before dispatching any reset. Cancellation or acknowledgement errors return before the destructive owner is called, while successful acknowledgement is forwarded so setup does not prompt twice after state has moved. Noninteractive and headless gates remain fail-closed.

## User Impact

Users see and accept the security warning before any requested reset begins. Declining, cancelling, or encountering an acknowledgement error preserves existing state.

## Evidence

- Node 24.19.0 focused Vitest: 135/135 onboarding/reset tests passed.
- Coverage verifies guided and classic ordering, declined acknowledgement, headless invocation, noninteractive acceptance, reset preflight validation, and cancellation terminal cleanup.
- Source review traced every destructive move to `handleReset` after the new risk gate; no state-moving callee is reachable before acceptance.
- `git diff --check origin/main...HEAD` passed.
- TruffleHog diff scan passed.
- Independent persistent-state review found no P0-P2 issues and judged the top-level ordering boundary correct.
- Codex autoreview was attempted but unavailable because the Codex executable is not installed in this orb.

This PR is intentionally draft because it changes ordering around persistent-state reset behavior and should receive maintainer review before becoming ready.

AI-assisted: yes. No agent transcript included per publication instruction.
