### PR TITLE
refactor: encode internal runtime variants as closed unions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -371,7 +371,7 @@ extensions/discord/src/internal/gateway-dispatch.ts	7
 extensions/discord/src/internal/gateway-payload.ts	1
 extensions/discord/src/internal/gateway-voice-state-cache.ts	4
 extensions/discord/src/internal/gateway.ts	9
-extensions/discord/src/internal/interaction-dispatch.ts	14
+extensions/discord/src/internal/interaction-dispatch.ts	12
 extensions/discord/src/internal/interaction-options.ts	2
 extensions/discord/src/internal/interaction-response.ts	2
 extensions/discord/src/internal/interactions.ts	8
@@ -2898,7 +2898,7 @@ src/flows/doctor-core-checks.ts	4
 src/flows/doctor-health-contributions-final.ts	1
 src/flows/doctor-health-contributions.ts	2
 src/flows/doctor-removed-workspaces-state-check.ts	2
-src/flows/health-check-adapter.ts	2
+src/flows/health-check-adapter.ts	1
 src/flows/search-setup.ts	6
 src/gateway/agent-runtime-identity-token.ts	6
 src/gateway/agent-turn/agent-dedupe.ts	3

--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -4,7 +4,7 @@ import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Client } from "./client.js";
-import { BaseCommand } from "./commands.js";
+import { Command, type CommandOptions, type DiscordCommand } from "./commands.js";
 import { ComponentRegistry } from "./component-registry.js";
 import { Button, StringSelectMenu, parseCustomId } from "./components.js";
 import { DiscordError } from "./rest.js";
