### PR TITLE
refactor: replace assertion chains with typed fixture builders (wave 2)

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -812,17 +812,17 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("preserves the most recent user/assistant messages", () => {
     const messages: AgentMessage[] = [
       { role: "user", content: "older ask", timestamp: 1 },
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "older answer" }],
         timestamp: 2,
-      } as unknown as AgentMessage,
+      }),
       { role: "user", content: "recent ask", timestamp: 3 },
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "recent answer" }],
         timestamp: 4,
-      } as unknown as AgentMessage,
+      }),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -840,36 +840,36 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("drops orphaned tool results from preserved assistant turns", () => {
     const messages: AgentMessage[] = [
       { role: "user", content: "older ask", timestamp: 1 },
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "toolCall", id: "call_old", name: "read", arguments: {} }],
         timestamp: 2,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "toolResult",
         toolCallId: "call_old",
         toolName: "read",
         content: [{ type: "text", text: "old result" }],
         timestamp: 3,
-      } as unknown as AgentMessage,
+      }),
       { role: "user", content: "recent ask", timestamp: 4 },
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "toolCall", id: "call_recent", name: "read", arguments: {} }],
         timestamp: 5,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "toolResult",
         toolCallId: "call_recent",
         toolName: "read",
         content: [{ type: "text", text: "recent result" }],
         timestamp: 6,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "recent final answer" }],
         timestamp: 7,
-      } as unknown as AgentMessage,
+      }),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -901,29 +901,29 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const split = splitPreservedRecentTurns({
       messages: [
         { role: "user", content: "older ask", timestamp: 1 },
-        {
+        castAgentMessage({
           role: "assistant",
           content: [{ type: "text", text: "older answer" }],
           timestamp: 2,
-        } as unknown as AgentMessage,
+        }),
         { role: "user", content: "recent ask", timestamp: 3 },
-        {
+        castAgentMessage({
           role: "assistant",
           content: [{ type: "toolCall", id: "call_recent", name: "read", arguments: {} }],
           timestamp: 4,
-        } as unknown as AgentMessage,
-        {
+        }),
+        castAgentMessage({
           role: "toolResult",
           toolCallId: "call_recent",
           toolName: "read",
           content: [{ type: "text", text: "recent raw output" }],
           timestamp: 5,
-        } as unknown as AgentMessage,
-        {
+        }),
+        castAgentMessage({
           role: "assistant",
           content: [{ type: "text", text: "recent final answer" }],
           timestamp: 6,
-        } as unknown as AgentMessage,
+        }),
       ],
       recentTurnsPreserve: 1,
     });
@@ -943,27 +943,26 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const split = splitPreservedRecentTurns({
       messages: [
         { role: "user", content: "recent ask", timestamp: 1 },
-        { role: "assistant", content: toolCalls, timestamp: 2 } as unknown as AgentMessage,
-        ...toolCalls.map(
-          (toolCall, index) =>
-            ({
-              role: "toolResult",
-              toolCallId: toolCall.id,
-              toolName: "read",
-              content: [
-                {
-                  type: "text",
-                  text: `paired-result-${String(index).padStart(2, "0")}-${"x".repeat(700)}`,
-                },
-              ],
-              timestamp: index + 3,
-            }) as unknown as AgentMessage,
+        castAgentMessage({ role: "assistant", content: toolCalls, timestamp: 2 }),
+        ...toolCalls.map((toolCall, index) =>
+          castAgentMessage({
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: "read",
+            content: [
+              {
+                type: "text",
+                text: `paired-result-${String(index).padStart(2, "0")}-${"x".repeat(700)}`,
+              },
+            ],
+            timestamp: index + 3,
+          }),
         ),
-        {
+        castAgentMessage({
           role: "assistant",
           content: [{ type: "text", text: "terminal answer survives" }],
           timestamp: 33,
-        } as unknown as AgentMessage,
+        }),
       ],
       recentTurnsPreserve: 1,
     });
@@ -981,16 +980,16 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("formats preserved non-text messages with placeholders", () => {
     const section = preservedTurnsText([
-      {
+      castAgentMessage({
         role: "user",
         content: [{ type: "image", data: "abc", mimeType: "image/png" }],
         timestamp: 1,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "toolCall", id: "call_recent", name: "read", arguments: {} }],
         timestamp: 2,
-      } as unknown as AgentMessage,
+      }),
     ]);
 
     expect(section).toContain("- User: [non-text content: image]");
@@ -999,14 +998,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("keeps non-text placeholders for mixed-content preserved messages", () => {
     const section = preservedTurnsText([
-      {
+      castAgentMessage({
         role: "user",
         content: [
           { type: "text", text: "caption text" },
           { type: "image", data: "abc", mimeType: "image/png" },
         ],
         timestamp: 1,
-      } as unknown as AgentMessage,
+      }),
     ]);
 
     expect(section).toContain("- User: caption text");
@@ -1027,11 +1026,11 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("does not add non-text placeholders for text-only content blocks", () => {
     const section = preservedTurnsText([
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "plain text reply" }],
         timestamp: 1,
-      } as unknown as AgentMessage,
+      }),
     ]);
 
     expect(section).toContain("- Assistant: plain text reply");
@@ -1041,46 +1040,46 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("caps preserved tail when user turns are below preserve target", () => {
     const messages: AgentMessage[] = [
       { role: "user", content: "single user prompt", timestamp: 1 },
-      {
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-1" }],
         timestamp: 2,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-2" }],
         timestamp: 3,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-3" }],
         timestamp: 4,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-4" }],
         timestamp: 5,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-5" }],
         timestamp: 6,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-6" }],
         timestamp: 7,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-7" }],
         timestamp: 8,
-      } as unknown as AgentMessage,
-      {
+      }),
+      castAgentMessage({
         role: "assistant",
         content: [{ type: "text", text: "assistant-8" }],
         timestamp: 9,
-      } as unknown as AgentMessage,
+      }),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -1934,7 +1933,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
         ],
         turnPrefixMessages: [],
         firstKeptEntryId: "entry-1",
@@ -2278,14 +2277,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          {
+          castAgentMessage({
             role: "custom",
             customType: "openclaw.runtime-context",
             content: "secret runtime context",
             display: false,
             timestamp: 1.5,
-          } as unknown as AgentMessage,
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          }),
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: preservedUserText, timestamp: 3 },
         ],
         turnPrefixMessages: [],
@@ -2377,13 +2376,13 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: "latest ask status", timestamp: 3 },
-          {
+          castAgentMessage({
             role: "assistant",
             content: "latest assistant reply",
             timestamp: 4,
-          } as unknown as AgentMessage,
+          }),
         ],
         turnPrefixMessages: [],
         firstKeptEntryId: "entry-1",
@@ -2440,13 +2439,13 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: "latest ask status", timestamp: 3 },
-          {
+          castAgentMessage({
             role: "assistant",
             content: [{ type: "text", text: "latest assistant reply" }],
             timestamp: 4,
-          } as unknown as AgentMessage,
+          }),
         ],
         turnPrefixMessages: [
           { role: "user", content: "prefix request that was split out", timestamp: 0 },
@@ -2505,11 +2504,11 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "latest user ask", timestamp: 1 },
-          {
+          castAgentMessage({
             role: "assistant",
             content: [{ type: "text", text: "latest assistant reply" }],
             timestamp: 2,
-          } as unknown as AgentMessage,
+          }),
         ],
         turnPrefixMessages: [],
         firstKeptEntryId: "entry-1",
@@ -2642,7 +2641,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
         ],
         turnPrefixMessages: [] as AgentMessage[],
         firstKeptEntryId: "entry-1",
@@ -2734,7 +2733,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
-          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: "latest ask status", timestamp: 3 },
           {
             role: "assistant",
@@ -2998,31 +2997,30 @@ describe("compaction-safeguard recent-turn preservation", () => {
     }));
     const turnPrefixMessages = [
       { role: "user" as const, content: "raw tool request", timestamp: 100 },
-      {
+      castAgentMessage({
         role: "assistant" as const,
         content: toolCalls,
         timestamp: 101,
-      } as unknown as AgentMessage,
-      ...toolCalls.map(
-        (toolCall, index) =>
-          ({
-            role: "toolResult",
-            toolCallId: toolCall.id,
-            toolName: "read",
-            content: [
-              {
-                type: "text",
-                text: `finalizer-tool-output-${index}-${"r".repeat(600)}`,
-              },
-            ],
-            timestamp: index + 102,
-          }) as unknown as AgentMessage,
+      }),
+      ...toolCalls.map((toolCall, index) =>
+        castAgentMessage({
+          role: "toolResult",
+          toolCallId: toolCall.id,
+          toolName: "read",
+          content: [
+            {
+              type: "text",
+              text: `finalizer-tool-output-${index}-${"r".repeat(600)}`,
+            },
+          ],
+          timestamp: index + 102,
+        }),
       ),
-      {
+      castAgentMessage({
         role: "assistant" as const,
         content: [{ type: "text", text: "raw terminal answer survives" }],
         timestamp: 114,
-      } as unknown as AgentMessage,
+      }),
     ];
     const event = {
       preparation: {
@@ -3926,10 +3924,12 @@ describe("compaction-safeguard double-compaction guard", () => {
     ).toBe(false);
 
     expect(
-      testing.hasMeaningfulConversationContent({
-        role: "assistant",
-        content: [{ type: "reasoning", summary: [] }],
-      } as unknown as AgentMessage),
+      testing.hasMeaningfulConversationContent(
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "reasoning", summary: [] }],
+        }),
+      ),
     ).toBe(false);
   });
 

--- a/src/agents/embedded-agent-runner/model.test-harness.ts
+++ b/src/agents/embedded-agent-runner/model.test-harness.ts
@@ -1,5 +1,6 @@
 // Shared model fixtures for embedded runner model resolution tests.
 import { vi } from "vitest";
+import type { OpenClawConfig, OpenClawConfigInput } from "../../config/config.js";
 import type { ModelDefinitionConfig } from "../../config/types.js";
 
 type DiscoverModelsMock = typeof import("../agent-model-discovery.js").discoverModels;
@@ -15,6 +16,10 @@ export const makeModel = (id: string): ModelDefinitionConfig => ({
   contextWindow: 1,
   maxTokens: 1,
 });
