### PR TITLE
perf(test): remove Gmail watcher shutdown wait

### DIFF
--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -122,9 +122,6 @@ describePosix("gmail-watcher process-tree shutdown (integration)", () => {
 
     console.log("calling stopGmailWatcher...");
     await stopGmailWatcher();
-    await new Promise<void>((r) => {
-      setTimeout(r, 400);
-    });
 
     console.log(`gog alive after stop: ${alive(gogPid)}`);
     console.log(`credential-helper alive after stop: ${alive(helperPid)}`);


### PR DESCRIPTION
## What Problem This Solves

The Gmail watcher integration test added a fixed 400 ms sleep after `stopGmailWatcher()` even though shutdown had already completed. That redundant wait lengthened every run of the test without adding coverage.

## Why This Change Was Made

`stopGmailWatcher()` already awaits kill-tree escalation and then a 25 ms post-kill settle. The integration test's additional 400 ms sleep therefore delayed assertions after the lifecycle owner had finished its shutdown work.

This removes only that redundant delay. The real detached POSIX process-group assertion and the SIGTERM-resistant descendant assertion remain intact and now run immediately after `stopGmailWatcher()` resolves. A mutation that resolved shutdown when the leader exited failed because the credential-helper descendant was still alive, confirming that the retained assertions catch premature completion.

## User Impact

No production behavior changes. The Gmail watcher integration test completes faster while preserving its shutdown and descendant-cleanup coverage.

Production LOC: +0/-0. Tests: +0/-3. No changelog entry is needed for this test-only change.

## Evidence

Approved head: `d4d12582ac957cc46504f1a19e90198d39960f91`

Exact base: `65922f95070abd58684675349593a217b193fe0f`

Exact-base Testbox: `tbx_01m0674x1jw79tsypddxmvjzke`

Hosted proof: https://github.com/openclaw/openclaw/actions/runs/31973197001

- Integration suite: 10/10
- Gmail sibling tests: 24/24
- Kill-tree owner tests: 25/25
- Complete changed gate: green
- Controlled A/B wall time: 9.21 s average to 8.92 s average (-0.29 s, -3.1%)
- Controlled A/B Vitest time: 6.21 s to 5.915 s (-4.8%)
- Controlled A/B test body: 5.556 s to 5.250 s; both pairs measured exactly -306 ms (-5.5%)
- Mutation proof: resolving shutdown on leader exit failed with the credential helper still alive
- Fresh autoreview: clean, 0.99
