### PR TITLE
fix: doctor completes upgrades with legacy cron jobs

### DIFF
--- a/src/commands/doctor/shared/default-agent-role-materialization.write.test.ts
+++ b/src/commands/doctor/shared/default-agent-role-materialization.write.test.ts
@@ -466,6 +466,66 @@ describe("default role materialization authored writes", () => {
     await expect(fs.readFile(configPath, "utf8")).resolves.toBe(firstPersisted);
   });
 
+  it("assigns ownerless jobs in an unmigrated legacy cron file", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-json-cron-owner-"));
+    roots.push(root);
+    const configPath = path.join(root, "openclaw.json");
+    const storePath = path.join(root, "cron", "jobs.json");
+    const env = {
+      HOME: root,
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_TEST_FAST: "1",
+    } as NodeJS.ProcessEnv;
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ agents: { list: [{ id: "ops", default: true }, { id: "research" }] } }),
+    );
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          makeCronJob({ id: "ownerless" }),
+          makeCronJob({ id: "owned", agentId: "research" }),
+          { ...makeCronJob({ id: "session-owned" }), sessionKey: "agent:research:main" },
+        ],
+      }),
+    );
+    writeConfigMachineState("cron.store", storePath, { env });
+    const io = createConfigIO({
+      configPath,
+      env,
+      homedir: () => root,
+      observe: false,
+      logger: { warn: () => {}, error: () => {} },
+    });
+    const snapshot = await io.readConfigFileSnapshot();
+    const nextConfig: OpenClawConfig = {
+      ...snapshot.config,
+      agents: { ...snapshot.config.agents, ownership: "explicit" },
+    };
+
+    await io.writeConfigFile(nextConfig, {
+      baseSnapshot: snapshot,
+      explicitSetPaths: [["agents", "ownership"]],
+      explicitSetValueSource: nextConfig,
+    });
+
+    const persistedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(persistedConfig.agents).toMatchObject({
+      ownership: "explicit",
+      entries: { ops: {}, research: {} },
+    });
+    const persistedStore = JSON.parse(await fs.readFile(storePath, "utf8"));
+    expect(persistedStore.jobs).toMatchObject([
+      { id: "ownerless", agentId: "ops" },
+      { id: "owned", agentId: "research" },
+      { id: "session-owned", sessionKey: "agent:research:main" },
+    ]);
+    expect(persistedStore.jobs[2]).not.toHaveProperty("agentId");
+  });
+
   it("leaves the legacy owner marker intact when a cron row is corrupt", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-corrupt-cron-owner-write-"));
     roots.push(root);

--- a/src/config/io.cron-owner-refusal.test.ts
+++ b/src/config/io.cron-owner-refusal.test.ts
@@ -31,7 +31,7 @@ const deps = (
     activeGateway ? { ...activeGateway, createdAt: new Date(0).toISOString() } : undefined,
   ),
   loadLegacyCronRepairState: vi.fn(async () => (jobs ? state(jobs) : null)),
-  materializeLegacyDefaultCronJobOwners: vi.fn(() => 0),
+  materializeLegacyDefaultCronJobOwners: vi.fn(async () => 0),
 });
 const cfg = { agents: { entries: { ops: {} } } };
 
@@ -124,7 +124,7 @@ it("materializes a proven retained owner before the commit recheck", async () =>
       ]),
     ),
   );
