### PR TITLE
fix(ui): give queued-outbox badges their own outbox icon

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1352,6 +1352,7 @@ async function createChatPickerScenario(
     sessionRow("agent:main:home-server", "Home server migration", baseTime - 240_000, {
       execCwd: "/Users/peter/Projects",
       execNode: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+      hasAutomation: true,
       pinned: true,
     }),
     sessionRow("agent:main:whatsapp:group:family", "Family", baseTime - 90_000, {

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -62,6 +62,12 @@ export const icons = {
     <path d="M16 21h1a2 2 0 0 0 2-2v-5c0-1.1.9-2 2-2a2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1" />`),
   mail: strokeIcon(svg` <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
     <polyline points="22,6 12,13 2,6" />`),
+  // Outbox tray (Lucide inbox with the roof swapped for a rising arrow):
+  // queued-to-send messages. Keep the clock for automations/cron only.
+  outbox: strokeIcon(svg` <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+    <path d="M2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6" />
+    <path d="M12 10V3" />
+    <path d="m8 6 4-4 4 4" />`),
   star: strokeIcon(
     svg`<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />`,
   ),

--- a/ui/src/components/session-row-badges.test.ts
+++ b/ui/src/components/session-row-badges.test.ts
@@ -75,6 +75,22 @@ describe("session row placement badges", () => {
     expect(container.querySelector(".session-row-badges")).toBeNull();
   });
 
+  it("keeps the queued-outbox glyph distinct from the automation clock", () => {
+    render(
+      renderSessionRowBadges({
+        hasAutomation: true,
+        outboxCount: 1,
+      }),
+      container,
+    );
+
+    const automation = container.querySelector("[aria-label='Automation attached'] svg");
+    const queued = container.querySelector(".session-row-badge--queued svg");
+    expect(automation).not.toBeNull();
+    expect(queued).not.toBeNull();
+    expect(queued?.innerHTML).not.toBe(automation?.innerHTML);
+  });
+
   it.each(["local", "reclaimed"] satisfies SessionPlacementState[])(
     "keeps %s placement visually quiet",
     (placementState) => {

--- a/ui/src/components/session-row-badges.ts
+++ b/ui/src/components/session-row-badges.ts
@@ -157,7 +157,7 @@ export function renderSessionRowBadges(params: {
         )
       : nothing}
     ${outboxCount > 0
-      ? renderSessionRowBadge(outboxLabel, icons.clock, "session-row-badge--queued", outboxCount)
+      ? renderSessionRowBadge(outboxLabel, icons.outbox, "session-row-badge--queued", outboxCount)
       : nothing}
     ${params.hasComposerDraft
       ? renderSessionRowBadge(

--- a/ui/src/pages/chat/components/chat-composer-queue.ts
+++ b/ui/src/pages/chat/components/chat-composer-queue.ts
@@ -198,7 +198,7 @@ function renderChatQueueItem(
       ${reconnecting
         ? html`<span class="chat-queue__dot" aria-hidden="true"></span>`
         : html`<span class="chat-queue__icon" aria-hidden="true">
-            ${failed ? icons.alertTriangle : steered ? icons.cornerDownRight : icons.clock}
+            ${failed ? icons.alertTriangle : steered ? icons.cornerDownRight : icons.outbox}
           </span>`}
       ${renderChatAuthorAvatar(item.sender)}
       ${steered


### PR DESCRIPTION
## What Problem This Solves

The sidebar "message queued to send" badge and the chat composer queue reused the clock icon that also marks sessions with attached automations (and is the cron glyph across the config nav and cron page). A session with both an automation and a queued message showed two identical clocks side by side, distinguishable only by tooltip.

## Why This Change Was Made

The clock is firmly established as the automation/cron glyph; the queued badge was the squatter. Queued messages get a dedicated outbox tray icon (Lucide `inbox` geometry with the roof swapped for a rising arrow) — semantically literal for the `outboxCount` field it renders, and visually distinct from every other sidebar badge glyph (clock, lock, PR, warning triangle, pencil, globe) at the 12px badge size. Drafts intentionally keep the pencil: a draft means "your move", a queued message means "no action needed" — merging them was considered and rejected.

## User Impact

Sessions with queued outbox messages now show an outbox tray instead of a second clock, in the sidebar badge row and in the composer queue's pending items. Automation badges are unchanged.

Before (automation + 1 queued message):

![before](https://github.com/user-attachments/assets/f1f72166-fb53-4adc-9db3-b42722526c2c)

After:

![after](https://github.com/user-attachments/assets/8ac48010-e77d-4c4e-bde3-765210c0449d)

## Evidence

- New regression test renders a row with `hasAutomation: true` + `outboxCount: 1` and asserts the two badge SVGs differ; verified it fails on pre-fix code (queued badge reverted to clock: 1 failed / 24 passed) and passes with the fix.
- Focused UI suite: 631 test files / 9114 tests passed (`pnpm test` shard covering `ui/src`).
- `pnpm tsgo:ui`, `pnpm tsgo:scripts`, `pnpm tsgo:test:ui`, and focused oxlint all exit 0. `pnpm check:changed` remote delegation was unavailable (Blacksmith doctor red, Daytona quota exceeded), so lane proof ran locally per the documented fallback.
- Screenshots captured from the mocked Control UI dev server (`scripts/control-ui-mock-dev.ts`), which now flags the "Home server migration" fixture session with `hasAutomation: true` so the automation badge renders in mocked-dashboard proofs.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
