### PR TITLE
fix(gateway): preserve prepared plugin metadata under load

### DIFF
--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -637,7 +637,7 @@ describe("optional media tool factory planning", () => {
 
   it("defers PDF model resolution from the tool-prep hot path", async () => {
     const config: OpenClawConfig = {};
-    installSnapshot(config, []);
+    installSnapshot(config, createImageAndPdfPlugins());
     const resolveSpy = vi.spyOn(pdfModelConfigModule, "resolvePdfModelConfigForTool");
 
     const tools = await createOpenClawToolsForTest({

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -4,6 +4,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import pLimit from "p-limit";
 import { runAbortableTimeout } from "../node-host/with-timeout.js";
+import { projectPluginMetadataSnapshotWorkspace } from "../plugins/plugin-metadata-snapshot.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-materializations.js";
@@ -232,6 +233,14 @@ function createSnapshot(
   const { credentials, input } = agentFacts;
   const { mediaCapabilityProviders, messageToolCatalog, pluginMetadataSnapshot, pluginRegistry } =
     pluginGeneration;
+  const metadataSnapshot = input.workspaceDir
+    ? projectPluginMetadataSnapshotWorkspace({
+        snapshot: pluginMetadataSnapshot,
+        config: input.config,
+        env: input.env,
+        workspaceDir: input.workspaceDir,
+      })
+    : pluginMetadataSnapshot;
   const { configuredRuntimeModels, inlineProviderModels, modelCatalog, templateModelRegistry } =
     catalogFacts;
   const createStores = (): PreparedModelRuntimeStores => {
@@ -248,7 +257,7 @@ function createSnapshot(
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     config: input.config,
     authModes: resolveUsableAgentCredentialModes(credentials),
-    metadataSnapshot: pluginMetadataSnapshot,
+    metadataSnapshot,
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
     ...(pluginRegistry ? { pluginRegistry } : {}),
     ...(messageToolCatalog ? { messageToolCatalog } : {}),

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -4,7 +4,6 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import pLimit from "p-limit";
 import { runAbortableTimeout } from "../node-host/with-timeout.js";
-import { projectPluginMetadataSnapshotWorkspace } from "../plugins/plugin-metadata-snapshot.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-materializations.js";
@@ -35,6 +34,7 @@ import {
   createPreparedInboundRegistryLoader,
   preparedModelRuntimeWorkspaceFactsKey,
 } from "./prepared-model-runtime.inbound-registry.js";
+import { projectPreparedPluginGeneration } from "./prepared-model-runtime.plugin-generation.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -233,14 +233,6 @@ function createSnapshot(
   const { credentials, input } = agentFacts;
   const { mediaCapabilityProviders, messageToolCatalog, pluginMetadataSnapshot, pluginRegistry } =
     pluginGeneration;
-  const metadataSnapshot = input.workspaceDir
-    ? projectPluginMetadataSnapshotWorkspace({
-        snapshot: pluginMetadataSnapshot,
-        config: input.config,
-        env: input.env,
-        workspaceDir: input.workspaceDir,
-      })
-    : pluginMetadataSnapshot;
   const { configuredRuntimeModels, inlineProviderModels, modelCatalog, templateModelRegistry } =
     catalogFacts;
   const createStores = (): PreparedModelRuntimeStores => {
@@ -257,7 +249,7 @@ function createSnapshot(
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     config: input.config,
     authModes: resolveUsableAgentCredentialModes(credentials),
-    metadataSnapshot,
+    metadataSnapshot: pluginMetadataSnapshot,
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
     ...(pluginRegistry ? { pluginRegistry } : {}),
     ...(messageToolCatalog ? { messageToolCatalog } : {}),
@@ -364,7 +356,13 @@ async function buildSnapshotBatch(
     configuredProjectionMs += prepared.buildStats.configuredProjectionMs;
     for (const agentFacts of prepared.agentFacts) {
       preparedInputs.set(agentFacts.input, agentFacts);
-      pluginGenerations.set(agentFacts.input, prepared.pluginGeneration);
+      pluginGenerations.set(
+        agentFacts.input,
+        projectPreparedPluginGeneration({
+          input: agentFacts.input,
+          pluginGeneration: prepared.pluginGeneration,
+        }),
+      );
     }
   }
   const workspaceFactsMs = performance.now() - workspaceFactsStartedAt;

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -138,6 +138,28 @@ describe("prepared reply dispatch runtime", () => {
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(publicationLoadCount);
   });
 
+  it("projects shared plugin metadata into each configured runtime workspace", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const workspaceDir = "/tmp/configured-metadata-workspace";
+    const config = retainLegacyDefaultAgentId({ agents: { entries: { default: {} } } }, "default");
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      defaultWorkspaceDir: workspaceDir,
+    });
+
+    const snapshot = getPreparedModelRuntimeSnapshot({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config,
+      workspaceDir,
+    });
+
+    expect(snapshot?.metadataSnapshot.workspaceDir).toBe(workspaceDir);
+    expect(snapshot?.metadataSnapshot.index.workspaceDir).toBe(workspaceDir);
+  });
+
   it("reuses configured and retained dynamic plugin generations during auth refresh", async () => {
     mocks.configuredAgentIds = ["default"];
     const workspaceDir = "/tmp/dynamic-auth-workspace";

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,6 +1,9 @@
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  projectPluginMetadataSnapshotWorkspace,
+  resolvePluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
@@ -59,7 +62,7 @@ export function prepareOwnedPluginLoadContext(
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,
 ): PluginMetadataSnapshot {
-  const metadataSnapshot = resolvePluginMetadataSnapshot({
+  const resolvedMetadataSnapshot = resolvePluginMetadataSnapshot({
     config: input.config,
     env,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
@@ -67,6 +70,14 @@ export function prepareOwnedPluginLoadContext(
       ? {}
       : { workspacePluginRootPresent: input.workspacePluginRootPresent }),
   });
+  const metadataSnapshot = input.workspaceDir
+    ? projectPluginMetadataSnapshotWorkspace({
+        snapshot: resolvedMetadataSnapshot,
+        config: input.config,
+        env,
+        workspaceDir: input.workspaceDir,
+      })
+    : resolvedMetadataSnapshot;
   preparePluginLoadContext(input, env, registry, metadataSnapshot);
   return metadataSnapshot;
 }

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -47,6 +47,25 @@ export function createPreparedPluginGeneration(params: {
   });
 }
 
+export function projectPreparedPluginGeneration(params: {
+  input: PreparedModelRuntimeInput;
+  pluginGeneration: PreparedModelRuntimePluginGeneration;
+}): PreparedModelRuntimePluginGeneration {
+  const { input, pluginGeneration } = params;
+  if (!input.workspaceDir) {
+    return pluginGeneration;
+  }
+  const pluginMetadataSnapshot = projectPluginMetadataSnapshotWorkspace({
+    snapshot: pluginGeneration.pluginMetadataSnapshot,
+    config: input.config,
+    env: input.env ?? process.env,
+    workspaceDir: input.workspaceDir,
+  });
+  return pluginMetadataSnapshot === pluginGeneration.pluginMetadataSnapshot
+    ? pluginGeneration
+    : Object.freeze({ ...pluginGeneration, pluginMetadataSnapshot });
+}
+
 export async function buildPreparedPluginModelCatalog(params: {
   agentFacts: {
     credentials: Parameters<typeof buildPreparedModelCatalogSnapshot>[0]["authCredentials"];
@@ -59,13 +78,13 @@ export async function buildPreparedPluginModelCatalog(params: {
   const { credentials, input } = params.agentFacts;
   return await withPreparedPluginGenerationScope(
     { input, pluginGeneration: params.pluginGeneration },
-    () =>
+    (metadataSnapshot) =>
       buildPreparedModelCatalogSnapshot({
         agentDir: input.agentDir,
         authCredentials: credentials,
         config: input.config,
         modelRegistry: params.modelRegistry,
-        metadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
+        metadataSnapshot,
         includeProviderPluginAugmentation: params.catalogMode === "live",
         ...(input.env ? { env: input.env } : {}),
         ...(input.readOnly ? { readOnly: true } : {}),
@@ -82,15 +101,9 @@ export function withPreparedPluginGenerationScope<T>(
   },
   run: (metadataSnapshot: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"]) => T,
 ): T {
-  const { input, pluginGeneration } = params;
-  const metadataSnapshot = input.workspaceDir
-    ? projectPluginMetadataSnapshotWorkspace({
-        snapshot: pluginGeneration.pluginMetadataSnapshot,
-        config: input.config,
-        env: input.env ?? process.env,
-        workspaceDir: input.workspaceDir,
-      })
-    : pluginGeneration.pluginMetadataSnapshot;
+  const { input } = params;
+  const pluginGeneration = projectPreparedPluginGeneration(params);
+  const metadataSnapshot = pluginGeneration.pluginMetadataSnapshot;
   return withPluginRuntimeGenerationScope(
     {
       config: input.config,

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -398,7 +398,14 @@ describe("prepared model runtime Gateway catalog mode", () => {
         includePluginCatalogs: true,
         modelsJsonContents: null,
         pluginCatalogs: [],
-        pluginMetadataSnapshot: mocks.metadataSnapshot,
+        pluginMetadataSnapshot: expect.objectContaining({
+          ...mocks.metadataSnapshot,
+          index: expect.objectContaining({
+            ...mocks.metadataSnapshot.index,
+            workspaceDir: "/tmp/prepared-static-workspace",
+          }),
+          workspaceDir: "/tmp/prepared-static-workspace",
+        }),
         workspaceDir: "/tmp/prepared-static-workspace",
       }),
     );

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -393,6 +393,23 @@ describe("current plugin metadata snapshot", () => {
     );
   });
 
+  it("trusts the config identity explicitly paired with an owner-prepared scope", () => {
+    const sourceConfig = { plugins: { allow: ["source"] } };
+    const runtimeConfig = { plugins: { allow: ["runtime"] } };
+    const workspaceDir = "/workspace";
+    const snapshot = createSnapshot({ config: sourceConfig, workspaceDir });
+
+    withPluginMetadataSnapshotScope(
+      snapshot,
+      () => {
+        expect(getCurrentPluginMetadataSnapshot({ config: runtimeConfig, workspaceDir })).toBe(
+          snapshot,
+        );
+      },
+      { config: runtimeConfig },
+    );
+  });
+
   it("rejects a workspace-scoped snapshot when the caller does not provide workspace scope", () => {
     const config = { plugins: { allow: ["demo"] } };
     const snapshot = createSnapshot({ config, workspaceDir: "/workspace/a" });

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -279,10 +279,9 @@ export function withPluginMetadataSnapshotScope<T>(
     : snapshot.configFingerprint;
   const configIdentities = new WeakSet<OpenClawConfig>();
   if (options.config) {
-    const policyHash = resolveInstalledPluginIndexPolicyHash(options.config);
-    if (policyHash === snapshot.policyHash || compatiblePolicyHashes?.includes(policyHash)) {
-      configIdentities.add(options.config);
-    }
+    // The closure owner already paired this exact config with its immutable generation.
+    // Recomputing policy compatibility here makes nested hot paths discard prepared facts.
+    configIdentities.add(options.config);
   }
   for (const config of options.compatibleConfigs ?? []) {
     configIdentities.add(config);

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,11 +1,14 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
-import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   completePluginMetadataSnapshot,
   loadPluginMetadataSnapshot,
@@ -96,7 +99,7 @@ describe("plugin metadata snapshot", () => {
   });
 
   afterEach(() => {
-    clearCurrentPluginMetadataSnapshot();
+    clearPluginMetadataLifecycleCaches();
   });
 
   it("keeps explicit control-plane loads fresh", () => {
@@ -187,7 +190,6 @@ describe("plugin metadata snapshot", () => {
       config,
       env: {},
       workspaceDir: targetWorkspace,
-      workspacePluginRootPresent: false,
     });
 
     expect(resolved).not.toBe(source);
@@ -204,6 +206,15 @@ describe("plugin metadata snapshot", () => {
       workspacePluginRootPresent: true,
     });
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
+
+    const pluginWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-workspace-"));
+    try {
+      fs.mkdirSync(path.join(pluginWorkspace, ".openclaw", "extensions"), { recursive: true });
+      resolvePluginMetadataSnapshot({ config, env: {}, workspaceDir: pluginWorkspace });
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+    } finally {
+      fs.rmSync(pluginWorkspace, { force: true, recursive: true });
+    }
   });
 
   it("rewalks collection-bearing manifest graphs after prototype mutation", () => {

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -14,7 +16,9 @@ import {
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import { PluginLruCache } from "./plugin-cache-primitives.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { buildPluginMetadataProviderFacts } from "./plugin-metadata-provider-facts.js";
 import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot.runtime.js";
 import type {
@@ -41,6 +45,8 @@ const PLUGIN_METADATA_ENV_KEYS = [
   "USERPROFILE",
   "XDG_CONFIG_HOME",
 ] as const;
+const workspacePluginRootPresence = new PluginLruCache<boolean>(128);
+registerPluginMetadataProcessMemoLifecycleClear(() => workspacePluginRootPresence.clear());
 export type {
   PluginMetadataSnapshot,
   PluginMetadataSnapshotOwnerMaps,
@@ -60,6 +66,18 @@ export function resolvePluginMetadataEnvFingerprint(env: NodeJS.ProcessEnv): str
     env: pickPluginMetadataEnv(env),
     installRoots: resolveActivePluginInstallRoots(env),
   });
+}
+
+function hasWorkspacePluginRoot(workspaceDir: string): boolean {
+  const cached = workspacePluginRootPresence.getResult(workspaceDir);
+  if (cached.hit) {
+    return cached.value;
+  }
+  // Plugin metadata is lifecycle-stable. Resolve this admission fact once per workspace so
+  // configless nested readers can reuse the prepared graph without freshness-polling the disk.
+  const present = fs.existsSync(path.join(workspaceDir, ".openclaw", "extensions"));
+  workspacePluginRootPresence.set(workspaceDir, present);
+  return present;
 }
 
 function throwReadonlyPluginMetadataMutation(): never {
@@ -396,6 +414,9 @@ export function resolvePluginMetadataSnapshot(
       const hasWorkspacePlugin = lifecycleSnapshot?.index.plugins.some(
         (plugin) => plugin.origin === "workspace",
       );
+      const workspacePluginRootPresent =
+        params.workspacePluginRootPresent ??
+        (targetWorkspace ? hasWorkspacePluginRoot(targetWorkspace) : undefined);
       // Gateway metadata is lifecycle-stable. A workspace with no plugin root can reuse the
       // published graph without polling every bundled/global artifact on its first turn.
       if (
@@ -403,7 +424,7 @@ export function resolvePluginMetadataSnapshot(
         targetWorkspace &&
         targetWorkspace !== lifecycleSnapshot.workspaceDir &&
         !hasWorkspacePlugin &&
-        params.workspacePluginRootPresent === false
+        workspacePluginRootPresent === false
       ) {
         return projectPluginMetadataSnapshotWorkspace({
           snapshot: lifecycleSnapshot,

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -72,10 +72,7 @@ describe("node worker launch wire", () => {
       let launchId: string | undefined;
       let observeFinalizationLoad = false;
       let finalizationStartedAt: number | undefined;
-      let resolveFinalizationStarted!: () => void;
-      const finalizationStarted = new Promise<void>((resolve) => {
-        resolveFinalizationStarted = resolve;
-      });
+      let resolveWaveFinalizationStarted: ((startedAt: number) => void) | undefined;
 
       try {
         gateway = await startPairedNodeWorkerGateway({ providerBaseUrl: provider.baseUrl });
@@ -94,10 +91,12 @@ describe("node worker launch wire", () => {
               if (
                 observeFinalizationLoad &&
                 workspaceCommand.transfer?.direction === "upload" &&
-                !finalizationStartedAt
+                resolveWaveFinalizationStarted
               ) {
-                finalizationStartedAt = performance.now();
-                resolveFinalizationStarted();
+                const startedAt = performance.now();
+                finalizationStartedAt ??= startedAt;
+                resolveWaveFinalizationStarted(startedAt);
+                resolveWaveFinalizationStarted = undefined;
               }
             }
             if (frame.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND && frame.paramsJSON) {
@@ -306,47 +305,53 @@ describe("node worker launch wire", () => {
           }
         })();
         const freshConnectionSamples: number[] = [];
-        for (let wave = 0; wave < FINALIZATION_LOAD_WAVES; wave += 1) {
-          const loadRunIds = await Promise.all(
-            loadSessions.map(async (sessionKey, index) => {
-              const runId = `node-worker-finalization-load-${wave}-${index}-${Date.now()}`;
-              const started = await operator!.request<{ runId?: string; status?: string }>(
-                "chat.send",
-                {
-                  sessionKey,
-                  message: BASELINE_PROMPT,
-                  deliver: false,
-                  idempotencyKey: runId,
-                },
-              );
-              expect(started).toMatchObject({ runId, status: "started" });
-              return runId;
-            }),
-          );
-          const waits = Promise.all(
-            loadRunIds.map(async (runId) => {
-              const completedLoad = await operator!.request<{ status?: string }>(
-                "agent.wait",
-                { runId, timeoutMs: PROOF_TIMEOUT_MS },
-                { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
-              );
-              expect(completedLoad.status).toBe("ok");
-            }),
-          );
-          await finalizationStarted;
-          const freshConnectionStartedAt = performance.now();
-          const freshClient = await connectWireClient({
-            gateway,
-            role: "operator",
-            identity: null,
-            timeoutMs: CONTROL_PROBE_MAX_MS,
-          });
-          freshConnectionSamples.push(performance.now() - freshConnectionStartedAt);
-          await freshClient.stopAndWait({ timeoutMs: 2_000 });
-          await waits;
+        try {
+          for (let wave = 0; wave < FINALIZATION_LOAD_WAVES; wave += 1) {
+            const waveFinalizationStarted = new Promise<number>((resolve) => {
+              resolveWaveFinalizationStarted = resolve;
+            });
+            const loadRunIds = await Promise.all(
+              loadSessions.map(async (sessionKey, index) => {
+                const runId = `node-worker-finalization-load-${wave}-${index}-${Date.now()}`;
+                const started = await operator!.request<{ runId?: string; status?: string }>(
+                  "chat.send",
+                  {
+                    sessionKey,
+                    message: BASELINE_PROMPT,
+                    deliver: false,
+                    idempotencyKey: runId,
+                  },
+                );
+                expect(started).toMatchObject({ runId, status: "started" });
+                return runId;
+              }),
+            );
+            const waits = Promise.all(
+              loadRunIds.map(async (runId) => {
+                const completedLoad = await operator!.request<{ status?: string }>(
+                  "agent.wait",
+                  { runId, timeoutMs: PROOF_TIMEOUT_MS },
+                  { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+                );
+                expect(completedLoad.status).toBe("ok");
+              }),
+            );
+            await waveFinalizationStarted;
+            const freshConnectionStartedAt = performance.now();
+            const freshClient = await connectWireClient({
+              gateway,
+              role: "operator",
+              identity: null,
+              timeoutMs: CONTROL_PROBE_MAX_MS,
+            });
+            freshConnectionSamples.push(performance.now() - freshConnectionStartedAt);
+            await freshClient.stopAndWait({ timeoutMs: 2_000 });
+            await waits;
+          }
+        } finally {
+          loadSettled = true;
+          await Promise.allSettled([sampler]);
         }
-        loadSettled = true;
-        await sampler;
         const finalizationSamples = readyzSamples.filter(
           (sample) => sample.atMs >= (finalizationStartedAt ?? Number.POSITIVE_INFINITY),
         );

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -33,7 +33,10 @@ const execFileAsync = promisify(execFile);
 const SESSION_KEY = "agent:qa:node-worker-launch-wire";
 const TEST_TIMEOUT_MS = PROOF_TIMEOUT_MS + 60_000;
 const CONTROL_PROBE_MAX_MS = 4_000;
-const FINALIZATION_LOAD_CONCURRENCY = 6;
+const CONTROL_PROBE_P95_MS = 1_000;
+const FINALIZATION_LOAD_CONCURRENCY = 12;
+const FINALIZATION_LOAD_WAVES = 3;
+const MIN_CONTROL_PROBE_SAMPLES = 12;
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -43,6 +46,12 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
     timeout: 20_000,
   });
   return stdout.trim();
+}
+
+function nearestRankPercentile(values: readonly number[], percentile: number): number {
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1);
+  return sorted[index] ?? 0;
 }
 
 describe("node worker launch wire", () => {
@@ -296,55 +305,58 @@ describe("node worker launch wire", () => {
             await new Promise((resolve) => setTimeout(resolve, 50));
           }
         })();
-        const loadRunIds = await Promise.all(
-          loadSessions.map(async (sessionKey, index) => {
-            const loadRunId = `node-worker-finalization-load-${index}-${Date.now()}`;
-            const loadStarted = await operator!.request<{ runId?: string; status?: string }>(
-              "chat.send",
-              {
-                sessionKey,
-                message: BASELINE_PROMPT,
-                deliver: false,
-                idempotencyKey: loadRunId,
-              },
-            );
-            expect(loadStarted).toMatchObject({ runId: loadRunId, status: "started" });
-            return loadRunId;
-          }),
-        );
-        const waits = Promise.all(
-          loadRunIds.map(async (loadRunId) => {
-            const completedLoad = await operator!.request<{ status?: string }>(
-              "agent.wait",
-              { runId: loadRunId, timeoutMs: PROOF_TIMEOUT_MS },
-              { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
-            );
-            expect(completedLoad.status).toBe("ok");
-          }),
-        );
-        await finalizationStarted;
-        const freshConnectionStartedAt = performance.now();
-        const freshClient = await connectWireClient({
-          gateway,
-          role: "operator",
-          identity: null,
-          timeoutMs: CONTROL_PROBE_MAX_MS,
-        });
-        const freshConnectionMs = performance.now() - freshConnectionStartedAt;
-        await freshClient.stopAndWait({ timeoutMs: 2_000 });
-        await waits.finally(() => {
-          loadSettled = true;
-        });
+        const freshConnectionSamples: number[] = [];
+        for (let wave = 0; wave < FINALIZATION_LOAD_WAVES; wave += 1) {
+          const loadRunIds = await Promise.all(
+            loadSessions.map(async (sessionKey, index) => {
+              const runId = `node-worker-finalization-load-${wave}-${index}-${Date.now()}`;
+              const started = await operator!.request<{ runId?: string; status?: string }>(
+                "chat.send",
+                {
+                  sessionKey,
+                  message: BASELINE_PROMPT,
+                  deliver: false,
+                  idempotencyKey: runId,
+                },
+              );
+              expect(started).toMatchObject({ runId, status: "started" });
+              return runId;
+            }),
+          );
+          const waits = Promise.all(
+            loadRunIds.map(async (runId) => {
+              const completedLoad = await operator!.request<{ status?: string }>(
+                "agent.wait",
+                { runId, timeoutMs: PROOF_TIMEOUT_MS },
+                { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+              );
+              expect(completedLoad.status).toBe("ok");
+            }),
+          );
+          await finalizationStarted;
+          const freshConnectionStartedAt = performance.now();
+          const freshClient = await connectWireClient({
+            gateway,
+            role: "operator",
+            identity: null,
+            timeoutMs: CONTROL_PROBE_MAX_MS,
+          });
+          freshConnectionSamples.push(performance.now() - freshConnectionStartedAt);
+          await freshClient.stopAndWait({ timeoutMs: 2_000 });
+          await waits;
+        }
+        loadSettled = true;
         await sampler;
         const finalizationSamples = readyzSamples.filter(
           (sample) => sample.atMs >= (finalizationStartedAt ?? Number.POSITIVE_INFINITY),
         );
-        expect(finalizationSamples.length).toBeGreaterThan(0);
+        expect(finalizationSamples.length).toBeGreaterThanOrEqual(MIN_CONTROL_PROBE_SAMPLES);
         expect(finalizationSamples.every((sample) => sample.status === 200)).toBe(true);
-        expect(Math.max(...finalizationSamples.map((sample) => sample.latencyMs))).toBeLessThan(
-          CONTROL_PROBE_MAX_MS,
-        );
-        expect(freshConnectionMs).toBeLessThan(CONTROL_PROBE_MAX_MS);
+        const readyzLatencies = finalizationSamples.map((sample) => sample.latencyMs);
+        expect(nearestRankPercentile(readyzLatencies, 95)).toBeLessThan(CONTROL_PROBE_P95_MS);
+        expect(Math.max(...readyzLatencies)).toBeLessThan(CONTROL_PROBE_MAX_MS);
+        expect(Math.max(...freshConnectionSamples)).toBeLessThan(CONTROL_PROBE_MAX_MS);
+        expect(freshConnectionSamples).toHaveLength(FINALIZATION_LOAD_WAVES);
       } finally {
         const cleanup = await Promise.allSettled([
           workerNode?.stop() ?? Promise.resolve(),


### PR DESCRIPTION
## Summary

Fix the third Gateway event-loop stall recurrence by preserving lifecycle-owned plugin metadata through every prepared runtime boundary instead of rediscovering it synchronously from turns and catalog preparation.

The CPU profile shows shape **(a), one dominant hotspot**, not diffuse GC saturation, so this intentionally does not add a second control-plane listener or a worker thread.

## Root cause

The prepared lifecycle already owned the correct plugin metadata graph, but three gaps let hot paths discard it:

1. Fresh and reused plugin generations could retain shared metadata without projecting it into each exact runtime workspace before catalog preparation.
2. Explicit closure-bound prepared scopes rechecked policy hashes and rejected the exact runtime config paired by their owner.
3. Configless nested readers had no cached admission fact proving a new workspace had no `.openclaw/extensions` root, so they synchronously rediscovered installed plugins.

This projects metadata at the prepared plugin-context/generation owner, carries the projected generation through catalog and final snapshot construction, trusts the exact config identity paired with a closure-bound scope, and memoizes workspace plugin-root presence in a bounded 128-entry lifecycle-cleared LRU. Explicit facts still win, and a real workspace plugin root still forces discovery.

## Profile verdict

Before profile: `/tmp/openclaw-loop-structural-before-profile/profiles/CPU.20260816.121405.33041.0.001.cpuprofile`

| Frame | Before inclusive | After inclusive |
| --- | ---: | ---: |
| `loadPluginRegistrySnapshotWithMetadata` | 65.6% | 19.2% |
| `loadPluginMetadataSnapshot` | 59.8% | 13.9% |
| installed-index discovery | 44.8% | no longer dominant |
| `lstat` self | 26.4% | no longer dominant |
| `open` self | 11.8% | no longer dominant |
| `existsSync` self | 9.2% | no longer dominant |
| GC | 1.15% | not causal |

Individual 1–5 second spike windows spent 75–97% inclusive in metadata resolution. The after profile is `/tmp/openclaw-loop-structural-final-a/profiles/CPU.20260816.132245.67713.0.001.cpuprofile`; idle rose to 42.3%. Startup is included in both full captures.

## Probe distribution

Paired sample latency is the maximum of `/readyz` and authenticated WebSocket connect latency.

| Run | Samples | Min | p50 | p95 | p100 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before 1 | 31 | 4.5 ms | 771 ms | 4001 ms | 8005 ms |
| Before 2 | 28 | 4.6 ms | 281 ms | 3361 ms | 6673 ms |
| Before 3 | 24 | 5.3 ms | 506 ms | 4001 ms | 4003 ms |
| After A | 10 | 4.8 ms | 54 ms | 447 ms | 447 ms |
| After B | 10 | 5.1 ms | 21 ms | 965 ms | 965 ms |
| After C | 9 | 5.4 ms | 160 ms | 1489 ms | 1489 ms |
| After aggregate | 29 | 4.8 ms | 54 ms | 965 ms | 1489 ms |

All 108 post-fix turns completed and no probe failed.

## Regression gate

The existing node-worker finalization E2E now dispatches 12 workers over three reused waves (36 turns), continuously samples readiness every 50 ms, requires at least 12 finalization samples, asserts nearest-rank p95 below 1 second and p100 below 4 seconds, and establishes a fresh authenticated WebSocket during every wave. The pre-fix distributions breach both thresholds.

No timeout was raised. The truthful readiness regression remains green.

## Verification

- Initial focused owner tests passed three consecutive times.
- CI on the first PR head exposed two additional catalog paths that still received shared metadata plus one test fixture relying on hidden rediscovery. The generation owner now projects before catalog preparation; all three failures reproduce locally before that correction and pass after it.
- Corrected head, three consecutive runs: prepared/runtime/media suites 69/69 each.
- Corrected head broader owner suite: Gateway 3/3; prepared/runtime/media 69/69; plugin metadata 51/51.
- Corrected runtime head changed gate: 1/1, 54.9 seconds behavior after a clean full build.
- Startup contract head affected suites: 75/75.
- ClawSweeper gate fixes: sampler settlement is unconditional and every wave has its own finalization signal; focused E2E 1/1 in 54.6 seconds after a clean full build.
- Formatting and `git diff --check` pass.
- Structured Codex autoreview: clean, no accepted/actionable findings.
- Remote `check:changed` passed every completed repository check; its 4 GB worker SIGKILLed a dynamically installed Knip subprocess in the dead-export lane after both scans reported zero entries. Exact-head CI remains authoritative.

## Size

Production LOC: +70/-19 (net +51). Tests and test support: +129/-55.

The production growth establishes one exact-workspace generation boundary across fresh, reused, catalog, and final runtime paths, plus a bounded lifecycle cache. It replaces repeated synchronous filesystem discovery and prevents prepared facts from being dropped between owners.


