### PR TITLE
refactor(validation): type producers and drop internal re-validation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -810,7 +810,6 @@ extensions/memory-core/src/short-term-promotion-utils.ts	4
 extensions/memory-core/src/short-term-promotion.ts	1
 extensions/memory-core/src/standing-intents-tool.ts	5
 extensions/memory-core/src/standing-intents.ts	2
-extensions/memory-core/src/time.ts	1
 extensions/memory-core/src/tools.ts	4
 extensions/memory-lancedb/config.ts	4
 extensions/memory-lancedb/doctor-contract-api.ts	1

--- a/extensions/discord/src/monitor/native-command-bypass.ts
+++ b/extensions/discord/src/monitor/native-command-bypass.ts
@@ -1,14 +1,10 @@
-// Discord plugin module implements native command bypass behavior.
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-
 export function shouldBypassConfiguredAcpEnsure(commandName: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(commandName);
   // Recovery slash commands still need configured ACP readiness so stale dead
   // bindings are recreated before /new or /reset dispatches through them.
-  return normalized === "acp";
+  return commandName.trim().toLowerCase() === "acp";
 }
 
 export function shouldBypassConfiguredAcpGuildGuards(commandName: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(commandName);
-  return normalized === "new" || normalized === "reset";
+  const command = commandName.trim().toLowerCase();
+  return command === "new" || command === "reset";
 }

