### PR TITLE
fix(media): bound image-optimize fetch headroom to the image cap

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -1506,6 +1506,54 @@ describe("loadWebMedia", () => {
     }
   });
 
+  it("bounds explicit-cap image fetches at the optimize headroom, not the document cap", async () => {
+    // 30MB declared original: over the 24MB image-optimize headroom but well
+    // under the old 100MB document bound. The Content-Length precheck must
+    // reject before any body bytes are read.
+    const declaredBytes = 30 * 1024 * 1024;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(new ReadableStream<Uint8Array>(), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-length": String(declaredBytes),
+          },
+        }),
+    );
+
+    await expect(
+      loadWebMedia("https://example.test/huge.png", {
+        maxBytes: 5 * 1024 * 1024,
+        fetchImpl,
+        ssrfPolicy: { allowedHostnames: ["example.test"] },
+      }),
+    ).rejects.toThrow(/exceeds maxBytes/);
+  });
+
+  it("keeps compression headroom above an explicit cap for oversized originals", async () => {
+    // A 10MB-declared image is over the caller's 5MB cap but inside the
+    // optimize headroom: the fetch must proceed so compression can shrink it
+    // under the delivery cap.
+    const original = createSolidPngBuffer(64, 64, { r: 12, g: 34, b: 56 });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(Buffer.from(original), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+
+    const result = await loadWebMedia("https://example.test/photo.png", {
+      maxBytes: 5 * 1024 * 1024,
+      fetchImpl,
+      ssrfPolicy: { allowedHostnames: ["example.test"] },
+    });
+
+    expect(result.kind).toBe("image");
+    expect(result.buffer.length).toBeLessThanOrEqual(5 * 1024 * 1024);
+  });
+
   it("applies the shared remote read idle timeout for raw web media loads", async () => {
     const readIdleTimeoutMs = 20;
     const fetchImpl = makeStallingFetch(new Uint8Array([0x25, 0x50, 0x44, 0x46]));

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -160,6 +160,11 @@ function resolveWebMediaOptions(params: {
   };
 }
 
+// Pre-compression fetch headroom for callers with an explicit delivery cap:
+// enough to pull a large phone photo (~20MB+) and compress it under the cap,
+// without letting a tight channel cap buffer up to the 100MB document bound.
+const IMAGE_OPTIMIZE_HEADROOM_FACTOR = 4;
+
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
@@ -1131,13 +1136,19 @@ async function loadWebMediaInternal(
   };
 
   // Bound source reads before buffering. Optimized images may exceed their
-  // delivery cap because they are compressed before the final size check.
+  // delivery cap because they are compressed before the final size check, so
+  // an explicit caller cap gets image-compression headroom — sized off the
+  // image cap, not the 100MB document cap, or a tight channel cap would still
+  // permit a 100MB buffer from a hostile URL. Accepted tradeoff: originals
+  // above the headroom fail even when they would have compressed under the
+  // cap; the error names the fetch bound so the user can shrink the source.
   const defaultSourceReadCap = maxBytesForKind("document");
+  const imageOptimizeHeadroom = IMAGE_OPTIMIZE_HEADROOM_FACTOR * maxBytesForKind("image");
   const sourceReadCap =
     maxBytes === undefined
       ? defaultSourceReadCap
       : optimizeImages
-        ? Math.max(maxBytes, defaultSourceReadCap)
+        ? Math.max(maxBytes, imageOptimizeHeadroom)
         : maxBytes;
 
   if (hasHttpUrlPrefix(mediaUrl)) {


### PR DESCRIPTION
## What Problem This Solves

When a caller passed an explicit `maxBytes` and image optimization was on (the default), `loadWebMedia`'s source-read bound was inflated to `max(maxBytes, 100MB document cap)`. A channel with a 5MB attachment cap therefore let a hostile or merely oversized URL buffer up to 100MB into gateway memory before the final size check — 20× resource amplification — and the inflated bound applied before content classification, so it wasn't even limited to images.

## Why This Change Was Made

The inflation is intentional product behavior: oversized-but-compressible originals must be fetchable so compression can shrink them under the delivery cap (the code comment says exactly this). The fix keeps that behavior but sizes the headroom off the thing that justifies it: `IMAGE_OPTIMIZE_HEADROOM_FACTOR (4) × maxBytesForKind("image") (6MB) = 24MB` — enough for large phone photos — instead of the 100MB document cap. Worst-case amplification for a tight caller cap drops from 20× to ~4.8×.

Named tradeoff (documented at the constant): originals above 24MB that would have compressed under the cap now fail with a fetch error naming the bound, instead of buffering 100MB first. Callers without an explicit cap keep per-kind defaults, unchanged.

## User Impact

Channels with explicit attachment caps no longer allow ~100MB buffering per media fetch; oversized phone photos still auto-compress and deliver.

## Evidence

- **Live proof** (real localhost HTTP server through the real SSRF/fetch-guard/sharp stack, no mocked fetch): an 8.1MB noise PNG under a 5MB cap compressed to 3.75MB JPEG and delivered in 499ms; a 30MB-declared image was rejected at the Content-Length precheck in 7ms with `content length 31457280 exceeds maxBytes 25165824`.
- New regression in `src/media/web-media.test.ts`: 30MB-declared fetch under a 5MB cap rejects at the headroom (fails pre-fix — passes the old 100MB bound); companion test proves an over-cap-but-in-headroom original still compresses under the cap. Full web-media suite: 90/90.
- fetch + load-options suites pass; tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- Callers audited: delivery-queue-media-spool and message-action-params pass channel caps (the served flow); agent tools pass image-kind caps unaffected by the document bound.
- LOC: prod +13 −2 (constant + comment + bound), test +48.
