### PR TITLE
fix(ci): select aggregate QA evidence by manifest

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -444,21 +444,24 @@ jobs:
           QA_EVIDENCE_RUN_ID: ${{ inputs.qa_evidence_run_id }}
         run: |
           set -euo pipefail
-          mapfile -t evidence_paths < <(find .artifacts/maturity-evidence -type f -name qa-evidence.json | sort)
-          if [[ "${#evidence_paths[@]}" -eq 0 ]]; then
-            echo "Expected a qa-evidence.json file in the downloaded QA evidence artifact." >&2
+          mapfile -t manifest_paths < <(
+            find .artifacts/maturity-evidence -type f -name qa-profile-evidence-manifest.json | sort
+          )
+          if [[ "${#manifest_paths[@]}" -ne 1 ]]; then
+            echo "Expected exactly one aggregate QA evidence manifest, found ${#manifest_paths[@]}:" >&2
+            printf '%s\n' "${manifest_paths[@]}" >&2
             exit 1
           fi
-          if [[ "${#evidence_paths[@]}" -gt 1 ]]; then
-            echo "Expected exactly one qa-evidence.json file, found ${#evidence_paths[@]}:" >&2
-            printf '%s\n' "${evidence_paths[@]}" >&2
+          evidence_path="$(dirname "${manifest_paths[0]}")/qa-evidence.json"
+          if [[ ! -f "$evidence_path" || -L "$evidence_path" ]]; then
+            echo "Aggregate QA evidence is missing next to ${manifest_paths[0]}." >&2
             exit 1
           fi
-          echo "qa_evidence_path=${evidence_paths[0]}" >> "$GITHUB_OUTPUT"
+          echo "qa_evidence_path=${evidence_path}" >> "$GITHUB_OUTPUT"
           {
             echo "### QA evidence"
             echo
-            echo "- Evidence path: \`${evidence_paths[0]}\`"
+            echo "- Evidence path: \`${evidence_path}\`"
             echo "- Evidence source run: \`${QA_EVIDENCE_RUN_ID:-$GITHUB_RUN_ID}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8045,7 +8045,14 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     const requireEvidenceStep = publishJob.steps.find(
       (step: WorkflowStep) => step.name === "Require one QA evidence file",
     );
-    expect(requireEvidenceStep.run).toContain("Expected exactly one qa-evidence.json file");
+    expect(requireEvidenceStep.run).toContain(
+      "Expected exactly one aggregate QA evidence manifest",
+    );
+    expect(requireEvidenceStep.run).toContain("qa-profile-evidence-manifest.json");
+    expect(requireEvidenceStep.run).toContain(
+      'evidence_path="$(dirname "${manifest_paths[0]}")/qa-evidence.json"',
+    );
+    expect(requireEvidenceStep.run).toContain('[[ ! -f "$evidence_path" || -L "$evidence_path" ]]');
 
     const validateManifestStep = publishJob.steps.find(
       (step: WorkflowStep) => step.name === "Validate QA evidence manifest",


### PR DESCRIPTION
Related: #124612

## What Problem This Solves

Fixes an issue where maturity rendering rejected a valid sharded evidence bundle because recursive discovery counted the aggregate and every preserved shard/script `qa-evidence.json` file.

## Why This Change Was Made

The consumer now locates the unique aggregate evidence manifest and selects the adjacent aggregate `qa-evidence.json`. Nested shard evidence remains preserved for logs and screenshots without being mistaken for an additional scorecard input.

## User Impact

Maturity rendering can consume the successfully aggregated eight-shard evidence bundle instead of failing on nested evidence files.

**AI-assisted:** Yes.

## Evidence

- Protected rollout with eight successful shards and successful aggregation: https://github.com/openclaw/openclaw/actions/runs/31966737524
- Render failure: `Expected exactly one qa-evidence.json file, found 51`.
- Focused workflow guard: 119 passed, 2 platform-skipped.
- check-workflows, actionlint, zizmor, formatting, and git diff --check passed.
- Structured autoreview clean.
