### PR TITLE
fix(agents): keep queued followups from missing post-compaction context

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-complete.ts
+++ b/src/auto-reply/reply/agent-runner-result-complete.ts
@@ -132,18 +132,13 @@ export async function completeReplyAgentRun(input: {
 
     // Inject post-compaction workspace context for the next agent turn
     if (sessionKey) {
-      readPostCompactionContext(followupRun.run.workspaceDir, {
+      const contextContent = await readPostCompactionContext(followupRun.run.workspaceDir, {
         cfg,
         agentId: followupRun.run.agentId,
-      })
-        .then((contextContent) => {
-          if (contextContent) {
-            enqueueSystemEvent(contextContent, { sessionKey });
-          }
-        })
-        .catch(() => {
-          // Silent failure — post-compaction context is best-effort
-        });
+      });
+      if (contextContent) {
+        enqueueSystemEvent(contextContent, { sessionKey });
+      }
     }
 
     if (verboseEnabled) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -744,6 +744,71 @@ describe("runReplyAgent auto-compaction token update", () => {
     expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
   });
 
+  it("loads post-compaction context before starting a queued followup drain", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-post-compaction-queued-followup-"),
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "AGENTS.md"),
+      "## Session Startup\nRead the queued workspace startup file.\n\n## Red Lines\nNever skip startup context after compaction.\n",
+      "utf-8",
+    );
+    const sessionKey = "main";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now(), totalTokens: 50_000 };
+    runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
+      const onAgentEvent = requireRecord(params, "embedded agent params").onAgentEvent;
+      if (typeof onAgentEvent === "function") {
+        await onAgentEvent({ stream: "compaction", data: { phase: "start" } });
+        await onAgentEvent({ stream: "compaction", data: { phase: "end", completed: true } });
+      }
+      return { payloads: [{ text: "ok" }], meta: { agentMeta: {} } };
+    });
+
+    vi.mocked(scheduleFollowupDrain).mockImplementation((key) => {
+      const events = peekSystemEvents(key);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toContain("Read the queued workspace startup file.");
+      expect(events[0]).toContain("Never skip startup context after compaction.");
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+      workspaceDir,
+      config: {
+        agents: {
+          defaults: {
+            compaction: { postCompactionSections: ["Session Startup", "Red Lines"] },
+          },
+        },
+      },
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a provided reply operation active until final delivery completes", async () => {
     const sessionKey = "main";
     const sessionEntry = {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -748,65 +748,69 @@ describe("runReplyAgent auto-compaction token update", () => {
     const workspaceDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-post-compaction-queued-followup-"),
     );
-    await fs.writeFile(
-      path.join(workspaceDir, "AGENTS.md"),
-      "## Session Startup\nRead the queued workspace startup file.\n\n## Red Lines\nNever skip startup context after compaction.\n",
-      "utf-8",
-    );
-    const sessionKey = "main";
-    const sessionEntry = { sessionId: "session", updatedAt: Date.now(), totalTokens: 50_000 };
-    runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
-      const onAgentEvent = requireRecord(params, "embedded agent params").onAgentEvent;
-      if (typeof onAgentEvent === "function") {
-        await onAgentEvent({ stream: "compaction", data: { phase: "start" } });
-        await onAgentEvent({ stream: "compaction", data: { phase: "end", completed: true } });
-      }
-      return { payloads: [{ text: "ok" }], meta: { agentMeta: {} } };
-    });
+    try {
+      await fs.writeFile(
+        path.join(workspaceDir, "AGENTS.md"),
+        "## Session Startup\nRead the queued workspace startup file.\n\n## Red Lines\nNever skip startup context after compaction.\n",
+        "utf-8",
+      );
+      const sessionKey = "main";
+      const sessionEntry = { sessionId: "session", updatedAt: Date.now(), totalTokens: 50_000 };
+      runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
+        const onAgentEvent = requireRecord(params, "embedded agent params").onAgentEvent;
+        if (typeof onAgentEvent === "function") {
+          await onAgentEvent({ stream: "compaction", data: { phase: "start" } });
+          await onAgentEvent({ stream: "compaction", data: { phase: "end", completed: true } });
+        }
+        return { payloads: [{ text: "ok" }], meta: { agentMeta: {} } };
+      });
 
-    vi.mocked(scheduleFollowupDrain).mockImplementation((key) => {
-      const events = peekSystemEvents(key);
-      expect(events).toHaveLength(1);
-      expect(events[0]).toContain("Read the queued workspace startup file.");
-      expect(events[0]).toContain("Never skip startup context after compaction.");
-    });
+      vi.mocked(scheduleFollowupDrain).mockImplementation((key) => {
+        const events = peekSystemEvents(key);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toContain("Read the queued workspace startup file.");
+        expect(events[0]).toContain("Never skip startup context after compaction.");
+      });
 
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-      workspaceDir,
-      config: {
-        agents: {
-          defaults: {
-            compaction: { postCompactionSections: ["Session Startup", "Red Lines"] },
+      const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+        storePath: "",
+        sessionEntry,
+        workspaceDir,
+        config: {
+          agents: {
+            defaults: {
+              compaction: { postCompactionSections: ["Session Startup", "Red Lines"] },
+            },
           },
         },
-      },
-    });
+      });
 
-    await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: sessionKey,
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        typing,
+        sessionCtx,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        defaultModel: "anthropic/claude-opus-4-6",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
 
-    expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
+      expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps a provided reply operation active until final delivery completes", async () => {


### PR DESCRIPTION
Related: #75532

## What Problem This Solves

Fixes an issue where a queued follow-up turn could start immediately after auto-compaction before OpenClaw had finished reloading the workspace's configured post-compaction context. The next turn could therefore miss startup or safety instructions from `AGENTS.md` even though context refresh was enabled.

## Why This Change Was Made

The auto-compaction completion path now awaits the existing best-effort context reader and enqueues any resulting system event before run finalization can schedule the queued follow-up drain. The context reader already contains the failure-isolation policy, so this also removes a redundant caller-side promise chain without adding another queue or fallback path.

## User Impact

Queued turns after auto-compaction now reliably receive the configured workspace context before they begin. Ordinary turns, preflight compaction, context extraction, and read-failure behavior are unchanged.

## Evidence

- Exact head: `4fa44a19f6b5d76f9c34354d6ce4907b329cb7f9`
- Base: `d39a29fcbe6391b7be3aaa97397750026095a86c`
- Regression: `agent-runner.misc.runreplyagent.test.ts` observes the real run boundary and requires the context event to exist when follow-up drain scheduling begins. The case failed with the fire-and-forget pre-fix ordering and passes after the owner-path repair.
- Focused tests: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — 78/78 passed.
- Production typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- Core test typecheck: `node scripts/run-tsgo-core-test-shards.mjs` — passed.
- Formatting and type-aware lint: 2/2 files formatted; 0 warnings and 0 errors.
- `git diff --check origin/main...HEAD` — passed.
- ClawSweeper's exact-head P3 finding was addressed: the regression now removes its temporary workspace in `finally`; focused tests, formatting, lint, and `git diff --check` were rerun afterward.
- Fresh independent exact-head P0–P2 review: no findings; confirmed the context helper owns best-effort failures, the await holds no queue lock or transaction, the regression adds no test-only production seam, and all temporary filesystem state is cleaned.
- Bundled autoreview's TruffleHog preflight was clean; its Codex subprocess then failed authentication before returning structured review output. No finding was suppressed or treated as green.

Production LOC: +5/-10 (net -5) | Tests: +65/-0

AI-assisted: Yes.
