### PR TITLE
fix(memory): report indexed SQLite sessions

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -459,7 +459,7 @@ Index session transcripts and surface them via `memory_search`:
 | `sources`                     | `string[]` | `["memory"]`                                               | Add `"sessions"` to include transcripts  |
 
 <Warning>
-Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
+Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Active transcripts live in the agent's SQLite database, while retained transcript artifacts can live on disk. Treat access to both as part of the same trust boundary.
 </Warning>
 
 <Note>

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -1,4 +1,3 @@
-import os from "node:os";
 import path from "node:path";
 import { resolveMemorySearchStaleness } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
@@ -14,7 +13,6 @@ import {
 import {
   defaultRuntime,
   formatErrorMessage,
-  resolveStateDir,
   setVerbose,
   shortenHomeInString,
   shortenHomePath,
@@ -39,17 +37,14 @@ import {
   resolveShortTermRecallStorePath,
 } from "./short-term-promotion.js";
 const { accent, heading, info, muted, success, warn } = theme;
-function formatSourceLabel(source: string, workspaceDir: string, agentId: string): string {
+function formatSourceLabel(source: string, workspaceDir: string): string {
   if (source === "memory") {
     return shortenHomeInString(
       `memory (MEMORY.md + ${path.join(workspaceDir, "memory")}${path.sep}*.md)`,
     );
   }
   if (source === "sessions") {
-    const stateDir = resolveStateDir(process.env, os.homedir);
-    return shortenHomeInString(
-      `sessions (${path.join(stateDir, "agents", agentId, "sessions")}${path.sep}*.jsonl)`,
-    );
+    return "sessions (current transcripts + retained transcript artifacts)";
   }
   return source;
 }
@@ -71,7 +66,7 @@ export async function runMemoryIndex(
           const status = manager.status();
           const label = (text: string) => muted(`${text}:`);
           const sourceLabels = (status.sources ?? []).map((source) =>
-            formatSourceLabel(source, status.workspaceDir ?? "", agentId),
+            formatSourceLabel(source, status.workspaceDir ?? ""),
           );
           const extraPaths = status.workspaceDir
             ? formatExtraPaths(status.workspaceDir, status.extraPaths ?? [])

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -394,10 +394,10 @@ export function formatMemoryIndexOutcome(
   scan: MemorySourceScan | undefined,
   agentId: string,
 ): string {
-  if (status.workspaceDir && scan?.totalFiles === 0) {
+  const indexedFiles = status.files ?? 0;
+  if (indexedFiles === 0 && status.workspaceDir && scan?.totalFiles === 0) {
     return `No memory files found in ${shortenHomePath(status.workspaceDir)}; nothing indexed (${agentId}).`;
   }
-  const indexedFiles = status.files ?? 0;
   const fileLabel = indexedFiles === 1 ? "file" : "files";
   return `Memory index updated (${agentId}): ${indexedFiles} ${fileLabel} indexed.`;
 }

--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -15,7 +15,6 @@ export {
   getRuntimeConfig,
   resolveDefaultAgentId,
   resolveSessionTranscriptsDirForAgent,
-  resolveStateDir,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 export {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -19,6 +19,7 @@ import {
   spyRuntimeLogs,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatMemoryIndexOutcome } from "./cli-runtime-common.js";
 import { openMemoryCoreStateStore } from "./dreaming-state.js";
 import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term-promotion.js";
 import {
@@ -188,7 +189,7 @@ describe("memory cli", () => {
 
   function makeMemoryStatus(overrides: Record<string, unknown> = {}) {
     return {
-      backend: "builtin",
+      backend: "builtin" as const,
       files: 0,
       chunks: 0,
       dirty: false,
@@ -229,6 +230,27 @@ describe("memory cli", () => {
         typeof call[0] === "string" && call[0].includes(inactiveMemorySecretDiagnostic),
     );
   }
+
+  it.each([
+    {
+      name: "reports indexed SQLite session rows when the physical-file scan is empty",
+      files: 2,
+      expected: "Memory index updated (main): 2 files indexed.",
+    },
+    {
+      name: "keeps the genuine empty-index result as a no-op",
+      files: 0,
+      expected: `No memory files found in /tmp/openclaw; nothing indexed (main).`,
+    },
+  ])("$name", ({ files, expected }) => {
+    expect(
+      formatMemoryIndexOutcome(
+        makeMemoryStatus({ files }),
+        { sources: [], totalFiles: 0, issues: [] },
+        "main",
+      ),
+    ).toBe(expected);
+  });
 
   function stripAnsi(value: string) {
     let output = "";
@@ -1420,6 +1442,26 @@ describe("memory cli", () => {
       });
       expect(close).toHaveBeenCalled();
       expect(log).toHaveBeenCalledWith("Memory index updated (main): 1 file indexed.");
+    });
+  });
+
+  it("describes session index sources without implying active JSONL storage", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const close = vi.fn(async () => {});
+      const sync = vi.fn(async () => {});
+      mockManager({
+        sync,
+        status: () => makeMemoryStatus({ workspaceDir, sources: ["sessions"], files: 1 }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["index", "--verbose"]);
+
+      expectLogged(log, "sessions (current transcripts + retained transcript artifacts)");
+      expectNotLogged(log, "*.jsonl");
+      expectLogged(log, "Memory index updated (main): 1 file indexed.");
+      expect(close).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Related: #123863

AI-assisted: this focused repair was implemented and verified with Codex. No transcript is attached.

## What Problem This Solves

Fixes an issue where users indexing SQLite-backed active session transcripts could see `No memory files found...nothing indexed` even though the session rows were indexed successfully. This occurs when the authoritative memory index contains session rows but the separate retained-artifact file scan is empty.

## Why This Change Was Made

The post-sync memory manager status now remains authoritative for the indexed-file outcome. The physical source scan can produce the genuine zero-index no-op only when the manager also reports zero indexed files. Verbose output and the memory reference now describe active SQLite transcripts and retained transcript artifacts without implying that every session is an active JSONL file.

This does not change storage, schemas, configuration, protocol, or Plugin SDK surfaces. Exact corpus-denominator projection remains outside this focused CLI repair.

## User Impact

`openclaw memory index` and `openclaw memory status --index` now report indexed SQLite session rows truthfully. Genuinely empty indexes still return the existing successful no-op message.

Release-note context: Memory CLI indexing now reports successfully indexed SQLite session transcripts instead of a false empty-corpus outcome.

## Evidence

Hosted proof used Blacksmith Testbox `tbx_01m065fjw9vehcweh2mm08bw9m`: https://github.com/openclaw/openclaw/actions/runs/31971756524

The exact-head dependency check then identified the old JSONL formatter's now-unused internal `resolveStateDir` re-export. The focused cleanup passed on Testbox `tbx_01m066aadvg3078v37dkx15kzb`: https://github.com/openclaw/openclaw/actions/runs/31972475053

- `pnpm test extensions/memory-core/src/cli.test.ts` — 86/86 passed.
- `pnpm tsgo:extensions` — passed.
- `pnpm tsgo:extensions:test` — passed.
- Targeted Oxlint over the three changed TypeScript files — 0 warnings, 0 errors.
- Targeted `oxfmt --check` over all four changed files — passed.
- `pnpm check:database-first-legacy-stores` — passed.
- `pnpm deadcode:dependencies` and `pnpm deadcode:exports` — passed with zero unused production/full-tree exports.
- `pnpm check:docs` — passed: docs formatting, Markdown lint, MDX, i18n glossary, 6,495 internal links with zero broken links, and 1,175 validated config examples.
- `pnpm docs:list` — the memory reference remains indexed.
- `git diff --check` — passed.
- Fresh Codex autoreview — no accepted/actionable findings.

Source-blind built-CLI proof used isolated temporary state and deliberate FTS-only mode. It created an active session through the public session runtime, verified no active JSONL sidecar existed, indexed it, and searched a unique marker:

```text
no-active-jsonl=true
Memory index updated (main): 1 file indexed.
Sources: sessions (current transcripts + retained transcript artifacts)
{"retrieved":true,"source":"sessions","path":"sessions/main/source-blind-sqlite-session.jsonl"}
No memory files found in /tmp/.../workspace; nothing indexed (main).
behavior-contract=pass clauses=sqlite-only,truthful-index,verbose-storage,search-recall,genuine-empty
```

LOC classification: production `+5/-11` (net `-6`), tests `+43/-1`, docs `+1/-1`.