--- a/extensions/matrix/src/matrix/actions/limits.ts
+++ b/extensions/matrix/src/matrix/actions/limits.ts
@@ -1,6 +1,3 @@
-// Matrix plugin module implements limits behavior.
-import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
-
-export function resolveMatrixActionLimit(raw: unknown, fallback: number): number {
-  return resolveIntegerOption(raw, fallback, { min: 1 });
+export function resolveMatrixActionLimit(raw: number | undefined, fallback: number): number {
+  return Math.max(1, Math.floor(raw !== undefined && Number.isFinite(raw) ? raw : fallback));
 }

--- a/extensions/memory-core/src/time.ts
+++ b/extensions/memory-core/src/time.ts
@@ -1,11 +1,9 @@
-// Memory Core plugin module implements time behavior.
-import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
-
-export function resolveMemoryCoreNowMs(nowMs: unknown): number {
-  return timestampMsToIsoString(nowMs) === undefined ? Date.now() : (nowMs as number);
+export function resolveMemoryCoreNowMs(nowMs?: number): number {
+  const candidate = nowMs ?? Number.NaN;
+  return new Date(candidate).toJSON() === null ? Date.now() : candidate;
 }
 
-export function resolveMemoryCoreTimestamp(nowMs: unknown): string {
+export function resolveMemoryCoreTimestamp(nowMs?: number): string {
   const timestampMs = resolveMemoryCoreNowMs(nowMs);
-  return timestampMsToIsoString(timestampMs) ?? new Date().toISOString();
+  return new Date(timestampMs).toJSON() ?? new Date().toISOString();
 }

--- a/extensions/memory-wiki/src/time.ts
+++ b/extensions/memory-wiki/src/time.ts
@@ -1,8 +1,7 @@
-// Memory Wiki plugin module implements time behavior.
-import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
-
 export function resolveMemoryWikiTimestamp(nowMs?: number): string {
   return (
-    timestampMsToIsoString(nowMs) ?? timestampMsToIsoString(Date.now()) ?? new Date().toISOString()
+    new Date(nowMs ?? Date.now()).toJSON() ??
+    new Date(Date.now()).toJSON() ??
+    new Date().toISOString()
   );
 }

--- a/extensions/signal/src/rpc-context.ts
+++ b/extensions/signal/src/rpc-context.ts
@@ -1,23 +1,18 @@
-// Signal plugin module implements rpc context behavior.
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSignalAccount } from "./accounts.js";
 
 export function resolveSignalRpcContext(
   opts: { baseUrl?: string; account?: string; accountId?: string },
   accountInfo?: ReturnType<typeof resolveSignalAccount>,
 ) {
-  const hasBaseUrl = Boolean(normalizeOptionalString(opts.baseUrl));
-  const hasAccount = Boolean(normalizeOptionalString(opts.account));
-  if ((!hasBaseUrl || !hasAccount) && !accountInfo) {
+  const baseUrlOverride = opts.baseUrl?.trim();
+  const accountOverride = opts.account?.trim();
+  if ((!baseUrlOverride || !accountOverride) && !accountInfo) {
     throw new Error("Signal account config is required when baseUrl or account is missing");
   }
-  const resolvedAccount = accountInfo;
-  const baseUrl = normalizeOptionalString(opts.baseUrl) ?? resolvedAccount?.baseUrl;
+  const baseUrl = baseUrlOverride || accountInfo?.baseUrl;
   if (!baseUrl) {
     throw new Error("Signal base URL is required");
   }
-  const account =
-    normalizeOptionalString(opts.account) ??
-    normalizeOptionalString(resolvedAccount?.config.account);
+  const account = accountOverride || accountInfo?.config.account?.trim() || undefined;
   return { baseUrl, account };
 }

--- a/src/agents/accepted-session-spawn.ts
+++ b/src/agents/accepted-session-spawn.ts
@@ -2,8 +2,7 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-// Helpers for recognizing accepted session-spawn tool results in loosely typed
-// tool payloads and persisted delivery metadata.
+// Helpers for recognizing accepted session-spawn tool results.
 export type AcceptedSessionSpawn = {
   runId: string;
   childSessionKey: string;
@@ -24,14 +23,8 @@ export function normalizeAcceptedSessionSpawnResult(result: unknown): AcceptedSe
 }
 
 /** Return true when a collection contains at least one accepted child spawn. */
-export function hasAcceptedSessionSpawn(acceptedSessionSpawns?: readonly unknown[]): boolean {
-  return (acceptedSessionSpawns ?? []).some((spawn) => {
-    const record = asOptionalRecord(spawn);
-    if (!record) {
-      return false;
-    }
-    return Boolean(
-      normalizeOptionalString(record.runId) && normalizeOptionalString(record.childSessionKey),
-    );
-  });
+export function hasAcceptedSessionSpawn(
+  acceptedSessionSpawns?: readonly AcceptedSessionSpawn[],
+): boolean {
+  return Boolean(acceptedSessionSpawns?.length);
 }

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -1,9 +1,9 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeMediaReferenceForComparison } from "../../media/media-reference-comparison.js";
 /**
  * Extracts visible delivery evidence from embedded-agent run results.
  */
-import { hasAcceptedSessionSpawn } from "../accepted-session-spawn.js";
 import { collectMediaUrlsFromRecord, hasVisibleAgentPayload } from "./message-visibility.js";
 export { hasVisibleAgentPayload } from "./message-visibility.js";
 
@@ -114,6 +114,15 @@ function hasNonEmptyArray(value: unknown): boolean {
 
 function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some(hasNonEmptyString);
+}
+
+function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
+  return Array.isArray(value)
+    ? value.some((entry) => {
+        const spawn = asOptionalRecord(entry);
+        return hasNonEmptyString(spawn?.runId) && hasNonEmptyString(spawn?.childSessionKey);
+      })
+    : false;
 }
 
 function collectStringValues(value: unknown, output: Set<string>) {
@@ -520,8 +529,7 @@ export function hasVisibleOutboundDeliveryEvidence(result: AgentDeliveryEvidence
     // metadata exists, it owns visibility so blank sends cannot suppress recovery.
     (result.didSendViaMessagingTool === true &&
       !hasGranularMessagingToolDeliveryEvidence(result)) ||
-    (Array.isArray(result.acceptedSessionSpawns) &&
-      hasAcceptedSessionSpawn(result.acceptedSessionSpawns)) ||
+    hasAcceptedSessionSpawnEvidence(result.acceptedSessionSpawns) ||
     hasPositiveNumber(result.successfulCronAdds)
   );
 }
@@ -531,8 +539,7 @@ function hasCommittedNonMessagingOutboundDeliveryEvidence(
   result: Pick<AgentDeliveryEvidence, "acceptedSessionSpawns" | "successfulCronAdds">,
 ): boolean {
   return (
-    (Array.isArray(result.acceptedSessionSpawns) &&
-      hasAcceptedSessionSpawn(result.acceptedSessionSpawns)) ||
+    hasAcceptedSessionSpawnEvidence(result.acceptedSessionSpawns) ||
     hasPositiveNumber(result.successfulCronAdds)
   );
 }

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -41,6 +41,7 @@ import type { CronCreatorAuthorityCapability } from "../../cron-creator-authorit
 import type { BlockReplyPayload } from "../../embedded-agent-payloads.js";
 import type {
   BlockReplyChunking,
+  EmbeddedAgentEvent,
   ToolProgressDetailMode,
   ToolResultFormat,
 } from "../../embedded-agent-subscribe.shared-types.js";
@@ -345,11 +346,7 @@ export type RunEmbeddedAgentParams = {
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   /** Synchronous private observer for the sanitized per-tool result. */
   onAgentToolResult?: (event: { toolName: string; result: unknown; isError: boolean }) => void;
-  onAgentEvent?: (evt: {
-    stream: string;
-    data: Record<string, unknown>;
-    sessionKey?: string;
-  }) => void | Promise<void>;
+  onAgentEvent?: (evt: EmbeddedAgentEvent) => void | Promise<void>;
   onToolStreamBoundary?: () => void | Promise<void>;
   /**
    * Emit lifecycle "finishing" when the attempt ends; the caller owns the

--- a/src/agents/embedded-agent-subscribe.shared-types.ts
+++ b/src/agents/embedded-agent-subscribe.shared-types.ts
@@ -1,11 +1,26 @@
 /**
  * Shared display and chunking types for embedded-agent subscription handlers.
  */
+import type { AgentCommandOutputEventFields } from "../infra/agent-activity-events.js";
 import type { BlockReplyChunking } from "./embedded-agent-block-chunker.js";
 
 /** Rendering mode for completed tool results in subscribed replies. */
 export type ToolResultFormat = "markdown" | "plain";
 /** Detail level for in-flight tool progress messages. */
 export type ToolProgressDetailMode = "explain" | "raw";
+
+export type EmbeddedAgentEvent = {
+  stream: string;
+  data: Record<string, unknown> &
+    Omit<Partial<AgentCommandOutputEventFields>, "phase" | "status"> & {
+      phase?: string;
+      status?: string;
+      args?: Record<string, unknown>;
+      summary?: string;
+      commandBearing?: boolean;
+      isError?: boolean;
+    };
+  sessionKey?: string;
+};
 
 export type { BlockReplyChunking };

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -17,6 +17,7 @@ import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types
 import type { BlockReplyFlushContext } from "./embedded-agent-runner/types.js";
 import type {
   BlockReplyChunking,
+  EmbeddedAgentEvent,
   ToolProgressDetailMode,
   ToolResultFormat,
 } from "./embedded-agent-subscribe.shared-types.js";
@@ -74,11 +75,7 @@ export type SubscribeEmbeddedAgentSessionParams = {
     toolCallId?: string;
     source?: string;
   }) => void;
-  onAgentEvent?: (evt: {
-    stream: string;
-    data: Record<string, unknown>;
-    sessionKey?: string;
-  }) => void | Promise<void>;
+  onAgentEvent?: (evt: EmbeddedAgentEvent) => void | Promise<void>;
   onToolStreamBoundary?: () => void | Promise<void>;
   onHeartbeatToolResponse?: (response: HeartbeatToolResponse) => void | Promise<void>;
   /** "finishing" defers both success and error terminal ownership to the caller. */

--- a/src/auto-reply/reply/agent-runner-command-output.ts
+++ b/src/auto-reply/reply/agent-runner-command-output.ts
@@ -1,9 +1,7 @@
 import { asFiniteNumber as readFiniteNumberValue } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecordValue } from "@openclaw/normalization-core/record-coerce";
-import {
-  normalizeLowercaseStringOrEmpty,
-  readStringValue,
-} from "@openclaw/normalization-core/string-coerce";
+import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import type { EmbeddedAgentEvent } from "../../agents/embedded-agent-subscribe.shared-types.js";
 import { inferToolMetaFromArgsCore } from "../../agents/tool-display.js";
 import type { GetReplyOptions } from "../types.js";
 
@@ -36,19 +34,18 @@ function readNullableNumberValue(value: unknown): number | null | undefined {
 }
 
 function isCommandToolName(name: string | undefined): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  const normalized = name?.trim().toLowerCase();
   return normalized === "exec" || normalized === "bash" || normalized === "shell";
 }
 
 /** Projects a completed command-tool event into the channel command-output contract. */