@@ -20,16 +20,14 @@ afterEach(() => {
 function createTestCommand(params: {
   name: string;
   guildIds?: string[];
-  options?: unknown[];
-}): BaseCommand {
-  return new (class extends BaseCommand {
+  options?: CommandOptions;
+}): DiscordCommand {
+  return new (class extends Command {
     name = params.name;
     override description = `${params.name} command`;
-    type = ApplicationCommandType.ChatInput;
     override guildIds = params.guildIds;
-    serializeOptions() {
-      return params.options;
-    }
+    override options = params.options;
+    run() {}
   })();
 }
 

--- a/extensions/discord/src/internal/client.ts
+++ b/extensions/discord/src/internal/client.ts
@@ -2,7 +2,7 @@
 import type { APIInteraction } from "discord-api-types/v10";
 import type { DiscordCommandDeployHashStore } from "../command-deploy-store.js";
 import { DiscordCommandDeployer, type DeployCommandOptions } from "./command-deploy.js";
-import type { BaseCommand } from "./commands.js";
+import type { DiscordCommand } from "./commands.js";
 import { ComponentRegistry } from "./component-registry.js";
 import { BaseMessageInteractiveComponent, type Modal } from "./components.js";
 import { DiscordEntityCache } from "./entity-cache.js";
@@ -57,7 +57,7 @@ export class Client {
   routes: Route[] = [];
   plugins: Array<{ id: string; plugin: Plugin }> = [];
   options: ClientOptions;
-  commands: BaseCommand[];
+  commands: DiscordCommand[];
   listeners: AnyListener[];
   rest: RequestClient;
   componentHandler = new ComponentRegistry<BaseMessageInteractiveComponent>();
@@ -71,7 +71,7 @@ export class Client {
   constructor(
     options: ClientOptions,
     handlers: {
-      commands?: BaseCommand[];
+      commands?: DiscordCommand[];
       listeners?: AnyListener[];
       components?: BaseMessageInteractiveComponent[];
       modals?: Modal[];

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -213,6 +213,7 @@ describe("commandsEqual", () => {
  */
 describe("DiscordCommandDeployer SQLite cache", () => {
   class StaticCommand extends BaseCommand {
+    readonly commandKind = "leaf";
     name: string;
     override description = "ping the bot";
     type = ApplicationCommandType.ChatInput;

--- a/extensions/discord/src/internal/commands.ts
+++ b/extensions/discord/src/internal/commands.ts
@@ -19,6 +19,7 @@ type CommandOption = Record<string, unknown> & {
   autocomplete?: boolean | ((interaction: AutocompleteInteraction) => Promise<void>);
 };
 export type CommandOptions = CommandOption[];
+export type DiscordCommand = Command | CommandWithSubcommands;
 
 type RawSubcommandOption = {
   name?: unknown;
@@ -72,28 +73,21 @@ function findCommandOption(
   return options?.find((option) => option.name === name);
 }
 
-function hasCommandOptions(
-  command: BaseCommand,
-): command is BaseCommand & { options?: CommandOptions } {
-  return "options" in command;
-}
-
 export function resolveFocusedCommandOptionAutocompleteHandler(
-  command: BaseCommand,
+  command: DiscordCommand,
   interaction: AutocompleteInteraction,
 ): ((interaction: AutocompleteInteraction) => Promise<void>) | undefined {
   const focusedName = interaction.options.getFocused()?.name;
   const options =
-    "subcommands" in command && Array.isArray(command.subcommands)
+    command.commandKind === "group"
       ? findSelectedSubcommand(command.subcommands, interaction)?.options
-      : hasCommandOptions(command)
-        ? command.options
-        : undefined;
+      : command.options;
   const autocomplete = findCommandOption(options, focusedName)?.autocomplete;
   return typeof autocomplete === "function" ? autocomplete : undefined;
 }
 
 export abstract class BaseCommand {
+  abstract readonly commandKind: "leaf" | "group";
   id?: string;
   abstract name: string;
   description?: string;
@@ -133,6 +127,7 @@ export abstract class BaseCommand {
 }
 
 export abstract class Command extends BaseCommand {
+  readonly commandKind = "leaf";
   options?: CommandOptions;
   type = ApplicationCommandType.ChatInput;
   abstract run(interaction: unknown): unknown;
@@ -153,6 +148,7 @@ export abstract class Command extends BaseCommand {
 }
 
 export abstract class CommandWithSubcommands extends BaseCommand {
+  readonly commandKind = "group";
   type = ApplicationCommandType.ChatInput;
   abstract subcommands: Command[];
   async run(interaction: CommandInteraction): Promise<unknown> {

--- a/extensions/discord/src/internal/interaction-dispatch.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements interaction dispatch behavior.
 import { InteractionType, type APIInteraction } from "discord-api-types/v10";
 import {
-  type BaseCommand,
+  type DiscordCommand,
   deferCommandInteractionIfNeeded,
   resolveFocusedCommandOptionAutocompleteHandler,
 } from "./commands.js";
@@ -28,7 +28,7 @@ type DispatchModal = {
 };
 
 type DispatchClient = Parameters<typeof createInteraction>[0] & {
-  commands: BaseCommand[];
+  commands: DiscordCommand[];
   componentHandler: {
     resolve(customId: string, options?: { componentType?: number }): DispatchComponent | undefined;
     resolveOneOffComponent(params: {
@@ -60,20 +60,16 @@ export async function dispatchInteraction(
       await optionAutocomplete(autocompleteInteraction);
       return;
     }
-    if ("autocomplete" in command) {
-      await (
-        command as { autocomplete: (interaction: AutocompleteInteraction) => Promise<void> }
-      ).autocomplete(autocompleteInteraction);
+    if (command.commandKind === "leaf") {
+      await command.autocomplete(autocompleteInteraction);
     }
     return;
   }
   if (rawData.type === InteractionType.ApplicationCommand) {
     const command = client.commands.find((entry) => entry.name === readInteractionName(rawData));
-    if (command && "run" in command) {
+    if (command) {
       await deferCommandInteractionIfNeeded(command, interaction as CommandInteraction);
-      await (command as { run: (interaction: CommandInteraction) => Promise<void> }).run(
-        interaction as CommandInteraction,
-      );
+      await command.run(interaction as CommandInteraction);
     }
     return;
   }

--- a/extensions/discord/src/internal/test-builders.test-support.ts
+++ b/extensions/discord/src/internal/test-builders.test-support.ts
@@ -2,7 +2,7 @@
 import { ComponentType, InteractionType } from "discord-api-types/v10";
 import { vi, type Mock } from "vitest";
 import { Client } from "./client.js";
-import type { BaseCommand } from "./commands.js";
+import type { DiscordCommand } from "./commands.js";
 import type { RawInteraction } from "./interactions.js";
 import type { RequestClient, RequestData } from "./rest.js";
 
@@ -55,7 +55,7 @@ export function createAbortableFetchMock() {
 }
 
 export function createInternalTestClient(
-  commands: BaseCommand[] = [],
+  commands: DiscordCommand[] = [],
   options?: Partial<ClientOptions>,
 ): Client {
   return new Client(

--- a/extensions/discord/src/monitor/provider.interactions.ts
+++ b/extensions/discord/src/monitor/provider.interactions.ts
@@ -9,7 +9,11 @@ import {
   getDiscordExecApprovalApprovers,
   isDiscordExecApprovalClientEnabled,
 } from "../exec-approvals.js";
-import type { BaseCommand, BaseMessageInteractiveComponent, Modal } from "../internal/discord.js";
+import type {
+  BaseMessageInteractiveComponent,
+  DiscordCommand,
+  Modal,
+} from "../internal/discord.js";
 import { createDiscordVoiceCommand, DISCORD_VOICE_COMMAND_SPEC } from "../voice/command.js";
 import {
   createAgentComponentControls,
@@ -55,12 +59,12 @@ export function createDiscordProviderInteractionSurface(params: {
   abortSignal?: AbortSignal;
   createNativeCommand?: typeof createDiscordNativeCommand;
 }): {
-  commands: BaseCommand[];
+  commands: DiscordCommand[];
   components: BaseMessageInteractiveComponent[];
   modals: Modal[];
 } {
   const createNativeCommand = params.createNativeCommand ?? createDiscordNativeCommand;
-  const commands: BaseCommand[] = params.commandSpecs.map((spec) => {
+  const commands: DiscordCommand[] = params.commandSpecs.map((spec) => {
     if (
       params.nativeEnabled &&
       params.voiceEnabled &&

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -8,8 +8,8 @@ import type { DiscordCommandDeployHashStore } from "../command-deploy-store.js";
 import {
   Client,
   ReadyListener,
-  type BaseCommand,
   type BaseMessageInteractiveComponent,
+  type DiscordCommand,
   type Modal,
   type Plugin,
 } from "../internal/discord.js";
@@ -93,7 +93,7 @@ export async function createDiscordMonitorClient(params: {
   applicationId: string;
   token: string;
   restFetch?: typeof fetch;
-  commands: BaseCommand[];
+  commands: DiscordCommand[];
   components: BaseMessageInteractiveComponent[];
   modals: Modal[];
   voiceEnabled: boolean;

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -49,6 +49,7 @@ import {
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 type MessageCut = {
+  status: "cut";
   editorText?: string;
   editorAttachments?: Array<{ mimeType: string; data: string }>;
   editorMediaRefs?: Array<{ path: string; contentType: string }>;
@@ -290,7 +291,7 @@ function mutateSqliteSessionAtMessageInTransaction(
   }
   const events = loadTranscriptEventsFromDatabase(database, currentEntry.sessionId);
   const cut = params.mode === "switch" ? undefined : resolveMessageCut(events, params.entryId);
-  if (cut && "status" in cut) {
+  if (cut && cut.status !== "cut") {
     return cut;
   }
   if (params.mode === "switch") {
@@ -311,7 +312,7 @@ function mutateSqliteSessionAtMessageInTransaction(
     sessionId: nextSessionId,
   });
   const nextEvents =
-    params.mode === "fork" && cut && !("status" in cut)
+    params.mode === "fork" && cut?.status === "cut"
       ? [header, ...cut.prefix]
       : [
           header,
@@ -354,11 +355,11 @@ function mutateSqliteSessionAtMessageInTransaction(
     status: "created",
     key: params.targetKey,
     entry: nextEntry,
-    ...(cut && !("status" in cut) && cut.editorText ? { editorText: cut.editorText } : {}),
-    ...(cut && !("status" in cut) && cut.editorAttachments
+    ...(cut?.status === "cut" && cut.editorText ? { editorText: cut.editorText } : {}),
+    ...(cut?.status === "cut" && cut.editorAttachments
       ? { editorAttachments: cut.editorAttachments }
       : {}),
-    ...(cut && !("status" in cut) && cut.editorMediaRefs
+    ...(cut?.status === "cut" && cut.editorMediaRefs
       ? { editorMediaRefs: cut.editorMediaRefs }
       : {}),
   };
@@ -482,6 +483,7 @@ function resolveMessageCut(
   const editorAttachments = extractEditorAttachments(message.content);
   const editorMediaRefs = extractEditorMediaRefs(message);
   return {
+    status: "cut",
     editorText: extractEditorText(message.content),
     ...(editorAttachments ? { editorAttachments } : {}),
     ...(editorMediaRefs ? { editorMediaRefs } : {}),

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -45,7 +45,11 @@ import { detectSkillWorkshopToolPolicyDiagnostic } from "../skills/workshop/tool
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import { removedWorkspacesStateCheck } from "./doctor-removed-workspaces-state-check.js";
 import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
-import type { SplitHealthCheckInput } from "./health-check-runner-types.js";
+import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
+import type {
+  SplitHealthCheckDefinition,
+  SplitHealthCheckInput,
+} from "./health-check-runner-types.js";
 import type {
   HealthCheck,
   HealthCheckContext,
@@ -840,7 +844,7 @@ const legacyWhatsAppCrontabCheck: HealthCheck & { readonly defaultEnabled: false
   },
 };
 
-const legacyCronStoreCheck: SplitHealthCheckInput = {
+const legacyCronStoreCheck: SplitHealthCheckDefinition = {
   id: "core/doctor/legacy-cron-store",
   kind: "core",
   description: "Legacy cron store, run-log, and payload state is normalized.",
@@ -994,7 +998,7 @@ const gatewayPlatformNotesCheck: HealthCheck = {
   },
 };
 
-function createGatewayHealthCheck(deps: CoreHealthCheckDeps): SplitHealthCheckInput {
+function createGatewayHealthCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDefinition {
   return {
     id: GATEWAY_HEALTH_CHECK_ID,
     kind: "core",
@@ -1007,7 +1011,7 @@ function createGatewayHealthCheck(deps: CoreHealthCheckDeps): SplitHealthCheckIn
   };
 }
 
-function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckInput {
+function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDefinition {
   return {
     id: GATEWAY_DAEMON_CHECK_ID,
     kind: "core",
@@ -1318,7 +1322,7 @@ function createWorkspaceSuggestionsCheck(
 
 function createConvertedWorkflowChecks(
   deps: CoreHealthCheckDeps,
-): readonly SplitHealthCheckInput[] {
+): readonly SplitHealthCheckDefinition[] {
   return [
     claudeCliCheck,
     gatewayAuthCheck,
@@ -1384,7 +1388,7 @@ function createConvertedWorkflowChecks(
 export function createCoreHealthChecks(
   deps: CoreHealthCheckDeps = defaultCoreHealthCheckDeps,
 ): readonly SplitHealthCheckInput[] {
-  return [
+  const checks: readonly SplitHealthCheckDefinition[] = [
     gatewayConfigCheck,
     ...createConvertedWorkflowChecks(deps),
     commandOwnerCheck,
@@ -1392,6 +1396,7 @@ export function createCoreHealthChecks(
     browserClawdProfileResidueCheck,
     finalConfigValidationCheck,
   ];
+  return checks.map(defineSplitHealthCheckInput);
 }
 
 export const CORE_HEALTH_CHECKS: readonly SplitHealthCheckInput[] = createCoreHealthChecks();

--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -4,7 +4,9 @@ import type {
 } from "./doctor-health-contribution-types.js";
 import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
 import { renderStructuredHealthFindings } from "./doctor-health-contribution.js";
-import type { HealthCheck, HealthFinding } from "./health-checks.js";
+import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
+import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
+import type { HealthFinding } from "./health-checks.js";
 
 const loadHealthCheckRegistryModule = async () => await import("./health-check-registry.js");
 
@@ -22,7 +24,7 @@ function withDoctorHealthCheckFacts<T extends object>(
 
 export async function runStructuredHealthRepairs(
   ctx: DoctorHealthFlowContext,
-  resolveCoreChecks: () => Promise<readonly HealthCheck[]>,
+  resolveCoreChecks: () => Promise<readonly DetectableHealthCheckInput[]>,
 ): Promise<void> {
   if (!ctx.prompter.shouldRepair) {
     return;
@@ -34,7 +36,9 @@ export async function runStructuredHealthRepairs(
 
   const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
-  const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks());
+  const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks()).map(
+    defineSplitHealthCheckInput,
+  );
   const result = await runDoctorHealthRepairs(
     withDoctorHealthCheckFacts(ctx, {
       mode: "fix" as const,

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -81,7 +81,7 @@ export type DoctorContributionHealthCheck =
       readonly kind?: "core";
       readonly source?: string;
     })
-  | (Omit<RunnableHealthCheck, "id" | "kind" | "source"> & {
+  | (Omit<RunnableHealthCheck, "id" | "kind" | "source" | "sourceContract"> & {
       readonly id?: string;
       readonly kind?: "core";
       readonly source?: string;

--- a/src/flows/doctor-health-contribution.ts
+++ b/src/flows/doctor-health-contribution.ts
@@ -69,12 +69,14 @@ function normalizeContributionHealthCheck(
       `doctor contribution ${contributionId} must specify health check ids when it declares multiple healthChecks`,
     );
   }
-  return {
-    ...check,
+  const identity = {
     id,
     kind: check.kind ?? "core",
     source: check.source ?? "doctor",
   };
+  return "run" in check
+    ? { ...check, ...identity, sourceContract: "run" }
+    : { ...check, ...identity, sourceContract: "split" };
 }
 
 function deriveCoreHealthCheckId(contributionId: string): string {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3476,7 +3476,7 @@ describe("doctor health contributions", () => {
     await contribution.run(ctx);
 
     expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.any(Object), {
-      checks: [{ id: "plugin/example/unrelated", kind: "plugin" }],
+      checks: [{ id: "plugin/example/unrelated", kind: "plugin", sourceContract: "split" }],
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -19,7 +19,8 @@ import { createDoctorHealthContribution } from "./doctor-health-contribution.js"
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
-import type { HealthCheck, HealthCheckContext, HealthFinding } from "./health-checks.js";
+import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
+import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
 
 export type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 
@@ -409,10 +410,12 @@ function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
   ];
 }
 
-export async function resolveDoctorContributionHealthChecks(): Promise<readonly HealthCheck[]> {
+export async function resolveDoctorContributionHealthChecks(): Promise<
+  readonly DetectableHealthCheckInput[]
+> {
   const { createCoreHealthChecks } = await import("./doctor-core-checks.js");
   const checksById = new Map(createCoreHealthChecks().map((check) => [check.id, check]));
-  const checks: HealthCheck[] = [];
+  const checks: DetectableHealthCheckInput[] = [];
   for (const contribution of resolveDoctorHealthContributions()) {
     if (contribution.healthChecks.length > 0) {
       checks.push(...contribution.healthChecks.map(normalizeHealthCheck));

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -206,6 +206,7 @@ describe("runDoctorLintChecks", () => {
         { checkId: "targeted", severity: "warning" as const, message: "warn" },
       ]),
       defaultEnabled: false,
+      sourceContract: "split",
     });
 
     await expect(
@@ -236,6 +237,7 @@ describe("runDoctorLintChecks", () => {
         { checkId: "targeted", severity: "warning" as const, message: "warn" },
       ]),
       defaultEnabled: false,
+      sourceContract: "split",
     });
     const defaultEnabled = check("regular", async () => []);
 
@@ -253,6 +255,7 @@ describe("runDoctorLintChecks", () => {
 
   it("supports single-run checks in lint mode", async () => {
     const runnable: RunnableHealthCheck = {
+      sourceContract: "run",
       id: "run-check",
       kind: "core",
       description: "run check",

--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runDoctorHealthRepairs } from "./doctor-repair-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
-import type { RunnableHealthCheck, SplitHealthCheckInput } from "./health-check-runner-types.js";
-import type { HealthCheck, HealthFinding, HealthRepairContext } from "./health-checks.js";
+import type {
+  RegisteredHealthCheck,
+  RunnableHealthCheck,
+  SplitHealthCheckInput,
+} from "./health-check-runner-types.js";
+import type { HealthFinding, HealthRepairContext } from "./health-checks.js";
 
 function ctx(cfg: OpenClawConfig): HealthRepairContext {
   return {
@@ -27,8 +31,9 @@ function warningFinding(checkId: string): HealthFinding {
   };
 }
 
-function successfullyRepairedCheck(): HealthCheck {
+function successfullyRepairedCheck(): RegisteredHealthCheck {
   return normalizeHealthCheck({
+    sourceContract: "split",
     id: "test/repaired-first",
     kind: "core",
     description: "repairs before the unresolved check",
@@ -51,6 +56,7 @@ describe("runDoctorHealthRepairs", () => {
     const runModes: string[] = [];
     const scopes: unknown[] = [];
     const runnable: RunnableHealthCheck = {
+      sourceContract: "run",
       id: "test/run-repairable",
       kind: "core",
       description: "run repairable",
@@ -80,7 +86,7 @@ describe("runDoctorHealthRepairs", () => {
         };
       },
     };
-    const checks: HealthCheck[] = [normalizeHealthCheck(runnable)];
+    const checks: RegisteredHealthCheck[] = [normalizeHealthCheck(runnable)];
 
     const result = await runDoctorHealthRepairs(ctx({}), { checks });
 
@@ -95,8 +101,9 @@ describe("runDoctorHealthRepairs", () => {
 
   it("repairs modern checks and threads updated config", async () => {
     const scopes: unknown[] = [];
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/repairable",
         kind: "core",
         description: "repairable",
@@ -143,8 +150,9 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("retains non-repairable findings for the legacy doctor owner", async () => {
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/legacy-only",
         kind: "core",
         description: "legacy only",
@@ -171,8 +179,9 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("keeps split check findings when repair throws", async () => {
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/repair-throws",
         kind: "core",
         description: "repair throws",
@@ -207,8 +216,9 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("reports repair validation findings that remain after repair", async () => {
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/not-fixed",
         kind: "core",
         description: "not fixed",
@@ -245,8 +255,9 @@ describe("runDoctorHealthRepairs", () => {
 
   it("validates successful repairs by default", async () => {
     let detectCalls = 0;
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/no-default-validation",
         kind: "core",
         description: "no default validation",
@@ -284,8 +295,9 @@ describe("runDoctorHealthRepairs", () => {
 
   it("does not validate skipped or failed repair results", async () => {
     let validationCalls = 0;
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/skipped",
         kind: "core",
         description: "skipped",
@@ -324,6 +336,7 @@ describe("runDoctorHealthRepairs", () => {
     async (outcome) => {
       const unresolvedId = `test/split-${outcome}`;
       const unresolvedCheck = normalizeHealthCheck({
+        sourceContract: "split",
         id: unresolvedId,
         kind: "core",
         description: "unresolved split check",
@@ -369,6 +382,7 @@ describe("runDoctorHealthRepairs", () => {
     async (outcome) => {
       const unresolvedId = `test/runnable-${outcome}`;
       const runnable: RunnableHealthCheck = {
+        sourceContract: "run",
         id: unresolvedId,
         kind: "core",
         description: "unresolved runnable check",
@@ -401,8 +415,9 @@ describe("runDoctorHealthRepairs", () => {
   it("supports dry-run repairs without applying returned config or validating", async () => {
     const repairContexts: HealthRepairContext[] = [];
     let detectCalls = 0;
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/dry-run",
         kind: "core",
         description: "dry run",
@@ -463,8 +478,9 @@ describe("runDoctorHealthRepairs", () => {
 
   it("passes diff false and true through the repair API", async () => {
     const repairContexts: HealthRepairContext[] = [];
-    const checks: HealthCheck[] = [
+    const checks: RegisteredHealthCheck[] = [
       normalizeHealthCheck({
+        sourceContract: "split",
         id: "test/diff-preview",
         kind: "core",
         description: "diff preview",

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -2,7 +2,7 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
-import { normalizeHealthCheck } from "./health-check-adapter.js";
+import { defineSplitHealthCheckInput, normalizeHealthCheck } from "./health-check-adapter.js";
 import { listHealthChecks } from "./health-check-registry.js";
 import type {
   HealthCheckInput,
@@ -42,9 +42,8 @@ export async function runDoctorHealthRepairs(
   ctx: HealthRepairContext,
   opts: DoctorRepairRunOptions = {},
 ): Promise<DoctorRepairRunResult> {
-  const checks: readonly RegisteredHealthCheck[] = (opts.checks ?? listHealthChecks()).map(
-    normalizeHealthCheck,
-  );
+  const inputs = opts.checks ?? listHealthChecks().map(defineSplitHealthCheckInput);
+  const checks: readonly RegisteredHealthCheck[] = inputs.map(normalizeHealthCheck);
   const findings: HealthFinding[] = [];
   const remainingFindings: HealthFinding[] = [];
   const changes: string[] = [];

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -3,9 +3,16 @@ import type {
   HealthCheckInput,
   HealthCheckRunResult,
   RegisteredHealthCheck,
+  SplitHealthCheckDefinition,
   SplitHealthCheckInput,
 } from "./health-check-runner-types.js";
 import type { HealthRepairContext } from "./health-checks.js";
+
+export function defineSplitHealthCheckInput(
+  check: SplitHealthCheckDefinition,
+): SplitHealthCheckInput {
+  return { ...check, sourceContract: "split" };
+}
 
 // Adapts legacy split detect/repair checks and newer runnable checks to one runner contract.
 /** Wraps a detect/repair health check in the runnable health-check contract. */
@@ -57,32 +64,20 @@ function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthC
 
 /** Normalizes any supported health-check shape before lint/fix execution. */
 export function normalizeHealthCheck(check: HealthCheckInput): RegisteredHealthCheck {
-  if (
-    "detect" in check &&
-    check.detect !== undefined &&
-    "run" in check &&
-    check.run !== undefined &&
-    "sourceContract" in check
-  ) {
-    return check as RegisteredHealthCheck;
-  }
-  if ("detect" in check && check.detect !== undefined) {
+  if (check.sourceContract === "split") {
     return defineSplitHealthCheck(check);
   }
-  if ("run" in check && check.run !== undefined) {
-    return {
-      id: check.id,
-      kind: check.kind,
-      description: check.description,
-      source: check.source,
-      defaultEnabled: check.defaultEnabled,
-      sourceContract: "run",
-      async detect(ctx, scope) {
-        const result = await check.run({ ...ctx, repair: false }, scope);
-        return result.findings ?? [];
-      },
-      run: (ctx, scope) => check.run(ctx, scope),
-    };
-  }
-  throw new Error(`health check ${check.id} must define run() or detect()`);
+  return {
+    id: check.id,
+    kind: check.kind,
+    description: check.description,
+    source: check.source,
+    defaultEnabled: check.defaultEnabled,
+    sourceContract: "run",
+    async detect(ctx, scope) {
+      const result = await check.run({ ...ctx, repair: false }, scope);
+      return result.findings ?? [];
+    },
+    run: (ctx, scope) => check.run(ctx, scope),
+  };
 }

--- a/src/flows/health-check-registry.ts
+++ b/src/flows/health-check-registry.ts
@@ -28,7 +28,7 @@ export function listHealthChecks(): readonly HealthCheck[] {
 
 /** Returns registered extension checks after rejecting any reserved core doctor id claims. */
 export function listExtensionHealthChecksForDoctor(
-  coreChecks: readonly HealthCheck[],
+  coreChecks: readonly Pick<HealthCheck, "id">[],
 ): readonly HealthCheck[] {
   const coreIds = new Set(coreChecks.map((check) => check.id));
   const registeredChecks = listHealthChecks();

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -30,18 +30,27 @@ interface HealthCheckSelectionOptions {
   readonly defaultEnabled?: boolean;
 }
 
-export type SplitHealthCheckInput = HealthCheck & HealthCheckSelectionOptions;
+export type SplitHealthCheckDefinition = HealthCheck & HealthCheckSelectionOptions;
+export type SplitHealthCheckInput = SplitHealthCheckDefinition & {
+  readonly sourceContract: "split";
+};
 
 /** Health-check implementation that owns its own detect/repair orchestration. */
 export interface RunnableHealthCheck
   extends Pick<HealthCheck, "id" | "kind" | "description" | "source">, HealthCheckSelectionOptions {
+  readonly sourceContract: "run";
   run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
 }
 
 export type HealthCheckInput = SplitHealthCheckInput | RunnableHealthCheck;
 
 /** Normalized check contract consumed by lint and repair runners. */
-export interface RegisteredHealthCheck extends HealthCheck, HealthCheckSelectionOptions {
-  readonly sourceContract: "split" | "run";
-  run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
-}
+type RegisteredHealthCheckBase = HealthCheck &
+  HealthCheckSelectionOptions & {
+    run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
+  };
+
+export type RegisteredHealthCheck = RegisteredHealthCheckBase &
+  ({ readonly sourceContract: "split" } | { readonly sourceContract: "run" });
+
+export type DetectableHealthCheckInput = SplitHealthCheckInput | RegisteredHealthCheck;


### PR DESCRIPTION
## What Problem This Solves

Internal runtime contracts were carrying valid variants as overlapping structural shapes. Consumers had to rediscover the producer's intent with `in`, `Array.isArray`, and capability probes, leaving impossible combinations representable and preventing the compiler from enforcing exhaustive branches.

## Why This Change Was Made

This maintainer-requested runtime-validation pilot adds producer-owned discriminants only where the contract is genuinely internal: doctor health checks now carry `sourceContract: "split" | "run"`, Discord dispatch commands carry `commandKind: "leaf" | "group"`, and the private SQLite message-cut helper has a `status: "cut"` success arm. Consumers branch directly on those discriminants, and the assertion-safety baseline ratchets down with the removed casts.

Three scan candidates were intentionally stopped after boundary verification:

- Approval requests cross Gateway broadcast/list replay surfaces, and the existing resolver intentionally rejects ambiguous wire shapes.
- `OutboundDeliveryResult` is a public Plugin SDK contract whose four target fields are used or mutated across more than 15 plugin files.
- `CommandResolution` and `ExecutableResolution` are exported from the public `plugin-sdk/infra-runtime` entrypoint.

Changing those three would have expanded this internal-contract lane into protocol or Plugin SDK compatibility work.

## User Impact

No user-visible behavior changes. Maintainers get compiler-enforced internal variants and fewer defensive runtime probes while existing Gateway, storage, and Plugin SDK shapes remain unchanged.

## Evidence

| Target | Before → after | Guard sites deleted | LOC |
| --- | --- | ---: | ---: |
| Health checks | Undiscriminated split/run inputs → producer-owned `sourceContract` | 5 | prod +68/−51; tests +32/−13 |
| Discord commands | Capability-probed base classes → `commandKind` union through dispatch collections | 5 | prod +25/−29; tests/support +9/−10 |
| SQLite message cut | Status-presence success inference → private `status: "cut"` arm | 4 | prod +7/−5 |

The message-cut status never leaves the private transaction helper and is not persisted; the SQLite schema-version guard passed.

Validation:

- Post-rebase focused Vitest: 9 files, 245 tests passed (health/doctor 173, SQLite message-cut 21, Discord 51).
- `node scripts/check-changed.mjs`: passed all core/plugin production and test typechecks, full core/plugin/scripts lint, formatting, doctor contracts, dead exports, import cycles, database-first checks, and state schema-version guard.
- Blacksmith Testbox: `tbx_01m065erty05crs4zpyzb3mrq4`; Actions run https://github.com/openclaw/openclaw/actions/runs/31971732283.
- Autoreview: final branch bundle 37,424 bytes; secret scan clean; no accepted/actionable findings.

One local focused run initially timed out behind another worktree's active heavy-check lock. Two SecretRef assertions later failed only while that lane's long doctor E2E was active; the same final health batch passed 157/157 after the competing E2E ended. No test was weakened or changed for that contention.
