### PR TITLE
refactor(validation): consolidate boundary guards into schemas

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -524,7 +524,7 @@ extensions/file-transfer/src/tools/file-write-tool.ts	1
 extensions/file-transfer/src/tools/node-tool-invoke.ts	1
 extensions/firecrawl/index.ts	2
 extensions/firecrawl/src/config.ts	3
-extensions/firecrawl/src/firecrawl-client.ts	10
+extensions/firecrawl/src/firecrawl-client.ts	4
 extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts	5
 extensions/firecrawl/web-search-shared.ts	1
 extensions/fish-audio-speech/speech-provider.ts	1
@@ -1490,7 +1490,7 @@ extensions/zalo/src/proxy.ts	1
 extensions/zalo/src/setup-allow-from.ts	3
 extensions/zalo/src/setup-surface.ts	10
 extensions/zalo/src/token.ts	1
-extensions/zalo/src/webhook-spool.ts	2
+extensions/zalo/src/webhook-spool.ts	1
 extensions/zalouser/src/accounts.ts	1
 extensions/zalouser/src/group-policy.ts	2
 extensions/zalouser/src/ingress.ts	2
@@ -2900,7 +2900,7 @@ src/flows/doctor-health-contributions.ts	2
 src/flows/doctor-removed-workspaces-state-check.ts	2
 src/flows/health-check-adapter.ts	2
 src/flows/search-setup.ts	6
-src/gateway/agent-runtime-identity-token.ts	6
+src/gateway/agent-runtime-identity-token.ts	1
 src/gateway/agent-turn/agent-dedupe.ts	3
 src/gateway/agent-turn/agent-job.ts	1
 src/gateway/agent-turn/agent-restart-recovery-context.ts	1
@@ -3319,7 +3319,6 @@ src/infra/provider-usage.fetch.codex.ts	1
 src/infra/provider-usage.fetch.deepseek.ts	1
 src/infra/provider-usage.fetch.minimax.ts	2
 src/infra/push-apns-http2.ts	1
-src/infra/push-apns-store.ts	3
 src/infra/push-apns.relay.ts	1
 src/infra/push-apns.ts	7
 src/infra/push-web.ts	3
@@ -3471,7 +3470,7 @@ src/meeting-bot/browser-node.ts	2
 src/meeting-bot/browser-request.ts	3
 src/meeting-bot/browser-session-control.ts	1
 src/meeting-bot/chrome-node-result.ts	2
-src/meeting-bot/platform-adapter.ts	11
+src/meeting-bot/platform-adapter.ts	8
 src/meeting-bot/plugin-entry.ts	5
 src/meeting-bot/plugin-shell.ts	1
 src/meeting-bot/realtime-tool-continuity.ts	2
@@ -4133,7 +4132,7 @@ ui/src/lib/channels/index.ts	3
 ui/src/lib/chat/current-user-identity.ts	4
 ui/src/lib/chat/heartbeat-display.ts	4
 ui/src/lib/chat/message-extract.ts	7
-ui/src/lib/chat/message-normalizer.ts	4
+ui/src/lib/chat/message-normalizer.ts	3
 ui/src/lib/chat/outbox-store-codec.ts	1
 ui/src/lib/chat/outbox-store.ts	1
 ui/src/lib/chat/tool-call-patch.ts	1
@@ -4160,7 +4159,6 @@ ui/src/lib/sessions/session-key.ts	4
 ui/src/lib/sessions/swarm-activity.ts	1
 ui/src/lib/skills/index.ts	1
 ui/src/lib/workboard/metadata-contract-normalization.ts	1
-ui/src/lib/workboard/metadata-normalization.ts	26
 ui/src/lib/workboard/normalization.ts	5
 ui/src/lib/workboard/session-card-lookup.ts	2
 ui/src/lit/stream-auto-follow-controller.ts	1

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -8,7 +8,8 @@
   },
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.6"
+    "typebox": "1.3.6",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -27,6 +27,7 @@ import {
   type LookupFn,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { z } from "zod";
 import {
   DEFAULT_FIRECRAWL_BASE_URL,
   resolveFirecrawlApiKey,
@@ -299,58 +300,83 @@ function normalizeFirecrawlResultUrl(value: unknown): string | undefined {
   }
 }
 
+const optionalFirecrawlStringSchema = z.string().optional().catch(undefined);
+const invalidFirecrawlSearchItemSchema = z.unknown().transform(() => null);
+const firecrawlSearchMetadataSchema = z
+  .object({
+    sourceURL: optionalFirecrawlStringSchema,
+    title: optionalFirecrawlStringSchema,
+    publishedTime: optionalFirecrawlStringSchema,
+    publishedDate: optionalFirecrawlStringSchema,
+  })
+  .optional()
+  .catch(undefined);
+const firecrawlSearchItemSchema = z.object({
+  url: optionalFirecrawlStringSchema,
+  sourceURL: optionalFirecrawlStringSchema,
+  sourceUrl: optionalFirecrawlStringSchema,
+  title: optionalFirecrawlStringSchema,
+  description: optionalFirecrawlStringSchema,
+  snippet: optionalFirecrawlStringSchema,
+  summary: optionalFirecrawlStringSchema,
+  markdown: optionalFirecrawlStringSchema,
+  content: optionalFirecrawlStringSchema,
+  text: optionalFirecrawlStringSchema,
+  publishedDate: optionalFirecrawlStringSchema,
+  published: optionalFirecrawlStringSchema,
+  metadata: firecrawlSearchMetadataSchema,
+});
+const firecrawlSearchItemsSchema = z
+  .array(z.union([firecrawlSearchItemSchema, invalidFirecrawlSearchItemSchema]))
+  .transform((items) => items.filter((item) => item !== null));
+const firecrawlNestedSearchDataSchema = z.looseObject({
+  results: firecrawlSearchItemsSchema.optional().catch(undefined),
+  data: firecrawlSearchItemsSchema.optional().catch(undefined),
+  web: firecrawlSearchItemsSchema.optional().catch(undefined),
+});
+const firecrawlSearchPayloadSchema = z.looseObject({
+  data: z
+    .union([firecrawlSearchItemsSchema, firecrawlNestedSearchDataSchema])
+    .optional()
+    .catch(undefined),
+  results: firecrawlSearchItemsSchema.optional().catch(undefined),
+  web: z
+    .looseObject({ results: firecrawlSearchItemsSchema.optional().catch(undefined) })
+    .optional()
+    .catch(undefined),
+});
+
 function resolveSearchItems(payload: Record<string, unknown>): FirecrawlSearchItem[] {
+  const parsed = firecrawlSearchPayloadSchema.parse(payload);
+  const nestedData = Array.isArray(parsed.data) ? undefined : parsed.data;
   const candidates = [
-    payload.data,
-    payload.results,
-    (payload.data as { results?: unknown } | undefined)?.results,
-    (payload.data as { data?: unknown } | undefined)?.data,
-    (payload.data as { web?: unknown } | undefined)?.web,
-    (payload.web as { results?: unknown } | undefined)?.results,
+    Array.isArray(parsed.data) ? parsed.data : undefined,
+    parsed.results,
+    nestedData?.results,
+    nestedData?.data,
+    nestedData?.web,
+    parsed.web?.results,
   ];
-  const rawItems = candidates.find((candidate) => Array.isArray(candidate));
-  if (!Array.isArray(rawItems)) {
+  const rawItems = candidates.find((candidate) => candidate !== undefined);
+  if (!rawItems) {
     return [];
   }
   const items: FirecrawlSearchItem[] = [];
   for (const entry of rawItems.slice(0, FIRECRAWL_SEARCH_MAX_RESULTS)) {
-    if (!entry || typeof entry !== "object") {
-      continue;
-    }
-    const record = entry as Record<string, unknown>;
-    const metadata =
-      record.metadata && typeof record.metadata === "object"
-        ? (record.metadata as Record<string, unknown>)
-        : undefined;
-    const rawUrl =
-      (typeof record.url === "string" && record.url) ||
-      (typeof record.sourceURL === "string" && record.sourceURL) ||
-      (typeof record.sourceUrl === "string" && record.sourceUrl) ||
-      (typeof metadata?.sourceURL === "string" && metadata.sourceURL) ||
-      "";
+    const metadata = entry.metadata;
+    const rawUrl = entry.url || entry.sourceURL || entry.sourceUrl || metadata?.sourceURL || "";
     const url = normalizeFirecrawlResultUrl(rawUrl);
     if (!url) {
       continue;
     }
-    const title =
-      (typeof record.title === "string" && record.title) ||
-      (typeof metadata?.title === "string" && metadata.title) ||
-      "";
-    const description =
-      (typeof record.description === "string" && record.description) ||
-      (typeof record.snippet === "string" && record.snippet) ||
-      (typeof record.summary === "string" && record.summary) ||
-      undefined;
-    const content =
-      (typeof record.markdown === "string" && record.markdown) ||
-      (typeof record.content === "string" && record.content) ||
-      (typeof record.text === "string" && record.text) ||
-      undefined;
+    const title = entry.title || metadata?.title || "";
+    const description = entry.description || entry.snippet || entry.summary || undefined;
+    const content = entry.markdown || entry.content || entry.text || undefined;
     const rawPublished =
-      (typeof record.publishedDate === "string" && record.publishedDate) ||
-      (typeof record.published === "string" && record.published) ||
-      (typeof metadata?.publishedTime === "string" && metadata.publishedTime) ||
-      (typeof metadata?.publishedDate === "string" && metadata.publishedDate) ||
+      entry.publishedDate ||
+      entry.published ||
+      metadata?.publishedTime ||
+      metadata?.publishedDate ||
       undefined;
     const published =
       rawPublished && FIRECRAWL_PUBLISHED_DATE_RE.test(rawPublished) ? rawPublished : undefined;

--- a/extensions/teams-meetings/src/transports/teams-meetings-caption-capture.test.ts
+++ b/extensions/teams-meetings/src/transports/teams-meetings-caption-capture.test.ts
@@ -804,8 +804,10 @@ describe("Microsoft Teams meeting captions and permissions", () => {
       sessionMatched: true,
       urlMatched: true,
     });
-    expect(() =>
-      TEAMS_MEETINGS_PLATFORM_ADAPTER.browser.parseStatus({ result: "not-json" }),
-    ).toThrow("Microsoft Teams browser status JSON is malformed.");
+    for (const result of ["not-json", "null", "[]"]) {
+      expect(() => TEAMS_MEETINGS_PLATFORM_ADAPTER.browser.parseStatus({ result })).toThrow(
+        "Microsoft Teams browser status JSON is malformed.",
+      );
+    }
   });
 });

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -7,10 +7,10 @@ import {
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
+import { z } from "zod";
 import { ZaloApiError, type ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import { getZaloRuntime } from "./runtime.js";
@@ -37,6 +37,65 @@ type ZaloWebhookIngress = {
   stop: () => Promise<void>;
 };
 
+const nonEmptyWebhookStringSchema = z
+  .string()
+  .transform((value) => nonEmptyString(value))
+  .pipe(z.string());
+const optionalWebhookStringSchema = z.string().optional().catch(undefined);
+const webhookEnvelopeSchema = z
+  .looseObject({
+    ok: z.unknown().optional(),
+    result: z.looseObject({}).optional().catch(undefined),
+  })
+  .transform((envelope) => (envelope.ok === true && envelope.result ? envelope.result : envelope));
+const webhookAdmissionSchema = z.looseObject({
+  message: z.looseObject({
+    message_id: nonEmptyWebhookStringSchema,
+    chat: z.looseObject({ id: nonEmptyWebhookStringSchema }),
+  }),
+});
+const webhookSenderSchema = z.object({
+  id: nonEmptyWebhookStringSchema,
+  name: optionalWebhookStringSchema,
+  display_name: optionalWebhookStringSchema,
+  avatar: optionalWebhookStringSchema,
+  is_bot: z.boolean().optional().catch(undefined),
+});
+const webhookChatSchema = z.object({
+  id: nonEmptyWebhookStringSchema,
+  chat_type: z.enum(["PRIVATE", "GROUP"]),
+});
+const webhookMessageSchema = z.object({
+  message_id: nonEmptyWebhookStringSchema,
+  from: webhookSenderSchema,
+  chat: webhookChatSchema,
+  date: z.number().finite(),
+  text: optionalWebhookStringSchema,
+  photo_url: optionalWebhookStringSchema,
+  caption: optionalWebhookStringSchema,
+  sticker: optionalWebhookStringSchema,
+  message_type: optionalWebhookStringSchema,
+});
+const webhookUpdateSchema = z
+  .object({
+    event_name: z.enum([
+      "message.text.received",
+      "message.image.received",
+      "message.sticker.received",
+      "message.unsupported.received",
+    ]),
+    message: webhookMessageSchema,
+  })
+  .superRefine((update, context) => {
+    if (update.event_name === "message.text.received" && update.message.text === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["message", "text"],
+        message: "text event requires message.text",
+      });
+    }
+  });
+
 function parseRawRecord(rawEvent: string): Record<string, unknown> {
   let parsed: unknown;
   try {
@@ -44,18 +103,11 @@ function parseRawRecord(rawEvent: string): Record<string, unknown> {
   } catch (error) {
     throw new ZaloWebhookPayloadError("Zalo webhook body contains invalid JSON.", { cause: error });
   }
-  if (!isRecord(parsed)) {
+  const envelope = webhookEnvelopeSchema.safeParse(parsed);
+  if (!envelope.success) {
     throw new ZaloWebhookPayloadError("Zalo webhook body must be a JSON object.");
   }
-  return parsed;
-}
-
-function resolveUpdateRecord(envelope: Record<string, unknown>): Record<string, unknown> {
-  // Preserve the accepted direct and legacy { ok, result } envelope shapes.
-  if (envelope.ok === true && isRecord(envelope.result)) {
-    return envelope.result;
-  }
-  return envelope;
+  return envelope.data;
 }
 
 function inspectZaloWebhookEvent(rawEvent: string): {
@@ -63,17 +115,26 @@ function inspectZaloWebhookEvent(rawEvent: string): {
   laneKey: string;
   update: Record<string, unknown>;
 } {
-  const update = resolveUpdateRecord(parseRawRecord(rawEvent));
-  const message = isRecord(update.message) ? update.message : null;
-  const eventId = nonEmptyString(message?.message_id);
-  if (!eventId) {
+  const update = parseRawRecord(rawEvent);
+  const admission = webhookAdmissionSchema.safeParse(update);
+  if (!admission.success) {
+    const missingEventId = admission.error.issues.some(
+      (issue) =>
+        issue.path[0] === "message" && (issue.path.length === 1 || issue.path[1] === "message_id"),
+    );
+    if (missingEventId) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.message_id.");
+    }
+    const missingChatId = admission.error.issues.some(
+      (issue) => issue.path[0] === "message" && issue.path[1] === "chat",
+    );
+    if (missingChatId) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
+    }
     throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.message_id.");
   }
-  const chat = isRecord(message?.chat) ? message.chat : null;
-  const chatId = nonEmptyString(chat?.id);
-  if (!chatId) {
-    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
-  }
+  const eventId = admission.data.message.message_id;
+  const chatId = admission.data.message.chat.id;
   return { eventId, laneKey: `chat:${chatId}`, update };
 }
 
@@ -85,56 +146,42 @@ function parseClaimedUpdate(payload: ZaloWebhookSpoolPayload, claimedId: string)
   if (facts.eventId !== claimedId) {
     throw new ZaloWebhookPayloadError("Zalo webhook message id changed after durable admission.");
   }
-  const eventName = nonEmptyString(facts.update.event_name);
-  if (
-    eventName !== "message.text.received" &&
-    eventName !== "message.image.received" &&
-    eventName !== "message.sticker.received" &&
-    eventName !== "message.unsupported.received"
-  ) {
+  const parsed = webhookUpdateSchema.safeParse(facts.update);
+  if (!parsed.success) {
+    const paths = parsed.error.issues.map((issue) => issue.path.join("."));
+    if (paths.some((path) => path === "event_name")) {
+      throw new ZaloWebhookPayloadError("Zalo webhook event_name is unsupported.");
+    }
+    if (paths.some((path) => path === "message.from" || path.startsWith("message.from.id"))) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.from.id.");
+    }
+    if (paths.some((path) => path === "message.chat" || path.startsWith("message.chat.id"))) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
+    }
+    if (paths.some((path) => path.startsWith("message.chat.chat_type"))) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid chat type.");
+    }
+    if (paths.some((path) => path.startsWith("message.date"))) {
+      throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid date.");
+    }
+    if (paths.some((path) => path.startsWith("message.text"))) {
+      throw new ZaloWebhookPayloadError("Zalo text event is missing message.text.");
+    }
     throw new ZaloWebhookPayloadError("Zalo webhook event_name is unsupported.");
   }
