### PR TITLE
fix(gateway): worktree names from generated session titles; start title work at dispatch

### DIFF
--- a/src/agents/worktrees/name.test.ts
+++ b/src/agents/worktrees/name.test.ts
@@ -10,7 +10,10 @@ describe("slugifyWorktreeTitle", () => {
     expect(slugifyWorktreeTitle(title)).toBe(expected);
   });
 
-  it("truncates at the worktree contract limit without a trailing dash", () => {
+  it("truncates at the last complete word within the worktree contract limit", () => {
+    expect(slugifyWorktreeTitle(`${"a".repeat(50)} complete unfinished`)).toBe(
+      `${"a".repeat(50)}-complete`,
+    );
     expect(slugifyWorktreeTitle(`${"a".repeat(63)} two`)).toBe("a".repeat(63));
   });
 

--- a/src/agents/worktrees/name.ts
+++ b/src/agents/worktrees/name.ts
@@ -9,10 +9,13 @@ export function slugifyWorktreeTitle(title: string): string | undefined {
     .toLowerCase()
     .replace(/&/g, " and ")
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, WORKTREE_NAME_MAX_LENGTH)
-    .replace(/-+$/g, "");
-  return slug || undefined;
+    .replace(/^-+|-+$/g, "");
+  if (slug.length <= WORKTREE_NAME_MAX_LENGTH) {
+    return slug || undefined;
+  }
+  const truncated = slug.slice(0, WORKTREE_NAME_MAX_LENGTH);
+  const wordBoundary = truncated.lastIndexOf("-");
+  return wordBoundary > 0 ? truncated.slice(0, wordBoundary) : truncated;
 }
 
 /** Maps names that can converge after a `-1000` suffix into one allocation lane. */

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -9,6 +9,7 @@ import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js"
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withTimeout } from "../infra/fs-safe.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
@@ -29,6 +30,8 @@ type DashboardSessionTitleModelEntry = Pick<
 
 const DASHBOARD_SESSION_TITLE_MAX_CHARS = 60;
 const DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS = 1_000;
+const WORKTREE_SESSION_TITLE_TIMEOUT_MS = 8_000;
+const WORKTREE_SESSION_TITLE_ATTEMPT_TIMEOUT_MS = 4_000;
 const DASHBOARD_SESSION_TITLE_PROMPT =
   "Generate a concise session title (3-6 words, max 60 characters) from the user's first message. Use the same language as the message, in sentence case: capitalize only the first word and words that language always capitalizes. No emoji. Return only the title.";
 
