### PR TITLE
refactor(ui): derive cron types from gateway protocol

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -867,7 +867,6 @@ src/wizard/setup.finalize.ts
 src/wizard/setup.test.ts
 src/worker/worker.runtime.test.ts
 ui/src/api/gateway.node.test.ts
-ui/src/api/types.ts
 ui/src/lib/cron/index.test.ts
 ui/src/lib/cron/index.ts
 ui/src/lib/nodes/index.ts

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -20,12 +20,18 @@ const CronDateTimestampMsSchema = Type.Integer({
  */
 
 /** Builds create/patch payload variants while preserving per-call field optionality. */
-function cronAgentTurnPayloadSchema(params: {
-  message: TSchema;
-  model: TSchema;
-  fallbacks: TSchema;
-  toolsAllow: TSchema;
-  thinking: TSchema;
+function cronAgentTurnPayloadSchema<
+  TMessage extends TSchema,
+  TModel extends TSchema,
+  TFallbacks extends TSchema,
+  TToolsAllow extends TSchema,
+  TThinking extends TSchema,
+>(params: {
+  message: TMessage;
+  model: TModel;
+  fallbacks: TFallbacks;
+  toolsAllow: TToolsAllow;
+  thinking: TThinking;
 }) {
   return closedObject({
     kind: Type.Literal("agentTurn"),
@@ -44,7 +50,10 @@ function cronAgentTurnPayloadSchema(params: {
 }
 
 /** Builds command payload variants while preserving create/patch argv optionality. */
-function cronCommandPayloadSchema(params: { argv: TSchema; toolsAllow: TSchema }) {
+function cronCommandPayloadSchema<TArgv extends TSchema, TToolsAllow extends TSchema>(params: {
+  argv: TArgv;
+  toolsAllow: TToolsAllow;
+}) {
   return closedObject({
     kind: Type.Literal("command"),
     argv: params.argv,
@@ -59,7 +68,10 @@ function cronCommandPayloadSchema(params: { argv: TSchema; toolsAllow: TSchema }
   });
 }
 
-function cronScriptPayloadSchema(params: { script: TSchema; toolsAllow: TSchema }) {
+function cronScriptPayloadSchema<TScript extends TSchema, TToolsAllow extends TSchema>(params: {
+  script: TScript;
+  toolsAllow: TToolsAllow;
+}) {
   return closedObject({
     kind: Type.Literal("script"),
     script: params.script,
@@ -75,7 +87,7 @@ const CronSessionTargetSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("isolated"),
   Type.Literal("current"),
-  Type.String({ pattern: "^session:.+" }),
+  Type.TemplateLiteral("session:${string}", { pattern: "^session:.+" }),
 ]);
 /** Whether a cron job waits for heartbeat processing or wakes immediately. */
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
@@ -263,29 +275,34 @@ export const CronPacingSchema = Type.Object(
   },
 );
 
+const CronSystemEventPayloadSchema = closedObject({
+  kind: Type.Literal("systemEvent"),
+  text: NonEmptyString,
+  toolsAllow: Type.Optional(Type.Array(Type.String())),
+  toolsAllowIsDefault: Type.Optional(Type.Boolean()),
+});
+const CronAgentTurnPayloadSchema = cronAgentTurnPayloadSchema({
+  message: NonEmptyString,
+  model: Type.String(),
+  fallbacks: Type.Array(Type.String()),
+  toolsAllow: Type.Array(Type.String()),
+  thinking: Type.String(),
+});
+const CronCommandPayloadSchema = cronCommandPayloadSchema({
+  argv: Type.Array(NonEmptyString, { minItems: 1 }),
+  toolsAllow: Type.Array(Type.String()),
+});
+const CronScriptPayloadSchema = cronScriptPayloadSchema({
+  script: Type.String({ minLength: 1, maxLength: 65_536 }),
+  toolsAllow: Type.Array(Type.String()),
+});
+
 /** Full cron payload for new jobs. */
 const CronPayloadSchema = Type.Union([
-  closedObject({
-    kind: Type.Literal("systemEvent"),
-    text: NonEmptyString,
-    toolsAllow: Type.Optional(Type.Array(Type.String())),
-    toolsAllowIsDefault: Type.Optional(Type.Boolean()),
-  }),
-  cronAgentTurnPayloadSchema({
-    message: NonEmptyString,
-    model: Type.String(),
-    fallbacks: Type.Array(Type.String()),
-    toolsAllow: Type.Array(Type.String()),
-    thinking: Type.String(),
-  }),
-  cronCommandPayloadSchema({
-    argv: Type.Array(NonEmptyString, { minItems: 1 }),
-    toolsAllow: Type.Array(Type.String()),
-  }),
-  cronScriptPayloadSchema({
-    script: Type.String({ minLength: 1, maxLength: 65_536 }),
-    toolsAllow: Type.Array(Type.String()),
-  }),
+  CronSystemEventPayloadSchema,
+  CronAgentTurnPayloadSchema,
+  CronCommandPayloadSchema,
+  CronScriptPayloadSchema,
 ]);
 
 /**
@@ -293,7 +310,10 @@ const CronPayloadSchema = Type.Union([
  * gateway-converged only, so create/patch schemas intentionally omit it.
  */
 const CronReportedPayloadSchema = Type.Union([
-  ...CronPayloadSchema.anyOf,
+  CronSystemEventPayloadSchema,
+  CronAgentTurnPayloadSchema,
+  CronCommandPayloadSchema,
+  CronScriptPayloadSchema,
   closedObject({ kind: Type.Literal("heartbeat") }),
 ]);
 

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -87,7 +87,7 @@ const CronSessionTargetSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("isolated"),
   Type.Literal("current"),
-  Type.TemplateLiteral("session:${string}", { pattern: "^session:.+" }),
+  Type.String({ pattern: "^session:.+" }),
 ]);
 /** Whether a cron job waits for heartbeat processing or wakes immediately. */
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,4 +1,10 @@
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
+import type {
+  CronJob as ProtocolCronJob,
+  CronListParams,
+  CronRunLogEntry as ProtocolCronRunLogEntry,
+  CronRunsParams,
+} from "../../../packages/gateway-protocol/src/index.js";
 import type { AgentsListResult as ProtocolAgentsListResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import type { ChannelsStatusResult } from "../../../packages/gateway-protocol/src/schema/channels.js";
 import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
@@ -7,8 +13,6 @@ import type { SessionObserverDigest } from "../../../packages/gateway-protocol/s
 import type { PresenceEntry as ProtocolPresenceEntry } from "../../../packages/gateway-protocol/src/schema/snapshot.js";
 import type { SessionAgentStatus } from "../../../packages/gateway-protocol/src/session-agent-status.js";
 import type { SessionGoal } from "../../../src/config/sessions/types.js";
-import type { CronJobBase } from "../../../src/cron/types-shared.js";
-import type { CronPayload as CoreCronPayload } from "../../../src/cron/types.js";
 import type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 import type { FastModeSource } from "../../../src/shared/fast-mode.js";
 import type {
@@ -18,6 +22,8 @@ import type {
   SessionsPatchResultBase,
 } from "../../../src/shared/session-types.js";
 export type {
+  CronJob,
+  CronRunLogEntry,
   UpdateAvailable,
   UpdateHoldResult,
   UpdateScheduleState,
@@ -544,110 +550,15 @@ export type {
   SessionUsageTimeSeries,
 } from "../pages/usage/data-types.ts";
 
-export type CronRunStatus = "ok" | "error" | "skipped";
-export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
-export type CronJobsEnabledFilter = "all" | "enabled" | "disabled";
-export type CronJobsSortBy = "nextRunAtMs" | "updatedAtMs" | "name";
-export type CronRunScope = "job" | "all";
-export type CronRunsStatusValue = CronRunStatus;
-export type CronRunsStatusFilter = "all" | CronRunStatus;
-export type CronSortDir = "asc" | "desc";
-
-type CronSchedule =
-  | { kind: "at"; at: string }
-  | { kind: "every"; everyMs: number; anchorMs?: number }
-  | { kind: "cron"; expr: string; tz?: string; staggerMs?: number }
-  | { kind: "on-exit"; command: string; cwd?: string }
-  | {
-      kind: "stream";
-      command: string[];
-      cwd?: string;
-      mode?: "line" | "match";
-      match?: string;
-      batchMs?: number;
-      maxBatchBytes?: number;
-    };
-
-type CronSessionTarget = "main" | "isolated" | "current" | `session:${string}`;
-type CronWakeMode = "next-heartbeat" | "now";
-
-export type CronPayload = CoreCronPayload;
-
-type CronCompletionDestination = {
-  mode: "webhook";
-  to: string;
-};
-
-type CronDelivery = {
-  mode: "none" | "announce" | "webhook";
-  channel?: string;
-  to?: string;
-  threadId?: string | number;
-  accountId?: string;
-  bestEffort?: boolean;
-  completionDestination?: CronCompletionDestination;
-  failureDestination?: CronFailureDestination;
-};
-
-type CronFailureDestination = {
-  channel?: string;
-  to?: string;
-  mode?: "announce" | "webhook";
-  accountId?: string;
-};
-
-type CronFailureAlert = {
-  after?: number;
-  channel?: string;
-  to?: string;
-  cooldownMs?: number;
-  mode?: "announce" | "webhook";
-  accountId?: string;
-};
-
-type CronJobState = {
-  nextRunAtMs?: number;
-  runningAtMs?: number;
-  lastRunAtMs?: number;
-  lastRunStatus?: CronRunStatus;
-  lastStatus?: CronRunStatus;
-  lastError?: string;
-  lastErrorReason?: string;
-  lastDurationMs?: number;
-  consecutiveErrors?: number;
-  autoDisabled?: {
-    reason: "consecutive-failures" | "schedule-errors";
-    atMs: number;
-    consecutiveErrors: number;
-  };
-  lastDelivered?: boolean;
-  lastDeliveryStatus?: CronDeliveryStatus;
-  lastDeliveryError?: string;
-  lastFailureNotificationDelivered?: boolean;
-  lastFailureNotificationDeliveryStatus?: CronDeliveryStatus;
-  lastFailureNotificationDeliveryError?: string;
-  lastFailureAlertAtMs?: number;
-  streamStatus?: "starting" | "running" | "restarting" | "stopped" | "disabled" | "error";
-  streamError?: string;
-  streamConsecutiveFailures?: number;
-  streamRestartExhausted?: boolean;
-  streamSourceIdentity?: string;
-  streamDroppedBatches?: number;
-  streamCoalescedBatches?: number;
-  streamLastStartedAtMs?: number;
-  streamLastExitAtMs?: number;
-};
-
-export type CronJob = CronJobBase<
-  CronSchedule,
-  CronSessionTarget,
-  CronWakeMode,
-  CronPayload,
-  CronDelivery,
-  CronFailureAlert | false
-> & {
-  state?: CronJobState;
-};
+export type CronRunStatus = NonNullable<ProtocolCronRunLogEntry["status"]>;
+export type CronDeliveryStatus = NonNullable<ProtocolCronRunLogEntry["deliveryStatus"]>;
+export type CronJobsEnabledFilter = NonNullable<CronListParams["enabled"]>;
+export type CronJobsSortBy = NonNullable<CronListParams["sortBy"]>;
+export type CronRunScope = NonNullable<CronRunsParams["scope"]>;
+export type CronRunsStatusValue = NonNullable<CronRunsParams["statuses"]>[number];
+export type CronRunsStatusFilter = NonNullable<CronRunsParams["status"]>;
+export type CronSortDir = NonNullable<CronListParams["sortDir"]>;
+export type CronPayload = ProtocolCronJob["payload"];
 
 export type CronStatus = {
   enabled: boolean;
@@ -670,35 +581,8 @@ export type CronRunResult =
     }
   | { ok: false };
 
-export type CronRunLogEntry = {
-  ts: number;
-  jobId: string;
-  action?: "finished";
-  status?: CronRunStatus;
-  durationMs?: number;
-  error?: string;
-  summary?: string;
-  delivered?: boolean;
-  deliveryStatus?: CronDeliveryStatus;
-  deliveryError?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  runAtMs?: number;
-  nextRunAtMs?: number;
-  model?: string;
-  provider?: string;
-  usage?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    total_tokens?: number;
-    cache_read_tokens?: number;
-    cache_write_tokens?: number;
-  };
-  jobName?: string;
-};
-
 export type CronJobsListResult = {
-  jobs: CronJob[];
+  jobs: ProtocolCronJob[];
   snapshotRevision: string;
   total: number;
   limit: number;
@@ -708,7 +592,7 @@ export type CronJobsListResult = {
 };
 
 export type CronRunsResult = {
-  entries: CronRunLogEntry[];
+  entries: ProtocolCronRunLogEntry[];
   total?: number;
   limit?: number;
   offset?: number;
@@ -860,4 +744,3 @@ export type SystemAgentSetupVerifyResult =
 export type WizardNextResult =
   import("../../../packages/gateway-protocol/src/schema.js").WizardNextResult;
 export type WizardStep = import("../../../packages/gateway-protocol/src/schema.js").WizardStep;
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1522,6 +1522,7 @@ describe("cron controller", () => {
               sessionTarget: "main",
               wakeMode: "next-heartbeat",
               payload: { kind: "systemEvent", text: "ping" },
+              state: {},
             },
           ],
           { snapshotRevision: "daily-jobs" },
@@ -1798,14 +1799,14 @@ describe("cron controller", () => {
       const offset = (payload as { offset?: number } | undefined)?.offset ?? 0;
       if (offset === 0) {
         return {
-          entries: [{ ts: 2, jobId: "job-1", status: "ok", summary: "newest" }],
+          entries: [{ ts: 2, jobId: "job-1", action: "finished", status: "ok", summary: "newest" }],
           total: 2,
           hasMore: true,
           nextOffset: 1,
         };
       }
       return {
-        entries: [{ ts: 1, jobId: "job-1", status: "ok", summary: "older" }],
+        entries: [{ ts: 1, jobId: "job-1", action: "finished", status: "ok", summary: "older" }],
         total: 2,
         hasMore: false,
         nextOffset: null,
@@ -1824,7 +1825,13 @@ describe("cron controller", () => {
   });
 
   it("keeps the newest filtered run history when an older overview request finishes last", async () => {
-    const currentEntry = { ts: 2, jobId: "fresh-job", status: "ok" as const, summary: "fresh" };
+    const currentEntry = {
+      ts: 2,
+      jobId: "fresh-job",
+      action: "finished" as const,
+      status: "ok" as const,
+      summary: "fresh",
+    };
     const { older: olderOverview, state } = createCronRunsRace([currentEntry]);
 
     const olderLoad = loadCronRuns(state, null);
@@ -1833,11 +1840,14 @@ describe("cron controller", () => {
     expect(state.cronRuns).toEqual([currentEntry]);
 
     olderOverview.resolve(
-      createCronRunsResult([{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale" }], {
-        total: 8,
-        hasMore: true,
-        nextOffset: 1,
-      }),
+      createCronRunsResult(
+        [{ ts: 1, jobId: "stale-job", action: "finished", status: "ok", summary: "stale" }],
+        {
+          total: 8,
+          hasMore: true,
+          nextOffset: 1,
+        },
+      ),
     );
 
     await expect(olderLoad).resolves.toBe("skipped");
@@ -1851,6 +1861,7 @@ describe("cron controller", () => {
     const selectedEntry = {
       ts: 2,
       jobId: "selected-job",
+      action: "finished" as const,
       status: "ok" as const,
       summary: "selected history",
     };
@@ -1862,7 +1873,15 @@ describe("cron controller", () => {
     await expect(loadCronRuns(state, "selected-job")).resolves.toBe("ok");
 
     olderOverview.resolve(
-      createCronRunsResult([{ ts: 1, jobId: "other-job", status: "ok", summary: "wrong task" }]),
+      createCronRunsResult([
+        {
+          ts: 1,
+          jobId: "other-job",
+          action: "finished",
+          status: "ok",
+          summary: "wrong task",
+        },
+      ]),
     );
 
     await expect(olderLoad).resolves.toBe("skipped");
@@ -1874,6 +1893,7 @@ describe("cron controller", () => {
     const overviewEntry = {
       ts: 2,
       jobId: "overview-job",
+      action: "finished" as const,
       status: "ok" as const,
       summary: "current overview",
     };
@@ -1888,7 +1908,15 @@ describe("cron controller", () => {
     await expect(loadCronRuns(state, null)).resolves.toBe("ok");
 
     olderJobHistory.resolve(
-      createCronRunsResult([{ ts: 1, jobId: "selected-job", status: "ok", summary: "stale task" }]),
+      createCronRunsResult([
+        {
+          ts: 1,
+          jobId: "selected-job",
+          action: "finished",
+          status: "ok",
+          summary: "stale task",
+        },
+      ]),
     );
 
     await expect(olderLoad).resolves.toBe("skipped");
@@ -1900,11 +1928,20 @@ describe("cron controller", () => {
     const currentEntry = {
       ts: 3,
       jobId: "filtered-job",
+      action: "finished" as const,
       status: "error" as const,
       summary: "filtered result",
     };
     const { older: olderPage, state } = createCronRunsRace([currentEntry], {
-      cronRuns: [{ ts: 2, jobId: "previous-job", status: "ok", summary: "previous" }],
+      cronRuns: [
+        {
+          ts: 2,
+          jobId: "previous-job",
+          action: "finished",
+          status: "ok",
+          summary: "previous",
+        },
+      ],
       cronRunsHasMore: true,
       cronRunsNextOffset: 1,
     });
@@ -1917,7 +1954,15 @@ describe("cron controller", () => {
 
     olderPage.resolve(
       createCronRunsResult(
-        [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale older page" }],
+        [
+          {
+            ts: 1,
+            jobId: "stale-job",
+            action: "finished",
+            status: "ok",
+            summary: "stale older page",
+          },
+        ],
         { total: 9, hasMore: true, nextOffset: 2 },
       ),
     );
@@ -1930,7 +1975,13 @@ describe("cron controller", () => {
   });
 
   it("ignores a stale run-history failure after the current request succeeds", async () => {
-    const currentEntry = { ts: 2, jobId: "fresh-job", status: "ok" as const, summary: "fresh" };
+    const currentEntry = {
+      ts: 2,
+      jobId: "fresh-job",
+      action: "finished" as const,
+      status: "ok" as const,
+      summary: "fresh",
+    };
     const { older: olderFailure, state } = createCronRunsRace([currentEntry]);
 
     const olderLoad = loadCronRuns(state, null);
@@ -1955,7 +2006,7 @@ describe("cron controller", () => {
     expect(state.cronError).toBe("current cron history unavailable");
 
     olderOverview.resolve({
-      entries: [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale" }],
+      entries: [{ ts: 1, jobId: "stale-job", action: "finished", status: "ok", summary: "stale" }],
       total: 1,
       hasMore: false,
       nextOffset: null,

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -105,6 +105,15 @@ function isCronPayload(value: unknown): value is CronPayload {
   return false;
 }
 
+function isCronFormSessionTarget(value: string): value is CronFormState["sessionTarget"] {
+  return (
+    value === "main" ||
+    value === "isolated" ||
+    value === "current" ||
+    (value.startsWith("session:") && value.length > "session:".length)
+  );
+}
+
 export function getCronJobPayload(job: CronJob): CronPayload | null {
   const payload = (job as { payload?: unknown }).payload;
   return isCronPayload(payload) ? payload : null;
@@ -844,6 +853,9 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
   const failureAlert = job.failureAlert;
   const payload = getCronJobPayload(job);
   const payloadLocked = isReadOnlyCronPayload(payload);
+  if (!isCronFormSessionTarget(job.sessionTarget)) {
+    throw new TypeError(`Invalid cron session target: ${job.sessionTarget}`);
+  }
   const next: CronFormState = {
     ...prev,
     name: job.name,

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -34,6 +34,7 @@ export { loadCronFailingCount, loadCronScopeStats } from "./scope.ts";
 
 const CRON_CHANNEL_LAST = "last";
 type CronDelivery = NonNullable<CronJob["delivery"]>;
+type CronFormAnnounceDelivery = Extract<CronDelivery, { mode: "announce" }>;
 
 export type CronFormState = {
   name: string;
@@ -70,7 +71,7 @@ export type CronFormState = {
   deliveryAccountId: string;
   deliveryBestEffort: boolean;
   deliveryThreadId: CronDelivery["threadId"] | undefined;
-  deliveryCompletionDestination: CronDelivery["completionDestination"] | undefined;
+  deliveryCompletionDestination: CronFormAnnounceDelivery["completionDestination"] | undefined;
   deliveryFailureDestination: CronDelivery["failureDestination"] | undefined;
   failureAlertMode: "inherit" | "disabled" | "custom";
   failureAlertAfter: string;

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -408,6 +408,7 @@ describe("CronPage editor state sync", () => {
       sessionTarget: "isolated",
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "digest" },
+      state: {},
     };
     let serverEnabled = true;
     let removed = false;
@@ -485,6 +486,7 @@ describe("CronPage editor state sync", () => {
       sessionTarget: "isolated",
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "digest" },
+      state: {},
     };
     const request = vi.fn(async (method: string) => {
       if (method === "cron.list") {

--- a/ui/src/pages/cron/view-run-history.test.ts
+++ b/ui/src/pages/cron/view-run-history.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderCronView as renderView } from "./view.test-support.ts";
+
+function getElement<T extends Element>(
+  container: Element,
+  selector: string,
+  constructor: new () => T,
+): T {
+  const element = container.querySelector<T>(selector);
+  expect(element).toBeInstanceOf(constructor);
+  if (!(element instanceof constructor)) {
+    throw new Error(`Expected ${selector} to match ${constructor.name}`);
+  }
+  return element;
+}
+
+describe("cron view run history", () => {
+  it("renders runs sorted newest first and wires run filters", () => {
+    const onRunsFiltersChange = vi.fn();
+    const container = renderView({
+      listTab: "activity",
+      onRunsFiltersChange,
+      runs: [
+        { ts: 1_000, jobId: "job-1", action: "finished", status: "ok", summary: "older run" },
+        { ts: 2_000, jobId: "job-2", action: "finished", status: "ok", summary: "newer run" },
+      ],
+      status: { enabled: true, jobs: 2 },
+    });
+
+    const titles = Array.from(container.querySelectorAll(".cron-run-entry__title")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(titles[0]).toContain("job-2");
+    expect(titles[1]).toContain("job-1");
+
+    const search = getElement(container, ".cron-run-filter-search input", HTMLInputElement);
+    search.value = "fail";
+    search.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsQuery: "fail" });
+
+    const statusOption = container.querySelector<HTMLElement & { checked: boolean }>(
+      '[data-filter="status"] wa-dropdown-item[value="option:error"]',
+    );
+    expect(statusOption).not.toBeNull();
+    statusOption
+      ?.closest("wa-dropdown")
+      ?.dispatchEvent(
+        new CustomEvent("wa-select", { detail: { item: statusOption }, bubbles: true }),
+      );
+    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: ["error"] });
+
+    const clearCommand = container.querySelector<HTMLElement>(
+      '[data-filter="status"] wa-dropdown-item[value="command:clear"]',
+    );
+    clearCommand
+      ?.closest("wa-dropdown")
+      ?.dispatchEvent(
+        new CustomEvent("wa-select", { detail: { item: clearCommand }, bubbles: true }),
+      );
+    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: [] });
+  });
+
+  it("formats run token counts and durations in the rendered entry", () => {
+    const container = renderView({
+      listTab: "activity",
+      runs: [
+        {
+          ts: 4,
+          jobId: "job-total",
+          action: "finished",
+          status: "ok",
+          summary: "total usage",
+          durationMs: 90_000,
+          usage: { total_tokens: 1_234_567 },
+        },
+        {
+          ts: 3,
+          jobId: "job-split",
+          action: "finished",
+          status: "ok",
+          summary: "split usage",
+          durationMs: 500,
+          usage: { input_tokens: 50_000, output_tokens: 999 },
+        },
+        {
+          ts: 2,
+          jobId: "job-zero",
+          action: "finished",
+          status: "ok",
+          summary: "zero duration",
+          durationMs: 0,
+        },
+        {
+          ts: 1.5,
+          jobId: "job-invalid",
+          action: "finished",
+          status: "ok",
+          summary: "invalid duration",
+          durationMs: -1,
+        },
+        {
+          ts: 1,
+          jobId: "job-unknown",
+          action: "finished",
+          status: "ok",
+          summary: "unknown duration",
+        },
+      ],
+    });
+    const entries = Array.from(container.querySelectorAll(".cron-run-entry"));
+    const entryFor = (jobId: string) => {
+      const entry = entries.find((candidate) =>
+        candidate.querySelector(".cron-run-entry__title")?.textContent?.includes(jobId),
+      );
+      expect(entry).toBeInstanceOf(HTMLDivElement);
+      return entry;
+    };
+
+    const total = entryFor("job-total");
+    expect(total?.querySelector(".cron-run-entry__facts")?.textContent).toContain("1.2M Tokens");
+    expect(total?.querySelector(".cron-run-entry__meta")?.textContent).toContain("1m 30s");
+    expect(total?.textContent).not.toContain("1234567");
+    expect(total?.textContent).not.toContain("90000ms");
+
+    const split = entryFor("job-split");
+    expect(split?.querySelector(".cron-run-entry__facts")?.textContent).toContain(
+      "50k in / 999 out",
+    );
+    expect(split?.querySelector(".cron-run-entry__meta")?.textContent).toContain("500ms");
+    expect(entryFor("job-zero")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "0ms",
+    );
+    expect(entryFor("job-invalid")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "n/a",
+    );
+    expect(entryFor("job-unknown")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "n/a",
+    );
+  });
+
+  it("renders run summaries as sanitized markdown", () => {
+    const container = renderView({
+      listTab: "activity",
+      runs: [
+        {
+          ts: 1,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          summary: "**bold** <script>alert(1)</script>",
+        },
+      ],
+    });
+    const body = getElement(container, ".cron-run-entry__body", HTMLDivElement);
+    expect(body.querySelector("strong")?.textContent).toBe("bold");
+    expect(body.querySelector("script")).toBeNull();
+  });
+
+  it("shows run errors as the body when no summary exists", () => {
+    const container = renderView({
+      listTab: "activity",
+      runs: [{ ts: 1, jobId: "job-1", action: "finished", status: "error", error: "boom" }],
+    });
+    const body = getElement(container, ".cron-run-entry__body", HTMLDivElement);
+    expect(body.textContent).toContain("boom");
+  });
+
+  it("distinguishes an unfiltered empty state from filtered no-matches", () => {
+    const empty = renderView({ listTab: "activity" });
+    expect(empty.querySelector(".cron-empty-state")?.textContent).toContain("No runs yet");
+
+    const filtered = renderView({ listTab: "activity", runsQuery: "fail" });
+    expect(filtered.querySelector(".cron-runs__empty")?.textContent).toContain("No matching runs.");
+  });
+});

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -320,155 +320,6 @@ describe("cron view list pane", () => {
   });
 });
 
-describe("cron view run history", () => {
-  it("renders runs sorted newest first and wires run filters", () => {
-    const onRunsFiltersChange = vi.fn();
-    const container = renderView({
-      listTab: "activity",
-      onRunsFiltersChange,
-      runs: [
-        { ts: 1_000, jobId: "job-1", status: "ok", summary: "older run" },
-        { ts: 2_000, jobId: "job-2", status: "ok", summary: "newer run" },
-      ],
-      status: { enabled: true, jobs: 2 },
-    });
-
-    const titles = Array.from(container.querySelectorAll(".cron-run-entry__title")).map((el) =>
-      el.textContent?.trim(),
-    );
-    expect(titles[0]).toContain("job-2");
-    expect(titles[1]).toContain("job-1");
-
-    const search = getElement(container, ".cron-run-filter-search input", HTMLInputElement);
-    search.value = "fail";
-    search.dispatchEvent(new Event("input", { bubbles: true }));
-    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsQuery: "fail" });
-
-    const statusOption = container.querySelector<HTMLElement & { checked: boolean }>(
-      '[data-filter="status"] wa-dropdown-item[value="option:error"]',
-    );
-    expect(statusOption).not.toBeNull();
-    statusOption
-      ?.closest("wa-dropdown")
-      ?.dispatchEvent(
-        new CustomEvent("wa-select", { detail: { item: statusOption }, bubbles: true }),
-      );
-    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: ["error"] });
-
-    const clearCommand = container.querySelector<HTMLElement>(
-      '[data-filter="status"] wa-dropdown-item[value="command:clear"]',
-    );
-    clearCommand
-      ?.closest("wa-dropdown")
-      ?.dispatchEvent(
-        new CustomEvent("wa-select", { detail: { item: clearCommand }, bubbles: true }),
-      );
-    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: [] });
-  });
-
-  it("formats run token counts and durations in the rendered entry", () => {
-    const container = renderView({
-      listTab: "activity",
-      runs: [
-        {
-          ts: 4,
-          jobId: "job-total",
-          status: "ok",
-          summary: "total usage",
-          durationMs: 90_000,
-          usage: { total_tokens: 1_234_567 },
-        },
-        {
-          ts: 3,
-          jobId: "job-split",
-          status: "ok",
-          summary: "split usage",
-          durationMs: 500,
-          usage: { input_tokens: 50_000, output_tokens: 999 },
-        },
-        {
-          ts: 2,
-          jobId: "job-zero",
-          status: "ok",
-          summary: "zero duration",
-          durationMs: 0,
-        },
-        {
-          ts: 1.5,
-          jobId: "job-invalid",
-          status: "ok",
-          summary: "invalid duration",
-          durationMs: -1,
-        },
-        { ts: 1, jobId: "job-unknown", status: "ok", summary: "unknown duration" },
-      ],
-    });
-    const entries = Array.from(container.querySelectorAll(".cron-run-entry"));
-    const entryFor = (jobId: string) => {
-      const entry = entries.find((candidate) =>
-        candidate.querySelector(".cron-run-entry__title")?.textContent?.includes(jobId),
-      );
-      expect(entry).toBeInstanceOf(HTMLDivElement);
-      return entry;
-    };
-
-    const total = entryFor("job-total");
-    expect(total?.querySelector(".cron-run-entry__facts")?.textContent).toContain("1.2M Tokens");
-    expect(total?.querySelector(".cron-run-entry__meta")?.textContent).toContain("1m 30s");
-    expect(total?.textContent).not.toContain("1234567");
-    expect(total?.textContent).not.toContain("90000ms");
-
-    const split = entryFor("job-split");
-    expect(split?.querySelector(".cron-run-entry__facts")?.textContent).toContain(
-      "50k in / 999 out",
-    );
-    expect(split?.querySelector(".cron-run-entry__meta")?.textContent).toContain("500ms");
-    expect(entryFor("job-zero")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
-      "0ms",
-    );
-    expect(entryFor("job-invalid")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
-      "n/a",
-    );
-    expect(entryFor("job-unknown")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
-      "n/a",
-    );
-  });
-
-  it("renders run summaries as sanitized markdown", () => {
-    const container = renderView({
-      listTab: "activity",
-      runs: [
-        {
-          ts: 1,
-          jobId: "job-1",
-          status: "ok",
-          summary: "**bold** <script>alert(1)</script>",
-        },
-      ],
-    });
-    const body = getElement(container, ".cron-run-entry__body", HTMLDivElement);
-    expect(body.querySelector("strong")?.textContent).toBe("bold");
-    expect(body.querySelector("script")).toBeNull();
-  });
-
-  it("shows run errors as the body when no summary exists", () => {
-    const container = renderView({
-      listTab: "activity",
-      runs: [{ ts: 1, jobId: "job-1", status: "error", error: "boom" }],
-    });
-    const body = getElement(container, ".cron-run-entry__body", HTMLDivElement);
-    expect(body.textContent).toContain("boom");
-  });
-
-  it("distinguishes an unfiltered empty state from filtered no-matches", () => {
-    const empty = renderView({ listTab: "activity" });
-    expect(empty.querySelector(".cron-empty-state")?.textContent).toContain("No runs yet");
-
-    const filtered = renderView({ listTab: "activity", runsQuery: "fail" });
-    expect(filtered.querySelector(".cron-runs__empty")?.textContent).toContain("No matching runs.");
-  });
-});
-
 describe("cron view editor", () => {
   it("does not expose a tab panel when the selected job is unavailable", () => {
     const container = renderView({ editingJobId: "missing-job" });
@@ -1018,7 +869,16 @@ describe("cron view editor", () => {
       jobs: [job],
       editingJobId: "job-1",
       detailTab: "history",
-      runs: [{ ts: 5, jobId: "job-1", jobName: "Nightly digest", status: "ok", summary: "ran" }],
+      runs: [
+        {
+          ts: 5,
+          jobId: "job-1",
+          action: "finished",
+          jobName: "Nightly digest",
+          status: "ok",
+          summary: "ran",
+        },
+      ],
     });
     expect(container.querySelector(".cron-run-entry")).not.toBeNull();
     expect(container.querySelector(".cron-editor")).toBeNull();


### PR DESCRIPTION
## What Problem This Solves

The Control UI maintained a hand-copied cron wire model for schedules, targets, delivery, job state, jobs, and run-history entries. That copy had drifted from the Gateway protocol: job state was optional and incomplete, and run-history entries omitted newer canonical diagnostics, delivery, failure, run-id, and trigger fields. UI code therefore could not type against fields the Gateway already returns.

## Why This Change Was Made

The Control UI now re-exports `CronJob` and `CronRunLogEntry` from `@openclaw/gateway-protocol` and derives its cron filter/status aliases from protocol request types. The protocol payload helpers preserve their concrete TypeBox schema types instead of widening reported payload fields to `unknown`; runtime-only persistence fields remain owned by `src/cron/types.ts` and stay outside the wire model.

The editable `CronFormState` and its announce-delivery projection remain separately named UI input shapes, so form create/patch semantics are not collapsed into server result types. Existing run-history tests were moved to a focused sibling file only to keep the touched test under the max-lines gate.

AI-assisted maintainer-requested refactor; reviewed with the repository autoreview workflow.

## User Impact

No UI behavior or new display feature is added. Control UI code can now see all canonical cron fields returned by the Gateway, including job diagnostics/trigger state and run diagnostics, error reasons, failure-notification delivery, run IDs, and trigger outcomes. Follow-up display work can use those fields without extending a stale local model.

## Evidence

- Pre-fix audit confirmed `ui/src/api/types.ts` made `CronJob.state` optional and omitted canonical job/run-history fields present in `packages/gateway-protocol/src/schema/cron.ts`.
- Protocol cron validators: 29 tests passed.
- Focused Control UI cron tests: 8 files / 192 tests passed; final affected-file rerun: 4 files / 167 tests passed.
- Full Control UI Vitest lane: 630 files passed, 10 skipped; 9,097 tests passed, 50 skipped.
- `pnpm ui:build`: passed on Blacksmith Testbox with 818 finalized sidecars and all performance budgets green.
- `pnpm check:changed`: passed after the review fix on Blacksmith Testbox `tbx_01m06655szhhgmhaz3t62mdcej`, Actions run https://github.com/openclaw/openclaw/actions/runs/31972333901.
- Codex autoreview: clean; no accepted/actionable findings.
- ClawSweeper P1 addressed: the published broad `CronJob.sessionTarget` TypeScript contract is preserved; the Control UI narrows it only at the form boundary after runtime validation.
- Production LOC: +83/-167 (net -84). Tests: +252/-164 (net +88), including a 150-line test move. Tooling baseline: -1 stale max-lines entry.
- Visual proof: not applicable; this is a type-only ownership repair with no rendered UI change.
