### PR TITLE
fix(state): report v9 registry migration row decisions

### DIFF
--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -465,13 +465,20 @@ function isDefaultAgentDatabasePath(pathname: string, agentId: string): boolean 
   );
 }
 
+export type AgentDatabasePathMigrationSummary = {
+  relativized: number;
+  reanchored: string[];
+  deleted: string[];
+  preserved: number;
+};
+
 export function migrateAgentDatabaseRelativePaths(
   db: DatabaseSync,
   previousVersion: number,
   databasePath: string,
-): boolean {
+): AgentDatabasePathMigrationSummary {
   if (previousVersion >= 9 || !tableExists(db, "agent_databases")) {
-    return false;
+    return { relativized: 0, reanchored: [], deleted: [], preserved: 0 };
   }
   const rows = db.prepare("SELECT agent_id, path FROM agent_databases").all();
   const updatePath = db.prepare(
@@ -481,7 +488,9 @@ export function migrateAgentDatabaseRelativePaths(
   const hasPath = db.prepare(
     "SELECT 1 FROM agent_databases WHERE agent_id = ? AND path = ? LIMIT 1",
   );
-  let changed = false;
+  let relativized = 0;
+  const reanchored: string[] = [];
+  const deleted: string[] = [];
   for (const row of rows) {
     const agentId = row.agent_id;
     const registeredPath = row.path;
@@ -494,7 +503,7 @@ export function migrateAgentDatabaseRelativePaths(
     const storedPath = resolveOpenClawAgentDatabaseStoredPath(databasePath, registeredPath);
     if (!path.isAbsolute(storedPath)) {
       updatePath.run(storedPath, agentId, registeredPath);
-      changed = true;
+      relativized += 1;
     }
   }
   const stateDir = resolveOpenClawStateDirForDatabasePath(databasePath);
@@ -526,16 +535,21 @@ export function migrateAgentDatabaseRelativePaths(
         // The same agent already owns its in-root canonical registration. Keeping a second
         // default-layout registration guarantees duplicate canonical session keys on every list.
         deletePath.run(agentId, registeredPath);
-        changed = true;
+        deleted.push(registeredPath);
       } else if (existsSync(counterpartAbsolute)) {
         // Re-anchor a copied or moved state directory onto its copied database instead of
         // deleting the registration or leaving it dangling at the source root.
         updatePath.run(counterpartStored, agentId, registeredPath);
-        changed = true;
+        reanchored.push(registeredPath);
       }
     }
   }
-  return changed;
+  return {
+    relativized,
+    reanchored,
+    deleted,
+    preserved: rows.length - relativized - reanchored.length - deleted.length,
+  };
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {

--- a/src/state/openclaw-state-db.paths.ts
+++ b/src/state/openclaw-state-db.paths.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { isMainThread, threadId } from "node:worker_threads";
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { resolveStateDir } from "../config/paths.js";
-import type { AgentDatabasePathMigrationSummary } from "./openclaw-state-db-schema-repair.js";
 
 /**
  * Path helpers for the shared OpenClaw SQLite state database.
@@ -74,6 +73,12 @@ export function resolveOpenClawRegisteredAgentDatabasePath(
     : `${resolveOpenClawStateDirForDatabasePath(registryDatabasePath)}${path.sep}${storedPath}`;
 }
 
+type AgentPathMigrationObservation = {
+  relativized: number;
+  reanchored: string[];
+  deleted: string[];
+};
+
 type AgentPathMigrationLogger = {
   warn: (
     message: string,
@@ -81,7 +86,7 @@ type AgentPathMigrationLogger = {
   ) => void;
 };
 
-export function describeAgentPathMigration(summary: AgentDatabasePathMigrationSummary): string[] {
+export function describeAgentPathMigration(summary: AgentPathMigrationObservation): string[] {
   const { relativized, reanchored, deleted } = summary;
   if (relativized === 0 && reanchored.length === 0 && deleted.length === 0) {
     return [];
@@ -106,7 +111,7 @@ export function describeAgentPathMigration(summary: AgentDatabasePathMigrationSu
 
 export function warnAgentPathMigration(
   log: AgentPathMigrationLogger,
-  summary: AgentDatabasePathMigrationSummary,
+  summary: AgentPathMigrationObservation,
   databasePath: string,
 ): void {
   if (summary.reanchored.length === 0 && summary.deleted.length === 0) {

--- a/src/state/openclaw-state-db.paths.ts
+++ b/src/state/openclaw-state-db.paths.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isMainThread, threadId } from "node:worker_threads";
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { resolveStateDir } from "../config/paths.js";
+import type { AgentDatabasePathMigrationSummary } from "./openclaw-state-db-schema-repair.js";
 
 /**
  * Path helpers for the shared OpenClaw SQLite state database.
@@ -73,12 +74,6 @@ export function resolveOpenClawRegisteredAgentDatabasePath(
     : `${resolveOpenClawStateDirForDatabasePath(registryDatabasePath)}${path.sep}${storedPath}`;
 }
 
-type AgentPathMigrationObservation = {
-  relativized: number;
-  reanchored: string[];
-  deleted: string[];
-};
-
 type AgentPathMigrationLogger = {
   warn: (
     message: string,
@@ -86,7 +81,7 @@ type AgentPathMigrationLogger = {
   ) => void;
 };
 
-export function describeAgentPathMigration(summary: AgentPathMigrationObservation): string[] {
+export function describeAgentPathMigration(summary: AgentDatabasePathMigrationSummary): string[] {
   const { relativized, reanchored, deleted } = summary;
   if (relativized === 0 && reanchored.length === 0 && deleted.length === 0) {
     return [];
@@ -111,7 +106,7 @@ export function describeAgentPathMigration(summary: AgentPathMigrationObservatio
 
 export function warnAgentPathMigration(
   log: AgentPathMigrationLogger,
-  summary: AgentPathMigrationObservation,
+  summary: AgentDatabasePathMigrationSummary,
   databasePath: string,
 ): void {
   if (summary.reanchored.length === 0 && summary.deleted.length === 0) {

--- a/src/state/openclaw-state-db.paths.ts
+++ b/src/state/openclaw-state-db.paths.ts
@@ -72,3 +72,54 @@ export function resolveOpenClawRegisteredAgentDatabasePath(
     ? storedPath
     : `${resolveOpenClawStateDirForDatabasePath(registryDatabasePath)}${path.sep}${storedPath}`;
 }
+
+type AgentPathMigrationObservation = {
+  relativized: number;
+  reanchored: string[];
+  deleted: string[];
+};
+
+type AgentPathMigrationLogger = {
+  warn: (
+    message: string,
+    fields: { reanchored: string[]; deleted: string[]; path: string },
+  ) => void;
+};
+
+export function describeAgentPathMigration(summary: AgentPathMigrationObservation): string[] {
+  const { relativized, reanchored, deleted } = summary;
+  if (relativized === 0 && reanchored.length === 0 && deleted.length === 0) {
+    return [];
+  }
+  const decisions = reanchored.length + deleted.length;
+  const counts = [
+    `${relativized} relativized`,
+    reanchored.length > 0 && `${reanchored.length} re-anchored`,
+    deleted.length > 0 && `${deleted.length} removed`,
+  ].filter(Boolean);
+  return [
+    `Migrated agent database registry paths to state-relative storage${decisions > 0 ? ` (${counts.join(", ")})` : ""}`,
+    ...reanchored.map(
+      (registeredPath) =>
+        `Re-anchored agent database registry path ${registeredPath} to the current state directory`,
+    ),
+    ...deleted.map(
+      (registeredPath) => `Removed duplicate agent database registry path ${registeredPath}`,
+    ),
+  ];
+}
+
+export function warnAgentPathMigration(
+  log: AgentPathMigrationLogger,
+  summary: AgentPathMigrationObservation,
+  databasePath: string,
+): void {
+  if (summary.reanchored.length === 0 && summary.deleted.length === 0) {
+    return;
+  }
+  log.warn("agent database registry rows re-anchored or removed during v9 migration", {
+    reanchored: summary.reanchored,
+    deleted: summary.deleted,
+    path: databasePath,
+  });
+}

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1640,6 +1640,14 @@ describe("openclaw state database", () => {
       kind: "agent-databases-relative-paths-v9",
       path: databasePath,
     });
+    expect(repairOpenClawStateDatabaseSchema({ env })).toEqual({
+      changes: [
+        "Migrated agent database registry paths to state-relative storage (2 relativized, 1 re-anchored, 1 removed)",
+        `Re-anchored agent database registry path ${copiedForeignPath} to the current state directory`,
+        `Removed duplicate agent database registry path ${dualForeignPath}`,
+      ],
+      warnings: [],
+    });
     const migrated = openOpenClawStateDatabase({ env });
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(9);
     expect(

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -67,6 +67,7 @@ import {
 } from "./openclaw-state-db-schema-additive.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import {
+  type AgentDatabasePathMigrationSummary as AgentPathSummary,
   assertCanonicalStateSchemaShape,
   detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
   dropLegacyStateTables,
@@ -398,7 +399,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
         dropLegacyStateTables(db);
         migrateRetiredCommitmentsSchema(db, previousVersion);
         migrateWorkerPlacementExecutionModeSchema(db, previousVersion);
-        const agentPathMigration = migrateAgentPaths(db, previousVersion, pathname);
+        const pathMigration: AgentPathSummary = migrateAgentPaths(db, previousVersion, pathname);
         ensureAdditiveStateColumns(db);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
@@ -457,7 +458,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
             ),
         );
         assertOpenClawStateDatabaseForMaintenance(db, { pathname });
-        warnAgentPathMigration(stateDbLog, agentPathMigration, pathname);
+        warnAgentPathMigration(stateDbLog, pathMigration, pathname);
       },
       {
         busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -71,7 +71,7 @@ import {
   detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
   dropLegacyStateTables,
   markCurrentStateSchemaVersion,
-  migrateAgentDatabaseRelativePaths,
+  migrateAgentDatabaseRelativePaths as migrateAgentPaths,
   migrateRetiredCommitmentsSchema,
   migrateWorkerPlacementExecutionModeSchema,
   repairAgentDatabasesCompositePrimaryKey,
@@ -79,6 +79,7 @@ import {
 } from "./openclaw-state-db-schema-repair.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
+import { describeAgentPathMigration, warnAgentPathMigration } from "./openclaw-state-db.paths.js";
 import {
   assertOpenClawStateWriteAllowed,
   OpenClawStateOwnershipError,
@@ -204,9 +205,9 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
         if (migrateWorkerPlacementExecutionModeSchema(db, previousVersion)) {
           applied.push("Migrated cloud worker placements to execution modes");
         }
-        if (migrateAgentDatabaseRelativePaths(db, previousVersion, pathname)) {
-          applied.push("Migrated agent database registry paths to state-relative storage");
-        }
+        applied.push(
+          ...describeAgentPathMigration(migrateAgentPaths(db, previousVersion, pathname)),
+        );
         if (repairAgentDatabasesCompositePrimaryKey(db)) {
           applied.push(`Migrated shared state agent database registry primary key → agent_id,path`);
         }
@@ -397,7 +398,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
         dropLegacyStateTables(db);
         migrateRetiredCommitmentsSchema(db, previousVersion);
         migrateWorkerPlacementExecutionModeSchema(db, previousVersion);
-        migrateAgentDatabaseRelativePaths(db, previousVersion, pathname);
+        const agentPathMigration = migrateAgentPaths(db, previousVersion, pathname);
         ensureAdditiveStateColumns(db);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
@@ -456,6 +457,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
             ),
         );
         assertOpenClawStateDatabaseForMaintenance(db, { pathname });
+        warnAgentPathMigration(stateDbLog, agentPathMigration, pathname);
       },
       {
         busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,


### PR DESCRIPTION
## What Problem This Solves

State schema v9 made copied `agent_databases` registrations safe by relativizing, re-anchoring, deleting, or preserving rows during the v8→v9 migration. Those row-level decisions were silent: doctor reported only a generic migration line, and automatic runtime migration discarded the migration result entirely.

This is the maintainer-approved observability follow-up to #124728 (`4bc37cd5976`).

## Why This Change Was Made

`migrateAgentDatabaseRelativePaths` now returns the row-decision summary `{ relativized, reanchored, deleted, preserved }` while retaining the existing two-pass classification and mutation points.

Doctor renders the summary and names every original path it re-anchors or removes. Automatic runtime migration emits one structured `state/db` warning only when a row was re-anchored or removed. Pure relativization stays quiet at runtime.

No schema, configuration, or classification behavior changes. The observer formatting lives in the existing state-path owner so the already-large state DB and schema-repair modules remain below the lint ceiling; no helper file was added.

Production LOC: +80/-12 (net +68) | Tests: +8/-0. The production growth is the explicit operator-observability contract, structured summary, and bounded per-row evidence required for this migration.

## User Impact

Operators running `openclaw doctor --fix` now see how many registry paths were relativized, re-anchored, or removed and get one exact-path line for each re-anchor/removal. Automatic upgrades record the same higher-risk decisions in structured logs without warning for ordinary in-root relativization.

## Evidence

### Regression and validation

- Pre-fix focused regression failed because doctor returned only `Migrated agent database registry paths to state-relative storage`.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts src/state/openclaw-agent-db.test.ts src/config/sessions/startup-migration.registry-recovery.test.ts` — 253 unit tests + 2 startup-recovery tests passed, 5 skipped (one loaded-host rollback-journal timeout passed on isolated rerun; the complete command then passed on its single rerun).
- `pnpm build` — passed, including unified bundles, runtime postbuild, Plugin SDK checks, and Control UI build.
- Targeted oxlint on all four changed files — passed.
- `git diff --check` — passed.
- Autoreview against `origin/main` — clean, no accepted/actionable findings.

### Built CLI v8→v9 proof

The fixture uses three original absolute rows: one in-root, one foreign default-layout path with an in-root counterpart, and one foreign default-layout path without that counterpart. The preserved path is a symlink to a separate in-state SQLite file so later unrelated doctor media cleanup does not unregister the row after the v9 classifier preserves it.

```text
$ pnpm build
[build-all] tsdown-unified done
[build-all] runtime-postbuild done
✓ Control UI built

$ realpath "$STATE_DIR"; realpath "$FOREIGN_DIR"
/private/tmp/openclaw-v9-proof.gBNrzL
/private/tmp/openclaw-v9-proof-foreign.W27kTF

$ V9_STATE_DIR="$STATE_DIR" V9_FOREIGN_DIR="$FOREIGN_DIR" node --input-type=module -e '<seed current state schema, replace agent_databases with three absolute rows, set PRAGMA/schema_meta to 8>'
{
  "userVersion": 8,
  "schemaMeta": 8,
  "rows": [
    { "agent_id": "copied", "path": "/private/tmp/openclaw-v9-proof-foreign.W27kTF/agents/copied/agent/openclaw-agent.sqlite" },
    { "agent_id": "main", "path": "/private/tmp/openclaw-v9-proof.gBNrzL/agents/main/agent/openclaw-agent.sqlite" },
    { "agent_id": "preserved", "path": "/private/tmp/openclaw-v9-proof-foreign.W27kTF/agents/preserved/agent/openclaw-agent.sqlite" }
  ],
  "preservedCounterpartExists": false
}

$ OPENCLAW_STATE_DIR="$STATE_DIR" node openclaw.mjs doctor --fix --non-interactive --yes
◇  Doctor changes
│  - Migrated agent database registry paths to state-relative storage (1 relativized, 1 re-anchored)
│  - Re-anchored agent database registry path
│    /private/tmp/openclaw-v9-proof-foreign.W27kTF/agents/copied/agent/openclaw-agent.sqlite
│    to the current state directory

$ V9_STATE_DIR="$STATE_DIR" node --input-type=module -e '<read PRAGMA user_version, schema_meta, and agent_databases>'
{
  "userVersion": 9,
  "schemaMeta": 9,
  "rows": [
    { "agent_id": "copied", "path": "agents/copied/agent/openclaw-agent.sqlite" },
    { "agent_id": "main", "path": "agents/main/agent/openclaw-agent.sqlite" },
    { "agent_id": "preserved", "path": "/private/tmp/openclaw-v9-proof-foreign.W27kTF/agents/preserved/agent/openclaw-agent.sqlite" }
  ]
}
```
