### PR TITLE
fix(cli): restart disabled installed systemd services

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -236,12 +236,14 @@ describe("runServiceRestart token drift", () => {
 
   it("fails restart with the container hint when no service is installed", async () => {
     service.isLoaded.mockResolvedValue(false);
+    service.readCommand.mockResolvedValue(null);
+    const hasInstalledDefinition = vi.fn(async () => false);
     vi.stubEnv("OPENCLAW_CONTAINER_HINT", "openclaw-demo-container");
 
     await expect(
       runServiceRestart({
         serviceNoun: "Gateway",
-        service,
+        service: { ...service, hasInstalledDefinition } as GatewayService,
         renderStartHints: () => [
           "Restart the container or the service that manages it for openclaw-demo-container.",
           "openclaw gateway install",
@@ -268,6 +270,41 @@ describe("runServiceRestart token drift", () => {
     expect(payload.hintItems).toContainEqual(
       expect.objectContaining({ kind: "container-restart" }),
     );
+    expect(hasInstalledDefinition).toHaveBeenCalledWith({ env: process.env });
+  });
+
+  it("restarts a disabled installed service through its native manager", async () => {
+    service.isLoaded.mockResolvedValue(false);
+    const hasInstalledDefinition = vi.fn(async () => true);
+    const onNotLoaded = vi.fn(async () => null);
+    const renderStartHints = vi.fn(() => ["openclaw gateway install"]);
+    service.restart.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+      args?.onMutation?.({ mode: "systemctl-restart" });
+      return { outcome: "completed" };
+    });
+
+    await expect(
+      runServiceRestart({
+        ...createServiceRunArgs(),
+        service: { ...service, hasInstalledDefinition } as GatewayService,
+        renderStartHints,
+        onNotLoaded,
+      }),
+    ).resolves.toBe(true);
+
+    expect(hasInstalledDefinition).toHaveBeenCalledWith({ env: process.env });
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(onNotLoaded).not.toHaveBeenCalled();
+    expect(renderStartHints).not.toHaveBeenCalled();
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "restart",
+      source: "cli",
+      mode: "systemctl-restart",
+    });
+    expect(readJsonLog<{ ok?: boolean; result?: string; hints?: string[] }>()).toMatchObject({
+      ok: true,
+      result: "restarted",
+    });
   });
 
   it("runs the service mutation guard before restarting a loaded service", async () => {
@@ -331,6 +368,7 @@ describe("runServiceRestart token drift", () => {
 
   it("does not run the service mutation guard before not-loaded recovery", async () => {
     service.isLoaded.mockResolvedValue(false);
+    service.readCommand.mockResolvedValue(null);
     const beforeServiceMutation = vi.fn();
 
     await runServiceRestart({
@@ -534,6 +572,7 @@ describe("runServiceRestart token drift", () => {
   it("runs restart health checks after an unmanaged restart signal", async () => {
     const postRestartCheck = vi.fn(async () => {});
     service.isLoaded.mockResolvedValue(false);
+    service.readCommand.mockResolvedValue(null);
 
     await runServiceRestart({
       serviceNoun: "Gateway",
@@ -549,7 +588,6 @@ describe("runServiceRestart token drift", () => {
 
     expect(postRestartCheck).toHaveBeenCalledTimes(1);
     expect(service.restart).not.toHaveBeenCalled();
-    expect(service.readCommand).not.toHaveBeenCalled();
     const payload = readJsonLog<{ result?: string; message?: string }>();
     expect(payload.result).toBe("restarted");
     expect(payload.message).toContain("unmanaged process");
@@ -558,6 +596,7 @@ describe("runServiceRestart token drift", () => {
   it("emits loaded restart state when launchd repair handles a not-loaded restart", async () => {
     const postRestartCheck = vi.fn(async () => {});
     service.isLoaded.mockResolvedValue(false);
+    service.readCommand.mockResolvedValue(null);
 
     await runServiceRestart({
       serviceNoun: "Gateway",

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -115,19 +115,19 @@ async function resolveServiceLoadedOrFail(params: {
   fail: ReturnType<typeof createDaemonActionContext>["fail"];
   acceptInstalledDefinition?: boolean;
 }): Promise<boolean | null> {
-  // Returning null keeps failure emission centralized in the caller's action context.
+  // Keep native scope discovery in the adapter and failure emission in the action context.
+  const hasInstalledDefinition = async () =>
+    params.service.hasInstalledDefinition
+      ? await params.service.hasInstalledDefinition({ env: process.env }).catch(() => false)
+      : Boolean(await params.service.readCommand(process.env).catch(() => null));
   try {
-    return await params.service.isLoaded({ env: process.env });
+    const loaded = await params.service.isLoaded({ env: process.env });
+    return (
+      loaded || (Boolean(params.acceptInstalledDefinition) && (await hasInstalledDefinition()))
+    );
   } catch (err) {
-    if (params.acceptInstalledDefinition) {
-      // The adapter owns platform-specific install discovery; systemd spans
-      // user, system, marker-owned, and dueling definitions.
-      const installed = params.service.hasInstalledDefinition
-        ? await params.service.hasInstalledDefinition({ env: process.env }).catch(() => false)
-        : Boolean(await params.service.readCommand(process.env).catch(() => null));
-      if (installed) {
-        return true;
-      }
+    if (params.acceptInstalledDefinition && (await hasInstalledDefinition())) {
+      return true;
     }
     params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
     return null;


### PR DESCRIPTION
AI-assisted: yes. The implementation, proof, and landing review were performed with Codex under maintainer direction.

Related: #124711

## What Problem This Solves

Fixes a regression from #124711 where `openclaw gateway restart` and `openclaw node restart` on Linux treated an existing disabled systemd unit as absent. Operators received exit 1 and install guidance even though the installed unit had a valid native restart path.

## Why This Change Was Made

The shared restart owner now honors `acceptInstalledDefinition` when the loaded-state probe returns `false` as well as when it throws. Installation discovery stays adapter-owned: systemd uses its authoritative scope detector, while adapters without that seam retain their existing installed-command fallback.

True absence remains a failure, unsupported and unavailable checks with no definition remain truthful failures, and start/stop behavior is unchanged. There is no config, protocol, schema, public API, release, or deployment change.

## User Impact

Gateway and Node services that are installed but disabled can be restarted normally on Linux. They remain disabled after the explicit restart, while truly absent services still return install guidance and absent stop remains an idempotent success.

## Evidence

Regression provenance:

- Source PR: #124711, squash `57ebd205663b2b23a56605942b06507616887db5`
- Original base: `568b920b210af20f9f66add62e76fc440cca15f5`
- Final head: `8233d540183a37675fb60aa4ca5dbca6ef30f09a`
- Stable patch ID across rebases: `b5ec6699702319ac71e08ca0e1ff8fbff3c8e518`
- #123069 introduced installed-definition recovery for a thrown systemd probe; #124711 made a returned `false` terminal, exposing the false-vs-throw gap.

Pre-fix proof on untouched current main:

- Focused regression test: 2 expected failures. The installed-disabled case exited through `failServiceNotLoaded`; the corrected absence fixture showed the definition probe was never consulted.
- Real isolated systemd user manager on Blacksmith Testbox `tbx_01m05z4nzhkpbfk8aq6kgbaqxn`, Actions run https://github.com/openclaw/openclaw/actions/runs/31966277940: Gateway and Node units were installed, disabled, and inactive. Both restart commands exited 1 with install hints, left `MainPID=0`, and did not change native state. Cleanup verified both units `LoadState=not-found`.

Post-fix proof:

- macOS focused owner/caller/service tests: 102 passed.
- Linux focused lifecycle/systemd/Node/service tests: 281 passed.
- Full build passed on the patched Testbox tree.
- Real isolated systemd Gateway + Node: both JSON restarts returned `ok:true,result:"restarted"`; both human restarts exited 0 with native restart output and no install hints. Units remained disabled, became active with fresh PIDs/invocation IDs, then cleanup verified `LoadState=not-found`.
- Source-blind built CLI true-absence matrix: 12 Gateway/Node human+JSON start/restart/stop cases. Start/restart remained exit 1 with install guidance; stop remained exit 0 `not-loaded`.
- Targeted format, lint, production types, CLI test types, import cycles, and `git diff --check` passed.
- Testbox `check:changed` passed all `core` and `coreTests` lanes in 10m56s.
- Fresh Codex autoreview: no findings, `patch is correct`, confidence 0.99.
- Final exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31970350822 — green.
- The unrelated red-main extension boundary failure was repaired separately and landed in #124800 as `df5b5baf83022af3347d7f4219b186f69397728f`; it is not part of this PR.

Test-audit authoring gate:

- Protected behavior: a restartable installed definition reaches the native manager even when enabled-state is false.
- Credible regression: #124711 made returned-false state terminal; the new test failed on the exact pre-fix code.
- Existing coverage only covered a thrown loaded-state probe and accidentally modeled false absence with a non-null command.
- No test-only production seam was added.

ClawSweeper move disposition from #124711:

- Applied: distinguish an installed definition before restart failure.
- Applied: correct the false-absence fixture and add native-mutation/no-recovery/no-install-hint regression coverage.
- Applied: rerun focused lifecycle tests, real systemd behavior, exact build/static gates, and fresh autoreview.
- Skipped for this explicitly bounded P1 fix-forward: #124711's separate P2 wording request about macOS LaunchAgent start recovery. This PR changes no documented lifecycle contract and is limited to restoring disabled-installed systemd restart behavior.

LOC classification:

- Production TypeScript: `+11/-11` (net 0)
- Tests: `+41/-2` (net +39)
- Total: `+52/-13`
