### PR TITLE
refactor(agents): persist directive facts at the assistant write boundary

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2282,7 +2282,6 @@ src/auto-reply/reply/queue/drain.ts	2
 src/auto-reply/reply/queue/enqueue.ts	1
 src/auto-reply/reply/queue/settings.ts	1
 src/auto-reply/reply/reply-config-runtime-mode.ts	2
-src/auto-reply/reply/reply-directives.ts	1
 src/auto-reply/reply/reply-operation-run-state.ts	1
 src/auto-reply/reply/reply-payload-sending-hook.ts	1
 src/auto-reply/reply/reply-run-registry.registry.ts	1

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -336,6 +336,11 @@ export interface UserMessage {
 export interface AssistantMessage {
   role: "assistant";
   content: (TextContent | ThinkingContent | ToolCall)[];
+  openclawDelivery?: {
+    audioAsVoice?: true;
+    replyToCurrent?: true;
+    replyToId?: string;
+  };
   api: Api;
   provider: Provider;
   model: string;

--- a/src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
@@ -1,0 +1,44 @@
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { buildPayloads } from "./payloads.test-helpers.js";
+
+describe("buildEmbeddedRunPayloads delivery recovery", () => {
+  it("uses persisted delivery facts for a recovered final assistant", () => {
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Recovered answer" }],
+        openclawDelivery: {
+          audioAsVoice: true,
+          replyToCurrent: true,
+          replyToId: "message-7",
+        },
+      } as AssistantMessage,
+    });
+
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        text: "Recovered answer",
+        audioAsVoice: true,
+        replyToCurrent: true,
+        replyToId: "message-7",
+      }),
+    ]);
+  });
+
+  it("does not recover delivery facts by parsing a pre-upgrade assistant", () => {
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "[[reply_to:message-7]] Recovered answer" }],
+      } as AssistantMessage,
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Recovered answer");
+    expect(payloads[0]).not.toHaveProperty("replyToCurrent");
+    expect(payloads[0]).not.toHaveProperty("replyToId");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -134,6 +134,51 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("uses persisted delivery facts for a recovered final assistant", () => {
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Recovered answer" }],
+        openclawDelivery: {
+          audioAsVoice: true,
+          replyToCurrent: true,
+          replyToId: "message-7",
+        },
+      } as AssistantMessage & {
+        openclawDelivery: {
+          audioAsVoice: true;
+          replyToCurrent: true;
+          replyToId: string;
+        };
+      },
+    });
+
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        text: "Recovered answer",
+        audioAsVoice: true,
+        replyToCurrent: true,
+        replyToId: "message-7",
+      }),
+    ]);
+  });
+
+  it("does not recover delivery facts by parsing a pre-upgrade assistant", () => {
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "[[reply_to:message-7]] Recovered answer" }],
+      } as AssistantMessage,
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Recovered answer");
+    expect(payloads[0]).not.toHaveProperty("replyToCurrent");
+    expect(payloads[0]).not.toHaveProperty("replyToId");
+  });
+
   it("does not revive signed unphased text when explicit final-answer text is empty", () => {
     expectNoPayloads({
       lastAssistant: {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -134,51 +134,6 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("uses persisted delivery facts for a recovered final assistant", () => {
-    const payloads = buildPayloads({
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        content: [{ type: "text", text: "Recovered answer" }],
-        openclawDelivery: {
-          audioAsVoice: true,
-          replyToCurrent: true,
-          replyToId: "message-7",
-        },
-      } as AssistantMessage & {
-        openclawDelivery: {
-          audioAsVoice: true;
-          replyToCurrent: true;
-          replyToId: string;
-        };
-      },
-    });
-
-    expect(payloads).toEqual([
-      expect.objectContaining({
-        text: "Recovered answer",
-        audioAsVoice: true,
-        replyToCurrent: true,
-        replyToId: "message-7",
-      }),
-    ]);
-  });
-
-  it("does not recover delivery facts by parsing a pre-upgrade assistant", () => {
-    const payloads = buildPayloads({
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        content: [{ type: "text", text: "[[reply_to:message-7]] Recovered answer" }],
-      } as AssistantMessage,
-    });
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.text).toBe("Recovered answer");
-    expect(payloads[0]).not.toHaveProperty("replyToCurrent");
-    expect(payloads[0]).not.toHaveProperty("replyToId");
-  });
-
   it("does not revive signed unphased text when explicit final-answer text is empty", () => {
     expectNoPayloads({
       lastAssistant: {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -205,6 +205,9 @@ export function buildEmbeddedRunPayloads(params: {
   const currentAssistant = params.currentAssistant ?? undefined;
   const assistantForPayload =
     currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);
+  // Pre-upgrade recovered messages have no stored facts, and recovery intentionally does not
+  // reparse text; one in-flight reply can lose its target across this upgrade boundary.
+  const storedDelivery = assistantForPayload?.openclawDelivery;
   const lastAssistantStopReason = assistantForPayload?.stopReason;
   const lastAssistantErrored = lastAssistantStopReason === "error";
   const lastAssistantAborted = lastAssistantStopReason === "aborted";
@@ -376,16 +379,19 @@ export function buildEmbeddedRunPayloads(params: {
       replyToTag,
       replyToCurrent,
     } = parseReplyDirectives(text);
-    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
+    const delivery = shouldUseCanonicalFinalAnswer
+      ? {
+          ...storedDelivery,
+          replyToTag: Boolean(storedDelivery?.replyToCurrent || storedDelivery?.replyToId),
+        }
+      : { audioAsVoice, replyToId, replyToTag, replyToCurrent };
+    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !delivery.audioAsVoice) {
       continue;
     }
     replyItems.push({
       text: cleanedText,
       media: mediaUrls,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
+      ...delivery,
     });
     hasUserFacingAssistantReply = true;
     if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -15,6 +15,7 @@ import type {
   AgentSessionEventListener,
   AgentSessionWriteSettlementRunner,
 } from "./agent-session-types.js";
+import { replaceAgentMessageInPlace } from "./agent-session-utils.js";
 import { formatNoApiKeyFoundMessage } from "./auth-guidance.js";
 import {
   type ExtensionCommandContextActions,
@@ -421,7 +422,7 @@ export abstract class AgentSessionBase {
         if (event.message.role === "assistant") {
           const persisted = this.sessionManager.getEntry(entryId);
           if (persisted?.type === "message" && persisted.message.role === "assistant") {
-            this.replaceMessageInPlace(event.message, persisted.message);
+            replaceAgentMessageInPlace(event.message, persisted.message);
           }
           this.lastAssistantEntryId = entryId;
         } else if (event.message.role === "user") {
@@ -482,21 +483,6 @@ export abstract class AgentSessionBase {
     return undefined;
   }
 
-  private replaceMessageInPlace(target: AgentMessage, replacement: AgentMessage): void {
-    // Agent-core stores the finalized message object in its state before emitting message_end.
-    // SessionManager persistence happens later in handleAgentEvent() with event.message.
-    // Mutating this object in place keeps agent state, later turn/agent events, listeners,
-    // and the eventual SessionManager.appendMessage(event.message) persistence in sync.
-    if (target === replacement) {
-      return;
-    }
-
-    for (const key of Object.keys(target)) {
-      Reflect.deleteProperty(target, key);
-    }
-    Object.assign(target, replacement);
-  }
-
   /** Emit extension events based on agent events */
   private async emitExtensionEvent(event: AgentEvent): Promise<boolean> {
     if (event.type === "agent_start") {
@@ -540,7 +526,7 @@ export abstract class AgentSessionBase {
       };
       const replacement = await this.currentExtensionRunner.emitMessageEnd(extensionEvent);
       if (replacement) {
-        this.replaceMessageInPlace(event.message, replacement);
+        replaceAgentMessageInPlace(event.message, replacement);
         return true;
       }
     } else if (event.type === "tool_execution_start") {

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -419,6 +419,10 @@ export abstract class AgentSessionBase {
           throw error;
         }
         if (event.message.role === "assistant") {
+          const persisted = this.sessionManager.getEntry(entryId);
+          if (persisted?.type === "message" && persisted.message.role === "assistant") {
+            this.replaceMessageInPlace(event.message, persisted.message);
+          }
           this.lastAssistantEntryId = entryId;
         } else if (event.message.role === "user") {
           // A queued user message_end normally follows a committed append before listeners consume it.

--- a/src/agents/sessions/agent-session-utils.ts
+++ b/src/agents/sessions/agent-session-utils.ts
@@ -57,6 +57,18 @@ export function extractTextContent(content: unknown): string {
   return text;
 }
 
+export function replaceAgentMessageInPlace(target: AgentMessage, replacement: AgentMessage): void {
+  // Agent-core stores the finalized message object before emitting message_end.
+  // Mutating it in place keeps agent state, later events, and persistence in sync.
+  if (target === replacement) {
+    return;
+  }
+  for (const key of Object.keys(target)) {
+    Reflect.deleteProperty(target, key);
+  }
+  Object.assign(target, replacement);
+}
+
 export function estimateMessagesFromContent(messages: AgentMessage[]): number {
   return messages.reduce((total, message) => total + estimateTokens(message), 0);
 }

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -2,6 +2,7 @@ import {
   readActiveTranscriptEntryAnchor,
   type TranscriptEntryAnchor,
 } from "../../config/sessions/session-accessor.js";
+import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-message.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import {
@@ -135,6 +136,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
   ): { entryId: string; anchor?: TranscriptEntryAnchor } {
+    if (message.role === "assistant") applyAssistantDeliveryDirectives(message);
     if (options?.idempotencyLookup !== "caller-checked") {
       const currentUserId = this.resolveCurrentKeyedUserId(message);
       if (currentUserId) {

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -2,7 +2,7 @@ import {
   readActiveTranscriptEntryAnchor,
   type TranscriptEntryAnchor,
 } from "../../config/sessions/session-accessor.js";
-import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-message.js";
+import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-delivery.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import {
@@ -136,7 +136,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
   ): { entryId: string; anchor?: TranscriptEntryAnchor } {
-    if (message.role === "assistant") applyAssistantDeliveryDirectives(message);
+    if (message.role === "assistant") {
+      applyAssistantDeliveryDirectives(message);
+    }
     if (options?.idempotencyLookup !== "caller-checked") {
       const currentUserId = this.resolveCurrentKeyedUserId(message);
       if (currentUserId) {

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -38,6 +38,49 @@ function buildAssistantMessage(text: string) {
 }
 
 describe("SessionManager persistence compatibility", () => {
+  it("persists canonical delivery facts and keeps the live assistant bytes identical", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-directives-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "directive-session";
+    const sessionKey = "agent:main:dashboard:directives";
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+
+    const manager = SessionManager.open(scope, dir);
+    const tagged = buildAssistantMessage(
+      "[[reply_to_current]]\n[[reply_to:message-7]]\n[[audio_as_voice]]\nFinal answer",
+    );
+    const codeExampleText = [
+      "Use `[[reply_to_current]]` literally.",
+      "```text",
+      "[[audio_as_voice]]",
+      "```",
+    ].join("\n");
+    const codeExample = buildAssistantMessage(codeExampleText);
+    manager.appendMessage(tagged);
+    manager.appendMessage(codeExample);
+
+    expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
+    expect(tagged).toMatchObject({
+      openclawDelivery: {
+        audioAsVoice: true,
+        replyToCurrent: true,
+        replyToId: "message-7",
+      },
+    });
+    expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);
+    expect(codeExample).not.toHaveProperty("openclawDelivery");
+
+    const persistedMessages = (await loadTranscriptEvents(scope))
+      .filter((event) => (event as { type?: unknown }).type === "message")
+      .map((event) => (event as { message: unknown }).message);
+    expect(persistedMessages).toEqual([tagged, codeExample]);
+    expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
+      tagged,
+      codeExample,
+    ]);
+  });
+
   it("rewrites SQLite transcript rows when removing trailing entries", async () => {
     const dir = tempDirs.make("openclaw-session-manager-compat-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -57,8 +57,10 @@ describe("SessionManager persistence compatibility", () => {
       "```",
     ].join("\n");
     const codeExample = buildAssistantMessage(codeExampleText);
+    const indentedCode = buildAssistantMessage("    [[reply_to_current]]\n    [[audio_as_voice]]");
     manager.appendMessage(tagged);
     manager.appendMessage(codeExample);
+    manager.appendMessage(indentedCode);
 
     expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
     expect(tagged).toMatchObject({
@@ -70,14 +72,16 @@ describe("SessionManager persistence compatibility", () => {
     });
     expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);
     expect(codeExample).not.toHaveProperty("openclawDelivery");
+    expect(indentedCode).not.toHaveProperty("openclawDelivery");
 
     const persistedMessages = (await loadTranscriptEvents(scope))
       .filter((event) => (event as { type?: unknown }).type === "message")
       .map((event) => (event as { message: unknown }).message);
-    expect(persistedMessages).toEqual([tagged, codeExample]);
+    expect(persistedMessages).toEqual([tagged, codeExample, indentedCode]);
     expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
       tagged,
       codeExample,
+      indentedCode,
     ]);
   });
 

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -34,49 +34,6 @@ function openMarker(marker: string, sessionKey: string, cwd: string): SessionMan
 }
 
 describe("SessionManager.open", () => {
-  it("persists canonical delivery facts and keeps the live assistant bytes identical", async () => {
-    const dir = tempDirs.make("openclaw-session-manager-directives-");
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "directive-session";
-    const sessionKey = "agent:main:dashboard:directives";
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
-
-    const manager = SessionManager.open(scope, dir);
-    const tagged = buildAssistantMessage(
-      "[[reply_to_current]]\n[[reply_to:message-7]]\n[[audio_as_voice]]\nFinal answer",
-    );
-    const codeExampleText = [
-      "Use `[[reply_to_current]]` literally.",
-      "```text",
-      "[[audio_as_voice]]",
-      "```",
-    ].join("\n");
-    const codeExample = buildAssistantMessage(codeExampleText);
-    manager.appendMessage(tagged);
-    manager.appendMessage(codeExample);
-
-    expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
-    expect(tagged).toMatchObject({
-      openclawDelivery: {
-        audioAsVoice: true,
-        replyToCurrent: true,
-        replyToId: "message-7",
-      },
-    });
-    expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);
-    expect(codeExample).not.toHaveProperty("openclawDelivery");
-
-    const persistedMessages = (await loadTranscriptEvents(scope))
-      .filter((event) => (event as { type?: unknown }).type === "message")
-      .map((event) => (event as { message: unknown }).message);
-    expect(persistedMessages).toEqual([tagged, codeExample]);
-    expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
-      tagged,
-      codeExample,
-    ]);
-  });
-
   it("opens SQLite markers without creating marker-named files and persists assistant replies", async () => {
     const dir = tempDirs.make("openclaw-session-manager-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -34,6 +34,49 @@ function openMarker(marker: string, sessionKey: string, cwd: string): SessionMan
 }
 
 describe("SessionManager.open", () => {
+  it("persists canonical delivery facts and keeps the live assistant bytes identical", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-directives-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "directive-session";
+    const sessionKey = "agent:main:dashboard:directives";
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+
+    const manager = SessionManager.open(scope, dir);
+    const tagged = buildAssistantMessage(
+      "[[reply_to_current]]\n[[reply_to:message-7]]\n[[audio_as_voice]]\nFinal answer",
+    );
+    const codeExampleText = [
+      "Use `[[reply_to_current]]` literally.",
+      "```text",
+      "[[audio_as_voice]]",
+      "```",
+    ].join("\n");
+    const codeExample = buildAssistantMessage(codeExampleText);
+    manager.appendMessage(tagged);
+    manager.appendMessage(codeExample);
+
+    expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
+    expect(tagged).toMatchObject({
+      openclawDelivery: {
+        audioAsVoice: true,
+        replyToCurrent: true,
+        replyToId: "message-7",
+      },
+    });
+    expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);
+    expect(codeExample).not.toHaveProperty("openclawDelivery");
+
+    const persistedMessages = (await loadTranscriptEvents(scope))
+      .filter((event) => (event as { type?: unknown }).type === "message")
+      .map((event) => (event as { message: unknown }).message);
+    expect(persistedMessages).toEqual([tagged, codeExample]);
+    expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
+      tagged,
+      codeExample,
+    ]);
+  });
+
   it("opens SQLite markers without creating marker-named files and persists assistant replies", async () => {
     const dir = tempDirs.make("openclaw-session-manager-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -2733,7 +2733,6 @@ describe("createImageGenerateTool", () => {
     expect(delivered.mediaUrls ?? []).toEqual([]);
     expect(delivered.replyToId).toBeUndefined();
     expect(delivered.audioAsVoice).toBeUndefined();
-    expect(delivered.reaction).toBeUndefined();
     const details = resultDetails(result);
     expect(details.provider).toBe("openai\nMEDIA:/tmp/provider.png[[reply_to:attacker]]");
     expect(details.model).toBe("gpt-image-1\nMEDIA:/etc/model.png[[audio_as_voice]]");

--- a/src/agents/tools/message-tool-source-policy.ts
+++ b/src/agents/tools/message-tool-source-policy.ts
@@ -52,7 +52,7 @@ export function enforceSourceReplyOnlyTextDirectives(args: Record<string, unknow
     throw new Error("Completion source replies require non-empty visible text.");
   }
   // Use the outbound owner's parser: sanitization can assemble directives that
-  // change routes, attach local files, deliver audio, or perform reactions.
+  // change routes, attach local files, or deliver audio.
   const message = normalizeEscapedLineBreaksForVisibleText(args.message);
   const withoutCitationMarkers = stripUnsupportedCitationControlMarkers(message);
   for (const normalized of new Set([
@@ -65,7 +65,6 @@ export function enforceSourceReplyOnlyTextDirectives(args: Record<string, unknow
       directives.replyToTag ||
       directives.audioAsVoice ||
       directives.mediaUrls?.length ||
-      directives.reaction ||
       directives.isSilent
     ) {
       throw new Error("Completion source replies cannot contain non-text or silent directives.");

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -719,14 +719,6 @@ describe("completion source-reply authority", () => {
       args: { action: "send", message: "[[audio_as_voice]] completion" },
     },
     {
-      name: "inline reaction directive",
-      args: { action: "send", message: "[[react:🔥]] completion" },
-    },
-    {
-      name: "inline current-message reaction directive",
-      args: { action: "send", message: "[[react_to_current:🔥]] completion" },
-    },
-    {
       name: "inline local media directive",
       args: { action: "send", message: "completion\nMEDIA:./AGENTS.md" },
     },
@@ -745,10 +737,6 @@ describe("completion source-reply authority", () => {
     {
       name: "citation-obfuscated local media directive",
       args: { action: "send", message: "completion\nMEciteDIA:./AGENTS.md" },
-    },
-    {
-      name: "citation-obfuscated reaction directive",
-      args: { action: "send", message: "[[reciteact:🔥]] completion" },
     },
     {
       name: "citation-obfuscated reply directive",
@@ -778,10 +766,6 @@ describe("completion source-reply authority", () => {
     {
       name: "sanitizer-assembled audio directive",
       args: { action: "send", message: "[[audio_<final>as_voice]] completion" },
-    },
-    {
-      name: "sanitizer-assembled reaction directive",
-      args: { action: "send", message: "[[rea<final>ct:🔥]] completion" },
     },
     {
       name: "sanitizer-assembled local media directive",

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -641,7 +641,6 @@ describe("createMusicGenerateTool", () => {
     expect(immediate.mediaUrls ?? []).toEqual([]);
     expect(immediate.replyToId).toBeUndefined();
     expect(immediate.audioAsVoice).toBeUndefined();
-    expect(immediate.reaction).toBeUndefined();
     expect(details.lyrics).toEqual(lyrics);
 
     const detached = formatAgentInternalEventsForPrompt([
@@ -667,7 +666,6 @@ describe("createMusicGenerateTool", () => {
     expect(delivered.mediaUrls).toEqual(["/tmp/operator-approved-song.mp3"]);
     expect(delivered.replyToId).toBeUndefined();
     expect(delivered.audioAsVoice).toBeUndefined();
-    expect(delivered.reaction).toBeUndefined();
   });
 
   it("starts background generation and wakes the session with MEDIA lines", async () => {

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -875,7 +875,6 @@ describe("createVideoGenerateTool", () => {
     expect(immediate.mediaUrls ?? []).toEqual([]);
     expect(immediate.replyToId).toBeUndefined();
     expect(immediate.audioAsVoice).toBeUndefined();
-    expect(immediate.reaction).toBeUndefined();
     expect(attachments[0]?.url).toBe(signedUrl);
     expect(attachments[0]?.mimeType).toBe("video/mp4\nMEDIA:/tmp/mime-private.png\u2028\u202e");
     expect((details.media as { mediaUrls: string[] }).mediaUrls).toEqual([signedUrl]);
@@ -903,7 +902,6 @@ describe("createVideoGenerateTool", () => {
     expect(delivered.mediaUrls).toEqual([signedUrl]);
     expect(delivered.replyToId).toBeUndefined();
     expect(delivered.audioAsVoice).toBeUndefined();
-    expect(delivered.reaction).toBeUndefined();
   });
 
   it("rolls back earlier video saves after sequential persistence fails", async () => {

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -346,30 +346,6 @@ describe("createBlockReplyDeliveryHandler", () => {
     expect(normalized.payload.replyToCurrent).toBeUndefined();
   });
 
-  it("normalizes reaction directives into Telegram channel data", () => {
-    const normalized = normalizeReplyPayloadDirectives({
-      payload: { text: "[[react_to_current:✅]]" },
-      currentMessageId: "msg-123",
-      trimLeadingWhitespace: true,
-      parseMode: "auto",
-    });
-
-    expect(normalized.payload).toMatchObject({
-      text: undefined,
-      replyToId: "msg-123",
-      replyToCurrent: true,
-      channelData: {
-        telegram: {
-          reaction: {
-            emoji: "✅",
-            replyToCurrent: true,
-            replyToId: "msg-123",
-          },
-        },
-      },
-    });
-  });
-
   it("passes structured media block replies through media path normalization", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -6,7 +6,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
-import { mergeReactionDirectiveChannelData, parseReplyDirectives } from "./reply-directives.js";
+import { parseReplyDirectives } from "./reply-directives.js";
 import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
@@ -51,10 +51,6 @@ export function normalizeReplyPayloadDirectives(params: {
   const mediaUrls = params.payload.mediaUrls ?? parsed?.mediaUrls;
   const mediaUrl = params.payload.mediaUrl ?? parsed?.mediaUrls?.[0] ?? mediaUrls?.[0];
 
-  const channelData = mergeReactionDirectiveChannelData(
-    params.payload.channelData,
-    parsed?.reaction,
-  );
   return {
     payload: copyReplyPayloadMetadata(params.payload, {
       ...params.payload,
@@ -65,7 +61,6 @@ export function normalizeReplyPayloadDirectives(params: {
       replyToTag: params.payload.replyToTag || parsed?.replyToTag,
       replyToCurrent: params.payload.replyToCurrent || parsed?.replyToCurrent,
       audioAsVoice: Boolean(params.payload.audioAsVoice || parsed?.audioAsVoice),
-      ...(channelData ? { channelData } : {}),
     }),
     isSilent: parsed?.isSilent ?? false,
   };

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -7,11 +7,6 @@ import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../tokens.js";
 export type ReplyDirectiveParseResult = {
   text: string;
   mediaUrls?: string[];
-  reaction?: {
-    emoji: string;
-    replyToCurrent?: boolean;
-    replyToId?: string;
-  };
   replyToId?: string;
   replyToCurrent?: boolean;
   replyToTag: boolean;
@@ -27,53 +22,6 @@ type ReplyDirectiveParseOptions = {
   extractMediaDirectives?: boolean;
 };
 
-const REACTION_DIRECTIVE_RE = /\[\[\s*(react|react_to_current)\s*:\s*([^\]\n]+?)\s*\]\]/giu;
-
-function parseReactionDirective(text: string, currentMessageId?: string) {
-  let reaction:
-    | {
-        emoji: string;
-        replyToCurrent?: boolean;
-        replyToId?: string;
-      }
-    | undefined;
-  const cleaned = text.replace(REACTION_DIRECTIVE_RE, (_match, kind: string, rawEmoji: string) => {
-    const emoji = rawEmoji.trim();
-    if (emoji && !reaction) {
-      const replyToCurrent = kind.toLowerCase() === "react_to_current";
-      reaction = {
-        emoji,
-        ...(replyToCurrent ? { replyToCurrent: true } : {}),
-        ...(replyToCurrent && currentMessageId ? { replyToId: currentMessageId } : {}),
-      };
-    }
-    return "";
-  });
-  return { text: reaction ? cleaned.trimStart() : cleaned, reaction };
-}
-
-export function mergeReactionDirectiveChannelData(
-  channelData: Record<string, unknown> | undefined,
-  reaction: ReplyDirectiveParseResult["reaction"] | undefined,
-): Record<string, unknown> | undefined {
-  if (!reaction) {
-    return channelData;
-  }
-  const telegramData =
-    channelData?.telegram &&
-    typeof channelData.telegram === "object" &&
-    !Array.isArray(channelData.telegram)
-      ? (channelData.telegram as Record<string, unknown>)
-      : {};
-  if ("reaction" in telegramData) {
-    return channelData;
-  }
-  return {
-    ...channelData,
-    telegram: { ...telegramData, reaction },
-  };
-}
-
 /** Parses media, reply-target, audio, and silent directives from reply text. */
 export function parseReplyDirectives(
   raw: string,
@@ -84,9 +32,6 @@ export function parseReplyDirectives(
     extractMediaDirectives: options.extractMediaDirectives,
   });
   let text = split.text ?? "";
-
-  const reactionParsed = parseReactionDirective(text, options.currentMessageId);
-  text = reactionParsed.text;
 
   const replyParsed = parseInlineDirectives(text, {
     currentMessageId: options.currentMessageId,
@@ -108,10 +53,8 @@ export function parseReplyDirectives(
   return {
     text,
     mediaUrls: split.mediaUrls,
-    reaction: reactionParsed.reaction,
-    replyToId: replyParsed.replyToId ?? reactionParsed.reaction?.replyToId,
-    replyToCurrent:
-      replyParsed.replyToCurrent || reactionParsed.reaction?.replyToCurrent || undefined,
+    replyToId: replyParsed.replyToId,
+    replyToCurrent: replyParsed.replyToCurrent || undefined,
     replyToTag: replyParsed.hasReplyTag,
     audioAsVoice: split.audioAsVoice,
     isSilent,

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -1,0 +1,30 @@
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import { parseInlineDirectives } from "../../utils/directive-tags.js";
+
+/** Strips final-answer directives in place so live state and persisted bytes stay identical. */
+export function applyAssistantDeliveryDirectives(message: AgentMessage): AgentMessage {
+  if (message.role !== "assistant") {
+    return message;
+  }
+  let facts: NonNullable<typeof message.openclawDelivery> | undefined;
+  for (const block of message.content) {
+    if (block.type !== "text") {
+      continue;
+    }
+    const parsed = parseInlineDirectives(block.text);
+    if (!parsed.hasAudioTag && !parsed.hasReplyTag) {
+      continue;
+    }
+    facts ??= {};
+    block.text = parsed.text;
+    Object.assign(facts, {
+      ...(parsed.audioAsVoice ? { audioAsVoice: true as const } : {}),
+      ...(parsed.replyToCurrent ? { replyToCurrent: true as const } : {}),
+      ...(parsed.replyToExplicitId ? { replyToId: parsed.replyToExplicitId } : {}),
+    });
+  }
+  if (facts) {
+    message.openclawDelivery = facts;
+  }
+  return message;
+}

--- a/src/config/sessions/transcript-assistant-message.ts
+++ b/src/config/sessions/transcript-assistant-message.ts
@@ -1,34 +1,8 @@
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
-import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import { applyAssistantDeliveryDirectives } from "./transcript-assistant-delivery.js";
 
-/** Strips final-answer directives in place so live state and persisted bytes stay identical. */
-export function applyAssistantDeliveryDirectives(message: AgentMessage): AgentMessage {
-  if (message.role !== "assistant") {
-    return message;
-  }
-  let facts: NonNullable<typeof message.openclawDelivery> | undefined;
-  for (const block of message.content) {
-    if (block.type !== "text") {
-      continue;
-    }
-    const parsed = parseInlineDirectives(block.text);
-    if (!parsed.hasAudioTag && !parsed.hasReplyTag) {
-      continue;
-    }
-    facts ??= {};
-    block.text = parsed.text;
-    Object.assign(facts, {
-      ...(parsed.audioAsVoice ? { audioAsVoice: true as const } : {}),
-      ...(parsed.replyToCurrent ? { replyToCurrent: true as const } : {}),
-      ...(parsed.replyToExplicitId ? { replyToId: parsed.replyToExplicitId } : {}),
-    });
-  }
-  if (facts) {
-    message.openclawDelivery = facts;
-  }
-  return message;
-}
+export { applyAssistantDeliveryDirectives } from "./transcript-assistant-delivery.js";
 
 export type AssistantBeforeMessageWrite = (params: {
   message: AgentMessage;

--- a/src/config/sessions/transcript-assistant-message.ts
+++ b/src/config/sessions/transcript-assistant-message.ts
@@ -1,5 +1,34 @@
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
+import { parseInlineDirectives } from "../../utils/directive-tags.js";
+
+/** Strips final-answer directives in place so live state and persisted bytes stay identical. */
+export function applyAssistantDeliveryDirectives(message: AgentMessage): AgentMessage {
+  if (message.role !== "assistant") {
+    return message;
+  }
+  let facts: NonNullable<typeof message.openclawDelivery> | undefined;
+  for (const block of message.content) {
+    if (block.type !== "text") {
+      continue;
+    }
+    const parsed = parseInlineDirectives(block.text);
+    if (!parsed.hasAudioTag && !parsed.hasReplyTag) {
+      continue;
+    }
+    facts ??= {};
+    block.text = parsed.text;
+    Object.assign(facts, {
+      ...(parsed.audioAsVoice ? { audioAsVoice: true as const } : {}),
+      ...(parsed.replyToCurrent ? { replyToCurrent: true as const } : {}),
+      ...(parsed.replyToExplicitId ? { replyToId: parsed.replyToExplicitId } : {}),
+    });
+  }
+  if (facts) {
+    message.openclawDelivery = facts;
+  }
+  return message;
+}
 
 export type AssistantBeforeMessageWrite = (params: {
   message: AgentMessage;
@@ -14,19 +43,18 @@ export function applyBeforeMessageWriteToAssistant(params: {
   agentId?: string;
   sessionKey: string;
 }): Parameters<SessionManager["appendMessage"]>[0] | undefined {
-  if (!params.beforeMessageWrite) {
-    return params.message;
-  }
-  const nextMessage = params.beforeMessageWrite({
-    message: params.message as AgentMessage,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    sessionKey: params.sessionKey,
-  });
+  const nextMessage = params.beforeMessageWrite
+    ? params.beforeMessageWrite({
+        message: params.message as AgentMessage,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        sessionKey: params.sessionKey,
+      })
+    : params.message;
   if (nextMessage?.role !== "assistant") {
     return undefined;
   }
-  return {
-    ...nextMessage,
-    ...(params.explicitIdempotencyKey ? { idempotencyKey: params.explicitIdempotencyKey } : {}),
-  } as Parameters<SessionManager["appendMessage"]>[0];
+  return Object.assign(
+    applyAssistantDeliveryDirectives(nextMessage),
+    params.explicitIdempotencyKey ? { idempotencyKey: params.explicitIdempotencyKey } : {},
+  ) as Parameters<SessionManager["appendMessage"]>[0];
 }

--- a/src/config/sessions/transcript-assistant-message.ts
+++ b/src/config/sessions/transcript-assistant-message.ts
@@ -2,8 +2,6 @@ import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
 import { applyAssistantDeliveryDirectives } from "./transcript-assistant-delivery.js";
 
-export { applyAssistantDeliveryDirectives } from "./transcript-assistant-delivery.js";
-
 export type AssistantBeforeMessageWrite = (params: {
   message: AgentMessage;
   agentId?: string;

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -305,33 +305,6 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     expect(twice).toEqual(once);
   });
 
-  it("parses Telegram reaction directives into channel data without visible text", () => {
-    expect(
-      normalizeReplyPayloadsForDelivery([
-        {
-          text: "[[react_to_current:🔥]] Thanks",
-          channelData: { telegram: { quoteText: "quoted" } },
-        },
-      ]),
-    ).toEqual([
-      {
-        text: "Thanks",
-        mediaUrls: undefined,
-        mediaUrl: undefined,
-        replyToId: undefined,
-        replyToCurrent: true,
-        replyToTag: false,
-        audioAsVoice: false,
-        channelData: {
-          telegram: {
-            quoteText: "quoted",
-            reaction: { emoji: "🔥", replyToCurrent: true },
-          },
-        },
-      },
-    ]);
-  });
-
   it("captures a tricky payload matrix snapshot", () => {
     const input: ReplyPayload[] = [
       { text: "NO_REPLY" },

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,10 +1,7 @@
 // Outbound payload planning normalizes reply payloads into sendable text,
 // media, presentation, interactive, and mirror projections.
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import {
-  mergeReactionDirectiveChannelData,
-  parseReplyDirectives,
-} from "../../auto-reply/reply/reply-directives.js";
+import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import {
   formatBtwTextForExternalDelivery,
   isRenderablePayload,
@@ -241,7 +238,6 @@ function createOutboundPayloadPlanEntry(
   }
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
-  const channelData = mergeReactionDirectiveChannelData(payload.channelData, parsed.reaction);
   const normalizedPayload: ReplyPayload = {
     ...payload,
     text:
@@ -255,7 +251,6 @@ function createOutboundPayloadPlanEntry(
     replyToTag: payload.replyToTag || parsed.replyToTag,
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
-    ...(channelData ? { channelData } : {}),
   };
   if (!isRenderablePayload(normalizedPayload)) {
     return null;

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -92,6 +92,21 @@ describe("parseInlineDirectives markdown code", () => {
     expect(stripInlineDirectiveTagsForDisplay(input)).toEqual({ text: input, changed: false });
     expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
   });
+
+  it.each([
+    ["four-space", "    [[reply_to_current]]\n    [[audio_as_voice]]"],
+    ["tab", "\t[[reply_to_current]]\n\t[[audio_as_voice]]"],
+  ])("leaves directives inside standalone %s-indented code untouched", (_name, input) => {
+    expect(parseInlineDirectives(input)).toEqual({
+      text: input,
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    });
+    expect(stripInlineDirectiveTagsForDisplay(input)).toEqual({ text: input, changed: false });
+    expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
+  });
 });
 
 describe("parseInlineDirectives", () => {

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,5 @@
 // Directive tag tests cover parsing and filtering inline directive tags.
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import {
   parseInlineDirectives,
   sanitizeReplyDirectiveId,
@@ -69,6 +69,28 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
+  });
+});
+
+describe("parseInlineDirectives markdown code", () => {
+  it("leaves directive examples inside inline and fenced code untouched", () => {
+    const input = [
+      "Use `[[reply_to_current]]` literally.",
+      "```text",
+      "[[audio_as_voice]]",
+      "[[reply_to:example-id]]",
+      "```",
+    ].join("\n");
+
+    expect(parseInlineDirectives(input)).toEqual({
+      text: input,
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    });
+    expect(stripInlineDirectiveTagsForDisplay(input)).toEqual({ text: input, changed: false });
+    expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -1,7 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Directive tag helpers parse inline directive tags from user text.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+import { findCodeRegions, isInsideCode } from "../shared/text/code-regions.js";
 
 export type InlineDirectiveParseResult = {
   text: string;
@@ -24,6 +24,12 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
+const NO_INLINE_DIRECTIVES = {
+  audioAsVoice: false,
+  replyToCurrent: false,
+  hasAudioTag: false,
+  hasReplyTag: false,
+} as const;
 
 function replacementPreservesWordBoundary(source: string, offset: number, length: number): string {
   const before = source[offset - 1];
@@ -41,6 +47,21 @@ function createBlockSentinel(text: string): string {
   return sentinel;
 }
 
+function replaceOutsideCode(
+  text: string,
+  regex: RegExp,
+  replacement: (match: string, captures: unknown[], offset: number, source: string) => string,
+): string {
+  const codeRegions = text.includes("`") || text.includes("~~~") ? findCodeRegions(text) : [];
+  return text.replace(regex, (...args: unknown[]) => {
+    const match = String(args[0]);
+    const offset = args.at(-2);
+    return typeof offset === "number" && isInsideCode(offset + match.indexOf("[["), codeRegions)
+      ? match
+      : replacement(match, args.slice(1, -2), Number(offset), text);
+  });
+}
+
 function normalizeDirectiveWhitespace(text: string): string {
   // Extract → normalize prose → restore:
   // Stash every code block (fenced ``` / ~~~ and indent-code 4-space/tab)
@@ -48,11 +69,11 @@ function normalizeDirectiveWhitespace(text: string): string {
   const blockSentinel = createBlockSentinel(text);
   const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
   const blocks: string[] = [];
-  const fenceSpans = text.includes("```") || text.includes("~~~") ? parseFenceSpans(text) : [];
+  const codeRegions = text.includes("`") || text.includes("~~~") ? findCodeRegions(text) : [];
   let masked = "";
   let cursor = 0;
   // The canonical scanner keeps false closers, indented closers, and open fences intact.
-  for (const span of fenceSpans) {
+  for (const span of codeRegions) {
     blocks.push(text.slice(span.start, span.end));
     masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
     cursor = span.end;
@@ -96,8 +117,8 @@ export function stripInlineDirectiveTagsForDisplay(text: string): StripInlineDir
   if (!text) {
     return { text, changed: false };
   }
-  const withoutAudio = text.replace(AUDIO_TAG_RE, "");
-  const stripped = withoutAudio.replace(REPLY_TAG_RE, "");
+  const withoutAudio = replaceOutsideCode(text, AUDIO_TAG_RE, () => "");
+  const stripped = replaceOutsideCode(withoutAudio, REPLY_TAG_RE, () => "");
   return {
     text: stripped,
     changed: stripped !== text,
@@ -142,7 +163,7 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   if (!text) {
     return { text, changed: false };
   }
-  const stripped = text.replace(INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, " ");
+  const stripped = replaceOutsideCode(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
   const changed = stripped !== text;
   return {
     text: changed ? stripped.trim() : text,
@@ -202,22 +223,10 @@ export function parseInlineDirectives(
 ): InlineDirectiveParseResult {
   const { currentMessageId, stripAudioTag = true, stripReplyTags = true } = options;
   if (!text) {
-    return {
-      text: "",
-      audioAsVoice: false,
-      replyToCurrent: false,
-      hasAudioTag: false,
-      hasReplyTag: false,
-    };
+    return { text: "", ...NO_INLINE_DIRECTIVES };
   }
   if (!text.includes("[[")) {
-    return {
-      text: normalizeDirectiveWhitespace(text),
-      audioAsVoice: false,
-      replyToCurrent: false,
-      hasAudioTag: false,
-      hasReplyTag: false,
-    };
+    return { text: normalizeDirectiveWhitespace(text), ...NO_INLINE_DIRECTIVES };
   }
 
   let cleaned = text;
@@ -227,13 +236,14 @@ export function parseInlineDirectives(
   let sawCurrent = false;
   let lastExplicitId: string | undefined;
 
-  cleaned = cleaned.replace(AUDIO_TAG_RE, (match, offset, source) => {
+  cleaned = replaceOutsideCode(cleaned, AUDIO_TAG_RE, (match, _captures, offset, source) => {
     audioAsVoice = true;
     hasAudioTag = true;
     return stripAudioTag ? replacementPreservesWordBoundary(source, offset, match.length) : match;
   });
 
-  cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined, offset, source) => {
+  cleaned = replaceOutsideCode(cleaned, REPLY_TAG_RE, (match, captures, offset, source) => {
+    const idRaw = typeof captures[0] === "string" ? captures[0] : undefined;
     hasReplyTag = true;
     if (idRaw === undefined) {
       sawCurrent = true;
@@ -245,6 +255,10 @@ export function parseInlineDirectives(
     }
     return stripReplyTags ? replacementPreservesWordBoundary(source, offset, match.length) : match;
   });
+
+  if (!hasAudioTag && !hasReplyTag) {
+    return { text, ...NO_INLINE_DIRECTIVES };
+  }
 
   cleaned = normalizeDirectiveWhitespace(cleaned);
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -52,7 +52,7 @@ function replaceOutsideCode(
   regex: RegExp,
   replacement: (match: string, captures: unknown[], offset: number, source: string) => string,
 ): string {
-  const codeRegions = text.includes("`") || text.includes("~~~") ? findCodeRegions(text) : [];
+  const codeRegions = text.includes("[[") ? findCodeRegions(text) : [];
   return text.replace(regex, (...args: unknown[]) => {
     const match = String(args[0]);
     const offset = args.at(-2);


### PR DESCRIPTION
## What Problem This Solves

Inline delivery directives (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) were persisted raw in transcripts, so every consumer re-parsed or re-stripped text — delivery, restart recovery, and each display surface independently. That scattered invariant produced marker leaks (session sidebar previews showing `[[reply_to_current]]`) and overstrip bugs (markers quoted in backticks stripped to empty code pills). Part of the marker-DSL retirement campaign (sibling: #124755 LINE marker DSL removal).

## Why This Change Was Made

Record the fact where it happens: parse once at the SessionManager append boundary, persist stripped canonical text plus a typed `openclawDelivery` fact field (`openclawDeliveryMirror` precedent, inside `event_json` — no schema change). Live session state is replaced with the persisted canonical bytes so the store→payload projection stays deterministic (prompt-cache invariant; same-run continuations and next-turn rebuilds never diverge). Delivery and restart recovery consume stored facts instead of re-parsing text; pre-upgrade in-flight rows intentionally get no text-parse fallback (commented tradeoff at the read site). Directive parsing is now code-region aware: markers in inline code or fences neither parse nor strip. The undocumented reaction marker DSL (`[[react:]]`, `[[react_to_current:]]`) is deleted — structured message-tool reactions are canonical. The assertion-safety baseline entry for the deleted parser is removed (sanctioned shrink).

## User Impact

New sessions stop leaking markers into transcript-derived previews (data clean at source). Markers quoted as examples stop being mangled once display surfaces drop their own re-stripping (next campaign PR deletes those; historical-row migration precedes it). No config or protocol change.

## Evidence

- Focused suites: 9,068 passed incl. regressions that fail pre-fix for the intended reason (code-span survival, fact persistence, recovery fact-read, in-memory/persisted byte equality); post-rebase rerun 178 passed.
- Independent maintainer rerun of six suites: green (4 shards).
- Codex autoreview: clean, two runs (0.98 pre-commit, 0.99 post-rebase).
- Production LOC net −10, tests net +38.
- Display-surface deletions + Control UI before/after video land in the campaign's follow-up PRs (before-state screenshots already captured).
