### PR TITLE
fix(ui): keep mobile side chat interactive in tabbed panel

### DIFF
--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -124,6 +124,8 @@ type EmbeddedRunAttemptParamsBase = Omit<
   | "pluginHarnessToolPolicySafeDeniedTools"
   | "trajectoryRecorder"
 > & {
+  /** Host-prepared operator cap forwarded to native harness thread config. */
+  authoredContextTokenCap?: number;
   /** Audited exact denies that the plugin harness must enforce against native equivalents. */
   pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
 };

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -124,8 +124,6 @@ type EmbeddedRunAttemptParamsBase = Omit<
   | "pluginHarnessToolPolicySafeDeniedTools"
   | "trajectoryRecorder"
 > & {
-  /** Host-prepared operator cap forwarded to native harness thread config. */
-  authoredContextTokenCap?: number;
   /** Audited exact denies that the plugin harness must enforce against native equivalents. */
   pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
 };

--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -78,6 +78,11 @@ function scenario(): ControlUiMockGatewayScenario {
         additions: 4,
         deletions: 2,
       },
+      "sessions.companion.ask": {
+        answer: "The mobile side chat stayed inside its panel.",
+        ts: Date.UTC(2026, 7, 16, 12, 0),
+      },
+      "sessions.companion.state": { exchanges: [] },
       "sessions.files.list": {
         browser: {
           path: "ui/src/pages/chat",
@@ -872,13 +877,15 @@ suite.define(() => {
       },
       async ({ page }) => {
         await seedSettings(page, "light");
-        await installMockGateway(page, scenario());
+        const gateway = await installMockGateway(page, scenario());
         await page.goto(`${suite.server.baseUrl}chat`);
         await page.locator(".chat-group").first().waitFor();
         await page.locator(".chat-side-panel-toggle").click();
         await openFromEmpty(page, "Files");
         await openFromPlus(page, "Terminal");
-        await expect.poll(async () => tabLabels(page)).toEqual(["Files", "Terminal"]);
+        await openFromPlus(page, "Side chat");
+        await selectTab(page, "Side chat");
+        await expect.poll(async () => tabLabels(page)).toEqual(["Files", "Terminal", "Side chat"]);
         await expect.poll(() => narrowestRailTabLabel(page)).toBeGreaterThanOrEqual(24);
 
         const geometry = await sidePanel(page).evaluate((element) => {
@@ -888,6 +895,48 @@ suite.define(() => {
         expect(geometry.left).toBeGreaterThanOrEqual(0);
         expect(geometry.right).toBeLessThanOrEqual(geometry.viewport + 1);
         expect(geometry.width).toBeGreaterThan(300);
+
+        const companion = sidePanel(page).locator("openclaw-chat-session-rail");
+        const companionGeometry = await companion.locator(".chat-session-rail").evaluate((rail) => {
+          const body = rail.closest(".side-panel__body");
+          const bodyRect = body?.getBoundingClientRect();
+          const railRect = rail.getBoundingClientRect();
+          return {
+            bodyBottom: bodyRect?.bottom ?? 0,
+            bodyTop: bodyRect?.top ?? 0,
+            railBottom: railRect.bottom,
+            railTop: railRect.top,
+          };
+        });
+        expect(companionGeometry.railTop).toBeGreaterThanOrEqual(companionGeometry.bodyTop - 1);
+        expect(companionGeometry.railBottom).toBeLessThanOrEqual(companionGeometry.bodyBottom + 1);
+
+        const mainComposer = page.locator(".agent-chat__composer-combobox > textarea");
+        await mainComposer.click();
+        expect(await mainComposer.evaluate((element) => element === document.activeElement)).toBe(
+          true,
+        );
+        const input = companion.getByRole("textbox", { name: "Ask the session companion" });
+        await input.fill("Can I use side chat here?");
+        await companion.getByRole("button", { name: "Ask", exact: true }).click();
+        const request = await gateway.waitForRequest("sessions.companion.ask");
+        expect(request.params).toEqual({
+          agentId: "main",
+          question: "Can I use side chat here?",
+          sessionKey,
+        });
+        await companion
+          .getByText("The mobile side chat stayed inside its panel.", { exact: true })
+          .waitFor();
+        const companionActions = sidePanel(page).getByRole("button", {
+          name: "More companion actions",
+        });
+        await companionActions.click();
+        await sidePanel(page)
+          .locator('wa-dropdown-item[value="clear"]')
+          .waitFor({ state: "visible" });
+        await page.keyboard.press("Escape");
+        await captureRichPanel(page, "rails-side-chat-mobile-light");
 
         await sidePanel(page).getByRole("button", { name: "Expand side panel" }).click();
         await expect

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2132,7 +2132,7 @@ openclaw-chat-session-rail {
 
   /* No pane can hold a column at this width, so the companion takes the whole
      surface rather than hovering over part of it. */
-  .chat-session-rail--expanded {
+  .chat-session-rail--expanded:not(.chat-session-rail--embedded) {
     position: fixed;
     z-index: 35;
     inset: 0;


### PR DESCRIPTION
Related: #123874

## What Problem This Solves

Fixes an issue where users opening Side chat in the mobile tabbed-panel layout could see its content escape across the viewport and lose pointer access to the main composer and shared panel controls.

## Why This Change Was Made

The standalone session companion keeps its existing full-screen mobile presentation, while the embedded Side chat variant remains contained by the tabbed panel that owns its geometry. The existing mobile panel journey now opens Side chat and verifies containment, main-composer focus, companion submission, the returned answer, and the shared header menu.

Root cause: the embedded rail declaration from #123874 had the same specificity as a later generic mobile expanded-rail rule. Source order changed the embedded rail back to `position: fixed; inset: 0`, creating a transparent viewport-wide hit layer.

## User Impact

Mobile users can keep the main conversation interactive while Side chat is docked below it, ask companion questions, and use Side chat header controls without taps being intercepted.

## Evidence

- Before fix: full built-app reproduction at a 390×844 touch viewport showed the embedded rail spanning the viewport; Playwright reported `.chat-session-rail__thread` intercepting the shared header action.
- After fix: the built Control UI, served portlessly through Playwright asset interception with the canonical mocked Gateway, measured Side chat exactly inside its panel body (`top=466`, `bottom=832`), focused the main composer, sent the expected `sessions.companion.ask` request, rendered the answer, and opened the shared companion-actions menu. No console or page errors.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-session-rail.test.ts` — 41/41 passed.
- `node_modules/.bin/stylelint ui/src/styles/components.css --config config/stylelint.config.mjs` — passed.
- Changed-gate owner commands — formatting, UI/core test types, oxlint, stylelint, i18n, dependency/patch guards, dead-code scans, and repository ratchets passed. The pnpm dispatcher itself could not open its sandboxed metadata database, so the exact emitted commands were run directly.
- After removing a redundant SDK declaration flagged by ClawSweeper, `node --import tsx scripts/check-extension-package-tsc-boundary.mts --mode=compile` passed across all 123 plugin packages and `--mode=canary` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings; overall patch correctness 0.99.
- The standard local UI E2E server is sandbox-blocked at loopback bind (`listen EPERM`); exact-head CI remains the authoritative configured-lane run.

Production LOC: +1/-1 (net 0) | Tests: +51/-2

Provenance: clearly made visible by #123874 (`aed4510bd09`), authored by Vyctor H. Brzezowski and merged by `fuller-stack-dev` on 2026-08-16.
