### PR TITLE
fix(ci): invalidate agent harness SDK declarations

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -161,6 +161,8 @@ function listSourceDtsOutputs(sourceDir: string, outputPrefix: string) {
 const PLUGIN_SDK_TYPE_INPUTS = [
   "tsconfig.json",
   "src/plugin-sdk",
+  // agent-harness-runtime re-exports embedded attempt signatures into generated SDK declarations.
+  "src/agents/embedded-agent-runner/run/types.ts",
   // provider-auth re-exports these signatures into generated SDK declarations.
   "src/agents/cli-credentials.ts",
   "src/plugins/provider-runtime-model.types.ts",


### PR DESCRIPTION
## Summary

- add the embedded attempt type owner to Plugin SDK declaration cache inputs
- force stale cached SDK declarations to rebuild when agent harness attempt fields change

## Root cause

The Plugin SDK facade re-exports the embedded attempt parameter type, but the declaration cache digest did not include its source file. After the authored context-token cap field landed, sticky CI caches reused an older agent-harness declaration and the Codex plugin package boundary compiled against a type missing that field.

## Proof

- failing exact-main run: https://github.com/openclaw/openclaw/actions/runs/31968610046
- reproduced failure: Codex package boundary reported TS2339 for authoredContextTokenCap
- repaired exact boundary check on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31969461469
- changed-file checks passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31969247894
- autoreview: clean, no accepted actionable findings

Production delta: 0. Tooling delta: +2 lines. Test delta: 0; the exact boundary compile is the regression proof, matching the existing declaration-input invalidation pattern.
