### PR TITLE
fix(runners): align reclaim results with runtime

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7589,13 +7589,13 @@ public struct SessionsReclaimResult: Codable, Sendable {
     public let ok: Bool
     public let key: String
     public let sessionid: String
-    public let placement: ReclaimedSessionPlacement
+    public let placement: SessionsReclaimResultPlacement
 
     public init(
         ok: Bool,
         key: String,
         sessionid: String,
-        placement: ReclaimedSessionPlacement)
+        placement: SessionsReclaimResultPlacement)
     {
         self.ok = ok
         self.key = key
@@ -20328,6 +20328,37 @@ public enum SessionPlacement: Codable, Sendable {
         case .reconciling(let value): try value.encode(to: encoder)
         case .reclaimed(let value): try value.encode(to: encoder)
         case .failed(let value): try value.encode(to: encoder)
+        }
+    }
+}
+
+public enum SessionsReclaimResultPlacement: Codable, Sendable {
+    case local(LocalSessionPlacement)
+    case reclaimed(ReclaimedSessionPlacement)
+
+    private enum CodingKeys: String, CodingKey {
+        case discriminator = "state"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .discriminator)
+        switch discriminator {
+        case "local": self = try .local(LocalSessionPlacement(from: decoder))
+        case "reclaimed": self = try .reclaimed(ReclaimedSessionPlacement(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .discriminator,
+                in: container,
+                debugDescription: "Unknown SessionsReclaimResultPlacement discriminator value"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .local(let value): try value.encode(to: encoder)
+        case .reclaimed(let value): try value.encode(to: encoder)
         }
     }
 }

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -198,6 +198,8 @@ openclaw gateway call sessions.reclaim \
   --params '{"key":"agent:main:big-refactor"}'
 ```
 
+The result placement is `reclaimed` after an active worker is safely stopped. If an earlier failure already proved that the environment is gone, reclaim clears the failed placement and returns `local` instead. No other placement states are successful reclaim results.
+
 Placement moves through a durable state machine (`local → requested → provisioning → syncing → starting → active`), so a Gateway restart mid-dispatch reconciles instead of leaking machines. A failed model turn keeps the active placement available for a retry. Workspace path conflicts keep the local version, apply the rest of the cloud result, and preserve the staged cloud ref for inspection; other reconciliation or lifecycle failures retain their durable recovery fence and diagnostic tail until recovery can safely retry or reclaim the environment.
 
 ## What survives a dead machine

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -285,6 +285,7 @@ export {
   SessionsDispatchParamsSchema,
   SessionsDispatchResultSchema,
   SessionsReclaimParamsSchema,
+  SessionsReclaimResultPlacementSchema,
   SessionsReclaimResultSchema,
   SessionsSendParamsSchema,
   SessionsAbortParamsSchema,

--- a/packages/gateway-protocol/src/schema/session-placement.test.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.test.ts
@@ -5,6 +5,7 @@ import {
   SessionPlacementStateSchema,
   validateSessionsDispatchParams,
   validateSessionsReclaimParams,
+  validateSessionsReclaimResult,
 } from "../index.js";
 
 const placementStates = [
@@ -80,6 +81,33 @@ describe("session dispatch protocol schemas", () => {
     expect(validateSessionsReclaimParams({ key: "agent:main:dispatch", profileId: "dev" })).toBe(
       false,
     );
+  });
+
+  it("accepts exactly the reclaim owner's terminal outcomes", () => {
+    const result = {
+      ok: true,
+      key: "agent:main:dispatch",
+      sessionId: "session-dispatch",
+    };
+
+    expect(
+      validateSessionsReclaimResult({
+        ...result,
+        placement: { state: "local", ...basePlacement },
+      }),
+    ).toBe(true);
+    expect(
+      validateSessionsReclaimResult({
+        ...result,
+        placement: { state: "reclaimed", ...basePlacement },
+      }),
+    ).toBe(true);
+    for (const placement of [
+      { state: "requested", ...basePlacement },
+      { state: "active", ...basePlacement, ...workerOwnedFields },
+    ]) {
+      expect(validateSessionsReclaimResult({ ...result, placement })).toBe(false);
+    }
   });
 
   it("keeps placement states closed", () => {

--- a/packages/gateway-protocol/src/schema/session-placement.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.ts
@@ -252,7 +252,5 @@ export type SessionPlacementDiskSpace = Static<typeof SessionPlacementDiskSpaceS
 export type SessionsDispatchParams = Static<typeof SessionsDispatchParamsSchema>;
 export type SessionsDispatchResult = Static<typeof SessionsDispatchResultSchema>;
 export type SessionsReclaimParams = Static<typeof SessionsReclaimParamsSchema>;
-export type SessionsReclaimResultPlacement = Static<
-  typeof SessionsReclaimResultPlacementSchema
->;
+export type SessionsReclaimResultPlacement = Static<typeof SessionsReclaimResultPlacementSchema>;
 export type SessionsReclaimResult = Static<typeof SessionsReclaimResultSchema>;

--- a/packages/gateway-protocol/src/schema/session-placement.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.ts
@@ -209,13 +209,19 @@ export const SessionsReclaimParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
-/** Result returned once worker ownership has been destroyed and reclaimed. */
+/** Terminal placement returned after a worker reclaim operation. */
+export const SessionsReclaimResultPlacementSchema = Type.Union([
+  LocalSessionPlacementSchema,
+  ReclaimedSessionPlacementSchema,
+]);
+
+/** Result returned once worker ownership is reclaimed or a failed placement is cleared. */
 export const SessionsReclaimResultSchema = Type.Object(
   {
     ok: Type.Literal(true),
     key: NonEmptyString,
     sessionId: NonEmptyString,
-    placement: ReclaimedSessionPlacementSchema,
+    placement: SessionsReclaimResultPlacementSchema,
   },
   { additionalProperties: false },
 );
@@ -237,6 +243,7 @@ export const SessionPlacementProtocolSchemas = {
   SessionsDispatchParams: SessionsDispatchParamsSchema,
   SessionsDispatchResult: SessionsDispatchResultSchema,
   SessionsReclaimParams: SessionsReclaimParamsSchema,
+  SessionsReclaimResultPlacement: SessionsReclaimResultPlacementSchema,
   SessionsReclaimResult: SessionsReclaimResultSchema,
 } as const;
 
@@ -245,4 +252,7 @@ export type SessionPlacementDiskSpace = Static<typeof SessionPlacementDiskSpaceS
 export type SessionsDispatchParams = Static<typeof SessionsDispatchParamsSchema>;
 export type SessionsDispatchResult = Static<typeof SessionsDispatchResultSchema>;
 export type SessionsReclaimParams = Static<typeof SessionsReclaimParamsSchema>;
+export type SessionsReclaimResultPlacement = Static<
+  typeof SessionsReclaimResultPlacementSchema
+>;
 export type SessionsReclaimResult = Static<typeof SessionsReclaimResultSchema>;

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -232,6 +232,7 @@ export const validateSessionsRecoverParams = compile(S.SessionsRecoverParamsSche
 export const validateSessionsSendParams = compile(S.SessionsSendParamsSchema);
 export const validateSessionsDispatchParams = compile(S.SessionsDispatchParamsSchema);
 export const validateSessionsReclaimParams = compile(S.SessionsReclaimParamsSchema);
+export const validateSessionsReclaimResult = compile(S.SessionsReclaimResultSchema);
 export const validateSessionsMessagesSubscribeParams = compile(
   S.SessionsMessagesSubscribeParamsSchema,
 );

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -53,15 +53,12 @@ function resolveWorkerSessionTarget(params: {
     params.respond(false, undefined, requestedAgent.error);
     return undefined;
   }
-  const destination =
-    params.profileId !== undefined || params.deviceId !== undefined
-      ? resolveWorkerPlacementDestination({
-          cfg,
-          profileId: params.profileId,
-          deviceId: params.deviceId,
-        })
-      : undefined;
-  if (destination && !destination.ok) {
+  const destination = resolveWorkerPlacementDestination({
+    cfg,
+    profileId: params.profileId,
+    deviceId: params.deviceId,
+  });
+  if (!destination.ok) {
     respondInvalidWorkerSession(params.respond, destination.error);
     return undefined;
   }
@@ -76,7 +73,7 @@ function resolveWorkerSessionTarget(params: {
     respondInvalidWorkerSession(params.respond, `session not found: ${params.key}`);
     return undefined;
   }
-  return { cfg, target, entry, sessionId, dispatchTarget: destination?.value };
+  return { cfg, target, entry, sessionId, dispatchTarget: destination.value };
 }
 
 function hasManagedSessionWorktree(params: {

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -10,7 +10,7 @@ import { managedWorktrees } from "../../agents/worktrees/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
 import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
-import { DEVICE_WORKER_PROVIDER_ID } from "../worker-environments/device-provider.js";
+import { resolveWorkerPlacementDestination } from "../worker-environments/placement-destination.js";
 import { projectWorkerSessionPlacement } from "../worker-environments/placement-projector.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-record.js";
 import {
@@ -39,7 +39,7 @@ function respondInvalidWorkerSession(respond: RespondFn, message: string): void 
   respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
 }
 
-async function resolveWorkerSessionTarget(params: {
+function resolveWorkerSessionTarget(params: {
   key: string;
   agentId?: string;
   profileId?: string;
@@ -53,41 +53,17 @@ async function resolveWorkerSessionTarget(params: {
     params.respond(false, undefined, requestedAgent.error);
     return undefined;
   }
-  const profileId = normalizeOptionalString(params.profileId);
-  const deviceId = normalizeOptionalString(params.deviceId);
-  let dispatchTarget:
-    | {
-        profileId: string;
-        deviceId?: undefined;
-        inheritedProfile?: undefined;
-      }
-    | {
-        profileId: string;
-        deviceId: string;
-        inheritedProfile: {
-          providerId: typeof DEVICE_WORKER_PROVIDER_ID;
-          profileSnapshot: { install: "bundle"; settings: { device: string } };
-        };
-      }
-    | undefined;
-  if (profileId && !Object.hasOwn(cfg.cloudWorkers?.profiles ?? {}, profileId)) {
-    respondInvalidWorkerSession(
-      params.respond,
-      `cloud worker profile is not configured: ${profileId}`,
-    );
+  const destination =
+    params.profileId !== undefined || params.deviceId !== undefined
+      ? resolveWorkerPlacementDestination({
+          cfg,
+          profileId: params.profileId,
+          deviceId: params.deviceId,
+        })
+      : undefined;
+  if (destination && !destination.ok) {
+    respondInvalidWorkerSession(params.respond, destination.error);
     return undefined;
-  }
-  if (profileId) {
-    dispatchTarget = { profileId };
-  } else if (deviceId) {
-    dispatchTarget = {
-      profileId: `device:${deviceId}`,
-      deviceId,
-      inheritedProfile: {
-        providerId: DEVICE_WORKER_PROVIDER_ID,
-        profileSnapshot: { install: "bundle", settings: { device: deviceId } },
-      },
-    };
   }
   const target = loadAccessorSessionEntryForGatewayTarget({
     key: params.key,
@@ -100,7 +76,7 @@ async function resolveWorkerSessionTarget(params: {
     respondInvalidWorkerSession(params.respond, `session not found: ${params.key}`);
     return undefined;
   }
-  return { cfg, target, entry, sessionId, dispatchTarget };
+  return { cfg, target, entry, sessionId, dispatchTarget: destination?.value };
 }
 
 function hasManagedSessionWorktree(params: {
@@ -173,7 +149,7 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       respondInvalidWorkerSession(respond, "cloud worker dispatch is not configured");
       return;
     }
-    const resolved = await resolveWorkerSessionTarget({
+    const resolved = resolveWorkerSessionTarget({
       key,
       agentId: params.agentId,
       profileId: params.profileId,
@@ -280,7 +256,7 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       respondInvalidWorkerSession(respond, "cloud worker stop is not configured");
       return;
     }
-    const resolved = await resolveWorkerSessionTarget({
+    const resolved = resolveWorkerSessionTarget({
       key,
       agentId: params.agentId,
       context,

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -77,6 +77,27 @@ describe("sessions.dispatch", () => {
     );
   });
 
+  it("rejects an unconfigured cloud worker profile before dispatch", async () => {
+    const dispatch = vi.fn();
+    const respond = await invoke(
+      makeContext({
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: { getMany: () => new Map() },
+      }),
+      { profileId: "missing" },
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: "cloud worker profile is not configured: missing",
+      }),
+    );
+  });
+
   it("rejects sessions without their bound managed worktree", async () => {
     mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
     const dispatch = vi.fn();

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -98,6 +98,28 @@ describe("sessions.dispatch", () => {
     );
   });
 
+  it("treats a whitespace-only profile as an omitted dispatch target", async () => {
+    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+    const dispatch = vi.fn();
+    const respond = await invoke(
+      makeContext({
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: { getMany: () => new Map() },
+      }),
+      { profileId: " " },
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: "worker dispatch target is missing",
+      }),
+    );
+  });
+
   it("rejects sessions without their bound managed worktree", async () => {
     mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
     const dispatch = vi.fn();

--- a/src/gateway/worker-environments/placement-destination.ts
+++ b/src/gateway/worker-environments/placement-destination.ts
@@ -20,7 +20,7 @@ export function resolveWorkerPlacementDestination(params: {
   cfg: Pick<OpenClawConfig, "cloudWorkers">;
   profileId?: string;
   deviceId?: string;
-}): Result<WorkerPlacementDestination, string> {
+}): Result<WorkerPlacementDestination | undefined, string> {
   const profileId = normalizeOptionalString(params.profileId);
   if (profileId) {
     return Object.hasOwn(params.cfg.cloudWorkers?.profiles ?? {}, profileId)
@@ -29,7 +29,7 @@ export function resolveWorkerPlacementDestination(params: {
   }
   const deviceId = normalizeOptionalString(params.deviceId);
   if (!deviceId) {
-    return err("worker dispatch target is missing");
+    return ok(undefined);
   }
   return ok({
     profileId: `device:${deviceId}`,

--- a/src/gateway/worker-environments/placement-destination.ts
+++ b/src/gateway/worker-environments/placement-destination.ts
@@ -1,0 +1,42 @@
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider.js";
+import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
+
+type WorkerPlacementDestination =
+  | {
+      profileId: string;
+      deviceId?: undefined;
+      inheritedProfile?: undefined;
+    }
+  | {
+      profileId: string;
+      deviceId: string;
+      inheritedProfile: NonNullable<WorkerPlacementDispatchRequest["inheritedProfile"]>;
+    };
+
+export function resolveWorkerPlacementDestination(params: {
+  cfg: Pick<OpenClawConfig, "cloudWorkers">;
+  profileId?: string;
+  deviceId?: string;
+}): Result<WorkerPlacementDestination, string> {
+  const profileId = normalizeOptionalString(params.profileId);
+  if (profileId) {
+    return Object.hasOwn(params.cfg.cloudWorkers?.profiles ?? {}, profileId)
+      ? ok({ profileId })
+      : err(`cloud worker profile is not configured: ${profileId}`);
+  }
+  const deviceId = normalizeOptionalString(params.deviceId);
+  if (!deviceId) {
+    return err("worker dispatch target is missing");
+  }
+  return ok({
+    profileId: `device:${deviceId}`,
+    deviceId,
+    inheritedProfile: {
+      providerId: DEVICE_WORKER_PROVIDER_ID,
+      profileSnapshot: { install: "bundle", settings: { device: deviceId } },
+    },
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes a Gateway protocol mismatch where `sessions.reclaim` already returned either `local` or `reclaimed`, while the public result schema and generated native model accepted only `reclaimed`. A valid environment-free cleanup could therefore produce a runtime response that clients could not validate.

The same dispatch target policy was embedded in the RPC handler, leaving future stop-and-continue moves without a canonical way to resolve profile and device destinations.

## Why This Change Was Made

The reclaim result contract now exposes exactly the two runtime terminal outcomes. Profile validation and device inherited-profile construction move into one internal destination owner that normalizes optional input before deciding whether a target exists; the existing dispatch handler retains authorization, session, worktree, and orchestration responsibilities.

No move RPC, placement state, config, storage, SQLite, compatibility shim, or protocol-version bump is introduced.

Maintainer compatibility decision: accept the corrected OpenClawKit two-case enum. Native consumers must handle both `local` and `reclaimed`, because the Gateway already produces both and the prior concrete type was false.

## User Impact

Gateway clients can reliably parse every successful reclaim result, including failed-placement cleanup that returns the session to local execution. Existing profile/device dispatch behavior is unchanged, and the runner move implementation can reuse one destination policy instead of duplicating it.

Production LOC: +66/-41 (net +25). Generated Swift is +33/-2, tests +71, and docs +2. The source growth is the corrected public union plus one immediately reused destination ownership boundary.

## Evidence

- Exact-head required CI is green: https://github.com/openclaw/openclaw/actions/runs/31970217028
- Focused dispatch/reclaim/protocol coverage: 41 passed.
- Swift Gateway model generator `--check`: passed.
- Full extension package boundary compile (123 plugins) and canary passed locally.
- Docs inventory, workflow sanity, formatting, and `git diff --check`: passed.
- Whitespace-only targets preserve the pre-refactor normalized-absence behavior.
- Fresh P0–P2 autoreview on the patch: no actionable findings.
- ClawSweeper reports no actionable findings; its generated Swift compatibility decision is recorded in the PR discussion.

Known proof gaps: none.
