### PR TITLE
fix(gateway): stop a plugin dangerous flag from revoking desktop computer.act

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -134,7 +134,7 @@ The result and `window-before.png` / `window-after.png` stay under the scratch d
 
 ### Windows and Linux (experimental, direct SDK)
 
-The bundled `cua-computer` plugin provides an experimental fulfiller for Windows and Linux node hosts. It is disabled by default and uses the pinned CUA Driver SDK 0.19.3 contract directly:
+The bundled `cua-computer` plugin provides an experimental fulfiller for Windows and Linux node hosts. It is disabled by default on those platforms (macOS enables it by default for the CUA fulfiller above) and uses the pinned CUA Driver SDK 0.19.3 contract directly:
 
 1. Enable the plugin:
 
@@ -152,17 +152,17 @@ The bundled `cua-computer` plugin provides an experimental fulfiller for Windows
 
 3. Start `openclaw node run` from the interactive desktop session. The plugin repeats the artifact verification at startup before it imports native code, creates its configured SDK runtime lazily, then creates separate fixed window- and desktop-scoped trusted sessions for each provider execution. `escalate_scope` reads the already-desktop session state, so the window identity remains immutable. Completion, cancellation, Gateway disconnect, provider switching, local Stop, and command-host shutdown all close that exact execution, finalize or discard its recording resources, close both sessions, and shut down its runtime.
 
-4. Add `computer.act` to the Gateway allowlist. This plugin registers `computer.act` as a dangerous plugin node command, so enabling the plugin alone is not enough; the operator must opt in explicitly:
+4. Approve the pairing update that includes `computer.act`. Desktop `computer.act` is a built-in platform default, so plugin enablement plus that approval is the whole grant; no `gateway.nodes.commands.allow` entry is required. An operator who wants the command off can deny it:
 
    ```json5
    {
      gateway: {
-       nodes: { commands: { allow: ["computer.act"] } },
+       nodes: { commands: { deny: ["computer.act"] } },
      },
    }
    ```
 
-   Without this entry, `node.invoke` rejects `computer.act` even though the node advertises it.
+   A denied command is withheld from the node's advertised surface together with its `computer` capability, and the Gateway logs which commands it withheld.
 
 This fulfiller currently controls only the primary display. `hold_key`, `left_mouse_down`, and `left_mouse_up` are unavailable because the CUA Driver SDK has no desktop-scope held-input contract. Modifier-held clicks, scrolling, and dragging are rejected because the typed desktop methods do not accept modifiers. The `key` action accepts named keys, letters, and modifier combos (for example `cmd+c` or `Return`); digit and punctuation keys are rejected because the driver drops their layout-dependent shift state, so send that text through the `type` action instead. Cancellation is passed to the SDK for each node invocation.
 
