### PR TITLE
fix(ci): render only aggregate QA evidence

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -590,6 +590,16 @@ jobs:
             exit 1
           fi
 
+      - name: Prepare aggregate QA evidence for rendering
+        env:
+          QA_EVIDENCE_PATH: ${{ steps.evidence.outputs.qa_evidence_path }}
+        run: |
+          set -euo pipefail
+          render_evidence_dir=".artifacts/maturity-render-evidence"
+          rm -rf "$render_evidence_dir"
+          mkdir -p "$render_evidence_dir"
+          install -m 0644 "$QA_EVIDENCE_PATH" "$render_evidence_dir/qa-evidence.json"
+
       - name: Validate maturity score sources
         run: |
           node --import tsx --input-type=module <<'NODE'
@@ -617,7 +627,7 @@ jobs:
             --output-dir .artifacts/maturity-docs \
             --static-assets-dir .artifacts/maturity-docs/assets/maturity \
             --scores qa/maturity-scores.yaml \
-            --evidence-dir .artifacts/maturity-evidence \
+            --evidence-dir .artifacts/maturity-render-evidence \
             --strict-inputs \
             "${allow_failures_args[@]}"
           {
@@ -642,7 +652,7 @@ jobs:
           pnpm maturity:render -- \
             --output-dir docs \
             --scores qa/maturity-scores.yaml \
-            --evidence-dir .artifacts/maturity-evidence \
+            --evidence-dir .artifacts/maturity-render-evidence \
             --strict-inputs \
             "${allow_failures_args[@]}"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8122,11 +8122,25 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     });
     expect(generatedPrUploadStep.with.path.trim().split("\n")).toEqual(MATURITY_GENERATED_PR_PATHS);
 
+    const prepareRenderEvidenceStep = publishJob.steps.find(
+      (step: WorkflowStep) => step.name === "Prepare aggregate QA evidence for rendering",
+    );
+    expect(prepareRenderEvidenceStep.env.QA_EVIDENCE_PATH).toBe(
+      "${{ steps.evidence.outputs.qa_evidence_path }}",
+    );
+    expect(prepareRenderEvidenceStep.run).toContain(
+      'render_evidence_dir=".artifacts/maturity-render-evidence"',
+    );
+    expect(prepareRenderEvidenceStep.run).toContain(
+      'install -m 0644 "$QA_EVIDENCE_PATH" "$render_evidence_dir/qa-evidence.json"',
+    );
     for (const stepName of ["Render artifact docs", "Render committed docs preview"]) {
       const renderStep = publishJob.steps.find((step: WorkflowStep) => step.name === stepName);
       expect(renderStep.env.ALLOW_FAILURES).toBe("${{ inputs.allow_failures }}");
       expect(renderStep.run).toContain('[[ "$ALLOW_FAILURES" == "true" ]]');
       expect(renderStep.run).toContain("allow_failures_args+=(--allow-failures)");
+      expect(renderStep.run).toContain("--evidence-dir .artifacts/maturity-render-evidence");
+      expect(renderStep.run).not.toContain("--evidence-dir .artifacts/maturity-evidence");
       expect(renderStep.run).toContain('"${allow_failures_args[@]}"');
     }
     const renderArtifactStep = publishJob.steps.find(


### PR DESCRIPTION
Related: #124612

## What Problem This Solves

Fixes an issue where maturity rendering recursively scanned nested shard evidence after the aggregate had already been selected, causing strict-input validation to reject valid preserved payloads without scorecard fields.

## Why This Change Was Made

After manifest and provenance validation, the workflow copies only the aggregate `qa-evidence.json` into a render-only directory. Both docs render steps consume that directory, while the complete shard bundle remains available for artifacts, logs, and screenshots.

## User Impact

Maturity docs can render from the successful eight-shard aggregate without treating nested diagnostic evidence as additional scorecard inputs.

**AI-assisted:** Yes.

## Evidence

- Eight-shard and aggregate success: https://github.com/openclaw/openclaw/actions/runs/31966737524
- Recursive-render failure: https://github.com/openclaw/openclaw/actions/runs/31970456673
- Focused workflow guard: 119 passed, 2 platform-skipped.
- check-workflows, actionlint, zizmor, formatting, git diff --check passed.
- Structured autoreview clean.
