### PR TITLE
refactor(ui): align approval page with redesigned approval card

### DIFF
--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1978,13 +1978,23 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
         },
       );
 
+      // The descendant's pid file can be observed created-but-empty between its
+      // open() and write(); readiness must require parseable content, not
+      // existence, or the integer assertion below flakes on loaded runners.
+      const readDescendantPid = () => {
+        if (!existsSync(descendantPidPath)) {
+          return null;
+        }
+        const pid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
+        return Number.isInteger(pid) && pid > 0 ? pid : null;
+      };
       try {
         await waitForCondition(
-          () => existsSync(readyPath) && existsSync(descendantPidPath),
+          () => existsSync(readyPath) && readDescendantPid() !== null,
           "Bun global smoke descendant readiness",
         );
-        descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
-        expect(Number.isInteger(descendantPid)).toBe(true);
+        descendantPid = readDescendantPid() ?? 0;
+        expect(descendantPid).toBeGreaterThan(0);
         expect(isProcessAlive(descendantPid)).toBe(true);
 
         runner.kill("SIGTERM");

--- a/ui/src/e2e/approval-page.e2e.test.ts
+++ b/ui/src/e2e/approval-page.e2e.test.ts
@@ -22,6 +22,7 @@ const suite = createControlUiE2eSuite({
 const APPROVAL_ID = "Approval:Mobile/東京 100% 🦞";
 const APPROVAL_NOW_MS = Date.UTC(2026, 6, 10, 18, 0, 0);
 const ARTIFACT_DIR = path.resolve(".artifacts/control-ui-e2e/approval-page");
+const CAPTURE_UI_PROOF = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const MOBILE_RAW_VIDEO_DIR = path.join(ARTIFACT_DIR, "mobile-raw");
 const MOBILE_VIEWPORT = { height: 844, width: 390 } as const;
 const DESKTOP_VIEWPORT = { height: 800, width: 1200 } as const;
@@ -63,7 +64,28 @@ function pendingApproval(basePath: string): PendingApprovalSnapshot {
       commandPreview: 'curl --header "Authorization: <redacted>" …',
       warningText: "This command requests external network access.",
       host: "gateway",
-      nodeId: null,
+      nodeId: "runner-1",
+      agentId: "main",
+      allowedDecisions: ["allow-once", "deny"],
+    },
+  };
+}
+
+function pendingPluginApproval(basePath: string): PendingApprovalSnapshot {
+  return {
+    id: APPROVAL_ID,
+    status: "pending",
+    urlPath: approvalPath(basePath),
+    createdAtMs: APPROVAL_NOW_MS - 30_000,
+    expiresAtMs: APPROVAL_NOW_MS + 5 * 60_000,
+    presentation: {
+      kind: "plugin",
+      title: "Codex workspace command",
+      description: "Run the requested workspace command after operator review.",
+      detail: "pnpm test ui/src/pages/approval",
+      severity: "critical",
+      pluginId: "codex",
+      toolName: "workspace.exec",
       agentId: "main",
       allowedDecisions: ["allow-once", "deny"],
     },
@@ -94,7 +116,7 @@ async function createSurface(params: {
   recordVideo?: boolean;
   viewport: { height: number; width: number };
 }): Promise<ApprovalSurface> {
-  const rawVideoDir = params.recordVideo ? MOBILE_RAW_VIDEO_DIR : undefined;
+  const rawVideoDir = params.recordVideo && CAPTURE_UI_PROOF ? MOBILE_RAW_VIDEO_DIR : undefined;
   if (rawVideoDir) {
     await mkdir(ARTIFACT_DIR, { recursive: true });
     await rm(rawVideoDir, { force: true, recursive: true });
@@ -181,6 +203,15 @@ async function waitForStableApprovalPaint(page: Page): Promise<void> {
       );
     })
     .toBe(true);
+}
+
+async function captureProof(page: Page, name: string): Promise<void> {
+  if (!CAPTURE_UI_PROOF) {
+    return;
+  }
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  await waitForStableApprovalPaint(page);
+  await page.screenshot({ path: path.join(ARTIFACT_DIR, name) });
 }
 
 async function expectMobilePendingLayout(page: Page): Promise<void> {
@@ -284,15 +315,19 @@ suite.define(() => {
       ]);
       await expectMobilePendingLayout(mobile.page);
       expect(await mobile.page.title()).toBe("Command approval — OpenClaw");
-      await waitForStableApprovalPaint(mobile.page);
-      await mobile.page.screenshot({
-        path: path.join(ARTIFACT_DIR, "01-pending-mobile.png"),
-      });
+      expect(await mobile.page.locator(".approval-page__card").getAttribute("class")).toContain(
+        "approval-page__card--severity-warning",
+      );
+      expect(await mobile.page.locator('[data-approval-chip="agent"]').textContent()).toBe("main");
+      expect(await mobile.page.locator('[data-approval-chip="plugin"]').count()).toBe(0);
+      expect(await mobile.page.locator('[data-approval-chip="tool"]').count()).toBe(0);
+      expect(await mobile.page.locator(".approval-page__meta-row dt").allTextContents()).toEqual([
+        "Host",
+        "Node",
+      ]);
+      await captureProof(mobile.page, "after-pending-exec.png");
       await mobile.page.getByRole("button", { name: "Allow once" }).scrollIntoViewIfNeeded();
-      await waitForStableApprovalPaint(mobile.page);
-      await mobile.page.screenshot({
-        path: path.join(ARTIFACT_DIR, "01b-pending-actions-mobile.png"),
-      });
+      await captureProof(mobile.page, "after-pending-exec-actions.png");
 
       await Promise.all([
         mobile.page.getByRole("button", { name: "Allow once" }).click(),
@@ -350,14 +385,8 @@ suite.define(() => {
       expect(terminalFocus.top).toBeGreaterThanOrEqual(0);
       expect(terminalFocus.bottom).toBeLessThanOrEqual(terminalFocus.viewportHeight);
       expect(await mobile.page.title()).toBe("Approved here — OpenClaw");
-      await waitForStableApprovalPaint(mobile.page);
-      await mobile.page.screenshot({
-        path: path.join(ARTIFACT_DIR, "02-competing-answer-terminal.png"),
-      });
-      await waitForStableApprovalPaint(desktop.page);
-      await desktop.page.screenshot({
-        path: path.join(ARTIFACT_DIR, "02b-competing-answer-loser-desktop.png"),
-      });
+      await captureProof(mobile.page, "after-competing-answer-terminal.png");
+      await captureProof(desktop.page, "after-competing-answer-loser-desktop.png");
 
       const terminalReload = await mobile.page.reload();
       expect(terminalReload?.status()).toBe(200);
@@ -367,16 +396,43 @@ suite.define(() => {
       expect(new URL(mobile.page.url()).pathname).toBe(approvalPath(""));
       await expectStandaloneApprovalPage(mobile.page);
       await expectNoDecisionButtons(mobile.page);
-      await waitForStableApprovalPaint(mobile.page);
-      await mobile.page.screenshot({
-        path: path.join(ARTIFACT_DIR, "03-terminal-reload-mobile.png"),
-      });
+      await captureProof(mobile.page, "after-terminal-reload-mobile.png");
 
       expect(mobile.pageErrors).toEqual([]);
       expect(desktop.pageErrors).toEqual([]);
     } finally {
       await closeRecordedSurface(mobile, "approval-page-mobile.webm");
     }
+  });
+
+  it("renders plugin identity as chips with a severity accent", async () => {
+    const pending = pendingPluginApproval("");
+    const surface = await createSurface({
+      basePath: "",
+      pending,
+      viewport: DESKTOP_VIEWPORT,
+    });
+
+    const response = await surface.page.goto(approvalUrl(""));
+    expect(response?.status()).toBe(200);
+    await waitForApprovalPage(surface.page);
+    await surface.gateway.waitForRequest("approval.get");
+    await expectStandaloneApprovalPage(surface.page);
+
+    expect(await surface.page.locator(".approval-page__card").getAttribute("class")).toContain(
+      "approval-page__card--severity-danger",
+    );
+    expect(
+      await surface.page.locator(".approval-page__heading > .approval-page__chips").count(),
+    ).toBe(1);
+    expect(await surface.page.locator('[data-approval-chip="plugin"]').textContent()).toBe("codex");
+    expect(await surface.page.locator('[data-approval-chip="tool"]').textContent()).toBe(
+      "workspace.exec",
+    );
+    expect(await surface.page.locator('[data-approval-chip="agent"]').textContent()).toBe("main");
+    expect(await surface.page.locator(".approval-page__meta-row dt").allTextContents()).toEqual([]);
+    await captureProof(surface.page, "after-pending-plugin.png");
+    expect(surface.pageErrors).toEqual([]);
   });
 
   it("preserves a mounted deep link across the authentication gate", async () => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1764,14 +1764,11 @@ export const en: TranslationMap = {
     details: "Details",
     labels: {
       host: "Host",
-      agent: "Agent",
       session: "Session",
       cwd: "CWD",
       resolved: "Resolved",
       security: "Security",
       ask: "Ask",
-      severity: "Severity",
-      plugin: "Plugin",
     },
   },
   approvalPage: {

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -41,7 +41,7 @@ function pendingApproval(
       commandPreview: "printf …",
       warningText: null,
       host: "gateway",
-      nodeId: null,
+      nodeId: "runner-1",
       agentId: "main",
       allowedDecisions: ["allow-once", "deny"],
     },
@@ -69,6 +69,24 @@ function expiredApproval(): ExpiredApprovalSnapshot {
     reason: "timeout",
     resolvedAtMs: 2_000,
   } as ExpiredApprovalSnapshot;
+}
+
+function pluginApproval(severity = "warning"): PendingApprovalSnapshot {
+  return pendingApproval({
+    id: "plugin:approval-1",
+    urlPath: "/approve/plugin%3Aapproval-1",
+    presentation: {
+      kind: "plugin",
+      title: "Claude native tool: Bash",
+      description: '{"command":"printf …"}',
+      detail: '{"command":"printf \\"line one\\nline two\\""}',
+      severity,
+      pluginId: "claude-cli",
+      toolName: "Bash",
+      agentId: "main",
+      allowedDecisions: ["allow-once", "deny"],
+    },
+  });
 }
 
 function createGateway(
@@ -405,6 +423,13 @@ describe("ApprovalPage", () => {
       "Waiting for your decision",
     );
     expect(page.querySelector(".approval-page__preview")?.textContent).toBe("printf safe");
+    expect(page.querySelector(".approval-page__card--severity-warning")).not.toBeNull();
+    expect(page.querySelector('[data-approval-chip="agent"]')?.textContent).toBe("main");
+    expect(page.querySelector('[data-approval-chip="plugin"]')).toBeNull();
+    expect(page.querySelector('[data-approval-chip="tool"]')).toBeNull();
+    expect(
+      [...page.querySelectorAll(".approval-page__meta-row dt")].map((label) => label.textContent),
+    ).toEqual(["Host", "Node"]);
 
     (page.querySelector('[data-decision="allow-once"]') as HTMLButtonElement).click();
     await settle(page);
@@ -419,21 +444,7 @@ describe("ApprovalPage", () => {
   });
 
   it("renders reviewer-only plugin detail in a preformatted block", async () => {
-    const approval = pendingApproval({
-      id: "plugin:approval-1",
-      urlPath: "/approve/plugin%3Aapproval-1",
-      presentation: {
-        kind: "plugin",
-        title: "Claude native tool: Bash",
-        description: '{"command":"printf …"}',
-        detail: '{"command":"printf \\\"line one\\nline two\\\""}',
-        severity: "warning",
-        pluginId: "claude-cli",
-        toolName: "Bash",
-        agentId: "main",
-        allowedDecisions: ["allow-once", "deny"],
-      },
-    });
+    const approval = pluginApproval();
     const request = vi.fn(async () => ({ approval }) satisfies ApprovalGetResult);
     const { page } = createPage({
       client: { request } as unknown as GatewayBrowserClient,
@@ -445,6 +456,30 @@ describe("ApprovalPage", () => {
     expect(page.querySelector("pre.approval-page__preview.mono")?.textContent).toBe(
       approval.presentation.kind === "plugin" ? approval.presentation.detail : undefined,
     );
+    expect(page.querySelector('[data-approval-chip="plugin"]')?.textContent).toBe("claude-cli");
+    expect(page.querySelector('[data-approval-chip="tool"]')?.textContent).toBe("Bash");
+    expect(page.querySelector('[data-approval-chip="agent"]')?.textContent).toBe("main");
+    expect(page.querySelectorAll(".approval-page__meta-row")).toHaveLength(0);
+    expect(page.textContent).not.toContain("Severity:");
+    expect(page.textContent).not.toContain("Plugin:");
+    expect(page.textContent).not.toContain("Agent:");
+  });
+
+  it.each([
+    ["info", "info"],
+    ["warning", "warning"],
+    ["critical", "danger"],
+  ])("maps plugin severity %s to the %s page accent", async (severity, expected) => {
+    const approval = pluginApproval(severity);
+    const request = vi.fn(async () => ({ approval }) satisfies ApprovalGetResult);
+    const { page } = createPage({
+      client: { request } as unknown as GatewayBrowserClient,
+      id: approval.id,
+    });
+
+    await settle(page);
+
+    expect(page.querySelector(`.approval-page__card--severity-${expected}`)).not.toBeNull();
   });
 
   it("keeps the selected decision named while a resolution is in flight", async () => {

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -7,6 +7,7 @@ import type {
   ApprovalResolveResult,
   ExpiredApprovalSnapshot,
   PendingApprovalSnapshot,
+  PluginApprovalPresentation,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -71,7 +72,9 @@ function expiredApproval(): ExpiredApprovalSnapshot {
   } as ExpiredApprovalSnapshot;
 }
 
-function pluginApproval(severity = "warning"): PendingApprovalSnapshot {
+function pluginApproval(
+  severity: NonNullable<PluginApprovalPresentation["severity"]> = "warning",
+): PendingApprovalSnapshot {
   return pendingApproval({
     id: "plugin:approval-1",
     urlPath: "/approve/plugin%3Aapproval-1",
@@ -469,7 +472,7 @@ describe("ApprovalPage", () => {
     ["info", "info"],
     ["warning", "warning"],
     ["critical", "danger"],
-  ])("maps plugin severity %s to the %s page accent", async (severity, expected) => {
+  ] as const)("maps plugin severity %s to the %s page accent", async (severity, expected) => {
     const approval = pluginApproval(severity);
     const request = vi.fn(async () => ({ approval }) satisfies ApprovalGetResult);
     const { page } = createPage({

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -37,7 +37,8 @@ function isUnavailableApprovalError(error: unknown): boolean {
   const reason = isRecord(error.details) ? error.details.reason : undefined;
   return (
     reason === "APPROVAL_NOT_FOUND" ||
-    ["APPROVAL_NOT_FOUND", "INVALID_REQUEST"].includes(error.gatewayCode ?? "")
+    error.gatewayCode === "APPROVAL_NOT_FOUND" ||
+    error.gatewayCode === "INVALID_REQUEST"
   );
 }
 
@@ -49,25 +50,28 @@ function formatApprovalTime(timestampMs: number): string {
 }
 
 function decisionLabel(decision: ApprovalDecision): string {
-  return t(
-    decision === "allow-once"
-      ? "execApproval.allowOnce"
-      : decision === "allow-always"
-        ? "execApproval.alwaysAllow"
-        : "execApproval.deny",
-  );
+  switch (decision) {
+    case "allow-once":
+      return t("execApproval.allowOnce");
+    case "allow-always":
+      return t("execApproval.alwaysAllow");
+    case "deny":
+      return t("execApproval.deny");
+  }
+  const unreachable: never = decision;
+  return unreachable;
 }
 
 function appliedDecisionMatches(
   result: ApprovalResolveResult,
   decision: ApprovalDecision,
 ): boolean {
-  return (
-    !result.applied ||
-    (decision === "deny"
-      ? result.approval.status === "denied"
-      : result.approval.status === "allowed" && result.approval.decision === decision)
-  );
+  if (!result.applied) {
+    return true;
+  }
+  return decision === "deny"
+    ? result.approval.status === "denied"
+    : result.approval.status === "allowed" && result.approval.decision === decision;
 }
 
 function renderMetaRow(label: string, value?: string | null) {
@@ -138,7 +142,8 @@ function terminalTitle(approval: ApprovalSnapshot, origin: ResolutionOrigin): st
     case "pending":
       return t("approvalPage.pending");
   }
-  return status satisfies never;
+  const unreachable: never = status;
+  return unreachable;
 }
 
 function terminalDescription(approval: ApprovalSnapshot, origin: ResolutionOrigin): string {
@@ -160,7 +165,8 @@ function terminalDescription(approval: ApprovalSnapshot, origin: ResolutionOrigi
     case "pending":
       return t("approvalPage.pendingDescription");
   }
-  return status satisfies never;
+  const unreachable: never = status;
+  return unreachable;
 }
 
 export class ApprovalPage extends OpenClawLightDomElement {
@@ -683,9 +689,9 @@ export class ApprovalPage extends OpenClawLightDomElement {
     const rawSeverity = active?.kind === "plugin" ? active.severity?.trim().toLowerCase() : null;
     // Keep this mapping aligned with the sibling exec-approval-card.ts surface.
     const severity =
-      active?.kind === "exec" || ["warning", "warn"].includes(rawSeverity ?? "")
+      active?.kind === "exec" || rawSeverity === "warning" || rawSeverity === "warn"
         ? "warning"
-        : ["danger", "critical", "error"].includes(rawSeverity ?? "")
+        : rawSeverity === "danger" || rawSeverity === "critical" || rawSeverity === "error"
           ? "danger"
           : "info";
     return html`

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -37,8 +37,7 @@ function isUnavailableApprovalError(error: unknown): boolean {
   const reason = isRecord(error.details) ? error.details.reason : undefined;
   return (
     reason === "APPROVAL_NOT_FOUND" ||
-    error.gatewayCode === "APPROVAL_NOT_FOUND" ||
-    error.gatewayCode === "INVALID_REQUEST"
+    ["APPROVAL_NOT_FOUND", "INVALID_REQUEST"].includes(error.gatewayCode ?? "")
   );
 }
 
@@ -50,28 +49,25 @@ function formatApprovalTime(timestampMs: number): string {
 }
 
 function decisionLabel(decision: ApprovalDecision): string {
-  switch (decision) {
-    case "allow-once":
-      return t("execApproval.allowOnce");
-    case "allow-always":
-      return t("execApproval.alwaysAllow");
-    case "deny":
-      return t("execApproval.deny");
-  }
-  const unreachable: never = decision;
-  return unreachable;
+  return t(
+    decision === "allow-once"
+      ? "execApproval.allowOnce"
+      : decision === "allow-always"
+        ? "execApproval.alwaysAllow"
+        : "execApproval.deny",
+  );
 }
 
 function appliedDecisionMatches(
   result: ApprovalResolveResult,
   decision: ApprovalDecision,
 ): boolean {
-  if (!result.applied) {
-    return true;
-  }
-  return decision === "deny"
-    ? result.approval.status === "denied"
-    : result.approval.status === "allowed" && result.approval.decision === decision;
+  return (
+    !result.applied ||
+    (decision === "deny"
+      ? result.approval.status === "denied"
+      : result.approval.status === "allowed" && result.approval.decision === decision)
+  );
 }
 
 function renderMetaRow(label: string, value?: string | null) {
@@ -80,6 +76,13 @@ function renderMetaRow(label: string, value?: string | null) {
         <dt>${label}</dt>
         <dd title=${value}><bdi dir="ltr">${value}</bdi></dd>
       </div>`
+    : nothing;
+}
+
+function renderApprovalChip(kind: "plugin" | "tool" | "agent", value?: string | null) {
+  const text = value?.trim();
+  return text
+    ? html`<span class="approval-page__chip mono" data-approval-chip=${kind}>${text}</span>`
     : nothing;
 }
 
@@ -100,7 +103,6 @@ function renderPresentation(presentation: ApprovalPresentation) {
       <dl class="approval-page__meta">
         ${renderMetaRow(t("execApproval.labels.host"), presentation.host)}
         ${renderMetaRow(t("approvalPage.nodeLabel"), presentation.nodeId)}
-        ${renderMetaRow(t("execApproval.labels.agent"), presentation.agentId)}
       </dl>
     `;
   }
@@ -111,19 +113,6 @@ function renderPresentation(presentation: ApprovalPresentation) {
     ${presentation.kind === "plugin" && presentation.detail
       ? html`<pre class="approval-page__preview mono" dir="ltr">${presentation.detail}</pre>`
       : nothing}
-    <dl class="approval-page__meta">
-      ${
-        // severity/pluginId/toolName exist only on the plugin presentation.
-        // exec is rendered in its own branch above and carries no toolName
-        // (ExecApprovalPresentationSchema is closed); system-agent has none.
-        presentation.kind === "plugin"
-          ? html`${renderMetaRow(t("execApproval.labels.severity"), presentation.severity)}
-            ${renderMetaRow(t("execApproval.labels.plugin"), presentation.pluginId)}
-            ${renderMetaRow(t("approvalPage.toolLabel"), presentation.toolName)}`
-          : nothing
-      }
-      ${renderMetaRow(t("execApproval.labels.agent"), presentation.agentId)}
-    </dl>
   `;
 }
 function terminalTitle(approval: ApprovalSnapshot, origin: ResolutionOrigin): string {
@@ -149,8 +138,7 @@ function terminalTitle(approval: ApprovalSnapshot, origin: ResolutionOrigin): st
     case "pending":
       return t("approvalPage.pending");
   }
-  const unreachable: never = status;
-  return unreachable;
+  return status satisfies never;
 }
 
 function terminalDescription(approval: ApprovalSnapshot, origin: ResolutionOrigin): string {
@@ -172,8 +160,7 @@ function terminalDescription(approval: ApprovalSnapshot, origin: ResolutionOrigi
     case "pending":
       return t("approvalPage.pendingDescription");
   }
-  const unreachable: never = status;
-  return unreachable;
+  return status satisfies never;
 }
 
 export class ApprovalPage extends OpenClawLightDomElement {
@@ -627,6 +614,13 @@ export class ApprovalPage extends OpenClawLightDomElement {
       </div>
       <div class="approval-page__heading">
         <h1 id="approval-page-title" tabindex=${pending ? nothing : -1}>${title}</h1>
+        <div class="approval-page__chips">
+          ${presentation.kind === "plugin"
+            ? html`${renderApprovalChip("plugin", presentation.pluginId)}
+              ${renderApprovalChip("tool", presentation.toolName)}`
+            : nothing}
+          ${renderApprovalChip("agent", presentation.agentId)}
+        </div>
         <p>${statusDescription}</p>
       </div>
       ${renderPresentation(presentation)}
@@ -685,11 +679,20 @@ export class ApprovalPage extends OpenClawLightDomElement {
         : disconnected
           ? "connection-error"
           : (this.approval?.status ?? "loading");
+    const active = this.approval?.presentation;
+    const rawSeverity = active?.kind === "plugin" ? active.severity?.trim().toLowerCase() : null;
+    // Keep this mapping aligned with the sibling exec-approval-card.ts surface.
+    const severity =
+      active?.kind === "exec" || ["warning", "warn"].includes(rawSeverity ?? "")
+        ? "warning"
+        : ["danger", "critical", "error"].includes(rawSeverity ?? "")
+          ? "danger"
+          : "info";
     return html`
       <main class="approval-page" data-state=${documentState}>
         <div class="approval-page__backdrop" aria-hidden="true"></div>
         <section
-          class="approval-page__card"
+          class="approval-page__card approval-page__card--severity-${severity}"
           aria-labelledby="approval-page-title"
           aria-busy=${this.loading || this.resolving ? "true" : "false"}
         >

--- a/ui/src/styles/approval.css
+++ b/ui/src/styles/approval.css
@@ -28,15 +28,29 @@
 }
 
 .approval-page__card {
+  --approval-page-accent: var(--border);
+
   position: relative;
   z-index: 1;
   width: 100%;
   overflow: hidden;
-  border: 1px solid var(--border-strong);
-  border-left: 3px solid var(--accent);
+  border: 1px solid color-mix(in srgb, var(--approval-page-accent) 45%, var(--border));
+  border-left: 3px solid var(--approval-page-accent);
   border-radius: 4px 18px 18px 4px;
-  background: color-mix(in srgb, var(--card) 96%, transparent);
+  background: color-mix(in srgb, var(--approval-page-accent) 5%, var(--card));
   box-shadow: var(--shadow-xl);
+}
+
+.approval-page__card--severity-info {
+  --approval-page-accent: var(--border);
+}
+
+.approval-page__card--severity-warning {
+  --approval-page-accent: var(--warn);
+}
+
+.approval-page__card--severity-danger {
+  --approval-page-accent: var(--danger);
 }
 
 .approval-page__card::after {
@@ -45,8 +59,8 @@
   right: 0;
   width: 72px;
   height: 72px;
-  border-top: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  border-right: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--approval-page-accent) 55%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--approval-page-accent) 55%, transparent);
   border-radius: 0 17px 0 0;
   content: "";
   pointer-events: none;
@@ -148,6 +162,26 @@
   color: var(--muted-strong);
   font-size: var(--control-ui-text-md);
   line-height: 1.55;
+}
+
+.approval-page__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.approval-page__chips:not(:has(.approval-page__chip)) {
+  display: none;
+}
+
+.approval-page__chip {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  font-weight: 500;
 }
 
 .approval-page__preview-label {


### PR DESCRIPTION
## What Problem This Solves

The standalone approval deep-link page kept the old label-row style after [PR #124767](https://github.com/openclaw/openclaw/pull/124767) redesigned the chat approval card. It still showed Severity, Plugin, and Agent as text rows and did not use severity color, leaving the two approval surfaces visually inconsistent.

## Why This Change Was Made

This brings both approval surfaces under one design language: severity becomes a color accent, while identity renders as compact chips. Agent identity deliberately stays on this session-less page, where that context remains useful, but now appears as a chip alongside plugin and tool identity.

## User Impact

The standalone page now gives approval cards an info, warning, or danger stripe and tint based on severity. Plugin, tool, and agent chips sit directly under the title, while the old Severity, Plugin, and Agent label rows are removed. The now-unused `execApproval.labels.severity`, `execApproval.labels.plugin`, and `execApproval.labels.agent` English i18n keys were deleted after verifying they had no references, and the raw-copy baseline was regenerated keylessly.

### Before

![Standalone approval page before the redesign](https://github.com/user-attachments/assets/e6635545-1f6a-4792-a6ae-98d66006c488)

### After

![Pending exec approval with severity tint and identity chips](https://github.com/user-attachments/assets/42492dde-eb72-43d2-be27-3d46a2a1401b)

![Pending plugin approval with severity tint and identity chips](https://github.com/user-attachments/assets/fd29dd56-ff45-4bec-8532-a47acecb34f9)

## Evidence

- 29 focused unit tests and 7 approval-page E2E tests updated and passing; the E2E coverage now uses the proof-capture pattern for the rendered states.
- UI typecheck, stylelint, keyless i18n verification, oxlint, and formatting checks pass.
- The post-rebase focused command `pnpm test ui/src/pages/approval ui/src/e2e/approval-page.e2e.test.ts` passed; its UI directory routing also completed the broader UI unit configuration successfully.
- Coordinator review and Codex autoreview are clean.
- AI-assisted and reviewed with Codex.

Follow-up to [PR #124767](https://github.com/openclaw/openclaw/pull/124767).