-export function buildCommandOutputFromToolResultEvent(evt: {
-  stream: string;
-  data: Record<string, unknown>;
-}): Parameters<NonNullable<GetReplyOptions["onCommandOutput"]>>[0] | undefined {
-  if (evt.stream !== "tool" || readStringValue(evt.data.phase) !== "result") {
+export function buildCommandOutputFromToolResultEvent(
+  evt: EmbeddedAgentEvent,
+): Parameters<NonNullable<GetReplyOptions["onCommandOutput"]>>[0] | undefined {
+  if (evt.stream !== "tool" || evt.data.phase !== "result") {
     return undefined;
   }
-  const name = readStringValue(evt.data.name);
+  const name = evt.data.name;
   const commandBearing = evt.data.commandBearing === true;
   if (!name || (!commandBearing && !isCommandToolName(name))) {
     return undefined;
@@ -56,21 +53,19 @@ export function buildCommandOutputFromToolResultEvent(evt: {
   const result = readRecordValue(evt.data.result);
   const details = readRecordValue(result?.details);
   const output =
-    readStringValue(evt.data.output) ??
+    evt.data.output ??
     readStringValue(result?.output) ??
     readStringValue(details?.output) ??
     readToolResultText(evt.data.result);
   const explicitStatus =
-    readStringValue(evt.data.status) ??
-    readStringValue(result?.status) ??
-    readStringValue(details?.status);
+    evt.data.status ?? readStringValue(result?.status) ?? readStringValue(details?.status);
   const exitCode = readNullableNumberValue(
     result?.exitCode ?? details?.exitCode ?? evt.data.exitCode,
   );
   const durationMs = readFiniteNumberValue(
     result?.durationMs ?? details?.durationMs ?? evt.data.durationMs,
   );
-  const cwd = readStringValue(evt.data.cwd);
+  const cwd = evt.data.cwd;
   const errorStatus =
     evt.data.isError === true ? "failed" : evt.data.isError === false ? "completed" : undefined;
   // A bare result carries no outcome of its own: runners that report one send a
@@ -90,15 +85,15 @@ export function buildCommandOutputFromToolResultEvent(evt: {
   }
   // Keep the line describing the command, not its output: without a title the
   // terminal line would replace the request with whatever the tool printed.
-  const args = readRecordValue(evt.data.args);
+  const args = evt.data.args;
   const title =
-    readStringValue(evt.data.title) ??
+    evt.data.title ??
     (args ? inferToolMetaFromArgsCore(name, args, { detailMode: "explain" }) : undefined);
   return {
-    itemId: readStringValue(evt.data.itemId),
+    itemId: evt.data.itemId,
     phase: "end",
     title,
-    toolCallId: readStringValue(evt.data.toolCallId),
+    toolCallId: evt.data.toolCallId,
     name,
     output,
     status: explicitStatus ?? errorStatus,

--- a/src/cron/isolated-agent.run-timeout-override.test.ts
+++ b/src/cron/isolated-agent.run-timeout-override.test.ts
@@ -21,11 +21,10 @@ describe("resolveCronRunTimeoutOverrideMs", () => {
     expect(resolveCronRunTimeoutOverrideMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
-  it("omits the signal when the cron payload has no positive numeric timeout", () => {
+  it("omits the signal when the cron payload has no positive finite timeout", () => {
     expect(resolveCronRunTimeoutOverrideMs(undefined)).toBeUndefined();
     expect(resolveCronRunTimeoutOverrideMs(0)).toBeUndefined();
     expect(resolveCronRunTimeoutOverrideMs(-1)).toBeUndefined();
     expect(resolveCronRunTimeoutOverrideMs(Number.NaN)).toBeUndefined();
-    expect(resolveCronRunTimeoutOverrideMs("300")).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/run-timeout.ts
+++ b/src/cron/isolated-agent/run-timeout.ts
@@ -1,7 +1,10 @@
 /** Converts cron payload timeout overrides into embedded-runner timeout signals. */
-import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 
 /** Converts explicit cron payload timeoutSeconds into a timer-safe millisecond override signal. */
-export function resolveCronRunTimeoutOverrideMs(timeoutSeconds: unknown): number | undefined {
-  return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds);
+export function resolveCronRunTimeoutOverrideMs(timeoutSeconds?: number): number | undefined {
+  const timeoutMs = Math.floor((timeoutSeconds ?? 0) * 1000);
+  return Number.isFinite(timeoutSeconds) && timeoutMs > 0
+    ? Math.min(timeoutMs, MAX_TIMER_TIMEOUT_MS)
+    : undefined;
 }

--- a/src/infra/agent-activity-events.ts
+++ b/src/infra/agent-activity-events.ts
@@ -32,7 +32,7 @@ export type AgentItemEventData = Record<string, unknown> & {
 };
 
 /** Incremental command output payload associated with an item/tool call. */
-export type AgentCommandOutputEventData = Record<string, unknown> & {
+export type AgentCommandOutputEventFields = {
   itemId: string;
   phase: "delta" | "end";
   title: string;
@@ -44,6 +44,7 @@ export type AgentCommandOutputEventData = Record<string, unknown> & {
   durationMs?: number;
   cwd?: string;
 };
+export type AgentCommandOutputEventData = Record<string, unknown> & AgentCommandOutputEventFields;
 
 /** Patch summary payload emitted after an agent applies file changes. */
 export type AgentPatchSummaryEventData = Record<string, unknown> & {

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -1,9 +1,6 @@
-// Normalizes heartbeat wake reasons for logs and UI.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-
 // Heartbeat wake reasons are displayed/logged, so normalize blanks to a stable
 // default before they reach scheduling or diagnostics.
 /** Normalize a heartbeat wake reason for logs and UI. */
 export function normalizeHeartbeatWakeReason(reason?: string): string {
-  return normalizeOptionalString(reason) ?? "requested";
+  return reason?.trim() || "requested";
 }

--- a/src/plugin-sdk/expect-runtime.ts
+++ b/src/plugin-sdk/expect-runtime.ts
@@ -1,6 +1,7 @@
-import { expectDefined as expectDefinedCore } from "../../packages/normalization-core/src/expect.js";
-
 // Keep the public declaration local so sibling normalization helpers stay private.
 export function expectDefined<T>(value: T | null | undefined, context: string): T {
-  return expectDefinedCore(value, context);
+  if (value === null || value === undefined) {
+    throw new Error("expected " + context + " to be defined");
+  }
+  return value;
 }


### PR DESCRIPTION
## What Problem This Solves

Internal agent events, accepted-spawn records, and typed option/time values were repeatedly treated as unknown at their consumers. That duplicated runtime validation, obscured producer contracts, and left dead malformed-input behavior in otherwise typed paths.

## Why This Change Was Made

This maintainer-requested runtime-validation pilot strengthens the internal event and accepted-spawn producer types, then removes the now-obsolete consumer checks while preserving trimming, defaults, finite/range handling, and invariant assertions. Validation remains at genuine CLI/tool/provider and durable-evidence boundaries.

Exact scan accounting:

- `extensions/signal/src/rpc-context.ts`: deleted 5 C rechecks; retained trim/fallback/error semantics.
- `src/auto-reply/reply/agent-runner-command-output.ts`: fixed 9 B envelope fields at the shared producer contract, deleted 1 C tool-name recheck, and retained all 11 A raw CLI/tool-result validations.
- `src/agents/accepted-session-spawn.ts`: resolved 3 D sites as typed-runtime C and deleted them; retained the 4 A loose tool-result checks and moved durable `unknown` evidence validation to its boundary owner.
- `extensions/memory-wiki/src/time.ts` and `extensions/memory-core/src/time.ts`: deleted 2 C sites each while retaining JavaScript Date-range fallback semantics. They remain local because memory-wiki cannot cleanly take a runtime dependency on memory-core's private implementation.
- `src/cron/isolated-agent/run-timeout.ts`, `src/infra/heartbeat-reason.ts`, `src/plugin-sdk/expect-runtime.ts`, and `extensions/matrix/src/matrix/actions/limits.ts`: deleted 1 C site each; retained timer caps, defaults, trim behavior, invariant errors, and numeric bounds.
- `extensions/discord/src/monitor/native-command-bypass.ts`: deleted 2 C sites; retained trim/lowercase matching.
- `src/agents/embedded-agent-runner/abort.ts`: resolved all 4 D sites as A and intentionally kept them because provider/runtime promises may reject with arbitrary thrown values.

The Plugin SDK `expectDefined` export keeps the same generic signature, error text, and runtime behavior. No public SDK shape changed.

## User Impact

No user-visible behavior changes. Internal contracts are clearer and malformed-input validation remains at the boundaries that actually receive malformed input.

Production LOC: +82/-91 (net -9) | Tests: +1/-2 (net -1) | Ratchet baseline: +0/-1 | Total net: -11.

## Evidence

- Focused owner proof: 8 Vitest shards, 12 files, 284 tests passed.
- Final post-type-fix spot proof: 2 Vitest shards, 41 tests passed.
- `node scripts/check-changed.mjs`: passed on Blacksmith Testbox `tbx_01m0629wca710e0eyy4kg2jtn8`; Actions run https://github.com/openclaw/openclaw/actions/runs/31969030308.
  - Four TypeScript graphs passed.
  - Full core lint: 17,132 files, 0 warnings/errors.
  - Full extension lint: 8,142 files, 0 warnings/errors.
  - Scripts lint: 714 files, 0 warnings/errors.
  - Plugin SDK exports/surface, dead exports, formatting, import cycles, database-first, and architecture guards passed.
- Autoreview: clean; no accepted/actionable findings.

AI-assisted: yes. The change and retained external boundaries were manually traced through producers and callers before editing.
