### PR TITLE
perf(webui): reuse the chat metadata catalog across pages

### DIFF
--- a/ui/src/app/app-host.chat-metadata.test.ts
+++ b/ui/src/app/app-host.chat-metadata.test.ts
@@ -1,0 +1,47 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { peekChatMetadata, rememberChatMetadata } from "../lib/chat/chat-metadata-store.ts";
+import "./app-host.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "./context.ts";
+
+type ChatMetadataShell = HTMLElement & {
+  runtime: { context: ApplicationContext };
+  handleGatewayEvent: (event: { event: string; payload: unknown }) => void;
+  synchronizeGateway: (snapshot: ApplicationGatewaySnapshot) => void;
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+it("invalidates chat metadata on config changes and same-client reconnects", () => {
+  vi.useFakeTimers();
+  const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+  const connected = {
+    client,
+    phase: "connected",
+    sessionKey: "agent:main:main",
+  } as ApplicationGatewaySnapshot;
+  const context = {
+    gateway: { snapshot: connected },
+    runtimeConfig: {
+      state: { configFormDirty: false, configSnapshot: null },
+      ensureLoaded: vi.fn(async () => null),
+      refresh: vi.fn(async () => null),
+    },
+  } as unknown as ApplicationContext;
+  const shell = document.createElement("openclaw-app-shell") as unknown as ChatMetadataShell;
+  shell.runtime = { context };
+
+  shell.synchronizeGateway(connected);
+  rememberChatMetadata(client, "main", { commands: [], models: [] });
+  shell.handleGatewayEvent({ event: "config.changed", payload: {} });
+  expect(peekChatMetadata(client, "main")).toBeUndefined();
+
+  rememberChatMetadata(client, "main", { commands: [], models: [] });
+  shell.synchronizeGateway({ ...connected, phase: "reconnecting" });
+  shell.synchronizeGateway(connected);
+  expect(peekChatMetadata(client, "main")).toBeUndefined();
+});

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -24,6 +24,7 @@ import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
+import { invalidateChatMetadataStore } from "../lib/chat/chat-metadata-store.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
@@ -422,6 +423,12 @@ class OpenClawShell
     this.shellNavigation.selectChatSession(sessionKey, agentId);
   }
   private readonly handleGatewayEvent = (event: GatewayEventFrame) => {
+    if (event.event === "config.changed") {
+      const client = this.context?.gateway?.snapshot.client;
+      if (client) {
+        invalidateChatMetadataStore(client);
+      }
+    }
     this.shellGateway.handleGatewayEvent(event);
   };
 