@@ -160,6 +163,7 @@ async function generateDashboardSessionTitle(params: {
   entry?: DashboardSessionTitleModelEntry;
   userMessage: string;
   attachments?: readonly ChatAttachment[];
+  timeoutMs?: number;
 }): Promise<string | null> {
   const sourceText = buildDashboardSessionTitleSource({
     message: params.userMessage,
@@ -200,8 +204,63 @@ async function generateDashboardSessionTitle(params: {
     ...(preferredProfile ? { preferredProfile } : {}),
     normalizeLabel: normalizeDashboardSessionTitle,
     maxLength: DASHBOARD_SESSION_TITLE_MAX_CHARS,
+    ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
   });
   return generated ? normalizeDashboardSessionTitle(generated) : null;
+}
+
+export function prepareWorktreeSessionTitle(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  userMessage: string;
+  attachments?: readonly ChatAttachment[];
+  onError: (error: unknown) => void;
+}) {
+  const source = buildDashboardSessionTitleSource({
+    message: params.userMessage,
+    attachments: params.attachments,
+  });
+  if (!source) {
+    return undefined;
+  }
+  const generated = withTimeout(
+    generateDashboardSessionTitle({
+      ...params,
+      timeoutMs: WORKTREE_SESSION_TITLE_ATTEMPT_TIMEOUT_MS,
+    }),
+    WORKTREE_SESSION_TITLE_TIMEOUT_MS,
+    "worktree title generation",
+  ).catch((error: unknown) => {
+    params.onError(error);
+    return null;
+  });
+  return {
+    source,
+    generated,
+    persist: async (
+      agentId: string,
+      entry: SessionEntry,
+      sessionKey: string,
+      storePath: string,
+    ) => {
+      try {
+        const attempt = await maybeGenerateSessionTitle({
+          cfg: params.cfg,
+          agentId,
+          entry,
+          sessionId: entry.sessionId,
+          sessionKey,
+          storePath,
+          userMessage: source,
+          titleGeneration: generated,
+        });
+        return attempt.kind === "persisted";
+      } catch (error) {
+        params.onError(error);
+        return false;
+      }
+    },
+  };
 }
 
 export async function maybeGenerateDashboardSessionTitle(params: {
@@ -238,6 +297,7 @@ export async function maybeGenerateSessionTitle(params: {
   storePath: string;
   currentUserMessage?: string;
   userMessage: string;
+  titleGeneration?: Promise<string | null>;
 }): Promise<SessionTitleAttempt> {
   if (hasExplicitSessionName(params.entry) || params.entry?.sessionId !== params.sessionId) {
     return { kind: "skipped" };
@@ -278,12 +338,13 @@ export async function maybeGenerateSessionTitle(params: {
     sessionTitleRequests,
     requestKey,
     async () => {
-      const displayName = await generateDashboardSessionTitle({
-        cfg: params.cfg,
-        agentId: params.agentId,
-        entry: params.entry,
-        userMessage: sourceText,
-      });
+      const displayName = await (params.titleGeneration ??
+        generateDashboardSessionTitle({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          entry: params.entry,
+          userMessage: sourceText,
+        }));
       if (!displayName) {
         return false;
       }

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -516,17 +516,18 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
         // in chat-send-admission.ts: unreferenced staged media is discarded.
         void discardPreparedChatSendAttachments(attachments.offloadedRefs);
       }
-      // Cosmetic title work starts only after the accepted turn finishes. Starting it
-      // before dispatch can make a cold utility runtime starve the user's real turn.
-      scheduleChatDashboardSessionTitle({
-        admittedSessionId,
-        agentId,
-        cfg,
-        context,
-        request,
-        sessionKey,
-        sessionLoadOptions: session.sessionLoadOptions,
-        storePath: session.storePath,
-      });
     });
+  // Title work starts at turn admission, concurrently with the launched run. It must never run
+  // serially before dispatch (a cold utility runtime can starve the turn) or wait for completion
+  // (long or interrupted first turns would silently remain untitled, and restart loses the chain).
+  scheduleChatDashboardSessionTitle({
+    admittedSessionId,
+    agentId,
+    cfg,
+    context,
+    request,
+    sessionKey,
+    sessionLoadOptions: session.sessionLoadOptions,
+    storePath: session.storePath,
+  });
 }

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -27,7 +27,7 @@ import {
 } from "../../projects/project-registry.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
-import { buildDashboardSessionTitleSource } from "../dashboard-session-title.js";
+import { prepareWorktreeSessionTitle } from "../dashboard-session-title.js";
 import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "../method-scopes.js";
 import { buildDashboardSessionKey, createGatewaySession } from "../session-create-service.js";
 import { ensureSessionGroupRegistered } from "../session-groups.js";
@@ -234,6 +234,22 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const explicitSessionLabel = normalizeOptionalString(p.label);
+    // Start before repository resolution, but cap the whole shared request: either
+    // naming gets a title within eight seconds or creation falls back to the raw source.
+    const worktreeTitle =
+      p.worktree === true && !requestedWorktreeName && !explicitSessionLabel
+        ? prepareWorktreeSessionTitle({
+            cfg,
+            agentId: normalizeAgentId(
+              catalogAgentId ?? explicitlyRequestedAgent.agentId ?? explicitlyRequestedAgentId,
+            ),
+            userMessage: initialMessage ?? "",
+            attachments: initialAttachments,
+            onError: (error) =>
+              sessionLog.warn(`worktree title failed: ${formatErrorMessage(error)}`),
+          })
+        : undefined;
     let projectRoot: string | undefined;
     if (requestedProjectId) {
       const project = resolveProjectRegistry(cfg, requestedProjectId);
@@ -423,17 +439,14 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
             }
             sessionWorktree = existing;
           } else {
+            const generatedTitle = await worktreeTitle?.generated;
             sessionWorktree = await managedWorktrees.create({
               repoRoot: workspace,
               ownerKind: "session",
               ownerId: lifecycleTarget.key,
               name: requestedWorktreeName,
               suggestedName: slugifyWorktreeTitle(
-                normalizeOptionalString(p.label) ??
-                  buildDashboardSessionTitleSource({
-                    message: initialMessage ?? "",
-                    attachments: initialAttachments,
-                  }),
+                explicitSessionLabel ?? generatedTitle ?? worktreeTitle?.source ?? "",
               ),
               baseRef: requestedWorktreeBaseRef,
               // Checkout hooks and .openclaw/worktree-setup.sh run repo code; keep them
@@ -576,6 +589,9 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         // that point may suppress follow-on work, but cannot roll back the session.
         if (!authority.hasActive()) {
           return;
+        }
+        if (await worktreeTitle?.persist(agentId, entry, key, storePath)) {
+          emitSessionsChanged(context, { sessionKey: key, agentId, reason: "chat.title" });
         }
         await captureCreatedSessionDiffBaseline({ key, agentId, cfg, entry, storePath });
         if (hasInitialTurn) {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -676,30 +676,6 @@ test("createGatewaySession forwards its commit guard into main-session reset", a
   }
 });
 
-test("createGatewaySession persists a generated title only for a new session", async () => {
-  await createSessionStoreDir();
-  const { createGatewaySession } = await import("./session-create-service.js");
-  const key = "agent:main:dashboard:generated-worktree-title";
-  const base = {
-    cfg: getRuntimeConfig(),
-    agentId: "main",
-    key,
-    commandSource: "test",
-  };
-
-  const created = await createGatewaySession({
-    ...base,
-    generatedDisplayName: "Readable Worktree Names",
-  });
-  expect(created).toMatchObject({ ok: true, entry: { displayName: "Readable Worktree Names" } });
-
-  const reused = await createGatewaySession({
-    ...base,
-    generatedDisplayName: "Replacement Title",
-  });
-  expect(reused).toMatchObject({ ok: true, entry: { displayName: "Readable Worktree Names" } });
-});
-
 test("chat.send fences dashboard title persistence from concurrent session deletion", async () => {
   const { storePath } = await createSessionStoreDir();
   const { ws } = await openClient();
@@ -741,9 +717,6 @@ test("chat.send fences dashboard title persistence from concurrent session delet
     });
     expect(sent.ok, JSON.stringify(sent.error)).toBe(true);
     await waitForFast(() => expect(dispatchInboundMessageMock).toHaveBeenCalled());
-    expect(dashboardTitleScheduleMocks.schedule).not.toHaveBeenCalled();
-
-    finishDispatch?.();
     await waitForFast(() => expect(dashboardTitleScheduleMocks.schedule).toHaveBeenCalled(), {
       timeout: 5_000,
     });
@@ -754,6 +727,7 @@ test("chat.send fences dashboard title persistence from concurrent session delet
       }),
     );
     await titleStarted;
+    finishDispatch?.();
 
     let deletionSettled = false;
     const deletion = directSessionReq<{ deleted: boolean }>("sessions.delete", {
@@ -774,6 +748,49 @@ test("chat.send fences dashboard title persistence from concurrent session delet
   } finally {
     finishDispatch?.();
     finishTitle?.();
+    ws.close();
+  }
+});
+
+test("chat.send persists a dashboard title while the first turn is still running", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const { ws } = await openClient();
+  let finishDispatch: (() => void) | undefined;
+  let dispatchFinished = false;
+  const dispatchPending = new Promise<void>((resolve) => {
+    finishDispatch = resolve;
+  });
+  dispatchInboundMessageMock.mockImplementationOnce(async () => {
+    await dispatchPending;
+    dispatchFinished = true;
+    return {
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    };
+  });
+  try {
+    const created = await rpcReq<{ key: string }>(ws, "sessions.create", {
+      agentId: "main",
+      key: "agent:main:dashboard:title-during-turn",
+    });
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    const sessionKey = requireNonEmptyString(created.payload?.key, "created session key");
+
+    const sent = await rpcReq(ws, "chat.send", {
+      sessionKey,
+      message: "Help me plan the release",
+      idempotencyKey: "dashboard-title-during-turn",
+    });
+    expect(sent.ok, JSON.stringify(sent.error)).toBe(true);
+    await waitForFast(() => expect(dispatchInboundMessageMock).toHaveBeenCalled());
+    await waitForFast(() =>
+      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+        displayName: "Generated Dashboard Title",
+      }),
+    );
+    expect(dispatchFinished).toBe(false);
+  } finally {
+    finishDispatch?.();
     ws.close();
   }
 });
@@ -1333,7 +1350,7 @@ test("sessions.create preserves a committed worktree when initial-turn setup fai
   }
 });
 