-  injected.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(() => {
+  injected.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(async () => {
     injected.loadLegacyCronRepairState.mockResolvedValue(
       state([
         { id: "ownerless", agentId: "ops" },
@@ -161,7 +161,7 @@ it("keeps ambiguous and failed owner handoffs as typed refusals", async () => {
   expect(ambiguous.materializeLegacyDefaultCronJobOwners).not.toHaveBeenCalled();
 
   const failed = deps(undefined, [{ id: "ownerless" }]);
-  failed.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(() => {
+  failed.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(async () => {
     throw new Error("database is temporarily read-only");
   });
   const failure = prepareCronOwnerWriteRefusal(

--- a/src/config/io.cron-owner-refusal.ts
+++ b/src/config/io.cron-owner-refusal.ts
@@ -104,7 +104,7 @@ async function assertSafe(
   }
   if ((unresolved > 0 || projectedDynamicDefaults > 0) && provenOwnerAgentId) {
     try {
-      deps.materializeLegacyDefaultCronJobOwners({
+      await deps.materializeLegacyDefaultCronJobOwners({
         storePath,
         legacyDefaultAgentId: provenOwnerAgentId,
         env,

--- a/src/cron/legacy-default-agent-owner-migration.test.ts
+++ b/src/cron/legacy-default-agent-owner-migration.test.ts
@@ -33,13 +33,13 @@ function fixture(label: string) {
   return { env, storePath, storeKey, database };
 }
 
-it("preserves undecodable JSON and bumps the epoch once", () => {
+it("preserves undecodable JSON and bumps the epoch once", async () => {
   const { env, storePath, storeKey, database } = fixture("openclaw-cron-owner-");
   database
     .prepare("UPDATE cron_jobs SET agent_id = ' ', job_json = ? WHERE store_key = ?")
     .run("{malformed", storeKey);
 
-  expect(migrate(storePath, env)).toBe(1);
+  expect(await migrate(storePath, env)).toBe(1);
   expect(loadCronRows(database, storeKey)[0]).toMatchObject({
     agent_id: "ops",
     job_json: "{malformed",
@@ -53,7 +53,7 @@ it("preserves undecodable JSON and bumps the epoch once", () => {
   ).toBe(1);
 });
 
-it("preserves a session-scoped owner stored only in job JSON", () => {
+it("preserves a session-scoped owner stored only in job JSON", async () => {
   const { env, storePath, storeKey, database } = fixture("openclaw-cron-json-owner-");
   const row = loadCronRows(database, storeKey)[0];
   const jobJson = JSON.parse(row?.job_json ?? "{}") as Record<string, unknown>;
@@ -65,7 +65,7 @@ it("preserves a session-scoped owner stored only in job JSON", () => {
     )
     .run(JSON.stringify(jobJson), storeKey);
 
-  expect(migrate(storePath, env)).toBe(0);
+  expect(await migrate(storePath, env)).toBe(0);
   const preserved = loadCronRows(database, storeKey)[0];
   const preservedJobJson = JSON.parse(preserved?.job_json ?? "{}") as Record<string, unknown>;
   expect(preserved?.agent_id).toBeNull();
@@ -75,13 +75,13 @@ it("preserves a session-scoped owner stored only in job JSON", () => {
   expect(preservedJobJson).not.toHaveProperty("agentId");
 });
 
-it("rolls back the row when the epoch bump fails", () => {
+it("rolls back the row when the epoch bump fails", async () => {
   const { env, storePath, storeKey, database } = fixture("openclaw-cron-atomic-");
   ensureCronStoreEpochSchema(database);
   database.exec(`CREATE TRIGGER fail_epoch BEFORE UPDATE OF store_epoch ON cron_store_epochs
       BEGIN SELECT RAISE(ABORT, 'synthetic epoch failure'); END`);
 
-  expect(() => migrate(storePath, env)).toThrow("synthetic epoch failure");
+  await expect(migrate(storePath, env)).rejects.toThrow("synthetic epoch failure");
   expect(loadCronRows(database, storeKey)[0]?.agent_id).toBeNull();
 });
 

--- a/src/cron/legacy-default-agent-owner-migration.ts
+++ b/src/cron/legacy-default-agent-owner-migration.ts
@@ -1,19 +1,70 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isMissingPathError } from "../infra/errors.js";
+import { writeTextAtomic } from "../infra/json-files.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { cronStoreKey } from "./store/key.js";
 import { materializeCronRowAgentOwners } from "./store/row-codec.js";
 
-export function materializeLegacyDefaultCronJobOwners(params: {
+async function materializeLegacyJsonOwners(storePath: string, agentId: string): Promise<number> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(storePath, "utf8");
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return 0;
+    }
+    throw error;
+  }
+  const parsed = parseJsonWithJson5Fallback(raw);
+  const jobs = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.jobs)
+      ? parsed.jobs
+      : [];
+  let rewritten = 0;
+  for (const job of jobs) {
+    if (
+      !isRecord(job) ||
+      normalizeOptionalString(job.agentId) ||
+      parseAgentSessionKey(normalizeOptionalString(job.sessionKey))?.agentId
+    ) {
+      continue;
+    }
+    job.agentId = agentId;
+    rewritten += 1;
+  }
+  if (rewritten === 0) {
+    return 0;
+  }
+  await writeTextAtomic(storePath, JSON.stringify(parsed, null, 2), {
+    mode: 0o600,
+    tempPrefix: path.basename(storePath),
+    trailingNewline: true,
+    beforeRename: async () => {
+      if ((await fs.readFile(storePath, "utf8")) !== raw) {
+        throw new Error("legacy cron source changed while assigning its retained owner");
+      }
+    },
+  });
+  return rewritten;
+}
+
+export async function materializeLegacyDefaultCronJobOwners(params: {
   storePath: string;
   legacyDefaultAgentId: string;
   env?: NodeJS.ProcessEnv;
-}): number {
+}): Promise<number> {
   const agentId = normalizeAgentId(params.legacyDefaultAgentId);
-  return runOpenClawStateWriteTransaction(
-    ({ db }) =>
-      materializeCronRowAgentOwners(db, cronStoreKey(path.resolve(params.storePath)), agentId),
+  const storePath = path.resolve(params.storePath);
+  const sqliteCount = runOpenClawStateWriteTransaction(
+    ({ db }) => materializeCronRowAgentOwners(db, cronStoreKey(storePath), agentId),
     { env: params.env },
     { operationLabel: "cron.legacy-default-owner" },
   );
+  return sqliteCount + (await materializeLegacyJsonOwners(storePath, agentId));
 }

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -134,7 +134,7 @@ export async function start(state: CronServiceState): Promise<void> {
       return;
     }
     if (state.deps.legacyDefaultAgentId) {
-      const rewritten = materializeLegacyDefaultCronJobOwners({
+      const rewritten = await materializeLegacyDefaultCronJobOwners({
         storePath: state.deps.storePath,
         legacyDefaultAgentId: state.deps.legacyDefaultAgentId,
       });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a multi-agent installation with an unmigrated legacy cron store could have `openclaw doctor --fix` leave the configuration upgrade unapplied. The config write safety check repeatedly saw ownerless jobs in `cron/jobs.json`, even though the retained legacy owner was known.

## Why This Change Was Made

Owner materialization now covers both the SQLite cron partition and a still-active legacy JSON source before the config write rechecks ownership. The JSON rewrite is atomic, preserves explicit and session-scoped owners, and refuses to overwrite a source that changed during the operation. All scheduler and config callers await completion.

Production LOC grows because the legacy JSON source requires a durable compare-before-replace path that did not exist in the SQLite-only materializer; the migration remains in the existing ownership boundary without a new compatibility layer.

## User Impact

`openclaw doctor --fix` can now complete the ownership/config migration and then import legacy cron jobs into SQLite without manual intervention or lost job ownership.

## Evidence

- Regression was demonstrated failing before the fix with `Config write refused: ... contains 1 ownerless legacy cron job(s)` and passing afterward.
- Focused Vitest: 28 tests passed across cron materialization, config refusal, and authored config-write integration.
- Real upgrade fixture: 120 ownerless legacy crawl jobs, mixed two-agent config, and empty SQLite. Doctor exited 0, converted `agents.list` to explicit keyed entries, removed retired `contextTokens`, archived `cron/jobs.json`, and produced 121/121 owned SQLite cron rows (including the Doctor-created heartbeat). `PRAGMA integrity_check` returned `ok`; `foreign_key_check` returned no rows.
- Targeted oxlint: 0 warnings/errors.
- Core typecheck passed. The broader core-test typecheck reached an unrelated pre-existing `ui/src/lib/nodes/index.ts` `Uint8Array<ArrayBufferLike>` error.
- No live provider or channel send was performed.
