### PR TITLE
fix(ui): keep sent images visible through history handoff

### DIFF
--- a/ui/src/e2e/chat-send-pending-handoff.e2e.test.ts
+++ b/ui/src/e2e/chat-send-pending-handoff.e2e.test.ts
@@ -1,6 +1,6 @@
 // Control UI E2E tests cover the pending-send bubble handoff to authoritative history.
 import type { Page } from "playwright";
-import { afterEach, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -8,11 +8,12 @@ const suite = createControlUiE2eSuite({
   name: "Control UI chat send pending handoff",
 });
 
-let page: Page | undefined;
 type FrameSample = {
   t: number;
   present: boolean;
   rowKeys: string[];
+  imageCount: number;
+  loadedImageCount: number;
 };
 
 type SamplerWindow = Window & {
@@ -21,10 +22,14 @@ type SamplerWindow = Window & {
 };
 
 const PROBE_TEXT = "Flicker probe message 4242";
+const IMAGE_PROBE_TEXT = "Image flicker probe message 4242";
+const ONE_PIXEL_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+const ONE_PIXEL_PNG_DATA_URL = `data:image/png;base64,${ONE_PIXEL_PNG_B64}`;
 const USER_ECHO_ENTRY_ID = "pending-handoff-user-echo";
 
-async function startFrameSampler(currentPage: Page): Promise<void> {
-  await currentPage.evaluate((probeText) => {
+async function startFrameSampler(currentPage: Page, probeText = PROBE_TEXT): Promise<void> {
+  await currentPage.evaluate((text) => {
     const win = window as SamplerWindow;
     const frames: FrameSample[] = [];
     win.openclawSendFrameSamples = frames;
@@ -37,17 +42,24 @@ async function startFrameSampler(currentPage: Page): Promise<void> {
         return;
       }
       const rows = [...document.querySelectorAll<HTMLElement>("[data-virtual-row-key]")].filter(
-        (row) => (row.textContent ?? "").includes(probeText),
+        (row) => (row.textContent ?? "").includes(text),
       );
+      const images = rows.flatMap((row) => [
+        ...row.querySelectorAll<HTMLImageElement>(".chat-message-image"),
+      ]);
       frames.push({
         t: performance.now(),
         present: rows.length > 0,
         rowKeys: rows.map((row) => row.dataset.virtualRowKey ?? ""),
+        imageCount: images.length,
+        loadedImageCount: images.filter(
+          (image) => image.complete && image.naturalWidth > 0 && image.naturalHeight > 0,
+        ).length,
       });
       requestAnimationFrame(sample);
     };
     requestAnimationFrame(sample);
-  }, PROBE_TEXT);
+  }, probeText);
 }
 
 async function stopFrameSampler(currentPage: Page): Promise<FrameSample[]> {
@@ -58,28 +70,33 @@ async function stopFrameSampler(currentPage: Page): Promise<FrameSample[]> {
   });
 }
 
-/** Presence gaps (frames where the probe text vanished after first paint) and
- * the distinct row keys the probe bubble rendered under, in order. */
-function analyzeFrameSamples(frames: FrameSample[]): { gapFrames: number; keyTimeline: string[] } {
-  const firstVisible = frames.findIndex((frame) => frame.present);
-  expect(firstVisible).toBeGreaterThanOrEqual(0);
-  // Counting through the final sample also catches a permanent disappearance.
-  expect(frames[frames.length - 1]?.present).toBe(true);
-  let gapFrames = 0;
-  for (let index = firstVisible; index < frames.length; index++) {
-    if (frames[index]?.present === false) {
-      gapFrames += 1;
-    }
-  }
+function analyzeFrameContinuity(
+  frames: FrameSample[],
+  isHealthy: (frame: FrameSample) => boolean = (frame) => frame.present,
+): string[] {
+  const firstHealthy = frames.findIndex(isHealthy);
+  expect(firstHealthy).toBeGreaterThanOrEqual(0);
+  const continuityFrames = frames.slice(firstHealthy);
+  expect(
+    continuityFrames
+      .filter((frame) => !isHealthy(frame))
+      .map((frame) => ({
+        imageCount: frame.imageCount,
+        loadedImageCount: frame.loadedImageCount,
+        present: frame.present,
+        rowKeys: frame.rowKeys,
+        t: frame.t,
+      })),
+  ).toEqual([]);
   const keyTimeline: string[] = [];
-  for (const frame of frames) {
+  for (const frame of continuityFrames) {
     for (const key of frame.rowKeys) {
       if (keyTimeline[keyTimeline.length - 1] !== key) {
         keyTimeline.push(key);
       }
     }
   }
-  return { gapFrames, keyTimeline };
+  return keyTimeline;
 }
 
 const BASE_HISTORY = [
@@ -91,28 +108,43 @@ const BASE_HISTORY = [
   },
 ];
 
+type ChatSendParams = {
+  attachments?: Array<{ content?: string; mimeType?: string }>;
+  idempotencyKey?: string;
+};
+
 async function openChatAndSubmitProbe(
   currentPage: Page,
   gateway: MockGatewayControls,
-  opts?: { deferSend?: boolean },
-): Promise<string> {
+  opts: { attachImage?: boolean; deferSend?: boolean; probeText?: string } = {},
+): Promise<{ runId: string; sendParams: ChatSendParams }> {
+  const probeText = opts.probeText ?? PROBE_TEXT;
   await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
   await currentPage.getByText("Ready.").waitFor({ timeout: 10_000 });
   await gateway.waitForRequest("sessions.list");
-  if (opts?.deferSend) {
+  if (opts.attachImage) {
+    await currentPage.locator(".agent-chat__file-input").setInputFiles({
+      name: "pixel.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+    });
+    await currentPage.locator(".chat-attachment-thumb").waitFor({ state: "visible" });
+  }
+  if (opts.deferSend) {
     await gateway.deferNext("chat.send");
   }
-  await startFrameSampler(currentPage);
-  await currentPage.locator(".agent-chat__input textarea").fill(PROBE_TEXT);
+  await startFrameSampler(currentPage, probeText);
+  await currentPage.locator(".agent-chat__input textarea").fill(probeText);
   await currentPage.locator(".agent-chat__input textarea").press("Enter");
   const send = await gateway.waitForRequest("chat.send");
-  const runId = (send.params as { idempotencyKey?: string }).idempotencyKey ?? "";
+  const sendParams = send.params as ChatSendParams;
+  const runId = sendParams.idempotencyKey ?? "";
   expect(runId).toBeTruthy();
   await currentPage
     .locator("[data-virtual-row-key]")
-    .getByText(PROBE_TEXT, { exact: true })
+    .getByText(probeText, { exact: true })
     .waitFor({ timeout: 10_000 });
-  return runId;
+  return { runId, sendParams };
 }
 
 async function finishRunAndSettle(
@@ -183,90 +215,119 @@ async function finishRunAndSettle(
   return stopFrameSampler(currentPage);
 }
 
+function isHealthyImageFrame(frame: FrameSample): boolean {
+  return frame.rowKeys.length === 1 && frame.imageCount === 1 && frame.loadedImageCount === 1;
+}
+
 suite.define(() => {
-  afterEach(async () => {
-    await page
-      ?.context()
-      .close()
-      .catch(() => {});
-    page = undefined;
-  });
+  it("keeps a submitted image visible through run completion and history reload", async () => {
+    await suite.withPage(
+      { viewport: { height: 800, width: 1200 } },
+      async ({ page: currentPage }) => {
+        const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });
+        const { runId, sendParams } = await openChatAndSubmitProbe(currentPage, gateway, {
+          attachImage: true,
+          deferSend: true,
+          probeText: IMAGE_PROBE_TEXT,
+        });
 
-  it("keeps the submitted user turn visible through run completion and history reload", async () => {
-    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
-    const currentPage = await context.newPage();
-    page = currentPage;
-    const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });
+        expect(sendParams.attachments?.[0]).toMatchObject({
+          content: ONE_PIXEL_PNG_B64,
+          mimeType: "image/png",
+        });
+        // A locally submitted turn plays the composer entry animation exactly once.
+        expect(await currentPage.locator(".chat-bubble--user-turn-enter").count()).toBe(1);
+        await expect
+          .poll(() =>
+            currentPage.evaluate(() =>
+              ((window as SamplerWindow).openclawSendFrameSamples ?? []).some(
+                (frame) =>
+                  frame.rowKeys.length === 1 &&
+                  frame.imageCount === 1 &&
+                  frame.loadedImageCount === 1,
+              ),
+            ),
+          )
+          .toBe(true);
+        await gateway.resolveDeferred("chat.send");
 
-    const runId = await openChatAndSubmitProbe(currentPage, gateway);
-    // A locally submitted turn plays the composer entry animation exactly once.
-    expect(await currentPage.locator(".chat-bubble--user-turn-enter").count()).toBe(1);
+        const frames = await finishRunAndSettle(currentPage, gateway, runId, {
+          content: [
+            { text: IMAGE_PROBE_TEXT, type: "text" },
+            {
+              type: "image",
+              url: ONE_PIXEL_PNG_DATA_URL,
+              source: { type: "url", url: ONE_PIXEL_PNG_DATA_URL },
+            },
+          ],
+          role: "user",
+          timestamp: Date.now(),
+          __openclaw: { id: USER_ECHO_ENTRY_ID, idempotencyKey: runId, seq: 2 },
+        });
 
-    const frames = await finishRunAndSettle(currentPage, gateway, runId, {
-      content: [{ text: PROBE_TEXT, type: "text" }],
-      role: "user",
-      timestamp: Date.now(),
-      __openclaw: { id: USER_ECHO_ENTRY_ID, idempotencyKey: runId, seq: 2 },
-    });
-
-    const { gapFrames, keyTimeline } = analyzeFrameSamples(frames);
-    // The submitted text must never disappear once visible.
-    expect(gapFrames).toBe(0);
-    // The bubble keeps one identity through the pending -> history handoff, so
-    // the DOM node is never remounted (no animation replay, no layout jump).
-    expect(new Set(keyTimeline).size).toBe(1);
+        const keyTimeline = analyzeFrameContinuity(frames, isHealthyImageFrame);
+        // The bubble keeps one identity through the pending -> history handoff, so
+        // the DOM node is never remounted (no animation replay, no layout jump).
+        expect(new Set(keyTimeline).size).toBe(1);
+        const submittedRow = currentPage
+          .locator("[data-virtual-row-key]")
+          .filter({ hasText: IMAGE_PROBE_TEXT });
+        expect(await submittedRow.getByText("Attached image", { exact: false }).count()).toBe(0);
+      },
+    );
   });
 
   it("keeps the submitted user turn visible when the session echo lands before the send ack", async () => {
-    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
-    const currentPage = await context.newPage();
-    page = currentPage;
-    const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });
+    await suite.withPage(
+      { viewport: { height: 800, width: 1200 } },
+      async ({ page: currentPage }) => {
+        const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });
+        const { runId } = await openChatAndSubmitProbe(currentPage, gateway, { deferSend: true });
 
-    const runId = await openChatAndSubmitProbe(currentPage, gateway, { deferSend: true });
+        // The Gateway persists and broadcasts the user turn before the ack resolves.
+        const userEcho = {
+          content: [{ text: PROBE_TEXT, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+          __openclaw: { id: USER_ECHO_ENTRY_ID, idempotencyKey: runId, seq: 2 },
+        };
+        await gateway.setHistoryMessages([...BASE_HISTORY, userEcho]);
+        const historyRequestsBefore = (await gateway.getRequests("chat.history")).length;
+        await gateway.emitGatewayEvent("session.message", {
+          activeRunIds: [runId],
+          clientRunId: runId,
+          hasActiveRun: true,
+          message: userEcho,
+          messageId: "pending-handoff-echo-1",
+          messageSeq: 2,
+          session: {
+            activeRunIds: [runId],
+            hasActiveRun: true,
+            key: "main",
+            kind: "direct",
+            status: "running",
+            updatedAt: Date.now(),
+          },
+          sessionKey: "main",
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("chat.history")).length, {
+            timeout: 10_000,
+          })
+          .toBeGreaterThan(historyRequestsBefore);
+        await currentPage.waitForTimeout(300);
+        await gateway.resolveDeferred("chat.send");
 
-    // The Gateway persists and broadcasts the user turn before the ack resolves.
-    const userEcho = {
-      content: [{ text: PROBE_TEXT, type: "text" }],
-      role: "user",
-      timestamp: Date.now(),
-      __openclaw: { id: USER_ECHO_ENTRY_ID, idempotencyKey: runId, seq: 2 },
-    };
-    await gateway.setHistoryMessages([...BASE_HISTORY, userEcho]);
-    const historyRequestsBefore = (await gateway.getRequests("chat.history")).length;
-    await gateway.emitGatewayEvent("session.message", {
-      activeRunIds: [runId],
-      clientRunId: runId,
-      hasActiveRun: true,
-      message: userEcho,
-      messageId: "pending-handoff-echo-1",
-      messageSeq: 2,
-      session: {
-        activeRunIds: [runId],
-        hasActiveRun: true,
-        key: "main",
-        kind: "direct",
-        status: "running",
-        updatedAt: Date.now(),
+        const frames = await finishRunAndSettle(currentPage, gateway, runId, userEcho);
+        const keyTimeline = analyzeFrameContinuity(frames);
+        expect(new Set(keyTimeline).size).toBe(1);
+        // The single stable key above proves the node never remounted, so the
+        // entry animation cannot have replayed; at most the one submitted turn
+        // still carries the (inert, completed) animation class.
+        expect(
+          await currentPage.locator(".chat-bubble--user-turn-enter").count(),
+        ).toBeLessThanOrEqual(1);
       },
-      sessionKey: "main",
-    });
-    await expect
-      .poll(async () => (await gateway.getRequests("chat.history")).length, { timeout: 10_000 })
-      .toBeGreaterThan(historyRequestsBefore);
-    await currentPage.waitForTimeout(300);
-    await gateway.resolveDeferred("chat.send");
-
-    const frames = await finishRunAndSettle(currentPage, gateway, runId, userEcho);
-
-    const { gapFrames, keyTimeline } = analyzeFrameSamples(frames);
-    expect(gapFrames).toBe(0);
-    expect(new Set(keyTimeline).size).toBe(1);
-    // The single stable key above proves the node never remounted, so the
-    // entry animation cannot have replayed; at most the one submitted turn
-    // still carries the (inert, completed) animation class.
-    expect(await currentPage.locator(".chat-bubble--user-turn-enter").count()).toBeLessThanOrEqual(
-      1,
     );
   });
 });

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -8530,11 +8530,16 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toEqual([]);
     expect(host.chatMessages[0]).toMatchObject({
       role: "user",
+      content: [
+        {
+          type: "image",
+          url: dataUrl,
+          source: { type: "url", url: dataUrl },
+        },
+      ],
       __openclaw: { idempotencyKey: "steer-att-run:user" },
     });
-    // Inline data-URL images render as a labeled placeholder block; the point
-    // is the turn materializes with content instead of vanishing.
-    expect(JSON.stringify(host.chatMessages[0])).toContain("Attached image: shot.png");
+    expect(JSON.stringify(host.chatMessages[0])).not.toContain("Attached image");
   });
 
   it("materializes both the run's queued turn and its steered follow-up at the terminal event", () => {

--- a/ui/src/pages/chat/initial-turn-handoff.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.ts
@@ -67,9 +67,7 @@ export function prepareInitialUserMessageHandoff(
       : undefined;
   const message: ApplicationInitialUserMessage = {
     role: "user",
-    content: buildUserChatMessageContentBlocks(item.text, durableAttachments, {
-      renderInlineImageDataUrls: true,
-    }),
+    content: buildUserChatMessageContentBlocks(item.text, durableAttachments),
     timestamp: item.createdAt,
     __openclaw: {
       idempotencyKey: `${runId}:user`,

--- a/ui/src/pages/chat/user-message-content.ts
+++ b/ui/src/pages/chat/user-message-content.ts
@@ -17,23 +17,9 @@ type UserChatMessageContentBlock = {
   };
 };
 
-type BuildUserChatMessageContentOptions = {
-  renderInlineImageDataUrls?: boolean;
-};
-
-function isInlineDataUrl(value: string): boolean {
-  return /^\s*data:/iu.test(value);
-}
-
-function formatInlineImageAttachmentPlaceholder(attachment: ChatAttachment): string {
-  const label = attachment.fileName?.trim();
-  return label ? `Attached image: ${label}` : "Attached image";
-}
-
 export function buildUserChatMessageContentBlocks(
   message: string,
   attachments?: readonly ChatAttachment[],
-  options: BuildUserChatMessageContentOptions = {},
 ): UserChatMessageContentBlock[] {
   const blocks: UserChatMessageContentBlock[] = [];
   const text = message.trim();
@@ -46,10 +32,6 @@ export function buildUserChatMessageContentBlocks(
       continue;
     }
     if (attachment.mimeType.startsWith("image/")) {
-      if (isInlineDataUrl(previewUrl) && !options.renderInlineImageDataUrls) {
-        blocks.push({ type: "text", text: formatInlineImageAttachmentPlaceholder(attachment) });
-        continue;
-      }
       blocks.push({
         type: "image",
         url: previewUrl,


### PR DESCRIPTION
Closes #124817

## What Problem This Solves

Fixes an issue where users sending an image attachment in an existing Control UI chat would see the image disappear at run completion, then reappear after authoritative chat history loaded.

## Why This Change Was Made

The terminal handoff already preserves attachment bytes before releasing the composer-owned Blob URL, but the shared user-message content builder converted the resulting inline image data URL into an `Attached image` text placeholder. This change removes that scheme-specific downgrade so every local transcript projection uses the same image block; the redundant initial-session opt-in disappears with it.

The repair stays at the shared attachment-to-content owner. Queue retirement, payload ownership, Gateway transport, and history timing are unchanged.

## User Impact

A just-sent image now remains continuously visible in the same message bubble from optimistic submission through terminal queue retirement and authoritative history adoption. The prompt no longer looks as though it lost its attachment while the run is finishing.

## Evidence

The comparison uses the real Control UI in Chromium against a deterministic Gateway WebSocket harness. History adoption is deliberately delayed so the handoff is visible: the pre-fix side replaces the image with a placeholder, while the fixed side keeps the decoded image on screen.

![Before and after: image prompt handoff](https://github.com/user-attachments/assets/aa25e712-83e8-46c6-a9cb-2b2bd923579f)

https://github.com/user-attachments/assets/ad5fb7d1-409e-472e-a39d-a9aeb3e4a7f0

Pre-fix regression proof:

- The frame sampler observed one stable virtual-row key, followed by a terminal-handoff frame with `imageCount: 0` and `loadedImageCount: 0` while the row remained present.
- The same E2E passes after the owner fix and requires exactly one decoded image on every frame through authoritative history adoption.

Focused validation:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-send-pending-handoff.e2e.test.ts` — 2 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts -t 'materializes an attachment-only steered chip from store-backed payload bytes'` — 1 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.media.test.ts` — 13 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/history-merge.test.ts` — 23 passed.
- `node scripts/run-tsgo-core-test-shards.mjs` and the targeted UI typecheck passed.
- Targeted oxlint/stylelint, formatting, and `git diff --check` passed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/31972702478) completed green, including all 12 Control UI E2E shards, UI checks, real-Gateway UI E2E, build artifacts, lint, and test-type shards.
- ClawSweeper artifact: A, no findings or rank-up moves.
- Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +1/-21 (net -20) | Tests: +172/-106 (net +66)

AI-assisted: yes. I understand the attachment lifecycle, the shared projection boundary, and the final diff.
