### PR TITLE
fix(agent): configless exec fails without configured roster

### DIFF
--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -1,0 +1,27 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveRunWorkspaceDir } from "../agents/workspace-run.js";
+import { buildExecRunConfig, resolveExecBaseConfig } from "./agent-exec.js";
+
+describe("agent exec configless workspace ownership", () => {
+  it.each([
+    { name: "environment-only auth", options: { authEnvOnly: true } },
+    { name: "isolated mode", options: { isolated: true } },
+  ])("materializes the main-agent roster for $name", async ({ options }) => {
+    const config = buildExecRunConfig({
+      base: await resolveExecBaseConfig(options),
+      cwd: "/run/here",
+    });
+
+    expect(
+      resolveRunWorkspaceDir({
+        agentId: "main",
+        config,
+        workspaceDir: "/run/here",
+      }),
+    ).toMatchObject({
+      agentId: "main",
+      workspaceDir: resolve("/run/here"),
+    });
+  });
+});

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -296,12 +296,12 @@ describe("agent exec command composition", () => {
     });
   });
 
-  it("creates and removes ephemeral state around the embedded run", async () => {
+  it("creates and removes ephemeral state for a configless run", async () => {
     const { runtime } = createRuntime();
     let observedStateDir = "";
     let observedConfigPath: string | undefined;
     let observedConfig: unknown;
-    const result = await agentExecCommand("inspect", {}, runtime, {
+    const result = await agentExecCommand("inspect", { authEnvOnly: true }, runtime, {
       runAgent: vi.fn(async () => {
         observedStateDir = process.env.OPENCLAW_STATE_DIR ?? "";
         observedConfigPath = process.env.OPENCLAW_CONFIG_PATH;
@@ -1118,18 +1118,16 @@ describe("agent exec base config resolution", () => {
     );
   });
 
-  it("reads no config at all under --auth-env-only", async () => {
+  it("loads no authored config under --auth-env-only", async () => {
     const seedPath = await writeSeed(JSON.stringify(seedConfig));
 
     // A config can supply provider credentials through several surfaces, so
-    // env-only means no config at all.
-    await expect(resolveExecBaseConfig({ authEnvOnly: true })).resolves.toEqual({});
+    // env-only means no authored config; only the canonical missing-config migration applies.
+    await expect(resolveExecBaseConfig({ authEnvOnly: true })).resolves.toEqual({
+      agents: { entries: { main: {} } },
+    });
     // Proves the assertion above is not vacuous.
     const inherited = await resolveExecBaseConfig({ config: seedPath });
     expect(inherited.models?.providers?.custom?.apiKey).toBe("sk-config");
-  });
-
-  it("ignores the ambient config under --isolated", async () => {
-    await expect(resolveExecBaseConfig({ isolated: true })).resolves.toEqual({});
   });
 });

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -396,7 +396,13 @@ export async function resolveExecBaseConfig(
     throw new Error(`--config cannot be combined with ${conflicting}.`);
   }
   if (opts.isolated || opts.authEnvOnly === true) {
-    return {};
+    // A missing config is normally passed through the persisted-config
+    // migrations, which materialize the legacy main agent. Configless exec
+    // modes must preserve that runtime contract even though they skip all
+    // authored config and its credential surfaces.
+    const { migratePersistedImplicitMainRoster } = await import("../config/legacy.roster.js");
+    const { coerceConfig } = await import("../config/io.read-helpers.js");
+    return coerceConfig(migratePersistedImplicitMainRoster({}).config);
   }
   const { createConfigIO, getRuntimeConfig } = await import("../config/io.js");
   if (!opts.config) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw agent exec --auth-env-only` or `--isolated` without a configured agent roster would fail workspace resolution before the provider request with `No agents configured; run workspace resolution requires an explicit roster.`

## Why This Change Was Made

Configless exec modes now apply the same canonical missing-config roster migration as the ordinary config loader while continuing to ignore every authored config and credential surface. This repairs the configuration ownership boundary instead of adding a workspace-resolution exception or duplicating a fallback roster in the caller.

## User Impact

Environment-only and isolated agent executions can start from a genuinely configless state and still resolve the canonical `main` agent workspace. Authored configuration remains excluded in both modes.

## Evidence

- Independent fail-before proof on unmodified `main`: the new two-case workspace regression test failed for both `--auth-env-only` and `--isolated` with `RunWorkspaceRosterRequiredError`.
- Exact-head focused tests: 53 passed across `agent-exec.configless.test.ts` and `agent-exec.test.ts`.
- Exact-head core and commands-test TypeScript checks passed.
- Exact-head targeted Oxlint: 0 warnings and 0 errors.
- Exact-head Oxfmt and `git diff --check` passed.
- TruffleHog pre-commit scan passed with no secrets.
- Structured Codex review (`gpt-5.6-sol`, high reasoning): no accepted/actionable findings; overall correctness 0.99.
