### PR TITLE
fix(protocol): model cron run delivery trace

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15844,6 +15844,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let deliverystatus: AnyCodable?
     public let deliveryerror: String?
     public let failurenotificationdelivery: [String: AnyCodable]?
+    public let delivery: [String: AnyCodable]?
     public let sessionid: String?
     public let sessionkey: String?
     public let runid: String?
@@ -15869,6 +15870,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         deliverystatus: AnyCodable? = nil,
         deliveryerror: String? = nil,
         failurenotificationdelivery: [String: AnyCodable]? = nil,
+        delivery: [String: AnyCodable]? = nil,
         sessionid: String? = nil,
         sessionkey: String? = nil,
         runid: String? = nil,
@@ -15893,6 +15895,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.deliverystatus = deliverystatus
         self.deliveryerror = deliveryerror
         self.failurenotificationdelivery = failurenotificationdelivery
+        self.delivery = delivery
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runid = runid
@@ -15919,6 +15922,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         case deliverystatus = "deliveryStatus"
         case deliveryerror = "deliveryError"
         case failurenotificationdelivery = "failureNotificationDelivery"
+        case delivery
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runid = "runId"

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -3,6 +3,7 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
+  type CronRunLogEntry,
   validateCronAddParams,
   validateCronGetParams,
   validateCronListParams,
@@ -11,7 +12,7 @@ import {
   validateCronRunsParams,
   validateCronUpdateParams,
 } from "./index.js";
-import { CronJobSchema } from "./schema/cron.js";
+import { CronJobSchema, CronRunLogEntrySchema } from "./schema/cron.js";
 
 /**
  * Cron validator regressions for public scheduler RPC payloads.
@@ -75,6 +76,30 @@ describe("cron protocol validators", () => {
       }),
     ).toBe(false);
     expect(validateCronUpdateParams(update({ state: job.state }))).toBe(false);
+  });
+
+  it("models the delivery trace returned in cron run history", () => {
+    const entry = {
+      ts: 1,
+      jobId: "job-1",
+      action: "finished",
+      status: "ok",
+      delivery: {
+        intended: { channel: "telegram", to: "chat-1", source: "explicit" },
+        resolved: { channel: "telegram", to: "chat-1", ok: true },
+        messageToolSentTo: [{ channel: "telegram", to: "chat-1", threadId: "topic-1" }],
+        fallbackUsed: false,
+        delivered: true,
+      },
+    } as const satisfies CronRunLogEntry;
+
+    expect(Value.Check(CronRunLogEntrySchema, entry)).toBe(true);
+    expect(
+      Value.Check(CronRunLogEntrySchema, {
+        ...entry,
+        delivery: { ...entry.delivery, unsupported: true },
+      }),
+    ).toBe(false);
   });
 
   it("rejects client-authored scheduled authority provenance", () => {

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -441,6 +441,37 @@ const CronFailureNotificationDeliverySchema = closedObject({
   error: Type.Optional(Type.String()),
 });
 
+const CronDeliveryTraceTargetProperties = {
+  channel: Type.Optional(Type.String()),
+  to: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  accountId: Type.Optional(Type.String()),
+  threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  source: Type.Optional(Type.Union([Type.Literal("explicit"), Type.Literal("last")])),
+};
+
+const CronDeliveryTraceSchema = closedObject({
+  intended: Type.Optional(closedObject(CronDeliveryTraceTargetProperties)),
+  resolved: Type.Optional(
+    closedObject({
+      ...CronDeliveryTraceTargetProperties,
+      ok: Type.Boolean(),
+      error: Type.Optional(Type.String()),
+    }),
+  ),
+  messageToolSentTo: Type.Optional(
+    Type.Array(
+      closedObject({
+        channel: Type.String(),
+        to: Type.Optional(Type.String()),
+        accountId: Type.Optional(Type.String()),
+        threadId: Type.Optional(Type.String()),
+      }),
+    ),
+  ),
+  fallbackUsed: Type.Optional(Type.Boolean()),
+  delivered: Type.Optional(Type.Boolean()),
+});
+
 const CronAutoDisabledSchema = closedObject({
   reason: Type.Union([Type.Literal("consecutive-failures"), Type.Literal("schedule-errors")]),
   atMs: CronDateTimestampMsSchema,
@@ -728,6 +759,7 @@ export const CronRunLogEntrySchema = closedObject({
   deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
   deliveryError: Type.Optional(Type.String()),
   failureNotificationDelivery: Type.Optional(CronFailureNotificationDeliverySchema),
+  delivery: Type.Optional(CronDeliveryTraceSchema),
   sessionId: Type.Optional(NonEmptyString),
   sessionKey: Type.Optional(NonEmptyString),
   runId: Type.Optional(NonEmptyString),


### PR DESCRIPTION
Related: #124827

## What Problem This Solves

Fixes an issue where TypeScript consumers of `cron.runs` could not access the optional delivery trace that the Gateway already returns for run-history entries. The runtime record and Gateway response included the field, but `CronRunLogEntrySchema` omitted it, leaving the published protocol type incomplete.

## Why This Change Was Made

Adds a closed, additive delivery-trace schema matching the existing runtime owner: intended and resolved targets, message-tool targets, fallback usage, and delivery outcome. The run-log schema now exposes that optional field instead of stripping existing response data or maintaining a second client-side copy.

This is the late ClawSweeper finding from #124827 and completes that refactor's original invariant: Gateway responses and Control UI protocol types share one canonical model.

AI-assisted maintainer repair; reviewed with the repository autoreview workflow.

## User Impact

No runtime response changes. Protocol and Control UI TypeScript code can now safely inspect the delivery trace already present on some cron run-history entries.

## Evidence

- Regression: a `CronRunLogEntry` containing the existing delivery trace now compiles and passes `CronRunLogEntrySchema`; an unknown trace field is rejected by the closed schema.
- Protocol cron validators: 1 file / 30 tests passed.
- `@openclaw/gateway-protocol` package build: passed, including declarations.
- `pnpm check:changed`: passed on Testbox `tbx_01m0685j2xpbgfgc2fz6pfpq6f`, Actions run https://github.com/openclaw/openclaw/actions/runs/31974077220.
- Exact `pnpm protocol:check`: passed with `PROTOCOL_SINCE_BASE_SHA=9b17b9341453b62d717ed7bc0ecd1a365294262e` on Testbox `tbx_01m0694cretz5r54nmzmx8e118`, Actions run https://github.com/openclaw/openclaw/actions/runs/31974882782.
- Codex autoreview: clean; no accepted/actionable findings.
- LOC: production +32/-0; tests +26/-1; generated Swift +4/-0.
- Visual proof: not applicable; rendered UI and wire bytes are unchanged.
