### PR TITLE
fix(ui): restore task count badge

### DIFF
--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -398,8 +398,8 @@ suite.define(() => {
                 [16, 16],
                 [16, 16],
               ],
-              taskBadgeCenterDelta: 0,
-              taskBadgeContained: true,
+              taskBadgeCenterDelta: 6,
+              taskBadgeContained: false,
             });
 
           await page.locator(".chat-side-panel-toggle").click();

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -585,21 +585,23 @@ openclaw-chat-pane {
 }
 
 .chat-pane__actions .chat-tasks-toggle {
-  width: auto;
-  gap: 3px;
-  padding-inline: 5px;
+  position: relative;
 }
 
 .chat-tasks-toggle__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 7px;
-  color: currentColor;
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-  line-height: 1;
+  position: absolute;
+  top: 0;
+  right: -2px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: var(--radius-full);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 14px;
+  text-align: center;
 }
 
 .chat-pane__sharing-menu {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with active background tasks saw the count rendered inline beside the checklist icon, widening the chat rail action instead of showing the compact overlaid badge. This regressed in #123874.

## Why This Change Was Made

**Root cause:** #123874 kept the task-count markup but replaced the owning absolute badge CSS with inline-counter styling.

This PR restores the task toggle's positioning context and the compact accent badge in the split-view CSS owner. It also reverses the existing light/dark browser geometry invariant so the count must be offset from, and extend beyond, the icon button rather than remain centered and contained. No duplicate test was added.

## User Impact

Active background-task counts once again appear as a small badge over the checklist icon, preserving the consistent width and rhythm of the chat rail actions.

## Evidence

- Regression proof: with the test expectation changed but the production CSS reverted, both light and dark cases failed because the badge remained centered and contained (`centerDelta: 0`, `contained: true`).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-rail-columns.e2e.test.ts` — 5 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/chat/background-tasks.e2e.test.ts` — 3 passed.
- `node scripts/check-changed.mjs -- ui/src/styles/chat/split-view.css ui/src/e2e/chat-rail-columns.e2e.test.ts` — passed.
- Production CSS: +14/-12 (net +2). Test: +2/-2 (net 0).

### Visual evidence

| View | Light | Dark |
| --- | --- | --- |
| Badge closeup | ![Task count badge overlaid on the checklist icon in light mode](https://github.com/user-attachments/assets/0dae6bee-0143-44ef-9fb7-93473412c13c) | ![Task count badge overlaid on the checklist icon in dark mode](https://github.com/user-attachments/assets/6d0ff557-9ba3-419e-b1ed-258ece12d3aa) |
| Chat with rail open | ![Chat page with the side rail open and task count badge visible in light mode](https://github.com/user-attachments/assets/1eadd59c-92c8-4d2f-b841-f5c17813be99) | ![Chat page with the side rail open and task count badge visible in dark mode](https://github.com/user-attachments/assets/2bd0091d-c9ff-4ac6-a09f-1f2fa8f70beb) |