-test("sessions.create names its managed worktree without waiting for the model title", async () => {
+test("sessions.create shares its generated title with the worktree and first chat send", async () => {
   const openClawState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-session-worktree-title-",
@@ -1341,7 +1358,7 @@ test("sessions.create names its managed worktree without waiting for the model t
   const workspace = await initializeGitWorkspace(openClawState.root);
   closeOpenClawStateDatabaseForTest();
   testState.agentConfig = { workspace };
-  await createSessionStoreDir();
+  const { storePath } = await createSessionStoreDir();
   const { ws } = await openClient({ scopes: ["operator.admin"] });
   let worktreeId: string | undefined;
   const pastedText = `Pasted deployment plan ${"x".repeat(2_000)}`;
@@ -1351,51 +1368,129 @@ test("sessions.create names its managed worktree without waiting for the model t
     mimeType: "text/plain",
     content: Buffer.from(pastedText).toString("base64"),
   };
-  let resolveTitle: ((title: string) => void) | undefined;
-  dashboardTitleGenerationMocks.generate.mockReturnValueOnce(
-    new Promise<string>((resolve) => {
-      resolveTitle = resolve;
-    }),
-  );
+  dashboardTitleGenerationMocks.generate.mockResolvedValueOnce("Attachment Repair");
   dispatchInboundMessageMock.mockResolvedValueOnce({
     queuedFinal: false,
     counts: { block: 0, final: 0, tool: 0 },
   });
-  const createResult = rpcReq<{
-    key: string;
-    worktree: { id: string; branch: string };
-  }>(ws, "sessions.create", {
-    agentId: "main",
-    worktree: true,
-    message,
-    attachments: [attachment],
-  });
-  let createSettled = false;
-  void createResult.then(() => {
-    createSettled = true;
-  });
   try {
-    await waitForFast(() => expect(createSettled).toBe(true), {
-      timeout: 1_000,
+    const created = await rpcReq<{
+      key: string;
+      worktree: { id: string; branch: string };
+    }>(ws, "sessions.create", {
+      agentId: "main",
+      worktree: true,
+      message,
+      attachments: [attachment],
     });
-    const created = await createResult;
 
     expect(created.ok, JSON.stringify(created.error)).toBe(true);
     worktreeId = created.payload?.worktree.id;
-    expect(created.payload?.worktree.branch).toBe(
-      "openclaw/review-this-rollout-pasted-deployment-plan-xxxxxxxxxxxxxxxxxxxxx",
+    expect(created.payload?.worktree.branch).toBe("openclaw/attachment-repair");
+    const sessionKey = requireNonEmptyString(created.payload?.key, "created session key");
+    await waitForFast(() => expect(dashboardTitleScheduleMocks.schedule).toHaveBeenCalled());
+    expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+      displayName: "Attachment Repair",
+    });
+    expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 4_000 }),
     );
-    resolveTitle?.("Attachment Repair");
+    expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledOnce();
   } finally {
-    resolveTitle?.("Attachment Repair");
-    const created = await createResult;
-    worktreeId ??= created.payload?.worktree.id;
     if (worktreeId) {
       await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });
     }
     closeOpenClawStateDatabaseForTest();
     testState.agentConfig = undefined;
     ws.close();
+    await openClawState.cleanup();
+  }
+});
+
+test.each([
+  {
+    name: "generator error",
+    key: "agent:main:subagent:worktree-title-error",
+    arrange: () => dashboardTitleGenerationMocks.generate.mockRejectedValueOnce(new Error("boom")),
+  },
+  {
+    name: "overall timeout",
+    key: "agent:main:subagent:worktree-title-timeout",
+    arrange: () =>
+      dashboardTitleGenerationMocks.generate.mockReturnValueOnce(new Promise<string>(() => {})),
+  },
+])(
+  "sessions.create falls back to the raw title source after $name",
+  async ({ key, arrange }) => {
+    const openClawState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-session-worktree-title-fallback-",
+    });
+    const workspace = await initializeGitWorkspace(openClawState.root);
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = { workspace };
+    await createSessionStoreDir();
+    const { ws } = await openClient({ scopes: ["operator.admin"] });
+    let worktreeId: string | undefined;
+    arrange();
+    try {
+      const created = await rpcReq<{ worktree: { id: string; branch: string } }>(
+        ws,
+        "sessions.create",
+        {
+          agentId: "main",
+          key,
+          worktree: true,
+          message: "Investigate the raw fallback title",
+        },
+      );
+
+      expect(created.ok, JSON.stringify(created.error)).toBe(true);
+      worktreeId = created.payload?.worktree.id;
+      expect(created.payload?.worktree.branch).toBe("openclaw/investigate-the-raw-fallback-title");
+      expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledOnce();
+    } finally {
+      if (worktreeId) {
+        await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });
+      }
+      closeOpenClawStateDatabaseForTest();
+      testState.agentConfig = undefined;
+      ws.close();
+      await openClawState.cleanup();
+    }
+  },
+  15_000,
+);
+
+test("sessions.create keeps the crustacean fallback when no title source exists", async () => {
+  const openClawState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-session-worktree-empty-title-",
+  });
+  const workspace = await initializeGitWorkspace(openClawState.root);
+  closeOpenClawStateDatabaseForTest();
+  testState.agentConfig = { workspace };
+  await createSessionStoreDir();
+  let worktreeId: string | undefined;
+  try {
+    const created = await directSessionReq<{ worktree: { id: string; branch: string } }>(
+      "sessions.create",
+      { agentId: "main", worktree: true },
+      { client: { connect: { scopes: ["operator.admin"] } } as never },
+    );
+
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    worktreeId = created.payload?.worktree.id;
+    expect(created.payload?.worktree.branch).toMatch(
+      /^openclaw\/[a-z]+-(?:barnacle|claw|crab|crayfish|krill|langoustine|lobster|prawn|shrimp|shell)$/,
+    );
+    expect(dashboardTitleGenerationMocks.generate).not.toHaveBeenCalled();
+  } finally {
+    if (worktreeId) {
+      await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });
+    }
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = undefined;
     await openClawState.cleanup();
   }
 });

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -229,8 +229,6 @@ export async function createGatewaySession(params: {
   agentId?: string;
   label?: string;
   category?: string;
-  /** Trusted model-generated title, persisted with a newly created dashboard session. */
-  generatedDisplayName?: string;
   model?: string;
   thinkingLevel?: string;
   /** Registry identity recorded only when this request creates a logical session node. */
@@ -293,7 +291,6 @@ export async function createGatewaySession(params: {
 }): Promise<CreateGatewaySessionResult> {
   const requestedKey = normalizeOptionalString(params.key);
   const parentSessionKey = normalizeOptionalString(params.parentSessionKey);
-  const generatedDisplayName = normalizeOptionalString(params.generatedDisplayName);
   const projectId = normalizeOptionalString(params.projectId);
   const explicitAgentId = normalizeOptionalString(params.agentId);
   const explicitKeyAgentId = parseAgentSessionKey(requestedKey)?.agentId;
@@ -1027,7 +1024,6 @@ export async function createGatewaySession(params: {
           ...(params.creation && createdNewEntry ? buildSessionCreationStamp(params.creation) : {}),
           ...(params.visibility && createdNewEntry ? { visibility: params.visibility } : {}),
           ...(projectId && createdNewEntry ? { projectId } : {}),
-          ...(generatedDisplayName && createdNewEntry ? { displayName: generatedDisplayName } : {}),
           ...(catalogResolvedModel && catalogAgentRuntime
             ? {
                 providerOverride: catalogResolvedModel.provider,


### PR DESCRIPTION
## What Problem This Solves

Two related dashboard session-title defects, both reported from a production team gateway:

1. **Worktree/branch names were raw prompt slugs.** A managed worktree created from the Control UI `/new` page with a first message got a 64-char slug of the raw prompt, truncated mid-word — e.g. `openclaw/if-you-look-closely-at-the-sidebar-i-see-this-reply-to-current-m`. The docs (`docs/concepts/managed-worktrees.md`, `docs/gateway/protocol.md`) already promise the "generated first-message title" supplies the name; the code never delivered that after #122471.
2. **Session titles silently never generated for long first turns.** #122471 moved title generation into the dispatch chain's `.finally()`, which awaits the entire first agent turn. A single-prompt autonomous session (first turn = hours) shows no AI title the whole time, and a gateway restart mid-turn kills the in-process chain — the title is then never generated. Operator-visible symptom: recent sessions listed by raw fallback names only.

## Why This Change Was Made

One invariant owns both defects: **title work starts at turn admission — bounded, concurrent, shared by every consumer.**

- `sessions.create` (worktree path, no explicit `worktreeName`/label): starts the shared title generation at request start, concurrent with repository resolution and `git worktree add`; the naming point waits under a hard 8s cap (4s per model attempt) and falls back to the raw-prompt slug, then the crustacean name. The generated title is persisted as `displayName` through the existing guarded path and shared in-flight map, so the later chat-send pass performs no second model call.
- `chat.send`: title scheduling moves from the post-turn `.finally()` to dispatch start — concurrent with the run, never serially before it. #122471's actual startup-stall causes (catalog loading and cold isolated-completion work on turn start) remain fixed; this preserves that win while removing the wait-for-turn-completion regression. (Pre-#122471 the create path waited serially and unbounded with a `loadGatewayModelCatalog` call in-path — that shape is not reintroduced.)
- `slugifyWorktreeTitle` now truncates at the last full word within the 64-char cap, so even fallback slugs no longer cut mid-word.
- Dead `generatedDisplayName` plumbing in `session-create-service.ts` (vestige of the pre-#122471 approach) is removed.

Naming precedence: explicit `worktreeName` > session label > generated title > raw-prompt slug > crustacean name. Generation failure or timeout never fails or blocks session creation beyond the cap. Docs already describe exactly this behavior — no docs changes needed.

## User Impact

- Worktree and branch names are readable titles: `openclaw/worktree-naming-from-prompts-needs-investigation` instead of a mid-word raw cut.
- Sidebar/header titles appear seconds after the first send, while the first turn is still running; a restart no longer permanently untitles a session (loss window shrinks from turn-length to seconds, and any later send retries).
- Sidebar, worktree, and branch all derive from one shared generation — one utility-model call per session.

## Evidence

- **Tests**: 144 passing across 5 suites (`server.sessions.create` 97, `dashboard-session-title` 32, `worktrees/name` 7, `worktrees/service.naming` 6, plus chat-send replies): `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/gateway/dashboard-session-title.test.ts src/gateway/server-methods/chat-send-command-replies.test.ts src/agents/worktrees/name.test.ts src/agents/worktrees/service.naming.test.ts`. New regression test ("persists a dashboard title while the first turn is still running") fails pre-fix in 1.7s (verified by temporarily reverting the scheduling move). Fallback tests cover generator error, overall timeout, empty-source crustacean fallback, and non-dashboard (subagent-key) creates.
- **Live proof** (isolated dev gateway, fresh `OPENCLAW_STATE_DIR`, port 19277, real `anthropic/claude-haiku-4-5`): Control UI `/new` with Worktree selected and prompt "The worktree names our team gateway creates are just the first few words of my prompt truncated mid-word…" produced branch `openclaw/worktree-naming-from-prompts-needs-investigation`, and the header/sidebar title "Worktree naming from prompts needs investigation" was visible at 15s while the turn was still running (stop button active). Screenshots + video below.
- **Build**: `pnpm build` green, no `INEFFECTIVE_DYNAMIC_IMPORT`. Autoreview (Codex) clean. `check-changed` lanes green.
- **LOC**: production net +77 (shared bounded generation + guarded persistence in `dashboard-session-title.ts`; dispatch move is net-neutral; −4 dead param removal), tests net +98.

Session created with worktree (title already generated, run active):

![session created](https://github.com/user-attachments/assets/60f81df5-d873-428a-b826-cf2450aa126d)

Title + worktree name settled at 15s, first turn still running:

![title settled](https://github.com/user-attachments/assets/a6cabe88-fe80-419f-ab9a-52326f0ff470)

Full flow video:

https://github.com/user-attachments/assets/d16ce27c-6ed9-4ee1-83ba-ce4dc7c8a8c2

## ClawSweeper rank-up moves — disposition

The review's finding is correct: the prestarted title request carries no session entry, so an explicit `p.model`/catalog target does not steer the create-time title call (it uses the agent's utility/default route). Stated skip, not silent: the faithful fix requires threading the resolved model selection (owned by `session-create-service`) ahead of lifecycle preparation without reintroducing the pre-#122471 blocking catalog load — an owner refactor tracked as a named follow-up task ("Honor explicit session model in create-time title generation"). Interim behavior degrades gracefully: if the default route cannot serve, the worktree name falls back to the raw-prompt slug and the first chat-send retriggers title generation with full session-entry fidelity (existing tests cover that path).
