### PR TITLE
fix(channels): route targetless direct-message replies to sender

### DIFF
--- a/src/channels/direct-dm.test.ts
+++ b/src/channels/direct-dm.test.ts
@@ -199,8 +199,11 @@ describe("dispatchInboundDirectDm", () => {
       onDispatchError: vi.fn(),
     });
 
-    expect(vi.mocked(buildChannelInboundEventContext).mock.calls.at(-1)?.[0].channelIngress).toBe(
-      "unsupported",
-    );
+    const contextParams = vi.mocked(buildChannelInboundEventContext).mock.calls.at(-1)?.[0];
+    expect(contextParams?.channelIngress).toBe("unsupported");
+    expect(contextParams?.reply).toEqual({
+      to: "reef:bot-1",
+      originatingTo: "reef:peer-1",
+    });
   });
 });

--- a/src/channels/direct-dm.ts
+++ b/src/channels/direct-dm.ts
@@ -101,7 +101,7 @@ async function buildDirectDmContext(
     },
     reply: {
       to: params.recipientAddress,
-      originatingTo: params.originatingTo ?? params.recipientAddress,
+      originatingTo: params.originatingTo ?? params.senderAddress,
     },
     message: {
       body,
@@ -232,7 +232,7 @@ export async function dispatchInboundDirectDmWithRuntime(
     CommandAuthorized: params.commandAuthorized,
     ...(params.inboundAccessAuthorized === true ? { InboundAccessAuthorized: true } : {}),
     OriginatingChannel: params.originatingChannel ?? params.channel,
-    OriginatingTo: params.originatingTo ?? params.recipientAddress,
+    OriginatingTo: params.originatingTo ?? params.senderAddress,
     NativeDirectUserId: params.peer.id,
     ...params.extraContext,
   });

--- a/src/plugin-sdk/direct-dm.test.ts
+++ b/src/plugin-sdk/direct-dm.test.ts
@@ -2,7 +2,9 @@
  * Tests direct-message guard policy helpers exposed through the SDK.
  */
 import { describe, expect, it, vi } from "vitest";
+import { resolveOriginMessageTo } from "../auto-reply/reply/origin-routing.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveImplicitMessageActionTarget } from "../infra/outbound/message-action-normalization.js";
 import {
   createDirectDmPreCryptoGuardPolicy,
   createPreCryptoDirectDmAuthorizer,
@@ -242,16 +244,16 @@ describe("channel-inbound direct-message helpers", () => {
     });
   });
 