@@ -220,7 +220,7 @@ Once the node-local control is enabled and the pairing update is approved, `comp
 
 On macOS, default-on means a paired gateway can drive pointer and keyboard input as soon as the required macOS grants exist. There is no per-action confirmation. Turn off **Allow Computer Control** before pairing, or at any later time, to stop advertising and accepting `computer.act`.
 
-`gateway.nodes.commands.deny` remains an explicit global revocation and always wins. The native macOS Peekaboo fulfiller does not need a `gateway.nodes.commands.allow` entry. CUA registers `computer.act` as a dangerous plugin node command on every platform, so selecting CUA on macOS or enabling the plugin on Windows/Linux also requires an explicit `gateway.nodes.commands.allow` entry. An authenticated operator with `operator.write` can invoke an enabled, paired command through `node.invoke`; there is no per-action admin check.
+`gateway.nodes.commands.deny` remains an explicit global revocation and always wins; a denied `computer.act` is withheld from the node's advertised surface together with its `computer` capability, and the Gateway records what it withheld. No fulfiller needs a `gateway.nodes.commands.allow` entry: `computer.act` is a built-in desktop platform default, so node-local enablement plus pairing approval is the whole grant on every platform and for either fulfiller. An authenticated operator with `operator.write` can invoke an enabled, paired command through `node.invoke`; there is no per-action admin check.
 
 ## Safety
 

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
   resolveNodePairingCommandAllowlist,
+  retainFulfilledNodeCapabilities,
 } from "./node-command-policy.js";
 import {
   filterLegacyNodeProtocolFeatures,
@@ -782,50 +783,53 @@ describe("gateway/node-command-policy", () => {
     expect(resolveNodeCommandAllowlist(cfg, macNode).has("computer.act")).toBe(false);
   });
 
-  it("requires an explicit allow for the dangerous cua-computer plugin command", () => {
+  it("scopes a plugin dangerous flag to plugin surfaces, not core platform defaults", () => {
+    // A bundled computer-use provider plugin registers computer.act as dangerous
+    // so it needs a registered invoke policy. That flag must not revoke the core
+    // desktop platform default, whose grant is node enablement plus pairing.
     const registry = createEmptyPluginRegistry();
-    registry.nodeHostCommands.push({
-      pluginId: "cua-computer",
-      pluginName: "CUA Computer",
-      source: "/extensions/cua-computer/index.ts",
-      rootDir: "/extensions/cua-computer",
-      command: {
-        command: "computer.act",
-        cap: "computer",
-        dangerous: true,
-        handle: async () => "{}",
-      },
-    });
-    registry.nodeInvokePolicies.push({
-      pluginId: "cua-computer",
-      pluginName: "CUA Computer",
-      source: "/extensions/cua-computer/index.ts",
-      rootDir: "/extensions/cua-computer",
-      pluginConfig: {},
-      policy: {
-        commands: ["computer.act"],
-        dangerous: true,
-        handle: async (ctx) => await ctx.invokeNode(),
-      },
-    });
+    for (const command of ["computer.act", "cua.driver.reset"]) {
+      registry.nodeHostCommands.push({
+        pluginId: "cua-computer",
+        pluginName: "CUA Computer",
+        source: "/extensions/cua-computer/index.ts",
+        rootDir: "/extensions/cua-computer",
+        command: {
+          command,
+          cap: "computer",
+          dangerous: true,
+          agentTool: {
+            name: command.replaceAll(".", "_"),
+            description: "Computer surface",
+            defaultPlatforms: ["windows"],
+          },
+          handle: async () => "{}",
+        },
+      });
+      registry.nodeInvokePolicies.push({
+        pluginId: "cua-computer",
+        pluginName: "CUA Computer",
+        source: "/extensions/cua-computer/index.ts",
+        rootDir: "/extensions/cua-computer",
+        pluginConfig: {},
+        policy: {
+          commands: [command],
+          dangerous: true,
+          handle: async (ctx) => await ctx.invokeNode(),
+        },
+      });
+    }
     setActivePluginRegistry(registry);
 
     const node = {
       platform: "windows",
       deviceFamily: "Windows",
-      commands: ["computer.act"],
-      approvedCommands: ["computer.act"],
+      commands: ["computer.act", "cua.driver.reset"],
+      approvedCommands: ["computer.act", "cua.driver.reset"],
     };
-    expect(resolveNodeCommandAllowlist({} as OpenClawConfig, node).has("computer.act")).toBe(false);
-
-    const allowlist = resolveNodeCommandAllowlist(
-      {
-        gateway: {
-          nodes: { commands: { allow: ["computer.act"] } },
-        },
-      } as OpenClawConfig,
-      node,
-    );
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, node);
+    expect(allowlist.has("computer.act")).toBe(true);
+    expect(allowlist.has("cua.driver.reset")).toBe(false);
     expect(
       isNodeCommandAllowed({
         command: "computer.act",
@@ -833,6 +837,42 @@ describe("gateway/node-command-policy", () => {
         allowlist,
       }),
     ).toEqual({ ok: true });
+
+    const opted = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: { commands: { allow: ["cua.driver.reset"] } },
+        },
+      } as OpenClawConfig,
+      node,
+    );
+    expect(opted.has("cua.driver.reset")).toBe(true);
+  });
+
+  it("drops a capability whose declared commands all failed the allowlist", () => {
+    const denied = resolveNodePairingCommandAllowlist(
+      { gateway: { nodes: { commands: { deny: ["computer.act"] } } } } as OpenClawConfig,
+      { platform: "macos", deviceFamily: "Mac", commands: ["computer.act", "screen.snapshot"] },
+    );
+    expect(
+      retainFulfilledNodeCapabilities({
+        caps: ["canvas", "screen", "computer"],
+        withheldCommands: ["computer.act"],
+        admittedCommands: normalizeDeclaredNodeCommands({
+          declaredCommands: ["computer.act", "screen.snapshot"],
+          allowlist: denied,
+        }),
+      }),
+    ).toEqual(["canvas", "screen"]);
+
+    // A capability the node never backed with a core-owned command is untouched.
+    expect(
+      retainFulfilledNodeCapabilities({
+        caps: ["computer"],
+        admittedCommands: [],
+        withheldCommands: [],
+      }),
+    ).toEqual(["computer"]);
   });
 
   it("allows node-enabled and paired mobile UI without a persistent allow", () => {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -408,7 +408,16 @@ function resolveNodeCommandAllowlistInternal(
   });
   const extra = cfg.gateway?.nodes?.commands?.allow ?? [];
   const deny = new Set(cfg.gateway?.nodes?.commands?.deny ?? []);
-  const dangerousPluginCommands = new Set(listDangerousPluginNodeCommands());
+  // A plugin `dangerous` flag governs the surface that plugin contributes
+  // (listDefaultPluginNodeCommands) and forces a registered invoke policy. It is
+  // not authority to revoke a command core itself declares in PLATFORM_DEFAULTS,
+  // whose grant chain is node-local enablement plus pairing approval. Letting it
+  // do so disabled desktop `computer.act` on every Gateway that auto-starts a
+  // bundled computer-use provider plugin.
+  const baseCommands = new Set(base);
+  const dangerousPluginCommands = new Set(
+    listDangerousPluginNodeCommands().filter((command) => !baseCommands.has(command)),
+  );
   // Dangerous built-ins that also appear in PLATFORM_DEFAULTS stay declarable
   // at pairing but do not enter the runtime allowlist by default.
   const dangerousBuiltinCommands =
@@ -493,6 +502,33 @@ export function normalizeDeclaredNodeCommands(params: {
   return normalizeDeclaredCommands(params.declaredCommands).filter((command) =>
     params.allowlist.has(command),
   );
+}
+
+// Capability and command are one advertisement: a node offers `computer` because
+// it can run `computer.act`. Keeping the capability after policy withheld every
+// command that fulfills it yields a surface that reads as available and then
+// rejects every invoke. Families core does not own here stay untouched.
+const CAPABILITY_COMMAND_FAMILIES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["camera", new Set([...CAMERA_COMMANDS, ...MAC_CAMERA_COMMANDS, ...CAMERA_DANGEROUS_COMMANDS])],
+  ["computer", new Set(COMPUTER_COMMANDS)],
+  ["location", new Set(MOBILE_NODE_COMMANDS.location)],
+  ["screen", new Set([...SCREEN_COMMANDS, ...SCREEN_DANGEROUS_COMMANDS])],
+]);
+
+/** Drops capabilities whose commands policy withheld without admitting a sibling. */
+export function retainFulfilledNodeCapabilities(params: {
+  caps: readonly string[];
+  admittedCommands: readonly string[];
+  withheldCommands: readonly string[];
+}): string[] {
+  return params.caps.filter((capability) => {
+    const family = CAPABILITY_COMMAND_FAMILIES.get(capability);
+    return (
+      !family ||
+      !params.withheldCommands.some((command) => family.has(command)) ||
+      params.admittedCommands.some((command) => family.has(command))
+    );
+  });
 }
 
 export function isNodeCommandAllowed(params: {

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import type { NodePairingRequestInput, PairedDeviceNode } from "../infra/device-pairing-node.js";
+import { registerComputerUseProvider } from "../plugins/computer-use-contract.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { resolveEffectiveComputerUseDescriptor } from "./node-computer-use-descriptor.js";
@@ -256,6 +257,118 @@ describe("reconcileNodePairingOnConnect", () => {
       }),
     ).toEqual(computerUseDescriptor());
     expect(result.shouldClearPendingPairings).toBe(true);
+  });
+
+  it("keeps an approved computer.act surface effective while a computer-use provider plugin is active", async () => {
+    // Reproduces a default macOS Gateway: the bundled computer-use provider plugin
+    // auto-starts there, so its own registrations are in the active registry while
+    // a native macOS node reconnects on an already-approved desktop surface.
+    const registry = createEmptyPluginRegistry();
+    registerComputerUseProvider(
+      {
+        registerNodeHostCommand: (command) => {
+          registry.nodeHostCommands.push({
+            pluginId: "cua-computer",
+            pluginName: "CUA Computer",
+            source: "/extensions/cua-computer/index.ts",
+            rootDir: "/extensions/cua-computer",
+            command,
+          });
+        },
+      },
+      {
+        id: "fixture",
+        label: "Fixture",
+        capabilities: () => computerUseDescriptor(),
+        isAvailable: () => true,
+        openExecution: () => {
+          throw new Error("unused");
+        },
+      },
+    );
+    registry.nodeInvokePolicies.push({
+      pluginId: "cua-computer",
+      pluginName: "CUA Computer",
+      source: "/extensions/cua-computer/index.ts",
+      rootDir: "/extensions/cua-computer",
+      pluginConfig: {},
+      policy: {
+        commands: ["computer.act"],
+        dangerous: true,
+        handle: async (ctx) => await ctx.invokeNode(),
+      },
+    });
+    setActivePluginRegistry(registry);
+    const requestPairing = vi.fn();
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "test",
+          platform: "macos",
+          deviceFamily: "Mac",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+        caps: ["screen", "computer"],
+        commands: ["screen.snapshot", "computer.act"],
+        computerUse: computerUseDescriptor(),
+      }),
+      pairedNode: makePairedNode({
+        caps: ["screen", "computer"],
+        commands: ["screen.snapshot", "computer.act"],
+      }),
+      requestPairing,
+    });
+
+    expect(requestPairing).not.toHaveBeenCalled();
+    expect(result.declaredCommands).toEqual(["screen.snapshot", "computer.act"]);
+    expect(result.effectiveCommands).toEqual(["screen.snapshot", "computer.act"]);
+    expect(result.declaredCaps).toEqual(["screen", "computer"]);
+    expect(result.effectiveCaps).toEqual(["screen", "computer"]);
+    expect(
+      resolveEffectiveComputerUseDescriptor({
+        commands: result.effectiveCommands,
+        declared: result.declaredComputerUse,
+      }),
+    ).toEqual(computerUseDescriptor());
+  });
+
+  it("drops a capability whose declared commands were all filtered by policy", async () => {
+    // Capability and command are one advertisement. An operator deny that removes
+    // every declared computer command must remove the capability with it instead
+    // of leaving a surface that reads as available and rejects every invoke.
+    const requestPairing = makePendingPairingRequest("req-denied-computer");
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {
+        gateway: { nodes: { commands: { deny: ["computer.act"] } } },
+      } as never,
+      connectParams: makeNodeConnectParams({
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "test",
+          platform: "macos",
+          deviceFamily: "Mac",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+        caps: ["screen", "computer"],
+        commands: ["screen.snapshot", "computer.act"],
+        computerUse: computerUseDescriptor(),
+      }),
+      pairedNode: makePairedNode({
+        caps: ["screen", "computer"],
+        commands: ["screen.snapshot"],
+      }),
+      requestPairing,
+    });
+
+    expect(result.declaredCommands).toEqual(["screen.snapshot"]);
+    expect(result.declaredCaps).toEqual(["screen"]);
+    expect(result.effectiveCaps).toEqual(["screen"]);
+    expect(result.withheldCommands).toEqual(["computer.act"]);
+    expect(requestPairing).not.toHaveBeenCalled();
   });
 
   it("requests pairing when a macOS node first declares computer.act", async () => {

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -8,7 +8,10 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import type { NodePairingRequestInput, PairedDeviceNode } from "../infra/device-pairing-node.js";
-import { registerComputerUseProvider } from "../plugins/computer-use-contract.js";
+import {
+  registerComputerUseProvider,
+  type ComputerUseCapabilityDescriptor,
+} from "../plugins/computer-use-contract.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { resolveEffectiveComputerUseDescriptor } from "./node-computer-use-descriptor.js";
@@ -46,7 +49,7 @@ function makePendingPairingRequest(requestId: string) {
   }));
 }
 
-function computerUseDescriptor() {
+function computerUseDescriptor(): ComputerUseCapabilityDescriptor {
   return {
     contractVersion: 2 as const,
     provider: { id: "fixture", label: "Fixture", generation: "generation-1" },

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -8,6 +8,7 @@ import type {
   RequestNodePairingResult,
 } from "../infra/device-pairing-node.js";
 import { normalizeNodeApprovalSurfaceList } from "../infra/node-pairing-surface.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   parseComputerUseCapabilityDescriptor,
   type ComputerUseCapabilityDescriptor,
@@ -15,7 +16,10 @@ import {
 import {
   normalizeDeclaredNodeCommands,
   resolveNodePairingCommandAllowlist,
+  retainFulfilledNodeCapabilities,
 } from "./node-command-policy.js";
+
+const log = createSubsystemLogger("gateway/node-connect");
 
 // Node connect reconciliation turns declared caps/commands/permissions into the
 // effective runtime surface. New or upgraded surfaces create a pending pairing
@@ -26,6 +30,8 @@ type NodeConnectPairingReconcileResult = {
   effectiveCaps: string[];
   declaredCommands: string[];
   effectiveCommands: string[];
+  /** Commands the node declared that gateway policy refused to admit. */
+  withheldCommands: string[];
   declaredComputerUse?: ComputerUseCapabilityDescriptor;
   declaredPermissions?: Record<string, boolean>;
   effectivePermissions?: Record<string, boolean>;
@@ -142,13 +148,23 @@ export async function reconcileNodePairingOnConnect(params: {
     commands: params.connectParams.commands,
   };
   const pairingAllowlist = resolveNodePairingCommandAllowlist(params.cfg, policyNode);
+  const connectCommands = normalizeNodeApprovalSurfaceList(params.connectParams.commands);
   const declared = normalizeDeclaredNodeCommands({
-    declaredCommands: Array.isArray(params.connectParams.commands)
-      ? params.connectParams.commands
-      : [],
+    declaredCommands: connectCommands,
     allowlist: pairingAllowlist,
   });
-  const declaredCaps = normalizeNodeApprovalSurfaceList(params.connectParams.caps);
+  // Caps and commands arrive as one advertisement and must stay one after policy,
+  // or the node reads as capable and rejects every invoke. Refusing a declared
+  // command is an operator-visible decision, so it is recorded where it happens.
+  const withheldCommands = connectCommands.filter((command) => !declared.includes(command));
+  const declaredCaps = retainFulfilledNodeCapabilities({
+    caps: normalizeNodeApprovalSurfaceList(params.connectParams.caps),
+    admittedCommands: declared,
+    withheldCommands,
+  });
+  if (withheldCommands.length > 0) {
+    log.warn(`node command surface withheld node=${nodeId} commands=${withheldCommands.join(",")}`);
+  }
   const declaredPermissions = normalizePermissionMap(params.connectParams.permissions);
   const declaredComputerUse =
     params.connectParams.computerUse === undefined
@@ -176,6 +192,7 @@ export async function reconcileNodePairingOnConnect(params: {
       effectiveCaps: [],
       declaredCommands: declared,
       effectiveCommands: [],
+      withheldCommands,
       ...(declaredComputerUse ? { declaredComputerUse } : {}),
       declaredPermissions,
       effectivePermissions: undefined,
@@ -232,6 +249,7 @@ export async function reconcileNodePairingOnConnect(params: {
       effectiveCaps: effectiveApprovedDeclaredCaps,
       declaredCommands: declared,
       effectiveCommands: effectiveApprovedDeclaredCommands,
+      withheldCommands,
       ...(declaredComputerUse ? { declaredComputerUse } : {}),
       declaredPermissions,
       effectivePermissions: effectiveApprovedDeclaredPermissions,
@@ -245,6 +263,7 @@ export async function reconcileNodePairingOnConnect(params: {
     effectiveCaps: declaredCaps,
     declaredCommands: declared,
     effectiveCommands: declared,
+    withheldCommands,
     ...(declaredComputerUse ? { declaredComputerUse } : {}),
     declaredPermissions,
     effectivePermissions: declaredPermissions,


### PR DESCRIPTION
## What Problem This Solves

Computer use is unavailable across every connected desktop node. No node advertises `computer.act`, so the built-in `computer` agent tool — whose eligibility requires both `computer.act` and `screen.snapshot` — is gated off everywhere. Node records show the `computer` capability present, `computer.act` absent, and no `computerUse` descriptor. Correctly configured Macs (Computer Control enabled, Peekaboo provider, Accessibility and Screen Recording granted) are affected. Older pairing rows created before 2026.8 still carry `computer.act`, so this is a regression, not a missing feature.

The macOS node is not at fault. `MacNodeModeCoordinator.resolvedCommands` appends `OpenClawComputerCommand.act` whenever `resolvedCaps` produced the `computer` capability, and the connect frame merges both from the same snapshot, so cap-present implies command-present in every frame the node sends.

The Gateway drops it. `resolveNodeCommandAllowlistInternal` (`src/gateway/node-command-policy.ts`) subtracts every plugin-declared dangerous command from the composed allowlist — after `base` is built from `PLATFORM_DEFAULTS`, and with no exemption even in the pairing allowlist, where core's own dangerous defaults *are* exempted. `computer.act` is simultaneously a core desktop platform default (`COMPUTER_COMMANDS`, `PLATFORM_DEFAULTS.macos/windows/linux`, grant chain = node-local enablement + pairing approval) and a plugin-declared dangerous command: `registerComputerUseProvider` registers it with `dangerous: true` (`src/plugins/computer-use-contract.ts:670`) and `cua-computer` registers a matching dangerous invoke policy.

`cua-computer` carries `"enabledByDefaultOnPlatforms": ["darwin"]`, added by #123635. Since that landed, every macOS-hosted Gateway auto-starts the plugin, `listDangerousPluginNodeCommands()` returns `computer.act`, and it is stripped from both the runtime and the pairing allowlist. `normalizeDeclaredNodeCommands` in `node-connect-reconcile.ts` then removes it from the node's declaration entirely — so no pairing upgrade is detected, no prompt is raised, and nothing is recorded. Capabilities are not allowlist-filtered, so the `computer` capability survives, and `resolveEffectiveComputerUseDescriptor` drops the descriptor because `computer.act` is missing. That reproduces all four observed columns exactly.

## Why This Change Was Made

Two separate defects, fixed at their owners.

**Plugin `dangerous` is not authority over core platform defaults.** The flag has two jobs: keep a plugin's own command out of the default plugin allowlist (`listDefaultPluginNodeCommands`, which already filters it), and force a registered risk-classifying invoke policy (`node-invoke-plugin-policy.ts` fails closed without one). Neither requires revoking a command core itself declares in `PLATFORM_DEFAULTS`. The allowlist subtraction is now scoped to commands outside that base, so a plugin still gates its own dangerous surface behind `gateway.nodes.commands.allow` while the desktop `computer.act` default keeps its documented grant chain. Operator `deny` still wins.

**A capability and its commands are one advertisement.** The reconciler filtered commands and passed capabilities through untouched, so cap-without-command was representable — a node that reads as capable and rejects every invoke, with no recorded reason. That is this repo's worst bug class, and it is why the failure was invisible for two weeks. `retainFulfilledNodeCapabilities` now drops a capability when policy withheld commands from its family and admitted none, using core's existing command-family groupings; capabilities core owns no family for are untouched, so only a declared-then-withheld family loses its capability. Withheld commands are recorded by the reconciler itself, so both the WebSocket node transport and the watch HTTP transport get the same record from one owner.

## User Impact

Desktop computer use works again out of the box: an enabled, paired macOS/Windows/Linux node advertises `computer.act` and its `computerUse` descriptor, and the `computer` agent tool becomes available. No config change or reconnect ritual is required beyond restarting the Gateway.

`gateway.nodes.commands.allow: ["computer.act"]` is no longer needed on Windows/Linux with the `cua-computer` plugin; existing entries keep working. `deny` is unchanged and still removes the command — and now removes the `computer` capability with it instead of leaving a capability that rejects every invoke. The Gateway logs the exact commands it withheld from a connecting node.

Docs updated: `docs/nodes/computer-use.md` no longer instructs operators to add the allowlist entry, and states the plugin's real default-enablement.

## Evidence

Regression coverage fails on pre-fix code for the intended reason. Both new cases in `src/gateway/node-connect-reconcile.test.ts` exercise the connect-frame reconciliation boundary — the pairing allowlist, the plugin registry, and command normalization together — not `resolvedCaps`/`resolvedCommands` in isolation, which is exactly why the existing suite (which ran with an empty plugin registry) never caught this.

Pre-fix on `main`:

```
FAIL  keeps an approved computer.act surface effective while a computer-use provider plugin is active
  expected [ 'screen.snapshot' ] to deeply equal [ 'screen.snapshot', 'computer.act' ]
