### PR TITLE
fix(gateway): surface failed node event delivery

### DIFF
--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -2,6 +2,7 @@
  * Gateway node registry tests.
  */
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import {
   MAX_DATE_TIMESTAMP_MS,
   MAX_TIMER_TIMEOUT_MS,
@@ -18,6 +19,9 @@ import {
   NODE_WORKER_WORKSPACE_EXEC_COMMAND,
 } from "../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagnostic-log-capture.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { listConnectedNodePluginTools } from "./node-plugin-tool-snapshot.js";
 import {
@@ -2602,6 +2606,52 @@ describe("gateway/node-registry", () => {
       expect(socket.send).not.toHaveBeenCalled();
     },
   );
+
+  it("rate-limits failed event delivery warnings for registered nodes", async () => {
+    const capture = createDiagnosticLogRecordCapture();
+    setLoggerOverride({
+      level: "warn",
+      consoleLevel: "silent",
+      file: path.join(resolvePreferredOpenClawTmpDir(), `node-event-send-${process.pid}.log`),
+    });
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const registry = createTestNodeRegistry();
+    const client = makeClient("conn-1", "node-1", [], {
+      socket: createTestNodeSocket([], WebSocket.CLOSING) as unknown as GatewayWsClient["socket"],
+    });
+    registerNodeSession(registry, client, {});
+
+    try {
+      expect(registry.sendEvent("node-1", "normal.failed", {})).toBe(false);
+      expect(registry.sendEvent("node-1", "normal.failed", {})).toBe(false);
+      expect(registry.sendEventRaw("node-1", "raw.failed", null)).toBe(false);
+
+      now.mockReturnValue(31_001);
+      expect(registry.sendEventRaw("node-1", "raw.failed", null)).toBe(false);
+      now.mockReturnValue(61_002);
+      expect(registry.sendEvent("node-1", "normal.failed", {})).toBe(false);
+
+      client.invalidated = true;
+      expect(registry.sendEvent("node-1", "invalidated.failed", {})).toBe(false);
+      expect(registry.unregister("conn-1")).toBe("node-1");
+      expect(registry.sendEvent("node-1", "unregistered.failed", {})).toBe(false);
+      await capture.flush();
+
+      const warnings = capture.records.filter(
+        (record) => record.message === "node event delivery failed",
+      );
+      expect(warnings.map((record) => record.attributes)).toEqual([
+        expect.objectContaining({ nodeId: "node-1", event: "normal.failed" }),
+        expect.objectContaining({ nodeId: "node-1", event: "raw.failed" }),
+        expect.objectContaining({ nodeId: "node-1", event: "normal.failed" }),
+      ]);
+    } finally {
+      capture.cleanup();
+      setLoggerOverride(null);
+      resetLogger();
+      now.mockRestore();
+    }
+  });
 
   it("drops a delayed voice-wake snapshot after persistent generation changes", async () => {
     let resolveCurrent!: (state: { identity: string; generation?: string } | undefined) => void;

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -17,6 +17,7 @@ import { setActiveNodeContext } from "../infra/active-node-context.js";
 import type { PairedDeviceNodeBinding } from "../infra/device-pairing-node-state.js";
 import { NODE_MCP_TOOLS_CALL_COMMAND } from "../infra/node-commands.js";
 import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   parseComputerUseCapabilityDescriptor,
   type ComputerUseCapabilityDescriptor,
@@ -135,6 +136,9 @@ const SERIALIZED_EVENT_PAYLOAD = Symbol("openclaw.serializedEventPayload");
 const AUTHORIZED_SYSTEM_RUN_EVENT_GRACE_MS = 5 * 60 * 1000;
 const WEBSOCKET_OPEN_READY_STATE = 1;
 const SLOW_CONSUMER_CLOSE_CODE = 1008;
+const FAILED_EVENT_LOG_INTERVAL_MS = 30_000;
+const log = createSubsystemLogger("gateway/nodes");
+const failedEventLogAtByNode = new WeakMap<NodeSession, number>();
 export type SerializedEventPayload = {
   readonly json: string;
   readonly [SERIALIZED_EVENT_PAYLOAD]: true;
@@ -1292,7 +1296,7 @@ export class NodeRegistry {
     if (!node) {
       return false;
     }
-    return this.sendEventRawInternal(node, event, payloadJSON);
+    return this.observeEventSend(node, event, this.sendEventRawInternal(node, event, payloadJSON));
   }
 
   /** Sends command-free events only to the exact authenticated pairing connection. */
@@ -1372,7 +1376,7 @@ export class NodeRegistry {
       }
       node = resolution.session;
     }
-    return this.sendEventRawInternal(node, event, payloadJSON);
+    return this.observeEventSend(node, event, this.sendEventRawInternal(node, event, payloadJSON));
   }
 
   private sendEventInternal(node: NodeSession, event: string, payload: unknown): boolean {
@@ -1440,7 +1444,20 @@ export class NodeRegistry {
   }
 
   private sendEventToSession(node: NodeSession, event: string, payload: unknown): boolean {
-    return this.sendEventInternal(node, event, payload);
+    return this.observeEventSend(node, event, this.sendEventInternal(node, event, payload));
+  }
+
+  private observeEventSend(node: NodeSession, event: string, sent: boolean): boolean {
+    if (sent || this.nodesById.get(node.nodeId) !== node || node.client.invalidated === true) {
+      return sent;
+    }
+    const now = Date.now();
+    const lastLoggedAt = failedEventLogAtByNode.get(node);
+    if (lastLoggedAt === undefined || now - lastLoggedAt >= FAILED_EVENT_LOG_INTERVAL_MS) {
+      failedEventLogAtByNode.set(node, now);
+      log.warn("node event delivery failed", { nodeId: node.nodeId, event });
+    }
+    return sent;
   }
 
   private isNodeWebSocketOpen(node: NodeSession): boolean {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -124,6 +124,8 @@ type EmbeddedRunAttemptParamsBase = Omit<
   | "pluginHarnessToolPolicySafeDeniedTools"
   | "trajectoryRecorder"
 > & {
+  /** Per-model context cap authored by the operator and forwarded to harness runtimes. */
+  authoredContextTokenCap?: number;
   /** Audited exact denies that the plugin harness must enforce against native equivalents. */
   pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node event fanout could silently lose an event when a registered node socket was closing, slow, or rejected a send. Operators received no record of the failed delivery, and a dropped terminal chat event could leave the node rendering a run that never terminates.

## Why This Change Was Made

The node registry now records failed synchronous send admission at the boundary that owns both normal and raw node event delivery. Warnings include the node ID and event name, are limited to once per connected node session every 30 seconds, and are suppressed after the node is invalidated or unregistered.

The rate limiter is deliberately local and lifecycle-bounded with a `WeakMap`; this avoids retaining disconnected sessions and keeps unrelated authentication logging outside this fix.

Per-node event sequencing is not included. The outer gateway event frame already allows an optional `seq`, but targeted node events would need to share the same per-connection allocator as general broadcasts to avoid collisions. The TypeScript node host, Apple node session, Android node session, and watch HTTP transport also need coordinated gap-handling behavior. That additive protocol/client follow-up needs Gateway and native/node-host owner review.

The first exact-head CI run also exposed a current-`main` Plugin SDK declaration regression: the packaged Codex harness lost the already-intended optional operator-authored context cap. This PR makes that field explicit in the facade so package-boundary compilation matches the core contract. Upstream Codex accepts the corresponding optional `model_context_window` override and clamps it to the model maximum.

## User Impact

Operators now get a bounded warning when OpenClaw cannot admit an event for delivery to a still-registered node, including enough context to identify the affected node and event. This makes previously silent fanout loss diagnosable without adding retries or changing the node wire protocol.

Production LOC: +22/-3 (net +19) | Tests: +50/-0

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/gateway/node-registry.test.ts -t "rate-limits failed event delivery warnings for registered nodes"` failed with no warning records (`1 failed | 115 skipped`).
- Focused final proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/node-registry.test.ts` — 116 tests passed.
- Initial changed gate: Blacksmith Testbox `tbx_01m0618s9qp51ttzjxnmcjhz5p`, exit 0; https://github.com/openclaw/openclaw/actions/runs/31968142627
- The first exact-head CI run reproduced the current-`main` packaged Codex failure in `check-additional-extension-package-boundary`: https://github.com/openclaw/openclaw/actions/runs/31968972481
- Package-boundary repair proof: `node --import tsx scripts/check-extension-package-tsc-boundary.mts --mode=compile` — all 123 plugins compiled, including Codex.
- Final build and changed gate: Blacksmith Testbox `tbx_01m0633esygbw0gcyqxeswb97z`, exit 0; https://github.com/openclaw/openclaw/actions/runs/31969733504
- Formatting and patch integrity: targeted `oxfmt` checks and `git diff --check` passed.
- Fresh autoreview: the node delivery fix and the follow-up Plugin SDK contract repair both completed with no accepted/actionable findings.
- Current-main verification: the reported node registry, subscription fanout, chat terminal cleanup, protocol schema, and node-client consumer paths were unchanged on current `origin/main` before this patch.

AI-assisted: yes. The implementation and evidence were reviewed against the affected owner boundary before publication.
