### PR TITLE
fix(test): nested compiler checks time out under parent lock

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -33,6 +33,7 @@ import { runWithFailedTrailer } from "./lib/failed-trailer.mts";
 import {
   acquireLocalHeavyCheckLockSync,
   resolveLocalHeavyCheckEnv,
+  withLocalHeavyCheckLockHeld,
 } from "./lib/local-heavy-check-runtime.mts";
 import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { listGeneratedExtensionAssetSources } from "./lib/static-extension-assets.mts";
@@ -156,13 +157,7 @@ if (!isDirectRun()) {
 }
 
 export function createChangedCheckChildEnv(baseEnv: NodeJS.ProcessEnv = process.env) {
-  const resolvedBaseEnv = resolveLocalHeavyCheckEnv(baseEnv);
-  return {
-    ...resolvedBaseEnv,
-    OPENCLAW_OXLINT_SKIP_LOCK: "1",
-    OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD: "1",
-    OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD: "1",
-  };
+  return withLocalHeavyCheckLockHeld(resolveLocalHeavyCheckEnv(baseEnv));
 }
 
 function hasAndroidVersionSyncPath(paths: string[]) {

--- a/scripts/ci-run-node-test-shard.mts
+++ b/scripts/ci-run-node-test-shard.mts
@@ -19,7 +19,10 @@ import type { Readable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
-import { acquireLocalHeavyCheckLockSync } from "./lib/local-heavy-check-runtime.mts";
+import {
+  acquireLocalHeavyCheckLockSync,
+  withLocalHeavyCheckLockHeld,
+} from "./lib/local-heavy-check-runtime.mts";
 
 // Two concurrent plans halve the serial tail of packed jobs. Children run with
 // inner test-projects parallelism 1 so a job never exceeds two Vitest runs;
@@ -122,32 +125,30 @@ export function buildChildEnv(
     // races. The scratch fallback preserves per-plan isolation.
     [FS_MODULE_CACHE_PATH_ENV_KEY]: join(persistentCacheRoot || scratchDir, cacheDirectory),
     OPENCLAW_TEST_PROJECTS_PARALLEL: "1",
-    // This wrapper holds the repo heavy-check lock; children skipping it is
-    // what lets two plans run concurrently instead of serializing on the lock.
-    OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD: "1",
   };
-  if (entry.kind === "target") {
-    return childEnv;
-  }
-  const plan = entry.plan;
-  if (plan.shard_name) {
-    childEnv.OPENCLAW_VITEST_SHARD_NAME = plan.shard_name;
-  }
-  if (plan.env && typeof plan.env === "object" && !Array.isArray(plan.env)) {
-    for (const [key, value] of Object.entries(plan.env)) {
-      if (typeof value === "string") {
-        childEnv[key] = value;
+  if (entry.kind === "group") {
+    const plan = entry.plan;
+    if (plan.shard_name) {
+      childEnv.OPENCLAW_VITEST_SHARD_NAME = plan.shard_name;
+    }
+    if (plan.env && typeof plan.env === "object" && !Array.isArray(plan.env)) {
+      for (const [key, value] of Object.entries(plan.env)) {
+        if (typeof value === "string") {
+          childEnv[key] = value;
+        }
       }
     }
+    if (Array.isArray(plan.includePatterns) && plan.includePatterns.length > 0) {
+      const includeFile = join(scratchDir, `node-test-include-${index}.json`);
+      writeFileSync(includeFile, JSON.stringify(plan.includePatterns), "utf8");
+      childEnv.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
+    } else {
+      delete childEnv.OPENCLAW_VITEST_INCLUDE_FILE;
+    }
   }
-  if (Array.isArray(plan.includePatterns) && plan.includePatterns.length > 0) {
-    const includeFile = join(scratchDir, `node-test-include-${index}.json`);
-    writeFileSync(includeFile, JSON.stringify(plan.includePatterns), "utf8");
-    childEnv.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
-  } else {
-    delete childEnv.OPENCLAW_VITEST_INCLUDE_FILE;
-  }
-  return childEnv;
+  // This wrapper owns the shared lock, so every nested heavy-check wrapper must
+  // inherit that ownership rather than queueing behind its own parent.
+  return withLocalHeavyCheckLockHeld(childEnv);
 }
 
 export function pruneFsModuleCache(root: string, maxBytes = FS_MODULE_CACHE_MAX_BYTES) {

--- a/scripts/lib/local-heavy-check-runtime.mts
+++ b/scripts/lib/local-heavy-check-runtime.mts
@@ -60,6 +60,16 @@ export function resolveLocalHeavyCheckEnv(env: Env = process.env) {
   };
 }
 
+/** Mark every nested heavy-check wrapper as covered by one parent-held lock. */
+export function withLocalHeavyCheckLockHeld(env: Env): Env {
+  return {
+    ...env,
+    OPENCLAW_OXLINT_SKIP_LOCK: "1",
+    OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD: "1",
+    OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD: "1",
+  };
+}
+
 /** Resolve a repo tool from this worktree or the primary checkout's installed toolchain. */
 export function resolveRepoToolBinPath(
   toolName: string,

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -5,7 +5,10 @@ import fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import pMap from "p-map";
 import { formatMs } from "./lib/check-timing-summary.mts";
-import { acquireLocalHeavyCheckLockSync } from "./lib/local-heavy-check-runtime.mts";
+import {
+  acquireLocalHeavyCheckLockSync,
+  withLocalHeavyCheckLockHeld,
+} from "./lib/local-heavy-check-runtime.mts";
 import {
   isCiLikeEnv,
   resolveLocalFullSuiteProfile,
@@ -309,7 +312,7 @@ async function main() {
           baseEnv,
           cwd: process.cwd(),
         });
-  const runSpecs = applyDefaultMultiSpecVitestCachePaths(
+  let runSpecs = applyDefaultMultiSpecVitestCachePaths(
     applyDefaultVitestNoOutputTimeout(
       applyFullExtensionsHeapBudget(rawRunSpecs, { env: baseEnv }),
       {
@@ -325,13 +328,20 @@ async function main() {
     return;
   }
 
-  releaseLock = shouldAcquireLocalHeavyCheckLock(runSpecs, baseEnv)
+  const acquiresLocalHeavyCheckLock = shouldAcquireLocalHeavyCheckLock(runSpecs, baseEnv);
+  releaseLock = acquiresLocalHeavyCheckLock
     ? acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
         env: baseEnv,
         toolName: "test",
       })
     : () => {};
+  if (acquiresLocalHeavyCheckLock || baseEnv.OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD === "1") {
+    runSpecs = runSpecs.map((spec) => ({
+      ...spec,
+      env: withLocalHeavyCheckLockHeld(spec.env),
+    }));
+  }
 
   const isFullSuiteRun =
     targetArgs.length === 0 &&

--- a/test/scripts/ci-run-node-test-shard.test.ts
+++ b/test/scripts/ci-run-node-test-shard.test.ts
@@ -110,7 +110,9 @@ describe("scripts/ci-run-node-test-shard.mts", () => {
     expect(childEnv.IGNORED).toBeUndefined();
     expect(childEnv.OPENCLAW_VITEST_SHARD_NAME).toBe("g");
     expect(childEnv.OPENCLAW_TEST_PROJECTS_PARALLEL).toBe("1");
+    expect(childEnv.OPENCLAW_OXLINT_SKIP_LOCK).toBe("1");
     expect(childEnv.OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD).toBe("1");
+    expect(childEnv.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD).toBe("1");
     expect(childEnv.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH).toBe(
       path.join(scratchDir, "vitest-cache-3"),
     );

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForOxlint,
   shouldAcquireLocalHeavyCheckLockForTsgo,
+  withLocalHeavyCheckLockHeld,
 } from "../../scripts/lib/local-heavy-check-runtime.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -43,6 +44,18 @@ function makeEnv(overrides: Record<string, string | undefined> = {}) {
 }
 
 describe("local-heavy-check-runtime", () => {
+  it("marks every nested heavy-check wrapper as covered by the parent lock", () => {
+    const baseEnv = { BASE: "1" };
+
+    expect(withLocalHeavyCheckLockHeld(baseEnv)).toEqual({
+      BASE: "1",
+      OPENCLAW_OXLINT_SKIP_LOCK: "1",
+      OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD: "1",
+      OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD: "1",
+    });
+    expect(baseEnv).toEqual({ BASE: "1" });
+  });
+
   it("resolves repo tools from the primary checkout for dependency-less worktrees", () => {
     const primaryRoot = createTempDir("openclaw-primary-checkout-");
     const cwd = path.join(primaryRoot, ".codex", "worktrees", "task", "openclaw");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running package tests could see a nested compiler check wait on the heavy-check lock already held by the parent test process and then time out. Affected tests failed even though no competing heavy check was running.

## Why This Change Was Made

Parent heavy-check owners now pass the complete shared lock-ownership markers to every child process through one existing runtime helper. Nested tsgo, oxlint, and test wrappers therefore recognize that the parent already owns the lock instead of trying to reacquire it.

The change is limited to local/CI check orchestration and does not weaken cross-process serialization between independent top-level checks.

## User Impact

Developers and CI can run package tests that invoke nested compiler checks without false two-second lock timeouts or long self-deadlocks.

AI-assisted: yes. The implementation and validation were reviewed by the author, including two independent Codex autoreview passes with no findings.

## Evidence

Canonical pre-fix repro:

```text
OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS=2000 pnpm test packages/ai/src/package.e2e.test.ts
[tsgo] queued behind the local heavy-check lock held by test ...
Timed out waiting for .git/openclaw-local-checks/heavy-check.lock
```

Exact-head fixed-path proof:

```text
OPENCLAW_E2E_USE_PREBUILT_DIST=1 \
OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS=2000 \
node --import tsx scripts/test-projects.mts packages/ai/src/package.e2e.test.ts
✓ packages/ai/src/package.e2e.test.ts (2 tests)
```

Focused and pre-PR validation:

```text
pnpm vitest run --config vitest.config.ts \
  test/scripts/test-projects.test.ts \
  test/scripts/changed-lanes.test.ts \
  test/scripts/ci-run-node-test-shard.test.ts \
  test/scripts/local-heavy-check-runtime.test.ts
✓ 4 files, 465 tests

node scripts/run-tsgo.mjs --project tsconfig.scripts.json --pretty false
node scripts/run-tsgo.mjs --project tsconfig.json --pretty false
node scripts/check-changed.mjs
# completed successfully; changed-file lint/format plus targeted tests

git diff --check origin/main...HEAD
pnpm exec oxfmt --check <all changed files>
# passed
```