@@ -588,6 +595,13 @@ class OpenClawShell
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
+    if (this.previousGatewayPhase !== "connected" && snapshot.phase === "connected") {
+      // A reconnect can retain the browser client, so object identity alone
+      // cannot keep metadata from crossing logical Gateway connections.
+      if (snapshot.client) {
+        invalidateChatMetadataStore(snapshot.client);
+      }
+    }
     this.shellGateway.synchronizeGateway(snapshot);
   }
 

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -1,0 +1,257 @@
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  gatewayStartupUnavailableDetails,
+} from "@openclaw/gateway-client/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ChatMetadataResult } from "../../pages/chat/chat-history.ts";
+import {
+  invalidateChatMetadataStore,
+  loadChatMetadata,
+  peekChatMetadata,
+  rememberChatMetadata,
+  revalidateChatMetadata,
+} from "./chat-metadata-store.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function clientWith(request: ReturnType<typeof vi.fn>): GatewayBrowserClient {
+  return { request } as unknown as GatewayBrowserClient;
+}
+
+function metadata(modelId: string): ChatMetadataResult {
+  return {
+    commands: [],
+    models: [{ id: modelId, name: modelId, provider: "openai" }],
+  };
+}
+
+function startupUnavailableError(retryAfterMs = 250): GatewayRequestError {
+  return new GatewayRequestError({
+    code: "UNAVAILABLE",
+    message: "gateway startup sidecars are still initializing",
+    details: gatewayStartupUnavailableDetails(),
+    retryable: true,
+    retryAfterMs,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("chat metadata store", () => {
+  it("returns a cached result without requesting it again", async () => {
+    const result = metadata("cached-model");
+    const request = vi.fn().mockResolvedValue(result);
+    const client = clientWith(request);
+
+    await expect(loadChatMetadata(client, " main ")).resolves.toBe(result);
+    await expect(loadChatMetadata(client, "main")).resolves.toBe(result);
+
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("shares one pending load between concurrent readers", async () => {
+    const pending = deferred<ChatMetadataResult>();
+    const request = vi.fn().mockReturnValue(pending.promise);
+    const client = clientWith(request);
+
+    const first = loadChatMetadata(client, "main");
+    const second = loadChatMetadata(client, "main");
+
+    expect(second).toBe(first);
+    expect(request).toHaveBeenCalledOnce();
+    pending.resolve(metadata("shared-model"));
+    await expect(first).resolves.toEqual(metadata("shared-model"));
+  });
+
+  it("clears a failed pending load so a later read can retry", async () => {
+    const result = metadata("recovered-model");
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("metadata unavailable"))
+      .mockResolvedValueOnce(result);
+    const client = clientWith(request);
+
+    await expect(loadChatMetadata(client, "main")).rejects.toThrow("metadata unavailable");
+    await expect(loadChatMetadata(client, "main")).resolves.toBe(result);
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses remembered startup metadata as the current snapshot", async () => {
+    const result = metadata("startup-model");
+    const request = vi.fn();
+    const client = clientWith(request);
+
+    rememberChatMetadata(client, "main", result);
+
+    expect(peekChatMetadata(client, "main")).toBe(result);
+    await expect(loadChatMetadata(client, "main")).resolves.toBe(result);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("drops every agent snapshot when the client store is invalidated", async () => {
+    const main = metadata("main-model");
+    const worker = metadata("worker-model");
+    const request = vi.fn().mockResolvedValue(main);
+    const client = clientWith(request);
+    rememberChatMetadata(client, "main", main);
+    rememberChatMetadata(client, "worker", worker);
+
+    invalidateChatMetadataStore(client);
+
+    expect(peekChatMetadata(client, "main")).toBeUndefined();
+    expect(peekChatMetadata(client, "worker")).toBeUndefined();
+    await expect(loadChatMetadata(client, "main")).resolves.toBe(main);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the stale snapshot readable while one fresh revalidation replaces it", async () => {
+    const oldResult = metadata("old-model");
+    const nextResult = metadata("next-model");
+    const refresh = deferred<ChatMetadataResult>();
+    const request = vi.fn().mockReturnValue(refresh.promise);
+    const client = clientWith(request);
+    rememberChatMetadata(client, "main", oldResult);
+
+    const first = revalidateChatMetadata(client, "main");
+    const second = revalidateChatMetadata(client, "main");
+
+    expect(second).toBe(first);
+    expect(peekChatMetadata(client, "main")).toBe(oldResult);
+    expect(request).toHaveBeenCalledOnce();
+    refresh.resolve(nextResult);
+    await expect(first).resolves.toBe(nextResult);
+    expect(peekChatMetadata(client, "main")).toBe(nextResult);
+  });
+
+  it("does not let an older plain load clobber a newer revalidation", async () => {
+    const older = deferred<ChatMetadataResult>();
+    const newer = deferred<ChatMetadataResult>();
+    const request = vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+    const client = clientWith(request);
+
+    const olderLoad = loadChatMetadata(client, "main");
+    const newerLoad = revalidateChatMetadata(client, "main");
+    newer.resolve(metadata("new-model"));
+    await newerLoad;
+    older.resolve(metadata("old-model"));
+    await olderLoad;
+
+    expect(peekChatMetadata(client, "main")).toEqual(metadata("new-model"));
+  });
+
+  it("retries canonical startup unavailability and caches the recovered catalog", async () => {
+    vi.useFakeTimers();
+    const result = metadata("recovered-model");
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(startupUnavailableError(250))
+      .mockResolvedValueOnce(result);
+    const client = clientWith(request);
+    const controller = new AbortController();
+
+    const refresh = revalidateChatMetadata(client, "main", {
+      signal: controller.signal,
+      startupRetryWindowMs: 60_000,
+    });
+    await vi.advanceTimersByTimeAsync(249);
+    expect(request).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(refresh).resolves.toBe(result);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(peekChatMetadata(client, "main")).toBe(result);
+  });
+
+  it("does not retry unrelated retryable unavailable errors", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn().mockRejectedValue(
+      new GatewayRequestError({
+        code: "UNAVAILABLE",
+        message: "database temporarily unavailable",
+        details: { reason: "database-busy" },
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    );
+    const client = clientWith(request);
+
+    const refresh = revalidateChatMetadata(client, "main", {
+      startupRetryWindowMs: 60_000,
+    });
+    const rejection = expect(refresh).rejects.toThrow("database temporarily unavailable");
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await rejection;
+    expect(request).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts a pending startup retry", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn().mockRejectedValue(startupUnavailableError(2_000));
+    const client = clientWith(request);
+    const controller = new AbortController();
+    const refresh = revalidateChatMetadata(client, "main", {
+      signal: controller.signal,
+      startupRetryWindowMs: 60_000,
+    });
+    const rejection = expect(refresh).rejects.toMatchObject({ name: "AbortError" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("stops startup retries at the configured deadline", async () => {
+    vi.useFakeTimers();
+    const startedAt = Date.UTC(2026, 7, 2);
+    vi.setSystemTime(startedAt);
+    const attemptTimes: number[] = [];
+    const request = vi.fn().mockImplementation(() => {
+      attemptTimes.push(Date.now());
+      return Promise.reject(startupUnavailableError(2_000));
+    });
+    const client = clientWith(request);
+    const refresh = revalidateChatMetadata(client, "main", {
+      startupRetryWindowMs: 60_000,
+    });
+    const rejection = expect(refresh).rejects.toThrow("gateway startup sidecars");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejection;
+
+    expect(attemptTimes).toHaveLength(30);
+    expect(attemptTimes[0]).toBe(startedAt);
+    expect(attemptTimes.at(-1)).toBe(startedAt + 58_000);
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "chat.metadata",
+      { agentId: "main" },
+      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+    );
+    expect(request).toHaveBeenLastCalledWith(
+      "chat.metadata",
+      { agentId: "main" },
+      { timeoutMs: 2_000 },
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -159,10 +159,8 @@ describe("chat metadata store", () => {
       .mockRejectedValueOnce(startupUnavailableError(250))
       .mockResolvedValueOnce(result);
     const client = clientWith(request);
-    const controller = new AbortController();
 
     const refresh = revalidateChatMetadata(client, "main", {
-      signal: controller.signal,
       startupRetryWindowMs: 60_000,
     });
     await vi.advanceTimersByTimeAsync(249);
@@ -196,28 +194,6 @@ describe("chat metadata store", () => {
     await rejection;
     expect(request).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("aborts a pending startup retry", async () => {
-    vi.useFakeTimers();
-    const request = vi.fn().mockRejectedValue(startupUnavailableError(2_000));
-    const client = clientWith(request);
-    const controller = new AbortController();
-    const refresh = revalidateChatMetadata(client, "main", {
-      signal: controller.signal,
-      startupRetryWindowMs: 60_000,
-    });
-    const rejection = expect(refresh).rejects.toMatchObject({ name: "AbortError" });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(vi.getTimerCount()).toBe(1);
-
-    controller.abort();
-    await vi.advanceTimersByTimeAsync(0);
-
-    await rejection;
-    expect(vi.getTimerCount()).toBe(0);
-    await vi.advanceTimersByTimeAsync(2_000);
-    expect(request).toHaveBeenCalledOnce();
   });
 
   it("stops startup retries at the configured deadline", async () => {

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -4,13 +4,13 @@ import {
 } from "@openclaw/gateway-client/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ChatMetadataResult } from "../../pages/chat/chat-history.ts";
 import {
   invalidateChatMetadataStore,
   loadChatMetadata,
   peekChatMetadata,
   rememberChatMetadata,
   revalidateChatMetadata,
+  type ChatMetadataResult,
 } from "./chat-metadata-store.ts";
 
 function deferred<T>() {

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -42,7 +42,9 @@ function metadataEntryFor(
 }
 
 function waitForMetadataRetry(delayMs: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, delayMs));
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delayMs);
+  });
 }
 
 async function requestChatMetadata(

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -2,8 +2,13 @@ import {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   resolveGatewayStartupRetryAfterMs,
 } from "@openclaw/gateway-client/browser";
+import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ChatMetadataResult } from "../../pages/chat/chat-history.ts";
+import type { ModelCatalogEntry } from "../../api/types.ts";
+
+export type ChatMetadataResult = CommandsListResult & {
+  models?: ModelCatalogEntry[];
+};
 
 type ChatMetadataEntry = {
   result?: ChatMetadataResult;

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -1,0 +1,202 @@
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  resolveGatewayStartupRetryAfterMs,
+} from "@openclaw/gateway-client/browser";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ChatMetadataResult } from "../../pages/chat/chat-history.ts";
+
+type ChatMetadataEntry = {
+  result?: ChatMetadataResult;
+  loadPending?: Promise<ChatMetadataResult>;
+  revalidationPending?: Promise<ChatMetadataResult>;
+  latestRequest?: Promise<ChatMetadataResult>;
+};
+
+const chatMetadataCache = new WeakMap<GatewayBrowserClient, Map<string, ChatMetadataEntry>>();
+
+function chatMetadataAgentKey(agentId: string | null | undefined): string {
+  return agentId?.trim() ?? "";
+}
+
+function metadataEntryFor(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+): ChatMetadataEntry {
+  const key = chatMetadataAgentKey(agentId);
+  let cache = chatMetadataCache.get(client);
+  if (!cache) {
+    cache = new Map();
+    chatMetadataCache.set(client, cache);
+  }
+  let entry = cache.get(key);
+  if (!entry) {
+    entry = {};
+    cache.set(key, entry);
+  }
+  return entry;
+}
+
+function metadataAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("New-session metadata retry aborted", "AbortError");
+}
+
+function waitForMetadataRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(metadataAbortError(signal));
+  }
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      globalThis.clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      if (signal) {
+        reject(metadataAbortError(signal));
+      }
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    const timer = globalThis.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+  });
+}
+
+async function requestChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  opts?: { signal?: AbortSignal; startupRetryWindowMs?: number },
+): Promise<ChatMetadataResult> {
+  const params = agentId ? { agentId } : {};
+  const retryWindowMs = opts?.startupRetryWindowMs;
+  const signal = opts?.signal;
+  if (retryWindowMs === undefined) {
+    return signal
+      ? client.request<ChatMetadataResult>("chat.metadata", params, { signal })
+      : client.request<ChatMetadataResult>("chat.metadata", params);
+  }
+
+  const deadlineAt = Date.now() + retryWindowMs;
+  let latestStartupError: Error | undefined;
+
+  while (true) {
+    if (signal?.aborted) {
+      throw metadataAbortError(signal);
+    }
+
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw latestStartupError ?? new Error("New-session metadata retry deadline elapsed");
+    }
+
+    try {
+      return await client.request<ChatMetadataResult>("chat.metadata", params, {
+        ...(signal ? { signal } : {}),
+        timeoutMs: Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, remainingMs),
+      });
+    } catch (error) {
+      const requestError =
+        error instanceof Error
+          ? error
+          : new Error("New-session metadata request failed", { cause: error });
+      const retryAfterMs = resolveGatewayStartupRetryAfterMs(requestError);
+      if (retryAfterMs === null) {
+        throw requestError;
+      }
+
+      const retryRemainingMs = deadlineAt - Date.now();
+      if (retryRemainingMs <= 0) {
+        throw requestError;
+      }
+
+      latestStartupError = requestError;
+      await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs), signal);
+    }
+  }
+}
+
+function beginChatMetadataRequest(
+  entry: ChatMetadataEntry,
+  pendingKey: "loadPending" | "revalidationPending",
+  request: Promise<ChatMetadataResult>,
+): Promise<ChatMetadataResult> {
+  const pending = request
+    .then((result) => {
+      // The newest request owns the snapshot even when an older load settles later.
+      if (entry.latestRequest === pending) {
+        entry.result = result;
+      }
+      return result;
+    })
+    .finally(() => {
+      if (entry[pendingKey] === pending) {
+        entry[pendingKey] = undefined;
+      }
+    });
+  entry[pendingKey] = pending;
+  entry.latestRequest = pending;
+  return pending;
+}
+
+export function peekChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+): ChatMetadataResult | undefined {
+  return chatMetadataCache.get(client)?.get(chatMetadataAgentKey(agentId))?.result;
+}
+
+export function loadChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+): Promise<ChatMetadataResult> {
+  const entry = metadataEntryFor(client, agentId);
+  if (entry.result) {
+    return Promise.resolve(entry.result);
+  }
+  if (entry.loadPending) {
+    return entry.loadPending;
+  }
+  if (entry.revalidationPending) {
+    return entry.revalidationPending;
+  }
+
+  return beginChatMetadataRequest(entry, "loadPending", requestChatMetadata(client, agentId));
+}
+
+export function revalidateChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  opts?: { signal?: AbortSignal; startupRetryWindowMs?: number },
+): Promise<ChatMetadataResult> {
+  const entry = metadataEntryFor(client, agentId);
+  if (entry.revalidationPending) {
+    return entry.revalidationPending;
+  }
+
+  return beginChatMetadataRequest(
+    entry,
+    "revalidationPending",
+    requestChatMetadata(client, agentId, opts),
+  );
+}
+
+export function rememberChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  result: ChatMetadataResult,
+): void {
+  const entry = metadataEntryFor(client, agentId);
+  entry.result = result;
+  entry.loadPending = undefined;
+  entry.revalidationPending = undefined;
+  entry.latestRequest = undefined;
+}
+
+export function invalidateChatMetadataStore(client: GatewayBrowserClient): void {
+  chatMetadataCache.delete(client);
+}

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -41,59 +41,25 @@ function metadataEntryFor(
   return entry;
 }
 
-function metadataAbortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new DOMException("New-session metadata retry aborted", "AbortError");
-}
-
-function waitForMetadataRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted) {
-    return Promise.reject(metadataAbortError(signal));
-  }
-
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      globalThis.clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-    };
-    const onAbort = () => {
-      cleanup();
-      if (signal) {
-        reject(metadataAbortError(signal));
-      }
-    };
-
-    signal?.addEventListener("abort", onAbort, { once: true });
-    const timer = globalThis.setTimeout(() => {
-      cleanup();
-      resolve();
-    }, delayMs);
-  });
+function waitForMetadataRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, delayMs));
 }
 
 async function requestChatMetadata(
   client: GatewayBrowserClient,
   agentId: string | null | undefined,
-  opts?: { signal?: AbortSignal; startupRetryWindowMs?: number },
+  opts?: { startupRetryWindowMs?: number },
 ): Promise<ChatMetadataResult> {
   const params = agentId ? { agentId } : {};
   const retryWindowMs = opts?.startupRetryWindowMs;
-  const signal = opts?.signal;
   if (retryWindowMs === undefined) {
-    return signal
-      ? client.request<ChatMetadataResult>("chat.metadata", params, { signal })
-      : client.request<ChatMetadataResult>("chat.metadata", params);
+    return client.request<ChatMetadataResult>("chat.metadata", params);
   }
 
   const deadlineAt = Date.now() + retryWindowMs;
   let latestStartupError: Error | undefined;
 
   while (true) {
-    if (signal?.aborted) {
-      throw metadataAbortError(signal);
-    }
-
     const remainingMs = deadlineAt - Date.now();
     if (remainingMs <= 0) {
       throw latestStartupError ?? new Error("New-session metadata retry deadline elapsed");
@@ -101,7 +67,6 @@ async function requestChatMetadata(
 
     try {
       return await client.request<ChatMetadataResult>("chat.metadata", params, {
-        ...(signal ? { signal } : {}),
         timeoutMs: Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, remainingMs),
       });
     } catch (error) {
@@ -120,7 +85,7 @@ async function requestChatMetadata(
       }
 
       latestStartupError = requestError;
-      await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs), signal);
+      await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs));
     }
   }
 }
