### PR TITLE
fix(ui): make light-theme diff syntax readable

### DIFF
--- a/ui/src/styles/base-theme-contrast.node.test.ts
+++ b/ui/src/styles/base-theme-contrast.node.test.ts
@@ -48,6 +48,18 @@ const CHIP_SURFACE_MIN_STEP = 1.05;
 const CHIP_BORDER_MIN_STEP = 1.25;
 
 /*
+ * Diff syntax uses its own translucent tint inside code surfaces. The ink must
+ * remain readable after that tint is composited onto every surface a markdown
+ * code block can use; missing light-mode overrides previously left additions
+ * at 1.15:1 on --bg-muted.
+ */
+const DIFF_SELECTORS = [
+  ":is(.code-block, .code-block-wrapper pre code.hljs) .hljs-addition",
+  ":is(.code-block, .code-block-wrapper pre code.hljs) .hljs-deletion",
+] as const;
+const DIFF_HOST_SURFACES = ["--bg", "--bg-muted", "--card"] as const;
+
+/*
  * Link contrast guardrail for painted chat bubbles.
  *
  * Accent-colored links can collapse into the accent-derived user fill, while
@@ -376,6 +388,37 @@ describe("Control UI theme contrast", () => {
           failures.push(
             `${themeName}: chip border ${chip.border} ${border} on ${hostToken} ${host} = ${borderStep.toFixed(2)}:1 (< ${CHIP_BORDER_MIN_STEP}:1)`,
           );
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps highlighted diff lines at WCAG AA on every code surface", () => {
+    const componentsCss = fs.readFileSync(path.join(stylesDir, "components.css"), "utf8");
+    const diffStyles = DIFF_SELECTORS.map((selector) => {
+      const rule = readRuleBody(componentsCss, selector);
+      const foregroundToken = rule.match(/color:\s*var\((--[\w-]+)\)/u)?.[1];
+      const tint = rule.match(/background:\s*([^;]+);/u)?.[1];
+      if (!foregroundToken || !tint) {
+        throw new Error(`could not read diff colors from "${selector}"`);
+      }
+      return { foregroundToken, tint };
+    });
+    const failures: string[] = [];
+    for (const [themeName, tokens] of themes) {
+      for (const { foregroundToken, tint } of diffStyles) {
+        const foreground = resolveOpaqueColor(`var(${foregroundToken})`, tokens);
+        const resolvedTint = resolveColor(tint, tokens);
+        for (const surfaceToken of DIFF_HOST_SURFACES) {
+          const host = resolveOpaqueColor(`var(${surfaceToken})`, tokens);
+          const background = composite(resolvedTint, host);
+          const ratio = contrastRatio(foreground, background);
+          if (ratio < AA_NORMAL_TEXT_MIN) {
+            failures.push(
+              `${themeName}: ${foregroundToken} on ${tint} over ${surfaceToken} = ${ratio.toFixed(2)}:1 (< ${AA_NORMAL_TEXT_MIN}:1)`,
+            );
+          }
         }
       }
     }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -550,6 +550,8 @@
   --hljs-type: #953800;
   --hljs-attribute: #116329;
   --hljs-meta: #57606a;
+  --hljs-deletion: #a40e26;
+  --hljs-addition: #116329;
 
   /* Light shadows - Subtle, warm-tinted */
   --shadow-sm: 0 1px 2px rgba(60, 42, 24, 0.05);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading highlighted diffs in a light Control UI theme could barely see additions because the light palette inherited pastel ink intended for dark code surfaces.

## Why This Change Was Made

Light mode now overrides the shared diff addition and deletion ink at the theme-token owner. The contrast audit also composites each existing diff tint over every supported code-block surface across all shipped theme families, preventing another one-theme-only regression.

## User Impact

Diff additions and deletions remain immediately distinguishable while their text now clears WCAG AA in light mode. Addition contrast on the reported surface improves from **1.15:1** to **5.53:1**.

## Evidence

| Before — dark-theme ink inherited in light mode | After — light-theme semantic ink |
| --- | --- |
| <img src="https://placehold.co/680x88/EAF5E9/7EE787.png?text=%2B%20const%20addition%20%3D%20%22%237ee787%22%3B%20%2F%2F%20inherited%20dark-theme%20ink&amp;font=roboto" width="680" alt="Before: low-contrast pastel green diff addition on a pale green light-theme tint"> | <img src="https://placehold.co/680x88/EAF5E9/116329.png?text=%2B%20const%20addition%20%3D%20%22%23116329%22%3B%20%2F%2F%20readable%20light-theme%20ink&amp;font=roboto" width="680" alt="After: dark green diff addition on the same pale green light-theme tint"> |

The same mocked Control UI chat fixture was also captured locally before and after the token change. Both states retained the existing green tint and `+` marker; only the semantic ink changed.

- `base-theme-contrast.node.test.ts`: 4/4 tests passed
- `oxfmt --check`: passed
- `stylelint`: passed
- `git diff --check`: passed
- Autoreview: no accepted/actionable findings

Production LOC: **+2/-0** | Tests: **+43/-0**

Provenance: made visible by #123156 (`843017073cc2`), which centralized the syntax palette but left the dark diff tokens inherited by light mode.