-  it("dispatches direct DMs through the standard route/session/reply pipeline", async () => {
+  it("routes a targetless contextual reply to the inbound Reef peer", async () => {
     const { recordInboundSession, dispatchReplyWithBufferedBlockDispatcher, runtime } =
       createDirectDmRuntime();
     const deliver = vi.fn(async () => {});
     const channelIngress = await resolveStableChannelMessageIngress({
-      channelId: "nostr",
+      channelId: "reef",
       accountId: "default",
-      subject: { stableId: "sender-1" },
-      conversation: { kind: "direct", id: "sender-1" },
-      dmPolicy: "open",
+      subject: { stableId: "clawstudio" },
+      conversation: { kind: "direct", id: "clawstudio" },
+      dmPolicy: "allowlist",
     });
 
     const result = await dispatchInboundDirectDmWithRuntime({
@@ -260,14 +262,14 @@ describe("channel-inbound direct-message helpers", () => {
         session: { store: { type: "jsonl" } },
       } as never,
       runtime,
-      channel: "nostr",
-      channelLabel: "Nostr",
+      channel: "reef",
+      channelLabel: "Reef",
       accountId: "default",
-      peer: { kind: "direct", id: "sender-1" },
-      senderId: "sender-1",
-      senderAddress: "nostr:sender-1",
-      recipientAddress: "nostr:bot-1",
-      conversationLabel: "sender-1",
+      peer: { kind: "direct", id: "clawstudio" },
+      senderId: "clawstudio",
+      senderAddress: "reef:clawstudio",
+      recipientAddress: "reef:roboclaw",
+      conversationLabel: "@clawstudio's agent",
       rawBody: "hello world",
       messageId: "event-123",
       extraContext: {
@@ -284,19 +286,26 @@ describe("channel-inbound direct-message helpers", () => {
 
     expect(result.route.agentId).toBe("agent-main");
     expect(result.route.accountId).toBe("default");
-    expect(result.route.sessionKey).toBe("dm:sender-1");
+    expect(result.route.sessionKey).toBe("dm:clawstudio");
     expect(result.storePath).toBe("/tmp/direct-dm-session-store");
     expect(result.ctxPayload.Body).toBe("env:hello world");
     expect(result.ctxPayload.BodyForAgent).toBe("hello world");
-    expect(result.ctxPayload.From).toBe("nostr:sender-1");
-    expect(result.ctxPayload.To).toBe("nostr:bot-1");
-    expect(result.ctxPayload.SenderId).toBe("sender-1");
+    expect(result.ctxPayload.From).toBe("reef:clawstudio");
+    expect(result.ctxPayload.To).toBe("reef:roboclaw");
+    expect(result.ctxPayload.SenderId).toBe("clawstudio");
     expect(result.ctxPayload.MessageSid).toBe("event-123");
     expect(result.ctxPayload.ReplyToId).toBe("event-parent");
     expect(result.ctxPayload.MessageThreadId).toBe("thread-7");
-    expect(result.ctxPayload.NativeDirectUserId).toBe("sender-1");
-    expect(result.ctxPayload.OriginatingTo).toBe("nostr:bot-1");
+    expect(result.ctxPayload.NativeDirectUserId).toBe("clawstudio");
+    expect(result.ctxPayload.OriginatingTo).toBe("reef:clawstudio");
     expect(result.ctxPayload.CommandAuthorized).toBe(true);
+    const currentChannelId = resolveOriginMessageTo({
+      originatingTo: result.ctxPayload.OriginatingTo,
+      to: result.ctxPayload.To,
+    });
+    expect(
+      resolveImplicitMessageActionTarget({ currentChannelId, currentChannelProvider: "reef" }),
+    ).toBe("reef:clawstudio");
     expect(recordInboundSession).toHaveBeenCalledTimes(1);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledWith({ text: "reply text" });


### PR DESCRIPTION
Closes #124836

## What Problem This Solves

Fixes an issue where an agent replying contextually to an inbound Reef direct message would target its own local Reef handle instead of the authenticated peer that sent the message. The remote agent received and processed the message, but its generated reply was rejected and the originating `conversations_turn` timed out.

## Why This Change Was Made

Direct-message context now keeps `To` as the local recipient while defaulting `OriginatingTo` to the authenticated sender address. This repairs the shared owner boundary used by Reef and Nostr instead of adding Reef-specific compensation or a fallback path.

Production LOC: +2/-2 (net 0) | Tests: +33/-21

## User Impact

Reef conversations can complete targetless contextual replies to the originating peer, including correlated `conversations_turn` calls. Nostr direct-message context follows the same sender-target invariant.

## Evidence

- Live pre-fix proof across two active Reef friends:
  - outbound correlation persisted
  - signed delivery receipt reached `accepted` and `read`
  - receiving agent generated the exact requested reply
  - contextual send resolved to the receiver's own handle and failed as unapproved
  - originating turn timed out
- Regression provenance proof: temporarily restoring the old default makes the focused test fail with `expected reef:receiver to be reef:sender`; restoring this patch passes.
- Focused tests:
  - `node scripts/run-vitest.mjs src/channels/direct-dm.test.ts src/plugin-sdk/direct-dm.test.ts` — 12 passed
  - `node scripts/run-vitest.mjs extensions/reef/src/channel.test.ts extensions/nostr/src/channel.inbound.test.ts` — 20 passed
- Formatting and patch integrity:
  - `node_modules/.bin/oxfmt --check src/channels/direct-dm.ts src/channels/direct-dm.test.ts src/plugin-sdk/direct-dm.test.ts`
  - `git diff --check`
- Blacksmith Testbox `tbx_01m0659bea4fdz450kx75pe5qf`: SDK export/surface checks, core + extension type checks, targeted oxlint, plugin boundary report, and import-cycle check passed.
  - https://github.com/openclaw/openclaw/actions/runs/31971594575
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Post-merge live proof is intentional: both managed installations consume `origin/main`; after merge they will be updated to the same latest main and the bidirectional Reef conversation will be rerun. Any deployed regression will be repaired in a follow-up PR before closeout.

AI-assisted: yes. The maintainer inspected the complete diff, owner boundary, callers, sibling channels, history, tests, and live failure evidence.