+
+export function makeOpenClawConfigFixture(input: OpenClawConfigInput = {}): OpenClawConfig {
+  return input as OpenClawConfig;
+}
 
 export const OPENAI_CODEX_TEMPLATE_MODEL = {
   id: "gpt-5.3-codex",

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -257,6 +257,7 @@ import { buildInlineProviderModels } from "./model.inline-provider.js";
 import { resolveModel, resolveModelAsync, resolveModelWithRegistry } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
+  makeOpenClawConfigFixture,
   makeModel,
   mockDiscoveredModel,
   OPENAI_CODEX_TEMPLATE_MODEL,
@@ -478,13 +479,13 @@ function makeProviderConfig(
   provider: string,
   overrides: Record<string, unknown> = {},
 ): OpenClawConfig {
-  return {
+  return makeOpenClawConfigFixture({
     models: {
       providers: {
         [provider]: { models: [], ...overrides },
       },
     },
-  } as unknown as OpenClawConfig;
+  });
 }
 
 const deepSeekCatalogCompat = {
@@ -702,14 +703,14 @@ describe("resolveModel", () => {
     const defaultAgentDir = path.join(rootDir, "default-agent");
     fs.mkdirSync(agentDir, { recursive: true });
     fs.mkdirSync(defaultAgentDir, { recursive: true });
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         list: [
           { id: "main", default: true, agentDir: defaultAgentDir },
           { id: "worker", agentDir },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", agentDir, cfg, {
@@ -739,11 +740,11 @@ describe("resolveModel", () => {
     const workspaceDir = path.join(rootDir, "workspace");
     fs.mkdirSync(agentDir, { recursive: true });
     mockModelDiscovery();
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         list: [{ id: "workspace-agent", default: true, agentDir, workspace: workspaceDir }],
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModel("openai", "gpt-5.5", agentDir, cfg, {
       runtimeHooks: createRuntimeHooks(),
@@ -1084,7 +1085,7 @@ describe("resolveModel", () => {
   });
 
   it("falls back to bundled static catalog rows without agent discovery", async () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -1094,7 +1095,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "openai",
       id: "gpt-5.3-codex",
@@ -1228,7 +1229,7 @@ describe("resolveModel", () => {
       contextWindow: 262_144,
       maxTokens: 262_144,
     });
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           fireworks: {
@@ -1245,7 +1246,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest(
       "fireworks",
@@ -1441,7 +1442,7 @@ describe("resolveModel", () => {
         image: { maxSidePx: 2048, preferredSidePx: 1536, tokenMode: "provider" },
       },
     });
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           mistral: {
@@ -1458,7 +1459,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = await resolveModelAsync("mistral", "mistral-medium-3-5", "/tmp/agent", cfg, {
       allowBundledStaticCatalogFallback: true,
@@ -2062,7 +2063,7 @@ describe("resolveModel", () => {
       "typoProvider",
       "typoed-model",
       "/tmp/agent",
-      cfg as unknown as OpenClawConfig,
+      makeOpenClawConfigFixture(cfg),
     );
 
     expect(result.model).toBeUndefined();
@@ -2084,7 +2085,7 @@ describe("resolveModel", () => {
       "openai",
       "typoed-model",
       "/tmp/agent",
-      cfg as unknown as OpenClawConfig,
+      makeOpenClawConfigFixture(cfg),
     );
 
     expect(result.model).toBeUndefined();
@@ -2154,7 +2155,7 @@ describe("resolveModel", () => {
   });
 
   it("defaults baseUrl-only local custom fallback models to chat completions", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           model: { primary: "local-agent-proxy/gpt-5.2" },
@@ -2168,7 +2169,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("local-agent-proxy", "gpt-5.2", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2444,7 +2445,7 @@ describe("resolveModel", () => {
     mockMinimalModelDiscovery("ollama", "qwen3:32b", {
       params: { num_ctx: 4096, keep_alive: "1m" },
     });
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           models: {
@@ -2467,7 +2468,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
 
@@ -2528,7 +2529,7 @@ describe("resolveModel", () => {
       "openai",
       "gpt-5.5",
       "/tmp/agent",
-      cfg as unknown as OpenClawConfig,
+      makeOpenClawConfigFixture(cfg),
     );
 
     expect(result.error).toBeUndefined();
@@ -2553,7 +2554,7 @@ describe("resolveModel", () => {
       "openai",
       "gpt-5.5",
       "/tmp/agent",
-      cfg as unknown as OpenClawConfig,
+      makeOpenClawConfigFixture(cfg),
     );
 
     expect(result.error).toBeUndefined();
@@ -2610,7 +2611,7 @@ describe("resolveModel", () => {
 
   it("applies agent default model params without explicit provider config", () => {
     mockMinimalModelDiscovery("ollama", "llama3.2");
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           models: {
@@ -2620,7 +2621,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("ollama", "llama3.2", "/tmp/agent", cfg);
 
@@ -3043,7 +3044,7 @@ describe("resolveModel", () => {
   );
 
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           custom: {
@@ -3058,7 +3059,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
 
@@ -3068,7 +3069,7 @@ describe("resolveModel", () => {
 
   it("resolves custom MLX-style Hugging Face ids without adding the provider prefix", () => {
     const modelId = "mlx-community/Qwen3-30B-A3B-6bit";
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           model: { primary: `mlx/${modelId}` },
@@ -3090,7 +3091,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("mlx", modelId, "/tmp/agent", cfg);
 
@@ -3105,7 +3106,7 @@ describe("resolveModel", () => {
 
   it("prefers provider-prefixed configured metadata over discovered text-only models", () => {
     mockMinimalModelDiscovery("custom", "vision-model", { input: ["text"] });
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           custom: {
@@ -3120,7 +3121,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
 
@@ -3133,7 +3134,7 @@ describe("resolveModel", () => {
   });
 
   it("keeps unknown fallback models text-only instead of borrowing image input from another configured model", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           custom: {
@@ -3147,7 +3148,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("custom", "typoed-model", "/tmp/agent", cfg);
 
@@ -3222,7 +3223,7 @@ describe("resolveModel", () => {
   });
 
   it("suggests adding config entry when a non-bundled provider model is missing", async () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           models: {
@@ -3230,7 +3231,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = await resolveModelAsync("custom-provider", "some-model", "/tmp/agent", cfg, {
       runtimeHooks: createRuntimeHooks(),
@@ -3243,7 +3244,7 @@ describe("resolveModel", () => {
   });
 
   it("points runtime-bound model entries at the runtime catalog instead of provider registration", async () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       agents: {
         defaults: {
           models: {
@@ -3253,7 +3254,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = await resolveModelAsync("openai", "gpt-5.3-codex", "/tmp/agent", cfg, {
       runtimeHooks: createRuntimeHooks(),
@@ -3266,7 +3267,7 @@ describe("resolveModel", () => {
   });
 
   it("repairs stale text-only Foundry fallback rows for GPT-family models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           "microsoft-foundry": {
@@ -3283,7 +3284,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("microsoft-foundry", "gpt-5.4", "/tmp/agent", cfg);
 
@@ -3291,7 +3292,7 @@ describe("resolveModel", () => {
   });
 
   it("repairs stale text-only Anthropic fallback rows for Claude vision models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           anthropic: {
@@ -3308,7 +3309,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("anthropic", "claude-sonnet-4-5", "/tmp/agent", cfg);
 
@@ -3316,7 +3317,7 @@ describe("resolveModel", () => {
   });
 
   it("repairs stale text-only Foundry discovered rows for GPT-family models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           "microsoft-foundry": {
@@ -3333,7 +3334,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     mockDiscoveredModel(discoverModels, {
       provider: "microsoft-foundry",
@@ -3381,7 +3382,7 @@ describe("resolveModel", () => {
   });
 
   it("matches prefixed OpenRouter native ids in configured fallback models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openrouter: {
@@ -3399,7 +3400,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const models = buildInlineProviderModels(cfg.models?.providers ?? {});
     const model = models.find((entry) => entry.id === "openrouter/healer-alpha");
@@ -3592,7 +3593,7 @@ describe("resolveModel", () => {
 
   it("threads the model id through inline configured transport normalization", () => {
     const normalizeProviderTransportWithPlugin = vi.fn(() => undefined);
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -3608,7 +3609,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModel("openai", "gpt-5.5", "/tmp/agent", cfg, {
       authStorage: { mocked: true } as never,
@@ -3646,7 +3647,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           onehub: {
@@ -3664,7 +3665,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("onehub", "glm-5", "/tmp/agent", cfg);
 
@@ -3698,7 +3699,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           "amazon-bedrock": {
@@ -3723,7 +3724,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("bedrock", "bedrock-alias-exact-test", "/tmp/agent", cfg);
 
@@ -3827,7 +3828,7 @@ describe("resolveModel", () => {
   it("applies canonical openai overrides when resolving the gpt-5.4-codex alias", () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -3845,7 +3846,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("openai", "gpt-5.4-codex", "/tmp/agent", cfg);
 
@@ -3865,7 +3866,7 @@ describe("resolveModel", () => {
   it("prefers alias-specific overrides over canonical ones for gpt-5.4-codex", () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -3885,7 +3886,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("openai", "gpt-5.4-codex", "/tmp/agent", cfg);
 
@@ -3923,7 +3924,7 @@ describe("resolveModel", () => {
   });
 
   it("does not build a configured fallback for unsupported xAI multi-agent models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           xai: {
@@ -3933,7 +3934,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("xai", "grok-4.20-multi-agent-0309", "/tmp/agent", cfg);
 
@@ -3977,7 +3978,7 @@ describe("resolveModel", () => {
   it("lets official openai metadata override stale configured model rows", () => {
     mockOpenAIForwardCompatDiscovery();
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -3999,7 +4000,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("openai", "gpt-5.5-pro", "/tmp/agent", cfg);
 
@@ -4041,7 +4042,7 @@ describe("resolveModel", () => {
       contextWindow: 400_000,
     });
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -4062,7 +4063,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("openai", "gpt-5.5", "/tmp/agent", cfg);
 
@@ -4326,7 +4327,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           openai: {
@@ -4335,7 +4336,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("openai", "gpt-5.4", "/tmp/agent", cfg);
 
@@ -4352,7 +4353,7 @@ describe("resolveModel", () => {
   });
 
   it("applies configured overrides to github-copilot dynamic models", () => {
-    const cfg = {
+    const cfg = makeOpenClawConfigFixture({
       models: {
         providers: {
           "github-copilot": {
@@ -4371,7 +4372,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("github-copilot", "gpt-5.4-mini", "/tmp/agent", cfg);
 

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -5,6 +5,7 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 
 type ProviderRequestPolicyConfigMockResult = {
   allowPrivateNetwork: boolean;
@@ -180,12 +181,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   function sentinelModel(): Model<"openai-responses"> {
-    return {
+    return makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
   }
 
   it("swaps sentinels in Request-form headers", async () => {
@@ -284,12 +285,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("pushes provider capture metadata into the shared guarded fetch seam", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.openai.com/v1/responses", {
@@ -312,12 +313,12 @@ describe("buildGuardedModelFetch", () => {
 
   it("rejects successful streamed OpenAI-compatible responses with HTML content", async () => {
     const release = vi.fn(async () => undefined);
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "private-model",
       provider: "custom-openai",
       api: "openai-completions",
       baseUrl: "https://proxy.example.com",
-    } as unknown as Model<"openai-completions">;
+    });
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response("<html>not the API</html>", {
         status: 200,
@@ -355,12 +356,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://chatgpt.com/backend-api/codex/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openclaw-openai-chatgpt-responses-transport",
       baseUrl: "https://chatgpt.com/backend-api/codex",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://chatgpt.com/backend-api/codex/responses",
@@ -385,12 +386,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://chatgpt.com/backend-api/codex/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openclaw-openai-chatgpt-responses-transport",
       baseUrl: "https://chatgpt.com/backend-api/codex",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const responsePromise = buildGuardedModelFetch(model)(
       "https://chatgpt.com/backend-api/codex/responses",
@@ -425,12 +426,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://chatgpt.com/backend-api/codex/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openclaw-openai-chatgpt-responses-transport",
       baseUrl: "https://chatgpt.com/backend-api/codex",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://chatgpt.com/backend-api/codex/responses",
@@ -454,12 +455,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://chatgpt.com/backend-api/codex/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openclaw-openai-chatgpt-responses-transport",
       baseUrl: "https://chatgpt.com/backend-api/codex",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://chatgpt.com/backend-api/codex/responses",
@@ -480,12 +481,12 @@ describe("buildGuardedModelFetch", () => {
 
   it("rejects missing content-type streamed OpenAI-compatible responses with HTML bodies", async () => {
     const release = vi.fn(async () => undefined);
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "private-model",
       provider: "custom-openai",
       api: "openai-completions",
       baseUrl: "https://proxy.example.com",
-    } as unknown as Model<"openai-completions">;
+    });
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(responseStreamText("<html>not the API</html>")),
       finalUrl: "https://proxy.example.com/chat/completions",
@@ -510,12 +511,12 @@ describe("buildGuardedModelFetch", () => {
   it("ensures configured local services before the model request", async () => {
     const release = vi.fn();
     ensureModelProviderLocalServiceMock.mockResolvedValue({ release });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     const response = await fetcher("http://127.0.0.1:18000/v1/chat/completions", {
@@ -544,12 +545,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.anthropic.com/v1/messages",
       release,
     });
-    const model = {
+    const model = makeProviderModelFixture<"anthropic-messages">({
       id: "claude-sonnet-4-6",
       provider: "anthropic",
       api: "anthropic-messages",
       baseUrl: "https://api.anthropic.com",
-    } as unknown as Model<"anthropic-messages">;
+    });
 
     const fetcher = buildGuardedModelFetch(model, undefined, { sanitizeSse: false });
     const response = await fetcher("https://api.anthropic.com/v1/messages", {
@@ -570,12 +571,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("passes model request headers to local service health probes", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
     const headers = {
       Authorization: "Bearer health-secret",
       "X-Tenant": "acme",
@@ -592,12 +593,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("passes model request abort signals to local service startup", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
     const controller = new AbortController();
 
     const fetcher = buildGuardedModelFetch(model);
@@ -617,12 +618,12 @@ describe("buildGuardedModelFetch", () => {
   it("passes model request timeouts to local service startup", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     try {
       const fetcher = buildGuardedModelFetch(model, 750);
@@ -649,12 +650,12 @@ describe("buildGuardedModelFetch", () => {
   it("caps oversized model request timeouts before arming abort signals", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     try {
       const fetcher = buildGuardedModelFetch(model, Number.MAX_SAFE_INTEGER);
@@ -677,13 +678,13 @@ describe("buildGuardedModelFetch", () => {
 
   it("ignores non-positive model request timeout metadata", async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
       requestTimeoutMs: -1,
-    } as unknown as Model<"openai-completions">;
+    });
 
     try {
       const fetcher = buildGuardedModelFetch(model);
@@ -706,12 +707,12 @@ describe("buildGuardedModelFetch", () => {
     const combinedController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
     const anySpy = vi.spyOn(AbortSignal, "any").mockReturnValue(combinedController.signal);
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     try {
       const fetcher = buildGuardedModelFetch(model, 750);
@@ -741,12 +742,12 @@ describe("buildGuardedModelFetch", () => {
     const release = vi.fn();
     ensureModelProviderLocalServiceMock.mockResolvedValue({ release });
     fetchWithSsrFGuardMock.mockRejectedValue(new Error("network down"));
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "deepseek-v4-flash",
       provider: "ds4",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:18000/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
 
@@ -757,12 +758,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("scopes fake-IP DNS exemptions to the configured provider host", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
@@ -779,12 +780,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("does not apply fake-IP exemptions to non-provider hosts", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://uploads.openai.com/v1/files", { method: "POST" });
@@ -798,12 +799,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "lmstudio",
       api: "openai-completions",
       baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
@@ -821,12 +822,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "custom-vllm",
       api: "openai-completions",
       baseUrl: "https://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
@@ -843,12 +844,12 @@ describe("buildGuardedModelFetch", () => {
       privateNetworkExplicitlyDenied: true,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "lmstudio",
       api: "openai-completions",
       baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
@@ -862,12 +863,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "local" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "lmstudio",
       api: "openai-completions",
       baseUrl: "http://127.0.0.1:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://127.0.0.1:1234/v1/chat/completions", { method: "POST" });
@@ -883,12 +884,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "lmstudio",
       api: "openai-completions",
       baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://10.0.0.5:4321/v1/chat/completions", { method: "POST" });
@@ -902,12 +903,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "openai-public" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "openai",
       api: "openai-completions",
       baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
@@ -921,12 +922,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "meta-native" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "muse-spark-1.1",
       provider: "meta",
       api: "openai-responses",
       baseUrl: "https://api.meta.ai/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.meta.ai/v1/responses", { method: "POST" });
@@ -997,12 +998,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: false,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "qwen3:32b",
       provider: "custom-metadata",
       api: "openai-completions",
       baseUrl: entry.baseUrl,
-    } as unknown as Model<"openai-completions">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher(entry.requestUrl, { method: "POST" });
@@ -1016,12 +1017,12 @@ describe("buildGuardedModelFetch", () => {
       allowPrivateNetwork: true,
       policy: { endpointClass: "custom" },
     });
-    const model = {
+    const model = makeProviderModelFixture<"ollama">({
       id: "qwen3:32b",
       provider: "ollama",
       api: "ollama",
       baseUrl: "http://10.0.0.5:11434",
-    } as unknown as Model<"ollama">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://10.0.0.5:11434/api/chat", { method: "POST" });
@@ -1035,12 +1036,12 @@ describe("buildGuardedModelFetch", () => {
 
   it("uses trusted env-proxy mode for provider calls when no explicit dispatcher policy is configured", async () => {
     shouldUseEnvHttpProxyForUrlMock.mockReturnValueOnce(true);
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
@@ -1065,12 +1066,12 @@ describe("buildGuardedModelFetch", () => {
   it("keeps explicit provider dispatcher policies in strict guarded-fetch mode", async () => {
     shouldUseEnvHttpProxyForUrlMock.mockReturnValueOnce(true);
     buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
@@ -1080,12 +1081,12 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("threads explicit transport timeouts into the shared guarded fetch seam", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const fetcher = buildGuardedModelFetch(model, 123_456);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
@@ -1094,13 +1095,13 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("threads resolved provider timeout metadata into the shared guarded fetch seam", async () => {
-    const model = {
+    const model = makeProviderModelFixture<"ollama">({
       id: "qwen3:32b",
       provider: "ollama",
       api: "ollama",
       baseUrl: "http://127.0.0.1:11434",
       requestTimeoutMs: 300_000,
-    } as unknown as Model<"ollama">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://127.0.0.1:11434/api/chat", { method: "POST" });
@@ -1111,12 +1112,12 @@ describe("buildGuardedModelFetch", () => {
   it("does not force explicit debug proxy overrides onto plain HTTP model transports", async () => {
     process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
     process.env.OPENCLAW_DEBUG_PROXY_URL = "http://127.0.0.1:7799";
-    const model = {
+    const model = makeProviderModelFixture<"ollama-chat">({
       id: "kimi-k2.5:cloud",
       provider: "ollama",
       api: "ollama-chat",
       baseUrl: "http://127.0.0.1:11434/v1",
-    } as unknown as Model<"ollama-chat">;
+    });
 
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://127.0.0.1:11434/v1/chat/completions", {
@@ -1146,12 +1147,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-responses",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)("https://openrouter.ai/api/v1/responses", {
       method: "POST",
@@ -1172,12 +1173,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
     const body = JSON.stringify({ model: "gpt-5.5", stream: true });
     const parse = vi.spyOn(JSON, "parse");
 
@@ -1202,12 +1203,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1249,12 +1250,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "moonshotai/kimi-k2.6",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1280,12 +1281,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1307,12 +1308,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "moonshotai/kimi-k2.6",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1361,12 +1362,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release,
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1398,12 +1399,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://gateway.example/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "MiniMax-M3",
       provider: "hetu",
       api: "openai-completions",
       baseUrl: "https://gateway.example/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const responsePromise = buildGuardedModelFetch(model)(
       "https://gateway.example/v1/chat/completions",
@@ -1444,12 +1445,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.5",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
     const request = new Request("https://api.openai.com/v1/responses", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -1486,12 +1487,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "moonshotai/kimi-k2.6",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1518,12 +1519,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-completions",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://api.openai.com/v1/chat/completions",
@@ -1555,12 +1556,12 @@ describe("buildGuardedModelFetch", () => {
         "https://generativelanguage.googleapis.com/v1beta/models/gemini:streamGenerateContent",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gemini-3.1-pro-preview",
       provider: "google",
       api: "openai-completions",
       baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini:streamGenerateContent",
@@ -1591,12 +1592,12 @@ describe("buildGuardedModelFetch", () => {
       release: vi.fn(async () => undefined),
       refreshTimeout,
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1628,12 +1629,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1663,12 +1664,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "gpt-5.4",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1711,12 +1712,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://openrouter.ai/api/v1/chat/completions",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"openai-completions">({
       id: "moonshotai/kimi-k2.6",
       provider: "openrouter",
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
-    } as unknown as Model<"openai-completions">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://openrouter.ai/api/v1/chat/completions",
@@ -1762,12 +1763,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"azure-openai-responses">({
       id: "gpt-5.5",
       provider: "azure",
       api: "azure-openai-responses",
       baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
-    } as unknown as Model<"azure-openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://custom-azure.openai.azure.com/openai/v1/responses",
@@ -1797,12 +1798,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
       release,
     });
-    const model = {
+    const model = makeProviderModelFixture<"azure-openai-responses">({
       id: "gpt-5.5",
       provider: "azure",
       api: "azure-openai-responses",
       baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
-    } as unknown as Model<"azure-openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://custom-azure.openai.azure.com/openai/v1/responses",
@@ -1847,12 +1848,12 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
       release: vi.fn(async () => undefined),
     });
-    const model = {
+    const model = makeProviderModelFixture<"azure-openai-responses">({
       id: "gpt-5.5",
       provider: "azure",
       api: "azure-openai-responses",
       baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
-    } as unknown as Model<"azure-openai-responses">;
+    });
 
     const response = await buildGuardedModelFetch(model)(
       "https://custom-azure.openai.azure.com/openai/v1/responses",
@@ -1869,19 +1870,19 @@ describe("buildGuardedModelFetch", () => {
   });
 
   describe("long retry-after handling", () => {
-    const anthropicModel = {
+    const anthropicModel = makeProviderModelFixture<"anthropic-messages">({
       id: "sonnet-4.6",
       provider: "anthropic",
       api: "anthropic-messages",
       baseUrl: "https://api.anthropic.com/v1",
-    } as unknown as Model<"anthropic-messages">;
+    });
 
-    const openaiModel = {
+    const openaiModel = makeProviderModelFixture<"openai-responses">({
       id: "gpt-5.4",
       provider: "openai",
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
+    });
 
     it("injects x-should-retry:false when a retryable response exceeds the default wait cap", async () => {
       fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/test-helpers/provider-model-fixture.ts
+++ b/src/agents/test-helpers/provider-model-fixture.ts
@@ -1,0 +1,27 @@
+/** Complete provider model fixtures with typed scenario overrides. */
+import type { Api, Model } from "openclaw/plugin-sdk/llm";
+
+type ProviderModelFixture<TApi extends Api> = Partial<
+  Omit<Model<TApi>, "id" | "provider" | "api" | "baseUrl">
+> &
+  Pick<Model<TApi>, "id" | "provider" | "baseUrl"> & {
+    /** Transport aliases intentionally exercise normalization before the canonical API is restored. */
+    api: string;
+    /** Guarded transport accepts this provider metadata extension before SDK normalization. */
+    requestTimeoutMs?: number;
+  };
+
+export function makeProviderModelFixture<TApi extends Api>(
+  overrides: ProviderModelFixture<TApi>,
+): Model<TApi> {
+  return {
+    name: overrides.id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 16_000,
+    maxTokens: 4_096,
+    ...overrides,
+    api: overrides.api as TApi,
+  };
+}

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -6,6 +6,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import * as loggingConfigModule from "../logging/config.js";
+import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
 
 // AgentMessage includes custom message types without content; this accessor
@@ -15,10 +16,10 @@ function msgContent(msg: AgentMessage): unknown {
 }
 
 function textMessage(text: string): AgentMessage {
-  return {
+  return castAgentMessage({
     role: "assistant",
     content: [{ type: "text", text }],
-  } as unknown as AgentMessage;
+  });
 }
 
 function cfg(_mode: "tools" | "off", patterns?: string[]): OpenClawConfig {
@@ -82,7 +83,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("keeps pagination cursors readable while still masking credential tool args (#104992)", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -98,7 +99,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
     const args = (
       msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
         arguments: Record<string, string>;
@@ -115,7 +116,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("still masks a secret-shaped value even under an exempt pagination key (#104992)", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -125,7 +126,7 @@ describe("redactTranscriptMessage", () => {
           arguments: { page_token: "sk-abcdef1234567890xyz" },
         },
       ],
-    } as unknown as AgentMessage;
+    });
     const args = (
       msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
         arguments: Record<string, string>;
@@ -137,12 +138,12 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts thinking block", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         { type: "thinking", thinking: "secret sk-abcdef1234567890xyz", thinkingSignature: "sig" },
       ],
-    } as unknown as AgentMessage;
+    });
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
       (msgContent(result) as Array<{ thinking: string }>)[0],
@@ -163,7 +164,7 @@ describe("redactTranscriptMessage", () => {
         secret: "sk-abcdef1234567890xyz",
       },
     });
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openai-responses",
       model: "gpt-5.5",
@@ -193,7 +194,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(
       msg,
@@ -232,7 +233,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves only validated OpenAI compaction replay state", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openclaw-openai-responses-transport",
       model: "gpt-5.6-luna",
@@ -252,7 +253,7 @@ describe("redactTranscriptMessage", () => {
         authProfileHash: "oe8bkr3r8947",
         secret: "sk-abcdef1234567890xyz",
       },
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       providerReplay: Record<string, unknown>;
@@ -275,7 +276,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves validated OpenAI compaction suppression state", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openclaw-openai-responses-transport",
       model: "gpt-5.6-luna",
@@ -294,7 +295,7 @@ describe("redactTranscriptMessage", () => {
         authProfileHash: "oe8bkr3r8947",
         secret: "sk-abcdef1234567890xyz",
       },
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       providerReplay: Record<string, unknown>;
@@ -315,7 +316,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves validated Anthropic compaction state while redacting its summary", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "anthropic-messages",
       model: "claude-sonnet-4-6",
@@ -334,7 +335,7 @@ describe("redactTranscriptMessage", () => {
         authProfileHash: "oe8bkr3r8947",
         secret: "sk-another-secret-value",
       },
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       providerReplay: Record<string, unknown>;
@@ -365,7 +366,7 @@ describe("redactTranscriptMessage", () => {
       content: [{ type: "text", text: "visible" }],
     };
     const suppression = redactTranscriptMessage(
-      {
+      castAgentMessage({
         ...base,
         providerReplay: {
           v: 1,
@@ -376,7 +377,7 @@ describe("redactTranscriptMessage", () => {
           model: "claude-sonnet-4-6",
           baseUrlHash: "ozhevd1smnk8s",
         },
-      } as unknown as AgentMessage,
+      }),
       cfg("tools"),
     ) as unknown as { providerReplay: Record<string, unknown> };
     expect(suppression.providerReplay).toMatchObject({
@@ -405,7 +406,7 @@ describe("redactTranscriptMessage", () => {
       },
     ]) {
       const result = redactTranscriptMessage(
-        { ...base, providerReplay } as unknown as AgentMessage,
+        castAgentMessage({ ...base, providerReplay }),
         cfg("tools"),
       );
       expect(result).not.toHaveProperty("providerReplay");
@@ -416,7 +417,7 @@ describe("redactTranscriptMessage", () => {
     ["oversized", "i".repeat(10_000)],
     ["non-string", 42],
   ])("removes an %s optional OpenAI compaction id while preserving state", (_name, id) => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openclaw-openai-responses-transport",
       model: "gpt-5.6-luna",
@@ -433,7 +434,7 @@ describe("redactTranscriptMessage", () => {
         model: "gpt-5.6-luna",
         baseUrlHash: "ozhevd1smnk8s",
       },
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       providerReplay: Record<string, unknown>;
@@ -468,14 +469,14 @@ describe("redactTranscriptMessage", () => {
       baseUrlHash: "ozhevd1smnk8s",
       ...override,
     };
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openclaw-openai-responses-transport",
       model: "gpt-5.6-luna",
       provider: "openai",
       content: [{ type: "text", text: "visible" }],
       providerReplay,
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
 
@@ -484,13 +485,13 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("handles configured providers without explicit models", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openai-responses",
       model: "gpt-5.5",
       provider: "openai",
       content: [{ type: "text", text: "visible", textSignature: "response-item-1" }],
-    } as unknown as AgentMessage;
+    });
     const inputCfg = {
       logging: { redactSensitive: "tools" },
       models: { providers: { openai: { apiKey: "test-key" } } },
@@ -586,13 +587,13 @@ describe("redactTranscriptMessage", () => {
   ])(
     "preserves replay signatures for managed transport $api",
     ({ api, provider, block, signatureKey, expectedSignature }) => {
-      const msg = {
+      const msg = castAgentMessage({
         role: "assistant",
         api,
         model: "managed-model",
         provider,
         content: [block],
-      } as unknown as AgentMessage;
+      });
 
       const result = redactTranscriptMessage(
         msg,
@@ -621,7 +622,7 @@ describe("redactTranscriptMessage", () => {
       index: 1,
       secret: "sk-abcdef1234567890xyz",
     });
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openai-completions",
       model: "anthropic/claude-sonnet-4.6",
@@ -635,7 +636,7 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -657,7 +658,7 @@ describe("redactTranscriptMessage", () => {
       data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
       format: null,
     });
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "openai-completions",
       provider: "openrouter",
@@ -670,7 +671,7 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -685,7 +686,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves Google tool-call thought signatures while redacting arguments", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
@@ -713,7 +714,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -731,7 +732,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves Google text and legacy thinking signatures", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
@@ -752,7 +753,7 @@ describe("redactTranscriptMessage", () => {
           thought_signature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools", [GOOGLE_THOUGHT_SIGNATURE]));
     const blocks = msgContent(result) as Array<Record<string, string>>;
@@ -777,12 +778,12 @@ describe("redactTranscriptMessage", () => {
     "preserves structured OpenAI text signatures for %s",
     (api) => {
       const textSignature = JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID });
-      const msg = {
+      const msg = castAgentMessage({
         role: "assistant",
         api,
         provider: "github-copilot",
         content: [{ type: "text", text: "visible", textSignature }],
-      } as unknown as AgentMessage;
+      });
 
       const result = redactTranscriptMessage(msg, cfg("tools", [COPILOT_CONNECTION_BOUND_ID]));
       const block = expectDefined(
@@ -798,13 +799,13 @@ describe("redactTranscriptMessage", () => {
     ["anthropic-messages", "anthropic", "claude-sonnet-4-6"],
   ])("preserves commentary phase signatures for %s", (api, provider, model) => {
     const textSignature = JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" });
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api,
       provider,
       model,
       content: [{ type: "text", text: "I will check.", textSignature }],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -815,7 +816,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves Anthropic redacted_thinking data while redacting siblings", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "anthropic-messages",
       provider: "anthropic",
@@ -836,7 +837,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const thinkingBlock = expectDefined(
@@ -870,7 +871,7 @@ describe("redactTranscriptMessage", () => {
       id: "reasoning-encrypted-1",
       secret: "sk-abcdef1234567890xyz",
     });
-    const googleMsg = {
+    const googleMsg = castAgentMessage({
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
@@ -888,8 +889,8 @@ describe("redactTranscriptMessage", () => {
           thinkingSignature: ALIBABA_CREDENTIAL_COLLISION,
         },
       ],
-    } as unknown as AgentMessage;
-    const anthropicMsg = {
+    });
+    const anthropicMsg = castAgentMessage({
       role: "assistant",
       api: "bedrock-converse-stream",
       provider: "amazon-bedrock",
@@ -901,8 +902,8 @@ describe("redactTranscriptMessage", () => {
         },
         { type: "redacted_thinking", data: githubToken },
       ],
-    } as unknown as AgentMessage;
-    const openAICompletionsMsg = {
+    });
+    const openAICompletionsMsg = castAgentMessage({
       role: "assistant",
       api: "openai-completions",
       provider: "openrouter",
@@ -922,8 +923,8 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: githubToken,
         },
       ],
-    } as unknown as AgentMessage;
-    const googleOpenAICompletionsMsg = {
+    });
+    const googleOpenAICompletionsMsg = castAgentMessage({
       role: "assistant",
       api: "openclaw-openai-completions-transport",
       model: "gemini-3.1-pro",
@@ -937,8 +938,8 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: OPENAI_COMPAT_OPAQUE_COLLISION,
         },
       ],
-    } as unknown as AgentMessage;
-    const veniceGeminiMsg = {
+    });
+    const veniceGeminiMsg = castAgentMessage({
       role: "assistant",
       api: "openai-completions",
       model: "gemini-3-6-flash",
@@ -952,8 +953,8 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: OPENAI_COMPAT_OPAQUE_COLLISION,
         },
       ],
-    } as unknown as AgentMessage;
-    const openAIResponsesMsg = {
+    });
+    const openAIResponsesMsg = castAgentMessage({
       role: "assistant",
       api: "openai-responses",
       model: "gpt-5.5",
@@ -971,7 +972,7 @@ describe("redactTranscriptMessage", () => {
           }),
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const googleBlocks = msgContent(redactTranscriptMessage(googleMsg, cfg("tools"))) as Array<
       Record<string, string>
@@ -1048,7 +1049,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("keeps unknown and malformed replay fields credential-safe", () => {
-    const customProviderMsg = {
+    const customProviderMsg = castAgentMessage({
       role: "assistant",
       api: "custom-provider-api",
       model: "custom-model",
@@ -1071,8 +1072,8 @@ describe("redactTranscriptMessage", () => {
           }),
         },
       ],
-    } as unknown as AgentMessage;
-    const malformedGoogleMsg = {
+    });
+    const malformedGoogleMsg = castAgentMessage({
       role: "assistant",
       api: "google-generative-ai",
       model: "gemini-3.1-pro",
@@ -1086,7 +1087,7 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: OPAQUE_CREDENTIAL_COLLISION,
         },
       ],
-    } as unknown as AgentMessage;
+    });
     const malformedKnownOpaqueMessages = [
       {
         role: "assistant",
@@ -1135,7 +1136,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts provider-shaped fields when the assistant route is missing", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1151,7 +1152,7 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: GOOGLE_THOUGHT_SIGNATURE,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(
       msg,
@@ -1168,7 +1169,7 @@ describe("redactTranscriptMessage", () => {
       encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
       summary: [],
     });
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       api: "custom-provider-api",
       model: "custom-model",
@@ -1187,7 +1188,7 @@ describe("redactTranscriptMessage", () => {
           thoughtSignature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(
       msg,
@@ -1208,7 +1209,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts provider-shaped fields outside direct assistant content blocks", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1225,17 +1226,17 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     expect(JSON.stringify(msgContent(result))).not.toContain("sk-abcdef1234567890xyz");
   });
 
   it("redacts partialJson block", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [{ type: "toolCallDelta", partialJson: '{"key":"sk-abcdef1234567890xyz"}' }],
-    } as unknown as AgentMessage;
+    });
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
       (msgContent(result) as Array<{ partialJson: string }>)[0],
@@ -1245,7 +1246,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts nested strings in assistant tool-call arguments", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1259,7 +1260,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1286,7 +1287,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts structured secret fields in assistant tool-call arguments", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1301,7 +1302,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1325,7 +1326,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts structured tool-use input payloads", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1340,7 +1341,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1364,7 +1365,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts defensive function-call input payloads", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1377,7 +1378,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1396,7 +1397,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts arbitrary gateway/custom content-block fields recursively", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1413,7 +1414,7 @@ describe("redactTranscriptMessage", () => {
           safe: "visible",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = (msgContent(result) as Array<Record<string, unknown>>)[0];
@@ -1431,7 +1432,7 @@ describe("redactTranscriptMessage", () => {
       apiKey: "plainsecretvalue123",
     };
     details.self = details;
-    const msg = {
+    const msg = castAgentMessage({
       role: "toolResult",
       toolCallId: "call_1",
       toolName: "send_request",
@@ -1439,7 +1440,7 @@ describe("redactTranscriptMessage", () => {
       details,
       isError: false,
       timestamp: Date.now(),
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       details: Record<string, unknown>;
@@ -1449,7 +1450,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts structured secret fields in tool-result details", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "toolResult",
       toolCallId: "call_1",
       toolName: "send_request",
@@ -1462,7 +1463,7 @@ describe("redactTranscriptMessage", () => {
       },
       isError: false,
       timestamp: Date.now(),
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       content: Array<{ text: string }>;
@@ -1488,16 +1489,16 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts string-form content", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "user",
       content: "my key is sk-abcdef1234567890xyz",
-    } as unknown as AgentMessage;
+    });
     const result = redactTranscriptMessage(msg, cfg("tools"));
     expect(msgContent(result) as string).not.toContain("sk-abcdef1234567890xyz");
   });
 
   it("preserves image data while redacting adjacent transcript text", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "user",
       content: [
         { type: "text", text: "my key is sk-abcdef1234567890xyz" },
@@ -1507,7 +1508,7 @@ describe("redactTranscriptMessage", () => {
           mimeType: "image/png",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const content = msgContent(result) as Array<{ type: string; text?: string; data?: string }>;
@@ -1521,7 +1522,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts fake image payloads that are not valid image base64", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "user",
       content: [
         {
@@ -1530,7 +1531,7 @@ describe("redactTranscriptMessage", () => {
           mimeType: "image/png",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const content = msgContent(result) as Array<{ data: string }>;
@@ -1538,7 +1539,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves valid BMP image base64 while redacting adjacent text", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "user",
       content: [
         { type: "text", text: "my key is sk-abcdef1234567890xyz" },
@@ -1548,7 +1549,7 @@ describe("redactTranscriptMessage", () => {
           mimeType: "image/bmp",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const content = msgContent(result) as Array<{ type: string; text?: string; data?: string }>;
@@ -1561,7 +1562,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("preserves provider-style image base64 source data", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1574,7 +1575,7 @@ describe("redactTranscriptMessage", () => {
           apiKey: "plainsecretvalue123",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1586,7 +1587,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("canonicalizes preserved image MIME from sniffed base64 bytes", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1598,7 +1599,7 @@ describe("redactTranscriptMessage", () => {
           },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1611,7 +1612,7 @@ describe("redactTranscriptMessage", () => {
 
   it("preserves image data URLs without exempting non-image data fields", () => {
     const dataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1620,7 +1621,7 @@ describe("redactTranscriptMessage", () => {
           data: "AKIDABCDEFGHIJKLMNOP",
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1633,7 +1634,7 @@ describe("redactTranscriptMessage", () => {
 
   it("preserves valid non-browser image data URLs in transcripts", () => {
     const dataUrl = `data:image/bmp;base64,${BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1641,7 +1642,7 @@ describe("redactTranscriptMessage", () => {
           image_url: dataUrl,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1654,7 +1655,7 @@ describe("redactTranscriptMessage", () => {
   it("preserves image data URLs with metadata parameters before base64", () => {
     const dataUrl = `data:image/png;charset=utf-8;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
     const canonicalDataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1662,7 +1663,7 @@ describe("redactTranscriptMessage", () => {
           image_url: dataUrl,
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1674,7 +1675,7 @@ describe("redactTranscriptMessage", () => {
 
   it("preserves nested image_url data URL payloads", () => {
     const dataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1682,7 +1683,7 @@ describe("redactTranscriptMessage", () => {
           image_url: { url: dataUrl },
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = expectDefined(
@@ -1693,7 +1694,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts documented transcript text fields on content-less message types", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "bashExecution",
       command: "OPENAI_API_KEY=sk-abcdef1234567890xyz openclaw health",
       output: "failed with sk-abcdef1234567890xyz",
@@ -1701,7 +1702,7 @@ describe("redactTranscriptMessage", () => {
       cancelled: false,
       truncated: false,
       timestamp: Date.now(),
-    } as unknown as AgentMessage;
+    });
 
     const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
       command: string;
@@ -1712,17 +1713,17 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts assistant error and summary transcript fields", () => {
-    const assistant = {
+    const assistant = castAgentMessage({
       role: "assistant",
       content: [{ type: "text", text: "safe" }],
       errorMessage: "provider rejected sk-abcdef1234567890xyz",
-    } as unknown as AgentMessage;
-    const summary = {
+    });
+    const summary = castAgentMessage({
       role: "compactionSummary",
       summary: "summary mentions sk-abcdef1234567890xyz",
       tokensBefore: 10,
       timestamp: Date.now(),
-    } as unknown as AgentMessage;
+    });
 
     const assistantResult = redactTranscriptMessage(assistant, cfg("tools")) as unknown as {
       errorMessage: string;
@@ -1754,7 +1755,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts structured tool-call secrets regardless of retired mode input", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1764,7 +1765,7 @@ describe("redactTranscriptMessage", () => {
           arguments: { apiKey: "plainsecretvalue123", password: "hunter2" },
         },
       ],
-    } as unknown as AgentMessage;
+    });
     const result = redactTranscriptMessage(msg, cfg("off"));
     expect(result).not.toBe(msg);
     expect(JSON.stringify(msgContent(result))).not.toContain("plainsecretvalue123");
@@ -1772,7 +1773,7 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("redacts structured tool-result details regardless of retired mode input", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "toolResult",
       toolCallId: "call_1",
       toolName: "send_request",
@@ -1780,7 +1781,7 @@ describe("redactTranscriptMessage", () => {
       details: { apiKey: "plainsecretvalue123", password: "hunter2" },
       isError: false,
       timestamp: Date.now(),
-    } as unknown as AgentMessage;
+    });
     const result = redactTranscriptMessage(msg, cfg("off")) as unknown as { details: unknown };
     expect(result).not.toBe(msg);
     expect(JSON.stringify(result.details)).not.toContain("plainsecretvalue123");
@@ -1797,7 +1798,7 @@ describe("redactTranscriptMessage", () => {
     const readLoggingConfig = vi
       .spyOn(loggingConfigModule, "readLoggingConfig")
       .mockReturnValue({});
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [
         {
@@ -1811,7 +1812,7 @@ describe("redactTranscriptMessage", () => {
           }),
         },
       ],
-    } as unknown as AgentMessage;
+    });
 
     try {
       expect(JSON.stringify(redactTranscriptMessage(msg))).not.toContain("sk-abcdef1234567890xyz");
@@ -1831,10 +1832,10 @@ describe("redactTranscriptMessage", () => {
   });
 
   it("passes through non-object and null blocks without throwing", () => {
-    const msg = {
+    const msg = castAgentMessage({
       role: "assistant",
       content: [null, 42, "raw string"],
-    } as unknown as AgentMessage;
+    });
     expect(() => redactTranscriptMessage(msg, cfg("tools"))).not.toThrow();
   });
 });

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -10,6 +10,7 @@ import {
   isEmbeddedAgentRunActive,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { testing as embeddedRunTesting } from "../../agents/embedded-agent-runner/runs.test-support.js";
+import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
 import { clearRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -31,10 +32,14 @@ import {
 } from "../../plugins/memory-state.test-fixtures.js";
 import { GatewayDrainingError } from "../../process/command-queue.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
-import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.shared.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { FollowupRun, QueueSettings } from "./queue.js";
+import {
+  createTestQueueSettings,
+  createTestQueuedFollowupRun,
+  createTestTemplateContext,
+} from "./agent-runner.test-fixtures.js";
+import type { FollowupRun } from "./queue.js";
 import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
 import { createReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "./reply-run-registry.test-support.js";
@@ -375,14 +380,14 @@ describe("runReplyAgent auto-compaction token update", () => {
     workspaceDir?: string;
   }) {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "whatsapp",
       OriginatingTo: "+15550001111",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -405,7 +410,7 @@ describe("runReplyAgent auto-compaction token update", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
     return { typing, sessionCtx, resolvedQueue, followupRun };
   }
 
@@ -1045,14 +1050,14 @@ describe("runReplyAgent block streaming", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "discord",
       OriginatingTo: "channel:C1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1088,7 +1093,7 @@ describe("runReplyAgent block streaming", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "text_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1150,14 +1155,14 @@ describe("runReplyAgent block streaming", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "discord",
       OriginatingTo: "channel:C1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1193,7 +1198,7 @@ describe("runReplyAgent block streaming", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "text_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const resultPromise = runReplyAgent({
       commandBody: "hello",
@@ -1273,14 +1278,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1307,7 +1312,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1361,14 +1366,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1395,7 +1400,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1448,14 +1453,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1482,7 +1487,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1610,15 +1615,15 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
       CommandBody: "/trace raw show me everything",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1646,7 +1651,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1780,15 +1785,15 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
       CommandBody: "show me the answer",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1816,7 +1821,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1886,15 +1891,15 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
       CommandBody: "/trace raw",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -1921,7 +1926,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -1983,15 +1988,15 @@ describe("runReplyAgent Active Memory inline debug", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat:1",
       AccountId: "primary",
       MessageSid: "msg",
       CommandBody: "/trace raw",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2019,7 +2024,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -2053,14 +2058,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
 describe("runReplyAgent claude-cli routing", () => {
   function createRun() {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "webchat",
       OriginatingTo: "session:1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2085,7 +2090,7 @@ describe("runReplyAgent claude-cli routing", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -2161,7 +2166,7 @@ describe("runReplyAgent claude-cli routing", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "webchat",
       OriginatingTo: "session:1",
       AccountId: "primary",
@@ -2170,14 +2175,14 @@ describe("runReplyAgent claude-cli routing", () => {
       RawBody: "secret hitl prompt",
       BodyForAgent: "secret hitl prompt",
       Body: "secret hitl prompt",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       traceLevel: "raw",
     } as SessionEntry;
-    const followupRun = {
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "secret hitl prompt",
       summaryLine: "secret hitl prompt",
       enqueuedAt: Date.now(),
@@ -2204,7 +2209,7 @@ describe("runReplyAgent claude-cli routing", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "secret hitl prompt",
@@ -2249,18 +2254,18 @@ describe("runReplyAgent claude-cli routing", () => {
     });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "webchat",
       OriginatingTo: "session:1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
     } as SessionEntry;
-    const followupRun = {
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2293,7 +2298,7 @@ describe("runReplyAgent claude-cli routing", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -2332,14 +2337,14 @@ describe("runReplyAgent messaging tool dedupe", () => {
   ) {
     const typing = createMockTypingController();
     const sessionKey = opts.sessionKey ?? "main";
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: messageProvider,
       OriginatingTo: "channel:C1",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2364,7 +2369,7 @@ describe("runReplyAgent messaging tool dedupe", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -2464,15 +2469,15 @@ describe("runReplyAgent messaging tool dedupe", () => {
 describe("runReplyAgent reminder commitment guard", () => {
   function createRun(params?: { sessionKey?: string; omitSessionKey?: boolean }) {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       OriginatingTo: "chat",
       AccountId: "primary",
       MessageSid: "msg",
       Surface: "telegram",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2497,7 +2502,7 @@ describe("runReplyAgent reminder commitment guard", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -2690,15 +2695,15 @@ describe("runReplyAgent fallback reasoning tags", () => {
 
   function createRun(params?: { sessionEntry?: SessionEntry; sessionKey?: string }) {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "whatsapp",
       OriginatingTo: "+15550001111",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionKey = params?.sessionKey ?? "main";
-    const followupRun = {
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2724,7 +2729,7 @@ describe("runReplyAgent fallback reasoning tags", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -2824,13 +2829,13 @@ describe("runReplyAgent response usage footer", () => {
     model?: string;
   }) {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "whatsapp",
       OriginatingTo: "+15550001111",
       AccountId: "primary",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
 
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -2838,7 +2843,7 @@ describe("runReplyAgent response usage footer", () => {
       responseUsage: params.responseUsage,
     };
 
-    const followupRun = {
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -2865,7 +2870,7 @@ describe("runReplyAgent response usage footer", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -3078,12 +3083,12 @@ describe("runReplyAgent transient HTTP retry", () => {
       });
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -3108,7 +3113,7 @@ describe("runReplyAgent transient HTTP retry", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const runPromise = runReplyAgent({
       commandBody: "hello",
@@ -3153,12 +3158,12 @@ describe("runReplyAgent billing error classification", () => {
     );
 
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -3183,7 +3188,7 @@ describe("runReplyAgent billing error classification", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     const result = await runReplyAgent({
       commandBody: "hello",
@@ -3213,12 +3218,12 @@ describe("runReplyAgent billing error classification", () => {
 describe("runReplyAgent mid-turn rate-limit fallback", () => {
   function createRun() {
     const typing = createMockTypingController();
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "telegram",
       MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
+    });
+    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
@@ -3243,7 +3248,7 @@ describe("runReplyAgent mid-turn rate-limit fallback", () => {
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
       },
-    } as unknown as FollowupRun;
+    });
 
     return runReplyAgent({
       commandBody: "hello",
@@ -3325,7 +3330,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     successfulCronAdds?: number;
     resolvedVerboseLevel?: VerboseLevel;
     isNewSession?: boolean;
-    inboundEventKind?: string;
+    inboundEventKind?: InboundEventKind;
     transcriptPrompt?: string;
     summaryLine?: string;
     strandedReplyRetry?: boolean;
@@ -3378,7 +3383,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         : { successfulCronAdds: params.successfulCronAdds }),
     });
 
-    const sessionCtx = {
+    const sessionCtx = createTestTemplateContext({
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "+15550001111",
@@ -3386,8 +3391,8 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
       MessageSid: "msg",
       ChatType: "direct",
       ...(params.inboundEventKind ? { InboundEventKind: params.inboundEventKind } : {}),
-    } as unknown as TemplateContext;
-    const followupRun = {
+    });
+    const followupRun = createTestQueuedFollowupRun({
       prompt: "hello",
       summaryLine: params.summaryLine ?? "hello",
       ...(params.strandedReplyRetry ? { strandedReplyRetry: true } : {}),
@@ -3419,7 +3424,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         blockReplyBreak: "message_end",
         sourceReplyDeliveryMode: "message_tool_only",
       },
-    } as unknown as FollowupRun;
+    });
 
     // Seeding the SQLite session entry above resolves the runtime config
     // (getRuntimeConfig) and pins an empty `{}` snapshot; leaving it in place
@@ -3439,7 +3444,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         commandBody: "hello",
         followupRun,
         queueKey: sessionKey,
-        resolvedQueue: { mode: "interrupt" } as unknown as QueueSettings,
+        resolvedQueue: createTestQueueSettings({ mode: "interrupt" }),
         shouldSteer: false,
         shouldFollowup: false,
         isActive: false,

--- a/src/auto-reply/reply/agent-runner.test-fixtures.ts
+++ b/src/auto-reply/reply/agent-runner.test-fixtures.ts
@@ -2,7 +2,25 @@
 import type { SessionEntry } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { FollowupRun } from "./queue.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+
+type FollowupRunFixture = Pick<FollowupRun, "prompt" | "summaryLine" | "enqueuedAt"> &
+  Partial<Omit<FollowupRun, "prompt" | "summaryLine" | "enqueuedAt" | "run">> & {
+    run: Partial<Omit<FollowupRun["run"], "skillsSnapshot">> & {
+      skillsSnapshot?: Partial<FollowupRun["run"]["skillsSnapshot"]>;
+    };
+  };
+
+export function createTestTemplateContext(
+  overrides: Partial<TemplateContext> = {},
+): TemplateContext {
+  return { ...overrides };
+}
+
+export function createTestQueueSettings(overrides: Partial<QueueSettings> = {}): QueueSettings {
+  return { mode: "interrupt", ...overrides };
+}
 
 export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun {
   return {
@@ -31,6 +49,10 @@ export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {
       ...overrides,
     },
   } satisfies FollowupRun;
+}
+
+export function createTestQueuedFollowupRun(fixture: FollowupRunFixture): FollowupRun {
+  return fixture as FollowupRun;
 }
 
 export function withTestModelContextTokens(params: {

--- a/src/commands/doctor.e2e-harness.test-helpers.ts
+++ b/src/commands/doctor.e2e-harness.test-helpers.ts
@@ -1,0 +1,144 @@
+/** Small runtime and orchestration helpers for the doctor E2E harness. */
+import { vi } from "vitest";
+import { defineMockFn, type MockFn } from "../test-utils/vitest-mock-fn.js";
+import { createDoctorConfigSnapshot } from "./doctor-config-snapshot.test-helpers.js";
+
+export type DoctorConfigSnapshotFixtureParams = {
+  config?: Record<string, unknown>;
+  parsed?: Record<string, unknown>;
+  valid?: boolean;
+  issues?: Array<{ path: string; message: string }>;
+  legacyIssues?: Array<{ path: string; message: string }>;
+};
+
+export function setDoctorStdinTty(value: boolean | undefined): void {
+  try {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value,
+      configurable: true,
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export function createGatewayUpdateResult() {
+  return {
+    status: "skipped",
+    mode: "unknown",
+    steps: [],
+    durationMs: 0,
+  } as const;
+}
+
+export function createCommandWithTimeoutResult() {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+  } as const;
+}
+
+export function createLegacyConfigSnapshot() {
+  return {
+    path: "/tmp/openclaw.json",
+    exists: false,
+    raw: null,
+    parsed: {},
+    valid: true,
+    config: {},
+    issues: [],
+    legacyIssues: [],
+  } as const;
+}
+
+export function createDoctorServiceMocks() {
+  return {
+    findLegacyGatewayServices: defineMockFn(vi.fn().mockResolvedValue([])),
+    uninstallLegacyGatewayServices: defineMockFn(vi.fn().mockResolvedValue([])),
+    findExtraGatewayServices: defineMockFn(vi.fn().mockResolvedValue([])),
+    findSystemGatewayServices: defineMockFn(vi.fn().mockResolvedValue([])),
+    renderGatewayServiceCleanupHints: defineMockFn(vi.fn().mockReturnValue(["cleanup"])),
+    auditGatewayServiceConfig: defineMockFn(vi.fn().mockResolvedValue({ ok: true, issues: [] })),
+    buildGatewayInstallPlan: defineMockFn(
+      vi.mocked(
+        vi.fn().mockResolvedValue({
+          programArguments: ["node", "cli", "gateway", "--port", "18789"],
+          workingDirectory: "/tmp",
+          environment: {},
+        }),
+      ),
+    ),
+    resolveGatewayAuthTokenForService: defineMockFn(
+      vi.fn().mockResolvedValue({ token: undefined }),
+    ),
+    resolveGatewayProgramArguments: defineMockFn(
+      vi.fn().mockResolvedValue({
+        programArguments: ["node", "cli", "gateway", "--port", "18789"],
+      }),
+    ),
+    serviceInstall: defineMockFn(vi.fn().mockResolvedValue(undefined)),
+    serviceIsLoaded: defineMockFn(vi.fn().mockResolvedValue(false)),
+    serviceStop: defineMockFn(vi.fn().mockResolvedValue(undefined)),
+    serviceRestart: defineMockFn(vi.fn().mockResolvedValue(undefined)),
+    serviceUninstall: defineMockFn(vi.fn().mockResolvedValue(undefined)),
+    serviceReadCommand: defineMockFn(vi.fn().mockResolvedValue(null)),
+    callGateway: defineMockFn(vi.fn().mockRejectedValue(new Error("gateway closed"))),
+  };
+}
+
+export function applyMockDoctorConfigSnapshot(
+  readConfigFileSnapshot: MockFn,
+  params: DoctorConfigSnapshotFixtureParams = {},
+): void {
+  readConfigFileSnapshot.mockResolvedValue(createDoctorConfigSnapshot(params));
+}
+
+export function createDoctorRuntime() {
+  return {
+    log: defineMockFn(vi.fn()),
+    error: defineMockFn(vi.fn()),
+    exit: defineMockFn(vi.fn()),
+  };
+}
+
+export async function arrangeLegacyStateMigrationFixture(deps: {
+  confirm: MockFn;
+  createDetection: (params: { hasLegacySessions: boolean; preview: string[] }) => unknown;
+  detectLegacyStateMigrations: MockFn;
+  mockDoctorConfigSnapshot: () => void;
+  runLegacyStateMigrations: MockFn;
+}): Promise<{
+  doctorCommand: unknown;
+  runtime: { log: MockFn; error: MockFn; exit: MockFn };
+  detectLegacyStateMigrations: MockFn;
+  runLegacyStateMigrations: MockFn;
+}> {
+  deps.mockDoctorConfigSnapshot();
+
+  const { doctorCommand } = await import("./doctor.js");
+  const runtime = createDoctorRuntime();
+
+  deps.detectLegacyStateMigrations.mockClear();
+  deps.runLegacyStateMigrations.mockClear();
+  deps.detectLegacyStateMigrations.mockResolvedValue(
+    deps.createDetection({
+      hasLegacySessions: true,
+      preview: ["- Legacy sessions detected"],
+    }),
+  );
+  deps.runLegacyStateMigrations.mockResolvedValueOnce({
+    changes: ["migrated"],
+    warnings: [],
+  });
+  deps.confirm.mockClear();
+
+  return {
+    doctorCommand,
+    runtime,
+    detectLegacyStateMigrations: deps.detectLegacyStateMigrations,
+    runLegacyStateMigrations: deps.runLegacyStateMigrations,
+  };
+}

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -5,161 +5,127 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { afterEach, beforeEach, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import type { MockFn } from "../test-utils/vitest-mock-fn.js";
-import { createDoctorConfigSnapshot } from "./doctor-config-snapshot.test-helpers.js";
+import { defineMockFn, type MockFn } from "../test-utils/vitest-mock-fn.js";
 import {
   readEmbeddedGatewayTokenForTest,
   testServiceAuditCodes,
 } from "./doctor-service-audit.test-helpers.js";
 import type { LegacyStateDetection } from "./doctor-state-migrations.js";
+import {
+  applyMockDoctorConfigSnapshot,
+  arrangeLegacyStateMigrationFixture,
+  createCommandWithTimeoutResult,
+  createDoctorServiceMocks,
+  createDoctorRuntime as createDoctorRuntimeFixture,
+  createGatewayUpdateResult,
+  createLegacyConfigSnapshot,
+  type DoctorConfigSnapshotFixtureParams,
+  setDoctorStdinTty,
+} from "./doctor.e2e-harness.test-helpers.js";
 
 let originalIsTTY: boolean | undefined;
 let originalStateDir: string | undefined;
 let originalUpdateInProgress: string | undefined;
 let tempStateDir: string | undefined;
 
-function setStdinTty(value: boolean | undefined) {
-  try {
-    Object.defineProperty(process.stdin, "isTTY", {
-      value,
-      configurable: true,
-    });
-  } catch {
-    // ignore
-  }
-}
+export const readConfigFileSnapshot = defineMockFn(vi.fn());
+export const confirm = defineMockFn(vi.fn().mockResolvedValue(true));
+const select = defineMockFn(vi.fn().mockResolvedValue("node"));
+const note = defineMockFn(vi.fn());
+export const writeConfigFile = defineMockFn(vi.fn().mockResolvedValue(undefined));
+export const resolveOpenClawPackageRoot = defineMockFn(vi.fn().mockResolvedValue(null));
+export const runGatewayUpdate = defineMockFn(
+  vi.fn().mockResolvedValue(createGatewayUpdateResult()),
+);
+const collectRelevantDoctorPluginIds = defineMockFn(vi.fn(() => []));
+const listPluginDoctorLegacyConfigRules = defineMockFn(vi.fn(() => []));
+const runDoctorHealthContributions = defineMockFn(vi.fn(defaultRunDoctorHealthContributions));
+const maybeRepairMemoryRecallHealth = defineMockFn(vi.fn().mockResolvedValue(undefined));
+const noteMemorySearchHealth = defineMockFn(vi.fn().mockResolvedValue(undefined));
+const noteMemoryRecallHealth = defineMockFn(vi.fn().mockResolvedValue(undefined));
+const migrateLegacyConfig = defineMockFn(
+  vi.fn((raw: unknown) => ({
+    config: raw as Record<string, unknown>,
+    changes: ["Moved routing.allowFrom → channels.whatsapp.allowFrom."],
+  })),
+);
 
-function createGatewayUpdateResult() {
-  return {
-    status: "skipped",
-    mode: "unknown",
-    steps: [],
-    durationMs: 0,
-  } as const;
-}
-
-function createCommandWithTimeoutResult() {
-  return {
+const runExec = defineMockFn(
+  vi.fn().mockResolvedValue({
     stdout: "",
     stderr: "",
-    code: 0,
-    signal: null,
-    killed: false,
-  } as const;
-}
-
-function createLegacyConfigSnapshot() {
-  return {
-    path: "/tmp/openclaw.json",
-    exists: false,
-    raw: null,
-    parsed: {},
-    valid: true,
-    config: {},
-    issues: [],
-    legacyIssues: [],
-  } as const;
-}
-
-export const readConfigFileSnapshot = vi.fn() as unknown as MockFn;
-export const confirm = vi.fn().mockResolvedValue(true) as unknown as MockFn;
-const select = vi.fn().mockResolvedValue("node") as unknown as MockFn;
-const note = vi.fn() as unknown as MockFn;
-export const writeConfigFile = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-export const resolveOpenClawPackageRoot = vi.fn().mockResolvedValue(null) as unknown as MockFn;
-export const runGatewayUpdate = vi
-  .fn()
-  .mockResolvedValue(createGatewayUpdateResult()) as unknown as MockFn;
-const collectRelevantDoctorPluginIds = vi.fn(() => []) as unknown as MockFn;
-const listPluginDoctorLegacyConfigRules = vi.fn(() => []) as unknown as MockFn;
-const runDoctorHealthContributions = vi.fn(
-  defaultRunDoctorHealthContributions,
-) as unknown as MockFn;
-const maybeRepairMemoryRecallHealth = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const noteMemorySearchHealth = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const noteMemoryRecallHealth = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const migrateLegacyConfig = vi.fn((raw: unknown) => ({
-  config: raw as Record<string, unknown>,
-  changes: ["Moved routing.allowFrom → channels.whatsapp.allowFrom."],
-})) as unknown as MockFn;
-
-const runExec = vi.fn().mockResolvedValue({
-  stdout: "",
-  stderr: "",
-}) as unknown as MockFn;
-export const runCommandWithTimeout = vi
-  .fn()
-  .mockResolvedValue(createCommandWithTimeoutResult()) as unknown as MockFn;
-
-export const ensureAuthProfileStore = vi
-  .fn()
-  .mockReturnValue({ version: 1, profiles: {} }) as unknown as MockFn;
-
-const legacyReadConfigFileSnapshot = vi
-  .fn()
-  .mockResolvedValue(createLegacyConfigSnapshot()) as unknown as MockFn;
-const createConfigIO = vi.fn(() => ({
-  readConfigFileSnapshot: legacyReadConfigFileSnapshot,
-})) as unknown as MockFn;
-
-const findLegacyGatewayServices = vi.fn().mockResolvedValue([]) as unknown as MockFn;
-const uninstallLegacyGatewayServices = vi.fn().mockResolvedValue([]) as unknown as MockFn;
-const findExtraGatewayServices = vi.fn().mockResolvedValue([]) as unknown as MockFn;
-const findSystemGatewayServices = vi.fn().mockResolvedValue([]) as unknown as MockFn;
-const renderGatewayServiceCleanupHints = vi.fn().mockReturnValue(["cleanup"]) as unknown as MockFn;
-const auditGatewayServiceConfig = vi
-  .fn()
-  .mockResolvedValue({ ok: true, issues: [] }) as unknown as MockFn;
-const buildGatewayInstallPlan = vi.mocked(
-  vi.fn().mockResolvedValue({
-    programArguments: ["node", "cli", "gateway", "--port", "18789"],
-    workingDirectory: "/tmp",
-    environment: {},
   }),
-) as unknown as MockFn;
-const resolveGatewayAuthTokenForService = vi
-  .fn()
-  .mockResolvedValue({ token: undefined }) as unknown as MockFn;
-const resolveGatewayProgramArguments = vi.fn().mockResolvedValue({
-  programArguments: ["node", "cli", "gateway", "--port", "18789"],
-}) as unknown as MockFn;
-const serviceInstall = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-export const serviceIsLoaded = vi.fn().mockResolvedValue(false) as unknown as MockFn;
-const serviceStop = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-export const serviceRestart = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const serviceUninstall = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const serviceReadCommand = vi.fn().mockResolvedValue(null) as unknown as MockFn;
-export const callGateway = vi
-  .fn()
-  .mockRejectedValue(new Error("gateway closed")) as unknown as MockFn;
+);
+export const runCommandWithTimeout = defineMockFn(
+  vi.fn().mockResolvedValue(createCommandWithTimeoutResult()),
+);
 
-export const autoMigrateLegacyStateDir = vi.fn().mockResolvedValue({
-  migrated: false,
-  skipped: false,
-  changes: [],
-  warnings: [],
-}) as unknown as MockFn;
-const autoMigrateLegacyState = vi.fn().mockResolvedValue({
-  migrated: false,
-  skipped: false,
-  changes: [],
-  warnings: [],
-}) as unknown as MockFn;
-const autoMigrateLegacyPluginDoctorState = vi.fn().mockResolvedValue({
-  migrated: false,
-  skipped: false,
-  changes: [],
-  warnings: [],
-}) as unknown as MockFn;
-const autoMigrateLegacyTaskStateSidecars = vi.fn().mockResolvedValue({
-  migrated: false,
-  skipped: false,
-  changes: [],
-  warnings: [],
-}) as unknown as MockFn;
-const runChannelPluginStartupMaintenance = vi
-  .fn()
-  .mockResolvedValue(undefined) as unknown as MockFn;
+export const ensureAuthProfileStore = defineMockFn(
+  vi.fn().mockReturnValue({ version: 1, profiles: {} }),
+);
+
+const legacyReadConfigFileSnapshot = defineMockFn(
+  vi.fn().mockResolvedValue(createLegacyConfigSnapshot()),
+);
+const createConfigIO = defineMockFn(
+  vi.fn(() => ({
+    readConfigFileSnapshot: legacyReadConfigFileSnapshot,
+  })),
+);
+
+const {
+  auditGatewayServiceConfig,
+  buildGatewayInstallPlan,
+  callGateway,
+  findExtraGatewayServices,
+  findLegacyGatewayServices,
+  findSystemGatewayServices,
+  renderGatewayServiceCleanupHints,
+  resolveGatewayAuthTokenForService,
+  resolveGatewayProgramArguments,
+  serviceInstall,
+  serviceIsLoaded,
+  serviceReadCommand,
+  serviceRestart,
+  serviceStop,
+  serviceUninstall,
+  uninstallLegacyGatewayServices,
+} = createDoctorServiceMocks();
+export { callGateway, serviceIsLoaded, serviceRestart };
+
+export const autoMigrateLegacyStateDir = defineMockFn(
+  vi.fn().mockResolvedValue({
+    migrated: false,
+    skipped: false,
+    changes: [],
+    warnings: [],
+  }),
+);
+const autoMigrateLegacyState = defineMockFn(
+  vi.fn().mockResolvedValue({
+    migrated: false,
+    skipped: false,
+    changes: [],
+    warnings: [],
+  }),
+);
+const autoMigrateLegacyPluginDoctorState = defineMockFn(
+  vi.fn().mockResolvedValue({
+    migrated: false,
+    skipped: false,
+    changes: [],
+    warnings: [],
+  }),
+);
+const autoMigrateLegacyTaskStateSidecars = defineMockFn(
+  vi.fn().mockResolvedValue({
+    migrated: false,
+    skipped: false,
+    changes: [],
+    warnings: [],
+  }),
+);
+const runChannelPluginStartupMaintenance = defineMockFn(vi.fn().mockResolvedValue(undefined));
 
 function defaultRunDoctorHealthContributions(ctx: {
   cfg: Record<string, unknown>;
@@ -357,14 +323,16 @@ function createLegacyStateMigrationDetectionResult(params?: {
   };
 }
 
-const detectLegacyStateMigrations = vi
-  .fn()
-  .mockResolvedValue(createLegacyStateMigrationDetectionResult()) as unknown as MockFn;
+const detectLegacyStateMigrations = defineMockFn(
+  vi.fn().mockResolvedValue(createLegacyStateMigrationDetectionResult()),
+);
 
-const runLegacyStateMigrations = vi.fn().mockResolvedValue({
-  changes: [],
-  warnings: [],
-}) as unknown as MockFn;
+const runLegacyStateMigrations = defineMockFn(
+  vi.fn().mockResolvedValue({
+    changes: [],
+    warnings: [],
+  }),
+);
 
 vi.mock("@clack/prompts", () => ({
   confirm,
@@ -624,26 +592,11 @@ vi.mock("../channels/plugins/lifecycle-startup.js", () => ({
 }));
 
 /** Configures the mocked doctor config snapshot with a partial snapshot override. */
-export function mockDoctorConfigSnapshot(
-  params: {
-    config?: Record<string, unknown>;
-    parsed?: Record<string, unknown>;
-    valid?: boolean;
-    issues?: Array<{ path: string; message: string }>;
-    legacyIssues?: Array<{ path: string; message: string }>;
-  } = {},
-) {
-  readConfigFileSnapshot.mockResolvedValue(createDoctorConfigSnapshot(params));
+export function mockDoctorConfigSnapshot(params: DoctorConfigSnapshotFixtureParams = {}): void {
+  applyMockDoctorConfigSnapshot(readConfigFileSnapshot, params);
 }
 
-/** Creates a runtime mock that captures doctor command output and exits. */
-export function createDoctorRuntime() {
-  return {
-    log: vi.fn() as unknown as MockFn,
-    error: vi.fn() as unknown as MockFn,
-    exit: vi.fn() as unknown as MockFn,
-  };
-}
+export const createDoctorRuntime = createDoctorRuntimeFixture;
 
 /** Sets up temporary legacy state paths and mocked config for migration tests. */
 export async function arrangeLegacyStateMigrationTest(): Promise<{
@@ -652,32 +605,13 @@ export async function arrangeLegacyStateMigrationTest(): Promise<{
   detectLegacyStateMigrations: MockFn;
   runLegacyStateMigrations: MockFn;
 }> {
-  mockDoctorConfigSnapshot();
-
-  const { doctorCommand } = await import("./doctor.js");
-  const runtime = createDoctorRuntime();
-
-  detectLegacyStateMigrations.mockClear();
-  runLegacyStateMigrations.mockClear();
-  detectLegacyStateMigrations.mockResolvedValue(
-    createLegacyStateMigrationDetectionResult({
-      hasLegacySessions: true,
-      preview: ["- Legacy sessions detected"],
-    }),
-  );
-  runLegacyStateMigrations.mockResolvedValueOnce({
-    changes: ["migrated"],
-    warnings: [],
-  });
-
-  confirm.mockClear();
-
-  return {
-    doctorCommand,
-    runtime,
+  return arrangeLegacyStateMigrationFixture({
+    confirm,
+    createDetection: createLegacyStateMigrationDetectionResult,
     detectLegacyStateMigrations,
+    mockDoctorConfigSnapshot,
     runLegacyStateMigrations,
-  };
+  });
 }
 
 beforeEach(() => {
@@ -737,7 +671,7 @@ beforeEach(() => {
   runChannelPluginStartupMaintenance.mockReset().mockResolvedValue(undefined);
 
   originalIsTTY = process.stdin.isTTY;
-  setStdinTty(true);
+  setDoctorStdinTty(true);
   originalStateDir = process.env.OPENCLAW_STATE_DIR;
   originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
   process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
@@ -750,7 +684,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  setStdinTty(originalIsTTY);
+  setDoctorStdinTty(originalIsTTY);
   if (originalStateDir === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {

--- a/src/config/env-preserve.test.ts
+++ b/src/config/env-preserve.test.ts
@@ -1,13 +1,14 @@
 // Covers preserved environment-variable config normalization.
 import { describe, it, expect } from "vitest";
 import { restoreEnvVarRefs } from "./env-preserve.js";
+import { createProcessEnvFixture } from "./test-helpers.js";
 
 describe("restoreEnvVarRefs", () => {
-  const env = {
+  const env = createProcessEnvFixture({
     ANTHROPIC_API_KEY: "sk-ant-api03-real-key",
     OPENAI_API_KEY: "sk-openai-real-key",
     MY_TOKEN: "tok-12345",
-  } as unknown as NodeJS.ProcessEnv;
+  });
 
   it("restores a simple ${VAR} reference when value matches", () => {
     const incoming = { apiKey: "sk-ant-api03-real-key" };
@@ -79,7 +80,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("handles missing env var (cannot verify match)", () => {
-    const envMissing = {} as unknown as NodeJS.ProcessEnv;
+    const envMissing = createProcessEnvFixture({});
     const incoming = { apiKey: "some-value" };
     const parsed = { apiKey: "${MISSING_VAR}" };
     // Can't resolve the template, so keep incoming as-is
@@ -95,7 +96,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("restores partially resolved templates when missing vars remain literal", () => {
-    const partialEnv = { API_TOKEN: "secret" } as unknown as NodeJS.ProcessEnv;
+    const partialEnv = createProcessEnvFixture({ API_TOKEN: "secret" });
     const incoming = { value: "secret:${OPTIONAL_SUFFIX}" };
     const parsed = { value: "${API_TOKEN}:${OPTIONAL_SUFFIX}" };
 
@@ -105,10 +106,10 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("rejects structural changes to arrays containing environment references", () => {
-    const duplicateEnv = {
+    const duplicateEnv = createProcessEnvFixture({
       PLUGIN_A: "same-plugin",
       PLUGIN_B: "same-plugin",
-    } as unknown as NodeJS.ProcessEnv;
+    });
 
     expect(() =>
       restoreEnvVarRefs(["same-plugin"], ["${PLUGIN_A}", "${PLUGIN_B}"], duplicateEnv),
@@ -126,25 +127,37 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("restores escaped literals beside real environment-backed array entries", () => {
-    const result = restoreEnvVarRefs(["secret", "${ESCAPED}"], ["${TOKEN}", "$${ESCAPED}"], {
-      TOKEN: "secret",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["secret", "${ESCAPED}"],
+      ["${TOKEN}", "$${ESCAPED}"],
+      createProcessEnvFixture({
+        TOKEN: "secret",
+      }),
+    );
 
     expect(result).toEqual(["${TOKEN}", "$${ESCAPED}"]);
   });
 
   it("allows appending after stable environment-backed array entries", () => {
-    const result = restoreEnvVarRefs(["base-plugin", "extra-plugin"], ["${BASE_PLUGIN}"], {
-      BASE_PLUGIN: "base-plugin",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["base-plugin", "extra-plugin"],
+      ["${BASE_PLUGIN}"],
+      createProcessEnvFixture({
+        BASE_PLUGIN: "base-plugin",
+      }),
+    );
 
     expect(result).toEqual(["${BASE_PLUGIN}", "extra-plugin"]);
   });
 
   it("allows removing a unique environment-backed array entry", () => {
-    const result = restoreEnvVarRefs([], ["${BASE_PLUGIN}"], {
-      BASE_PLUGIN: "base-plugin",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      [],
+      ["${BASE_PLUGIN}"],
+      createProcessEnvFixture({
+        BASE_PLUGIN: "base-plugin",
+      }),
+    );
 
     expect(result).toEqual([]);
   });
@@ -163,10 +176,10 @@ describe("restoreEnvVarRefs", () => {
           deny: ["${DENIED_PLUGIN}", "keep"],
         },
       },
-      {
+      createProcessEnvFixture({
         BASE_PLUGIN: "base-plugin",
         DENIED_PLUGIN: "demo",
-      } as unknown as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(result).toEqual({
@@ -178,9 +191,13 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("allows replacing a unique environment-backed array entry", () => {
-    const result = restoreEnvVarRefs(["replacement"], ["${BASE_PLUGIN}"], {
-      BASE_PLUGIN: "base-plugin",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["replacement"],
+      ["${BASE_PLUGIN}"],
+      createProcessEnvFixture({
+        BASE_PLUGIN: "base-plugin",
+      }),
+    );
 
     expect(result).toEqual(["replacement"]);
   });
@@ -189,7 +206,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ id: "main", workspace: "/workspace/main", name: "new" }],
       [{ id: "main", workspace: "${WORKSPACE}", name: "old" }],
-      { WORKSPACE: "/workspace/main" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ WORKSPACE: "/workspace/main" }),
     );
 
     expect(result).toEqual([{ id: "main", workspace: "${WORKSPACE}", name: "new" }]);
@@ -199,7 +216,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ name: "new", token: "secret" }],
       [{ name: "old", token: "${TOKEN}" }],
-      { TOKEN: "secret" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ TOKEN: "secret" }),
     );
 
     expect(result).toEqual([{ name: "new", token: "${TOKEN}" }]);
@@ -209,7 +226,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ match: { peer: { id: "peer-1" } } }, { match: { peer: { id: "peer-2" } } }],
       [{ match: { peer: { id: "${PEER_ID}" } } }],
-      { PEER_ID: "peer-1" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ PEER_ID: "peer-1" }),
     );
 
     expect(result).toEqual([
@@ -226,7 +243,7 @@ describe("restoreEnvVarRefs", () => {
           { name: "second", token: "literal" },
         ],
         [{ name: "old", token: "${TOKEN}" }],
-        { TOKEN: "secret" } as unknown as NodeJS.ProcessEnv,
+        createProcessEnvFixture({ TOKEN: "secret" }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -242,10 +259,10 @@ describe("restoreEnvVarRefs", () => {
           { name: "first", token: "${TOKEN_A}" },
           { name: "second", token: "${TOKEN_B}" },
         ],
-        {
+        createProcessEnvFixture({
           TOKEN_A: "secret-a",
           TOKEN_B: "secret-b",
-        } as unknown as NodeJS.ProcessEnv,
+        }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -261,10 +278,10 @@ describe("restoreEnvVarRefs", () => {
           { account: "first", token: "${TOKEN_A}" },
           { account: "second", token: "${TOKEN_B}" },
         ],
-        {
+        createProcessEnvFixture({
           TOKEN_A: "secret-a",
           TOKEN_B: "secret-b",
-        } as unknown as NodeJS.ProcessEnv,
+        }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -279,10 +296,10 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "first", name: "first", match: { peer: { id: "${PEER_A}" } } },
         { agentId: "second", name: "second", match: { peer: { id: "${PEER_B}" } } },
       ],
-      {
+      createProcessEnvFixture({
         PEER_A: "peer-a",
         PEER_B: "peer-b",
-      } as unknown as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(result).toEqual([
@@ -295,7 +312,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ agentId: "main", match: { accountId: "next" }, token: "secret" }],
       [{ agentId: "main", match: { accountId: "old" }, token: "${TOKEN}" }],
-      { TOKEN: "secret" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ TOKEN: "secret" }),
     );
 
     expect(result).toEqual([{ agentId: "main", match: { accountId: "next" }, token: "${TOKEN}" }]);
@@ -305,7 +322,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ accountId: "next", to: "user@example.com" }],
       [{ accountId: "old", to: "${APPROVAL_TARGET}" }],
-      { APPROVAL_TARGET: "user@example.com" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ APPROVAL_TARGET: "user@example.com" }),
     );
 
     expect(result).toEqual([{ accountId: "next", to: "${APPROVAL_TARGET}" }]);
@@ -321,10 +338,10 @@ describe("restoreEnvVarRefs", () => {
         { accountId: "old", to: "${APPROVAL_TARGET_A}" },
         { accountId: "second", to: "${APPROVAL_TARGET_B}" },
       ],
-      {
+      createProcessEnvFixture({
         APPROVAL_TARGET_A: "user-a@example.com",
         APPROVAL_TARGET_B: "user-b@example.com",
-      } as unknown as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(result).toEqual([
@@ -343,10 +360,10 @@ describe("restoreEnvVarRefs", () => {
         { account: "first", enabled: false, token: "${TOKEN_A}" },
         { account: "second", enabled: true, token: "${TOKEN_B}" },
       ],
-      {
+      createProcessEnvFixture({
         TOKEN_A: "secret-a",
         TOKEN_B: "secret-b",
-      } as unknown as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(result).toEqual([
@@ -362,7 +379,7 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "first", match: { peer: { id: "${PEER_A}" } } },
         { agentId: "second", match: { peer: { id: "peer-b" } } },
       ],
-      { PEER_A: "peer-a" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ PEER_A: "peer-a" }),
     );
 
     expect(result).toEqual([{ agentId: "second", match: { peer: { id: "peer-b" } } }]);
@@ -376,10 +393,10 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "second", match: { peer: { id: "${PEER_B}" } } },
         { agentId: "retained", match: { peer: { id: "peer-c" } } },
       ],
-      {
+      createProcessEnvFixture({
         PEER_A: "peer-a",
         PEER_B: "peer-b",
-      } as unknown as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(result).toEqual([{ agentId: "retained", match: { peer: { id: "peer-c" } } }]);
@@ -396,10 +413,10 @@ describe("restoreEnvVarRefs", () => {
           { id: "duplicate", workspace: "${WORKSPACE_A}", name: "a" },
           { id: "duplicate", workspace: "${WORKSPACE_B}", name: "b" },
         ],
-        {
+        createProcessEnvFixture({
           WORKSPACE_A: "/workspace/a",
           WORKSPACE_B: "/workspace/b",
-        } as unknown as NodeJS.ProcessEnv,
+        }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -412,10 +429,10 @@ describe("restoreEnvVarRefs", () => {
           { id: "duplicate", sessionKey: "${SESSION_A}" },
           { id: "duplicate", sessionKey: "${SESSION_B}" },
         ],
-        {
+        createProcessEnvFixture({
           SESSION_A: "same",
           SESSION_B: "same",
-        } as unknown as NodeJS.ProcessEnv,
+        }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -427,7 +444,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "duplicate", sessionKey: "${SESSION_KEY}" },
         { id: "duplicate", sessionKey: "literal" },
       ],
-      { SESSION_KEY: "secret" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ SESSION_KEY: "secret" }),
     );
 
     expect(result).toEqual([{ id: "duplicate", sessionKey: "literal" }]);
@@ -435,9 +452,13 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects renaming stable ids on env-backed array objects", () => {
     expect(() =>
-      restoreEnvVarRefs([{ id: "new", token: "secret" }], [{ id: "old", token: "${TOKEN}" }], {
-        TOKEN: "secret",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        [{ id: "new", token: "secret" }],
+        [{ id: "old", token: "${TOKEN}" }],
+        createProcessEnvFixture({
+          TOKEN: "secret",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -448,7 +469,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "main", workspace: "/workspace/main" },
         { id: "ops", workspace: "${OPS_WORKSPACE}" },
       ],
-      { OPS_WORKSPACE: "/workspace/ops" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ OPS_WORKSPACE: "/workspace/ops" }),
     );
 
     expect(result).toEqual([{ id: "main", workspace: "/workspace/main" }]);
@@ -461,7 +482,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "ops", workspace: "${OPS_WORKSPACE}" },
         { id: "main", name: "old" },
       ],
-      { OPS_WORKSPACE: "/workspace/ops" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ OPS_WORKSPACE: "/workspace/ops" }),
     );
 
     expect(result).toEqual([{ id: "main", name: "new" }]);
@@ -469,32 +490,48 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects same-index template matches against authored literal duplicates", () => {
     expect(() =>
-      restoreEnvVarRefs(["same"], ["${PLUGIN_PATH}", "same"], {
-        PLUGIN_PATH: "same",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["same"],
+        ["${PLUGIN_PATH}", "same"],
+        createProcessEnvFixture({
+          PLUGIN_PATH: "same",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects same-index scalar matches after surrounding array restructuring", () => {
     expect(() =>
-      restoreEnvVarRefs(["tail", "secret"], ["old", "${TOKEN}", "tail"], {
-        TOKEN: "secret",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["tail", "secret"],
+        ["old", "${TOKEN}", "tail"],
+        createProcessEnvFixture({
+          TOKEN: "secret",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("allows trailing sibling edits beside a scalar environment reference", () => {
-    const result = restoreEnvVarRefs(["base-plugin", "replacement"], ["${BASE_PLUGIN}", "old"], {
-      BASE_PLUGIN: "base-plugin",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["base-plugin", "replacement"],
+      ["${BASE_PLUGIN}", "old"],
+      createProcessEnvFixture({
+        BASE_PLUGIN: "base-plugin",
+      }),
+    );
 
     expect(result).toEqual(["${BASE_PLUGIN}", "replacement"]);
   });
 
   it("allows prefix edits before a same-index scalar environment reference", () => {
-    const result = restoreEnvVarRefs(["new", "base-plugin"], ["old", "${BASE_PLUGIN}"], {
-      BASE_PLUGIN: "base-plugin",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["new", "base-plugin"],
+      ["old", "${BASE_PLUGIN}"],
+      createProcessEnvFixture({
+        BASE_PLUGIN: "base-plugin",
+      }),
+    );
 
     expect(result).toEqual(["new", "${BASE_PLUGIN}"]);
   });
@@ -513,7 +550,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       ["secret", "literal", "${ESCAPED}"],
       ["${TOKEN}", "$${ESCAPED}", "literal"],
-      { TOKEN: "secret" } as unknown as NodeJS.ProcessEnv,
+      createProcessEnvFixture({ TOKEN: "secret" }),
     );
 
     expect(result).toEqual(["${TOKEN}", "literal", "$${ESCAPED}"]);
@@ -631,9 +668,13 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects escaped literal moves onto indexes claimed by real references", () => {
     expect(() =>
-      restoreEnvVarRefs(["${B}", "changed"], ["${A}", "$${B}", "tail"], {
-        A: "x",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["${B}", "changed"],
+        ["${A}", "$${B}", "tail"],
+        createProcessEnvFixture({
+          A: "x",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -654,18 +695,26 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("preserves intentional real references beside same-name escaped literals", () => {
-    const result = restoreEnvVarRefs(["secret", "${TOKEN}"], ["${TOKEN}", "$${TOKEN}"], {
-      TOKEN: "secret",
-    } as unknown as NodeJS.ProcessEnv);
+    const result = restoreEnvVarRefs(
+      ["secret", "${TOKEN}"],
+      ["${TOKEN}", "$${TOKEN}"],
+      createProcessEnvFixture({
+        TOKEN: "secret",
+      }),
+    );
 
     expect(result).toEqual(["${TOKEN}", "$${TOKEN}"]);
   });
 
   it("rejects ambiguous same-name real and escaped reference reorders", () => {
     expect(() =>
-      restoreEnvVarRefs(["${TOKEN}", "secret"], ["${TOKEN}", "$${TOKEN}"], {
-        TOKEN: "secret",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["${TOKEN}", "secret"],
+        ["${TOKEN}", "$${TOKEN}"],
+        createProcessEnvFixture({
+          TOKEN: "secret",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -693,9 +742,13 @@ describe("restoreEnvVarRefs", () => {
 
   it("does not let a same-path active reference mask an activated escaped literal", () => {
     expect(() =>
-      restoreEnvVarRefs(["changed-${TOKEN}"], ["${TOKEN}-$${TOKEN}"], {
-        TOKEN: "secret",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["changed-${TOKEN}"],
+        ["${TOKEN}-$${TOKEN}"],
+        createProcessEnvFixture({
+          TOKEN: "secret",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -726,24 +779,32 @@ describe("restoreEnvVarRefs", () => {
           { id: "literal", token: "$${TOKEN}" },
           { id: "active", token: "${TOKEN}" },
         ],
-        { TOKEN: "secret" } as unknown as NodeJS.ProcessEnv,
+        createProcessEnvFixture({ TOKEN: "secret" }),
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects replacing a scalar template while adding its resolved value elsewhere", () => {
     expect(() =>
-      restoreEnvVarRefs(["replacement", "admin"], ["${ADMIN_ID}", "old"], {
-        ADMIN_ID: "admin",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["replacement", "admin"],
+        ["${ADMIN_ID}", "old"],
+        createProcessEnvFixture({
+          ADMIN_ID: "admin",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects replacing a scalar template while adding its resolved value in a longer array", () => {
     expect(() =>
-      restoreEnvVarRefs(["old", "replacement", "admin"], ["${ADMIN_ID}", "old"], {
-        ADMIN_ID: "admin",
-      } as unknown as NodeJS.ProcessEnv),
+      restoreEnvVarRefs(
+        ["old", "replacement", "admin"],
+        ["${ADMIN_ID}", "old"],
+        createProcessEnvFixture({
+          ADMIN_ID: "admin",
+        }),
+      ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -769,7 +830,7 @@ describe("restoreEnvVarRefs", () => {
     // At read time, MY_VAR was "original-value" and resolved ${MY_VAR} → "original-value"
     // Then config.env or external mutation changed MY_VAR to "mutated-value"
     // Caller is writing back "original-value" (the value they got from the read)
-    const mutatedEnv = { MY_VAR: "mutated-value" } as unknown as NodeJS.ProcessEnv;
+    const mutatedEnv = createProcessEnvFixture({ MY_VAR: "mutated-value" });
     const incoming = { key: "original-value" };
     const parsed = { key: "${MY_VAR}" };
 
@@ -780,7 +841,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("correctly restores when env var value hasn't changed", () => {
-    const stableEnv = { MY_VAR: "stable-value" } as unknown as NodeJS.ProcessEnv;
+    const stableEnv = createProcessEnvFixture({ MY_VAR: "stable-value" });
     const incoming = { key: "stable-value" };
     const parsed = { key: "${MY_VAR}" };
 
@@ -793,7 +854,7 @@ describe("restoreEnvVarRefs", () => {
     // With env snapshots: at read time MY_VAR was "old-value", so incoming is "old-value".
     // Caller changed it to "new-value". Live env also changed to "new-value".
     // But using the READ-TIME snapshot ("old-value"), we correctly see mismatch and keep incoming.
-    const readTimeEnv = { MY_VAR: "old-value" } as unknown as NodeJS.ProcessEnv;
+    const readTimeEnv = createProcessEnvFixture({ MY_VAR: "old-value" });
     const incoming = { key: "new-value" }; // caller intentionally changed this
     const parsed = { key: "${MY_VAR}" };
 
@@ -839,7 +900,7 @@ describe("restoreEnvVarRefs", () => {
     const parsed = Object.create({
       toString: "${TEST_VALUE}",
     }) as Record<string, unknown>;
-    const testEnv = { TEST_VALUE: "resolved-value" } as unknown as NodeJS.ProcessEnv;
+    const testEnv = createProcessEnvFixture({ TEST_VALUE: "resolved-value" });
 
     expect(restoreEnvVarRefs({ toString: "resolved-value" }, parsed, testEnv)).toEqual({
       toString: "resolved-value",

--- a/src/config/test-helpers.ts
+++ b/src/config/test-helpers.ts
@@ -35,6 +35,10 @@ export async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise
   }
 }
 
+export function createProcessEnvFixture(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...overrides };
+}
+
 export async function writeOpenClawConfig(home: string, config: unknown): Promise<string> {
   const configPath = path.join(home, ".openclaw", "openclaw.json");
   await fs.mkdir(path.dirname(configPath), { recursive: true });

--- a/src/flows/doctor-health-contributions.test-support.ts
+++ b/src/flows/doctor-health-contributions.test-support.ts
@@ -1,5 +1,9 @@
+import { vi } from "vitest";
+import type { DoctorPrompter } from "../commands/doctor-prompter.js";
+import type { OpenClawConfig, OpenClawConfigInput } from "../config/config.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 import "./doctor-health-contributions.js";
+import type { runDoctorLintChecks } from "./doctor-lint-flow.js";
 import type { HealthCheckInput, RunnableHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheck } from "./health-checks.js";
 import type { FlowContribution } from "./types.js";
@@ -39,6 +43,59 @@ type DoctorHealthContributionTestApi = {
     contributions: readonly DoctorHealthContribution[],
   ): Promise<void>;
 };
+
+type DoctorHealthFlowContextFixture = Partial<Omit<DoctorHealthFlowContext, "configResult">> & {
+  configResult?: Partial<DoctorHealthFlowContext["configResult"]>;
+};
+
+type DoctorLintContext = Parameters<typeof runDoctorLintChecks>[0];
+
+export function createDoctorConfigFixture(input: OpenClawConfigInput): OpenClawConfig {
+  return input as OpenClawConfig;
+}
+
+export function createDoctorLintContext(
+  fixture: Pick<DoctorLintContext, "cfg"> & Partial<Omit<DoctorLintContext, "cfg">>,
+): DoctorLintContext {
+  return fixture as DoctorLintContext;
+}
+
+function createDoctorPrompterFixture(): DoctorPrompter {
+  return {
+    confirm: vi.fn(async () => false),
+    confirmAutoFix: vi.fn(async () => false),
+    confirmAggressiveAutoFix: vi.fn(async () => false),
+    confirmRuntimeRepair: vi.fn(async () => false),
+    select: vi.fn(async (_params, fallback) => fallback),
+    shouldRepair: false,
+    shouldForce: false,
+    repairMode: {
+      shouldRepair: false,
+      shouldForce: false,
+      nonInteractive: true,
+      canPrompt: false,
+      updateInProgress: false,
+    },
+  };
+}
+
+export function createDoctorHealthFlowContext(
+  overrides: DoctorHealthFlowContextFixture = {},
+): DoctorHealthFlowContext {
+  const { configResult, ...contextOverrides } = overrides;
+  const cfg = overrides.cfg ?? {};
+  return {
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    options: {},
+    prompter: createDoctorPrompterFixture(),
+    configResult: { ...configResult, cfg: configResult?.cfg ?? cfg },
+    cfg,
+    cfgForPersistence: cfg,
+    sourceConfigValid: true,
+    configPath: "/tmp/openclaw.json",
+    ...contextOverrides,
+  };
+}
 
 function getTestApi(): DoctorHealthContributionTestApi {
   const api = (globalThis as Record<PropertyKey, unknown>)[

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -11,7 +11,10 @@ import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
 import { resolveDoctorContributionHealthChecks } from "./doctor-health-contributions.js";
 import {
+  createDoctorConfigFixture,
   createDoctorHealthContribution,
+  createDoctorHealthFlowContext,
+  createDoctorLintContext,
   resolveDoctorHealthContributions,
   runDoctorHealthContributionList,
 } from "./doctor-health-contributions.test-support.js";
@@ -970,12 +973,12 @@ describe("doctor health contributions", () => {
     mocks.maybeRepairLegacyPluginManifestContracts.mockResolvedValueOnce(true);
     const invalidatePluginMetadataSnapshot = vi.fn();
     const contribution = requireDoctorContribution("doctor:legacy-plugin-manifests");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       prompter: buildDoctorPrompter(true),
       invalidatePluginMetadataSnapshot,
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1432,13 +1435,13 @@ describe("doctor health contributions", () => {
 
   it("keeps release configured plugin installs repair-only", async () => {
     const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {}, sourceLastTouchedVersion: "2026.4.29" },
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(false),
       env: {},
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1455,14 +1458,14 @@ describe("doctor health contributions", () => {
     });
     const invalidatePluginMetadataSnapshot = vi.fn();
     const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {}, sourceLastTouchedVersion: "2026.4.29" },
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       env: {},
       invalidatePluginMetadataSnapshot,
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1486,7 +1489,7 @@ describe("doctor health contributions", () => {
       touchedConfig: true,
     });
     const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {}, sourceLastTouchedVersion: "2026.5.16-beta.4" },
       sourceConfigValid: true,
@@ -1499,7 +1502,7 @@ describe("doctor health contributions", () => {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
       },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1519,7 +1522,7 @@ describe("doctor health contributions", () => {
     const contribution = requireDoctorContribution("doctor:web-fetch-proxy");
     const cfg = { gateway: { mode: "local" as const } };
     const env = { HTTPS_PROXY: "http://proxy.example:8080" };
-    const ctx = { cfg, env } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    const ctx = createDoctorHealthFlowContext({ cfg, env });
 
     expect(ids.indexOf("doctor:security")).toBeLessThan(ids.indexOf("doctor:web-fetch-proxy"));
     await contribution.run(ctx);
@@ -1563,12 +1566,12 @@ describe("doctor health contributions", () => {
         path: "plugins.entries.codex",
       },
     ]);
-    const ctx = {
+    const ctx = createDoctorLintContext({
       cfg: { plugins: { entries: { codex: { enabled: true } } } },
       mode: "lint",
       allowExecSecretRefs: true,
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as unknown as Parameters<typeof runDoctorLintChecks>[0];
+    });
 
     await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
       checksRun: 0,
@@ -1617,10 +1620,12 @@ describe("doctor health contributions", () => {
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
-    await contribution.run({
-      cfg,
-      options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0]);
+    await contribution.run(
+      createDoctorHealthFlowContext({
+        cfg,
+        options: { nonInteractive: true },
+      }),
+    );
 
     expect(mocks.gatherDaemonStatus).toHaveBeenCalledWith({
       rpc: {
@@ -1654,10 +1659,12 @@ describe("doctor health contributions", () => {
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
-    await contribution.run({
-      cfg,
-      options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0]);
+    await contribution.run(
+      createDoctorHealthFlowContext({
+        cfg,
+        options: { nonInteractive: true },
+      }),
+    );
 
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
       pluginVersionDrift: undefined,
@@ -1684,10 +1691,12 @@ describe("doctor health contributions", () => {
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
-    await contribution.run({
-      cfg,
-      options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0]);
+    await contribution.run(
+      createDoctorHealthFlowContext({
+        cfg,
+        options: { nonInteractive: true },
+      }),
+    );
 
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
       pluginVersionDrift: undefined,
@@ -1803,10 +1812,10 @@ describe("doctor health contributions", () => {
         },
       },
     };
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg,
       options: {},
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1828,11 +1837,13 @@ describe("doctor health contributions", () => {
 
     const contribution = requireDoctorContribution("doctor:heartbeat-cadence-migration");
     const cfg = { agents: { defaults: { heartbeat: { every: "15m" } } } };
-    await contribution.run({
-      cfg,
-      prompter: buildDoctorPrompter(true),
-      env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" },
-    } as unknown as DoctorContributionRunContext);
+    await contribution.run(
+      createDoctorHealthFlowContext({
+        cfg,
+        prompter: buildDoctorPrompter(true),
+        env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" },
+      }),
+    );
 
     expect(mocks.maybeMigrateHeartbeatCadenceToCron).toHaveBeenCalledWith({
       cfg,
@@ -1910,7 +1921,7 @@ describe("doctor health contributions", () => {
     expect(check).toMatchObject({ defaultEnabled: false });
 
     const ctx = {
-      cfg: {
+      cfg: createDoctorConfigFixture({
         channels: {
           telegram: {
             accounts: {
@@ -1920,7 +1931,7 @@ describe("doctor health contributions", () => {
           },
         },
         bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
-      } as unknown as OpenClawConfig,
+      }),
       mode: "lint" as const,
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
     };
@@ -1944,7 +1955,7 @@ describe("doctor health contributions", () => {
 
   it("preserves allow-exec Gateway SecretRef resolution in auth health", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-auth");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {
         gateway: {
           mode: "local",
@@ -1956,7 +1967,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { allowExec: true, nonInteractive: true },
       env: { OPENCLAW_TEST_GATEWAY_TOKEN: "1" },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1978,14 +1989,14 @@ describe("doctor health contributions", () => {
 
   it("forwards allow-exec to Gateway service repair", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-services");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: { gateway: { mode: "local" } },
       configResult: {},
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { allowExec: true },
-    } as unknown as DoctorContributionRunContext;
+    });
 
     await contribution.run(ctx);
 
@@ -2000,7 +2011,7 @@ describe("doctor health contributions", () => {
 
   it("hints how to enable authenticated GitHub project search", async () => {
     const contribution = requireDoctorContribution("doctor:github-projects");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: {},
       sourceConfigValid: true,
@@ -2008,7 +2019,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       env: {},
-    } as unknown as DoctorContributionRunContext;
+    });
 
     await contribution.run(ctx);
     expect(mocks.note).toHaveBeenCalledWith(expect.stringContaining("GH_TOKEN"), "GitHub projects");
@@ -2028,14 +2039,14 @@ describe("doctor health contributions", () => {
     const cfg = { session: { store: "/tmp/shared-sessions.json" } };
     const detected = { preview: ["legacy sessions"], warnings: [], notices: [] };
     mocks.detectLegacyStateMigrations.mockResolvedValue(detected);
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg,
       configResult: {},
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2080,7 +2091,7 @@ describe("doctor health contributions", () => {
       checksRepaired: 0,
       checksValidated: 1,
     }));
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: {},
       sourceConfigValid: true,
@@ -2088,7 +2099,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2121,7 +2132,7 @@ describe("doctor health contributions", () => {
       checksRepaired: 1,
       checksValidated: 1,
     }));
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: {},
       sourceConfigValid: true,
@@ -2129,7 +2140,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2143,14 +2154,14 @@ describe("doctor health contributions", () => {
     const cfg = { session: { store: "/tmp/shared-sessions.json" } };
     const detected = { preview: ["legacy sessions"], warnings: [], notices: [] };
     mocks.detectLegacyStateMigrations.mockResolvedValue(detected);
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg,
       configResult: {},
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true, repair: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2184,14 +2195,14 @@ describe("doctor health contributions", () => {
       warnings: [],
       notices: ["Left reviewed legacy residue in place."],
     });
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: {},
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2207,7 +2218,7 @@ describe("doctor health contributions", () => {
       ({ path }: { path: string }) => path === "gateway.auth.token",
     );
     mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {
         gateway: {
           mode: "local",
@@ -2218,7 +2229,7 @@ describe("doctor health contributions", () => {
       prompter: buildDoctorPrompter(false),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -2233,13 +2244,13 @@ describe("doctor health contributions", () => {
 
   it("runs the receipted auth migration after repairing OAuth sidecars", async () => {
     const contribution = requireDoctorContribution("doctor:auth-profiles");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3187,7 +3198,7 @@ describe("doctor health contributions", () => {
       healthChecks,
       run: legacyRun,
     });
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
@@ -3196,7 +3207,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3234,7 +3245,7 @@ describe("doctor health contributions", () => {
       label: "Test structured run",
       healthChecks,
     });
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
@@ -3243,7 +3254,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3340,7 +3351,7 @@ describe("doctor health contributions", () => {
       label: "Test structured findings",
       healthChecks,
     });
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
@@ -3349,7 +3360,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3369,7 +3380,7 @@ describe("doctor health contributions", () => {
       label: "Test structured dry-run",
       healthChecks,
     });
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
@@ -3378,7 +3389,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3431,7 +3442,7 @@ describe("doctor health contributions", () => {
       calls.push("note");
     });
     const contribution = requireDoctorContribution("doctor:browser");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
@@ -3440,7 +3451,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       configPath: "/tmp/fake-openclaw.json",
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3461,7 +3472,7 @@ describe("doctor health contributions", () => {
 
   it("keeps core-kind repairs out of the extension repair pass", async () => {
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {} },
       sourceConfigValid: true,
@@ -3471,7 +3482,7 @@ describe("doctor health contributions", () => {
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -3486,7 +3497,7 @@ describe("doctor health contributions", () => {
       { id: "core/doctor/shell-completion", kind: "plugin" },
     ]);
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {} },
       sourceConfigValid: true,
@@ -3496,7 +3507,7 @@ describe("doctor health contributions", () => {
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await expect(contribution.run(ctx)).rejects.toThrow(
       "health check already registered: core/doctor/shell-completion",
@@ -3510,7 +3521,7 @@ describe("doctor health contributions", () => {
       { id: "core/doctor/shell-completion", kind: "core" },
     ]);
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: {},
       configResult: { cfg: {} },
       sourceConfigValid: true,
@@ -3520,7 +3531,7 @@ describe("doctor health contributions", () => {
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await expect(contribution.run(ctx)).rejects.toThrow(
       "health check already registered: core/doctor/shell-completion",
@@ -3547,8 +3558,8 @@ describe("doctor health contributions", () => {
           checksValidated: 1,
         };
       });
-      const ctx = {
-        cfg: {
+      const ctx = createDoctorHealthFlowContext({
+        cfg: createDoctorConfigFixture({
           channels: {
             telegram: {
               accounts: {
@@ -3558,7 +3569,7 @@ describe("doctor health contributions", () => {
             },
           },
           bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
-        } as unknown as OpenClawConfig,
+        }),
         configResult: { cfg: {} },
         sourceConfigValid: true,
         prompter: buildDoctorPrompter(shouldRepair),
@@ -3567,7 +3578,7 @@ describe("doctor health contributions", () => {
         cfgForPersistence: {},
         configPath: "/tmp/fake-openclaw.json",
         env: {},
-      } as unknown as Parameters<(typeof contribution)["run"]>[0];
+      });
 
       await contribution.run(ctx);
 
@@ -3856,7 +3867,7 @@ describe("doctor health contributions", () => {
     };
     mocks.maybeRepairGatewayServiceConfig.mockResolvedValueOnce(repairedCfg);
 
-    const ctx = {
+    const ctx = createDoctorHealthFlowContext({
       cfg: originalCfg,
       cfgForPersistence: originalCfg,
       configResult: {
@@ -3871,7 +3882,7 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: {},
       env: {},
-    } as unknown as DoctorContributionRunContext;
+    });
 
     await migrationWriteContribution.run(ctx);
     await gatewayServicesContribution.run(ctx);

--- a/src/test-utils/vitest-mock-fn.ts
+++ b/src/test-utils/vitest-mock-fn.ts
@@ -5,3 +5,8 @@
 // oxlint-disable-next-line typescript/no-explicit-any
 export type MockFn<T extends (...args: any[]) => any = (...args: any[]) => any> =
   import("vitest").Mock<T>;
+
+/** Preserves a Vitest mock's precise implementation type behind the shared named mock type. */
+export function defineMockFn<T extends MockFn>(mock: T): T {
+  return mock;
+}


### PR DESCRIPTION
## What Problem This Solves

Dense test fixtures in the next-highest assertion-chain clusters obscured their intended runtime types behind repeated `as unknown as` chains. That made fixtures easier to drift, harder to review, and invisible to normal TypeScript checking.

## Why This Change Was Made

This maintainer-requested wave extends the established typed-fixture pattern from #124625 across eight fitting clusters. Shared builders validate ordinary fixture overrides while deliberately malformed boundary fixtures retain explicit casts. Two heterogeneous clusters were left unchanged instead of forcing unrelated shapes through artificial abstractions.

The oversized doctor harness was also split along its existing test-support boundary so the touched file remains lint-clean without a suppression; legacy-store literals remain in their grandfathered doctor owner.

AI-assisted: yes. The final uncommitted and branch reviews both reported no actionable findings.

## User Impact

No user-visible runtime behavior changes. Maintainers get type-checked test setup, fewer unsafe assertion chains, and clearer intentional-negative fixtures while every existing test and assertion remains in place.

## Evidence

Scratch scan on the rebased branch:

| Cluster | Chains before → after | Test count before → after | Result |
| --- | ---: | ---: | --- |
| `src/agents/transcript-redact.test.ts` | 73 → 16 | 63 → 63 | Typed message fixture boundary; 16 intentional projection/malformed-input casts retained |
| `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` | 64 → 1 | 77 → 77 | Extended existing agent-runner fixtures; partial `SessionEntry` cast retained |
| `src/agents/provider-transport-fetch.test.ts` | 54 → 0 | 96 → 96 | Complete generic provider-model fixture |
| `src/agents/embedded-agent-runner/model.test.ts` | 49 → 16 | 150 → 150 | Config fixture builder; incomplete-model and discovery/projection casts retained |
| `ui/src/app/app-host.test.ts` | 49 → 49 | unchanged (not rerun) | Skipped: 18 unrelated shell/application target types, not one builder family |
| `extensions/voice-call/src/webhook.test.ts` | 45 → 45 | unchanged (not rerun) | Skipped: 15+ unrelated manager, handler, request, and private-state target types |
| `src/commands/doctor.e2e-harness.ts` | 45 → 0 | 38 → 38 discovered | Named Vitest mocks; latest schema consumer 3/3 green |
| `src/config/env-preserve.test.ts` | 44 → 0 | 72 → 72 | Typed process-environment fixture |
| `src/agents/agent-hooks/compaction-safeguard.test.ts` | 43 → 3 | 129 → 129 | Shared agent-message fixture; three lifecycle doubles retained |
| `src/flows/doctor-health-contributions.test.ts` | 43 → 10 | 115 → 115 | Typed doctor contexts; invalid/legacy migration inputs retained |

Accepted clusters: **415 → 46 chains** (369 removed). Skipped heterogeneous clusters remained unchanged. Production LOC: **+0/-0**; all **+1116/-838** lines are tests or test support, including mechanical formatting around builder calls and the doctor harness split.

Validation:

- `node scripts/run-vitest.mjs` on every changed direct test file: 63, 77, 96, 150, 72, 129, and 115 tests passed with identical before/after counts.
- Doctor harness consumers: 27, 6, 2, and 3 tests discovered before and after. A pre-existing `shortenPathWithHome(undefined)` failure in the 6-test migration consumer reproduced before edits; the final runtime-export proof is 3/3 green.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31974728028
- `AUTOREVIEW=".claude/skills/autoreview/scripts/autoreview"; "$AUTOREVIEW" --mode branch --base origin/main` — clean, no actionable findings.
- `git diff --check` — clean.