-  const message = facts.update.message as Record<string, unknown>;
-  const from = isRecord(message.from) ? message.from : null;
-  const chat = isRecord(message.chat) ? message.chat : null;
-  const fromId = nonEmptyString(from?.id);
-  if (!from || !fromId) {
-    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.from.id.");
-  }
-  const chatId = nonEmptyString(chat?.id);
-  if (!chatId) {
-    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
-  }
-  if (chat?.chat_type !== "PRIVATE" && chat?.chat_type !== "GROUP") {
-    throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid chat type.");
-  }
-  if (typeof message.date !== "number" || !Number.isFinite(message.date)) {
-    throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid date.");
-  }
-  if (eventName === "message.text.received" && typeof message.text !== "string") {
-    throw new ZaloWebhookPayloadError("Zalo text event is missing message.text.");
-  }
+  const { event_name: eventName, message } = parsed.data;
   return {
     event_name: eventName,
     message: {
       message_id: claimedId,
-      from: {
-        id: fromId,
-        ...(typeof from.name === "string" ? { name: from.name } : {}),
-        ...(typeof from.display_name === "string" ? { display_name: from.display_name } : {}),
-        ...(typeof from.avatar === "string" ? { avatar: from.avatar } : {}),
-        ...(typeof from.is_bot === "boolean" ? { is_bot: from.is_bot } : {}),
-      },
-      chat: {
-        id: chatId,
-        chat_type: chat.chat_type,
-      },
+      from: message.from,
+      chat: message.chat,
       date: message.date,
-      ...(typeof message.text === "string" ? { text: message.text } : {}),
-      ...(typeof message.photo_url === "string" ? { photo_url: message.photo_url } : {}),
-      ...(typeof message.caption === "string" ? { caption: message.caption } : {}),
-      ...(typeof message.sticker === "string" ? { sticker: message.sticker } : {}),
-      ...(typeof message.message_type === "string" ? { message_type: message.message_type } : {}),
+      ...(message.text !== undefined ? { text: message.text } : {}),
+      ...(message.photo_url !== undefined ? { photo_url: message.photo_url } : {}),
+      ...(message.caption !== undefined ? { caption: message.caption } : {}),
+      ...(message.sticker !== undefined ? { sticker: message.sticker } : {}),
+      ...(message.message_type !== undefined ? { message_type: message.message_type } : {}),
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,6 +932,9 @@ importers:
       typebox:
         specifier: 1.3.6
         version: 1.3.6
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2435,6 +2438,9 @@ importers:
       remend:
         specifier: 1.3.0
         version: 1.3.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/markdown-it':
         specifier: 14.1.2

--- a/src/gateway/agent-runtime-identity-token.test.ts
+++ b/src/gateway/agent-runtime-identity-token.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -39,6 +40,32 @@ function readExecApprovals(): {
   socket?: { token?: string };
 } {
   return readExecApprovalsSnapshot().file;
+}
+
+function rewriteSignedPayload(
+  token: string,
+  mutate: (payload: Record<string, unknown>) => void,
+): string {
+  const [payloadPart] = token.split(".");
+  if (!payloadPart) {
+    throw new Error("missing payload");
+  }
+  const payload = JSON.parse(Buffer.from(payloadPart, "base64url").toString("utf8")) as Record<
+    string,
+    unknown
+  >;
+  mutate(payload);
+  const rewritten = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const secret = readExecApprovals().socket?.token;
+  if (!secret) {
+    throw new Error("missing signing secret");
+  }
+  const signature = createHmac("sha256", secret)
+    .update("openclaw:gateway-agent-runtime-identity-token:v1")
+    .update("\0")
+    .update(rewritten)
+    .digest("base64url");
+  return `${rewritten}.${signature}`;
 }
 
 async function importRuntimeTokenModule(): Promise<
@@ -193,6 +220,33 @@ describe("agent runtime identity token", () => {
         turnSourceLocal: true,
       }),
     ).rejects.toThrow("cannot be both local and channel-bound");
+  });
+
+  it("preserves the signed payload structural acceptance boundary", async () => {
+    useTempHome();
+    const runtimeToken = await importRuntimeTokenModule();
+    const token = await runtimeToken.mintAgentRuntimeIdentityToken({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      ...operationalRun(),
+    });
+
+    const withUnknownField = rewriteSignedPayload(token, (payload) => {
+      payload.futurePayloadField = { version: 2 };
+    });
+    await expect(
+      runtimeToken.verifyAgentRuntimeIdentityToken(withUnknownField),
+    ).resolves.toMatchObject({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    });
+
+    const withInvalidKnownField = rewriteSignedPayload(token, (payload) => {
+      payload.turnSourceLocal = false;
+    });
+    await expect(
+      runtimeToken.verifyAgentRuntimeIdentityToken(withInvalidKnownField),
+    ).resolves.toBeUndefined();
   });
 
   it("omits execution identity from a different operational run", async () => {

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -1,7 +1,7 @@
 // Purpose-scoped local agent runtime identity token for Gateway clients.
 import { createHmac } from "node:crypto";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { z } from "zod";
 import type { OperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import {
   parseExecutionIdentityAdmissionToken,
@@ -92,53 +92,145 @@ type AgentRuntimeIdentityTokenPayload = {
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
 };
 
-function decodeWorkerTurnClaim(value: unknown): WorkerSessionTurnClaim | undefined {
-  if (!isRecord(value) || !isRecord(value.owner) || value.owner.kind !== "worker") {
-    return undefined;
-  }
-  const sessionId = normalizeOptionalString(value.sessionId);
-  const claimId = normalizeOptionalString(value.claimId);
-  const runId = normalizeOptionalString(value.runId);
-  const environmentId = normalizeOptionalString(value.owner.environmentId);
-  const placementGeneration = value.placementGeneration;
-  const ownerEpoch = value.owner.ownerEpoch;
-  if (
-    !sessionId ||
-    !claimId ||
-    !runId ||
-    !environmentId ||
-    !Number.isSafeInteger(placementGeneration) ||
-    (placementGeneration as number) < 0 ||
-    !Number.isSafeInteger(ownerEpoch) ||
-    (ownerEpoch as number) < 0
-  ) {
-    return undefined;
-  }
-  return {
-    sessionId,
-    claimId,
-    runId,
-    placementGeneration: placementGeneration as number,
-    owner: { kind: "worker", environmentId, ownerEpoch: ownerEpoch as number },
-  };
-}
+const normalizedRequiredStringSchema = z
+  .string()
+  .transform(normalizeOptionalString)
+  .pipe(z.string());
+const ignoredOptionalStringSchema = z.unknown().transform(normalizeOptionalString).optional();
+const safeNonNegativeIntegerSchema = z
+  .number()
+  .refine(Number.isSafeInteger)
+  .refine((value) => value >= 0);
+const operationalRunInstanceSchema = z.object({
+  instanceId: normalizedRequiredStringSchema,
+  runId: normalizedRequiredStringSchema,
+});
+const workerTurnClaimSchema = z
+  .object({
+    sessionId: normalizedRequiredStringSchema,
+    claimId: normalizedRequiredStringSchema,
+    runId: normalizedRequiredStringSchema,
+    placementGeneration: safeNonNegativeIntegerSchema,
+    owner: z.object({
+      kind: z.literal("worker"),
+      environmentId: normalizedRequiredStringSchema,
+      ownerEpoch: safeNonNegativeIntegerSchema,
+    }),
+  })
+  .transform(
+    (claim): WorkerSessionTurnClaim => ({
+      sessionId: claim.sessionId,
+      claimId: claim.claimId,
+      runId: claim.runId,
+      placementGeneration: claim.placementGeneration,
+      owner: claim.owner,
+    }),
+  );
+const delegatedAuthoritySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("local"),
+    lifecycleGeneration: normalizedRequiredStringSchema,
+    claimId: normalizedRequiredStringSchema,
+    operationalRunInstance: operationalRunInstanceSchema,
+  }),
+  z.object({
+    kind: z.literal("worker"),
+    lifecycleGeneration: normalizedRequiredStringSchema,
+    claimId: normalizedRequiredStringSchema,
+    operationalRunInstance: operationalRunInstanceSchema,
+    turnClaim: workerTurnClaimSchema,
+  }),
+]);
+const stringListSchema = z
+  .array(z.string())
+  .transform((entries) => entries.map((entry) => entry.trim()).filter(Boolean));
+const sessionSpawnContextSchema = z
+  .object({
+    completionOwnerSessionKey: normalizedRequiredStringSchema.optional(),
+    inheritedToolPolicy: z.object({
+      version: z.literal(1),
+      allow: stringListSchema,
+      deny: stringListSchema,
+    }),
+  })
+  .transform(
+    (context): AgentRuntimeSessionSpawnContext => ({
+      ...(context.completionOwnerSessionKey
+        ? { completionOwnerSessionKey: context.completionOwnerSessionKey }
+        : {}),
+      inheritedToolPolicy: context.inheritedToolPolicy,
+    }),
+  );
+const cronCreatorAuthorityGrantSchema = z
+  .object({
+    runId: normalizedRequiredStringSchema,
+    token: normalizedRequiredStringSchema,
+  })
+  .transform((grant): CronCreatorAuthorityGrant => grant);
+const messageActionToolContextSchema = z
+  .object({
+    currentChannelId: ignoredOptionalStringSchema,
+    currentChatType: z
+      .unknown()
+      .transform((value) => normalizeChatType(typeof value === "string" ? value : undefined))
+      .optional(),
+    currentMessagingTarget: ignoredOptionalStringSchema,
+    currentGraphChannelId: ignoredOptionalStringSchema,
+    currentChannelProvider: ignoredOptionalStringSchema,
+    currentThreadTs: ignoredOptionalStringSchema,
+    currentMessageId: z.union([z.string(), z.number()]).optional(),
+    currentSourceTurnId: ignoredOptionalStringSchema,
+    replyToMode: z.enum(["off", "first", "all", "batched"]).optional(),
+    hasRepliedRef: z.object({ value: z.boolean() }).optional(),
+    sameChannelThreadRequired: z.boolean().optional().catch(undefined),
+    skipCrossContextDecoration: z.boolean().optional().catch(undefined),
+  })
+  .transform(
+    (context): InternalChannelThreadingToolContext => ({
+      ...context,
+      currentChannelProvider: context.currentChannelProvider as ChannelId | undefined,
+    }),
+  );
+const messageActionContextSchema = z.object({
+  expiresAtMs: z.number().finite(),
+  sourceReplyFinal: z.boolean().optional(),
+  sourceReplyToolCallId: normalizedRequiredStringSchema.optional(),
+  sessionId: ignoredOptionalStringSchema,
+  sourceReplySessionKey: ignoredOptionalStringSchema,
+  requesterAccountId: ignoredOptionalStringSchema,
+  requesterSenderId: ignoredOptionalStringSchema,
+  toolContext: messageActionToolContextSchema.optional(),
+});
+const cronSelfManagementContextSchema = z.object({
+  jobId: normalizedRequiredStringSchema,
+  expiresAtMs: z.number().finite(),
+});
+const agentRuntimeIdentityTokenPayloadSchema = z.object({
+  kind: z.literal(AGENT_RUNTIME_IDENTITY_TOKEN_KIND),
+  agentId: z.string(),
+  sessionKey: z.string(),
+  operationalRunInstance: operationalRunInstanceSchema,
+  delegatedAuthority: delegatedAuthoritySchema,
+  approvalOwnerPluginId: z.string().optional().catch(undefined),
+  executionIdentity: z.unknown().optional(),
+  turnSourceChannel: z.string().optional().catch(undefined),
+  turnSourceLocal: z.literal(true).optional(),
+  turnSourceTo: z.string().optional().catch(undefined),
+  turnSourceAccountId: z.string().optional().catch(undefined),
+  turnSourceThreadId: z.union([z.string(), z.number()]).optional().catch(undefined),
+  messageActionContext: messageActionContextSchema.optional(),
+  cronSelfManagementContext: cronSelfManagementContextSchema.optional(),
+  cronToolsAllowCapture: z.literal("final-executable-surface").optional(),
+  cronCreatorAuthorityGrant: cronCreatorAuthorityGrantSchema.optional(),
+  sessionSpawnContext: sessionSpawnContextSchema.optional(),
+});
 
 function decodeDelegatedAuthority(
-  value: unknown,
+  value: z.infer<typeof delegatedAuthoritySchema>,
   operationalRunInstance: OperationalRunInstanceRef,
 ): AgentRuntimeDelegatedAuthority | undefined {
-  if (!isRecord(value) || (value.kind !== "local" && value.kind !== "worker")) {
-    return undefined;
-  }
-  const lifecycleGeneration = normalizeOptionalString(value.lifecycleGeneration);
-  const claimId = normalizeOptionalString(value.claimId);
-  const rawOperational = value.operationalRunInstance;
-  const instanceId = isRecord(rawOperational)
-    ? normalizeOptionalString(rawOperational.instanceId)
-    : undefined;
-  const runId = isRecord(rawOperational)
-    ? normalizeOptionalString(rawOperational.runId)
-    : undefined;
+  const { lifecycleGeneration, claimId } = value;
+  const { instanceId, runId } = value.operationalRunInstance;
   if (
     !lifecycleGeneration ||
     !claimId ||
@@ -155,46 +247,9 @@ function decodeDelegatedAuthority(
   if (value.kind === "local") {
     return { kind: "local", ...owner };
   }
-  const turnClaim = decodeWorkerTurnClaim(value.turnClaim);
-  return turnClaim?.runId === operationalRunInstance.runId
-    ? { kind: "worker", ...owner, turnClaim }
+  return value.turnClaim.runId === operationalRunInstance.runId
+    ? { kind: "worker", ...owner, turnClaim: value.turnClaim }
     : undefined;
-}
-
-function decodeStringList(value: unknown): string[] | undefined {
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
-    return undefined;
-  }
-  return value.map((entry) => entry.trim()).filter(Boolean);
-}
-
-function decodeSessionSpawnContext(value: unknown): AgentRuntimeSessionSpawnContext | undefined {
-  if (!isRecord(value) || !isRecord(value.inheritedToolPolicy)) {
-    return undefined;
-  }
-  const policy = value.inheritedToolPolicy;
-  const allow = decodeStringList(policy.allow);
-  const deny = decodeStringList(policy.deny);
-  if (policy.version !== 1 || !allow || !deny) {
-    return undefined;
-  }
-  const completionOwnerSessionKey = normalizeOptionalString(value.completionOwnerSessionKey);
-  if (value.completionOwnerSessionKey !== undefined && !completionOwnerSessionKey) {
-    return undefined;
-  }
-  return {
-    ...(completionOwnerSessionKey ? { completionOwnerSessionKey } : {}),
-    inheritedToolPolicy: { version: 1, allow, deny },
-  };
-}
-
-function decodeCronCreatorAuthorityGrant(value: unknown): CronCreatorAuthorityGrant | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const runId = normalizeOptionalString(value.runId);
-  const token = normalizeOptionalString(value.token);
-  return runId && token ? { runId, token } : undefined;
 }
 
 async function readSharedAgentRuntimeIdentitySecret(): Promise<string | null> {
@@ -224,166 +279,58 @@ function encodePayload(payload: AgentRuntimeIdentityTokenPayload): string {
 }
 
 function decodeMessageActionContext(
-  value: unknown,
+  value: z.infer<typeof messageActionContextSchema>,
   nowMs: number,
 ): AgentRuntimeMessageActionContext | undefined {
-  if (
-    !isRecord(value) ||
-    typeof value.expiresAtMs !== "number" ||
-    !Number.isFinite(value.expiresAtMs) ||
-    nowMs >= value.expiresAtMs
-  ) {
+  if (nowMs >= value.expiresAtMs) {
     return undefined;
   }
-  const rawToolContext = value.toolContext;
-  const sourceReplyFinal = value.sourceReplyFinal;
-  const sourceReplyToolCallId = normalizeOptionalString(value.sourceReplyToolCallId);
-  if (sourceReplyFinal !== undefined && typeof sourceReplyFinal !== "boolean") {
-    return undefined;
-  }
-  if (value.sourceReplyToolCallId !== undefined && !sourceReplyToolCallId) {
-    return undefined;
-  }
-  if (rawToolContext !== undefined && !isRecord(rawToolContext)) {
-    return undefined;
-  }
-  const rawCurrentChatType = rawToolContext?.currentChatType;
-  const currentChatType = normalizeChatType(
-    typeof rawCurrentChatType === "string" ? rawCurrentChatType : undefined,
-  );
-  const currentMessageId = rawToolContext?.currentMessageId;
-  const replyToMode = rawToolContext?.replyToMode;
-  const hasRepliedRef = rawToolContext?.hasRepliedRef;
-  if (
-    (currentMessageId !== undefined &&
-      typeof currentMessageId !== "string" &&
-      typeof currentMessageId !== "number") ||
-    (replyToMode !== undefined &&
-      replyToMode !== "off" &&
-      replyToMode !== "first" &&
-      replyToMode !== "all" &&
-      replyToMode !== "batched") ||
-    (hasRepliedRef !== undefined &&
-      (!isRecord(hasRepliedRef) || typeof hasRepliedRef.value !== "boolean"))
-  ) {
-    return undefined;
-  }
-  const readOptionalBoolean = (key: string): boolean | undefined => {
-    const candidate = rawToolContext?.[key];
-    return typeof candidate === "boolean" ? candidate : undefined;
-  };
-  const toolContext: InternalChannelThreadingToolContext | undefined = rawToolContext
-    ? ({
-        currentChannelId: normalizeOptionalString(rawToolContext.currentChannelId),
-        currentChatType,
-        currentMessagingTarget: normalizeOptionalString(rawToolContext.currentMessagingTarget),
-        currentGraphChannelId: normalizeOptionalString(rawToolContext.currentGraphChannelId),
-        currentChannelProvider: normalizeOptionalString(rawToolContext.currentChannelProvider) as
-          | ChannelId
-          | undefined,
-        currentThreadTs: normalizeOptionalString(rawToolContext.currentThreadTs),
-        currentMessageId,
-        currentSourceTurnId: normalizeOptionalString(rawToolContext.currentSourceTurnId),
-        replyToMode:
-          replyToMode === "off" ||
-          replyToMode === "first" ||
-          replyToMode === "all" ||
-          replyToMode === "batched"
-            ? replyToMode
-            : undefined,
-        hasRepliedRef:
-          isRecord(hasRepliedRef) && typeof hasRepliedRef.value === "boolean"
-            ? { value: hasRepliedRef.value }
-            : undefined,
-        sameChannelThreadRequired: readOptionalBoolean("sameChannelThreadRequired"),
-        skipCrossContextDecoration: readOptionalBoolean("skipCrossContextDecoration"),
-      } satisfies InternalChannelThreadingToolContext)
-    : undefined;
   const context = {
     expiresAtMs: value.expiresAtMs,
-    sessionId: normalizeOptionalString(value.sessionId),
-    sourceReplySessionKey: normalizeOptionalString(value.sourceReplySessionKey),
-    requesterAccountId: normalizeOptionalString(value.requesterAccountId),
-    requesterSenderId: normalizeOptionalString(value.requesterSenderId),
-    toolContext,
+    sessionId: value.sessionId,
+    sourceReplySessionKey: value.sourceReplySessionKey,
+    requesterAccountId: value.requesterAccountId,
+    requesterSenderId: value.requesterSenderId,
+    toolContext: value.toolContext,
   };
-  if (sourceReplyFinal === true) {
-    if (!sourceReplyToolCallId) {
+  if (value.sourceReplyFinal === true) {
+    if (!value.sourceReplyToolCallId) {
       return undefined;
     }
-    return { ...context, sourceReplyFinal: true, sourceReplyToolCallId };
+    return {
+      ...context,
+      sourceReplyFinal: true,
+      sourceReplyToolCallId: value.sourceReplyToolCallId,
+    };
   }
   return {
     ...context,
-    ...(sourceReplyFinal === false ? { sourceReplyFinal: false as const } : {}),
-    ...(sourceReplyToolCallId ? { sourceReplyToolCallId } : {}),
+    ...(value.sourceReplyFinal === false ? { sourceReplyFinal: false as const } : {}),
+    ...(value.sourceReplyToolCallId ? { sourceReplyToolCallId: value.sourceReplyToolCallId } : {}),
   };
 }
 
 function decodePayload(value: string, nowMs: number): AgentRuntimeIdentityTokenPayload | undefined {
   try {
     const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
-    if (!parsed || typeof parsed !== "object") {
+    const result = agentRuntimeIdentityTokenPayloadSchema.safeParse(parsed);
+    if (!result.success) {
       return undefined;
     }
-    const raw = parsed as {
-      kind?: unknown;
-      agentId?: unknown;
-      sessionKey?: unknown;
-      operationalRunInstance?: unknown;
-      approvalOwnerPluginId?: unknown;
-      turnSourceChannel?: unknown;
-      turnSourceLocal?: unknown;
-      turnSourceTo?: unknown;
-      turnSourceAccountId?: unknown;
-      turnSourceThreadId?: unknown;
-      messageActionContext?: unknown;
-      cronSelfManagementContext?: unknown;
-      sessionSpawnContext?: unknown;
-      cronToolsAllowCapture?: unknown;
-      cronCreatorAuthorityGrant?: unknown;
-      executionIdentity?: unknown;
-      delegatedAuthority?: unknown;
-    };
-    if (
-      raw.kind !== AGENT_RUNTIME_IDENTITY_TOKEN_KIND ||
-      typeof raw.agentId !== "string" ||
-      typeof raw.sessionKey !== "string"
-    ) {
-      return undefined;
-    }
+    const raw = result.data;
     const agentId = normalizeAgentId(raw.agentId);
     const sessionKey = raw.sessionKey.trim();
-    const approvalOwnerPluginId = normalizeOptionalString(
-      typeof raw.approvalOwnerPluginId === "string" ? raw.approvalOwnerPluginId : undefined,
-    );
-    const rawOperationalRunInstance = raw.operationalRunInstance;
-    const operationalInstanceId = isRecord(rawOperationalRunInstance)
-      ? normalizeOptionalString(rawOperationalRunInstance.instanceId)
-      : undefined;
-    const operationalRunId = isRecord(rawOperationalRunInstance)
-      ? normalizeOptionalString(rawOperationalRunInstance.runId)
-      : undefined;
-    const turnSourceAccountId = normalizeOptionalAccountId(
-      typeof raw.turnSourceAccountId === "string" ? raw.turnSourceAccountId : undefined,
-    );
-    const turnSourceChannel = normalizeOptionalString(
-      typeof raw.turnSourceChannel === "string" ? raw.turnSourceChannel : undefined,
-    );
-    const turnSourceLocal = raw.turnSourceLocal === true ? true : undefined;
-    if (raw.turnSourceLocal !== undefined && turnSourceLocal !== true) {
-      return undefined;
-    }
+    const approvalOwnerPluginId = normalizeOptionalString(raw.approvalOwnerPluginId);
+    const operationalInstanceId = raw.operationalRunInstance.instanceId;
+    const operationalRunId = raw.operationalRunInstance.runId;
+    const turnSourceAccountId = normalizeOptionalAccountId(raw.turnSourceAccountId);
+    const turnSourceChannel = normalizeOptionalString(raw.turnSourceChannel);
+    const turnSourceLocal = raw.turnSourceLocal;
     if (turnSourceLocal && turnSourceChannel) {
       return undefined;
     }
-    const turnSourceTo = normalizeOptionalString(
-      typeof raw.turnSourceTo === "string" ? raw.turnSourceTo : undefined,
-    );
-    const turnSourceThreadId =
-      typeof raw.turnSourceThreadId === "string" || typeof raw.turnSourceThreadId === "number"
-        ? raw.turnSourceThreadId
-        : undefined;
+    const turnSourceTo = normalizeOptionalString(raw.turnSourceTo);
+    const turnSourceThreadId = raw.turnSourceThreadId;
     if (!agentId || !sessionKey || !operationalInstanceId || !operationalRunId) {
       return undefined;
     }
@@ -398,55 +345,22 @@ function decodePayload(value: string, nowMs: number): AgentRuntimeIdentityTokenP
     if (!delegatedAuthority) {
       return undefined;
     }
-    const messageActionContext =
-      raw.messageActionContext === undefined
-        ? undefined
-        : decodeMessageActionContext(raw.messageActionContext, nowMs);
+    const messageActionContext = raw.messageActionContext
+      ? decodeMessageActionContext(raw.messageActionContext, nowMs)
+      : undefined;
     if (raw.messageActionContext !== undefined && !messageActionContext) {
       return undefined;
     }
-    const rawCronSelfManagement = raw.cronSelfManagementContext;
-    const cronSelfManagementJobId =
-      isRecord(rawCronSelfManagement) && typeof rawCronSelfManagement.jobId === "string"
-        ? rawCronSelfManagement.jobId.trim()
-        : "";
-    const cronSelfManagementExpiresAtMs = isRecord(rawCronSelfManagement)
-      ? rawCronSelfManagement.expiresAtMs
-      : undefined;
     const cronSelfManagementContext =
-      cronSelfManagementJobId &&
-      typeof cronSelfManagementExpiresAtMs === "number" &&
-      Number.isFinite(cronSelfManagementExpiresAtMs) &&
-      nowMs < cronSelfManagementExpiresAtMs
-        ? {
-            jobId: cronSelfManagementJobId,
-            expiresAtMs: cronSelfManagementExpiresAtMs,
-          }
+      raw.cronSelfManagementContext && nowMs < raw.cronSelfManagementContext.expiresAtMs
+        ? raw.cronSelfManagementContext
         : undefined;
-    if (rawCronSelfManagement !== undefined && !cronSelfManagementContext) {
+    if (raw.cronSelfManagementContext !== undefined && !cronSelfManagementContext) {
       return undefined;
     }
-    const sessionSpawnContext =
-      raw.sessionSpawnContext === undefined
-        ? undefined
-        : decodeSessionSpawnContext(raw.sessionSpawnContext);
-    if (raw.sessionSpawnContext !== undefined && !sessionSpawnContext) {
-      return undefined;
-    }
-    const cronToolsAllowCapture =
-      raw.cronToolsAllowCapture === "final-executable-surface"
-        ? raw.cronToolsAllowCapture
-        : undefined;
-    if (raw.cronToolsAllowCapture !== undefined && !cronToolsAllowCapture) {
-      return undefined;
-    }
-    const cronCreatorAuthorityGrant =
-      raw.cronCreatorAuthorityGrant === undefined
-        ? undefined
-        : decodeCronCreatorAuthorityGrant(raw.cronCreatorAuthorityGrant);
-    if (raw.cronCreatorAuthorityGrant !== undefined && !cronCreatorAuthorityGrant) {
-      return undefined;
-    }
+    const sessionSpawnContext = raw.sessionSpawnContext;
+    const cronToolsAllowCapture = raw.cronToolsAllowCapture;
+    const cronCreatorAuthorityGrant = raw.cronCreatorAuthorityGrant;
     if (cronCreatorAuthorityGrant && !cronToolsAllowCapture) {
       return undefined;
     }

--- a/src/infra/push-apns-store.ts
+++ b/src/infra/push-apns-store.ts
@@ -4,6 +4,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 // Canonical shared-SQLite store for APNs device and relay registrations.
 import type { Insertable, Selectable } from "kysely";
+import { z } from "zod";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -218,114 +219,62 @@ export function normalizeApnsEnvironment(value: unknown): ApnsEnvironment | null
   return null;
 }
 
-function normalizeDirectRegistration(
-  record: Partial<DirectApnsRegistration> & { nodeId?: unknown; token?: unknown },
-): DirectApnsRegistration | null {
-  if (typeof record.nodeId !== "string" || typeof record.token !== "string") {
-    return null;
-  }
-  const nodeId = normalizeApnsNodeId(record.nodeId);
-  const token = normalizeApnsToken(record.token);
-  const topic = normalizeApnsTopic(typeof record.topic === "string" ? record.topic : "");
-  const environment = normalizeApnsEnvironment(record.environment);
-  const updatedAtMs =
-    typeof record.updatedAtMs === "number" &&
-    Number.isSafeInteger(record.updatedAtMs) &&
-    record.updatedAtMs >= 0
-      ? record.updatedAtMs
-      : null;
-  if (
-    !isValidApnsNodeId(nodeId) ||
-    !isValidApnsTopic(topic) ||
-    !isLikelyApnsToken(token) ||
-    !environment ||
-    updatedAtMs === null
-  ) {
-    return null;
-  }
-  return {
-    nodeId,
-    transport: "direct",
-    token,
-    topic,
-    environment,
-    updatedAtMs,
-  };
-}
-
-function normalizeRelayRegistration(
-  record: Partial<RelayApnsRegistration> & {
-    nodeId?: unknown;
-    relayHandle?: unknown;
-    sendGrant?: unknown;
-  },
-  normalizeOrigin: (value: unknown) => string | undefined,
-): RelayApnsRegistration | null {
-  if (
-    typeof record.nodeId !== "string" ||
-    typeof record.relayHandle !== "string" ||
-    typeof record.sendGrant !== "string" ||
-    typeof record.installationId !== "string"
-  ) {
-    return null;
-  }
-  const nodeId = normalizeApnsNodeId(record.nodeId);
-  const relayHandle = normalizeRelayHandle(record.relayHandle);
-  const sendGrant = record.sendGrant.trim();
-  const installationId = normalizeInstallationId(record.installationId);
-  const topic = normalizeApnsTopic(typeof record.topic === "string" ? record.topic : "");
-  const environment = normalizeApnsEnvironment(record.environment);
-  const distribution = normalizeDistribution(record.distribution);
-  const relayOrigin = normalizeOrigin(record.relayOrigin);
-  const updatedAtMs =
-    typeof record.updatedAtMs === "number" &&
-    Number.isSafeInteger(record.updatedAtMs) &&
-    record.updatedAtMs >= 0
-      ? record.updatedAtMs
-      : null;
-  if (
-    !isValidApnsNodeId(nodeId) ||
-    !isValidRelayIdentifier(relayHandle) ||
-    !isValidRelayIdentifier(sendGrant, MAX_SEND_GRANT_LENGTH) ||
-    !isValidRelayIdentifier(installationId) ||
-    !isValidApnsTopic(topic) ||
-    !environment ||
-    distribution !== "official" ||
-    updatedAtMs === null
-  ) {
-    return null;
-  }
-  return {
-    nodeId,
-    transport: "relay",
-    relayHandle,
-    sendGrant,
-    installationId,
-    topic,
-    environment,
-    distribution,
-    updatedAtMs,
-    ...(relayOrigin ? { relayOrigin } : {}),
-    tokenDebugSuffix: normalizeTokenDebugSuffix(record.tokenDebugSuffix),
-  };
-}
+const apnsNodeIdSchema = z.string().transform(normalizeApnsNodeId).refine(isValidApnsNodeId);
+const apnsTopicSchema = z.string().transform(normalizeApnsTopic).refine(isValidApnsTopic);
+const apnsEnvironmentSchema = z
+  .unknown()
+  .transform(normalizeApnsEnvironment)
+  .pipe(z.enum(["sandbox", "production"]));
+const apnsUpdatedAtSchema = z
+  .number()
+  .refine(Number.isSafeInteger)
+  .refine((value) => value >= 0);
+const directApnsRegistrationSchema = z.object({
+  nodeId: apnsNodeIdSchema,
+  transport: z.string().transform(normalizeLowercaseStringOrEmpty).pipe(z.literal("direct")),
+  token: z.string().transform(normalizeApnsToken).refine(isLikelyApnsToken),
+  topic: apnsTopicSchema,
+  environment: apnsEnvironmentSchema,
+  updatedAtMs: apnsUpdatedAtSchema,
+});
+const relayApnsRegistrationSchema = z.object({
+  nodeId: apnsNodeIdSchema,
+  transport: z.string().transform(normalizeLowercaseStringOrEmpty).pipe(z.literal("relay")),
+  relayHandle: z.string().transform(normalizeRelayHandle).refine(isValidRelayIdentifier),
+  sendGrant: z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => isValidRelayIdentifier(value, MAX_SEND_GRANT_LENGTH)),
+  installationId: z.string().transform(normalizeInstallationId).refine(isValidRelayIdentifier),
+  topic: apnsTopicSchema,
+  environment: apnsEnvironmentSchema,
+  distribution: z.unknown().transform(normalizeDistribution).pipe(z.literal("official")),
+  updatedAtMs: apnsUpdatedAtSchema,
+  relayOrigin: z.unknown().optional(),
+  tokenDebugSuffix: z.unknown().optional().transform(normalizeTokenDebugSuffix),
+});
+const canonicalApnsRegistrationSchema = z.union([
+  directApnsRegistrationSchema,
+  relayApnsRegistrationSchema,
+]);
 
 function normalizeCanonicalApnsRegistrationWithRelayOrigin(
   record: unknown,
   normalizeOrigin: (value: unknown) => string | undefined,
 ): ApnsRegistration | null {
-  if (!record || typeof record !== "object" || Array.isArray(record)) {
+  const result = canonicalApnsRegistrationSchema.safeParse(record);
+  if (!result.success) {
     return null;
   }
-  const candidate = record as Record<string, unknown>;
-  const transport = normalizeLowercaseStringOrEmpty(candidate.transport);
-  if (transport === "relay") {
-    return normalizeRelayRegistration(candidate as Partial<RelayApnsRegistration>, normalizeOrigin);
+  if (result.data.transport === "direct") {
+    return result.data;
   }
-  if (transport === "direct") {
-    return normalizeDirectRegistration(candidate as Partial<DirectApnsRegistration>);
-  }
-  return null;
+  const relayOrigin = normalizeOrigin(result.data.relayOrigin);
+  const { relayOrigin: _rawRelayOrigin, ...registration } = result.data;
+  return {
+    ...registration,
+    ...(relayOrigin ? { relayOrigin } : {}),
+  };
 }
 
 /** Normalizes one canonical registration with an explicit transport discriminator. */

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -126,41 +126,39 @@ const meetingTranscriptLineSchema = z
     text,
   }));
 
-const meetingBrowserStatusSchema = z
-  .looseObject({
-    inCall: optionalBrowserBoolean,
-    micMuted: optionalBrowserBoolean,
-    cameraOff: optionalBrowserBoolean,
-    lobbyWaiting: optionalBrowserBoolean,
-    captionCaptureRequested: optionalBrowserBoolean,
-    captioning: optionalBrowserBoolean,
-    captionsEnabledAttempted: optionalBrowserBoolean,
-    transcriptLines: optionalBrowserNumber,
-    lastCaptionAt: optionalBrowserString,
-    lastCaptionSpeaker: optionalBrowserString,
-    lastCaptionText: optionalBrowserString,
-    recentTranscript: z
-      .array(z.union([meetingTranscriptLineSchema, invalidBrowserArrayItemSchema]))
-      .transform((lines) => lines.filter((line) => line !== null))
-      .optional()
-      .catch(undefined),
-    audioInputRouted: optionalBrowserBoolean,
-    audioInputDeviceLabel: optionalBrowserString,
-    audioInputRouteError: optionalBrowserString,
-    audioOutputRouted: optionalBrowserBoolean,
-    audioOutputDeviceLabel: optionalBrowserString,
-    audioOutputRouteError: optionalBrowserString,
-    audioOutputRouteRetryable: optionalBrowserBoolean,
-    manualAction: z.object({ reason: z.string(), message: z.string() }).optional().catch(undefined),
-    url: optionalBrowserString,
-    title: optionalBrowserString,
-    notes: z
-      .array(z.union([z.string(), invalidBrowserArrayItemSchema]))
-      .transform((notes) => notes.filter((note) => note !== null))
-      .optional()
-      .catch(undefined),
-  })
-  .catch({});
+const meetingBrowserStatusSchema = z.looseObject({
+  inCall: optionalBrowserBoolean,
+  micMuted: optionalBrowserBoolean,
+  cameraOff: optionalBrowserBoolean,
+  lobbyWaiting: optionalBrowserBoolean,
+  captionCaptureRequested: optionalBrowserBoolean,
+  captioning: optionalBrowserBoolean,
+  captionsEnabledAttempted: optionalBrowserBoolean,
+  transcriptLines: optionalBrowserNumber,
+  lastCaptionAt: optionalBrowserString,
+  lastCaptionSpeaker: optionalBrowserString,
+  lastCaptionText: optionalBrowserString,
+  recentTranscript: z
+    .array(z.union([meetingTranscriptLineSchema, invalidBrowserArrayItemSchema]))
+    .transform((lines) => lines.filter((line) => line !== null))
+    .optional()
+    .catch(undefined),
+  audioInputRouted: optionalBrowserBoolean,
+  audioInputDeviceLabel: optionalBrowserString,
+  audioInputRouteError: optionalBrowserString,
+  audioOutputRouted: optionalBrowserBoolean,
+  audioOutputDeviceLabel: optionalBrowserString,
+  audioOutputRouteError: optionalBrowserString,
+  audioOutputRouteRetryable: optionalBrowserBoolean,
+  manualAction: z.object({ reason: z.string(), message: z.string() }).optional().catch(undefined),
+  url: optionalBrowserString,
+  title: optionalBrowserString,
+  notes: z
+    .array(z.union([z.string(), invalidBrowserArrayItemSchema]))
+    .transform((notes) => notes.filter((note) => note !== null))
+    .optional()
+    .catch(undefined),
+});
 
 function parseMeetingBrowserStatus<Health extends MeetingBrowserHealth>(
   result: unknown,

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { formatErrorMessage } from "../infra/errors.js";
 import { ensureMeetingAudioBackend, resolveMeetingAudioRuntimeForFormat } from "./audio-backend.js";
 import { createMeetingChromeTransport } from "./chrome-transport.js";
@@ -109,16 +110,57 @@ function browserResultString(result: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-function parseMeetingManualAction(value: unknown): MeetingBrowserHealth["manualAction"] {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const action = value as Record<string, unknown>;
-  if (typeof action.reason !== "string" || typeof action.message !== "string") {
-    return undefined;
-  }
-  return { reason: action.reason, message: action.message };
-}
+const optionalBrowserString = z.string().optional().catch(undefined);
+const optionalBrowserBoolean = z.boolean().optional().catch(undefined);
+const optionalBrowserNumber = z.number().optional().catch(undefined);
+const invalidBrowserArrayItemSchema = z.unknown().transform(() => null);
+const meetingTranscriptLineSchema = z
+  .object({
+    at: optionalBrowserString,
+    speaker: optionalBrowserString,
+    text: z.string().refine((value) => value.trim().length > 0),
+  })
+  .transform(({ at, speaker, text }) => ({
+    ...(at !== undefined ? { at } : {}),
+    ...(speaker !== undefined ? { speaker } : {}),
+    text,
+  }));
+
+const meetingBrowserStatusSchema = z
+  .looseObject({
+    inCall: optionalBrowserBoolean,
+    micMuted: optionalBrowserBoolean,
+    cameraOff: optionalBrowserBoolean,
+    lobbyWaiting: optionalBrowserBoolean,
+    captionCaptureRequested: optionalBrowserBoolean,
+    captioning: optionalBrowserBoolean,
+    captionsEnabledAttempted: optionalBrowserBoolean,
+    transcriptLines: optionalBrowserNumber,
+    lastCaptionAt: optionalBrowserString,
+    lastCaptionSpeaker: optionalBrowserString,
+    lastCaptionText: optionalBrowserString,
+    recentTranscript: z
+      .array(z.union([meetingTranscriptLineSchema, invalidBrowserArrayItemSchema]))
+      .transform((lines) => lines.filter((line) => line !== null))
+      .optional()
+      .catch(undefined),
+    audioInputRouted: optionalBrowserBoolean,
+    audioInputDeviceLabel: optionalBrowserString,
+    audioInputRouteError: optionalBrowserString,
+    audioOutputRouted: optionalBrowserBoolean,
+    audioOutputDeviceLabel: optionalBrowserString,
+    audioOutputRouteError: optionalBrowserString,
+    audioOutputRouteRetryable: optionalBrowserBoolean,
+    manualAction: z.object({ reason: z.string(), message: z.string() }).optional().catch(undefined),
+    url: optionalBrowserString,
+    title: optionalBrowserString,
+    notes: z
+      .array(z.union([z.string(), invalidBrowserArrayItemSchema]))
+      .transform((notes) => notes.filter((note) => note !== null))
+      .optional()
+      .catch(undefined),
+  })
+  .catch({});
 
 function parseMeetingBrowserStatus<Health extends MeetingBrowserHealth>(
   result: unknown,
@@ -133,74 +175,37 @@ function parseMeetingBrowserStatus<Health extends MeetingBrowserHealth>(
   if (!raw) {
     return undefined;
   }
-  let parsed: Record<string, unknown>;
+  let parsed: z.infer<typeof meetingBrowserStatusSchema>;
   try {
-    parsed = JSON.parse(raw) as Record<string, unknown>;
+    parsed = meetingBrowserStatusSchema.parse(JSON.parse(raw));
   } catch {
     throw new Error(options.malformedStatusMessage);
   }
   return {
-    inCall: typeof parsed.inCall === "boolean" ? parsed.inCall : undefined,
-    micMuted: typeof parsed.micMuted === "boolean" ? parsed.micMuted : undefined,
-    cameraOff: typeof parsed.cameraOff === "boolean" ? parsed.cameraOff : undefined,
-    lobbyWaiting: typeof parsed.lobbyWaiting === "boolean" ? parsed.lobbyWaiting : undefined,
-    captionCaptureRequested:
-      typeof parsed.captionCaptureRequested === "boolean"
-        ? parsed.captionCaptureRequested
-        : undefined,
-    captioning: typeof parsed.captioning === "boolean" ? parsed.captioning : undefined,
-    captionsEnabledAttempted:
-      typeof parsed.captionsEnabledAttempted === "boolean"
-        ? parsed.captionsEnabledAttempted
-        : undefined,
-    transcriptLines:
-      typeof parsed.transcriptLines === "number" ? parsed.transcriptLines : undefined,
-    lastCaptionAt: typeof parsed.lastCaptionAt === "string" ? parsed.lastCaptionAt : undefined,
-    lastCaptionSpeaker:
-      typeof parsed.lastCaptionSpeaker === "string" ? parsed.lastCaptionSpeaker : undefined,
-    lastCaptionText:
-      typeof parsed.lastCaptionText === "string" ? parsed.lastCaptionText : undefined,
-    recentTranscript: Array.isArray(parsed.recentTranscript)
-      ? parsed.recentTranscript.flatMap((value) => {
-          if (!value || typeof value !== "object") {
-            return [];
-          }
-          const line = value as { at?: unknown; speaker?: unknown; text?: unknown };
-          if (typeof line.text !== "string" || !line.text.trim()) {
-            return [];
-          }
-          return [
-            {
-              ...(typeof line.at === "string" ? { at: line.at } : {}),
-              ...(typeof line.speaker === "string" ? { speaker: line.speaker } : {}),
-              text: line.text,
-            },
-          ];
-        })
-      : undefined,
-    audioInputRouted:
-      typeof parsed.audioInputRouted === "boolean" ? parsed.audioInputRouted : undefined,
-    audioInputDeviceLabel:
-      typeof parsed.audioInputDeviceLabel === "string" ? parsed.audioInputDeviceLabel : undefined,
-    audioInputRouteError:
-      typeof parsed.audioInputRouteError === "string" ? parsed.audioInputRouteError : undefined,
-    audioOutputRouted:
-      typeof parsed.audioOutputRouted === "boolean" ? parsed.audioOutputRouted : undefined,
-    audioOutputDeviceLabel:
-      typeof parsed.audioOutputDeviceLabel === "string" ? parsed.audioOutputDeviceLabel : undefined,
-    audioOutputRouteError:
-      typeof parsed.audioOutputRouteError === "string" ? parsed.audioOutputRouteError : undefined,
-    audioOutputRouteRetryable:
-      typeof parsed.audioOutputRouteRetryable === "boolean"
-        ? parsed.audioOutputRouteRetryable
-        : undefined,
-    manualAction: parseMeetingManualAction(parsed.manualAction),
-    browserUrl: typeof parsed.url === "string" ? parsed.url : undefined,
-    browserTitle: typeof parsed.title === "string" ? parsed.title : undefined,
+    inCall: parsed.inCall,
+    micMuted: parsed.micMuted,
+    cameraOff: parsed.cameraOff,
+    lobbyWaiting: parsed.lobbyWaiting,
+    captionCaptureRequested: parsed.captionCaptureRequested,
+    captioning: parsed.captioning,
+    captionsEnabledAttempted: parsed.captionsEnabledAttempted,
+    transcriptLines: parsed.transcriptLines,
+    lastCaptionAt: parsed.lastCaptionAt,
+    lastCaptionSpeaker: parsed.lastCaptionSpeaker,
+    lastCaptionText: parsed.lastCaptionText,
+    recentTranscript: parsed.recentTranscript,
+    audioInputRouted: parsed.audioInputRouted,
+    audioInputDeviceLabel: parsed.audioInputDeviceLabel,
+    audioInputRouteError: parsed.audioInputRouteError,
+    audioOutputRouted: parsed.audioOutputRouted,
+    audioOutputDeviceLabel: parsed.audioOutputDeviceLabel,
+    audioOutputRouteError: parsed.audioOutputRouteError,
+    audioOutputRouteRetryable: parsed.audioOutputRouteRetryable,
+    manualAction: parsed.manualAction,
+    browserUrl: parsed.url,
+    browserTitle: parsed.title,
     status: "browser-control",
-    notes: Array.isArray(parsed.notes)
-      ? parsed.notes.filter((note): note is string => typeof note === "string")
-      : undefined,
+    notes: parsed.notes,
     ...options.statusFields?.(parsed),
   } as unknown as Health;
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,8 @@
     "lit": "3.3.3",
     "markdown-it": "14.3.0",
     "markdown-it-task-lists": "2.1.1",
-    "remend": "1.3.0"
+    "remend": "1.3.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/markdown-it": "14.1.2",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -3,7 +3,7 @@
  */
 
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
-import { asRecord as asMessageRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import {
   extractCanvasShortcodes,
@@ -26,6 +26,107 @@ import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
 const OPAQUE_ID_LABEL_SUFFIX_RE =
   /\s+\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)$/iu;
 const OPAQUE_ID_LABEL_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+const optionalMessageStringSchema = z.string().optional().catch(undefined);
+const optionalMessageNumberSchema = z.number().optional().catch(undefined);
+const rawMcpAppSchema = z
+  .looseObject({
+    viewId: optionalMessageStringSchema,
+    serverName: optionalMessageStringSchema,
+    toolName: optionalMessageStringSchema,
+    uiResourceUri: optionalMessageStringSchema,
+    toolCallId: optionalMessageStringSchema,
+    originSessionKey: optionalMessageStringSchema,
+  })
+  .optional()
+  .catch(undefined);
+const rawCanvasPreviewSchema = z
+  .looseObject({
+    title: optionalMessageStringSchema,
+    preferredHeight: optionalMessageNumberSchema,
+    url: optionalMessageStringSchema,
+    viewId: optionalMessageStringSchema,
+    className: optionalMessageStringSchema,
+    style: optionalMessageStringSchema,
+    mcpApp: rawMcpAppSchema,
+  })
+  .optional()
+  .catch(undefined);
+const rawAttachmentSchema = z
+  .looseObject({
+    url: optionalMessageStringSchema,
+    label: optionalMessageStringSchema,
+    mimeType: optionalMessageStringSchema,
+    artifactId: optionalMessageStringSchema,
+    sizeBytes: optionalMessageNumberSchema,
+    durationMs: optionalMessageNumberSchema,
+    width: optionalMessageNumberSchema,
+    height: optionalMessageNumberSchema,
+  })
+  .optional()
+  .catch(undefined);
+const rawAudioSourceSchema = z
+  .looseObject({
+    media_type: optionalMessageStringSchema,
+    data: optionalMessageStringSchema,
+    url: optionalMessageStringSchema,
+  })
+  .optional()
+  .catch(undefined);
+const rawContentBlockSchema = z.looseObject({
+  text: optionalMessageStringSchema,
+  source: rawAudioSourceSchema,
+  attachment: rawAttachmentSchema,
+  preview: rawCanvasPreviewSchema,
+  rawText: optionalMessageStringSchema,
+  label: optionalMessageStringSchema,
+  fileName: optionalMessageStringSchema,
+  mimeType: optionalMessageStringSchema,
+  artifactId: optionalMessageStringSchema,
+  url: optionalMessageStringSchema,
+  sizeBytes: optionalMessageNumberSchema,
+  durationMs: optionalMessageNumberSchema,
+  width: optionalMessageNumberSchema,
+  height: optionalMessageNumberSchema,
+});
+const rawContentBlocksSchema = z
+  .array(z.union([rawContentBlockSchema, z.unknown().transform(() => null)]))
+  .transform((items) =>
+    items.filter((item): item is z.infer<typeof rawContentBlockSchema> => item !== null),
+  );
+const rawOpenClawMetadataSchema = z
+  .looseObject({
+    replyToId: optionalMessageStringSchema,
+    replyToPreview: z
+      .object({
+        text: optionalMessageStringSchema,
+        senderLabel: optionalMessageStringSchema,
+      })
+      .optional()
+      .catch(undefined),
+  })
+  .optional()
+  .catch(undefined);
+const rawMessageSchema = z
+  .looseObject({
+    role: optionalMessageStringSchema,
+    content: z.union([z.string(), rawContentBlocksSchema]).optional().catch(undefined),
+    text: optionalMessageStringSchema,
+    timestamp: optionalMessageNumberSchema,
+    id: optionalMessageStringSchema,
+    senderLabel: optionalMessageStringSchema,
+    toolCallId: optionalMessageStringSchema,
+    tool_call_id: optionalMessageStringSchema,
+    toolUseId: optionalMessageStringSchema,
+    tool_use_id: optionalMessageStringSchema,
+    toolName: optionalMessageStringSchema,
+    tool_name: optionalMessageStringSchema,
+    __openclaw: rawOpenClawMetadataSchema,
+  })
+  .catch({});
+
+type RawContentBlock = z.infer<typeof rawContentBlockSchema>;
+type RawCanvasPreview = z.infer<typeof rawCanvasPreviewSchema>;
 
 function splitOpaqueIdLabel(label: string): { display: string; id: string } | null {
   // A nameless legacy sender labels as the bare UUID; keep it as the
@@ -64,33 +165,31 @@ export function normalizeRoleForGrouping(role: string): string {
 }
 
 export function isToolResultMessage(message: unknown): boolean {
-  // Malformed transcript entries coerce to an empty record so property reads
-  // degrade to role "unknown" instead of crashing the event handler.
-  const m = asMessageRecord(message);
-  const role = typeof m.role === "string" ? m.role.toLowerCase() : "";
+  const m = rawMessageSchema.parse(message);
+  const role = m.role?.toLowerCase() ?? "";
   return role === "toolresult" || role === "tool_result";
 }
 
 export function isStandaloneToolMessageForDisplay(message: unknown): boolean {
-  const m = asMessageRecord(message);
-  const role = typeof m.role === "string" ? normalizeRoleForGrouping(m.role) : "unknown";
+  const m = rawMessageSchema.parse(message);
+  const role = m.role ? normalizeRoleForGrouping(m.role) : "unknown";
   return (
     role === "tool" ||
-    typeof m.toolCallId === "string" ||
-    typeof m.tool_call_id === "string" ||
-    typeof m.toolUseId === "string" ||
-    typeof m.tool_use_id === "string" ||
-    typeof m.toolName === "string" ||
-    typeof m.tool_name === "string"
+    m.toolCallId !== undefined ||
+    m.tool_call_id !== undefined ||
+    m.toolUseId !== undefined ||
+    m.tool_use_id !== undefined ||
+    m.toolName !== undefined ||
+    m.tool_name !== undefined
   );
 }
 
 function isTextContentBlock(
-  item: Record<string, unknown>,
+  item: RawContentBlock,
   role: string,
-): item is Record<string, unknown> & { text: string } {
+): item is RawContentBlock & { text: string } {
   return (
-    typeof item.text === "string" &&
+    item.text !== undefined &&
     (item.type === "text" ||
       (role === "user" && item.type === "input_text") ||
       (role === "assistant" && (item.type === "input_text" || item.type === "output_text")))
@@ -98,14 +197,13 @@ function isTextContentBlock(
 }
 
 function coerceCanvasPreview(
-  value: unknown,
+  preview: RawCanvasPreview,
 ):
   | Extract<NonNullable<NormalizedMessage["content"][number]>, { type: "canvas" }>["preview"]
   | null {
-  if (!isRecord(value)) {
+  if (!preview) {
     return null;
   }
-  const preview = value;
   if (preview.kind !== "canvas" || preview.surface === "tool_card") {
     return null;
   }
@@ -113,7 +211,7 @@ function coerceCanvasPreview(
   if (!render) {
     return null;
   }
-  const mcpApp = isRecord(preview.mcpApp) ? preview.mcpApp : undefined;
+  const mcpApp = preview.mcpApp;
   const boardWidgetName = isCanvasBoardWidgetName(preview.boardWidgetName)
     ? preview.boardWidgetName
     : undefined;
@@ -121,29 +219,25 @@ function coerceCanvasPreview(
     kind: "canvas",
     surface: "assistant_message",
     render,
-    ...(typeof preview.title === "string" ? { title: preview.title } : {}),
-    ...(typeof preview.preferredHeight === "number"
-      ? { preferredHeight: preview.preferredHeight }
-      : {}),
-    ...(typeof preview.url === "string" ? { url: preview.url } : {}),
-    ...(typeof preview.viewId === "string" ? { viewId: preview.viewId } : {}),
-    ...(typeof preview.className === "string" ? { className: preview.className } : {}),
-    ...(typeof preview.style === "string" ? { style: preview.style } : {}),
+    ...(preview.title !== undefined ? { title: preview.title } : {}),
+    ...(preview.preferredHeight !== undefined ? { preferredHeight: preview.preferredHeight } : {}),
+    ...(preview.url !== undefined ? { url: preview.url } : {}),
+    ...(preview.viewId !== undefined ? { viewId: preview.viewId } : {}),
+    ...(preview.className !== undefined ? { className: preview.className } : {}),
+    ...(preview.style !== undefined ? { style: preview.style } : {}),
     ...(preview.sandbox === "strict" || preview.sandbox === "scripts"
       ? { sandbox: preview.sandbox }
       : {}),
     ...(boardWidgetName ? { boardWidgetName } : {}),
-    ...(typeof mcpApp?.viewId === "string" && mcpApp.viewId.trim()
+    ...(mcpApp?.viewId?.trim()
       ? {
           mcpApp: {
             viewId: mcpApp.viewId,
-            ...(typeof mcpApp.serverName === "string" ? { serverName: mcpApp.serverName } : {}),
-            ...(typeof mcpApp.toolName === "string" ? { toolName: mcpApp.toolName } : {}),
-            ...(typeof mcpApp.uiResourceUri === "string"
-              ? { uiResourceUri: mcpApp.uiResourceUri }
-              : {}),
-            ...(typeof mcpApp.toolCallId === "string" ? { toolCallId: mcpApp.toolCallId } : {}),
-            ...(typeof mcpApp.originSessionKey === "string"
+            ...(mcpApp.serverName !== undefined ? { serverName: mcpApp.serverName } : {}),
+            ...(mcpApp.toolName !== undefined ? { toolName: mcpApp.toolName } : {}),
+            ...(mcpApp.uiResourceUri !== undefined ? { uiResourceUri: mcpApp.uiResourceUri } : {}),
+            ...(mcpApp.toolCallId !== undefined ? { toolCallId: mcpApp.toolCallId } : {}),
+            ...(mcpApp.originSessionKey !== undefined
               ? { originSessionKey: mcpApp.originSessionKey }
               : {}),
           },
@@ -239,23 +333,20 @@ function inferAttachmentKind(url: string): {
 }
 
 function coerceAudioContentBlock(
-  item: Record<string, unknown>,
+  item: RawContentBlock,
 ): Extract<MessageContentItem, { type: "attachment" }> | null {
   if (item.type !== "audio") {
     return null;
   }
   const source = item.source;
-  if (!isRecord(source)) {
+  if (!source) {
     return null;
   }
-  const sourceRecord = source;
-  const mediaType =
-    typeof sourceRecord.media_type === "string" &&
-    sourceRecord.media_type.trim().toLowerCase().startsWith("audio/")
-      ? sourceRecord.media_type.trim()
-      : "audio/mpeg";
-  if (sourceRecord.type === "base64" && typeof sourceRecord.data === "string") {
-    const data = sourceRecord.data.trim();
+  const mediaType = source.media_type?.trim().toLowerCase().startsWith("audio/")
+    ? source.media_type.trim()
+    : "audio/mpeg";
+  if (source.type === "base64" && source.data !== undefined) {
+    const data = source.data.trim();
     if (!data) {
       return null;
     }
@@ -265,14 +356,14 @@ function coerceAudioContentBlock(
       attachment: {
         url,
         kind: "audio",
-        label: typeof item.label === "string" && item.label.trim() ? item.label.trim() : "Audio",
+        label: item.label?.trim() || "Audio",
         mimeType: mediaType,
         ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
       },
     };
   }
-  if (sourceRecord.type === "url" && typeof sourceRecord.url === "string") {
-    const url = sourceRecord.url.trim();
+  if (source.type === "url" && source.url !== undefined) {
+    const url = source.url.trim();
     if (!url) {
       return null;
     }
@@ -281,7 +372,7 @@ function coerceAudioContentBlock(
       attachment: {
         url,
         kind: "audio",
-        label: typeof item.label === "string" && item.label.trim() ? item.label.trim() : "Audio",
+        label: item.label?.trim() || "Audio",
         mimeType: mediaType,
         ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
       },
@@ -291,9 +382,9 @@ function coerceAudioContentBlock(
 }
 
 function coerceManagedMediaContentBlock(
-  item: Record<string, unknown>,
+  item: RawContentBlock,
 ): Extract<MessageContentItem, { type: "attachment" }> | null {
-  if ((item.type !== "audio" && item.type !== "video") || typeof item.url !== "string") {
+  if ((item.type !== "audio" && item.type !== "video") || item.url === undefined) {
     return null;
   }
   const url = item.url.trim();
@@ -302,34 +393,27 @@ function coerceManagedMediaContentBlock(
   }
   const kind = item.type;
   const fallbackLabel = kind === "audio" ? "Audio" : "Video";
-  const label =
-    typeof item.fileName === "string" && item.fileName.trim()
-      ? item.fileName.trim()
-      : typeof item.label === "string" && item.label.trim()
-        ? item.label.trim()
-        : fallbackLabel;
+  const label = item.fileName?.trim() || item.label?.trim() || fallbackLabel;
   return {
     type: "attachment",
     attachment: {
       url,
       kind,
       label,
-      ...(typeof item.mimeType === "string" ? { mimeType: item.mimeType } : {}),
-      ...(typeof item.artifactId === "string" ? { artifactId: item.artifactId } : {}),
+      ...(item.mimeType !== undefined ? { mimeType: item.mimeType } : {}),
+      ...(item.artifactId !== undefined ? { artifactId: item.artifactId } : {}),
       ...(kind === "audio" && item.isVoiceNote === true ? { isVoiceNote: true } : {}),
       ...(item.playback === "native" || item.playback === "transcode"
         ? { playback: item.playback }
         : {}),
-      ...(typeof item.sizeBytes === "number" && item.sizeBytes >= 0
-        ? { sizeBytes: item.sizeBytes }
-        : {}),
-      ...(typeof item.durationMs === "number" && item.durationMs >= 0
+      ...(item.sizeBytes !== undefined && item.sizeBytes >= 0 ? { sizeBytes: item.sizeBytes } : {}),
+      ...(item.durationMs !== undefined && item.durationMs >= 0
         ? { durationMs: item.durationMs }
         : {}),
-      ...(kind === "video" && typeof item.width === "number" && item.width > 0
+      ...(kind === "video" && item.width !== undefined && item.width > 0
         ? { width: item.width }
         : {}),
-      ...(kind === "video" && typeof item.height === "number" && item.height > 0
+      ...(kind === "video" && item.height !== undefined && item.height > 0
         ? { height: item.height }
         : {}),
     },
@@ -445,25 +529,25 @@ function expandTextContent(text: string): {
  * Normalize a raw message object into a consistent structure.
  */
 export function normalizeMessage(message: unknown): NormalizedMessage {
-  const m = asMessageRecord(message);
-  let role = typeof m.role === "string" ? m.role : "unknown";
+  const m = rawMessageSchema.parse(message);
+  let role = m.role ?? "unknown";
 
   // Detect tool messages by common gateway shapes.
   // Some tool events come through as assistant role with tool_* items in the content array.
   const hasToolId =
-    typeof m.toolCallId === "string" ||
-    typeof m.tool_call_id === "string" ||
-    typeof m.toolUseId === "string" ||
-    typeof m.tool_use_id === "string";
+    m.toolCallId !== undefined ||
+    m.tool_call_id !== undefined ||
+    m.toolUseId !== undefined ||
+    m.tool_use_id !== undefined;
 
   const contentRaw = m.content;
-  const contentItems = Array.isArray(contentRaw) ? contentRaw.filter(isRecord) : null;
+  const contentItems = Array.isArray(contentRaw) ? contentRaw : null;
   const hasToolContent =
     contentItems?.some(
       (item) => isToolResultContentType(item.type) || isToolCallContentType(item.type),
     ) ?? false;
 
-  const hasToolName = typeof m.toolName === "string" || typeof m.tool_name === "string";
+  const hasToolName = m.toolName !== undefined || m.tool_name !== undefined;
 
   if (hasToolId || hasToolContent || hasToolName) {
     role = "toolResult";
@@ -498,27 +582,15 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       } else if (item.type === "audio") {
         return [];
       }
-      if (item.type === "attachment" && isRecord(item.attachment)) {
-        const attachment = item.attachment as {
-          url?: unknown;
-          kind?: unknown;
-          label?: unknown;
-          mimeType?: unknown;
-          isVoiceNote?: unknown;
-          artifactId?: unknown;
-          playback?: unknown;
-          sizeBytes?: unknown;
-          durationMs?: unknown;
-          width?: unknown;
-          height?: unknown;
-        };
+      if (item.type === "attachment" && item.attachment) {
+        const attachment = item.attachment;
         if (
-          typeof attachment.url !== "string" ||
+          attachment.url === undefined ||
           (attachment.kind !== "image" &&
             attachment.kind !== "audio" &&
             attachment.kind !== "video" &&
             attachment.kind !== "document") ||
-          typeof attachment.label !== "string"
+          attachment.label === undefined
         ) {
           return [];
         }
@@ -529,31 +601,29 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
               url: attachment.url,
               kind: attachment.kind,
               label: attachment.label,
-              ...(typeof attachment.mimeType === "string" ? { mimeType: attachment.mimeType } : {}),
+              ...(attachment.mimeType !== undefined ? { mimeType: attachment.mimeType } : {}),
               ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
-              ...(typeof attachment.artifactId === "string"
-                ? { artifactId: attachment.artifactId }
-                : {}),
+              ...(attachment.artifactId !== undefined ? { artifactId: attachment.artifactId } : {}),
               ...(attachment.playback === "native" || attachment.playback === "transcode"
                 ? { playback: attachment.playback }
                 : {}),
-              ...(typeof attachment.sizeBytes === "number" && attachment.sizeBytes >= 0
+              ...(attachment.sizeBytes !== undefined && attachment.sizeBytes >= 0
                 ? { sizeBytes: attachment.sizeBytes }
                 : {}),
-              ...(typeof attachment.durationMs === "number" && attachment.durationMs >= 0
+              ...(attachment.durationMs !== undefined && attachment.durationMs >= 0
                 ? { durationMs: attachment.durationMs }
                 : {}),
-              ...(typeof attachment.width === "number" && attachment.width > 0
+              ...(attachment.width !== undefined && attachment.width > 0
                 ? { width: attachment.width }
                 : {}),
-              ...(typeof attachment.height === "number" && attachment.height > 0
+              ...(attachment.height !== undefined && attachment.height > 0
                 ? { height: attachment.height }
                 : {}),
             },
           },
         ];
       }
-      if (item.type === "canvas" && isRecord(item.preview)) {
+      if (item.type === "canvas" && item.preview) {
         const preview = coerceCanvasPreview(item.preview);
         if (!preview) {
           return [];
@@ -562,7 +632,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           {
             type: "canvas" as const,
             preview,
-            rawText: typeof item.rawText === "string" ? item.rawText : null,
+            rawText: item.rawText ?? null,
           },
         ];
       }
@@ -599,7 +669,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
         },
       ];
     });
-  } else if (typeof m.text === "string") {
+  } else if (m.text !== undefined) {
     if (isAssistantMessage) {
       const expanded = expandTextContent(m.text);
       content = expanded.content;
@@ -610,30 +680,23 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     }
   }
 
-  const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
-  const id = typeof m.id === "string" ? m.id : undefined;
-  const rawOpenClawMeta = m["__openclaw"];
-  const openClawMeta = isRecord(rawOpenClawMeta) ? rawOpenClawMeta : undefined;
-  const structuredReplyToId =
-    typeof openClawMeta?.replyToId === "string" ? openClawMeta.replyToId.trim() : "";
+  const timestamp = m.timestamp ?? Date.now();
+  const id = m.id;
+  const openClawMeta = m["__openclaw"];
+  const structuredReplyToId = openClawMeta?.replyToId?.trim() ?? "";
   if (structuredReplyToId) {
     replyTarget = { kind: "id", id: structuredReplyToId };
   }
-  const rawReplyPreview = openClawMeta?.replyToPreview;
-  const replyPreviewRecord = isRecord(rawReplyPreview) ? rawReplyPreview : undefined;
-  const replyPreviewText =
-    typeof replyPreviewRecord?.text === "string" ? replyPreviewRecord.text.trim() : "";
-  const replyPreviewSender =
-    typeof replyPreviewRecord?.senderLabel === "string"
-      ? replyPreviewRecord.senderLabel.trim()
-      : "";
+  const replyPreviewRecord = openClawMeta?.replyToPreview;
+  const replyPreviewText = replyPreviewRecord?.text?.trim() ?? "";
+  const replyPreviewSender = replyPreviewRecord?.senderLabel?.trim() ?? "";
   const metaSender = normalizeSenderIdentity({
     id: openClawMeta?.senderId,
     name: openClawMeta?.senderName,
     username: openClawMeta?.senderUsername,
     profileAvatarUrl: openClawMeta?.senderProfileAvatarUrl,
   });
-  const rawLabel = typeof m.senderLabel === "string" ? m.senderLabel.trim() : "";
+  const rawLabel = m.senderLabel?.trim() ?? "";
   const legacyLabelIdentity = rawLabel ? splitOpaqueIdLabel(rawLabel) : null;
   const senderLabel = rawLabel
     ? (legacyLabelIdentity?.display ?? rawLabel)

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -316,6 +316,18 @@ describe("workboard controller", () => {
     ).toBe("claude-cli");
   });
 
+  it("filters malformed metadata children without discarding valid siblings", () => {
+    expect(
+      normalizeMetadata({
+        comments: [
+          { id: "comment-1", body: "kept", createdAt: 1 },
+          { id: "comment-2", body: 42, createdAt: 2 },
+          null,
+        ],
+      }),
+    ).toEqual({ comments: [{ id: "comment-1", body: "kept", createdAt: 1 }] });
+  });
+
   describe("runtime ownership", () => {
     it("keeps state pristine when lifecycle teardown happens before first access", () => {
       const pristineHost = {};

--- a/ui/src/lib/workboard/metadata-normalization.ts
+++ b/ui/src/lib/workboard/metadata-normalization.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
 import {
   normalizeAutomation,
   normalizeDiagnosticAction,
@@ -15,409 +15,362 @@ import {
   WORKBOARD_PROOF_STATUSES,
   WORKBOARD_STATUSES,
   WORKBOARD_TEMPLATE_IDS,
-  type WorkboardArtifact,
-  type WorkboardAttachment,
-  type WorkboardAttemptStatus,
-  type WorkboardClaim,
-  type WorkboardComment,
-  type WorkboardDiagnostic,
   type WorkboardDiagnosticAction,
-  type WorkboardDiagnosticKind,
-  type WorkboardDiagnosticSeverity,
   type WorkboardEvent,
-  type WorkboardEventKind,
   type WorkboardExecution,
-  type WorkboardExecutionMode,
-  type WorkboardExecutionStatus,
-  type WorkboardLink,
-  type WorkboardLinkType,
   type WorkboardMetadata,
-  type WorkboardNotification,
-  type WorkboardNotificationKind,
-  type WorkboardProof,
-  type WorkboardProofStatus,
-  type WorkboardRunAttempt,
-  type WorkboardStatus,
-  type WorkboardTemplateId,
-  type WorkboardWorkerLog,
-  type WorkboardWorkerProtocol,
 } from "./types.ts";
 
-export function normalizeExecution(value: unknown): WorkboardExecution | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : "";
-  const engine = typeof value.engine === "string" ? value.engine.trim() : "";
-  const mode = WORKBOARD_EXECUTION_MODES.includes(value.mode as WorkboardExecutionMode)
-    ? (value.mode as WorkboardExecutionMode)
-    : null;
-  const status = WORKBOARD_EXECUTION_STATUSES.includes(value.status as WorkboardExecutionStatus)
-    ? (value.status as WorkboardExecutionStatus)
-    : "idle";
-  const model = typeof value.model === "string" && value.model.trim() ? value.model.trim() : "";
-  const startedAt = typeof value.startedAt === "number" ? value.startedAt : 0;
-  const updatedAt = typeof value.updatedAt === "number" ? value.updatedAt : startedAt;
-  if (!id || !mode || !startedAt) {
-    return undefined;
-  }
-  return {
-    id,
-    kind: "agent-session",
-    mode,
-    status,
-    startedAt,
-    updatedAt,
-    ...(engine ? { engine } : {}),
-    ...(model ? { model } : {}),
-    ...(typeof value.sessionKey === "string" ? { sessionKey: value.sessionKey } : {}),
-    ...(typeof value.runId === "string" ? { runId: value.runId } : {}),
-  };
+const optionalStringSchema = z.string().optional().catch(undefined);
+const optionalNumberSchema = z.number().optional().catch(undefined);
+const trimmedRequiredStringSchema = z
+  .string()
+  .transform((value) => value.trim())
+  .pipe(z.string().min(1));
+const invalidArrayItemSchema = z.unknown().transform(() => null);
+
+function tolerantArray<T>(schema: z.ZodType<T>) {
+  return z
+    .array(z.union([schema, invalidArrayItemSchema]))
+    .transform((items) => items.filter((item): item is T => item !== null))
+    .optional()
+    .catch(undefined);
 }
 
-function normalizeEvent(value: unknown): WorkboardEvent | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : "";
-  const kind = WORKBOARD_EVENT_KINDS.includes(value.kind as WorkboardEventKind)
-    ? (value.kind as WorkboardEventKind)
-    : null;
-  const at = typeof value.at === "number" && Number.isFinite(value.at) ? value.at : 0;
-  if (!id || !kind || !at) {
-    return null;
-  }
-  const fromStatus = WORKBOARD_STATUSES.includes(value.fromStatus as WorkboardStatus)
-    ? (value.fromStatus as WorkboardStatus)
-    : undefined;
-  const toStatus = WORKBOARD_STATUSES.includes(value.toStatus as WorkboardStatus)
-    ? (value.toStatus as WorkboardStatus)
-    : undefined;
-  return {
-    id,
-    kind,
-    at,
-    ...(fromStatus ? { fromStatus } : {}),
-    ...(toStatus ? { toStatus } : {}),
-    ...(typeof value.sessionKey === "string" ? { sessionKey: value.sessionKey } : {}),
-    ...(typeof value.runId === "string" ? { runId: value.runId } : {}),
-  };
+const workboardExecutionSchema = z
+  .object({
+    id: trimmedRequiredStringSchema,
+    engine: optionalStringSchema.transform((value) => value?.trim() || undefined),
+    mode: z.enum(WORKBOARD_EXECUTION_MODES),
+    status: z.enum(WORKBOARD_EXECUTION_STATUSES).catch("idle"),
+    model: optionalStringSchema.transform((value) => value?.trim() || undefined),
+    sessionKey: optionalStringSchema,
+    runId: optionalStringSchema,
+    startedAt: z.number().refine((value) => value !== 0),
+    updatedAt: optionalNumberSchema,
+  })
+  .transform(
+    (value): WorkboardExecution => ({
+      id: value.id,
+      kind: "agent-session",
+      mode: value.mode,
+      status: value.status,
+      startedAt: value.startedAt,
+      updatedAt: value.updatedAt ?? value.startedAt,
+      ...(value.engine ? { engine: value.engine } : {}),
+      ...(value.model ? { model: value.model } : {}),
+      ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : {}),
+      ...(value.runId !== undefined ? { runId: value.runId } : {}),
+    }),
+  );
+
+const workboardEventSchema = z
+  .object({
+    id: trimmedRequiredStringSchema,
+    kind: z.enum(WORKBOARD_EVENT_KINDS),
+    at: z
+      .number()
+      .finite()
+      .refine((value) => value !== 0),
+    fromStatus: z.enum(WORKBOARD_STATUSES).optional().catch(undefined),
+    toStatus: z.enum(WORKBOARD_STATUSES).optional().catch(undefined),
+    sessionKey: optionalStringSchema,
+    runId: optionalStringSchema,
+  })
+  .transform(
+    (value): WorkboardEvent => ({
+      id: value.id,
+      kind: value.kind,
+      at: value.at,
+      ...(value.fromStatus ? { fromStatus: value.fromStatus } : {}),
+      ...(value.toStatus ? { toStatus: value.toStatus } : {}),
+      ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : {}),
+      ...(value.runId !== undefined ? { runId: value.runId } : {}),
+    }),
+  );
+
+const attemptSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(WORKBOARD_ATTEMPT_STATUSES).catch("running"),
+    startedAt: z.number(),
+    endedAt: optionalNumberSchema,
+    engine: optionalStringSchema.transform((value) => value?.trim() || undefined),
+    mode: z.enum(WORKBOARD_EXECUTION_MODES).optional().catch(undefined),
+    model: optionalStringSchema,
+    sessionKey: optionalStringSchema,
+    runId: optionalStringSchema,
+    error: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    status: value.status,
+    startedAt: value.startedAt,
+    ...(value.endedAt !== undefined ? { endedAt: value.endedAt } : {}),
+    ...(value.engine ? { engine: value.engine } : {}),
+    ...(value.mode ? { mode: value.mode } : {}),
+    ...(value.model !== undefined ? { model: value.model } : {}),
+    ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : {}),
+    ...(value.runId !== undefined ? { runId: value.runId } : {}),
+    ...(value.error !== undefined ? { error: value.error } : {}),
+  }));
+const commentSchema = z
+  .object({
+    id: z.string(),
+    body: z.string(),
+    createdAt: z.number(),
+    updatedAt: optionalNumberSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    body: value.body,
+    createdAt: value.createdAt,
+    ...(value.updatedAt !== undefined ? { updatedAt: value.updatedAt } : {}),
+  }));
+const linkSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(WORKBOARD_LINK_TYPES).catch("relates_to"),
+    createdAt: z.number(),
+    targetCardId: optionalStringSchema,
+    title: optionalStringSchema,
+    url: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    type: value.type,
+    createdAt: value.createdAt,
+    ...(value.targetCardId !== undefined ? { targetCardId: value.targetCardId } : {}),
+    ...(value.title !== undefined ? { title: value.title } : {}),
+    ...(value.url !== undefined ? { url: value.url } : {}),
+  }));
+const proofSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(WORKBOARD_PROOF_STATUSES).catch("unknown"),
+    createdAt: z.number(),
+    label: optionalStringSchema,
+    command: optionalStringSchema,
+    url: optionalStringSchema,
+    note: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    status: value.status,
+    createdAt: value.createdAt,
+    ...(value.label !== undefined ? { label: value.label } : {}),
+    ...(value.command !== undefined ? { command: value.command } : {}),
+    ...(value.url !== undefined ? { url: value.url } : {}),
+    ...(value.note !== undefined ? { note: value.note } : {}),
+  }));
+const artifactSchema = z
+  .object({
+    id: z.string(),
+    createdAt: z.number(),
+    label: optionalStringSchema,
+    url: optionalStringSchema,
+    path: optionalStringSchema,
+    mimeType: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    createdAt: value.createdAt,
+    ...(value.label !== undefined ? { label: value.label } : {}),
+    ...(value.url !== undefined ? { url: value.url } : {}),
+    ...(value.path !== undefined ? { path: value.path } : {}),
+    ...(value.mimeType !== undefined ? { mimeType: value.mimeType } : {}),
+  }));
+const attachmentSchema = z
+  .object({
+    id: z.string(),
+    cardId: z.string(),
+    fileName: z.string(),
+    byteSize: z.number(),
+    createdAt: z.number(),
+    mimeType: optionalStringSchema,
+    note: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    cardId: value.cardId,
+    fileName: value.fileName,
+    byteSize: value.byteSize,
+    createdAt: value.createdAt,
+    ...(value.mimeType !== undefined ? { mimeType: value.mimeType } : {}),
+    ...(value.note !== undefined ? { note: value.note } : {}),
+  }));
+const workerLogSchema = z
+  .object({
+    id: z.string(),
+    level: z.enum(["info", "warning", "error"]).catch("info"),
+    message: z.string(),
+    createdAt: z.number(),
+    sessionKey: optionalStringSchema,
+    runId: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    level: value.level,
+    message: value.message,
+    createdAt: value.createdAt,
+    ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : {}),
+    ...(value.runId !== undefined ? { runId: value.runId } : {}),
+  }));
+const workerProtocolSchema = z
+  .object({
+    state: z.enum(["idle", "running", "completed", "blocked", "violated"]),
+    updatedAt: z.number().catch(() => Date.now()),
+    detail: optionalStringSchema,
+  })
+  .transform((value) => ({
+    state: value.state,
+    updatedAt: value.updatedAt,
+    ...(value.detail !== undefined ? { detail: value.detail } : {}),
+  }))
+  .optional()
+  .catch(undefined);
+const claimSchema = z
+  .object({
+    ownerId: z.string(),
+    token: z.string(),
+    claimedAt: z.number(),
+    lastHeartbeatAt: z.number(),
+    expiresAt: optionalNumberSchema,
+  })
+  .transform((value) => ({
+    ownerId: value.ownerId,
+    token: value.token,
+    claimedAt: value.claimedAt,
+    lastHeartbeatAt: value.lastHeartbeatAt,
+    ...(value.expiresAt !== undefined ? { expiresAt: value.expiresAt } : {}),
+  }))
+  .optional()
+  .catch(undefined);
+const diagnosticSchema = z
+  .object({
+    kind: z.enum(WORKBOARD_DIAGNOSTIC_KINDS),
+    severity: z.enum(WORKBOARD_DIAGNOSTIC_SEVERITIES),
+    title: z.string(),
+    detail: optionalStringSchema,
+    firstSeenAt: optionalNumberSchema,
+    lastSeenAt: optionalNumberSchema,
+    count: optionalNumberSchema,
+    actions: z
+      .array(z.unknown())
+      .transform((actions) =>
+        actions
+          .map(normalizeDiagnosticAction)
+          .filter((action): action is WorkboardDiagnosticAction => action !== null),
+      )
+      .optional()
+      .catch(undefined),
+  })
+  .transform((value) => ({
+    kind: value.kind,
+    severity: value.severity,
+    title: value.title,
+    detail: value.detail ?? value.title,
+    firstSeenAt: value.firstSeenAt ?? Date.now(),
+    lastSeenAt: value.lastSeenAt ?? Date.now(),
+    count: value.count ?? 1,
+    actions: value.actions ?? [],
+  }));
+const notificationSchema = z
+  .object({
+    id: z.string(),
+    kind: z.enum(WORKBOARD_NOTIFICATION_KINDS),
+    message: z.string(),
+    createdAt: z.number(),
+    sequence: optionalNumberSchema,
+    sessionKey: optionalStringSchema,
+    runId: optionalStringSchema,
+  })
+  .transform((value) => ({
+    id: value.id,
+    kind: value.kind,
+    message: value.message,
+    createdAt: value.createdAt,
+    ...(value.sequence !== undefined ? { sequence: value.sequence } : {}),
+    ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : {}),
+    ...(value.runId !== undefined ? { runId: value.runId } : {}),
+  }));
+const staleSchema = z
+  .object({
+    detectedAt: optionalNumberSchema,
+    lastSessionUpdatedAt: optionalNumberSchema,
+    reason: optionalStringSchema,
+  })
+  .transform((value) => ({
+    detectedAt: value.detectedAt ?? Date.now(),
+    ...(value.lastSessionUpdatedAt !== undefined
+      ? { lastSessionUpdatedAt: value.lastSessionUpdatedAt }
+      : {}),
+    reason: value.reason ?? "Session has not reported recent activity.",
+  }))
+  .optional()
+  .catch(undefined);
+
+const workboardMetadataSchema = z
+  .object({
+    attempts: tolerantArray(attemptSchema),
+    comments: tolerantArray(commentSchema),
+    links: tolerantArray(linkSchema),
+    proof: tolerantArray(proofSchema),
+    artifacts: tolerantArray(artifactSchema),
+    attachments: tolerantArray(attachmentSchema),
+    workerLogs: tolerantArray(workerLogSchema),
+    workerProtocol: workerProtocolSchema,
+    automation: z.unknown().transform(normalizeAutomation).optional(),
+    claim: claimSchema,
+    diagnostics: tolerantArray(diagnosticSchema),
+    notifications: tolerantArray(notificationSchema),
+    templateId: z.enum(WORKBOARD_TEMPLATE_IDS).optional().catch(undefined),
+    archivedAt: optionalNumberSchema,
+    stale: staleSchema,
+    lifecycleStatusSourceUpdatedAt: z
+      .number()
+      .finite()
+      .transform((value) => Math.max(0, Math.trunc(value)))
+      .optional()
+      .catch(undefined),
+    failureCount: optionalNumberSchema,
+  })
+  .transform((value): WorkboardMetadata | undefined => {
+    const metadata: WorkboardMetadata = {
+      ...(value.attempts?.length ? { attempts: value.attempts } : {}),
+      ...(value.comments?.length ? { comments: value.comments } : {}),
+      ...(value.links?.length ? { links: value.links } : {}),
+      ...(value.proof?.length ? { proof: value.proof } : {}),
+      ...(value.artifacts?.length ? { artifacts: value.artifacts } : {}),
+      ...(value.attachments?.length ? { attachments: value.attachments } : {}),
+      ...(value.workerLogs?.length ? { workerLogs: value.workerLogs } : {}),
+      ...(value.workerProtocol ? { workerProtocol: value.workerProtocol } : {}),
+      ...(value.automation ? { automation: value.automation } : {}),
+      ...(value.claim ? { claim: value.claim } : {}),
+      ...(value.diagnostics?.length ? { diagnostics: value.diagnostics } : {}),
+      ...(value.notifications?.length ? { notifications: value.notifications } : {}),
+      ...(value.templateId ? { templateId: value.templateId } : {}),
+      ...(value.archivedAt !== undefined ? { archivedAt: value.archivedAt } : {}),
+      ...(value.stale ? { stale: value.stale } : {}),
+      ...(value.lifecycleStatusSourceUpdatedAt !== undefined
+        ? { lifecycleStatusSourceUpdatedAt: value.lifecycleStatusSourceUpdatedAt }
+        : {}),
+      ...(value.failureCount !== undefined ? { failureCount: value.failureCount } : {}),
+    };
+    return Object.keys(metadata).length ? metadata : undefined;
+  });
+
+export function normalizeExecution(value: unknown): WorkboardExecution | undefined {
+  const result = workboardExecutionSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 }
 
 export function normalizeEvents(value: unknown): WorkboardEvent[] {
-  return Array.isArray(value)
-    ? value.map(normalizeEvent).filter((event): event is WorkboardEvent => event !== null)
-    : [];
-}
-
-function normalizeWorkerProtocolState(
-  value: unknown,
-): WorkboardWorkerProtocol["state"] | undefined {
-  return value === "idle" ||
-    value === "running" ||
-    value === "completed" ||
-    value === "blocked" ||
-    value === "violated"
-    ? value
-    : undefined;
+  const result = tolerantArray(workboardEventSchema).safeParse(value);
+  return result.success ? (result.data ?? []) : [];
 }
 
 export function normalizeMetadata(value: unknown): WorkboardMetadata | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const attempts = Array.isArray(value.attempts)
-    ? value.attempts.flatMap((entry): WorkboardRunAttempt[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.startedAt !== "number"
-        ) {
-          return [];
-        }
-        const status = WORKBOARD_ATTEMPT_STATUSES.includes(entry.status as WorkboardAttemptStatus)
-          ? (entry.status as WorkboardAttemptStatus)
-          : "running";
-        const engine = typeof entry.engine === "string" ? entry.engine.trim() : "";
-        return [
-          {
-            id: entry.id,
-            status,
-            startedAt: entry.startedAt,
-            ...(typeof entry.endedAt === "number" ? { endedAt: entry.endedAt } : {}),
-            ...(engine ? { engine } : {}),
-            ...(WORKBOARD_EXECUTION_MODES.includes(entry.mode as WorkboardExecutionMode)
-              ? { mode: entry.mode as WorkboardExecutionMode }
-              : {}),
-            ...(typeof entry.model === "string" ? { model: entry.model } : {}),
-            ...(typeof entry.sessionKey === "string" ? { sessionKey: entry.sessionKey } : {}),
-            ...(typeof entry.runId === "string" ? { runId: entry.runId } : {}),
-            ...(typeof entry.error === "string" ? { error: entry.error } : {}),
-          },
-        ];
-      })
-    : [];
-  const comments = Array.isArray(value.comments)
-    ? value.comments.flatMap((entry): WorkboardComment[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.body !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            body: entry.body,
-            createdAt: entry.createdAt,
-            ...(typeof entry.updatedAt === "number" ? { updatedAt: entry.updatedAt } : {}),
-          },
-        ];
-      })
-    : [];
-  const links = Array.isArray(value.links)
-    ? value.links.flatMap((entry): WorkboardLink[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            type: WORKBOARD_LINK_TYPES.includes(entry.type as WorkboardLinkType)
-              ? (entry.type as WorkboardLinkType)
-              : "relates_to",
-            createdAt: entry.createdAt,
-            ...(typeof entry.targetCardId === "string" ? { targetCardId: entry.targetCardId } : {}),
-            ...(typeof entry.title === "string" ? { title: entry.title } : {}),
-            ...(typeof entry.url === "string" ? { url: entry.url } : {}),
-          },
-        ];
-      })
-    : [];
-  const proof = Array.isArray(value.proof)
-    ? value.proof.flatMap((entry): WorkboardProof[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            status: WORKBOARD_PROOF_STATUSES.includes(entry.status as WorkboardProofStatus)
-              ? (entry.status as WorkboardProofStatus)
-              : "unknown",
-            createdAt: entry.createdAt,
-            ...(typeof entry.label === "string" ? { label: entry.label } : {}),
-            ...(typeof entry.command === "string" ? { command: entry.command } : {}),
-            ...(typeof entry.url === "string" ? { url: entry.url } : {}),
-            ...(typeof entry.note === "string" ? { note: entry.note } : {}),
-          },
-        ];
-      })
-    : [];
-  const artifacts = Array.isArray(value.artifacts)
-    ? value.artifacts.flatMap((entry): WorkboardArtifact[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            createdAt: entry.createdAt,
-            ...(typeof entry.label === "string" ? { label: entry.label } : {}),
-            ...(typeof entry.url === "string" ? { url: entry.url } : {}),
-            ...(typeof entry.path === "string" ? { path: entry.path } : {}),
-            ...(typeof entry.mimeType === "string" ? { mimeType: entry.mimeType } : {}),
-          },
-        ];
-      })
-    : [];
-  const attachments = Array.isArray(value.attachments)
-    ? value.attachments.flatMap((entry): WorkboardAttachment[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.cardId !== "string" ||
-          typeof entry.fileName !== "string" ||
-          typeof entry.byteSize !== "number" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            cardId: entry.cardId,
-            fileName: entry.fileName,
-            byteSize: entry.byteSize,
-            createdAt: entry.createdAt,
-            ...(typeof entry.mimeType === "string" ? { mimeType: entry.mimeType } : {}),
-            ...(typeof entry.note === "string" ? { note: entry.note } : {}),
-          },
-        ];
-      })
-    : [];
-  const workerLogs = Array.isArray(value.workerLogs)
-    ? value.workerLogs.flatMap((entry): WorkboardWorkerLog[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          typeof entry.message !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            level:
-              entry.level === "warning" || entry.level === "error" || entry.level === "info"
-                ? entry.level
-                : "info",
-            message: entry.message,
-            createdAt: entry.createdAt,
-            ...(typeof entry.sessionKey === "string" ? { sessionKey: entry.sessionKey } : {}),
-            ...(typeof entry.runId === "string" ? { runId: entry.runId } : {}),
-          },
-        ];
-      })
-    : [];
-  const workerProtocolRecord = isRecord(value.workerProtocol) ? value.workerProtocol : null;
-  const workerProtocolState = normalizeWorkerProtocolState(workerProtocolRecord?.state);
-  const workerProtocol = workerProtocolState
-    ? {
-        state: workerProtocolState,
-        updatedAt:
-          typeof workerProtocolRecord?.updatedAt === "number"
-            ? workerProtocolRecord.updatedAt
-            : Date.now(),
-        ...(typeof workerProtocolRecord?.detail === "string"
-          ? { detail: workerProtocolRecord.detail }
-          : {}),
-      }
-    : undefined;
-  const claim: WorkboardClaim | undefined =
-    isRecord(value.claim) &&
-    typeof value.claim.ownerId === "string" &&
-    typeof value.claim.token === "string" &&
-    typeof value.claim.claimedAt === "number" &&
-    typeof value.claim.lastHeartbeatAt === "number"
-      ? {
-          ownerId: value.claim.ownerId,
-          token: value.claim.token,
-          claimedAt: value.claim.claimedAt,
-          lastHeartbeatAt: value.claim.lastHeartbeatAt,
-          ...(typeof value.claim.expiresAt === "number"
-            ? { expiresAt: value.claim.expiresAt }
-            : {}),
-        }
-      : undefined;
-  const diagnostics = Array.isArray(value.diagnostics)
-    ? value.diagnostics.flatMap((entry): WorkboardDiagnostic[] => {
-        if (
-          !isRecord(entry) ||
-          !WORKBOARD_DIAGNOSTIC_KINDS.includes(entry.kind as WorkboardDiagnosticKind) ||
-          !WORKBOARD_DIAGNOSTIC_SEVERITIES.includes(
-            entry.severity as WorkboardDiagnosticSeverity,
-          ) ||
-          typeof entry.title !== "string"
-        ) {
-          return [];
-        }
-        return [
-          {
-            kind: entry.kind as WorkboardDiagnosticKind,
-            severity: entry.severity as WorkboardDiagnosticSeverity,
-            title: entry.title,
-            detail: typeof entry.detail === "string" ? entry.detail : entry.title,
-            firstSeenAt: typeof entry.firstSeenAt === "number" ? entry.firstSeenAt : Date.now(),
-            lastSeenAt: typeof entry.lastSeenAt === "number" ? entry.lastSeenAt : Date.now(),
-            count: typeof entry.count === "number" ? entry.count : 1,
-            actions: Array.isArray(entry.actions)
-              ? entry.actions
-                  .map(normalizeDiagnosticAction)
-                  .filter((action): action is WorkboardDiagnosticAction => action !== null)
-              : [],
-          },
-        ];
-      })
-    : [];
-  const notifications = Array.isArray(value.notifications)
-    ? value.notifications.flatMap((entry): WorkboardNotification[] => {
-        if (
-          !isRecord(entry) ||
-          typeof entry.id !== "string" ||
-          !WORKBOARD_NOTIFICATION_KINDS.includes(entry.kind as WorkboardNotificationKind) ||
-          typeof entry.message !== "string" ||
-          typeof entry.createdAt !== "number"
-        ) {
-          return [];
-        }
-        return [
-          {
-            id: entry.id,
-            kind: entry.kind as WorkboardNotificationKind,
-            message: entry.message,
-            createdAt: entry.createdAt,
-            ...(typeof entry.sequence === "number" ? { sequence: entry.sequence } : {}),
-            ...(typeof entry.sessionKey === "string" ? { sessionKey: entry.sessionKey } : {}),
-            ...(typeof entry.runId === "string" ? { runId: entry.runId } : {}),
-          },
-        ];
-      })
-    : [];
-  const stale = isRecord(value.stale)
-    ? {
-        detectedAt:
-          typeof value.stale.detectedAt === "number" ? value.stale.detectedAt : Date.now(),
-        ...(typeof value.stale.lastSessionUpdatedAt === "number"
-          ? { lastSessionUpdatedAt: value.stale.lastSessionUpdatedAt }
-          : {}),
-        reason:
-          typeof value.stale.reason === "string"
-            ? value.stale.reason
-            : "Session has not reported recent activity.",
-      }
-    : undefined;
-  const automation = normalizeAutomation(value.automation);
-  const lifecycleStatusSourceUpdatedAt =
-    typeof value.lifecycleStatusSourceUpdatedAt === "number" &&
-    Number.isFinite(value.lifecycleStatusSourceUpdatedAt)
-      ? Math.max(0, Math.trunc(value.lifecycleStatusSourceUpdatedAt))
-      : undefined;
-  const metadata: WorkboardMetadata = {
-    ...(attempts.length ? { attempts } : {}),
-    ...(comments.length ? { comments } : {}),
-    ...(links.length ? { links } : {}),
-    ...(proof.length ? { proof } : {}),
-    ...(artifacts.length ? { artifacts } : {}),
-    ...(attachments.length ? { attachments } : {}),
-    ...(workerLogs.length ? { workerLogs } : {}),
-    ...(workerProtocol ? { workerProtocol } : {}),
-    ...(automation ? { automation } : {}),
-    ...(claim ? { claim } : {}),
-    ...(diagnostics.length ? { diagnostics } : {}),
-    ...(notifications.length ? { notifications } : {}),
-    ...(WORKBOARD_TEMPLATE_IDS.includes(value.templateId as WorkboardTemplateId)
-      ? { templateId: value.templateId as WorkboardTemplateId }
-      : {}),
-    ...(typeof value.archivedAt === "number" ? { archivedAt: value.archivedAt } : {}),
-    ...(stale ? { stale } : {}),
-    ...(lifecycleStatusSourceUpdatedAt !== undefined ? { lifecycleStatusSourceUpdatedAt } : {}),
-    ...(typeof value.failureCount === "number" ? { failureCount: value.failureCount } : {}),
-  };
-  return Object.keys(metadata).length ? metadata : undefined;
+  const result = workboardMetadataSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Seven external-data boundaries still reconstructed runtime types through long, duplicated `typeof` / `Array.isArray` / `isRecord` cascades. That made the accepted input contract difficult to audit and left downstream types dependent on casts instead of the validator that actually owned ingress.

## Why This Change Was Made

This pilot replaces those cascades with one Zod schema or a small discriminated schema set at each boundary. Schemas preserve the existing tolerant normalization rules: unknown keys remain accepted where record guards accepted them, malformed optional fields remain omitted, invalid list entries remain filtered, and cross-field/domain checks stay with their owner.

The two Control UI modules now declare Zod directly, but this does not add a new browser dependency: Zod was already an intentional member of the stable `config-runtime` chunk. Firecrawl now declares the runtime dependency it directly imports. The assertion-safety ratchet shrinks by 44 grandfathered assertions.

Structural-probe inventory (`typeof` + `Array.isArray` + `isRecord`, whole target file):

| Boundary | Before | After | Accepted-input statement |
| --- | ---: | ---: | --- |
| Workboard metadata | 103 | 0 | No previously accepted input is rejected. Unknown metadata keys are stripped as before; invalid child rows are filtered independently and existing defaults remain. |
| Chat messages | 70 | 6 | No previously accepted message is rejected. Non-object messages still normalize to role `unknown`; malformed blocks/fields remain omitted while valid siblings survive. |
| Signed runtime identity token | 40 | 5 | No previously accepted signed payload is rejected. Unknown outer and nested keys remain accepted then stripped; invalid known fields and all lifecycle/cross-field checks still fail closed. |
| APNs registrations | 17 | 5 | No previously accepted canonical registration is rejected. Transport normalization, identifier/token constraints, relay-origin normalization, and null-on-invalid behavior are unchanged. |
| Zalo webhook envelopes | 22 | 4 | No previously accepted direct or legacy `{ ok, result }` envelope is rejected. Admission identity checks, replay validation, and error categories remain unchanged. |
| Meeting browser status | 48 | 19 | No previously accepted status object is rejected. JSON non-objects continue to fail through the platform-specific malformed-status path; unknown platform fields remain available to adapter extensions. |
| Firecrawl search responses | 44 | 26 | No previously accepted response variant is rejected. Candidate precedence and per-item filtering remain unchanged across `data`, `results`, nested `data`, and `web` envelopes. |

Zod rejects non-finite numeric values that `typeof value === "number"` could theoretically admit, but those values cannot cross the owning JSON boundaries; APNs timestamps come from STRICT integer storage. No shipped input contract changes.

## User Impact

No user-facing behavior change. Runtime validation now has one source of truth per ingress boundary and downstream code consumes inferred types. This makes malformed external inputs easier to reason about without adding UI startup weight.

Production TypeScript is `+998/-1043` (net `-45`); direct dependency manifests are `+4/-2`; tests are `+71/-3`; generated lockfile is `+6/-0`; the safety baseline is `+5/-7`.

## Evidence

- Focused owner proof: 395 tests pass across Workboard, chat normalization, signed runtime identity, APNs storage, Zalo webhook spooling, meeting status parsing, and Firecrawl response normalization.
- New error-path coverage protects per-item Workboard filtering and the signed-token structural acceptance boundary without adding production test seams.
- The existing Teams malformed-status case now covers malformed JSON, JSON `null`, and arrays; all reject through the platform-specific error.
- `node scripts/check-changed.mjs --dry-run` — all lanes selected.
- `node scripts/check-changed.mjs` — pass on Testbox run https://github.com/openclaw/openclaw/actions/runs/31969621820; all package locks, production/test/script typechecks, full core/extensions/scripts lint, dead exports, plugin boundaries, and import cycles pass.
- `corepack pnpm ui:build` — pass on Testbox run https://github.com/openclaw/openclaw/actions/runs/31970627938; Zod remains in `config-runtime`; startup JS is 335,413 B gzip versus the 335,452 B baseline (39 B smaller).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Rebase proof: pre/post patch IDs are identical (`c229b77af19ab7c9a1a43f5fccb461084175ee8b`).

All seven requested targets landed in the pilot; no target was stopped.
