### PR TITLE
fix(ui): show session changes in the review panel

### DIFF
--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -1,14 +1,22 @@
 // Control UI tests cover the session diff panel (sessions.diff RPC).
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
+import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionUrl,
   installMockGateway,
+  navigateToControlUiSession,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
-import { activateChatHeaderPanelAction } from "./chat-side-panel.test-support.ts";
+import {
+  activateChatHeaderPanelAction,
+  openChatSidePanelType,
+} from "./chat-side-panel.test-support.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -80,6 +88,77 @@ const NOTES_PATCH = [
   "",
 ].join("\n");
 
+const SESSION_DIFF_RESPONSE = {
+  sessionKey: "main",
+  root: "/tmp/checkout",
+  branch: "feature/panel",
+  baseRef: "main",
+  files: [
+    {
+      path: "src/app.ts",
+      status: "modified",
+      additions: 2,
+      deletions: 1,
+      patch: APP_PATCH,
+    },
+    {
+      path: "notes.md",
+      status: "added",
+      additions: 2,
+      deletions: 0,
+      untracked: true,
+      patch: NOTES_PATCH,
+    },
+  ],
+  additions: 4,
+  deletions: 1,
+};
+
+async function waitForSessionDiff(page: import("playwright").Page): Promise<void> {
+  await expect.poll(() => page.locator(".session-diff").count()).toBe(1);
+  await expect
+    .poll(() => page.locator(".session-diff__filename").allTextContents())
+    .toEqual(["app.ts", "notes.md"]);
+}
+
+async function seedPersistedReviewLayouts(
+  page: import("playwright").Page,
+  sessionKeys: string[],
+): Promise<void> {
+  await page.addInitScript(
+    ({ key, persistedSessionKeys }) => {
+      const layout = {
+        columns: [
+          {
+            id: "side-panel-column",
+            side: "right",
+            panels: [{ id: "detail", slot: "detail" }],
+            activePanelId: "detail",
+            height: 360,
+            width: 360,
+          },
+        ],
+        open: true,
+        expanded: false,
+      };
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          sessionKey: persistedSessionKeys[0],
+          lastActiveSessionKey: persistedSessionKeys[0],
+          sidebarSessionLayouts: Object.fromEntries(
+            persistedSessionKeys.map((sessionKey) => [sessionKey, layout]),
+          ),
+        }),
+      );
+    },
+    {
+      key: controlUiBundledSettingsStorageKey(server.baseUrl),
+      persistedSessionKeys: sessionKeys,
+    },
+  );
+}
+
 describeControlUiE2e("session diff panel", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -101,6 +180,221 @@ describeControlUiE2e("session diff panel", () => {
   });
 
   afterEach(closeContexts);
+
+  it("opens the session diff when Review is added from the panel menu", async () => {
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.files.list": {
+          sessionKey: "main",
+          root: "/tmp/checkout",
+          gitCheckout: true,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+        "sessions.diff": SESSION_DIFF_RESPONSE,
+      },
+    });
+    await page.goto(`${server.baseUrl}chat`);
+
+    await openChatSidePanelType(page, "Files");
+    await openChatSidePanelType(page, "Review");
+
+    await waitForSessionDiff(page);
+  });
+
+  it("loads the session diff into a persisted empty Review panel", async () => {
+    const sessionKey = "agent:main:persisted-review";
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    await seedPersistedReviewLayouts(page, [sessionKey]);
+    await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.files.list": {
+          sessionKey,
+          root: "/tmp/checkout",
+          gitCheckout: true,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+        "sessions.diff": { ...SESSION_DIFF_RESPONSE, sessionKey },
+      },
+    });
+
+    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+
+    await waitForSessionDiff(page);
+  });
+
+  it("replaces an automatically seeded diff when the pane session changes", async () => {
+    const firstSessionKey = "agent:main:first-review";
+    const secondSessionKey = "agent:main:second-review";
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    await seedPersistedReviewLayouts(page, [firstSessionKey, secondSessionKey]);
+    const gateway = await installMockGateway(page, {
+      sessionKey: firstSessionKey,
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.list": {
+          count: 2,
+          defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+          path: "",
+          sessions: [
+            { key: firstSessionKey, kind: "direct", updatedAt: 2 },
+            { key: secondSessionKey, kind: "direct", updatedAt: 1 },
+          ],
+          ts: Date.now(),
+        },
+        "sessions.files.list": {
+          cases: [firstSessionKey, secondSessionKey].map((sessionKey) => ({
+            match: { sessionKey },
+            response: {
+              sessionKey,
+              root: "/tmp/checkout",
+              gitCheckout: true,
+              files: [],
+              browser: { path: "", entries: [] },
+            },
+          })),
+        },
+        "sessions.diff": {
+          cases: [
+            {
+              match: { sessionKey: firstSessionKey },
+              response: { ...SESSION_DIFF_RESPONSE, sessionKey: firstSessionKey },
+            },
+            {
+              match: { sessionKey: secondSessionKey },
+              response: {
+                ...SESSION_DIFF_RESPONSE,
+                sessionKey: secondSessionKey,
+                files: [
+                  {
+                    path: "second.md",
+                    status: "added",
+                    additions: 2,
+                    deletions: 0,
+                    untracked: true,
+                    patch: NOTES_PATCH.replaceAll("notes.md", "second.md"),
+                  },
+                ],
+                additions: 2,
+                deletions: 0,
+              },
+            },
+          ],
+        },
+      },
+    });
+    await page.goto(controlUiSessionUrl(server.baseUrl, firstSessionKey));
+    await waitForSessionDiff(page);
+
+    await navigateToControlUiSession(page, secondSessionKey);
+
+    await expect
+      .poll(() => page.locator(".session-diff__filename").allTextContents())
+      .toEqual(["second.md"]);
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.diff")).at(-1)?.params)
+      .toMatchObject({ sessionKey: secondSessionKey });
+  });
+
+  it("opens the session diff from the branch change stats", async () => {
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "sessions.diff",
+        SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+      ],
+      methodResponses: {
+        [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+        "sessions.files.list": {
+          sessionKey: "main",
+          root: "/tmp/checkout",
+          gitCheckout: true,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+        "sessions.diff": SESSION_DIFF_RESPONSE,
+      },
+    });
+    await page.goto(`${server.baseUrl}chat`);
+    let watchedKey = "";
+    await expect
+      .poll(async () => {
+        const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+        const params = requests.at(-1)?.params as { sessionKeys?: unknown } | undefined;
+        const first = Array.isArray(params?.sessionKeys) ? params.sessionKeys[0] : undefined;
+        watchedKey = typeof first === "string" ? first : "";
+        return watchedKey;
+      })
+      .not.toBe("");
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.files.list")).length)
+      .toBe(1);
+    await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+      sessions: {
+        [watchedKey]: {
+          pullRequests: [],
+          branch: {
+            owner: "openclaw",
+            repo: "openclaw",
+            branch: "feature/panel",
+            additions: 142,
+            deletions: 198,
+          },
+          rateLimited: false,
+          status: "ready",
+        },
+      },
+    });
+
+    await page
+      .locator('.chat-pr[data-state="branch"]')
+      .getByRole("button", { name: "Show session changes" })
+      .click();
+
+    await waitForSessionDiff(page);
+  });
+
+  it("keeps Review empty without requesting a diff for a non-git session", async () => {
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.files.list": {
+          sessionKey: "main",
+          root: "/tmp/plain-workspace",
+          gitCheckout: false,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+      },
+    });
+    await page.goto(`${server.baseUrl}chat`);
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.files.list")).length)
+      .toBe(1);
+
+    await openChatSidePanelType(page, "Files");
+    await openChatSidePanelType(page, "Review");
+
+    await expect
+      .poll(() =>
+        page.getByText("Open a change, file, image, or tool result to review it here.").count(),
+      )
+      .toBe(1);
+    expect(await gateway.getRequests("sessions.diff")).toHaveLength(0);
+  });
 
   it("opens the diff sidebar with per-file patches and gap markers", async () => {
     const context = await newBrowserContext();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -56,8 +56,10 @@ import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import { createPageState } from "./chat-state-page.ts";
 import { invalidateChatMetadataCache, refreshPageChat } from "./chat-state-refresh.ts";
 import { resetChatViewState } from "./chat-view-state.ts";
+import { detailSlotOpen } from "./components/chat-detail-slot.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
 import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
+import { resolveSessionDiffSidebarContent } from "./components/chat-session-workspace.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
@@ -645,6 +647,24 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     const board = this.resolveBoardView();
     this.syncRetainedBoardSession(board);
     this.sessionPanelToggles.flush();
+    this.seedSessionDiffSidebar();
+  }
+
+  private seedSessionDiffSidebar(): void {
+    const state = this.state;
+    const detailOpen =
+      state?.sidebarLayout.open === true && detailSlotOpen(state.sidebarLayout) && this.presented;
+    if (!state || !detailOpen || state.sidebarContent !== null) {
+      return;
+    }
+    const content = resolveSessionDiffSidebarContent(state);
+    if (!content) {
+      return;
+    }
+    // The null check is the per-pane/session transition latch. Assign content
+    // only: activating or opening the panel would override user intent.
+    state.sidebarContent = content;
+    state.requestUpdate?.();
   }
 
   override disconnectedCallback() {

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -447,6 +447,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       // A dismissed open PR still exists, so the row must not offer a duplicate.
       pullRequestsRateLimited: this.sessionPullRequestsRateLimited,
       pullRequestsExpanded: this.sessionPullRequestsExpanded,
+      onOpenSessionDiff: sessionWorkspace.onOpenDiff,
       onExpandPullRequests: () => {
         this.sessionPullRequestsExpanded = true;
         this.requestUpdate();

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -254,6 +254,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     pullRequestsBranch?: ControlUiSessionBranch;
     pullRequestsRateLimited?: boolean;
     pullRequestsExpanded?: boolean;
+    onOpenSessionDiff?: () => void;
     onExpandPullRequests?: () => void;
     onDismissPullRequest?: (pullRequest: ControlUiSessionPullRequest) => void;
   };
@@ -525,6 +526,7 @@ export function renderChat(props: ChatProps) {
                     expanded: props.pullRequestsExpanded === true,
                     onExpand: () => props.onExpandPullRequests?.(),
                     onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
+                    onOpenSessionDiff: props.onOpenSessionDiff,
                   })}
                   ${renderChatSessionSuggestions({
                     suggestions: props.sessionSuggestions ?? [],

--- a/ui/src/pages/chat/components/chat-pull-requests.test.ts
+++ b/ui/src/pages/chat/components/chat-pull-requests.test.ts
@@ -273,6 +273,28 @@ describe("renderChatPullRequests", () => {
     expect(row?.querySelector(".chat-pr__warning")).toBeNull();
     // The branch row is not dismissible; it reflects the checkout itself.
     expect(row?.querySelector(".chat-pr__dismiss")).toBeNull();
+    expect(row?.querySelector("button.chat-pr__diff")).toBeNull();
+  });
+
+  it("opens the session diff from interactive branch stats", () => {
+    const onOpenSessionDiff = vi.fn();
+    render(
+      renderChatPullRequests({
+        pullRequests: [],
+        branch: sessionBranch(),
+        rateLimited: false,
+        expanded: false,
+        onExpand: () => {},
+        onDismiss: () => {},
+        onOpenSessionDiff,
+      }),
+      container,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>("button.chat-pr__diff");
+    expect(button?.getAttribute("aria-label")).toBe("Show session changes");
+    button?.click();
+    expect(onOpenSessionDiff).toHaveBeenCalledOnce();
   });
 
   it("hides the Create PR link while the branch has no createUrl", () => {

--- a/ui/src/pages/chat/components/chat-pull-requests.ts
+++ b/ui/src/pages/chat/components/chat-pull-requests.ts
@@ -188,16 +188,32 @@ function visibleChatPullRequests(
   };
 }
 
-function renderDiffStats(item: { additions?: number; deletions?: number }) {
+function renderDiffStats(
+  item: { additions?: number; deletions?: number },
+  onOpenSessionDiff?: () => void,
+) {
   if (typeof item.additions !== "number" && typeof item.deletions !== "number") {
     return nothing;
   }
-  return html`
-    <span class="chat-pr__diff">
-      <span class="chat-pr__additions">+${formatDiffCount(item.additions ?? 0)}</span>
-      <span class="chat-pr__deletions">−${formatDiffCount(item.deletions ?? 0)}</span>
-    </span>
-  `;
+  const additions = html`<span class="chat-pr__additions"
+    >+${formatDiffCount(item.additions ?? 0)}</span
+  >`;
+  const deletions = html`<span class="chat-pr__deletions"
+    >−${formatDiffCount(item.deletions ?? 0)}</span
+  >`;
+  if (onOpenSessionDiff) {
+    return html`
+      <button
+        class="chat-pr__diff"
+        type="button"
+        aria-label=${t("chat.sessionDiff.show")}
+        @click=${onOpenSessionDiff}
+      >
+        ${additions} ${deletions}
+      </button>
+    `;
+  }
+  return html` <span class="chat-pr__diff">${additions} ${deletions}</span> `;
 }
 
 function renderRateLimitWarning() {
@@ -215,7 +231,11 @@ function renderRateLimitWarning() {
 // branch is unpushed the gateway omits createUrl — the row then just reports
 // the session's local changed files. While rate limited, "no PR found" is
 // unreliable, so the warning stays visible here.
-function renderBranchRow(branch: ControlUiSessionBranch, rateLimited: boolean) {
+function renderBranchRow(
+  branch: ControlUiSessionBranch,
+  rateLimited: boolean,
+  onOpenSessionDiff?: () => void,
+) {
   return html`
     <article class="chat-pr" data-state="branch">
       <span class="chat-pr__link chat-pr__link--static">
@@ -224,7 +244,8 @@ function renderBranchRow(branch: ControlUiSessionBranch, rateLimited: boolean) {
         <span class="chat-pr__branch">${branch.branch}</span>
       </span>
       <span class="chat-pr__meta">
-        ${renderDiffStats(branch)} ${rateLimited ? renderRateLimitWarning() : nothing}
+        ${renderDiffStats(branch, onOpenSessionDiff)}
+        ${rateLimited ? renderRateLimitWarning() : nothing}
         ${branch.createUrl
           ? html`
               <a
@@ -250,6 +271,7 @@ export function renderChatPullRequests(props: {
   expanded: boolean;
   onExpand: () => void;
   onDismiss: (pullRequest: ControlUiSessionPullRequest) => void;
+  onOpenSessionDiff?: () => void;
 }) {
   if (props.pullRequests.length === 0 && !props.branch) {
     return nothing;
@@ -257,7 +279,9 @@ export function renderChatPullRequests(props: {
   const { visible, hiddenCount } = visibleChatPullRequests(props.pullRequests, props.expanded);
   return html`
     <div class="chat-prs" aria-live="polite">
-      ${props.branch ? renderBranchRow(props.branch, props.rateLimited) : nothing}
+      ${props.branch
+        ? renderBranchRow(props.branch, props.rateLimited, props.onOpenSessionDiff)
+        : nothing}
       ${visible.map((pullRequest) => {
         const merged = pullRequest.state === "merged";
         return html`

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -690,11 +690,7 @@ export function createSessionWorkspaceProps(
   ) {
     loadWorkspace(state, workspace);
   }
-  const canOpenDiff =
-    isGatewayMethodAdvertised(state, "sessions.diff") === true &&
-    Boolean(state.client) &&
-    workspace.list?.sessionKey === state.sessionKey &&
-    workspace.list.gitCheckout !== false;
+  const diffContent = resolveSessionDiffSidebarContent(state);
   return {
     collapsed: options?.expanded === true ? false : workspace.collapsed,
     sessionKey: state.sessionKey,
@@ -734,10 +730,20 @@ export function createSessionWorkspaceProps(
       }, 160);
     },
     onOpenArtifact: (artifactId) => openArtifact(state, workspace, artifactId),
-    onOpenDiff: canOpenDiff
-      ? () => state.handleOpenSidebar(buildSessionDiffSidebarContent(state))
-      : undefined,
+    onOpenDiff: diffContent ? () => state.handleOpenSidebar(diffContent) : undefined,
   };
+}
+
+export function resolveSessionDiffSidebarContent(
+  state: SessionWorkspaceHost,
+): SidebarContent | null {
+  const workspace = getWorkspaceState(state);
+  const canOpenDiff =
+    isGatewayMethodAdvertised(state, "sessions.diff") === true &&
+    Boolean(state.client) &&
+    workspace.list?.sessionKey === state.sessionKey &&
+    workspace.list.gitCheckout !== false;
+  return canOpenDiff ? buildSessionDiffSidebarContent(state) : null;
 }
 
 /** Sidebar payload whose loader refetches sessions.diff for the pane's session. */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2168,6 +2168,13 @@ button.chat-reply-preview--message:disabled {
   font: 12px/1.4 var(--mono);
 }
 
+button.chat-pr__diff {
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: var(--cursor-action);
+}
+
 .chat-pr__additions {
   color: var(--ok);
 }


### PR DESCRIPTION
## What Problem This Solves

The chat side panel named **Review** could not show the thing it is named after. Opening it — from the `+` panel-type menu, or simply reloading with it persisted open — rendered only the empty state "Open a change, file, image, or tool result to review it here.", even when the session sat on a git checkout with changes. The session diff was reachable only through the pane header's `⋯` → "Show session changes", two levels deep in a menu.

At the same time the branch row above the composer advertises the session's work (`+142 −198`) as a static `chat-pr__link--static` span with no click target. So the UI showed a change summary that looks like an affordance, next to a panel whose whole purpose is reviewing changes, and no path between them. Operators reasonably read that as "my changes are missing".

The panel has been a passive viewer since it was introduced (#104184): content only ever arrived when something pushed a `SidebarContent` into it. That was coherent while the slot could not be opened directly. #123874 unified the chat rails into a tabbed panel and gave the slot a front door, but carried the passive model across unchanged — so the panel gained a way to be opened empty and kept a policy that assumed it could not be.

## Why This Change Was Made

Severity order in this repo puts silent no-outcome above everything else, and "never dead-end" is explicit: opening Review is an action, and it ended with no visible outcome and no recorded reason. The name is a promise the panel did not keep.

The fix states the invariant once — *Review open + no content + session has a usable git checkout → show that session's diff* — and implements it at the owner boundary rather than in the view. `canOpenDiff` and the `sessions.diff` loader are lifted into a single `resolveSessionDiffSidebarContent` used by both the header action and the new seeding, so eligibility policy is not duplicated. Seeding lives in the pane's `updated()` lifecycle, which covers all three ways to arrive at an empty Review panel (menu open, persisted-open reload, session switch) with one mechanism instead of three special cases.

Deliberate boundaries: the seed assigns content only — it never opens or activates the panel, so it cannot override where the operator is looking; and it never replaces content the operator opened explicitly (file, tool result, image, task). Sessions without a git checkout keep today's empty state and issue no `sessions.diff` request.

## User Impact

Opening Review on a session with a checkout now shows that session's changes immediately, with no menu hunting. The `+142 −198` branch chip becomes a real button into the same panel, keeping its "Create PR" link and rate-limit warning behavior unchanged. Non-git sessions are unaffected. No config, protocol, or gateway change; nothing to migrate.

## Evidence

**Before / after** — identical Playwright capture against the mocked Control UI dev server, run at the pre-fix commit (`6a0c9f43d2c`) and at this branch. Same script, same scenario, only the commit differs. Fixture data is the mock harness's own.

| Before | After |
| --- | --- |
| <img width="360" alt="Review panel empty state" src="https://github.com/user-attachments/assets/925f960b-dbd9-4fd0-8525-d612d4a8927a" /> | <img width="360" alt="Review panel showing the session diff" src="https://github.com/user-attachments/assets/e257219c-1bcd-4d19-a51c-b588c4eb6779" /> |

Machine-readable result from the same run: before `{"diffPanels":0,"emptyStates":1}`, after `{"diffPanels":1,"emptyStates":0}`.

**Tests** — `ui/src/e2e/chat-session-diff.e2e.test.ts` grew four cases covering the arrival paths and the negative case, and one for the branch chip:

- Review added from the panel menu loads the diff
- persisted empty Review panel loads the diff on page load, no user action
- switching the pane's session replaces the seeded diff (asserts the last `sessions.diff` request carries the new session key)
- clicking the branch change stats opens the diff
- a non-git session keeps the empty state and issues no `sessions.diff` request

```
pnpm test ui/src/e2e/chat-session-diff.e2e.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
   Duration  23.28s
```

```
pnpm test ui/src/pages/chat/components/chat-pull-requests.test.ts ui/src/pages/chat/components/chat-sidebar-region.test.ts
 Test Files  2 passed (2)
      Tests  32 passed (32)
```

`pnpm check:changed` green (typecheck UI + lint core/UI lanes). Fresh Codex `$autoreview --mode branch` clean: no accepted/actionable findings.

**reviewMetrics — production vs test LOC**: production `+78 / −18` (net **+60**), tests `+317 / −1`. This is a capability/default fix rather than a bug patch absorbed by an owner, so the growth is the seeding lifecycle hook, the extracted eligibility resolver, the accessible branch button, and handler threading. The extraction is net-neutral by itself; no guard or branch was bolted onto an existing path.

No `CHANGELOG.md` edit — release-only per repo policy; this section carries the release-note context.