@@ -176,8 +141,10 @@ export function loadChatMetadata(
 export function revalidateChatMetadata(
   client: GatewayBrowserClient,
   agentId: string | null | undefined,
-  opts?: { signal?: AbortSignal; startupRetryWindowMs?: number },
+  opts?: { startupRetryWindowMs?: number },
 ): Promise<ChatMetadataResult> {
+  // Shared revalidation outlives any one caller: consumers drop interest through
+  // ownership checks, while completion warms the cache for the next mount.
   const entry = metadataEntryFor(client, agentId);
   if (entry.revalidationPending) {
     return entry.revalidationPending;

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { AgentsPanel } from "../../lib/agents/panels.ts";
+import { invalidateChatMetadataStore } from "../../lib/chat/chat-metadata-store.ts";
 import { loadCronJobsPage, type CronState } from "../../lib/cron/index.ts";
 import type { AgentsRouteData } from "./route.ts";
 import "./agents-page.ts";
@@ -461,6 +462,7 @@ describe("AgentsPage gateway lifecycle", () => {
 
     page.loadActivePanelData();
     page.gateway.invalidate();
+    invalidateChatMetadataStore(page.client as GatewayBrowserClient);
     page.loadActivePanelData();
 
     await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(nextModels));
@@ -491,6 +493,7 @@ describe("AgentsPage gateway lifecycle", () => {
 
     setPageGateway(page, client, false);
     expect(page.chatModelCatalog).toEqual([]);
+    invalidateChatMetadataStore(client);
     setPageGateway(page, client);
     page.loadActivePanelData();
 

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -29,6 +29,11 @@ import {
   type AgentsState,
 } from "../../lib/agents/index.ts";
 import { DEFAULT_AGENT_PANEL, type AgentsPanel } from "../../lib/agents/panels.ts";
+import {
+  loadChatMetadata,
+  peekChatMetadata,
+  revalidateChatMetadata,
+} from "../../lib/chat/chat-metadata-store.ts";
 import { currentConfigObject } from "../../lib/config/config-state-model.ts";
 import {
   createInitialCronState,
@@ -120,9 +125,7 @@ class AgentsPage
   private agentIdentitySource: ApplicationContext["agentIdentity"] | null = null;
   private hasBoundSessions = false;
   private sessionsSource: ApplicationContext["sessions"] | null = null;
-  private chatModelCatalogClient: GatewayBrowserClient | null = null;
   private chatModelCatalogAgentId: string | null = null;
-  private readonly chatModelCatalogByAgentId = new Map<string, ModelCatalogEntry[]>();
   private chatModelCatalogRequest: {
     client: GatewayBrowserClient;
     generation: number;
@@ -138,9 +141,7 @@ class AgentsPage
       }
       this.invalidateTransientRequests();
       this.chatModelCatalog = [];
-      this.chatModelCatalogClient = null;
       this.chatModelCatalogAgentId = null;
-      this.chatModelCatalogByAgentId.clear();
       this.chatModelCatalogError = null;
     },
     onSnapshot: () => this.syncGatewayState(),
@@ -344,9 +345,7 @@ class AgentsPage
     this.agentsList = null;
     this.agentsSelectedId = null;
     this.chatModelCatalog = [];
-    this.chatModelCatalogClient = null;
     this.chatModelCatalogAgentId = null;
-    this.chatModelCatalogByAgentId.clear();
     this.chatModelCatalogError = null;
     this.resetSelectionState();
   }
@@ -550,10 +549,10 @@ class AgentsPage
     if (!client || !this.connected || !agentId) {
       return;
     }
-    if (!options.refresh && this.chatModelCatalogClient === client) {
-      const cached = this.chatModelCatalogByAgentId.get(agentId);
+    if (!options.refresh) {
+      const cached = peekChatMetadata(client, agentId);
       if (cached) {
-        this.chatModelCatalog = cached;
+        this.chatModelCatalog = cached.models ?? [];
         this.chatModelCatalogAgentId = agentId;
         this.chatModelCatalogError = null;
         return;
@@ -576,15 +575,15 @@ class AgentsPage
     this.chatModelCatalogError = null;
     // Chat metadata carries the selected agent's already-prepared startup models
     // without initiating the live discovery reserved for explicit picker use.
-    void client
-      .request<{ models?: ModelCatalogEntry[] }>("chat.metadata", { agentId })
+    const metadataRequest = options.refresh
+      ? revalidateChatMetadata(client, agentId)
+      : loadChatMetadata(client, agentId);
+    void metadataRequest
       .then((result) => {
         if (this.isCurrentRequest(client, generation, agentId)) {
           const models = result.models ?? [];
           this.chatModelCatalog = models;
-          this.chatModelCatalogClient = client;
           this.chatModelCatalogAgentId = agentId;
-          this.chatModelCatalogByAgentId.set(agentId, models);
           this.chatModelCatalogError = null;
         }
       })

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -3,16 +3,15 @@ import {
   readSessionMessageSequence,
 } from "@openclaw/gateway-client/browser";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsListResult,
   GatewaySessionRow,
   GatewaySessionsDefaults,
-  ModelCatalogEntry,
   SessionBranch,
   SessionsListResult,
 } from "../../api/types.ts";
+import type { ChatMetadataResult } from "../../lib/chat/chat-metadata-store.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
@@ -572,10 +571,6 @@ function reconcileLoadedHistoryTail(options: {
         : { hasMore: false, totalMessages: nextTotal },
   };
 }
-
-export type ChatMetadataResult = CommandsListResult & {
-  models?: ModelCatalogEntry[];
-};
 
 export type ChatEventPayload = {
   runId?: string;

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -31,9 +31,9 @@ import { stopChatRealtimeTalk } from "./chat-realtime.ts";
 import { retryReconnectableQueuedChatSends } from "./chat-send-actions.ts";
 import { retireChatModelSelectionOwnership } from "./chat-session.ts";
 import {
-  invalidateChatMetadataCache,
   refreshChatModelAuthStatus,
   refreshPageChat,
+  retireChatMetadataRequests,
 } from "./chat-state-refresh.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { releaseChatMediaResourceSubscriber } from "./components/chat-message-media.ts";
@@ -232,7 +232,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       invalidateChatAvatarCache(state);
       invalidateAssistantIdentityCache(state.client);
       state.assistantIdentityRequestVersion += 1;
-      invalidateChatMetadataCache(state);
+      retireChatMetadataRequests(state);
       this.swarmHydrator?.dispose();
       this.swarmHydrator = null;
       this.taskSuggestionsRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -54,7 +54,7 @@ import { setChatError } from "./chat-send-queue-state.ts";
 import { applySelectedChatAgent } from "./chat-session.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import { createPageState } from "./chat-state-page.ts";
-import { invalidateChatMetadataCache, refreshPageChat } from "./chat-state-refresh.ts";
+import { refreshPageChat, retireChatMetadataRequests } from "./chat-state-refresh.ts";
 import { resetChatViewState } from "./chat-view-state.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
 import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
@@ -546,7 +546,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
             invalidateChatAvatarCache(state);
             invalidateAssistantIdentityCache(state.client);
             state.assistantIdentityRequestVersion += 1;
-            invalidateChatMetadataCache(state);
+            retireChatMetadataRequests(state);
             void refreshChatAvatar(state).finally(() => state.requestUpdate?.());
           }
           handleQuestionPromptEvent(this.questionPromptState, event);

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { loadChatMetadata, rememberChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
@@ -50,79 +51,14 @@ type ChatMetadataRefreshOptions = {
   requestVersion?: number;
 };
 
-type ChatMetadataCacheEntry =
-  | { kind: "result"; result: ChatMetadataResult }
-  | { kind: "pending"; pending: Promise<ChatMetadataResult> };
-
-const chatMetadataCache = new WeakMap<GatewayBrowserClient, Map<string, ChatMetadataCacheEntry>>();
-
 const EMPTY_CHAT_METADATA_APPLY_RESULT: ChatMetadataApplyResult = {
   commands: false,
   models: false,
 };
 
-function chatMetadataAgentKey(agentId: string | null | undefined): string {
-  return agentId?.trim() ?? "";
-}
-
-function metadataCacheFor(client: GatewayBrowserClient): Map<string, ChatMetadataCacheEntry> {
-  let cache = chatMetadataCache.get(client);
-  if (!cache) {
-    cache = new Map();
-    chatMetadataCache.set(client, cache);
-  }
-  return cache;
-}
-
-function rememberChatMetadata(
-  client: GatewayBrowserClient,
-  agentId: string | null | undefined,
-  result: ChatMetadataResult,
+export function retireChatMetadataRequests(
+  host: Pick<ChatPageHost, "chatMetadataRequestVersion">,
 ): void {
-  metadataCacheFor(client).set(chatMetadataAgentKey(agentId), { kind: "result", result });
-}
-
-function loadChatMetadata(
-  client: GatewayBrowserClient,
-  agentId: string | null | undefined,
-): Promise<ChatMetadataResult> {
-  const cache = metadataCacheFor(client);
-  const key = chatMetadataAgentKey(agentId);
-  const cached = cache.get(key);
-  if (cached?.kind === "result") {
-    return Promise.resolve(cached.result);
-  }
-  if (cached?.kind === "pending") {
-    return cached.pending;
-  }
-  const pending = client
-    .request<ChatMetadataResult>("chat.metadata", agentId ? { agentId } : {})
-    .then(
-      (result) => {
-        const current = cache.get(key);
-        if (current?.kind === "pending" && current.pending === pending) {
-          cache.set(key, { kind: "result", result });
-        }
-        return result;
-      },
-      (error: unknown) => {
-        const current = cache.get(key);
-        if (current?.kind === "pending" && current.pending === pending) {
-          cache.delete(key);
-        }
-        throw error;
-      },
-    );
-  cache.set(key, { kind: "pending", pending });
-  return pending;
-}
-
-export function invalidateChatMetadataCache(
-  host: Pick<ChatPageHost, "chatMetadataRequestVersion" | "client">,
-): void {
-  if (host.client) {
-    chatMetadataCache.delete(host.client);
-  }
   host.chatMetadataRequestVersion += 1;
 }
 

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -1,6 +1,10 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { loadChatMetadata, rememberChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
+import {
+  loadChatMetadata,
+  rememberChatMetadata,
+  type ChatMetadataResult,
+} from "../../lib/chat/chat-metadata-store.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
@@ -8,7 +12,7 @@ import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { refreshChatAvatar, resolveAgentIdForSession } from "./chat-avatar.ts";
 import { applyRemoteSlashCommandsResult, refreshSlashCommands } from "./chat-commands.ts";
-import { loadChatHistory, type ChatMetadataResult } from "./chat-history.ts";
+import { loadChatHistory } from "./chat-history.ts";
 import { flushChatQueueForEvent } from "./chat-send-actions.ts";
 import { flushChatQueueAfterIdleSessionReconciliation } from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -16,9 +16,9 @@ import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import {
-  invalidateChatMetadataCache,
   refreshChatMetadata,
   refreshChatModelAuthStatus,
+  retireChatMetadataRequests,
 } from "./chat-state-refresh.ts";
 import { resolveChatAvatarUrl, selectedChatSessionRow } from "./chat-state-route.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
@@ -1670,51 +1670,30 @@ describe("refreshChatMetadata", () => {
     ]);
   });
 
-  it("does not let an older same-agent response overwrite the newest catalog", async () => {
-    let resolveFirst: (value: {
+  it("does not publish metadata after the pane retires its request owner", async () => {
+    let resolveMetadata: (value: {
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
     }) => void = () => {};
-    let resolveSecond: (value: {
-      commands: never[];
-      models: Array<{ id: string; name: string; provider: string }>;
-    }) => void = () => {};
-    const firstMetadata = new Promise<{
+    const pending = new Promise<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
     }>((resolve) => {
-      resolveFirst = resolve;
+      resolveMetadata = resolve;
     });
-    const secondMetadata = new Promise<{
-      commands: never[];
-      models: Array<{ id: string; name: string; provider: string }>;
-    }>((resolve) => {
-      resolveSecond = resolve;
-    });
-    let requestCount = 0;
-    const request = vi.fn(async () => {
-      requestCount += 1;
-      return await (requestCount === 1 ? firstMetadata : secondMetadata);
-    });
-    const state = createMetadataState(request);
+    const request = vi.fn().mockReturnValue(pending);
+    const existingCatalog = [{ id: "existing-model", name: "Existing Model", provider: "openai" }];
+    const state = createMetadataState(request, { chatModelCatalog: existingCatalog });
 
-    const firstRefresh = refreshChatMetadata(state);
-    invalidateChatMetadataCache(state);
-    const secondRefresh = refreshChatMetadata(state);
-    resolveSecond({
+    const refresh = refreshChatMetadata(state);
+    retireChatMetadataRequests(state);
+    resolveMetadata({
       commands: [],
-      models: [{ id: "new-model", name: "New Model", provider: "openai" }],
+      models: [{ id: "late-model", name: "Late Model", provider: "openai" }],
     });
-    await secondRefresh;
-    resolveFirst({
-      commands: [],
-      models: [{ id: "old-model", name: "Old Model", provider: "openai" }],
-    });
-    await firstRefresh;
+    await refresh;
 
-    expect(state.chatModelCatalog).toEqual([
-      { id: "new-model", name: "New Model", provider: "openai" },
-    ]);
+    expect(state.chatModelCatalog).toBe(existingCatalog);
   });
 
   it("loads compatibility models when the gateway does not advertise chat metadata", async () => {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,10 +1,5 @@
-import {
-  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
-  gatewayStartupUnavailableDetails,
-} from "@openclaw/gateway-client/browser";
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { NewSessionModelControl } from "./model-control.ts";
@@ -44,16 +39,6 @@ function contextWith(
     },
   } as unknown as ApplicationContext;
   return { context, navigate, request };
-}
-
-function startupUnavailableError(retryAfterMs = 250): GatewayRequestError {
-  return new GatewayRequestError({
-    code: "UNAVAILABLE",
-    message: "gateway startup sidecars are still initializing",
-    details: gatewayStartupUnavailableDetails(),
-    retryable: true,
-    retryAfterMs,
-  });
 }
 
 function deferred<T>() {
@@ -159,6 +144,9 @@ describe("new-session model runtime", () => {
       const container = renderControl(control, context);
       expect(container.querySelector('[data-chat-model-target-group="cliAgents"]')).not.toBeNull();
       expect(container.querySelector('[data-chat-model-target="anthropic"]')).not.toBeNull();
+      expect(
+        container.querySelector('[data-chat-model-select="true"]')?.getAttribute("aria-disabled"),
+      ).toBe("false");
       expect(container.textContent).not.toContain("History only");
     });
 
@@ -232,6 +220,37 @@ describe("new-session model runtime", () => {
     ).toBe("true");
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     pending.resolve({ models: [] });
+  });
+
+  it("renders a cached catalog immediately while a remounted control revalidates", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+    ];
+    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith(models);
+    const firstControl = new NewSessionModelControl(() => undefined);
+    firstControl.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(firstControl, context).querySelector(
+          '[data-chat-model-option="openai/gpt-5.6-luna"]',
+        ),
+      ).not.toBeNull(),
+    );
+    request.mockReturnValueOnce(refresh.promise);
+
+    const remountedControl = new NewSessionModelControl(() => undefined);
+    remountedControl.load(context, "main", true);
+
+    const container = renderControl(remountedControl, context);
+    expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).not.toContain(
+      "Loading models",
+    );
+    expect(
+      container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
+    ).not.toBeNull();
+    refresh.resolve({ models });
   });
 
   it("waits for selected-agent defaults after chat metadata resolves", async () => {
@@ -830,132 +849,5 @@ describe("new-session model runtime", () => {
     control.selected = "anthropic/sonnet-4.6";
 
     await vi.waitFor(() => expect(control.resolveAgentRuntime({ context })).toBeUndefined());
-  });
-
-  it("retries canonical startup-sidecars unavailability and restores the catalog", async () => {
-    vi.useFakeTimers();
-    const models: ModelCatalogEntry[] = [
-      {
-        id: "gpt-5.6-sol",
-        name: "GPT-5.6 Sol",
-        provider: "openai",
-        reasoning: true,
-      },
-      {
-        id: "gpt-5.6-terra",
-        name: "GPT-5.6 Terra",
-        provider: "openai",
-        reasoning: true,
-      },
-    ];
-    const { context, request } = contextWith(models);
-    request.mockReset();
-    request.mockRejectedValueOnce(startupUnavailableError(250)).mockResolvedValueOnce({ models });
-    const control = new NewSessionModelControl(() => undefined);
-
-    control.load(context, "main", true, {
-      preference: { model: "openai/gpt-5.6-terra", thinkingLevel: "high" },
-    });
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledOnce();
-
-    await vi.advanceTimersByTimeAsync(249);
-    expect(request).toHaveBeenCalledOnce();
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(control.selected).toBe("openai/gpt-5.6-terra");
-    expect(control.thinkingLevel).toBe("high");
-    expect(control.isRestoringPreference()).toBe(false);
-  });
-
-  it("does not retry other retryable UNAVAILABLE errors", async () => {
-    vi.useFakeTimers();
-    const { context, request } = contextWith([]);
-    request.mockReset();
-    request.mockRejectedValue(
-      new GatewayRequestError({
-        code: "UNAVAILABLE",
-        message: "database temporarily unavailable",
-        details: { reason: "database-busy" },
-        retryable: true,
-        retryAfterMs: 250,
-      }),
-    );
-    const control = new NewSessionModelControl(() => undefined);
-
-    control.load(context, "main", true);
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(0);
-
-    await vi.advanceTimersByTimeAsync(2_000);
-    expect(request).toHaveBeenCalledOnce();
-  });
-
-  it("aborts a pending startup retry when the catalog task is invalidated", async () => {
-    vi.useFakeTimers();
-    const { context, request } = contextWith([]);
-    request.mockReset();
-    request.mockRejectedValue(startupUnavailableError(2_000));
-    const control = new NewSessionModelControl(() => undefined);
-
-    control.load(context, "main", true);
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(1);
-
-    control.invalidate();
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(vi.getTimerCount()).toBe(0);
-    await vi.advanceTimersByTimeAsync(2_000);
-    expect(request).toHaveBeenCalledOnce();
-  });
-
-  it("stops startup-sidecars retries at the 60 second deadline", async () => {
-    vi.useFakeTimers();
-    const startedAt = Date.UTC(2026, 7, 2);
-    vi.setSystemTime(startedAt);
-    const { context, request } = contextWith([]);
-    const attemptTimes: number[] = [];
-    request.mockReset();
-    request.mockImplementation(() => {
-      attemptTimes.push(Date.now());
-      return Promise.reject(startupUnavailableError(2_000));
-    });
-    const control = new NewSessionModelControl(() => undefined);
-
-    control.load(context, "main", true);
-
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(attemptTimes).toHaveLength(30);
-    expect(attemptTimes[0]).toBe(startedAt);
-    expect(attemptTimes.at(-1)).toBe(startedAt + 58_000);
-    expect(request).toHaveBeenNthCalledWith(
-      1,
-      "chat.metadata",
-      { agentId: "main" },
-      {
-        signal: expect.any(AbortSignal),
-        timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
-      },
-    );
-    expect(request).toHaveBeenLastCalledWith(
-      "chat.metadata",
-      { agentId: "main" },
-      {
-        signal: expect.any(AbortSignal),
-        timeoutMs: 2_000,
-      },
-    );
-    expect(vi.getTimerCount()).toBe(0);
-
-    await vi.advanceTimersByTimeAsync(10_000);
-    expect(request).toHaveBeenCalledTimes(30);
   });
 });

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -253,6 +253,39 @@ describe("new-session model runtime", () => {
     refresh.resolve({ models });
   });
 
+  it("keeps a shared metadata request alive when its first control is torn down", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+    ];
+    const pending = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    request.mockImplementationOnce((_method, _params, options?: { signal?: AbortSignal }) => {
+      options?.signal?.addEventListener(
+        "abort",
+        () => pending.reject(new DOMException("metadata request aborted", "AbortError")),
+        { once: true },
+      );
+      return pending.promise;
+    });
+    const firstControl = new NewSessionModelControl(() => undefined);
+    firstControl.load(context, "main", true);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    firstControl.reset();
+    const remountedControl = new NewSessionModelControl(() => undefined);
+    remountedControl.load(context, "main", true);
+    pending.resolve({ models });
+
+    await vi.waitFor(() => {
+      const container = renderControl(remountedControl, context);
+      expect(container.querySelector("[data-chat-model-catalog-state]")).toBeNull();
+      expect(
+        container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
+      ).not.toBeNull();
+    });
+    expect(request).toHaveBeenCalledOnce();
+  });
+
   it("waits for selected-agent defaults after chat metadata resolves", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", reasoning: true },
@@ -782,15 +815,7 @@ describe("new-session model runtime", () => {
     ]);
     const control = new NewSessionModelControl(() => undefined);
     control.load(context, "main", true);
-    await vi.waitFor(() =>
-      expect(request).toHaveBeenCalledWith(
-        "chat.metadata",
-        { agentId: "main" },
-        expect.objectContaining({
-          signal: expect.any(AbortSignal),
-        }),
-      ),
-    );
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     await vi.waitFor(() => {
       control.selected = "openai/gpt-5.6-luna";
       expect(control.resolveAgentRuntime({ context })).toEqual({

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -1,7 +1,3 @@
-import {
-  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
-  resolveGatewayStartupRetryAfterMs,
-} from "@openclaw/gateway-client/browser";
 import type {
   SessionCatalog,
   SessionsCatalogListResult,
@@ -9,6 +5,7 @@ import type {
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
+import { peekChatMetadata, revalidateChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import {
   buildQualifiedChatModelValue,
   normalizeChatModelProviderId,
@@ -23,8 +20,6 @@ import {
   type ChatModelCatalogState,
 } from "../chat/components/chat-model-controls.ts";
 import type { NewSessionPreference } from "./preferences.ts";
-
-const NEW_SESSION_METADATA_RETRY_WINDOW_MS = 60_000;
 
 type NewSessionMetadataClient = NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
 type GatewayAgentRuntime = NonNullable<GatewayAgentRow["agentRuntime"]> & {
@@ -53,90 +48,6 @@ type ReconciledNewSessionSelection = {
   thinkingLevel: string;
   repaired: boolean;
 };
-
-function abortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new DOMException("New-session metadata retry aborted", "AbortError");
-}
-
-function waitForMetadataRetry(delayMs: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return Promise.reject(abortError(signal));
-  }
-
-  return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
-    const cleanup = () => {
-      if (timer !== null) {
-        globalThis.clearTimeout(timer);
-        timer = null;
-      }
-      signal.removeEventListener("abort", onAbort);
-    };
-    const onAbort = () => {
-      cleanup();
-      reject(abortError(signal));
-    };
-
-    signal.addEventListener("abort", onAbort, { once: true });
-    timer = globalThis.setTimeout(() => {
-      cleanup();
-      resolve();
-    }, delayMs);
-  });
-}
-
-async function requestNewSessionMetadata(
-  client: NewSessionMetadataClient,
-  agentId: string,
-  signal: AbortSignal,
-): Promise<{ models?: ModelCatalogEntry[] }> {
-  const deadlineAt = Date.now() + NEW_SESSION_METADATA_RETRY_WINDOW_MS;
-  let latestStartupError: Error | undefined;
-
-  while (true) {
-    if (signal.aborted) {
-      throw abortError(signal);
-    }
-
-    const remainingMs = deadlineAt - Date.now();
-    if (remainingMs <= 0) {
-      if (latestStartupError !== undefined) {
-        throw latestStartupError;
-      }
-      throw new Error("New-session metadata retry deadline elapsed");
-    }
-
-    try {
-      return await client.request<{ models?: ModelCatalogEntry[] }>(
-        "chat.metadata",
-        { agentId },
-        {
-          signal,
-          timeoutMs: Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, remainingMs),
-        },
-      );
-    } catch (error) {
-      const requestError =
-        error instanceof Error
-          ? error
-          : new Error("New-session metadata request failed", { cause: error });
-      const retryAfterMs = resolveGatewayStartupRetryAfterMs(requestError);
-      if (retryAfterMs === null) {
-        throw requestError;
-      }
-
-      const retryRemainingMs = deadlineAt - Date.now();
-      if (retryRemainingMs <= 0) {
-        throw requestError;
-      }
-
-      latestStartupError = requestError;
-      await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs), signal);
-    }
-  }
-}
 
 type DraftModelTarget = {
   entry?: ModelCatalogEntry;
@@ -320,6 +231,15 @@ export class NewSessionModelControl {
     this.notify();
   }
 
+  private publishMetadataCatalog(catalog: ModelCatalogEntry[], status: NewSessionMetadataStatus) {
+    this.metadataState = { catalog, hasSnapshot: true, status };
+    if (this.pendingSelectionGeneration === this.selectionGeneration) {
+      this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
+    }
+    this.restoringPreference = false;
+    this.notify();
+  }
+
   private startMetadataRequest(client: NewSessionMetadataClient, agentId: string) {
     this.cancelMetadataRequest();
     const controller = new AbortController();
@@ -330,12 +250,20 @@ export class NewSessionModelControl {
       controller,
       id: requestId,
     };
-    this.updateMetadataState({
-      ...this.metadataState,
-      status: this.metadataState.hasSnapshot ? "refreshing" : "loading",
-    });
+    const cached = peekChatMetadata(client, agentId);
+    if (Array.isArray(cached?.models)) {
+      this.publishMetadataCatalog(cached.models, "refreshing");
+    } else {
+      this.updateMetadataState({
+        ...this.metadataState,
+        status: this.metadataState.hasSnapshot ? "refreshing" : "loading",
+      });
+    }
 
-    void requestNewSessionMetadata(client, agentId, controller.signal).then(
+    void revalidateChatMetadata(client, agentId, {
+      signal: controller.signal,
+      startupRetryWindowMs: 60_000,
+    }).then(
       (result) => {
         // Aborted transports may still resolve. Only the request that still
         // owns the control may publish catalog data or restore preferences.
@@ -343,16 +271,7 @@ export class NewSessionModelControl {
           return;
         }
         this.activeMetadataRequest = undefined;
-        this.metadataState = {
-          catalog: Array.isArray(result.models) ? result.models : [],
-          hasSnapshot: true,
-          status: "ready",
-        };
-        if (this.pendingSelectionGeneration === this.selectionGeneration) {
-          this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
-        }
-        this.restoringPreference = false;
-        this.notify();
+        this.publishMetadataCatalog(Array.isArray(result.models) ? result.models : [], "ready");
       },
       () => {
         if (this.activeMetadataRequest?.id !== requestId) {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -102,7 +102,6 @@ export class NewSessionModelControl {
     | {
         agentId: string;
         client: NewSessionMetadataClient;
-        controller: AbortController;
         id: number;
       }
     | undefined;
@@ -142,13 +141,11 @@ export class NewSessionModelControl {
   }
 
   private cancelMetadataRequest() {
-    const active = this.activeMetadataRequest;
-    if (!active) {
+    if (!this.activeMetadataRequest) {
       return;
     }
     this.activeMetadataRequest = undefined;
     this.metadataRequestId += 1;
-    active.controller.abort();
   }
 
   private clearCatalogTargets() {
@@ -242,12 +239,10 @@ export class NewSessionModelControl {
 
   private startMetadataRequest(client: NewSessionMetadataClient, agentId: string) {
     this.cancelMetadataRequest();
-    const controller = new AbortController();
     const requestId = ++this.metadataRequestId;
     this.activeMetadataRequest = {
       agentId,
       client,
-      controller,
       id: requestId,
     };
     const cached = peekChatMetadata(client, agentId);
@@ -261,12 +256,11 @@ export class NewSessionModelControl {
     }
 
     void revalidateChatMetadata(client, agentId, {
-      signal: controller.signal,
       startupRetryWindowMs: 60_000,
     }).then(
       (result) => {
-        // Aborted transports may still resolve. Only the request that still
-        // owns the control may publish catalog data or restore preferences.
+        // Only the request that still owns the control may publish catalog data
+        // or restore preferences.
         if (this.activeMetadataRequest?.id !== requestId) {
           return;
         }


### PR DESCRIPTION
## What Problem This Solves

Every visit to the WebUI new-session page flashed "Loading models…" at the bottom composer, even when the user had just created a session moments earlier. The model catalog was re-fetched from scratch on every navigation because the page element — and its private catalog state — is rebuilt per visit.

Three UI call sites fetched `chat.metadata` independently: the chat pane had a module-level cache whose invalidation was owned by the chat pane itself (reconnect + `config.changed` handlers that only run while a chat pane is mounted), the new-session model control issued a private uncached request with its own 60s startup-retry loop, and the agents page issued a bare request plus kept a duplicate per-agent catalog map.

## Why This Change Was Made

One shared, app-owned `chat.metadata` store (`ui/src/lib/chat/chat-metadata-store.ts`) with stale-while-revalidate reads replaces the three scattered fetch paths:

- **App-level invalidation ownership**: `app-host` invalidates the store on `config.changed` and on every transition into a connected gateway phase. A reconnect can retain the browser client object, so object identity alone cannot fence logical connections — the invalidation now works regardless of which page is mounted, instead of only while a chat pane is alive.
- **New-session SWR**: a warm visit publishes the cached catalog synchronously as `refreshing` (picker fully usable immediately) and revalidates in the background. The startup-retry loop moved into the store; the control lost ~90 lines of private request plumbing.
- **Chat pane**: keeps its request-version ownership bump (`retireChatMetadataRequests`) but no longer owns the cache; the `models.list` compatibility fallback and picker-open refresh are unchanged.
- **Agents page**: routes through the shared store; the duplicate `chatModelCatalogByAgentId` map is deleted.
- `ChatMetadataResult` moved to the store as its type owner (was defined in `pages/chat/chat-history.ts`, which would have made lib→pages the only such import in the codebase).

## User Impact

Warm visits to the new-session page render the model picker instantly from the cached catalog while a background revalidation refreshes it. The cold first load per gateway connection still shows the honest one-time loading state. `sessions.create` remains the authoritative validator for the selected model, so a briefly stale catalog cannot create an invalid session.

## Evidence

**Focused tests** (all green): store unit tests (cache/single-flight/revalidate/stale-response/seed/invalidate/startup-retry), a regression test proving a remounted control renders the cached catalog with no "Loading models" before revalidation resolves (fails on pre-change code), app-host invalidation tests for `config.changed` + same-client reconnect, plus updated chat-state/agents-page/model-control suites — 121 tests across the touched suites, `tsgo:ui` clean, `check:changed` clean, `check:import-cycles` 0 cycles.

**Live before/after on a real dev gateway** (isolated `OPENCLAW_STATE_DIR`, own port, real Anthropic provider, prebuilt dist served by `openclaw gateway run`; Playwright drove cold load → in-app navigation to Home → in-app return to new-session; a MutationObserver recorded every DOM appearance of "Loading models" and a rAF sampler counted painted frames):

| | cold new-session load | warm new-session revisit |
|---|---|---|
| **before** (`ffa0929c7f2`) | 74 ms, painted | **60 ms visible, 1 painted frame** |
| **after** (this branch) | 72 ms, painted (unchanged) | **4 ms DOM transient, 0 painted frames** |

Before — warm revisit flashes "Loading models…" in the composer:

![before: warm revisit shows Loading models](https://github.com/user-attachments/assets/024f3901-7d2c-41db-a1ec-73529b3ab23d)

https://github.com/user-attachments/assets/c56fa02a-67a1-4c1f-bf53-ab31dee122a7

After — warm revisit renders the picker instantly populated ("Claude Fable 5 / High"):

![after: warm revisit instantly populated](https://github.com/user-attachments/assets/df03c879-e4ab-472d-9d59-9e1c02987507)

https://github.com/user-attachments/assets/11e58759-aed4-4908-a4ad-99fda837d43b

**Autoreview** (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings.

**LOC**: production +263/−194 (net +69: the shared store absorbs the moved retry loop, cache, and revalidation ownership; duplicate caches and per-page plumbing deleted), tests +358/−177.

Observed during live testing, pre-existing and out of scope: the Home-route chat composer paints its own ~100 ms loading flash on first visit because the chat pane requests `chat.metadata` under the empty agent key while new-session caches under the concrete agent id; unifying those keys on the resolved default agent id is a possible follow-up.
