### PR TITLE
fix(security): prevent approved scripts from changing before execution

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3493,7 +3493,6 @@ src/node-host/invoke-agent-cli-claude-params.ts	4
 src/node-host/invoke-agent-cli-claude.ts	2
 src/node-host/invoke-file-commands.ts	1
 src/node-host/invoke-payload.ts	5
-src/node-host/invoke-system-run-plan.ts	3
 src/node-host/invoke.ts	8
 src/node-host/mcp.ts	3
 src/node-host/node-worker-bundle-installer.ts	1

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -753,7 +753,6 @@ src/media/fetch.test.ts
 src/media/web-media.test.ts
 src/media/web-media.ts
 src/node-host/invoke-system-run-plan.test.ts
-src/node-host/invoke-system-run-plan.ts
 src/node-host/invoke-system-run.test.ts
 src/node-host/invoke-system-run.ts
 src/node-host/invoke.ts

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -11,6 +11,7 @@ import {
   runBeforeToolCallHook,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { prepareSystemRunMutableFileApproval } from "openclaw/plugin-sdk/plugin-test-runtime";
 // Codex tests cover approval bridge plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -121,6 +122,7 @@ function createParams(): EmbeddedRunAttemptParams {
     version: 1,
     assertActive: () => {},
     bindToolSurface: (tools) => tools,
+    prepareMutableFileApproval: prepareSystemRunMutableFileApproval,
     runBeforeToolCall: async ({ approvalMode = "request", ...request }) => {
       const requester = {
         ...((params.messageChannel ?? params.messageProvider)
@@ -208,7 +210,7 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "scheduled-command",
-        command: "dangerous-command",
+        command: "git status",
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -375,6 +377,102 @@ describe("Codex app-server approval bridge", () => {
     );
     findApprovalEvent(params, { status: "pending", approvalId: "plugin:approval-1" });
     findApprovalEvent(params, { status: "approved", approvalId: "plugin:approval-1" });
+  });
+
+  it("denies command approval when a script operand changes before the decision", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-script-drift-"));
+    const scriptPath = path.join(tempDir, "script.sh");
+    try {
+      await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
+      const params = createParams();
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "plugin:script-drift", status: "accepted" })
+        .mockImplementationOnce(async () => {
+          await fs.writeFile(scriptPath, "#!/bin/sh\necho mutated\n");
+          return { id: "plugin:script-drift", decision: "allow-once" };
+        });
+
+      const result = await handleCodexAppServerApprovalRequest({
+        method: "item/commandExecution/requestApproval",
+        requestParams: {
+          ...codexTestTurnIds(),
+          itemId: "cmd-script-drift",
+          command: `sh ${scriptPath}`,
+          cwd: tempDir,
+        },
+        paramsForRun: params,
+        ...codexTestTurnIds(),
+      });
+
+      expect(result).toEqual({ decision: "decline" });
+      findApprovalEvent(params, {
+        status: "denied",
+        approvalId: "plugin:script-drift",
+        message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts command approval when the bound script operand is unchanged", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-script-stable-"));
+    const scriptPath = path.join(tempDir, "script.sh");
+    try {
+      await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
+      const params = createParams();
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "plugin:script-stable", status: "accepted" })
+        .mockResolvedValueOnce({ id: "plugin:script-stable", decision: "allow-always" });
+
+      const result = await handleCodexAppServerApprovalRequest({
+        method: "item/commandExecution/requestApproval",
+        requestParams: {
+          ...codexTestTurnIds(),
+          itemId: "cmd-script-stable",
+          command: `sh ${scriptPath}`,
+          cwd: tempDir,
+        },
+        paramsForRun: params,
+        ...codexTestTurnIds(),
+      });
+
+      expect(result).toEqual({ decision: "accept" });
+      findApprovalEvent(params, {
+        status: "approved",
+        approvalId: "plugin:script-stable",
+        message: "Codex app-server approval granted for this byte-bound command only.",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("denies command approval when a script operand cannot be snapshotted", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-script-missing-"));
+    try {
+      const params = createParams();
+      const result = await handleCodexAppServerApprovalRequest({
+        method: "item/commandExecution/requestApproval",
+        requestParams: {
+          ...codexTestTurnIds(),
+          itemId: "cmd-script-missing",
+          command: `sh ${path.join(tempDir, "missing.sh")}`,
+          cwd: tempDir,
+        },
+        paramsForRun: params,
+        ...codexTestTurnIds(),
+      });
+
+      expect(result).toEqual({ decision: "decline" });
+      expect(mockCallGatewayTool).not.toHaveBeenCalled();
+      findApprovalEvent(params, {
+        status: "denied",
+        message: "SYSTEM_RUN_DENIED: approval requires an existing script operand",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps configured exec auto-review on the human approval route", async () => {
@@ -918,7 +1016,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({ decision: "acceptForSession" });
+    expect(result).toEqual({ decision: "accept" });
     expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
@@ -971,7 +1069,7 @@ describe("Codex app-server approval bridge", () => {
     "bash -lc '/approve abc123 allow-once'",
     "openclaw channels login --channel whatsapp",
     "sudo -EH bash -lc 'openclaw channels login --channel whatsapp'",
-  ])("keeps unsafe control command approvals on the plugin approval route: %s", async (command) => {
+  ])("fails closed or routes unsafe control command approval: %s", async (command) => {
     const params = createParams();
     params.config = {
       tools: {
@@ -1003,12 +1101,12 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({ decision: "accept" });
+    const bindable = !command.startsWith("/approve ");
+    expect(result).toEqual({ decision: bindable ? "accept" : "decline" });
     expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
-    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
-      "plugin.approval.request",
-      "plugin.approval.waitDecision",
-    ]);
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual(
+      bindable ? ["plugin.approval.request", "plugin.approval.waitDecision"] : [],
+    );
   });
 
   it("keeps security audit suppression edits on the plugin approval route", async () => {
@@ -1093,13 +1191,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({
-      decision: {
-        acceptWithExecpolicyAmendment: {
-          patterns: ["node"],
-        },
-      },
-    });
+    expect(result).toEqual({ decision: "decline" });
     expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
@@ -2080,7 +2172,7 @@ describe("Codex app-server approval bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({ decision: "acceptForSession" });
+    expect(result).toEqual({ decision: "accept" });
     const description = String(gatewayRequestPayload().description);
     expect(description).toContain("Command: npm install");
     expect(description).toContain("Additional permissions: network, fileSystem");
@@ -2134,7 +2226,10 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "cmd-sanitized",
-        command: ["pnpm", "test\n--watch", "\u001b[31mextensions/codex/src/app-server\u001b[0m"],
+        command: "printf safe",
+        commandActions: [
+          { command: "pnpm test\n--watch \u001b[31mextensions/codex/src/app-server\u001b[0m" },
+        ],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2190,7 +2285,12 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "cmd-osc",
-        command: `prefix ${esc}]8;;https://example.com${esc}\\VISIBLE${esc}]8;;${esc}\\ suffix`,
+        command: "printf safe",
+        commandActions: [
+          {
+            command: `prefix ${esc}]8;;https://example.com${esc}\\VISIBLE${esc}]8;;${esc}\\ suffix`,
+          },
+        ],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2234,7 +2334,8 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "cmd-omitted",
-        command: [oversizedPrefix, "TAIL"],
+        command: "printf safe",
+        commandActions: [{ command: oversizedPrefix }, { command: "TAIL" }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2258,7 +2359,8 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "cmd-clipped",
-        command: `${"a".repeat(5000)} tail`,
+        command: "printf safe",
+        commandActions: [{ command: `${"a".repeat(5000)} tail` }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2794,7 +2896,8 @@ describe("Codex app-server approval bridge", () => {
       requestParams: {
         ...codexTestTurnIds(),
         itemId: "cmd-utf16",
-        command,
+        command: "printf safe",
+        commandActions: [{ command }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2813,13 +2916,13 @@ describe("Codex app-server approval bridge", () => {
     [
       "command actions",
       {
-        command: "ignored fallback",
+        command: "printf safe",
         commandActions: [{ command: `${"\u0000".repeat(4095)}😀tail` }],
       },
     ],
   ])(
     "does not expose split surrogate pairs from the preview scan cap: %s",
-    async (_label, input) => {
+    async (label, input) => {
       const params = createParams();
       mockCallGatewayTool
         .mockResolvedValueOnce({ id: "plugin:approval-utf16-scan", status: "accepted" })
@@ -2836,12 +2939,18 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
       });
 
-      const event = findApprovalEvent(params, { status: "pending" });
-      const description = String(gatewayRequestPayload().description);
+      const bindable = label === "command actions";
+      const event = findApprovalEvent(params, { status: bindable ? "pending" : "denied" });
       expect(event.commandPreviewOmitted).toBe(true);
       expect(event.command).toBeUndefined();
-      expect(description).not.toContain(String.fromCharCode(0xd83d));
-      expect(() => encodeURIComponent(description)).not.toThrow();
+      if (bindable) {
+        const description = String(gatewayRequestPayload().description);
+        expect(description).not.toContain(String.fromCharCode(0xd83d));
+        expect(() => encodeURIComponent(description)).not.toThrow();
+      } else {
+        expect(mockCallGatewayTool).not.toHaveBeenCalled();
+        expect(() => encodeURIComponent(JSON.stringify(event))).not.toThrow();
+      }
     },
   );
 

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -53,6 +53,13 @@ const mockRunBeforeToolCallHook = vi.mocked(runBeforeToolCallHook);
 const requireRecord = createRequireRecord("record", "expected-label-capitalized");
 type AgentHarnessHostCapabilities = EmbeddedRunAttemptParams["hostCapabilities"];
 
+const prepareApprovalWithoutMutableFile: AgentHarnessHostCapabilities["prepareMutableFileApproval"] =
+  async () => ({
+    ok: true,
+    requiresOneShot: false,
+    revalidate: async () => ({ ok: true }),
+  });
+
 function gatewayCallAt(callIndex = 0) {
   const call = mockCallGatewayTool.mock.calls[callIndex];
   if (!call) {
@@ -204,6 +211,10 @@ describe("Codex app-server approval bridge", () => {
         payload: { version: 1 },
       },
     } as EmbeddedRunAttemptParams;
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -385,6 +396,10 @@ describe("Codex app-server approval bridge", () => {
     try {
       await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
       const params = createParams();
+      params.hostCapabilities = {
+        ...params.hostCapabilities,
+        prepareMutableFileApproval: prepareSystemRunMutableFileApproval,
+      };
       mockCallGatewayTool
         .mockResolvedValueOnce({ id: "plugin:script-drift", status: "accepted" })
         .mockImplementationOnce(async () => {
@@ -421,6 +436,10 @@ describe("Codex app-server approval bridge", () => {
     try {
       await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
       const params = createParams();
+      params.hostCapabilities = {
+        ...params.hostCapabilities,
+        prepareMutableFileApproval: prepareSystemRunMutableFileApproval,
+      };
       mockCallGatewayTool
         .mockResolvedValueOnce({ id: "plugin:script-stable", status: "accepted" })
         .mockResolvedValueOnce({ id: "plugin:script-stable", decision: "allow-always" });
@@ -452,6 +471,10 @@ describe("Codex app-server approval bridge", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-script-missing-"));
     try {
       const params = createParams();
+      params.hostCapabilities = {
+        ...params.hostCapabilities,
+        prepareMutableFileApproval: prepareSystemRunMutableFileApproval,
+      };
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
@@ -1071,6 +1094,12 @@ describe("Codex app-server approval bridge", () => {
     "sudo -EH bash -lc 'openclaw channels login --channel whatsapp'",
   ])("fails closed or routes unsafe control command approval: %s", async (command) => {
     const params = createParams();
+    if (!command.startsWith("/approve ")) {
+      params.hostCapabilities = {
+        ...params.hostCapabilities,
+        prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+      };
+    }
     params.config = {
       tools: {
         exec: {
@@ -1111,6 +1140,10 @@ describe("Codex app-server approval bridge", () => {
 
   it("keeps security audit suppression edits on the plugin approval route", async () => {
     const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
     params.config = {
       tools: {
         exec: {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -86,22 +86,66 @@ export async function handleCodexAppServerApprovalRequest(params: {
     requestParams,
     paramsForRun: params.paramsForRun,
   });
-  const resolvePolicyApproval = (
+  let revalidateMutableFileApproval:
+    | (() => Promise<{ ok: true } | { ok: false; message: string }>)
+    | undefined;
+  let mutableFileApprovalRequiresOneShot = false;
+  const resolvePolicyApproval = async (
     outcome: Extract<AppServerApprovalOutcome, "denied" | "approved-once" | "approved-session">,
     message = approvalResolutionMessage(outcome),
-  ): JsonValue => {
+    approvalId?: string,
+  ): Promise<JsonValue> => {
+    let resolvedOutcome = outcome;
+    let resolvedMessage = message;
+    // This is the last enforceable client boundary before Codex owns spawn.
+    // Releasing without this check would approve bytes changed during the wait.
+    if (outcome !== "denied" && revalidateMutableFileApproval) {
+      const binding = await revalidateMutableFileApproval();
+      if (!binding.ok) {
+        resolvedOutcome = "denied";
+        resolvedMessage = binding.message;
+      }
+    }
+    if (resolvedOutcome === "approved-session" && mutableFileApprovalRequiresOneShot) {
+      resolvedOutcome = "approved-once";
+      resolvedMessage = "Codex app-server approval granted for this byte-bound command only.";
+    }
     emitApprovalEvent(params.paramsForRun, {
       phase: "resolved",
       kind: context.kind,
-      status: outcome === "denied" ? "denied" : "approved",
+      status: resolvedOutcome === "denied" ? "denied" : "approved",
       title: context.title,
+      ...(approvalId ? { approvalId, approvalSlug: approvalId } : {}),
       ...context.eventDetails,
-      ...approvalEventScope(params.method, outcome),
-      message,
+      ...approvalEventScope(params.method, resolvedOutcome),
+      message: resolvedMessage,
     });
-    return buildApprovalResponse(params.method, context.requestParams, outcome);
+    return buildApprovalResponse(params.method, context.requestParams, resolvedOutcome);
   };
   try {
+    if (params.method === "item/commandExecution/requestApproval") {
+      const command = readPolicyCommand(requestParams);
+      const cwd = readString(requestParams, "cwd") ?? params.paramsForRun.workspaceDir;
+      // Snapshot the executable file operands before policy or operator waits;
+      // an unbound or unreadable script could otherwise change under the prompt.
+      const prepareMutableFileApproval =
+        params.paramsForRun.hostCapabilities.prepareMutableFileApproval;
+      if (!prepareMutableFileApproval) {
+        return await resolvePolicyApproval(
+          "denied",
+          "SYSTEM_RUN_DENIED: mutable file approval binding is unavailable",
+        );
+      }
+      const prepared = await prepareMutableFileApproval({
+        command: command ?? "",
+        cwd,
+      });
+      if (!prepared.ok) {
+        return await resolvePolicyApproval("denied", prepared.message);
+      }
+      mutableFileApprovalRequiresOneShot = prepared.requiresOneShot;
+      revalidateMutableFileApproval = prepared.revalidate;
+    }
     const policyOutcome = await runOpenClawToolPolicyForApprovalRequest({
       method: params.method,
       requestParams,
@@ -113,17 +157,17 @@ export async function handleCodexAppServerApprovalRequest(params: {
     });
     if (policyOutcome?.outcome === "denied") {
       recordNativeToolFailureDisposition(params, context, policyOutcome.failureDisposition);
-      return resolvePolicyApproval("denied", policyOutcome.reason);
+      return await resolvePolicyApproval("denied", policyOutcome.reason);
     }
     if (
       policyOutcome?.outcome === "approved-once" ||
       policyOutcome?.outcome === "approved-session"
     ) {
-      return resolvePolicyApproval(policyOutcome.outcome);
+      return await resolvePolicyApproval(policyOutcome.outcome);
     }
     const canAutoApproveConcreteToolCall = CONCRETE_TOOL_AUTO_APPROVAL_METHODS.has(params.method);
     if (canAutoApproveConcreteToolCall && params.autoApprove === true) {
-      return resolvePolicyApproval(
+      return await resolvePolicyApproval(
         "approved-session",
         "Codex app-server approval auto-approved by runtime policy.",
       );
@@ -183,6 +227,10 @@ export async function handleCodexAppServerApprovalRequest(params: {
       );
     } else if (outcome === "unavailable") {
       recordNativeToolFailureDisposition(params, context, approvalExpired ? "timed_out" : "failed");
+    }
+
+    if (outcome === "approved-once" || outcome === "approved-session") {
+      return await resolvePolicyApproval(outcome, approvalResolutionMessage(outcome), approvalId);
     }
 
     emitApprovalEvent(params.paramsForRun, {

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1920,12 +1920,12 @@ EOF`,
   });
 
   it("allows durable exact-command trust to bypass the synchronous allowlist miss", async () => {
-    const command = "node --version";
+    const command = "/bin/echo durable";
     evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: false,
       allowlistSatisfied: false,
-      segments: [{ resolution: null, argv: ["node", "--version"] }],
+      segments: [{ resolution: null, argv: ["/bin/echo", "durable"] }],
       segmentAllowlistEntries: [],
       segmentSatisfiedBy: [],
     });
@@ -2414,18 +2414,30 @@ EOF`,
   it.each([
     { name: "denies drift", mutate: true },
     { name: "runs unchanged bytes", mutate: false },
-  ])("binds detached gateway approval script operands: $name", async ({ mutate }) => {
+  ])("re-prompts durable detached gateway script approvals: $name", async ({ mutate }) => {
     const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-script-binding-"));
     const script = path.join(workdir, "script.sh");
+    const command = "sh script.sh";
     try {
       fs.writeFileSync(script, "#!/bin/sh\necho approved\n");
       evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
         allowlistMatches: [],
         analysisOk: true,
-        allowlistSatisfied: true,
+        allowlistSatisfied: false,
         segments: [{ resolution: null, argv: ["sh", "script.sh"] }],
         segmentAllowlistEntries: [],
         segmentSatisfiedBy: [],
+      });
+      hasDurableExecApprovalMock.mockReturnValue(true);
+      hasExactCommandDurableExecApprovalMock.mockReturnValue(true);
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: {
+          allowlist: [{ pattern: exactCommandMarker(command), source: "allow-always" }],
+          file: { version: 1, agents: {} },
+        },
+        hostSecurity: "allowlist",
+        hostAsk: "off",
+        askFallback: "deny",
       });
       createExecApprovalDecisionStateMock.mockReturnValue({
         baseDecision: { timedOut: false },
@@ -2436,7 +2448,7 @@ EOF`,
         if (mutate) {
           fs.writeFileSync(script, "#!/bin/sh\necho mutated\n");
         }
-        return mutate ? "allow-once" : "allow-always";
+        return "allow-once";
       });
       buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
       runExecProcessMock.mockResolvedValue({
@@ -2450,12 +2462,16 @@ EOF`,
       });
 
       const result = await runGatewayAllowlist({
-        command: "sh script.sh",
+        command,
         workdir,
         turnSourceChannel: "feishu",
       });
 
       expect(result.pendingResult?.details.status).toBe("approval-pending");
+      expect(resolveExecApprovalAllowedDecisionsMock).toHaveBeenCalledWith({
+        ask: "off",
+        allowAlwaysPersistence: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
+      });
       await vi.waitFor(() => {
         expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
       });
@@ -2466,11 +2482,7 @@ EOF`,
         expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
         expect(runExecProcessMock).not.toHaveBeenCalled();
       } else {
-        expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            allowAlwaysDecision: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
-          }),
-        );
+        expect(commitExecAuthorizationMock).toHaveBeenCalledOnce();
         expect(runExecProcessMock).toHaveBeenCalledOnce();
       }
     } finally {

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -944,7 +944,8 @@ describe("processGatewayAllowlist", () => {
   it("reviews and executes the same PATH-resolved executable", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auto-review-path-"));
     const shadowGit = path.join(tempDir, "git");
-    fs.writeFileSync(shadowGit, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    fs.copyFileSync(process.execPath, shadowGit);
+    fs.chmodSync(shadowGit, 0o755);
     try {
       const command = "git status";
       const canonicalShadowGit = fs.realpathSync(shadowGit);
@@ -963,7 +964,8 @@ describe("processGatewayAllowlist", () => {
       expect(defaultExecAutoReviewerMock).toHaveBeenCalledWith(
         expect.objectContaining({ resolvedPath: canonicalShadowGit }),
       );
-      expect(result).toEqual({ execCommandOverride: `${canonicalShadowGit} status` });
+      expect(result).toMatchObject({ execCommandOverride: `${canonicalShadowGit} status` });
+      await expect(result.revalidateBeforeExecution?.()).resolves.toBeUndefined();
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -984,7 +986,7 @@ describe("processGatewayAllowlist", () => {
     expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
-  it("keeps unrenderable heredoc commands on the human approval path", async () => {
+  it("fails closed before approval when a heredoc command cannot be operand-bound", async () => {
     const command = "python3 - <<'PY'\nprint('ok')\nPY";
     const authorizationPlan = await planShellAuthorization({
       command,
@@ -1015,8 +1017,12 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
-    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+    expect(result.deniedResult?.content[0]).toEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("approval cannot safely bind this command"),
+      }),
+    );
   });
 
   it("does not activate allowlist fallback for a full-policy heredoc without an approval", async () => {
@@ -1586,7 +1592,7 @@ describe("processGatewayAllowlist", () => {
     expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
-  it("requests human approval when auto-review cannot resolve the executable", async () => {
+  it("fails closed before approval when the executable cannot be resolved", async () => {
     const command = "openclaw-definitely-missing-executable --version";
     const { resolvedPath } = await configurePlanBackedCommand({ command });
     expect(resolvedPath).toBeUndefined();
@@ -1598,8 +1604,10 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
-    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+    expect(result.deniedResult?.content[0]).toEqual(
+      expect.objectContaining({ text: expect.stringContaining("requires a resolved executable") }),
+    );
   });
 
   it("does not use fallback-full when auto-review cannot parse the command", async () => {
@@ -1637,15 +1645,11 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
-    expect(enforceStrictInlineEvalApprovalBoundaryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        requiresAutoReviewHumanApproval: true,
-      }),
-    );
+    expect(enforceStrictInlineEvalApprovalBoundaryMock).not.toHaveBeenCalled();
     expect(result.deniedResult?.details.status).toBe("failed");
     expect(result.deniedResult?.content[0]).toEqual(
       expect.objectContaining({
-        text: "Exec denied (gateway id=req-1, approval-timeout): echo 'unterminated",
+        text: expect.stringContaining("approval cannot safely bind this command"),
       }),
     );
   });
@@ -2405,6 +2409,73 @@ EOF`,
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
     });
+  });
+
+  it.each([
+    { name: "denies drift", mutate: true },
+    { name: "runs unchanged bytes", mutate: false },
+  ])("binds detached gateway approval script operands: $name", async ({ mutate }) => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-script-binding-"));
+    const script = path.join(workdir, "script.sh");
+    try {
+      fs.writeFileSync(script, "#!/bin/sh\necho approved\n");
+      evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
+        allowlistMatches: [],
+        analysisOk: true,
+        allowlistSatisfied: true,
+        segments: [{ resolution: null, argv: ["sh", "script.sh"] }],
+        segmentAllowlistEntries: [],
+        segmentSatisfiedBy: [],
+      });
+      createExecApprovalDecisionStateMock.mockReturnValue({
+        baseDecision: { timedOut: false },
+        approvedByAsk: true,
+        deniedReason: null,
+      });
+      resolveApprovalDecisionOrUndefinedMock.mockImplementation(async () => {
+        if (mutate) {
+          fs.writeFileSync(script, "#!/bin/sh\necho mutated\n");
+        }
+        return mutate ? "allow-once" : "allow-always";
+      });
+      buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+      runExecProcessMock.mockResolvedValue({
+        session: { id: "sess-script-binding" },
+        promise: Promise.resolve({
+          status: "completed",
+          exitCode: 0,
+          timedOut: false,
+          aggregated: "approved",
+        }),
+      });
+
+      const result = await runGatewayAllowlist({
+        command: "sh script.sh",
+        workdir,
+        turnSourceChannel: "feishu",
+      });
+
+      expect(result.pendingResult?.details.status).toBe("approval-pending");
+      await vi.waitFor(() => {
+        expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
+      });
+      if (mutate) {
+        expect(requireSentFollowupText(0)).toContain(
+          "approval script operand changed before execution",
+        );
+        expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
+        expect(runExecProcessMock).not.toHaveBeenCalled();
+      } else {
+        expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allowAlwaysDecision: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
+          }),
+        );
+        expect(runExecProcessMock).toHaveBeenCalledOnce();
+      }
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
   });
 
   it("denies a detached approved process when restart drain wins admission", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -43,6 +43,11 @@ import {
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
 import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import {
+  prepareSystemRunMutableFileBinding,
+  revalidateSystemRunMutableFileBinding,
+  type SystemRunMutableFileBinding,
+} from "../infra/system-run-approval-binding.js";
+import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
@@ -134,6 +139,7 @@ type ProcessGatewayAllowlistParams = {
 type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
   allowWithoutEnforcedCommand?: boolean;
+  revalidateBeforeExecution?: () => Promise<AgentToolResult<ExecToolDetails> | undefined>;
   pendingResult?: AgentToolResult<ExecToolDetails>;
   deniedResult?: AgentToolResult<ExecToolDetails>;
 };
@@ -453,6 +459,25 @@ function buildGatewayExecApprovalDeniedToolResult(params: {
   };
 }
 
+/** Rechecks a gateway approval binding at the caller's final spawn boundary. */
+async function revalidateGatewayExecApprovalBinding(params: {
+  binding: SystemRunMutableFileBinding;
+  command: string;
+  cwd: string;
+}): Promise<AgentToolResult<ExecToolDetails> | undefined> {
+  const current = await revalidateSystemRunMutableFileBinding({
+    binding: params.binding,
+    cwd: params.cwd,
+  });
+  return current.ok
+    ? undefined
+    : buildGatewayExecApprovalDeniedToolResult({
+        deniedReason: current.message,
+        command: params.command,
+        cwd: params.cwd,
+      });
+}
+
 async function resolveGatewayExecApprovalFollowupText(params: {
   approvalFollowup?: ExecApprovalFollowupFactory;
   approvalId: string;
@@ -764,6 +789,40 @@ export async function processGatewayAllowlist(
         },
       };
     }
+    // Approval must capture script bytes before any reviewer or operator wait;
+    // command text alone does not prevent a referenced file from changing.
+    const mutableFileBinding = await prepareSystemRunMutableFileBinding({
+      command: {
+        kind: "segments",
+        segments: analysisOk ? allowlistEval.segments : [],
+      },
+      cwd: params.workdir,
+      env: params.env,
+    });
+    if (!mutableFileBinding.ok) {
+      return {
+        deniedResult: buildGatewayExecApprovalDeniedToolResult({
+          deniedReason: mutableFileBinding.message,
+          command: params.command,
+          cwd: params.workdir,
+        }),
+      };
+    }
+    // A reusable text grant cannot authorize future bytes at a mutable path.
+    // Treat allow-always as one-shot while retaining the operator's current allow.
+    const approvalAllowAlwaysPersistence =
+      mutableFileBinding.binding.operands.length > 0
+        ? createOneShotAllowAlwaysDecision()
+        : effectiveAllowAlwaysPersistence;
+    const revalidateBeforeExecution =
+      mutableFileBinding.binding.operands.length > 0
+        ? () =>
+            revalidateGatewayExecApprovalBinding({
+              binding: mutableFileBinding.binding,
+              command: params.command,
+              cwd: params.workdir,
+            })
+        : undefined;
     const [autoReviewSegment] = allowlistEval.segments;
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
@@ -837,6 +896,19 @@ export async function processGatewayAllowlist(
         decision.risk === "low" &&
         autoReviewEnforcedCommand
       ) {
+        const currentBinding = await revalidateSystemRunMutableFileBinding({
+          binding: mutableFileBinding.binding,
+          cwd: params.workdir,
+        });
+        if (!currentBinding.ok) {
+          return {
+            deniedResult: buildGatewayExecApprovalDeniedToolResult({
+              deniedReason: currentBinding.message,
+              command: params.command,
+              cwd: params.workdir,
+            }),
+          };
+        }
         params.warnings.push(
           `Exec auto-review allowed once (risk=${decision.risk}): ${decision.rationale}`,
         );
@@ -861,6 +933,7 @@ export async function processGatewayAllowlist(
         });
         return {
           execCommandOverride: autoReviewEnforcedCommand,
+          ...(revalidateBeforeExecution ? { revalidateBeforeExecution } : {}),
         };
       }
       params.warnings.push(
@@ -977,6 +1050,21 @@ export async function processGatewayAllowlist(
         );
       }
 
+      const currentBinding = await revalidateSystemRunMutableFileBinding({
+        binding: mutableFileBinding.binding,
+        cwd: params.workdir,
+      });
+      if (!currentBinding.ok) {
+        return {
+          deniedResult: buildGatewayExecApprovalDeniedToolResult({
+            approvalId,
+            deniedReason: currentBinding.message,
+            command: params.command,
+            cwd: params.workdir,
+          }),
+        };
+      }
+
       emitGatewayExecApprovalSecurityEvent({
         action: "exec.approval.approved",
         outcome: "success",
@@ -996,7 +1084,7 @@ export async function processGatewayAllowlist(
           params.workdir,
         ),
         ...(preResolvedDecision === "allow-always"
-          ? { allowAlwaysDecision: effectiveAllowAlwaysPersistence }
+          ? { allowAlwaysDecision: approvalAllowAlwaysPersistence }
           : {}),
       });
       const execCommandOverride =
@@ -1006,6 +1094,7 @@ export async function processGatewayAllowlist(
       return {
         execCommandOverride,
         allowWithoutEnforcedCommand: execCommandOverride === undefined,
+        ...(revalidateBeforeExecution ? { revalidateBeforeExecution } : {}),
       };
     }
     const resolvedPath = resolveApprovalAuditTrustPath(
@@ -1096,6 +1185,16 @@ export async function processGatewayAllowlist(
         deniedReason = deniedReason ?? "allowlist-miss";
       }
 
+      if (!deniedReason && approvedByAsk) {
+        const currentBinding = await revalidateSystemRunMutableFileBinding({
+          binding: mutableFileBinding.binding,
+          cwd: params.workdir,
+        });
+        if (!currentBinding.ok) {
+          deniedReason = currentBinding.message;
+        }
+      }
+
       emitGatewayExecApprovalSecurityEvent({
         action: deniedReason ? "exec.approval.denied" : "exec.approval.approved",
         outcome: deniedReason ? "denied" : "success",
@@ -1115,7 +1214,7 @@ export async function processGatewayAllowlist(
         authorizationSource:
           decision === null ? ("ask-fallback" as const) : ("explicit-approval" as const),
         allowAlwaysDecision:
-          decision === "allow-always" ? effectiveAllowAlwaysPersistence : undefined,
+          decision === "allow-always" ? approvalAllowAlwaysPersistence : undefined,
         execCommandOverride:
           decision === null && fallbackSecurity === "allowlist"
             ? fallbackEnforcedCommand
@@ -1179,6 +1278,7 @@ export async function processGatewayAllowlist(
       return {
         execCommandOverride: approvalDecision.execCommandOverride,
         allowWithoutEnforcedCommand: approvalDecision.execCommandOverride === undefined,
+        ...(revalidateBeforeExecution ? { revalidateBeforeExecution } : {}),
       };
     }
 
@@ -1251,6 +1351,7 @@ export async function processGatewayAllowlist(
       let admitted:
         | { status: "started"; run: Awaited<ReturnType<typeof runExecProcess>> }
         | { status: "approval-state-write-failed" }
+        | { status: "operand-drift"; message: string }
         | { status: "run-aborted" }
         | { status: "spawn-failed" };
       try {
@@ -1270,6 +1371,20 @@ export async function processGatewayAllowlist(
             });
           } catch {
             return { status: "approval-state-write-failed" as const };
+          }
+          if (params.signal?.aborted) {
+            return { status: "run-aborted" as const };
+          }
+
+          const currentBinding = await revalidateSystemRunMutableFileBinding({
+            binding: mutableFileBinding.binding,
+            cwd: params.workdir,
+          });
+          if (!currentBinding.ok) {
+            return {
+              status: "operand-drift" as const,
+              message: currentBinding.message,
+            };
           }
           if (params.signal?.aborted) {
             return { status: "run-aborted" as const };
@@ -1326,6 +1441,10 @@ export async function processGatewayAllowlist(
         return;
       }
       if (admitted.status === "run-aborted") {
+        return;
+      }
+      if (admitted.status === "operand-drift") {
+        await sendExecApprovalFollowupResult(followupTarget, admitted.message);
         return;
       }
       if (admitted.status === "spawn-failed") {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -698,7 +698,7 @@ export async function processGatewayAllowlist(
       env: params.env,
       segments: allowlistEval.segments,
     }) && !(hostSecurity === "full" && hostAsk === "off");
-  const requiresAsk =
+  const policyRequiresAsk =
     requiresExecApproval({
       ask: hostAsk,
       security: hostSecurity,
@@ -749,18 +749,47 @@ export async function processGatewayAllowlist(
       }),
     };
   }
+  let mutableFileBinding: SystemRunMutableFileBinding | undefined;
+  const durableApprovalRequiresBinding = hostSecurity === "allowlist" && durableApprovalSatisfied;
+  if (policyRequiresAsk || durableApprovalRequiresBinding) {
+    // Durable text grants cannot authorize future bytes. Prepare before they
+    // suppress prompting so mutable operands always return to one-shot review.
+    const prepared = await prepareSystemRunMutableFileBinding({
+      command: analysisOk
+        ? { kind: "segments", segments: allowlistEval.segments }
+        : { kind: "shell", text: params.command },
+      cwd: params.workdir,
+      env: params.env,
+    });
+    if (!prepared.ok) {
+      return {
+        deniedResult: buildGatewayExecApprovalDeniedToolResult({
+          deniedReason: prepared.message,
+          command: params.command,
+          cwd: params.workdir,
+        }),
+      };
+    }
+    mutableFileBinding = prepared.binding;
+  }
+  const mutableFileApprovalRequiresOneShot = (mutableFileBinding?.operands.length ?? 0) > 0;
+  const requiresAsk =
+    policyRequiresAsk || (durableApprovalRequiresBinding && mutableFileApprovalRequiresOneShot);
   const effectiveAllowAlwaysPersistence = resolveGatewayEffectiveAllowAlwaysPersistence({
     command: params.command,
     allowAlwaysPersistence,
     requiresAllowlistPlanApproval,
   });
+  const approvalAllowAlwaysPersistence = mutableFileApprovalRequiresOneShot
+    ? createOneShotAllowAlwaysDecision()
+    : effectiveAllowAlwaysPersistence;
   const approvalAllowedDecisions = resolveExecApprovalAllowedDecisions({
     ask: hostAsk,
-    allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
+    allowAlwaysPersistence: approvalAllowAlwaysPersistence,
   });
   const approvalUnavailableDecisions = resolveExecApprovalUnavailableDecisions({
     ask: hostAsk,
-    allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
+    allowAlwaysPersistence: approvalAllowAlwaysPersistence,
   });
   const unavailableDecisionRequestParams =
     approvalUnavailableDecisions.length > 0
@@ -789,36 +818,21 @@ export async function processGatewayAllowlist(
         },
       };
     }
-    // Approval must capture script bytes before any reviewer or operator wait;
-    // command text alone does not prevent a referenced file from changing.
-    const mutableFileBinding = await prepareSystemRunMutableFileBinding({
-      command: {
-        kind: "segments",
-        segments: analysisOk ? allowlistEval.segments : [],
-      },
-      cwd: params.workdir,
-      env: params.env,
-    });
-    if (!mutableFileBinding.ok) {
+    if (!mutableFileBinding) {
       return {
         deniedResult: buildGatewayExecApprovalDeniedToolResult({
-          deniedReason: mutableFileBinding.message,
+          deniedReason: "SYSTEM_RUN_DENIED: mutable file approval binding is unavailable",
           command: params.command,
           cwd: params.workdir,
         }),
       };
     }
-    // A reusable text grant cannot authorize future bytes at a mutable path.
-    // Treat allow-always as one-shot while retaining the operator's current allow.
-    const approvalAllowAlwaysPersistence =
-      mutableFileBinding.binding.operands.length > 0
-        ? createOneShotAllowAlwaysDecision()
-        : effectiveAllowAlwaysPersistence;
+    const approvalMutableFileBinding = mutableFileBinding;
     const revalidateBeforeExecution =
-      mutableFileBinding.binding.operands.length > 0
+      approvalMutableFileBinding.operands.length > 0
         ? () =>
             revalidateGatewayExecApprovalBinding({
-              binding: mutableFileBinding.binding,
+              binding: approvalMutableFileBinding,
               command: params.command,
               cwd: params.workdir,
             })
@@ -897,7 +911,7 @@ export async function processGatewayAllowlist(
         autoReviewEnforcedCommand
       ) {
         const currentBinding = await revalidateSystemRunMutableFileBinding({
-          binding: mutableFileBinding.binding,
+          binding: approvalMutableFileBinding,
           cwd: params.workdir,
         });
         if (!currentBinding.ok) {
@@ -1051,7 +1065,7 @@ export async function processGatewayAllowlist(
       }
 
       const currentBinding = await revalidateSystemRunMutableFileBinding({
-        binding: mutableFileBinding.binding,
+        binding: approvalMutableFileBinding,
         cwd: params.workdir,
       });
       if (!currentBinding.ok) {
@@ -1187,7 +1201,7 @@ export async function processGatewayAllowlist(
 
       if (!deniedReason && approvedByAsk) {
         const currentBinding = await revalidateSystemRunMutableFileBinding({
-          binding: mutableFileBinding.binding,
+          binding: approvalMutableFileBinding,
           cwd: params.workdir,
         });
         if (!currentBinding.ok) {
@@ -1377,7 +1391,7 @@ export async function processGatewayAllowlist(
           }
 
           const currentBinding = await revalidateSystemRunMutableFileBinding({
-            binding: mutableFileBinding.binding,
+            binding: approvalMutableFileBinding,
             cwd: params.workdir,
           });
           if (!currentBinding.ok) {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -750,7 +750,12 @@ export async function processGatewayAllowlist(
     };
   }
   let mutableFileBinding: SystemRunMutableFileBinding | undefined;
-  const durableApprovalRequiresBinding = hostSecurity === "allowlist" && durableApprovalSatisfied;
+  const durableApprovalRequiresBinding =
+    hostSecurity === "allowlist" &&
+    durableApprovalSatisfied &&
+    (!analysisOk ||
+      !allowlistSatisfied ||
+      (exactCommandDurableApprovalSatisfied && allowlistPlanUnavailableReason !== null));
   if (policyRequiresAsk || durableApprovalRequiresBinding) {
     // Durable text grants cannot authorize future bytes. Prepare before they
     // suppress prompting so mutable operands always return to one-shot review.

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -70,6 +70,8 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
 
+type GatewayApprovalRevalidator = () => Promise<AgentToolResult<ExecToolDetails> | undefined>;
+
 /** Creates an exec tool instance with runtime defaults and approval policy wiring. */
 export function createExecTool(
   defaults?: ExecToolDefaults,
@@ -205,6 +207,7 @@ export function createExecTool(
       }
       const startedAt = Date.now();
       let execCommandOverride: string | undefined;
+      let revalidateGatewayApproval: GatewayApprovalRevalidator | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
       const foregroundFallbackWarning =
@@ -535,10 +538,10 @@ export function createExecTool(
             return gatewayResult.deniedResult;
           }
           signal?.throwIfAborted();
-          execCommandOverride = gatewayResult.execCommandOverride;
-          if (gatewayResult.allowWithoutEnforcedCommand) {
-            execCommandOverride = undefined;
-          }
+          revalidateGatewayApproval = gatewayResult.revalidateBeforeExecution;
+          execCommandOverride = gatewayResult.allowWithoutEnforcedCommand
+            ? undefined
+            : gatewayResult.execCommandOverride;
         }
 
         // Pending approvals have not started the command. Add fallback warnings only
@@ -560,6 +563,10 @@ export function createExecTool(
           });
         }
 
+        const gatewayApprovalDenied = await revalidateGatewayApproval?.();
+        if (gatewayApprovalDenied) {
+          return gatewayApprovalDenied;
+        }
         signal?.throwIfAborted();
         run = await runExecProcess({
           command: params.command,

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1324,6 +1324,7 @@ describe("exec approvals", () => {
 
   it("shows full chained gateway commands in approval-pending message", async () => {
     const calls: string[] = [];
+    const command = `${JSON.stringify(process.execPath)} --version && ${JSON.stringify(process.execPath)} --version`;
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       calls.push(method);
       if (method === "exec.approval.request") {
@@ -1343,10 +1344,10 @@ describe("exec approvals", () => {
     });
 
     const result = await tool.execute("call-chain-gateway", {
-      command: "npm view diver --json | jq .name && brew outdated",
+      command,
     });
 
-    expectPendingCommandText(result, "npm view diver --json | jq .name && brew outdated");
+    expectPendingCommandText(result, command);
     expect(calls).toContain("exec.approval.request");
   });
 
@@ -1491,6 +1492,7 @@ describe("exec approvals", () => {
 
   it("shows full chained node commands in approval-pending message", async () => {
     const calls: string[] = [];
+    const command = `${JSON.stringify(process.execPath)} --version && ${JSON.stringify(process.execPath)} --version`;
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       calls.push(method);
       if (method === "node.invoke") {
@@ -1510,10 +1512,10 @@ describe("exec approvals", () => {
     });
 
     const result = await tool.execute("call-chain-node", {
-      command: "npm view diver --json | jq .name && brew outdated",
+      command,
     });
 
-    expectPendingCommandText(result, "npm view diver --json | jq .name && brew outdated");
+    expectPendingCommandText(result, command);
     expect(calls).toContain("exec.approval.request");
   });
 

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -7,14 +7,27 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { detectUnsafeExecControlShellCommand } from "../infra/exec-control-command-guard.js";
+import { prepareSystemRunMutableFileApproval } from "../infra/system-run-approval-binding.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 import { validateScriptFileForShellBleed } from "./bash-tools.exec-script-preflight.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "./runtime/index.js";
 
-vi.mock("./bash-tools.exec-host-gateway.js", () => ({
-  processGatewayAllowlist: async () => ({ allowWithoutEnforcedCommand: true }),
+const processGatewayAllowlistMock = vi.hoisted(() =>
+  vi.fn(
+    async (): Promise<{
+      allowWithoutEnforcedCommand: boolean;
+      revalidateBeforeExecution?: () => Promise<AgentToolResult<ExecToolDetails> | undefined>;
+    }> => ({ allowWithoutEnforcedCommand: true }),
+  ),
+);
+
+vi.mock("./bash-tools.exec-host-gateway.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bash-tools.exec-host-gateway.js")>()),
+  processGatewayAllowlist: processGatewayAllowlistMock,
 }));
 
 vi.mock("./bash-tools.exec-host-node.js", () => ({
@@ -38,6 +51,11 @@ const runExecPreflight = (params: { command: string; workdir: string }) =>
 
 afterEach(() => {
   __setFsSafeTestHooksForTest();
+});
+
+beforeEach(() => {
+  processGatewayAllowlistMock.mockReset();
+  processGatewayAllowlistMock.mockResolvedValue({ allowWithoutEnforcedCommand: true });
 });
 
 async function expectSymlinkSwapDuringPreflightToAvoidErrors(params: {
@@ -121,6 +139,64 @@ describe("exec interactive OpenClaw channel login guard", () => {
 });
 
 describeNonWin("exec script preflight", () => {
+  it.each([
+    { name: "denies changed bytes", mutate: true },
+    { name: "executes unchanged bytes", mutate: false },
+  ])("revalidates gateway approval script operands before spawn: $name", async ({ mutate }) => {
+    await withTempDir("openclaw-exec-approval-binding-", async (tmp) => {
+      const script = path.join(tmp, "script.sh");
+      await fs.writeFile(script, "#!/bin/sh\necho approved\n");
+      const prepared = await prepareSystemRunMutableFileApproval({
+        command: "sh script.sh",
+        cwd: tmp,
+      });
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error(prepared.message);
+      }
+      processGatewayAllowlistMock.mockResolvedValueOnce({
+        allowWithoutEnforcedCommand: true,
+        revalidateBeforeExecution: async () => {
+          const current = await prepared.revalidate();
+          if (current.ok) {
+            return undefined;
+          }
+          return {
+            content: [{ type: "text", text: current.message }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              durationMs: 0,
+              aggregated: current.message,
+              timedOut: false,
+              cwd: tmp,
+            },
+          };
+        },
+      });
+      if (mutate) {
+        await fs.writeFile(script, "#!/bin/sh\necho mutated\n");
+      }
+
+      const result = await runExecPreflight({ command: "sh script.sh", workdir: tmp });
+
+      if (mutate) {
+        expect(result.details.status).toBe("failed");
+        expect(result.content[0]).toEqual(
+          expect.objectContaining({
+            text: expect.stringContaining("approval script operand changed before execution"),
+          }),
+        );
+      } else {
+        expect(result.details.status).toBe("completed");
+        if (result.details.status !== "completed") {
+          throw new Error("expected completed exec result");
+        }
+        expect(result.details.aggregated).toBe("approved");
+      }
+    });
+  });
+
   it("blocks shell env var injection tokens in python scripts before execution", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const pyPath = path.join(tmp, "bad.py");

--- a/src/agents/cli-runner/claude-live-process-approval.test.ts
+++ b/src/agents/cli-runner/claude-live-process-approval.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   markMcpLoopbackToolCallFinished,
@@ -228,6 +231,87 @@ describe("Claude live process approvals", () => {
       }),
       { expectFinal: false },
     );
+  });
+
+  it("denies Claude Bash when an approved script operand changes before release", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-claude-drift-"));
+    const scriptPath = path.join(workspaceDir, "script.sh");
+    try {
+      await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "claude-native-script-drift" })
+        .mockImplementationOnce(async () => {
+          await fs.writeFile(scriptPath, "#!/bin/sh\necho mutated\n");
+          return { id: "claude-native-script-drift", decision: "allow-once" };
+        });
+      const live = mockClaudeLiveRun(supervisorSpawnMock, {
+        events: buildClaudeControlRequestEvents({
+          requestId: "req-script-drift",
+          toolUseId: "tool-script-drift",
+          input: { command: "sh script.sh" },
+          sessionId: "live-script-drift",
+        }),
+      });
+
+      await executePreparedCliRun(
+        buildClaudeLiveRunContext({
+          workspaceDir,
+          config: { tools: { exec: { security: "allowlist", ask: "on-miss" } } },
+        }),
+      );
+
+      await vi.waitFor(() =>
+        expect(live.writes.some((entry) => entry.includes('"control_response"'))).toBe(true),
+      );
+      expectClaudeControlDecision(live, {
+        behavior: "deny",
+        requestId: "req-script-drift",
+        messageIncludes: "approval script operand changed before execution",
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("releases Claude Bash when the approved script operand is unchanged", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-claude-stable-"));
+    const scriptPath = path.join(workspaceDir, "script.sh");
+    try {
+      await fs.writeFile(scriptPath, "#!/bin/sh\necho approved\n");
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "claude-native-script-stable" })
+        .mockResolvedValueOnce({
+          id: "claude-native-script-stable",
+          decision: "allow-once",
+        });
+      const live = mockClaudeLiveRun(supervisorSpawnMock, {
+        events: buildClaudeControlRequestEvents({
+          requestId: "req-script-stable",
+          toolUseId: "tool-script-stable",
+          input: { command: "sh script.sh" },
+          sessionId: "live-script-stable",
+        }),
+      });
+
+      await executePreparedCliRun(
+        buildClaudeLiveRunContext({
+          workspaceDir,
+          config: { tools: { exec: { security: "allowlist", ask: "on-miss" } } },
+        }),
+      );
+
+      await vi.waitFor(() =>
+        expect(live.writes.some((entry) => entry.includes('"control_response"'))).toBe(true),
+      );
+      expectClaudeControlDecision(live, {
+        behavior: "allow",
+        requestId: "req-script-stable",
+        toolUseId: "tool-script-stable",
+        updatedInput: { command: "sh script.sh" },
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("sends full reviewer detail for oversized non-Bash tool input", async () => {

--- a/src/agents/cli-runner/claude-live-process.ts
+++ b/src/agents/cli-runner/claude-live-process.ts
@@ -265,6 +265,7 @@ function acceptControlRequest(
       sessionKey: turn.diagnosticRefs.sessionKey,
       agentId: turn.diagnosticRefs.agentId,
       toolCallId: toolUseId,
+      cwd: turn.cwd,
       abortSignal: turn.abortSignal,
       ask: turn.execPermission.ask,
     });
@@ -292,9 +293,12 @@ function acceptControlRequest(
               message:
                 outcome.kind === "deny" && outcome.reason === "policy-oversized"
                   ? "OpenClaw denied Claude native tool use (Bash): the command is too large to display for out-of-band approval. Split it into smaller commands and retry."
-                  : outcome.kind === "deny" && outcome.reason === "user" && !runAborted
-                    ? `OpenClaw user denied Claude native tool use (${toolName}).`
-                    : `OpenClaw approval was not granted for Claude native tool use (${toolName}).`,
+                  : outcome.kind === "deny" && outcome.reason === "operand-binding"
+                    ? (outcome.message ??
+                      "OpenClaw denied Claude native tool use (Bash): the command could not be bound to stable script bytes.")
+                    : outcome.kind === "deny" && outcome.reason === "user" && !runAborted
+                      ? `OpenClaw user denied Claude native tool use (${toolName}).`
+                      : `OpenClaw approval was not granted for Claude native tool use (${toolName}).`,
             },
       });
     } catch {

--- a/src/agents/cli-runner/claude-live-tool-approval.test.ts
+++ b/src/agents/cli-runner/claude-live-tool-approval.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
   PLUGIN_APPROVAL_DETAIL_MAX_LENGTH,
 } from "../../infra/plugin-approvals.js";
+import { APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE } from "../../infra/system-run-approval-binding.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import {
   requestClaudeNativeToolApproval,
@@ -111,7 +115,7 @@ describe("requestClaudeNativeToolApproval", () => {
     await expect(
       requestClaudeNativeToolApproval({
         toolName: "Bash",
-        toolInput: {},
+        toolInput: { command: "ls" },
         pluginId: "claude-cli",
         ask: "on-miss",
       }),
@@ -124,7 +128,7 @@ describe("requestClaudeNativeToolApproval", () => {
     await expect(
       requestClaudeNativeToolApproval({
         toolName: "Bash",
-        toolInput: {},
+        toolInput: { command: "ls" },
         pluginId: "claude-cli",
         ask: "on-miss",
       }),
@@ -138,7 +142,7 @@ describe("requestClaudeNativeToolApproval", () => {
       .mockImplementationOnce(() => new Promise(() => {}));
     const approval = requestClaudeNativeToolApproval({
       toolName: "Bash",
-      toolInput: {},
+      toolInput: { command: "ls" },
       pluginId: "claude-cli",
       abortSignal: abortController.signal,
       ask: "on-miss",
@@ -154,7 +158,7 @@ describe("requestClaudeNativeToolApproval", () => {
     mockCallGatewayTool.mockImplementationOnce(() => new Promise(() => {}));
     const approval = requestClaudeNativeToolApproval({
       toolName: "Bash",
-      toolInput: {},
+      toolInput: { command: "ls" },
       pluginId: "claude-cli",
       abortSignal: abortController.signal,
       ask: "on-miss",
@@ -209,6 +213,34 @@ describe("requestClaudeNativeToolApproval", () => {
       detail: '{"command":"ls"}',
       allowedDecisions: ["allow-once", "deny"],
     });
+  });
+
+  it("checks Bash script drift before rejecting an unexpected allow-always", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-always-drift-"));
+    const script = path.join(cwd, "script.sh");
+    try {
+      fs.writeFileSync(script, "#!/bin/sh\necho approved\n");
+      mockCallGatewayTool.mockImplementationOnce(async () => {
+        fs.writeFileSync(script, "#!/bin/sh\necho changed\n");
+        return { id: "approval-unexpected-always", decision: "allow-always" };
+      });
+
+      await expect(
+        requestClaudeNativeToolApproval({
+          toolName: "Bash",
+          toolInput: { command: "sh script.sh" },
+          pluginId: "claude-cli",
+          cwd,
+          ask: "on-miss",
+        }),
+      ).resolves.toEqual({
+        kind: "deny",
+        reason: "operand-binding",
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("denies Bash whose channel description truncates even when detail would fit", async () => {
@@ -302,7 +334,7 @@ describe("requestClaudeNativeToolApproval", () => {
     mockCallGatewayTool.mockResolvedValueOnce({ id: "approval-7", decision: "deny" });
 
     await requestClaudeNativeToolApproval({
-      toolName: "Bash",
+      toolName: "WebFetch",
       toolInput: { toJSON: () => undefined },
       pluginId: "claude-cli",
       ask: "on-miss",

--- a/src/agents/cli-runner/claude-live-tool-approval.ts
+++ b/src/agents/cli-runner/claude-live-tool-approval.ts
@@ -7,6 +7,11 @@ import {
   PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
   truncatePluginApprovalDetail,
 } from "../../infra/plugin-approvals.js";
+import {
+  prepareSystemRunMutableFileBinding,
+  revalidateSystemRunMutableFileBinding,
+  type SystemRunMutableFileBinding,
+} from "../../infra/system-run-approval-binding.js";
 import { sliceUtf16Safe, truncateUtf16Safe } from "../../utils.js";
 import { callGatewayTool } from "../tools/gateway.js";
 
@@ -14,7 +19,11 @@ type ClaudeNativeToolApprovalPlan = "allow" | "deny" | "prompt";
 type ClaudeNativeToolApprovalDecision = "allow-once" | "allow-always" | "deny";
 type ClaudeNativeToolApprovalOutcome =
   | { kind: "allow"; grantAlways: boolean }
-  | { kind: "deny"; reason: "policy-oversized" | "user" | "unavailable" };
+  | {
+      kind: "deny";
+      reason: "operand-binding" | "policy-oversized" | "user" | "unavailable";
+      message?: string;
+    };
 
 const CLAUDE_NATIVE_TOOL_DESCRIPTION_HEAD_CHARS = 300;
 const CLAUDE_NATIVE_TOOL_DESCRIPTION_TAIL_CHARS = 80;
@@ -147,6 +156,7 @@ export async function requestClaudeNativeToolApproval(params: {
   sessionKey?: string;
   agentId?: string;
   toolCallId?: string;
+  cwd?: string;
   abortSignal?: AbortSignal;
   ask: ExecAsk;
 }): Promise<ClaudeNativeToolApprovalOutcome> {
@@ -183,6 +193,24 @@ export async function requestClaudeNativeToolApproval(params: {
           Array.from(summarySanitization.text).length > PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH))
     ) {
       return { kind: "deny", reason: "policy-oversized" };
+    }
+    const bashCommand =
+      params.toolName === CLAUDE_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL &&
+      typeof params.toolInput.command === "string"
+        ? params.toolInput.command
+        : undefined;
+    let mutableFileBinding: SystemRunMutableFileBinding | undefined;
+    if (params.toolName === CLAUDE_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL) {
+      // Bind script bytes before the out-of-band approval wait. Text-identical
+      // Bash input can otherwise execute a rewritten file after approval.
+      const prepared = await prepareSystemRunMutableFileBinding({
+        command: { kind: "shell", text: bashCommand ?? "" },
+        cwd: params.cwd,
+      });
+      if (!prepared.ok) {
+        return { kind: "deny", reason: "operand-binding", message: prepared.message };
+      }
+      mutableFileBinding = prepared.binding.operands.length > 0 ? prepared.binding : undefined;
     }
     const allowedDecisions = resolveClaudeNativeToolAllowedDecisions({
       ask: params.ask,
@@ -231,6 +259,17 @@ export async function requestClaudeNativeToolApproval(params: {
     }
     if (params.abortSignal?.aborted) {
       return { kind: "deny", reason: "unavailable" };
+    }
+    if ((decision === "allow-once" || decision === "allow-always") && mutableFileBinding) {
+      // This control response is OpenClaw's last boundary before Claude owns
+      // spawn, so reject bytes that changed during the approval wait.
+      const binding = await revalidateSystemRunMutableFileBinding({
+        binding: mutableFileBinding,
+        cwd: params.cwd,
+      });
+      if (!binding.ok) {
+        return { kind: "deny", reason: "operand-binding", message: binding.message };
+      }
     }
     if (decision === "allow-once") {
       return { kind: "allow", grantAlways: false };

--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -59,6 +59,7 @@ type ClaudeLiveActiveTool = {
 
 export type ClaudeLiveTurn = {
   backend: CliBackendConfig;
+  cwd: string;
   parseJsonlEvent?: CliBackendParseJsonlEvent;
   diagnosticRefs: {
     runId: string;
@@ -559,6 +560,7 @@ export function createClaudeTurn(params: {
 }): ClaudeLiveTurn {
   const turn: ClaudeLiveTurn = {
     backend: params.context.preparedBackend.backend,
+    cwd: params.context.cwd ?? params.context.workspaceDir,
     parseJsonlEvent: params.context.backendResolved.parseJsonlEvent,
     diagnosticRefs: {
       runId: params.context.params.runId,

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -9,6 +9,15 @@ export type AgentHarnessHostCapabilities = Readonly<{
   assertActive: () => void;
   /** Applies the exact host caller binding to a plugin-built tool surface. */
   bindToolSurface: (tools: AnyAgentTool[], options?: Readonly<{ cwd?: string }>) => AnyAgentTool[];
+  /** Core-owned byte binding for a native command approval, scoped to this admitted run. */
+  prepareMutableFileApproval?: (request: { command: string; cwd?: string }) => Promise<
+    | {
+        ok: true;
+        requiresOneShot: boolean;
+        revalidate: () => Promise<{ ok: true } | { ok: false; message: string }>;
+      }
+    | { ok: false; message: string }
+  >;
   /** Runs policy with host-fixed HookContext; callers provide only the native action tuple. */
   runBeforeToolCall: (
     request: Omit<

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -191,6 +194,29 @@ describe("agent harness host capability", () => {
         }),
       }),
     );
+  });
+
+  it("closes prepared mutable-file approval revalidators with the admitted run", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-host-binding-"));
+    try {
+      fs.writeFileSync(path.join(cwd, "script.sh"), "#!/bin/sh\necho approved\n");
+      const { attempt } = await admittedAttempt("run-file-binding", { cwd });
+      const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+      const prepared = await host.capabilities.prepareMutableFileApproval?.({
+        command: "sh script.sh",
+        cwd,
+      });
+      expect(prepared?.ok).toBe(true);
+      if (!prepared?.ok) {
+        throw new Error("expected mutable file approval binding");
+      }
+
+      host.close();
+
+      await expect(prepared.revalidate()).rejects.toThrow("no longer active");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("binds hooks to the native harness cwd instead of the agent workspace", async () => {

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { getActiveDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
+import { prepareSystemRunMutableFileApproval } from "../../infra/system-run-approval-binding.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import {
   getAdmittedRunDelegatedAuthority,
@@ -310,6 +311,24 @@ export function createAgentHarnessHostCapabilities(params: {
           .map((tool) => wrapToolWithAbortSignal(tool, boundAbortSignal))
           .map((tool) => gateBoundTool(tool, assertActive))
       );
+    },
+    prepareMutableFileApproval: async (request) => {
+      assertActive();
+      const prepared = await prepareSystemRunMutableFileApproval(request);
+      assertActive();
+      if (!prepared.ok) {
+        return prepared;
+      }
+      return Object.freeze({
+        ok: true,
+        requiresOneShot: prepared.requiresOneShot,
+        revalidate: async () => {
+          assertActive();
+          const current = await prepared.revalidate();
+          assertActive();
+          return current;
+        },
+      });
     },
     runBeforeToolCall,
     requestApproval: async (request) => {

--- a/src/agents/harness/native-hook-relay-permissions.ts
+++ b/src/agents/harness/native-hook-relay-permissions.ts
@@ -7,6 +7,11 @@ import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
+import {
+  prepareSystemRunMutableFileBinding,
+  revalidateSystemRunMutableFileBinding,
+  type SystemRunMutableFileBinding,
+} from "../../infra/system-run-approval-binding.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import {
@@ -53,6 +58,13 @@ const MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES = 512;
 const MCP_APPROVAL_UNAVAILABLE_REASON =
   'MCP tool approval timed out (no operator connected). Approve in the Control UI, or set mcp.servers.<id>.codex.defaultToolsApprovalMode:"approve" for trusted servers.';
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
+const NATIVE_SHELL_APPROVAL_TOOLS = new Set([
+  "bash",
+  "exec",
+  "exec_command",
+  "shell",
+  "shell_command",
+]);
 
 const {
   pendingPermissionApprovals,
@@ -188,15 +200,32 @@ export async function runNativeHookRelayPermissionRequest(params: {
     toolInput: params.adapter.readToolInput(params.invocation.rawPayload),
     ...(params.registration.signal ? { signal: params.registration.signal } : {}),
   };
+  const mutableFileBinding = await prepareNativeHookMutableFileBinding(request);
+  if (!mutableFileBinding.ok) {
+    return params.adapter.renderPermissionDecisionResponse("deny", mutableFileBinding.message);
+  }
   const approvalKey = nativeHookRelayPermissionApprovalKey({
     registration: params.registration,
     request,
+    binding: mutableFileBinding.binding,
   });
   const allowAlwaysKey = nativeHookRelayPermissionAllowAlwaysKey({
     registration: params.registration,
     request,
+    binding: mutableFileBinding.binding,
   });
   if (hasNativeHookRelayPermissionAllowAlways(allowAlwaysKey)) {
+    params.registration.assertActive?.();
+    if (mutableFileBinding.binding) {
+      const current = await revalidateSystemRunMutableFileBinding({
+        binding: mutableFileBinding.binding,
+        cwd: request.cwd,
+      });
+      params.registration.assertActive?.();
+      if (!current.ok) {
+        return params.adapter.renderPermissionDecisionResponse("deny", current.message);
+      }
+    }
     return params.adapter.renderPermissionDecisionResponse("allow");
   }
   const pendingApproval = pendingPermissionApprovals.get(approvalKey);
@@ -207,6 +236,19 @@ export async function runNativeHookRelayPermissionRequest(params: {
         approvalKey,
         request,
       }));
+    params.registration.assertActive?.();
+    if ((decision === "allow" || decision === "allow-always") && mutableFileBinding.binding) {
+      // PermissionRequest is OpenClaw's last boundary before the native runtime
+      // owns spawn; recheck after the wait before returning its allow response.
+      const current = await revalidateSystemRunMutableFileBinding({
+        binding: mutableFileBinding.binding,
+        cwd: request.cwd,
+      });
+      params.registration.assertActive?.();
+      if (!current.ok) {
+        return params.adapter.renderPermissionDecisionResponse("deny", current.message);
+      }
+    }
     if (decision === "allow") {
       return params.adapter.renderPermissionDecisionResponse("allow");
     }
@@ -257,6 +299,7 @@ async function startNativeHookRelayPermissionApprovalWithBudget(params: {
 function nativeHookRelayPermissionApprovalKey(params: {
   registration: NativeHookRelayRegistration;
   request: NativeHookRelayPermissionApprovalRequest;
+  binding?: SystemRunMutableFileBinding;
 }): string {
   return [
     params.registration.relayId,
@@ -265,12 +308,42 @@ function nativeHookRelayPermissionApprovalKey(params: {
       ? `call:${params.request.toolCallId}`
       : permissionRequestFallbackKey(params.request),
     permissionRequestContentFingerprint(params.request),
+    params.binding ? permissionRequestBindingFingerprint(params.binding) : "no-file-binding",
   ].join(":");
+}
+
+async function prepareNativeHookMutableFileBinding(
+  request: NativeHookRelayPermissionApprovalRequest,
+): Promise<{ ok: true; binding?: SystemRunMutableFileBinding } | { ok: false; message: string }> {
+  if (!NATIVE_SHELL_APPROVAL_TOOLS.has(request.toolName.trim().toLowerCase())) {
+    return { ok: true };
+  }
+  const command = readOptionalNonEmptyString(request.toolInput.command);
+  const prepared = await prepareSystemRunMutableFileBinding({
+    command: { kind: "shell", text: command ?? "" },
+    cwd: request.cwd,
+  });
+  if (!prepared.ok) {
+    return { ok: false, message: prepared.message };
+  }
+  return prepared.binding.operands.length > 0
+    ? { ok: true, binding: prepared.binding }
+    : { ok: true };
+}
+
+function permissionRequestBindingFingerprint(binding: SystemRunMutableFileBinding): string {
+  const hash = createHash("sha256");
+  for (const { argv, snapshot } of binding.operands) {
+    hash.update(JSON.stringify([argv, snapshot.argvIndex, snapshot.path, snapshot.sha256]));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
 }
 
 function nativeHookRelayPermissionAllowAlwaysKey(params: {
   registration: NativeHookRelayRegistration;
   request: NativeHookRelayPermissionApprovalRequest;
+  binding?: SystemRunMutableFileBinding;
 }): string {
   const hash = createHash("sha256");
   hash.update("openclaw:native-hook-relay:permission-allow-always:v2");
@@ -284,6 +357,10 @@ function nativeHookRelayPermissionAllowAlwaysKey(params: {
   hash.update(params.request.sessionKey ?? params.request.sessionId);
   hash.update("\0");
   hash.update(permissionRequestContentFingerprint(params.request));
+  hash.update("\0");
+  hash.update(
+    params.binding ? permissionRequestBindingFingerprint(params.binding) : "no-file-binding",
+  );
   return hash.digest("hex");
 }
 

--- a/src/agents/harness/native-hook-relay.approval-binding.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-binding.test.ts
@@ -1,4 +1,7 @@
 // Covers gateway waitDecision id binding for native hook relay permission approvals.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { callGatewayTool } from "../tools/gateway.js";
 import { invokeNativeHookRelay, registerNativeHookRelay, testing } from "./native-hook-relay.js";
@@ -29,17 +32,20 @@ function mockGatewayApproval(waitResult: { id?: string; decision?: string | null
   });
 }
 
-async function invokePermissionRequest(relayId: string) {
+async function invokePermissionRequest(
+  relayId: string,
+  options: { command?: string; cwd?: string } = {},
+) {
   return invokeNativeHookRelay({
     provider: "codex",
     relayId,
     event: "permission_request",
     rawPayload: {
       hook_event_name: "PermissionRequest",
-      cwd: "/repo",
+      cwd: options.cwd ?? "/repo",
       tool_name: "Bash",
       tool_use_id: "native-binding-call-1",
-      tool_input: { command: "printf binding" },
+      tool_input: { command: options.command ?? "printf binding" },
     },
   });
 }
@@ -82,5 +88,114 @@ describe("native hook relay approval id binding", () => {
       "plugin.approval.request",
       "plugin.approval.waitDecision",
     ]);
+  });
+
+  it("denies when a script operand changes during the permission approval", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-hook-drift-"));
+    const script = path.join(cwd, "script.sh");
+    try {
+      await fs.writeFile(script, "#!/bin/sh\necho approved\n");
+      mockCallGatewayTool.mockImplementation(async (method: string) => {
+        if (method === "plugin.approval.request") {
+          return { id: "approval-1", status: "accepted" };
+        }
+        if (method === "plugin.approval.waitDecision") {
+          await fs.writeFile(script, "#!/bin/sh\necho mutated\n");
+          return { id: "approval-1", decision: "allow-once" };
+        }
+        throw new Error(`unexpected gateway method: ${method}`);
+      });
+      const relay = registerNativeHookRelay({
+        provider: "codex",
+        relayId: "codex-script-drift",
+        sessionId: "session-1",
+        runId: "run-1",
+      });
+
+      const response = await invokePermissionRequest(relay.relayId, {
+        command: "sh script.sh",
+        cwd,
+      });
+
+      expect(JSON.parse(response.stdout)).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "deny",
+            message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+          },
+        },
+      });
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows an unchanged script operand after permission approval", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-hook-stable-"));
+    try {
+      await fs.writeFile(path.join(cwd, "script.sh"), "#!/bin/sh\necho approved\n");
+      mockGatewayApproval({ id: "approval-1", decision: "allow-once" });
+      const relay = registerNativeHookRelay({
+        provider: "codex",
+        relayId: "codex-script-stable",
+        sessionId: "session-1",
+        runId: "run-1",
+      });
+
+      const response = await invokePermissionRequest(relay.relayId, {
+        command: "sh script.sh",
+        cwd,
+      });
+
+      expect(JSON.parse(response.stdout)).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: { behavior: "allow" },
+        },
+      });
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reuse allow-always after bound script bytes change", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-hook-always-"));
+    const script = path.join(cwd, "script.sh");
+    try {
+      await fs.writeFile(script, "#!/bin/sh\necho approved\n");
+      mockCallGatewayTool.mockResolvedValueOnce({
+        id: "approval-always",
+        decision: "allow-always",
+      });
+      const relay = registerNativeHookRelay({
+        provider: "codex",
+        relayId: "codex-script-always",
+        sessionId: "session-1",
+        runId: "run-1",
+      });
+
+      const first = await invokePermissionRequest(relay.relayId, {
+        command: "sh script.sh",
+        cwd,
+      });
+      expect(JSON.parse(first.stdout).hookSpecificOutput.decision).toEqual({ behavior: "allow" });
+
+      await fs.writeFile(script, "#!/bin/sh\necho changed\n");
+      mockCallGatewayTool.mockReset();
+      mockCallGatewayTool.mockResolvedValueOnce({ id: "approval-changed", decision: "deny" });
+      const second = await invokePermissionRequest(relay.relayId, {
+        command: "sh script.sh",
+        cwd,
+      });
+
+      expect(mockCallGatewayTool).toHaveBeenCalledOnce();
+      expect(JSON.parse(second.stdout).hookSpecificOutput.decision).toEqual({
+        behavior: "deny",
+        message: "Denied by user",
+      });
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -992,13 +992,11 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-1",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
-    await Promise.resolve();
-
     const state = getNativeHookRelaySharedStateForTests();
-    expect(state.pendingPermissionApprovals.size).toBe(1);
+    await vi.waitFor(() => expect(state.pendingPermissionApprovals.size).toBe(1));
     expect(state.permissionApprovalWindows.get(relay.relayId)).toHaveLength(1);
 
     resolveDecision?.("allow-always");
@@ -1016,7 +1014,7 @@ describe("native hook relay registry", () => {
           cwd: "/repo",
           tool_name: "Bash",
           tool_use_id: "native-call-2",
-          tool_input: { command: "browserforce tabs" },
+          tool_input: { command: "git status" },
         },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
@@ -1051,7 +1049,7 @@ describe("native hook relay registry", () => {
           cwd: "/repo",
           tool_name: "Bash",
           tool_use_id: "native-call-1",
-          tool_input: { command: "browserforce tabs" },
+          tool_input: { command: "git status" },
         },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
@@ -1068,7 +1066,7 @@ describe("native hook relay registry", () => {
           cwd: "/repo",
           tool_name: "Bash",
           tool_use_id: "native-call-2",
-          tool_input: { command: "browserforce tabs" },
+          tool_input: { command: "git status" },
         },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
@@ -1115,7 +1113,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-1",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
     expect(JSON.parse(duplicateApproval.stdout)).toEqual({
@@ -1136,7 +1134,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-2",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
     expect(JSON.parse(primaryApproval.stdout)).toEqual({
@@ -3856,7 +3854,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-1",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
     relay.unregister();
@@ -3875,7 +3873,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-2",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
 
@@ -3918,7 +3916,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-1",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
     first.unregister();
@@ -3939,7 +3937,7 @@ describe("native hook relay registry", () => {
         cwd: "/repo",
         tool_name: "Bash",
         tool_use_id: "native-call-2",
-        tool_input: { command: "browserforce tabs" },
+        tool_input: { command: "git status" },
       },
     });
 
@@ -3949,7 +3947,7 @@ describe("native hook relay registry", () => {
       agentId: "agent-1",
       sessionId: "session-2",
       sessionKey: "agent:main:session-2",
-      toolInput: { command: "browserforce tabs" },
+      toolInput: { command: "git status" },
     });
   });
 
@@ -4017,7 +4015,7 @@ describe("native hook relay registry", () => {
         rawPayload: {
           hook_event_name: "PermissionRequest",
           tool_name: "Bash",
-          tool_input: { command: "cargo test" },
+          tool_input: { command: "git status" },
         },
       }),
     ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
@@ -4055,8 +4053,7 @@ describe("native hook relay registry", () => {
       rawPayload: payload,
     });
 
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(1));
     resolveDecision?.("allow");
     const responses = await Promise.all([first, second]);
 
@@ -4105,8 +4102,7 @@ describe("native hook relay registry", () => {
       event: "permission_request",
       rawPayload: payload,
     });
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(1));
     expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(1);
 
     firstRelay.unregister();
@@ -4122,8 +4118,7 @@ describe("native hook relay registry", () => {
       event: "permission_request",
       rawPayload: payload,
     });
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(2));
     expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(1);
 
     resolvers[0]?.("allow");
@@ -4136,8 +4131,10 @@ describe("native hook relay registry", () => {
       event: "permission_request",
       rawPayload: payload,
     });
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(2);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(2));
 
     resolvers[1]?.("allow");
     await expect(Promise.all([secondApproval, duplicateSecondApproval])).resolves.toHaveLength(2);
@@ -4182,8 +4179,7 @@ describe("native hook relay registry", () => {
       },
     });
 
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(2));
     const secondResponse = await second;
     expect(JSON.parse(secondResponse.stdout)).toEqual({
       hookSpecificOutput: {
@@ -4260,8 +4256,7 @@ describe("native hook relay registry", () => {
         rawPayload: duplicatePayload,
       }),
     );
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(1));
 
     const newRequest = invokeNativeHookRelay({
       provider: "codex",
@@ -4273,8 +4268,7 @@ describe("native hook relay registry", () => {
         tool_input: { command: "curl https://example.com" },
       },
     });
-    await Promise.resolve();
-    expect(approvalRequester).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(approvalRequester).toHaveBeenCalledTimes(2));
 
     for (const resolve of resolvers) {
       resolve("allow");

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -1,11 +1,17 @@
 // Covers system-run approval binding normalization and matching.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
   buildSystemRunApprovalBinding,
   buildSystemRunApprovalEnvBinding,
   matchSystemRunApprovalBinding,
   missingSystemRunApprovalBinding,
   normalizeSystemRunApprovalPlan,
+  prepareSystemRunMutableFileBinding,
+  revalidateSystemRunMutableFileBinding,
 } from "./system-run-approval-binding.js";
 
 function expectOk<T extends { ok: boolean }>(result: T): T & { ok: true } {
@@ -325,4 +331,502 @@ describe("missingSystemRunApprovalBinding", () => {
       },
     });
   });
+});
+
+describe("mutable file operand binding", () => {
+  it("binds every script in a compound command and detects drift", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-binding-"));
+    const first = path.join(cwd, "first.sh");
+    const second = path.join(cwd, "second.py");
+    try {
+      fs.writeFileSync(first, "#!/bin/sh\necho first\n");
+      fs.writeFileSync(second, "print('second')\n");
+      const command = { kind: "shell" as const, text: "sh first.sh && python3 second.py" };
+      const prepared = expectOk(await prepareSystemRunMutableFileBinding({ command, cwd }));
+
+      expect(prepared.binding.operands).toHaveLength(2);
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({ ok: true });
+
+      fs.writeFileSync(second, "print('changed')\n");
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds direct script executables", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-direct-"));
+    const script = path.join(cwd, "direct.sh");
+    try {
+      fs.writeFileSync(script, "#!/bin/sh\necho approved\n", { mode: 0o755 });
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "./direct.sh" },
+          cwd,
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(1);
+
+      fs.writeFileSync(script, "#!/bin/sh\necho changed\n", { mode: 0o755 });
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds mutable native executables", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-native-"));
+    const executable = path.join(cwd, "native-tool");
+    try {
+      fs.copyFileSync(process.execPath, executable);
+      fs.chmodSync(executable, 0o755);
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "./native-tool --version" },
+          cwd,
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(1);
+
+      fs.appendFileSync(executable, Buffer.from([0]));
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for shell startup file operands", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-startup-"));
+    try {
+      fs.writeFileSync(path.join(cwd, "init.sh"), "echo init\n");
+      fs.writeFileSync(path.join(cwd, "job.sh"), "echo job\n");
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "bash --rcfile init.sh -i job.sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-O", "extglob", "-i", "job.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["sh", "-s"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "--rcfile", "init.sh", "-c", "echo ok"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-i", "job.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for shell source built-ins", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-source-"));
+    try {
+      fs.writeFileSync(path.join(cwd, "loaded.sh"), "echo loaded\n");
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-c", "source loaded.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-c", "echo ok; source loaded.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: {
+            kind: "argv",
+            argv: ["env", "BASH_ENV=loaded.sh", "bash", "-c", "echo ok"],
+          },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup environment",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "bash -c 'echo ok'" },
+          cwd,
+          env: { ...process.env, BASH_ENV: path.join(cwd, "loaded.sh") },
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup environment",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["node", "--env-file=approved.env", "app.js"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-c", "sh < payload.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "cat payload.sh | sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell pipelines",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "command source loaded.sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell source operands",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for runtime code-loading and cwd options", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-bun-"));
+    try {
+      fs.writeFileSync(path.join(cwd, "loader.ts"), "export {};\n");
+      fs.writeFileSync(path.join(cwd, "app.ts"), "console.log('app');\n");
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bun", "--preload", "loader.ts", "app.ts"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message:
+          "SYSTEM_RUN_DENIED: approval cannot safely bind runtime code-loading or cwd options",
+      });
+      for (const command of [
+        ["ruby", "-S", "app.rb"],
+        ["perl", "-S", "app.pl"],
+      ]) {
+        await expect(
+          prepareSystemRunMutableFileBinding({ command: { kind: "argv", argv: command }, cwd }),
+        ).resolves.toEqual({
+          ok: false,
+          message:
+            "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+        });
+      }
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["ruby", "--require=loader.rb", "app.rb"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["ruby", "-Csub", "app.rb"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: {
+            kind: "argv",
+            argv: ["php", "-d", "auto_prepend_file=loader.php", "app.php"],
+          },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message:
+          "SYSTEM_RUN_DENIED: approval cannot safely bind runtime code-loading or cwd options",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["deno", "run", "--config", "deno.json", "app.ts"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message:
+          "SYSTEM_RUN_DENIED: approval cannot safely bind runtime code-loading or cwd options",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds mutable scripts resolved through PATH", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-path-script-"));
+    const binDir = path.join(cwd, "bin");
+    try {
+      fs.mkdirSync(binDir);
+      fs.writeFileSync(path.join(binDir, "workspace-tool"), "#!/bin/sh\necho tool\n", {
+        mode: 0o755,
+      });
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "workspace-tool" },
+          cwd,
+          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(1);
+
+      fs.writeFileSync(path.join(binDir, "workspace-tool"), "#!/bin/sh\necho changed\n", {
+        mode: 0o755,
+      });
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds both a PATH-resolved interpreter shim and its script operand", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-path-python-"));
+    const binDir = path.join(cwd, "bin");
+    const payload = path.join(cwd, "payload.py");
+    try {
+      fs.mkdirSync(binDir);
+      fs.writeFileSync(path.join(binDir, "python"), '#!/bin/sh\nexec python3 "$@"\n', {
+        mode: 0o755,
+      });
+      fs.writeFileSync(payload, "print('approved')\n");
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "python payload.py" },
+          cwd,
+          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(2);
+
+      fs.writeFileSync(payload, "print('changed')\n");
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds both an explicit interpreter shim and its script operand", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-explicit-python-"));
+    const shim = path.join(cwd, "python");
+    try {
+      fs.writeFileSync(shim, '#!/bin/sh\nexec python3 "$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(cwd, "payload.py"), "print('approved')\n");
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "./python payload.py" },
+          cwd,
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(2);
+
+      fs.writeFileSync(shim, '#!/bin/sh\nexec python3 -I "$@"\n', { mode: 0o755 });
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual({
+        ok: false,
+        message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when an earlier shell segment changes cwd", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-cd-"));
+    try {
+      fs.mkdirSync(path.join(cwd, "sub"));
+      fs.writeFileSync(path.join(cwd, "sub", "script.sh"), "echo sub\n");
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "cd sub && sh script.sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind commands after cwd changes",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["env", "-C", "sub", "sh", "script.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind dispatch cwd options",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a script operand does not exist", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-missing-"));
+    try {
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "sh missing.sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires an existing script operand",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "command-that-does-not-exist" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires a resolved executable",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "sh < missing.sh" },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this command",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let inline eval bypass a mutable loader operand", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-loader-"));
+    try {
+      fs.writeFileSync(path.join(cwd, "loader.js"), "module.exports = {};\n");
+      fs.writeFileSync(path.join(cwd, "payload.sh"), "echo payload\n", { mode: 0o755 });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: {
+            kind: "shell",
+            text: "node --require loader.js --eval 'console.log(1)'",
+          },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+      await expect(
+        prepareSystemRunMutableFileBinding({
+          command: { kind: "argv", argv: ["bash", "-c", "./payload.sh"] },
+          cwd,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "fails closed when a script operand is unreadable",
+    async () => {
+      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-unreadable-"));
+      const script = path.join(cwd, "unreadable.sh");
+      try {
+        fs.writeFileSync(script, "#!/bin/sh\necho hidden\n", { mode: 0o000 });
+        await expect(
+          prepareSystemRunMutableFileBinding({
+            command: { kind: "shell", text: "sh unreadable.sh" },
+            cwd,
+          }),
+        ).resolves.toEqual({
+          ok: false,
+          message: "SYSTEM_RUN_DENIED: approval requires a readable script operand",
+        });
+      } finally {
+        fs.chmodSync(script, 0o600);
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -386,6 +386,37 @@ describe("mutable file operand binding", () => {
     }
   });
 
+  it.each([
+    { name: "accepts unchanged bytes", mutate: false },
+    { name: "denies changed bytes", mutate: true },
+  ])("revalidates transparent-wrapper executables: $name", async ({ mutate }) => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-wrapper-"));
+    const script = path.join(cwd, "wrapped.sh");
+    try {
+      fs.writeFileSync(script, "#!/bin/sh\necho approved\n", { mode: 0o755 });
+      const prepared = expectOk(
+        await prepareSystemRunMutableFileBinding({
+          command: { kind: "shell", text: "env WRAPPED=1 ./wrapped.sh" },
+          cwd,
+        }),
+      );
+      expect(prepared.binding.operands).toHaveLength(1);
+      if (mutate) {
+        fs.writeFileSync(script, "#!/bin/sh\necho changed\n", { mode: 0o755 });
+      }
+
+      await expect(
+        revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
+      ).resolves.toEqual(
+        mutate
+          ? { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE }
+          : { ok: true },
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("binds mutable native executables", async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-native-"));
     const executable = path.join(cwd, "native-tool");

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -1,13 +1,34 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { sha256Hex } from "./crypto-digest.js";
 import { normalizeExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
 // Binds system-run approval requests to stable command identities.
 import type {
+  ExecCommandSegment,
   SystemRunApprovalBinding,
   SystemRunApprovalFileOperand,
   SystemRunApprovalPlan,
 } from "./exec-approvals.js";
+import { planShellAuthorization } from "./exec-authorization-plan.js";
+import { resolveCommandResolutionFromArgv } from "./exec-command-resolution.js";
 import { normalizeHostOverrideEnvVarKey } from "./host-env-security.js";
+import { extractShellCommandFromArgv } from "./system-run-command.js";
+import {
+  isSystemRunCommandTextBoundInterpreterInvocation,
+  resolveSystemRunMutableFileOperandTarget,
+  unwrapSystemRunMutableFileOperandArgv,
+} from "./system-run-mutable-file-operand.js";
+import {
+  looksLikeExplicitPathToken,
+  pathLooksMutableForShellPayloadSync,
+} from "./system-run-mutable-file-policy.js";
 import { normalizeNonEmptyString, normalizeStringArray } from "./system-run-normalize.js";
+import { hasPosixShellStartupEnvironment } from "./system-run-shell-file-operand.js";
+import { analyzeWindowsShellCommand } from "./windows-shell-command.js";
+
+export const APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE =
+  "SYSTEM_RUN_DENIED: approval script operand changed before execution";
 
 type NormalizedSystemRunEnvEntry = [key: string, value: string];
 
@@ -252,5 +273,436 @@ export function toSystemRunApprovalMismatchError(params: {
     ok: false,
     message: params.match.message,
     details,
+  };
+}
+
+function hashFileContentsSync(filePath: string): string {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function snapshotFileOperandAtPath(params: {
+  argvIndex: number;
+  filePath: string;
+}): { ok: true; snapshot: SystemRunApprovalFileOperand } | { ok: false; message: string } {
+  let realPath: string;
+  let stat: fs.Stats;
+  try {
+    realPath = fs.realpathSync(params.filePath);
+    stat = fs.statSync(realPath);
+  } catch {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires an existing script operand",
+    };
+  }
+  if (!stat.isFile()) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a file script operand",
+    };
+  }
+  let sha256: string;
+  try {
+    sha256 = hashFileContentsSync(realPath);
+  } catch {
+    // An unreadable script has no approved byte identity. Treating it as
+    // unbound would let later readable bytes execute under this approval.
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a readable script operand",
+    };
+  }
+  return { ok: true, snapshot: { argvIndex: params.argvIndex, path: realPath, sha256 } };
+}
+
+/** Captures file identity for a mutable script operand that approval is bound to. */
+export function resolveMutableFileOperandSnapshotSync(params: {
+  argv: string[];
+  cwd: string | undefined;
+  shellCommand: string | null;
+}): { ok: true; snapshot: SystemRunApprovalFileOperand | null } | { ok: false; message: string } {
+  const target = resolveSystemRunMutableFileOperandTarget(params);
+  if (!target.ok) {
+    return target;
+  }
+  if (target.argvIndex === null) {
+    return { ok: true, snapshot: null };
+  }
+  const operand = params.argv[target.argvIndex]?.trim();
+  if (!operand) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a stable script operand",
+    };
+  }
+  return snapshotFileOperandAtPath({
+    argvIndex: target.argvIndex,
+    filePath: path.resolve(params.cwd ?? process.cwd(), operand),
+  });
+}
+
+export function revalidateApprovedMutableFileOperand(params: {
+  snapshot: SystemRunApprovalFileOperand;
+  argv: string[];
+  cwd: string | undefined;
+}): boolean {
+  const operand = params.argv[params.snapshot.argvIndex]?.trim();
+  if (!operand) {
+    return false;
+  }
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(path.resolve(params.cwd ?? process.cwd(), operand));
+  } catch {
+    return false;
+  }
+  if (realPath !== params.snapshot.path) {
+    return false;
+  }
+  try {
+    return hashFileContentsSync(realPath) === params.snapshot.sha256;
+  } catch {
+    return false;
+  }
+}
+
+export type SystemRunMutableFileBinding = {
+  commands: string[][];
+  operands: Array<{
+    argv: string[];
+    snapshot: SystemRunApprovalFileOperand;
+    executable?: true;
+    pathSearch?: { path?: string; pathExt?: string };
+  }>;
+};
+
+type SystemRunMutableFileBindingCommand =
+  | { kind: "argv"; argv: string[]; shellCommand?: string | null }
+  | { kind: "segments"; segments: ExecCommandSegment[] }
+  | { kind: "shell"; text: string };
+
+type SystemRunMutableFileBindingResult =
+  | { ok: true; binding: SystemRunMutableFileBinding }
+  | { ok: false; message: string };
+
+const SHELL_CWD_MUTATORS = new Set(["cd", "chdir", "popd", "pushd"]);
+const SHELL_BUILTIN_DISPATCHERS = new Set(["builtin", "command"]);
+
+function prepareMutableFileBindingsForArgv(params: {
+  commands: readonly string[][];
+  cwd?: string;
+}): SystemRunMutableFileBindingResult {
+  const operands: SystemRunMutableFileBinding["operands"] = [];
+  const commands: string[][] = [];
+  const seen = new Set<string>();
+  for (const argv of params.commands) {
+    const key = JSON.stringify(argv);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    commands.push([...argv]);
+    const prepared = resolveMutableFileOperandSnapshotSync({
+      argv,
+      cwd: params.cwd,
+      shellCommand: extractShellCommandFromArgv(argv),
+    });
+    if (!prepared.ok) {
+      if (
+        prepared.message ===
+          "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command" &&
+        isSystemRunCommandTextBoundInterpreterInvocation(argv)
+      ) {
+        continue;
+      }
+      return prepared;
+    }
+    if (prepared.snapshot) {
+      operands.push({ argv: [...argv], snapshot: prepared.snapshot });
+    }
+  }
+  return {
+    ok: true,
+    binding: { commands, operands },
+  };
+}
+
+function prepareMutableFileBindingsForSegments(params: {
+  segments: ExecCommandSegment[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}): SystemRunMutableFileBindingResult {
+  if (params.segments.length === 0) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this command",
+    };
+  }
+  const pathOperands: SystemRunMutableFileBinding["operands"] = [];
+  const ordinaryCommands: string[][] = [];
+  for (const [index, segment] of params.segments.entries()) {
+    const effectiveArgv = unwrapSystemRunMutableFileOperandArgv(segment.argv);
+    const executableIndex = SHELL_BUILTIN_DISPATCHERS.has(effectiveArgv[0]?.trim() ?? "") ? 1 : 0;
+    const executable = effectiveArgv[executableIndex]?.trim() ?? "";
+    if (
+      hasPosixShellStartupEnvironment({
+        argv: segment.argv,
+        executable,
+        env: params.env,
+      })
+    ) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup environment",
+      };
+    }
+    if (executable && (executable === "." || executable === "source")) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell source operands",
+      };
+    }
+    if (SHELL_CWD_MUTATORS.has(executable) && index < params.segments.length - 1) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind commands after cwd changes",
+      };
+    }
+    const resolvedExecutable =
+      segment.resolution?.execution.resolvedRealPath ?? segment.resolution?.execution.resolvedPath;
+    if (
+      executable &&
+      !looksLikeExplicitPathToken(executable) &&
+      segment.resolution &&
+      !resolvedExecutable
+    ) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires a resolved executable",
+      };
+    }
+    if (
+      executable &&
+      resolvedExecutable &&
+      pathLooksMutableForShellPayloadSync(resolvedExecutable)
+    ) {
+      const snapshot = snapshotFileOperandAtPath({ argvIndex: 0, filePath: resolvedExecutable });
+      if (!snapshot.ok) {
+        return snapshot;
+      }
+      pathOperands.push({
+        argv: [...segment.argv],
+        snapshot: snapshot.snapshot,
+        executable: true,
+        ...(!looksLikeExplicitPathToken(executable)
+          ? {
+              pathSearch: {
+                path: params.env?.PATH ?? process.env.PATH,
+                pathExt: params.env?.PATHEXT ?? process.env.PATHEXT,
+              },
+            }
+          : {}),
+      });
+    }
+    ordinaryCommands.push(segment.argv);
+  }
+  const ordinary = prepareMutableFileBindingsForArgv({
+    commands: ordinaryCommands,
+    cwd: params.cwd,
+  });
+  if (!ordinary.ok) {
+    return ordinary;
+  }
+  return {
+    ok: true,
+    binding: {
+      commands: ordinary.binding.commands,
+      operands: [
+        ...ordinary.binding.operands,
+        ...pathOperands.filter(
+          (candidate) =>
+            !ordinary.binding.operands.some(
+              (operand) => operand.snapshot.path === candidate.snapshot.path,
+            ),
+        ),
+      ],
+    },
+  };
+}
+
+/** Captures every mutable file operand whose bytes an approval would release. */
+export async function prepareSystemRunMutableFileBinding(params: {
+  command: SystemRunMutableFileBindingCommand;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}): Promise<SystemRunMutableFileBindingResult> {
+  if (params.command.kind === "argv") {
+    const prepared = resolveMutableFileOperandSnapshotSync({
+      argv: params.command.argv,
+      cwd: params.cwd,
+      shellCommand: params.command.shellCommand ?? extractShellCommandFromArgv(params.command.argv),
+    });
+    if (!prepared.ok) {
+      return prepared;
+    }
+    return {
+      ok: true,
+      binding: {
+        commands: [[...params.command.argv]],
+        operands: prepared.snapshot
+          ? [{ argv: [...params.command.argv], snapshot: prepared.snapshot }]
+          : [],
+      },
+    };
+  }
+  if (params.command.kind === "segments") {
+    return prepareMutableFileBindingsForSegments({
+      segments: params.command.segments,
+      cwd: params.cwd,
+      env: params.env,
+    });
+  }
+
+  const commandText = params.command.text.trim();
+  if (!commandText) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a command binding",
+    };
+  }
+  if (params.env?.BASH_ENV?.trim() || params.env?.ENV?.trim()) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup environment",
+    };
+  }
+  if ((params.platform ?? process.platform) === "win32") {
+    const analysis = analyzeWindowsShellCommand({
+      command: commandText,
+      cwd: params.cwd,
+      env: params.env,
+      platform: "win32",
+    });
+    if (!analysis.ok || analysis.segments.length === 0) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this command",
+      };
+    }
+    return prepareMutableFileBindingsForSegments({
+      segments: analysis.segments,
+      cwd: params.cwd,
+      env: params.env,
+    });
+  }
+
+  const plan = await planShellAuthorization({
+    command: commandText,
+    cwd: params.cwd,
+    env: params.env,
+    platform: params.platform,
+  });
+  if (!plan.ok) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this command",
+    };
+  }
+  if (plan.groups.some((group) => group.candidates.length > 1)) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell pipelines",
+    };
+  }
+  const segments = plan.groups.flatMap((group) =>
+    group.candidates.map((candidate) => candidate.sourceSegment),
+  );
+  return prepareMutableFileBindingsForSegments({ segments, cwd: params.cwd, env: params.env });
+}
+
+/** Revalidates the exact approved bytes after all awaited policy and approval work. */
+export async function revalidateSystemRunMutableFileBinding(params: {
+  binding: SystemRunMutableFileBinding;
+  cwd?: string;
+}): Promise<{ ok: true } | { ok: false; message: string }> {
+  // Carry the prepared argv forward instead of reparsing after the approval;
+  // parser drift must not change which executable operands were authorized.
+  const current = prepareMutableFileBindingsForArgv({
+    commands: params.binding.commands,
+    cwd: params.cwd,
+  });
+  if (!current.ok) {
+    return { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE };
+  }
+  const signature = (binding: SystemRunMutableFileBinding) =>
+    binding.operands
+      .filter((operand) => !operand.executable)
+      .map(({ argv, snapshot }) =>
+        JSON.stringify([argv, snapshot.argvIndex, snapshot.path, snapshot.sha256]),
+      )
+      .toSorted();
+  const expected = signature(params.binding);
+  const actual = signature(current.binding);
+  if (
+    expected.length !== actual.length ||
+    expected.some((value, index) => value !== actual[index])
+  ) {
+    return { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE };
+  }
+  for (const operand of params.binding.operands) {
+    if (!operand.executable) {
+      continue;
+    }
+    let resolvedPath: string | undefined;
+    if (operand.pathSearch) {
+      const env = {
+        ...process.env,
+        ...(operand.pathSearch.path !== undefined ? { PATH: operand.pathSearch.path } : {}),
+        ...(operand.pathSearch.pathExt !== undefined
+          ? { PATHEXT: operand.pathSearch.pathExt }
+          : {}),
+      };
+      const resolution = resolveCommandResolutionFromArgv(operand.argv, params.cwd, env);
+      resolvedPath = resolution?.execution.resolvedRealPath ?? resolution?.execution.resolvedPath;
+    } else {
+      resolvedPath = path.resolve(params.cwd ?? process.cwd(), operand.argv[0] ?? "");
+    }
+    if (!resolvedPath || resolvedPath !== operand.snapshot.path) {
+      return { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE };
+    }
+    const snapshot = snapshotFileOperandAtPath({ argvIndex: 0, filePath: resolvedPath });
+    if (!snapshot.ok || snapshot.snapshot.sha256 !== operand.snapshot.sha256) {
+      return { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE };
+    }
+  }
+  return { ok: true };
+}
+
+/** Prepares an opaque revalidator so callers cannot replace the approved snapshot. */
+export async function prepareSystemRunMutableFileApproval(params: {
+  command: string;
+  cwd?: string;
+}): Promise<
+  | {
+      ok: true;
+      requiresOneShot: boolean;
+      revalidate: () => Promise<{ ok: true } | { ok: false; message: string }>;
+    }
+  | { ok: false; message: string }
+> {
+  const prepared = await prepareSystemRunMutableFileBinding({
+    command: { kind: "shell", text: params.command },
+    cwd: params.cwd,
+  });
+  if (!prepared.ok) {
+    return prepared;
+  }
+  const binding = prepared.binding;
+  return {
+    ok: true,
+    requiresOneShot: binding.operands.length > 0,
+    revalidate: async () =>
+      await revalidateSystemRunMutableFileBinding({ binding, cwd: params.cwd }),
   };
 }

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -654,20 +654,18 @@ export async function revalidateSystemRunMutableFileBinding(params: {
     if (!operand.executable) {
       continue;
     }
-    let resolvedPath: string | undefined;
-    if (operand.pathSearch) {
-      const env = {
-        ...process.env,
-        ...(operand.pathSearch.path !== undefined ? { PATH: operand.pathSearch.path } : {}),
-        ...(operand.pathSearch.pathExt !== undefined
-          ? { PATHEXT: operand.pathSearch.pathExt }
-          : {}),
-      };
-      const resolution = resolveCommandResolutionFromArgv(operand.argv, params.cwd, env);
-      resolvedPath = resolution?.execution.resolvedRealPath ?? resolution?.execution.resolvedPath;
-    } else {
-      resolvedPath = path.resolve(params.cwd ?? process.cwd(), operand.argv[0] ?? "");
-    }
+    const env = operand.pathSearch
+      ? {
+          ...process.env,
+          ...(operand.pathSearch.path !== undefined ? { PATH: operand.pathSearch.path } : {}),
+          ...(operand.pathSearch.pathExt !== undefined
+            ? { PATHEXT: operand.pathSearch.pathExt }
+            : {}),
+        }
+      : undefined;
+    const resolution = resolveCommandResolutionFromArgv(operand.argv, params.cwd, env);
+    const resolvedPath =
+      resolution?.execution.resolvedRealPath ?? resolution?.execution.resolvedPath;
     if (!resolvedPath || resolvedPath !== operand.snapshot.path) {
       return { ok: false, message: APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE };
     }

--- a/src/infra/system-run-mutable-file-operand.ts
+++ b/src/infra/system-run-mutable-file-operand.ts
@@ -1,0 +1,731 @@
+/** Detects mutable file operands in approved commands. */
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeNullableString,
+} from "@openclaw/normalization-core/string-coerce";
+import { splitShellArgs } from "../utils/shell-argv.js";
+import { detectPolicyInlineEval } from "./command-analysis/policy.js";
+import { isInterpreterLikeSafeBin } from "./exec-safe-bin-runtime-policy.js";
+import {
+  POSIX_PARSEABLE_SHELL_WRAPPERS,
+  POSIX_SHELL_WRAPPERS,
+  normalizeExecutableToken,
+  unwrapKnownDispatchWrapperInvocation,
+  unwrapKnownShellMultiplexerInvocation,
+} from "./exec-wrapper-resolution.js";
+import { parseInlineOptionToken } from "./inline-option-token.js";
+import {
+  normalizePackageManagerExecToken,
+  PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
+  PNPM_DLX_OPTIONS_WITH_VALUE,
+  PNPM_FLAG_OPTIONS,
+  PNPM_OPTIONS_WITH_VALUE,
+  unwrapKnownPackageManagerExecInvocation,
+} from "./package-manager-exec-wrapper.js";
+import {
+  BUN_OPTIONS_WITH_VALUE,
+  BUN_SUBCOMMANDS,
+  DENO_RUN_OPTIONS_WITH_VALUE,
+  NODE_OPTIONS_WITH_FILE_VALUE,
+  PERL_UNSAFE_APPROVAL_FLAGS,
+  RUBY_UNSAFE_APPROVAL_FLAGS,
+} from "./system-run-mutable-file-options.js";
+import {
+  isLikelyScriptLikePathSync,
+  looksLikeExplicitPathToken,
+  looksLikePathToken,
+  pathLooksMutableForShellPayloadSync,
+  resolvesToExistingFileSync,
+} from "./system-run-mutable-file-policy.js";
+import { hasUnbindableRuntimeApprovalOption } from "./system-run-runtime-file-options.js";
+import {
+  hasPosixShellCodeLoadingOption,
+  hasPosixShellStartupEnvironment,
+  resolvePosixShellScriptOperandIndex,
+} from "./system-run-shell-file-operand.js";
+
+const POSIX_SHELL_WRAPPER_SET: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
+const POSIX_PARSEABLE_SHELL_WRAPPER_SET: ReadonlySet<string> = POSIX_PARSEABLE_SHELL_WRAPPERS;
+const PACKAGE_MANAGER_EXECUTABLES = new Set(["corepack", "npm", "npx", "pnpm", "yarn"]);
+
+const MUTABLE_ARGV1_INTERPRETER_PATTERNS = [
+  /^(?:node|nodejs)$/,
+  /^perl$/,
+  /^php$/,
+  /^python(?:\d+(?:\.\d+)*)?$/,
+  /^ruby$/,
+] as const;
+
+const GENERIC_MUTABLE_SCRIPT_RUNNERS = new Set([
+  "esno",
+  "jiti",
+  "ts-node",
+  "ts-node-esm",
+  "tsx",
+  "vite-node",
+]);
+
+const OPAQUE_MUTABLE_SCRIPT_RUNNERS = new Set(["busybox", "toybox"]);
+
+function readTrimmedArgToken(argv: readonly string[], index: number): string {
+  return normalizeNullableString(argv[index]) ?? "";
+}
+
+type FileOperandCollection = {
+  hits: number[];
+  sawOptionValueFile: boolean;
+};
+
+function unwrapArgvForMutableOperand(argv: string[]): {
+  argv: string[];
+  baseIndex: number;
+  opaqueMultiplexerSeen: boolean;
+} {
+  let current = argv;
+  let baseIndex = 0;
+  let opaqueMultiplexerSeen = false;
+  while (true) {
+    const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(current);
+    if (dispatchUnwrap.kind === "unwrapped") {
+      baseIndex += current.length - dispatchUnwrap.argv.length;
+      current = dispatchUnwrap.argv;
+      continue;
+    }
+    const shellMultiplexerUnwrap = unwrapKnownShellMultiplexerInvocation(current);
+    if (shellMultiplexerUnwrap.kind === "unwrapped") {
+      if (OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(shellMultiplexerUnwrap.wrapper)) {
+        opaqueMultiplexerSeen = true;
+      }
+      baseIndex += current.length - shellMultiplexerUnwrap.argv.length;
+      current = shellMultiplexerUnwrap.argv;
+      continue;
+    }
+    const packageManagerUnwrap = unwrapKnownPackageManagerExecInvocation(current);
+    if (packageManagerUnwrap) {
+      baseIndex += current.length - packageManagerUnwrap.length;
+      current = packageManagerUnwrap;
+      continue;
+    }
+    return { argv: current, baseIndex, opaqueMultiplexerSeen };
+  }
+}
+
+function hasDispatchCwdOption(argv: string[]): boolean {
+  if (normalizeExecutableToken(argv[0] ?? "") !== "env") {
+    return false;
+  }
+  for (const token of argv.slice(1)) {
+    const normalized = token.trim().toLowerCase();
+    if (
+      normalized === "-c" ||
+      normalized.startsWith("-c=") ||
+      normalized === "--chdir" ||
+      normalized.startsWith("--chdir=")
+    ) {
+      return true;
+    }
+    if (!normalized.startsWith("-") && !normalized.includes("=")) {
+      return false;
+    }
+  }
+  return false;
+}
+
+export function unwrapSystemRunMutableFileOperandArgv(argv: string[]): string[] {
+  return unwrapArgvForMutableOperand(argv).argv;
+}
+
+function resolveOptionFilteredFileOperandIndex(params: {
+  argv: string[];
+  startIndex: number;
+  cwd: string | undefined;
+  optionsWithValue?: ReadonlySet<string>;
+}): number | null {
+  let afterDoubleDash = false;
+  for (let i = params.startIndex; i < params.argv.length; i += 1) {
+    const token = readTrimmedArgToken(params.argv, i);
+    if (!token) {
+      continue;
+    }
+    if (afterDoubleDash) {
+      return resolvesToExistingFileSync(token, params.cwd) ? i : null;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === "-") {
+      return null;
+    }
+    if (token.startsWith("-")) {
+      if (!token.includes("=") && params.optionsWithValue?.has(token)) {
+        i += 1;
+      }
+      continue;
+    }
+    return resolvesToExistingFileSync(token, params.cwd) ? i : null;
+  }
+  return null;
+}
+
+function resolveOptionFilteredPositionalIndex(params: {
+  argv: string[];
+  startIndex: number;
+  optionsWithValue?: ReadonlySet<string>;
+}): number | null {
+  let afterDoubleDash = false;
+  for (let i = params.startIndex; i < params.argv.length; i += 1) {
+    const token = readTrimmedArgToken(params.argv, i);
+    if (!token) {
+      continue;
+    }
+    if (afterDoubleDash) {
+      return i;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === "-") {
+      return null;
+    }
+    if (token.startsWith("-")) {
+      if (!token.includes("=") && params.optionsWithValue?.has(token)) {
+        i += 1;
+      }
+      continue;
+    }
+    return i;
+  }
+  return null;
+}
+
+function collectExistingFileOperandIndexes(params: {
+  argv: string[];
+  startIndex: number;
+  cwd: string | undefined;
+  optionsWithFileValue?: ReadonlySet<string>;
+}): FileOperandCollection {
+  let afterDoubleDash = false;
+  const hits: number[] = [];
+  for (let i = params.startIndex; i < params.argv.length; i += 1) {
+    const token = readTrimmedArgToken(params.argv, i);
+    if (!token) {
+      continue;
+    }
+    if (afterDoubleDash) {
+      if (resolvesToExistingFileSync(token, params.cwd)) {
+        hits.push(i);
+      }
+      continue;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === "-") {
+      return { hits: [], sawOptionValueFile: false };
+    }
+    if (token.startsWith("-")) {
+      const option = parseInlineOptionToken(token);
+      const flag = option.name;
+      const inlineValue = option.hasInlineValue ? option.inlineValue : undefined;
+      if (params.optionsWithFileValue?.has(normalizeLowercaseStringOrEmpty(flag))) {
+        if (inlineValue && resolvesToExistingFileSync(inlineValue, params.cwd)) {
+          hits.push(i);
+          return { hits, sawOptionValueFile: true };
+        }
+        const nextToken = readTrimmedArgToken(params.argv, i + 1);
+        if (!inlineValue && nextToken && resolvesToExistingFileSync(nextToken, params.cwd)) {
+          hits.push(i + 1);
+          return { hits, sawOptionValueFile: true };
+        }
+      }
+      continue;
+    }
+    if (resolvesToExistingFileSync(token, params.cwd)) {
+      hits.push(i);
+    }
+  }
+  return { hits, sawOptionValueFile: false };
+}
+
+function resolveGenericInterpreterScriptOperandIndex(params: {
+  argv: string[];
+  cwd: string | undefined;
+  optionsWithFileValue?: ReadonlySet<string>;
+}): number | null {
+  const collection = collectExistingFileOperandIndexes({
+    argv: params.argv,
+    startIndex: 1,
+    cwd: params.cwd,
+    optionsWithFileValue: params.optionsWithFileValue,
+  });
+  if (collection.sawOptionValueFile) {
+    return null;
+  }
+  return collection.hits.length === 1 ? expectDefined(collection.hits[0], "hits entry at 0") : null;
+}
+
+function resolveBunScriptOperandIndex(params: {
+  argv: string[];
+  cwd: string | undefined;
+}): number | null {
+  const directIndex = resolveOptionFilteredPositionalIndex({
+    argv: params.argv,
+    startIndex: 1,
+    optionsWithValue: BUN_OPTIONS_WITH_VALUE,
+  });
+  if (directIndex === null) {
+    return null;
+  }
+  const directToken = readTrimmedArgToken(params.argv, directIndex);
+  if (directToken === "run") {
+    return resolveOptionFilteredFileOperandIndex({
+      argv: params.argv,
+      startIndex: directIndex + 1,
+      cwd: params.cwd,
+      optionsWithValue: BUN_OPTIONS_WITH_VALUE,
+    });
+  }
+  if (BUN_SUBCOMMANDS.has(directToken)) {
+    return null;
+  }
+  if (!looksLikePathToken(directToken)) {
+    return null;
+  }
+  return directIndex;
+}
+
+function resolveDenoRunScriptOperandIndex(params: {
+  argv: string[];
+  cwd: string | undefined;
+}): number | null {
+  if (readTrimmedArgToken(params.argv, 1) !== "run") {
+    return null;
+  }
+  return resolveOptionFilteredFileOperandIndex({
+    argv: params.argv,
+    startIndex: 2,
+    cwd: params.cwd,
+    optionsWithValue: DENO_RUN_OPTIONS_WITH_VALUE,
+  });
+}
+
+function hasRubyUnsafeApprovalFlag(argv: string[]): boolean {
+  let afterDoubleDash = false;
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = readTrimmedArgToken(argv, i);
+    if (!token) {
+      continue;
+    }
+    if (afterDoubleDash) {
+      return false;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (
+      token === "-C" ||
+      token === "-I" ||
+      token === "-r" ||
+      token === "-S" ||
+      token === "--chdir"
+    ) {
+      return true;
+    }
+    if (
+      token.startsWith("-C") ||
+      token.startsWith("-I") ||
+      token.startsWith("-r") ||
+      token.startsWith("--chdir=") ||
+      token.startsWith("--require=")
+    ) {
+      return true;
+    }
+    if (RUBY_UNSAFE_APPROVAL_FLAGS.has(normalizeLowercaseStringOrEmpty(token))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasPerlUnsafeApprovalFlag(argv: string[]): boolean {
+  let afterDoubleDash = false;
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = readTrimmedArgToken(argv, i);
+    if (!token) {
+      continue;
+    }
+    if (afterDoubleDash) {
+      return false;
+    }
+    if (token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === "-I" || token === "-M" || token === "-m" || token === "-S") {
+      return true;
+    }
+    if (token.startsWith("-I") || token.startsWith("-M") || token.startsWith("-m")) {
+      return true;
+    }
+    if (PERL_UNSAFE_APPROVAL_FLAGS.has(token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasNodeFileLoadingOption(argv: string[]): boolean {
+  return argv.slice(1).some((token) => {
+    const normalized = token.trim().toLowerCase();
+    if (normalized === "-r" || normalized.startsWith("-r")) {
+      return true;
+    }
+    return [...NODE_OPTIONS_WITH_FILE_VALUE].some(
+      (flag) => normalized === flag || normalized.startsWith(`${flag}=`),
+    );
+  });
+}
+
+export function isSystemRunCommandTextBoundInterpreterInvocation(argv: string[]): boolean {
+  const unwrapped = unwrapArgvForMutableOperand(argv);
+  const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
+  if (POSIX_SHELL_WRAPPER_SET.has(executable)) {
+    return false;
+  }
+  if (
+    (executable === "node" || executable === "nodejs") &&
+    hasNodeFileLoadingOption(unwrapped.argv)
+  ) {
+    return false;
+  }
+  if (
+    (executable === "ruby" && hasRubyUnsafeApprovalFlag(unwrapped.argv)) ||
+    (executable === "perl" && hasPerlUnsafeApprovalFlag(unwrapped.argv))
+  ) {
+    return false;
+  }
+  if (
+    detectPolicyInlineEval([
+      {
+        raw: unwrapped.argv.join(" "),
+        argv: unwrapped.argv,
+        resolution: null,
+      },
+    ])
+  ) {
+    return true;
+  }
+  return (
+    unwrapped.argv.length === 2 &&
+    ["--help", "--version", "-h", "-v"].includes(unwrapped.argv[1]?.trim().toLowerCase() ?? "")
+  );
+}
+
+function isMutableScriptRunner(executable: string): boolean {
+  return (
+    GENERIC_MUTABLE_SCRIPT_RUNNERS.has(executable) ||
+    OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(executable) ||
+    isInterpreterLikeSafeBin(executable)
+  );
+}
+
+function resolveDirectScriptExecutableIndex(params: {
+  argv: string[];
+  cwd: string | undefined;
+}): number | null {
+  const unwrapped = unwrapArgvForMutableOperand(params.argv);
+  const executable = readTrimmedArgToken(unwrapped.argv, 0);
+  if (
+    PACKAGE_MANAGER_EXECUTABLES.has(normalizeExecutableToken(executable)) ||
+    !looksLikeExplicitPathToken(executable) ||
+    !resolvesToExistingFileSync(executable, params.cwd)
+  ) {
+    return null;
+  }
+  const resolvedPath = path.resolve(params.cwd ?? process.cwd(), executable);
+  return pathLooksMutableForShellPayloadSync(resolvedPath) ? unwrapped.baseIndex : null;
+}
+
+function resolveMutableFileOperandIndex(argv: string[], cwd: string | undefined): number | null {
+  const unwrapped = unwrapArgvForMutableOperand(argv);
+  const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
+  if (!executable) {
+    return null;
+  }
+  if (unwrapped.opaqueMultiplexerSeen || OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(executable)) {
+    return null;
+  }
+  if (POSIX_SHELL_WRAPPER_SET.has(executable)) {
+    if (!POSIX_PARSEABLE_SHELL_WRAPPER_SET.has(executable)) {
+      return null;
+    }
+    const shellIndex = resolvePosixShellScriptOperandIndex(unwrapped.argv, executable);
+    return shellIndex === null ? null : unwrapped.baseIndex + shellIndex;
+  }
+  if (MUTABLE_ARGV1_INTERPRETER_PATTERNS.some((pattern) => pattern.test(executable))) {
+    const operand = readTrimmedArgToken(unwrapped.argv, 1);
+    if (operand && operand !== "-" && !operand.startsWith("-")) {
+      return unwrapped.baseIndex + 1;
+    }
+  }
+  if (executable === "bun") {
+    const bunIndex = resolveBunScriptOperandIndex({
+      argv: unwrapped.argv,
+      cwd,
+    });
+    if (bunIndex !== null) {
+      return unwrapped.baseIndex + bunIndex;
+    }
+  }
+  if (executable === "deno") {
+    const denoIndex = resolveDenoRunScriptOperandIndex({
+      argv: unwrapped.argv,
+      cwd,
+    });
+    if (denoIndex !== null) {
+      return unwrapped.baseIndex + denoIndex;
+    }
+  }
+  if (executable === "ruby" && hasRubyUnsafeApprovalFlag(unwrapped.argv)) {
+    return null;
+  }
+  if (executable === "perl" && hasPerlUnsafeApprovalFlag(unwrapped.argv)) {
+    return null;
+  }
+  if (!isMutableScriptRunner(executable)) {
+    return resolveDirectScriptExecutableIndex({ argv, cwd });
+  }
+  const genericIndex = resolveGenericInterpreterScriptOperandIndex({
+    argv: unwrapped.argv,
+    cwd,
+    optionsWithFileValue:
+      executable === "node" || executable === "nodejs" ? NODE_OPTIONS_WITH_FILE_VALUE : undefined,
+  });
+  return genericIndex === null ? null : unwrapped.baseIndex + genericIndex;
+}
+
+function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | undefined): boolean {
+  if (/[;&|<>]/u.test(shellCommand)) {
+    return true;
+  }
+  const argv = splitShellArgs(shellCommand);
+  if (!argv || argv.length === 0) {
+    return false;
+  }
+  if (
+    resolveMutableFileOperandIndex(argv, cwd) !== null ||
+    requiresStableInterpreterApprovalBindingWithShellCommand({
+      argv,
+      cwd,
+      shellCommand: null,
+    })
+  ) {
+    return true;
+  }
+  const firstToken = readTrimmedArgToken(argv, 0);
+  if (firstToken === "." || firstToken === "source") {
+    return true;
+  }
+  if (!resolvesToExistingFileSync(firstToken, cwd)) {
+    return false;
+  }
+  if (!path.isAbsolute(firstToken)) {
+    return true;
+  }
+  const resolvedPath = path.resolve(cwd ?? process.cwd(), firstToken);
+  if (pathLooksMutableForShellPayloadSync(resolvedPath)) {
+    return true;
+  }
+  return isLikelyScriptLikePathSync(resolvedPath);
+}
+
+function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
+  argv: string[];
+  shellCommand: string | null;
+  cwd: string | undefined;
+}): boolean {
+  const unwrapped = unwrapArgvForMutableOperand(params.argv);
+  if (unwrapped.opaqueMultiplexerSeen) {
+    return true;
+  }
+  if (params.shellCommand !== null) {
+    return shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
+  }
+  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv, params.cwd)) {
+    return true;
+  }
+  const directExecutable = readTrimmedArgToken(unwrapped.argv, 0);
+  if (
+    looksLikeExplicitPathToken(directExecutable) &&
+    !resolvesToExistingFileSync(directExecutable, params.cwd)
+  ) {
+    return true;
+  }
+  const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
+  return (
+    Boolean(executable) &&
+    !POSIX_SHELL_WRAPPER_SET.has(executable) &&
+    isMutableScriptRunner(executable)
+  );
+}
+
+function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
+  if (normalizePackageManagerExecToken(argv[0] ?? "") !== "pnpm") {
+    return false;
+  }
+
+  let idx = 1;
+  while (idx < argv.length) {
+    const token = readTrimmedArgToken(argv, idx);
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      if (token !== "dlx") {
+        return false;
+      }
+      return pnpmDlxTailNeedsFailClosedBinding(argv.slice(idx + 1), cwd);
+    }
+    const parsedOption = parseInlineOptionToken(token);
+    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
+  let idx = 0;
+  while (idx < argv.length) {
+    const token = readTrimmedArgToken(argv, idx);
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
+    }
+    if (!token.startsWith("-")) {
+      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx), cwd);
+    }
+    const parsedOption = parseInlineOptionToken(token);
+    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
+    if (flag === "-c" || flag === "--shell-mode") {
+      return false;
+    }
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return true;
+  }
+
+  return true;
+}
+
+function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined): boolean {
+  return resolveMutableFileOperandIndex(argv, cwd) !== null;
+}
+
+export function resolveSystemRunMutableFileOperandTarget(params: {
+  argv: string[];
+  cwd: string | undefined;
+  shellCommand: string | null;
+}): { ok: true; argvIndex: number | null } | { ok: false; message: string } {
+  if (hasDispatchCwdOption(params.argv)) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind dispatch cwd options",
+    };
+  }
+  const unwrapped = unwrapArgvForMutableOperand(params.argv);
+  if (
+    hasPosixShellCodeLoadingOption(
+      unwrapped.argv,
+      normalizeExecutableToken(unwrapped.argv[0] ?? ""),
+    )
+  ) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup files",
+    };
+  }
+  if (
+    hasPosixShellStartupEnvironment({
+      argv: params.argv,
+      executable: normalizeExecutableToken(unwrapped.argv[0] ?? ""),
+      env: process.env,
+    })
+  ) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind shell startup environment",
+    };
+  }
+  if (
+    hasUnbindableRuntimeApprovalOption({
+      argv: unwrapped.argv,
+      executable: normalizeExecutableToken(unwrapped.argv[0] ?? ""),
+    })
+  ) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind runtime code-loading or cwd options",
+    };
+  }
+  const argvIndex = resolveMutableFileOperandIndex(params.argv, params.cwd);
+  if (argvIndex === null) {
+    if (
+      requiresStableInterpreterApprovalBindingWithShellCommand({
+        argv: params.argv,
+        shellCommand: params.shellCommand,
+        cwd: params.cwd,
+      })
+    ) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+      };
+    }
+    return { ok: true, argvIndex: null };
+  }
+  const rawOperand = readTrimmedArgToken(params.argv, argvIndex);
+  if (!rawOperand) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a stable script operand",
+    };
+  }
+  return { ok: true, argvIndex };
+}

--- a/src/infra/system-run-mutable-file-options.ts
+++ b/src/infra/system-run-mutable-file-options.ts
@@ -1,0 +1,117 @@
+/** Interpreter and runtime option tables used by mutable operand detection. */
+
+export const BUN_SUBCOMMANDS = new Set([
+  "add",
+  "audit",
+  "completions",
+  "create",
+  "exec",
+  "help",
+  "init",
+  "install",
+  "link",
+  "outdated",
+  "patch",
+  "pm",
+  "publish",
+  "remove",
+  "repl",
+  "run",
+  "test",
+  "unlink",
+  "update",
+  "upgrade",
+  "x",
+]);
+
+export const BUN_OPTIONS_WITH_VALUE = new Set([
+  "--backend",
+  "--bunfig",
+  "--conditions",
+  "--config",
+  "--console-depth",
+  "--cwd",
+  "--define",
+  "--elide-lines",
+  "--env-file",
+  "--extension-order",
+  "--filter",
+  "--hot",
+  "--inspect",
+  "--inspect-brk",
+  "--inspect-wait",
+  "--install",
+  "--jsx-factory",
+  "--jsx-fragment",
+  "--jsx-import-source",
+  "--loader",
+  "--origin",
+  "--port",
+  "--preload",
+  "--smol",
+  "--tsconfig-override",
+  "-c",
+  "-e",
+  "-p",
+  "-r",
+]);
+
+export const BUN_UNBINDABLE_APPROVAL_OPTIONS = new Set([
+  "--bunfig",
+  "--config",
+  "--cwd",
+  "--env-file",
+  "--loader",
+  "--preload",
+  "--tsconfig-override",
+  "-r",
+]);
+
+export const DENO_RUN_OPTIONS_WITH_VALUE = new Set([
+  "--cached-only",
+  "--cert",
+  "--config",
+  "--env-file",
+  "--ext",
+  "--harmony-import-attributes",
+  "--import-map",
+  "--inspect",
+  "--inspect-brk",
+  "--inspect-wait",
+  "--location",
+  "--log-level",
+  "--lock",
+  "--node-modules-dir",
+  "--no-check",
+  "--preload",
+  "--reload",
+  "--seed",
+  "--strace-ops",
+  "--unstable-bare-node-builtins",
+  "--v8-flags",
+  "--watch",
+  "--watch-exclude",
+  "-L",
+]);
+
+export const DENO_UNBINDABLE_APPROVAL_OPTIONS = new Set([
+  "--config",
+  "--env-file",
+  "--import-map",
+  "--lock",
+  "--node-modules-dir",
+  "--preload",
+]);
+
+export const NODE_OPTIONS_WITH_FILE_VALUE = new Set([
+  "--env-file",
+  "--env-file-if-exists",
+  "-r",
+  "--experimental-loader",
+  "--import",
+  "--loader",
+  "--require",
+]);
+
+export const RUBY_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-r", "--require"]);
+export const PERL_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-M", "-m"]);

--- a/src/infra/system-run-mutable-file-policy.ts
+++ b/src/infra/system-run-mutable-file-policy.ts
@@ -1,0 +1,163 @@
+/** Filesystem heuristics for mutable executable and script operands. */
+import fs from "node:fs";
+import path from "node:path";
+import { readFileWindowFullySync } from "./file-read.js";
+
+function pathComponentsFromRootSync(targetPath: string): string[] {
+  const parts: string[] = [];
+  let cursor = path.resolve(targetPath);
+  while (true) {
+    parts.unshift(cursor);
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      return parts;
+    }
+    cursor = parent;
+  }
+}
+
+function isOwnedByCurrentProcessSync(candidate: string): boolean {
+  if (process.platform === "win32" || typeof process.getuid !== "function") {
+    return false;
+  }
+  try {
+    return fs.statSync(candidate).uid === process.getuid();
+  } catch {
+    return false;
+  }
+}
+
+function isMutableByCurrentProcessSync(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.W_OK);
+    return true;
+  } catch {
+    return isOwnedByCurrentProcessSync(candidate);
+  }
+}
+
+export function hasMutableSymlinkPathComponentSync(targetPath: string): boolean {
+  for (const component of pathComponentsFromRootSync(targetPath)) {
+    try {
+      if (!fs.lstatSync(component).isSymbolicLink()) {
+        continue;
+      }
+      if (isMutableByCurrentProcessSync(path.dirname(component))) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function pathLooksMutableForShellPayloadSync(targetPath: string): boolean {
+  if (
+    isMutableByCurrentProcessSync(targetPath) ||
+    isMutableByCurrentProcessSync(path.dirname(targetPath)) ||
+    hasMutableSymlinkPathComponentSync(targetPath)
+  ) {
+    return true;
+  }
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(targetPath);
+  } catch {
+    return true;
+  }
+  return (
+    isMutableByCurrentProcessSync(realPath) ||
+    isMutableByCurrentProcessSync(path.dirname(realPath)) ||
+    hasMutableSymlinkPathComponentSync(realPath)
+  );
+}
+
+export function looksLikePathToken(token: string): boolean {
+  return (
+    token.startsWith(".") ||
+    token.startsWith("/") ||
+    token.startsWith("\\") ||
+    token.includes("/") ||
+    token.includes("\\") ||
+    path.extname(token).length > 0
+  );
+}
+
+export function looksLikeExplicitPathToken(token: string): boolean {
+  return (
+    token.startsWith(".") ||
+    token.startsWith("/") ||
+    token.startsWith("\\") ||
+    token.includes("/") ||
+    token.includes("\\")
+  );
+}
+
+export function resolvesToExistingFileSync(rawOperand: string, cwd: string | undefined): boolean {
+  if (!rawOperand) {
+    return false;
+  }
+  try {
+    return fs.statSync(path.resolve(cwd ?? process.cwd(), rawOperand)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
+  if (buffer.length >= 4 && buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+    return true;
+  }
+  if (
+    buffer.length >= 4 &&
+    (buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xbe, 0xba, 0xfe, 0xca])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbf])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xbf, 0xba, 0xfe, 0xca])))
+  ) {
+    return true;
+  }
+  if (buffer.length < 0x40 || !buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))) {
+    return false;
+  }
+  const peOffset = buffer.readUInt32LE(0x3c);
+  return (
+    peOffset >= 0 &&
+    peOffset <= buffer.length - 4 &&
+    buffer.subarray(peOffset, peOffset + 4).equals(Buffer.from([0x50, 0x45, 0x00, 0x00]))
+  );
+}
+
+export function isLikelyScriptLikePathSync(targetPath: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(targetPath);
+  } catch {
+    return true;
+  }
+  if (!stat.isFile()) {
+    return true;
+  }
+  let header: Buffer;
+  try {
+    const fd = fs.openSync(targetPath, "r");
+    try {
+      header = Buffer.alloc(1024);
+      const bytesRead = readFileWindowFullySync(fd, header, 0);
+      header = header.subarray(0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return true;
+  }
+  if (header.length === 0 || header.subarray(0, 2).equals(Buffer.from("#!"))) {
+    return true;
+  }
+  return !isKnownBinaryExecutableHeader(header);
+}

--- a/src/infra/system-run-runtime-file-options.ts
+++ b/src/infra/system-run-runtime-file-options.ts
@@ -1,0 +1,42 @@
+/** Rejects runtime options whose file/cwd effects cannot fit one operand binding. */
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { parseInlineOptionToken } from "./inline-option-token.js";
+import {
+  BUN_UNBINDABLE_APPROVAL_OPTIONS,
+  DENO_UNBINDABLE_APPROVAL_OPTIONS,
+} from "./system-run-mutable-file-options.js";
+
+function hasListedOption(argv: string[], options: ReadonlySet<string>): boolean {
+  return argv
+    .slice(1)
+    .some((token) =>
+      options.has(normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name)),
+    );
+}
+
+function hasPhpUnbindableOption(argv: string[]): boolean {
+  return argv.slice(1).some((token) => {
+    const normalized = token.trim().toLowerCase();
+    return (
+      normalized === "-c" ||
+      normalized.startsWith("-c=") ||
+      normalized === "--php-ini" ||
+      normalized.startsWith("--php-ini=") ||
+      normalized === "-d" ||
+      normalized.startsWith("-d")
+    );
+  });
+}
+
+export function hasUnbindableRuntimeApprovalOption(params: {
+  argv: string[];
+  executable: string;
+}): boolean {
+  if (params.executable === "bun") {
+    return hasListedOption(params.argv, BUN_UNBINDABLE_APPROVAL_OPTIONS);
+  }
+  if (params.executable === "deno") {
+    return hasListedOption(params.argv, DENO_UNBINDABLE_APPROVAL_OPTIONS);
+  }
+  return params.executable === "php" && hasPhpUnbindableOption(params.argv);
+}

--- a/src/infra/system-run-shell-file-operand.ts
+++ b/src/infra/system-run-shell-file-operand.ts
@@ -1,0 +1,122 @@
+/** POSIX shell option handling for mutable file operand detection. */
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { parseInlineOptionToken } from "./inline-option-token.js";
+import {
+  advancePosixInlineOptionScan,
+  POSIX_INLINE_COMMAND_FLAGS,
+  resolveInlineCommandMatch,
+} from "./shell-inline-command.js";
+import { POSIX_SHELL_WRAPPERS } from "./shell-wrapper-resolution.js";
+
+const POSIX_SHELL_WRAPPER_SET: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
+const POSIX_SHELL_OPTIONS_WITH_VALUE = new Set([
+  "--init-file",
+  "--rcfile",
+  "--startup-script",
+  "-O",
+  "-o",
+  "+O",
+  "+o",
+]);
+const POSIX_SHELL_CODE_LOADING_OPTIONS = new Set(["--init-file", "--rcfile", "--startup-script"]);
+const POSIX_SHELLS_WITH_PLUS_OPTIONS = new Set([
+  "ash",
+  "bash",
+  "dash",
+  "ksh",
+  "mksh",
+  "osh",
+  "sh",
+  "yash",
+  "zsh",
+]);
+
+function normalizeOptionFlag(token: string): string {
+  return normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name);
+}
+
+function isPosixShellOptionToken(token: string, supportsPlusOptions: boolean): boolean {
+  return token.startsWith("-") || (supportsPlusOptions && token.startsWith("+"));
+}
+
+export function resolvePosixShellScriptOperandIndex(
+  argv: string[],
+  executable: string,
+): number | null {
+  const supportsPlusOptions = POSIX_SHELLS_WITH_PLUS_OPTIONS.has(executable);
+  if (
+    resolveInlineCommandMatch(argv, POSIX_INLINE_COMMAND_FLAGS, {
+      allowCombinedC: true,
+      isOptionToken: (token) => isPosixShellOptionToken(token, supportsPlusOptions),
+      stopAtFirstNonOption: true,
+    }).valueTokenIndex !== null
+  ) {
+    return null;
+  }
+  let afterDoubleDash = false;
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i]?.trim() ?? "";
+    if (!token) {
+      continue;
+    }
+    if (token === "-" || (!afterDoubleDash && token === "-s")) {
+      return null;
+    }
+    if (!afterDoubleDash && token === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && isPosixShellOptionToken(token, supportsPlusOptions)) {
+      const flag = normalizeOptionFlag(token);
+      if (POSIX_SHELL_OPTIONS_WITH_VALUE.has(flag)) {
+        if (!token.includes("=")) {
+          i += 1;
+        }
+        continue;
+      }
+      i += advancePosixInlineOptionScan(token) - 1;
+      continue;
+    }
+    return i;
+  }
+  return null;
+}
+
+export function hasPosixShellCodeLoadingOption(argv: string[], executable: string): boolean {
+  if (!POSIX_SHELL_WRAPPER_SET.has(executable)) {
+    return false;
+  }
+  for (const token of argv.slice(1)) {
+    if (token === "--") {
+      return false;
+    }
+    if (POSIX_SHELL_CODE_LOADING_OPTIONS.has(normalizeOptionFlag(token))) {
+      return true;
+    }
+    if (token === "-s" || token === "--stdin") {
+      return true;
+    }
+    if (
+      token === "--interactive" ||
+      token === "-i" ||
+      (/^-[^-]*i/u.test(token) && !token.includes("="))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasPosixShellStartupEnvironment(params: {
+  argv: string[];
+  executable: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  if (!POSIX_SHELL_WRAPPER_SET.has(params.executable)) {
+    return false;
+  }
+  if (params.env?.BASH_ENV?.trim() || params.env?.ENV?.trim()) {
+    return true;
+  }
+  return params.argv.some((token) => /^(?:BASH_ENV|ENV)=/u.test(token.trim()));
+}

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -4,13 +4,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  revalidateApprovedMutableFileOperand,
+  resolveMutableFileOperandSnapshotSync,
+} from "../infra/system-run-approval-binding.js";
 import { formatExecCommand } from "../infra/system-run-command.js";
 import { withEnv } from "../test-utils/env.js";
 import {
   buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
-  revalidateApprovedMutableFileOperand,
-  resolveMutableFileOperandSnapshotSync,
 } from "./invoke-system-run-plan.js";
 
 type PathTokenSetup = {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -1,44 +1,14 @@
-/** Builds and revalidates system.run approval plans for cwd and mutable executable operands. */
-import crypto from "node:crypto";
+/** Builds and revalidates system.run approval plans for cwd and executable paths. */
 import fs from "node:fs";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeNullableString,
-} from "@openclaw/normalization-core/string-coerce";
-import type {
-  SystemRunApprovalFileOperand,
-  SystemRunApprovalPlan,
-} from "../infra/exec-approvals.js";
+import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
+import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
-import { isInterpreterLikeSafeBin } from "../infra/exec-safe-bin-runtime-policy.js";
-import {
-  isBlockedShellWrapperCommand,
-  POSIX_PARSEABLE_SHELL_WRAPPERS,
-  POSIX_SHELL_WRAPPERS,
-  normalizeExecutableToken,
-  unwrapKnownDispatchWrapperInvocation,
-  unwrapKnownShellMultiplexerInvocation,
-} from "../infra/exec-wrapper-resolution.js";
-import { readFileWindowFullySync } from "../infra/file-read.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
-import { parseInlineOptionToken } from "../infra/inline-option-token.js";
-import {
-  normalizePackageManagerExecToken,
-  PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
-  PNPM_DLX_OPTIONS_WITH_VALUE,
-  PNPM_FLAG_OPTIONS,
-  PNPM_OPTIONS_WITH_VALUE,
-  unwrapKnownPackageManagerExecInvocation,
-} from "../infra/package-manager-exec-wrapper.js";
-import {
-  advancePosixInlineOptionScan,
-  POSIX_INLINE_COMMAND_FLAGS,
-  resolveInlineCommandMatch,
-} from "../infra/shell-inline-command.js";
+import { resolveMutableFileOperandSnapshotSync } from "../infra/system-run-approval-binding.js";
 import { formatExecCommand, resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
-import { splitShellArgs } from "../utils/shell-argv.js";
+import { hasMutableSymlinkPathComponentSync } from "../infra/system-run-mutable-file-policy.js";
 
 /** File identity snapshot for the approved working directory. */
 export type ApprovedCwdSnapshot = {
@@ -46,909 +16,16 @@ export type ApprovedCwdSnapshot = {
   stat: fs.Stats;
 };
 
-const MUTABLE_ARGV1_INTERPRETER_PATTERNS = [
-  /^(?:node|nodejs)$/,
-  /^perl$/,
-  /^php$/,
-  /^python(?:\d+(?:\.\d+)*)?$/,
-  /^ruby$/,
-] as const;
-
-const GENERIC_MUTABLE_SCRIPT_RUNNERS = new Set([
-  "esno",
-  "jiti",
-  "ts-node",
-  "ts-node-esm",
-  "tsx",
-  "vite-node",
-]);
-
-const OPAQUE_MUTABLE_SCRIPT_RUNNERS = new Set(["busybox", "toybox"]);
-
-const BUN_SUBCOMMANDS = new Set([
-  "add",
-  "audit",
-  "completions",
-  "create",
-  "exec",
-  "help",
-  "init",
-  "install",
-  "link",
-  "outdated",
-  "patch",
-  "pm",
-  "publish",
-  "remove",
-  "repl",
-  "run",
-  "test",
-  "unlink",
-  "update",
-  "upgrade",
-  "x",
-]);
-
-const BUN_OPTIONS_WITH_VALUE = new Set([
-  "--backend",
-  "--bunfig",
-  "--conditions",
-  "--config",
-  "--console-depth",
-  "--cwd",
-  "--define",
-  "--elide-lines",
-  "--env-file",
-  "--extension-order",
-  "--filter",
-  "--hot",
-  "--inspect",
-  "--inspect-brk",
-  "--inspect-wait",
-  "--install",
-  "--jsx-factory",
-  "--jsx-fragment",
-  "--jsx-import-source",
-  "--loader",
-  "--origin",
-  "--port",
-  "--preload",
-  "--smol",
-  "--tsconfig-override",
-  "-c",
-  "-e",
-  "-p",
-  "-r",
-]);
-
-const DENO_RUN_OPTIONS_WITH_VALUE = new Set([
-  "--cached-only",
-  "--cert",
-  "--config",
-  "--env-file",
-  "--ext",
-  "--harmony-import-attributes",
-  "--import-map",
-  "--inspect",
-  "--inspect-brk",
-  "--inspect-wait",
-  "--location",
-  "--log-level",
-  "--lock",
-  "--node-modules-dir",
-  "--no-check",
-  "--preload",
-  "--reload",
-  "--seed",
-  "--strace-ops",
-  "--unstable-bare-node-builtins",
-  "--v8-flags",
-  "--watch",
-  "--watch-exclude",
-  "-L",
-]);
-
-const NODE_OPTIONS_WITH_FILE_VALUE = new Set([
-  "-r",
-  "--experimental-loader",
-  "--import",
-  "--loader",
-  "--require",
-]);
-
-const RUBY_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-r", "--require"]);
-const PERL_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-M", "-m"]);
-
-function normalizeOptionFlag(token: string): string {
-  return normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name);
-}
-
-function readTrimmedArgToken(argv: readonly string[], index: number): string {
-  return normalizeNullableString(argv[index]) ?? "";
-}
-
-const POSIX_SHELL_OPTIONS_WITH_VALUE = new Set([
-  "--init-file",
-  "--rcfile",
-  "--startup-script",
-  "-O",
-  "-o",
-  "+O",
-  "+o",
-]);
-
-const POSIX_SHELLS_WITH_PLUS_OPTIONS = new Set([
-  "ash",
-  "bash",
-  "dash",
-  "ksh",
-  "mksh",
-  "osh",
-  "sh",
-  "yash",
-  "zsh",
-]);
-
-function isPosixShellOptionToken(token: string, supportsPlusOptions: boolean): boolean {
-  return token.startsWith("-") || (supportsPlusOptions && token.startsWith("+"));
-}
-
-type FileOperandCollection = {
-  hits: number[];
-  sawOptionValueFile: boolean;
-};
-
-function pathComponentsFromRootSync(targetPath: string): string[] {
-  const absolute = path.resolve(targetPath);
-  const parts: string[] = [];
-  let cursor = absolute;
-  while (true) {
-    parts.unshift(cursor);
-    const parent = path.dirname(cursor);
-    if (parent === cursor) {
-      return parts;
-    }
-    cursor = parent;
-  }
-}
-
-function isOwnedByCurrentProcessSync(candidate: string): boolean {
-  if (process.platform === "win32" || typeof process.getuid !== "function") {
-    return false;
-  }
-  try {
-    return fs.statSync(candidate).uid === process.getuid();
-  } catch {
-    return false;
-  }
-}
-
-function isMutableByCurrentProcessSync(candidate: string): boolean {
-  try {
-    fs.accessSync(candidate, fs.constants.W_OK);
-    return true;
-  } catch {
-    return isOwnedByCurrentProcessSync(candidate);
-  }
-}
-
-function hasMutableSymlinkPathComponentSync(targetPath: string): boolean {
-  for (const component of pathComponentsFromRootSync(targetPath)) {
-    try {
-      if (!fs.lstatSync(component).isSymbolicLink()) {
-        continue;
-      }
-      const parentDir = path.dirname(component);
-      if (isMutableByCurrentProcessSync(parentDir)) {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  return false;
-}
-
-function pathLooksMutableForShellPayloadSync(targetPath: string): boolean {
-  if (
-    isMutableByCurrentProcessSync(targetPath) ||
-    isMutableByCurrentProcessSync(path.dirname(targetPath)) ||
-    hasMutableSymlinkPathComponentSync(targetPath)
-  ) {
-    return true;
-  }
-  let realPath: string;
-  try {
-    realPath = fs.realpathSync(targetPath);
-  } catch {
-    return true;
-  }
-  return (
-    isMutableByCurrentProcessSync(realPath) ||
-    isMutableByCurrentProcessSync(path.dirname(realPath)) ||
-    hasMutableSymlinkPathComponentSync(realPath)
-  );
-}
-
 function shouldPinExecutableForApproval(params: {
   shellCommand: string | null;
   wrapperChain: string[] | undefined;
 }): boolean {
-  if (params.shellCommand !== null) {
-    return false;
-  }
-  return (params.wrapperChain?.length ?? 0) === 0;
+  return params.shellCommand === null && (params.wrapperChain?.length ?? 0) === 0;
 }
 
-function hashFileContentsSync(filePath: string): string {
-  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
-}
-
-function looksLikePathToken(token: string): boolean {
-  return (
-    token.startsWith(".") ||
-    token.startsWith("/") ||
-    token.startsWith("\\") ||
-    token.includes("/") ||
-    token.includes("\\") ||
-    path.extname(token).length > 0
-  );
-}
-
-function resolvesToExistingFileSync(rawOperand: string, cwd: string | undefined): boolean {
-  if (!rawOperand) {
-    return false;
-  }
-  try {
-    return fs.statSync(path.resolve(cwd ?? process.cwd(), rawOperand)).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
-  if (buffer.length >= 4 && buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
-    return true;
-  }
-  if (
-    buffer.length >= 4 &&
-    (buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xbe, 0xba, 0xfe, 0xca])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbf])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xbf, 0xba, 0xfe, 0xca])))
-  ) {
-    return true;
-  }
-  if (buffer.length < 0x40 || !buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))) {
-    return false;
-  }
-  const peOffset = buffer.readUInt32LE(0x3c);
-  return (
-    peOffset >= 0 &&
-    peOffset <= buffer.length - 4 &&
-    buffer.subarray(peOffset, peOffset + 4).equals(Buffer.from([0x50, 0x45, 0x00, 0x00]))
-  );
-}
-
-function isLikelyScriptLikePathSync(targetPath: string): boolean {
-  let stat: fs.Stats;
-  try {
-    stat = fs.statSync(targetPath);
-  } catch {
-    return true;
-  }
-  if (!stat.isFile()) {
-    return true;
-  }
-  let header: Buffer;
-  try {
-    const fd = fs.openSync(targetPath, "r");
-    try {
-      header = Buffer.alloc(1024);
-      const bytesRead = readFileWindowFullySync(fd, header, 0);
-      header = header.subarray(0, bytesRead);
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return true;
-  }
-  if (header.length === 0) {
-    return true;
-  }
-  if (header.subarray(0, 2).equals(Buffer.from("#!"))) {
-    return true;
-  }
-  if (isKnownBinaryExecutableHeader(header)) {
-    return false;
-  }
-  return true;
-}
-
-function unwrapArgvForMutableOperand(argv: string[]): {
-  argv: string[];
-  baseIndex: number;
-  opaqueMultiplexerSeen: boolean;
-} {
-  let current = argv;
-  let baseIndex = 0;
-  let opaqueMultiplexerSeen = false;
-  while (true) {
-    const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(current);
-    if (dispatchUnwrap.kind === "unwrapped") {
-      baseIndex += current.length - dispatchUnwrap.argv.length;
-      current = dispatchUnwrap.argv;
-      continue;
-    }
-    const shellMultiplexerUnwrap = unwrapKnownShellMultiplexerInvocation(current);
-    if (shellMultiplexerUnwrap.kind === "unwrapped") {
-      if (OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(shellMultiplexerUnwrap.wrapper)) {
-        opaqueMultiplexerSeen = true;
-      }
-      baseIndex += current.length - shellMultiplexerUnwrap.argv.length;
-      current = shellMultiplexerUnwrap.argv;
-      continue;
-    }
-    const packageManagerUnwrap = unwrapKnownPackageManagerExecInvocation(current);
-    if (packageManagerUnwrap) {
-      baseIndex += current.length - packageManagerUnwrap.length;
-      current = packageManagerUnwrap;
-      continue;
-    }
-    return { argv: current, baseIndex, opaqueMultiplexerSeen };
-  }
-}
-
-function resolvePosixShellScriptOperandIndex(argv: string[], executable: string): number | null {
-  const supportsPlusOptions = POSIX_SHELLS_WITH_PLUS_OPTIONS.has(executable);
-  if (
-    resolveInlineCommandMatch(argv, POSIX_INLINE_COMMAND_FLAGS, {
-      allowCombinedC: true,
-      isOptionToken: (token) => isPosixShellOptionToken(token, supportsPlusOptions),
-      stopAtFirstNonOption: true,
-    }).valueTokenIndex !== null
-  ) {
-    return null;
-  }
-  let afterDoubleDash = false;
-  for (let i = 1; i < argv.length; i += 1) {
-    const token = readTrimmedArgToken(argv, i);
-    if (!token) {
-      continue;
-    }
-    if (token === "-") {
-      return null;
-    }
-    if (!afterDoubleDash && token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (!afterDoubleDash && token === "-s") {
-      return null;
-    }
-    if (!afterDoubleDash && isPosixShellOptionToken(token, supportsPlusOptions)) {
-      const flag = normalizeOptionFlag(token);
-      if (POSIX_SHELL_OPTIONS_WITH_VALUE.has(flag)) {
-        if (!token.includes("=")) {
-          i += 1;
-        }
-        continue;
-      }
-      i += advancePosixInlineOptionScan(token) - 1;
-      continue;
-    }
-    return i;
-  }
-  return null;
-}
-
-function resolveOptionFilteredFileOperandIndex(params: {
-  argv: string[];
-  startIndex: number;
-  cwd: string | undefined;
-  optionsWithValue?: ReadonlySet<string>;
-}): number | null {
-  let afterDoubleDash = false;
-  for (let i = params.startIndex; i < params.argv.length; i += 1) {
-    const token = readTrimmedArgToken(params.argv, i);
-    if (!token) {
-      continue;
-    }
-    if (afterDoubleDash) {
-      return resolvesToExistingFileSync(token, params.cwd) ? i : null;
-    }
-    if (token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (token === "-") {
-      return null;
-    }
-    if (token.startsWith("-")) {
-      if (!token.includes("=") && params.optionsWithValue?.has(token)) {
-        i += 1;
-      }
-      continue;
-    }
-    return resolvesToExistingFileSync(token, params.cwd) ? i : null;
-  }
-  return null;
-}
-
-function resolveOptionFilteredPositionalIndex(params: {
-  argv: string[];
-  startIndex: number;
-  optionsWithValue?: ReadonlySet<string>;
-}): number | null {
-  let afterDoubleDash = false;
-  for (let i = params.startIndex; i < params.argv.length; i += 1) {
-    const token = readTrimmedArgToken(params.argv, i);
-    if (!token) {
-      continue;
-    }
-    if (afterDoubleDash) {
-      return i;
-    }
-    if (token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (token === "-") {
-      return null;
-    }
-    if (token.startsWith("-")) {
-      if (!token.includes("=") && params.optionsWithValue?.has(token)) {
-        i += 1;
-      }
-      continue;
-    }
-    return i;
-  }
-  return null;
-}
-
-function collectExistingFileOperandIndexes(params: {
-  argv: string[];
-  startIndex: number;
-  cwd: string | undefined;
-  optionsWithFileValue?: ReadonlySet<string>;
-}): FileOperandCollection {
-  let afterDoubleDash = false;
-  const hits: number[] = [];
-  for (let i = params.startIndex; i < params.argv.length; i += 1) {
-    const token = readTrimmedArgToken(params.argv, i);
-    if (!token) {
-      continue;
-    }
-    if (afterDoubleDash) {
-      if (resolvesToExistingFileSync(token, params.cwd)) {
-        hits.push(i);
-      }
-      continue;
-    }
-    if (token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (token === "-") {
-      return { hits: [], sawOptionValueFile: false };
-    }
-    if (token.startsWith("-")) {
-      const option = parseInlineOptionToken(token);
-      const flag = option.name;
-      const inlineValue = option.hasInlineValue ? option.inlineValue : undefined;
-      if (params.optionsWithFileValue?.has(normalizeLowercaseStringOrEmpty(flag))) {
-        if (inlineValue && resolvesToExistingFileSync(inlineValue, params.cwd)) {
-          hits.push(i);
-          return { hits, sawOptionValueFile: true };
-        }
-        const nextToken = readTrimmedArgToken(params.argv, i + 1);
-        if (!inlineValue && nextToken && resolvesToExistingFileSync(nextToken, params.cwd)) {
-          hits.push(i + 1);
-          return { hits, sawOptionValueFile: true };
-        }
-      }
-      continue;
-    }
-    if (resolvesToExistingFileSync(token, params.cwd)) {
-      hits.push(i);
-    }
-  }
-  return { hits, sawOptionValueFile: false };
-}
-
-function resolveGenericInterpreterScriptOperandIndex(params: {
-  argv: string[];
-  cwd: string | undefined;
-  optionsWithFileValue?: ReadonlySet<string>;
-}): number | null {
-  const collection = collectExistingFileOperandIndexes({
-    argv: params.argv,
-    startIndex: 1,
-    cwd: params.cwd,
-    optionsWithFileValue: params.optionsWithFileValue,
-  });
-  if (collection.sawOptionValueFile) {
-    return null;
-  }
-  return collection.hits.length === 1 ? expectDefined(collection.hits[0], "hits entry at 0") : null;
-}
-
-function resolveBunScriptOperandIndex(params: {
-  argv: string[];
-  cwd: string | undefined;
-}): number | null {
-  const directIndex = resolveOptionFilteredPositionalIndex({
-    argv: params.argv,
-    startIndex: 1,
-    optionsWithValue: BUN_OPTIONS_WITH_VALUE,
-  });
-  if (directIndex === null) {
-    return null;
-  }
-  const directToken = readTrimmedArgToken(params.argv, directIndex);
-  if (directToken === "run") {
-    return resolveOptionFilteredFileOperandIndex({
-      argv: params.argv,
-      startIndex: directIndex + 1,
-      cwd: params.cwd,
-      optionsWithValue: BUN_OPTIONS_WITH_VALUE,
-    });
-  }
-  if (BUN_SUBCOMMANDS.has(directToken)) {
-    return null;
-  }
-  if (!looksLikePathToken(directToken)) {
-    return null;
-  }
-  return directIndex;
-}
-
-function resolveDenoRunScriptOperandIndex(params: {
-  argv: string[];
-  cwd: string | undefined;
-}): number | null {
-  if (readTrimmedArgToken(params.argv, 1) !== "run") {
-    return null;
-  }
-  return resolveOptionFilteredFileOperandIndex({
-    argv: params.argv,
-    startIndex: 2,
-    cwd: params.cwd,
-    optionsWithValue: DENO_RUN_OPTIONS_WITH_VALUE,
-  });
-}
-
-function hasRubyUnsafeApprovalFlag(argv: string[]): boolean {
-  let afterDoubleDash = false;
-  for (let i = 1; i < argv.length; i += 1) {
-    const token = readTrimmedArgToken(argv, i);
-    if (!token) {
-      continue;
-    }
-    if (afterDoubleDash) {
-      return false;
-    }
-    if (token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (token === "-I" || token === "-r") {
-      return true;
-    }
-    if (token.startsWith("-I") || token.startsWith("-r")) {
-      return true;
-    }
-    if (RUBY_UNSAFE_APPROVAL_FLAGS.has(normalizeLowercaseStringOrEmpty(token))) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function hasPerlUnsafeApprovalFlag(argv: string[]): boolean {
-  let afterDoubleDash = false;
-  for (let i = 1; i < argv.length; i += 1) {
-    const token = readTrimmedArgToken(argv, i);
-    if (!token) {
-      continue;
-    }
-    if (afterDoubleDash) {
-      return false;
-    }
-    if (token === "--") {
-      afterDoubleDash = true;
-      continue;
-    }
-    if (token === "-I" || token === "-M" || token === "-m") {
-      return true;
-    }
-    if (token.startsWith("-I") || token.startsWith("-M") || token.startsWith("-m")) {
-      return true;
-    }
-    if (PERL_UNSAFE_APPROVAL_FLAGS.has(token)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function isMutableScriptRunner(executable: string): boolean {
-  return (
-    GENERIC_MUTABLE_SCRIPT_RUNNERS.has(executable) ||
-    OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(executable) ||
-    isInterpreterLikeSafeBin(executable)
-  );
-}
-
-function resolveMutableFileOperandIndex(argv: string[], cwd: string | undefined): number | null {
-  const unwrapped = unwrapArgvForMutableOperand(argv);
-  const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
-  if (!executable) {
-    return null;
-  }
-  if (unwrapped.opaqueMultiplexerSeen || OPAQUE_MUTABLE_SCRIPT_RUNNERS.has(executable)) {
-    return null;
-  }
-  if ((POSIX_SHELL_WRAPPERS as ReadonlySet<string>).has(executable)) {
-    if (!(POSIX_PARSEABLE_SHELL_WRAPPERS as ReadonlySet<string>).has(executable)) {
-      return null;
-    }
-    const shellIndex = resolvePosixShellScriptOperandIndex(unwrapped.argv, executable);
-    return shellIndex === null ? null : unwrapped.baseIndex + shellIndex;
-  }
-  if (MUTABLE_ARGV1_INTERPRETER_PATTERNS.some((pattern) => pattern.test(executable))) {
-    const operand = readTrimmedArgToken(unwrapped.argv, 1);
-    if (operand && operand !== "-" && !operand.startsWith("-")) {
-      return unwrapped.baseIndex + 1;
-    }
-  }
-  if (executable === "bun") {
-    const bunIndex = resolveBunScriptOperandIndex({
-      argv: unwrapped.argv,
-      cwd,
-    });
-    if (bunIndex !== null) {
-      return unwrapped.baseIndex + bunIndex;
-    }
-  }
-  if (executable === "deno") {
-    const denoIndex = resolveDenoRunScriptOperandIndex({
-      argv: unwrapped.argv,
-      cwd,
-    });
-    if (denoIndex !== null) {
-      return unwrapped.baseIndex + denoIndex;
-    }
-  }
-  if (executable === "ruby" && hasRubyUnsafeApprovalFlag(unwrapped.argv)) {
-    return null;
-  }
-  if (executable === "perl" && hasPerlUnsafeApprovalFlag(unwrapped.argv)) {
-    return null;
-  }
-  if (!isMutableScriptRunner(executable)) {
-    return null;
-  }
-  const genericIndex = resolveGenericInterpreterScriptOperandIndex({
-    argv: unwrapped.argv,
-    cwd,
-    optionsWithFileValue:
-      executable === "node" || executable === "nodejs" ? NODE_OPTIONS_WITH_FILE_VALUE : undefined,
-  });
-  return genericIndex === null ? null : unwrapped.baseIndex + genericIndex;
-}
-
-function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | undefined): boolean {
-  const argv = splitShellArgs(shellCommand);
-  if (!argv || argv.length === 0) {
-    return false;
-  }
-  const snapshot = resolveMutableFileOperandSnapshotSync({
-    argv,
-    cwd,
-    shellCommand: null,
-  });
-  if (!snapshot.ok) {
-    return true;
-  }
-  if (snapshot.snapshot) {
-    return true;
-  }
-  const firstToken = readTrimmedArgToken(argv, 0);
-  if (!resolvesToExistingFileSync(firstToken, cwd)) {
-    return false;
-  }
-  if (!path.isAbsolute(firstToken)) {
-    return true;
-  }
-  const resolvedPath = path.resolve(cwd ?? process.cwd(), firstToken);
-  if (pathLooksMutableForShellPayloadSync(resolvedPath)) {
-    return true;
-  }
-  return isLikelyScriptLikePathSync(resolvedPath);
-}
-
-function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
-  argv: string[];
-  shellCommand: string | null;
-  cwd: string | undefined;
-}): boolean {
-  const unwrapped = unwrapArgvForMutableOperand(params.argv);
-  if (unwrapped.opaqueMultiplexerSeen) {
-    return true;
-  }
-  if (params.shellCommand !== null) {
-    return shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
-  }
-  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv, params.cwd)) {
-    return true;
-  }
-  const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
-  if (!executable) {
-    return false;
-  }
-  if ((POSIX_SHELL_WRAPPERS as ReadonlySet<string>).has(executable)) {
-    return false;
-  }
-  return isMutableScriptRunner(executable);
-}
-
-function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
-  if (normalizePackageManagerExecToken(argv[0] ?? "") !== "pnpm") {
-    return false;
-  }
-
-  let idx = 1;
-  while (idx < argv.length) {
-    const token = readTrimmedArgToken(argv, idx);
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      idx += 1;
-      continue;
-    }
-    if (!token.startsWith("-")) {
-      if (token !== "dlx") {
-        return false;
-      }
-      return pnpmDlxTailNeedsFailClosedBinding(argv.slice(idx + 1), cwd);
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return true;
-  }
-
-  return false;
-}
-
-function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
-  let idx = 0;
-  while (idx < argv.length) {
-    const token = readTrimmedArgToken(argv, idx);
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
-    }
-    if (!token.startsWith("-")) {
-      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx), cwd);
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (flag === "-c" || flag === "--shell-mode") {
-      return false;
-    }
-    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return true;
-  }
-
-  return true;
-}
-
-function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined): boolean {
-  const snapshot = resolveMutableFileOperandSnapshotSync({
-    argv,
-    cwd,
-    shellCommand: null,
-  });
-  return snapshot.ok && snapshot.snapshot !== null;
-}
-
-/** Captures file identity for a mutable script operand that approval is bound to. */
-export function resolveMutableFileOperandSnapshotSync(params: {
-  argv: string[];
-  cwd: string | undefined;
-  shellCommand: string | null;
-}): { ok: true; snapshot: SystemRunApprovalFileOperand | null } | { ok: false; message: string } {
-  const argvIndex = resolveMutableFileOperandIndex(params.argv, params.cwd);
-  if (argvIndex === null) {
-    if (
-      requiresStableInterpreterApprovalBindingWithShellCommand({
-        argv: params.argv,
-        shellCommand: params.shellCommand,
-        cwd: params.cwd,
-      })
-    ) {
-      return {
-        ok: false,
-        message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
-      };
-    }
-    return { ok: true, snapshot: null };
-  }
-  const rawOperand = readTrimmedArgToken(params.argv, argvIndex);
-  if (!rawOperand) {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval requires a stable script operand",
-    };
-  }
-  const resolvedPath = path.resolve(params.cwd ?? process.cwd(), rawOperand);
-  let realPath: string;
-  let stat: fs.Stats;
-  try {
-    realPath = fs.realpathSync(resolvedPath);
-    stat = fs.statSync(realPath);
-  } catch {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval requires an existing script operand",
-    };
-  }
-  if (!stat.isFile()) {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval requires a file script operand",
-    };
-  }
-  return {
-    ok: true,
-    snapshot: {
-      argvIndex,
-      path: realPath,
-      sha256: hashFileContentsSync(realPath),
-    },
-  };
-}
-
-function resolveCanonicalApprovalCwdSync(cwd: string):
-  | {
-      ok: true;
-      snapshot: ApprovedCwdSnapshot;
-    }
-  | { ok: false; message: string } {
+function resolveCanonicalApprovalCwdSync(
+  cwd: string,
+): { ok: true; snapshot: ApprovedCwdSnapshot } | { ok: false; message: string } {
   const requestedCwd = path.resolve(cwd);
   let cwdLstat: fs.Stats;
   let cwdStat: fs.Stats;
@@ -971,16 +48,10 @@ function resolveCanonicalApprovalCwdSync(cwd: string):
       message: "SYSTEM_RUN_DENIED: approval requires cwd to be a directory",
     };
   }
-  if (hasMutableSymlinkPathComponentSync(requestedCwd)) {
+  if (hasMutableSymlinkPathComponentSync(requestedCwd) || cwdLstat.isSymbolicLink()) {
     return {
       ok: false,
       message: "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink path components)",
-    };
-  }
-  if (cwdLstat.isSymbolicLink()) {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink cwd)",
     };
   }
   if (
@@ -988,53 +59,15 @@ function resolveCanonicalApprovalCwdSync(cwd: string):
     !sameFileIdentity(cwdStat, cwdRealStat) ||
     !sameFileIdentity(cwdLstat, cwdRealStat)
   ) {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval cwd identity mismatch",
-    };
+    return { ok: false, message: "SYSTEM_RUN_DENIED: approval cwd identity mismatch" };
   }
-  return {
-    ok: true,
-    snapshot: {
-      cwd: cwdReal,
-      stat: cwdStat,
-    },
-  };
+  return { ok: true, snapshot: { cwd: cwdReal, stat: cwdStat } };
 }
 
 /** Rechecks that the approved cwd still points at the same directory identity. */
 export function revalidateApprovedCwdSnapshot(params: { snapshot: ApprovedCwdSnapshot }): boolean {
   const current = resolveCanonicalApprovalCwdSync(params.snapshot.cwd);
-  if (!current.ok) {
-    return false;
-  }
-  return sameFileIdentity(params.snapshot.stat, current.snapshot.stat);
-}
-
-export function revalidateApprovedMutableFileOperand(params: {
-  snapshot: SystemRunApprovalFileOperand;
-  argv: string[];
-  cwd: string | undefined;
-}): boolean {
-  const operand = params.argv[params.snapshot.argvIndex]?.trim();
-  if (!operand) {
-    return false;
-  }
-  const resolvedPath = path.resolve(params.cwd ?? process.cwd(), operand);
-  let realPath: string;
-  try {
-    realPath = fs.realpathSync(resolvedPath);
-  } catch {
-    return false;
-  }
-  if (realPath !== params.snapshot.path) {
-    return false;
-  }
-  try {
-    return hashFileContentsSync(realPath) === params.snapshot.sha256;
-  } catch {
-    return false;
-  }
+  return current.ok && sameFileIdentity(params.snapshot.stat, current.snapshot.stat);
 }
 
 export function hardenApprovedExecutionPaths(params: {
@@ -1072,26 +105,16 @@ export function hardenApprovedExecutionPaths(params: {
     approvedCwdSnapshot = canonicalCwd.snapshot;
   }
 
-  if (params.argv.length === 0) {
-    return {
-      ok: true,
-      argv: params.argv,
-      argvChanged: false,
-      cwd: hardenedCwd,
-      approvedCwdSnapshot,
-    };
-  }
-
   const resolution = resolveCommandResolutionFromArgv(params.argv, hardenedCwd);
   if (
+    params.argv.length === 0 ||
     !shouldPinExecutableForApproval({
       shellCommand: params.shellCommand,
       wrapperChain: resolution?.wrapperChain,
     })
   ) {
-    // Preserve wrapper semantics for approval-based execution. Pinning the
-    // effective executable while keeping wrapper argv shape can shift positional
-    // arguments and execute a different command than approved.
+    // Wrapper argv must stay intact: replacing its effective executable can shift
+    // positional arguments and run a different command than the approved one.
     return {
       ok: true,
       argv: params.argv,
@@ -1109,7 +132,6 @@ export function hardenApprovedExecutionPaths(params: {
       message: "SYSTEM_RUN_DENIED: approval requires a stable executable path",
     };
   }
-
   if (pinnedExecutable === params.argv[0]) {
     return {
       ok: true,
@@ -1119,16 +141,9 @@ export function hardenApprovedExecutionPaths(params: {
       approvedCwdSnapshot,
     };
   }
-
   const argv = [...params.argv];
   argv[0] = pinnedExecutable;
-  return {
-    ok: true,
-    argv,
-    argvChanged: true,
-    cwd: hardenedCwd,
-    approvedCwdSnapshot,
-  };
+  return { ok: true, argv, argvChanged: true, cwd: hardenedCwd, approvedCwdSnapshot };
 }
 
 export function buildSystemRunApprovalPlan(params: {
@@ -1161,7 +176,7 @@ export function buildSystemRunApprovalPlan(params: {
     cwd: normalizeNullableString(params.cwd) ?? undefined,
   });
   if (!hardening.ok) {
-    return { ok: false, message: hardening.message };
+    return hardening;
   }
   const commandText = formatExecCommand(hardening.argv);
   const commandPreview =
@@ -1174,7 +189,7 @@ export function buildSystemRunApprovalPlan(params: {
     shellCommand: command.shellPayload,
   });
   if (!mutableFileOperand.ok) {
-    return { ok: false, message: mutableFileOperand.message };
+    return mutableFileOperand;
   }
   return {
     ok: true,
@@ -1189,4 +204,3 @@ export function buildSystemRunApprovalPlan(params: {
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -47,7 +47,12 @@ import {
   inspectHostExecEnvOverrides,
   sanitizeSystemRunEnvOverrides,
 } from "../infra/host-env-security.js";
-import { normalizeSystemRunApprovalPlan } from "../infra/system-run-approval-binding.js";
+import {
+  APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE,
+  normalizeSystemRunApprovalPlan,
+  revalidateApprovedMutableFileOperand,
+  resolveMutableFileOperandSnapshotSync,
+} from "../infra/system-run-approval-binding.js";
 import { formatExecCommand, resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
 import { logWarn } from "../logger.js";
 import type { NodeHostClient } from "./client.js";
@@ -61,8 +66,6 @@ import {
 import {
   hardenApprovedExecutionPaths,
   revalidateApprovedCwdSnapshot,
-  revalidateApprovedMutableFileOperand,
-  resolveMutableFileOperandSnapshotSync,
   type ApprovedCwdSnapshot,
 } from "./invoke-system-run-plan.js";
 import type {
@@ -155,8 +158,6 @@ const APPROVAL_CWD_DRIFT_DENIED_MESSAGE =
   "SYSTEM_RUN_DENIED: approval cwd changed before execution";
 const APPROVAL_SCRIPT_OPERAND_BINDING_DENIED_MESSAGE =
   "SYSTEM_RUN_DENIED: approval missing script operand binding";
-const APPROVAL_SCRIPT_OPERAND_DRIFT_DENIED_MESSAGE =
-  "SYSTEM_RUN_DENIED: approval script operand changed before execution";
 const APPROVAL_STATE_WRITE_FAILED_MESSAGE =
   "SYSTEM_RUN_DENIED: approval state could not be persisted";
 type ExecToolConfig = NonNullable<NonNullable<OpenClawConfig["tools"]>["exec"]>;

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -633,7 +633,7 @@ describe("node host invoke", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "keeps prepared allow-always coverage incomplete when any planned command is prompt-only",
+    "fails closed when a prepared command contains an unsafe shell pipeline",
     async () => {
       const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
       const skillBins: SkillBinsProvider = { current: async () => [] };
@@ -652,15 +652,19 @@ describe("node host invoke", () => {
         skillBins,
       );
 
-      const result = request.mock.calls[0]?.[1] as { payloadJSON?: string } | undefined;
-      const payload = JSON.parse(result?.payloadJSON ?? "{}") as {
-        allowAlwaysCoverage?: {
-          complete?: boolean;
-          patterns?: Array<{ pattern?: string }>;
-        };
-      };
-      expect(payload.allowAlwaysCoverage?.complete).toBe(false);
-      expect(payload.allowAlwaysCoverage?.patterns?.length).toBeGreaterThan(0);
+      expect(request).toHaveBeenCalledWith(
+        "node.invoke.result",
+        expect.objectContaining({
+          id: "invoke-prepare-partial",
+          nodeId: "node-1",
+          ok: false,
+          error: {
+            code: "INVALID_REQUEST",
+            message:
+              "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+          },
+        }),
+      );
     },
   );
 

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -61,6 +61,7 @@ export {
 } from "../infra/diagnostic-events.js";
 export { registerDiagnosticTracePropagationBridge } from "../infra/diagnostic-trace-propagation.js";
 export { runWithDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
+export { prepareSystemRunMutableFileApproval } from "../infra/system-run-approval-binding.js";
 export { logMessageDispatchStarted, logMessageProcessed } from "../logging/diagnostic.js";
 export { resolveBundledExplicitProviderContractsFromPublicArtifacts } from "../plugins/provider-contract-public-artifacts.js";
 export {


### PR DESCRIPTION
Fixes #124738

## What Problem This Solves

Fixes an issue where an operator could approve an exec command that referenced one script payload, but the runtime could execute different bytes if that script changed while the approval was pending. Because Codex is the default harness, default installations sent exec approvals through an operand-unbound path.

The verified live reproduction on `66dc9d1` was:

1. Write a script that produces `BENIGN-ORIGINAL`.
2. Ask the agent to execute it; approval remains pending with the summary `Command: sh …/script.sh`.
3. Rewrite the same file to produce `MUTATED-PAYLOAD-EXECUTED` while approval is pending.
4. Resolve with `allow-once`.
5. Observe `MUTATED-PAYLOAD-EXECUTED` execute instead of the reviewed bytes.

## Why This Change Was Made

The canonical infra owner now snapshots every mutable executable or script operand before the first policy, lifecycle, or operator wait. A missing, unreadable, unresolvable, or unsafe operand topology fails closed. After the authoritative approval decision and lifecycle check, each surface revalidates the same canonical real paths and SHA-256 byte identities at the last OpenClaw-owned boundary before control passes to the spawning runtime.

The invariant is enforced across:

- the Codex app-server command-execution approval bridge;
- gateway-host inline and detached exec;
- Claude native Bash approval;
- native `PermissionRequest` relay shell tools; and
- node-host system-run, whose pre-existing protection is preserved and migrated onto the canonical infra owner.

Non-command Codex file-change approvals are unaffected. The operand preparation and revalidation path is gated specifically to `item/commandExecution/requestApproval`; patch/file-change decisions retain their existing policy and response flow.

Byte-bound session approvals are downgraded to one-shot where a text-level reusable grant could otherwise authorize future bytes. Authority-bearing durable gateway grants are evaluated only after mutable-operand preparation; if bytes are mutable, the command re-prompts and the new decision remains one-shot. Redundant durable entries do not disturb commands independently authorized by current live policy. Operator-visible consequence: approvals that previously persisted may now re-prompt when a command depends on mutable executable or script bytes. Commands without mutable file operands retain their existing persistence behavior.

### Upstream Codex contract

Direct inspection of sibling `../codex` at `936f5eb3ee223ab34dcb221fa7c5f9943c8092bd` confirms that OpenClaw cannot rely on an upstream byte binding:

- the protocol carries command/cwd and decision data but no operand digest: [`app-server-protocol/src/protocol/v2/item.rs:1442-1516`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1442-L1516);
- the decision is correlated to the pending callback only by approval ID: [`core/src/session/mod.rs:2349-2430`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/core/src/session/mod.rs#L2349-L2430) and [`core/src/session/mod.rs:2939-2956`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/core/src/session/mod.rs#L2939-L2956); and
- after approval, execution proceeds through the orchestrator, shell runtime, and process spawn path: [`core/src/tools/orchestrator.rs:134-284`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/core/src/tools/orchestrator.rs#L134-L284), [`core/src/tools/runtimes/shell.rs:190-282`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/core/src/tools/runtimes/shell.rs#L190-L282), and [`core/src/exec.rs:909-965`](https://github.com/openai/codex/blob/936f5eb3ee223ab34dcb221fa7c5f9943c8092bd/codex-rs/core/src/exec.rs#L909-L965).

### Change size

The original security implementation is production +1,996/-1,030 (net +966), with tests and test support +1,075/-55. Two baseline entries were removed, ratcheting both baselines tighter; none were added.

The CI fixture follow-up added no production code. The ClawSweeper repairs reshape two existing production owners and add their focused regressions. Current PR totals are production +2,016/-1,033 (net +983), tests and test support +1,196/-100, and baselines +0/-2.

Most production churn moves the former node-host-only mutable-operand detector and policy out of a 1,026-line owner into the canonical infra owner, then wires that one implementation into the four previously unbound sibling surfaces. The remaining positive production delta pays for the shared security invariant, explicit fail-closed topology handling, closure-bound host capability, durable-grant ordering, transparent-wrapper revalidation, and final-boundary checks rather than parallel per-runtime detectors.

## User Impact

Approving a script-backed command now authorizes the bytes the operator actually reviewed. If the referenced executable or script changes during the approval window, OpenClaw returns a visible denial instead of releasing execution. Legitimate stable scripts and stable transparent-wrapper commands continue to run, while unsafe or unresolved shell topology fails closed with an actionable denial.

The security tradeoff is explicit: byte-bound approvals can re-prompt instead of persisting across future script contents.

## Evidence

Current head: `f062893e89bd6f0abc839aa6ee78eba6bc67fb43`.

- Full security-diff autoreview: clean; no accepted/actionable P0 findings, overall correctness `patch is correct` with 0.88 confidence.
- CI-repair autoreview: clean; no accepted/actionable P0 findings, overall correctness `patch is correct` with 0.99 confidence.
- ClawSweeper P1 repair autoreview: clean; no accepted/actionable P0 findings, overall correctness `patch is correct` with 0.98 confidence.
- Durable-policy compatibility autoreview: clean; no accepted/actionable P0 findings, overall correctness `patch is correct` with 0.97 confidence.
- Focused regression proof: `node scripts/run-vitest.mjs` across the changed approval tests, all `src/node-host/invoke-system-run*.test.ts` suites, and the CI-owned sibling suites — 624 passed, 5 skipped across 6 Vitest shards.
- Changed gate: `node scripts/check-changed.mjs` — exit 0. No remote provider was ready, so the documented trusted-source fallback ran the full gate locally; format, typecheck, lint, Plugin SDK, boundary, ratchet, dead-code, and architecture checks passed.
- Exact-head CI: run [`31978065216`](https://github.com/openclaw/openclaw/actions/runs/31978065216) is green for the current head.
- The first exact-head CI run (`31974629317`) exposed environment-dependent test fixtures and new async-preparation timing assumptions. The test-only follow-up uses host-resolvable commands, preserves real binding in operand tests, isolates unrelated policy tests from host filesystem identity, waits for the pre-approval phase, and asserts unsafe node-host pipelines fail closed.
- ClawSweeper then found two P1 owner-boundary gaps at `1c32da21b5eebc1f390375021ae9a96c4a03b067`: durable grants bypassed operand preparation, and explicit-path transparent wrappers revalidated the outer wrapper. The current head prepares before authority-bearing durable bypass, forces mutable durable commands back to one-shot review, preserves independently sufficient current-policy authorization, and resolves the original wrapper argv to the same effective executable during revalidation. Regressions cover changed and unchanged bytes for both cases.
- Redacted after-fix trace: snapshot `BENIGN-ORIGINAL`, mutate to `MUTATED-PAYLOAD-EXECUTED` while pending, apply `allow-once`, then final revalidation returns `SYSTEM_RUN_DENIED: approval script operand changed before execution` with `executionReleased: false`.
- Focused shell-dispatch proof: `eval "source ./payload.sh"` and `builtin eval "source ./payload.sh"` both fail closed with `SYSTEM_RUN_DENIED: approval requires a resolved executable`; shell built-ins are not treated as resolved external executables.
- Hashing latency: 64 MiB script, 2 warmups plus 20 measured approval cycles. Preparation mean/p50/p95: 28.2/28.3/28.7 ms. Post-decision revalidation mean/p50/p95: 26.5/26.5/26.8 ms. Combined mean/p50/p95: 54.7/54.9/55.4 ms. Each cycle reads and hashes the full 64 MiB file twice.
- The regression matrix covers stable operands, drift, deletion/unreadability, unresolved executables, unsafe shell/source/runtime options, PATH-resolved mutable executables, transparent wrappers, durable grants, allow-always/session behavior, lifecycle closure, and visible denial propagation across every wired surface.

This is an AI-assisted maintainer security repair prepared for human review. It must not be merged without maintainer security-boundary approval.

## Residual risk

external runtimes spawn only after OpenClaw returns allow, so revalidation-and-spawn is not atomic without upstream digest enforcement or OpenClaw-owned file descriptors; recursive shebang interpreter / dynamic dependency attestation is out of contract. Follow-up: #124930.

