### PR TITLE
perf(test): remove ClickClack scheduler waits

### DIFF
--- a/extensions/clickclack/src/discussions/durable-room-proof.test.ts
+++ b/extensions/clickclack/src/discussions/durable-room-proof.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
-import type { OpenClawPluginSessionsChangedEvent, PluginRuntime } from "openclaw/plugin-sdk/core";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -216,29 +216,14 @@ describe("ClickClack durable room real-behavior proof", () => {
       },
     } as unknown as PluginRuntime);
     setClickClackRuntime(runtime);
-    const eventHandlers = new Set<(event: OpenClawPluginSessionsChangedEvent) => void>();
     const service = new ClickClackDiscussionService(runtime, {
       clientFactory: (account) =>
         createClickClackClient({ baseUrl: account.apiEndpoint, token: account.token }),
       installationId: "11111111-2222-4333-8444-555555555555",
       bindingGenerationFactory: () => "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-      gatewayEvents: {
-        onSessionsChanged(handler) {
-          eventHandlers.add(handler);
-          return () => eventHandlers.delete(handler);
-        },
-      },
       startTimer: false,
     });
     cleanups.push(async () => service.cleanup());
-    const emit = async (event: OpenClawPluginSessionsChangedEvent) => {
-      for (const handler of eventHandlers) {
-        handler(event);
-      }
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 300);
-      });
-    };
 
     await service.open(sessionKey);
     const originalExternalRef = remote.channels[1]?.external_ref;
@@ -262,13 +247,13 @@ describe("ClickClack durable room real-behavior proof", () => {
     });
 
     sessionEntry = { ...sessionEntry!, archivedAt: 2 };
-    await emit({ sessionKey, reason: "archive" });
+    await service.reconcile(sessionKey);
     sessionEntry = { sessionId: "session-reset", label: "Durable proof room", updatedAt: 3 };
-    await emit({ sessionKey, reason: "reset" });
+    await service.reconcile(sessionKey);
     sessionEntry = undefined;
-    await emit({ sessionKey, reason: "delete" });
+    await service.reconcile(sessionKey);
     sessionEntry = { sessionId: "session-recreated", label: "Durable proof room", updatedAt: 4 };
-    await emit({ sessionKey, reason: "create" });
+    await service.reconcile(sessionKey);
 
     const history = await service.readLatestMessages(sessionKey, 30);
     await handleClickClackInbound({


### PR DESCRIPTION
## What Problem This Solves

The ClickClack durable-room proof was paying scheduler wait latency that belongs to the independently owned `service-events.test.ts` coverage. Those waits made this durable behavior test slower without strengthening its contract.

## Why This Change Was Made

Remove the redundant scheduler waits while retaining the durable proof boundary: a real HTTP client/server exchange, persisted room binding and history, and inbound dispatch all remain covered. Scheduler latency continues to be tested by `service-events.test.ts`.

## User Impact

No runtime behavior changes. The ClickClack test suite completes faster while preserving the durable-room behavior it protects.

## Evidence

- Exact-base Testbox proof on `tbx_01m063yk9aeaxptzevwx4v2za2`: https://github.com/openclaw/openclaw/actions/runs/31970452366
- Target plus sibling tests: 50/50 passed.
- Full ClickClack suite: 361/361 passed.
- Complete changed gate: passed.
- Controlled same-Testbox A/B: wall time 15.40s average to 14.31s average, an improvement of 1.10s / 7.1%; test body 1.4005s to 0.1905s, an improvement of 86.4%.
- Mutation proof: deleting the missing-session binding failed the preserved history assertion; production was then restored.
- Production LOC: +0/-0. Tests: +5/-20.
- Fresh structured autoreview: clean at 0.99. Deslop required no edits.
- Proof gaps: none.

AI-assisted: yes.