FAIL  drops a capability whose declared commands were all filtered by policy
  expected [ 'screen', 'computer' ] to deeply equal [ 'screen' ]
```

The first registers the real `registerComputerUseProvider` registrations into the active registry (the `dangerous: true` flag comes from production code, not a test literal) to reproduce a default macOS Gateway. The second proves the capability/command atomicity invariant under an operator `deny`.

`src/gateway/node-command-policy.test.ts` gained a helper-level case for the new invariant, and the test that encoded the bug ("requires an explicit allow for the dangerous cua-computer plugin command") was rewritten to assert the correct ownership split: a plugin-owned dangerous command still needs an explicit allow, a core platform default that a plugin also marks dangerous stays admitted.

No Swift change: the node already guarantees cap ⇒ command within a connect frame; the invariant broke on the Gateway.

Production LOC delta: +60/-5 (net +55), all in `src/gateway/node-command-policy.ts` and `src/gateway/node-connect-reconcile.ts`; tests +188/-35, docs +4/-4. The growth is the capability/command atomicity invariant and its recorded reason — a new ownership boundary that did not exist, not a guard bolted onto the old one. The root-cause fix itself is a 3-line scoping change. There is no smaller expression: without the family relation the Gateway cannot tell that a withheld command orphaned a capability, and the silent failure returns the next time any policy path filters a declared command.
