### PR TITLE
fix(ui): remove archived sessions from sidebar immediately

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -452,7 +452,11 @@ export function collectPromotedMainChildRows(input: {
   showCron: boolean;
   showSystem: boolean;
 }): GatewaySessionRow[] {
-  return [...input.rows, ...Object.values(input.childRowsByParent).flat()].filter((row) => {
+  // Canonical rows override stale child snapshots for lifecycle facts such as archive state.
+  const knownRows = new Map(
+    [...Object.values(input.childRowsByParent).flat(), ...input.rows].map((row) => [row.key, row]),
+  );
+  return [...knownRows.values()].filter((row) => {
     const parentKey = resolveUiSessionNavigationParentKey(row);
     return (
       parentKey != null &&

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -646,12 +646,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const lineageRouteAgentId = normalizeAgentId(
       parseAgentSessionKey(navigationState.routeSessionKey)?.agentId ?? "",
     );
-    const lineageSelected = Boolean(
-      lineageRoot && areUiSessionKeysEquivalent(lineageRoot.key, navigationState.routeSessionKey),
-    );
     if (
       lineageRoot &&
-      (lineageSelected || sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter)) &&
+      sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter) &&
       (lineageAgentId === selected || lineageRouteAgentId === selected) &&
       !adopted.has(lineageRoot.key) &&
       !areUiSessionKeysEquivalent(lineageRoot.key, mainSessionKey) &&

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -3,6 +3,7 @@ import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
+  captureUiProofEnabled,
   controlUiSessionPath,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
@@ -10,6 +11,7 @@ import {
   requireRecord,
   sessionRow,
   sessionsListResponse,
+  uiProofArtifactDir,
   waitForConfirmModal,
   waitForPatch,
 } from "./session-management.test-support.ts";
@@ -285,11 +287,14 @@ suite.define(() => {
     }
   });
 
-  it("keeps the selected session through archive refreshes and restores the composer", async () => {
+  it("removes the selected session from the sidebar while keeping archive recovery", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
     });
     const page = await context.newPage();
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
@@ -332,6 +337,8 @@ suite.define(() => {
       await expect
         .poll(() => new URL(page.url()).pathname)
         .toBe(controlUiSessionPath(selected.key));
+    };
+    const assertSelectedSidebarRow = async () => {
       const row = page.locator(`.sidebar-recent-session[data-session-key="${selected.key}"]`);
       await row.waitFor({ state: "visible", timeout: 10_000 });
       await expect
@@ -348,7 +355,9 @@ suite.define(() => {
       await rowFor(selected.key).waitFor({ state: "visible", timeout: 10_000 });
       await rowFor(selected.key).locator("a").first().click();
       await assertSelectedRoute();
+      await assertSelectedSidebarRow();
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      await captureUiProof(page, "selected-archive-before.png");
       await page.evaluate((sessionKey) => {
         const titleHistory: string[] = [];
         const paneTitleHistory: string[] = [];
@@ -447,6 +456,7 @@ suite.define(() => {
           sessionKey: row.key,
         });
         await assertSelectedRoute();
+        await assertSelectedSidebarRow();
       }
 
       const selectedRow = rowFor(selected.key);
@@ -466,17 +476,16 @@ suite.define(() => {
       );
       const archiveToast = page.locator("openclaw-toast-host .app-toast");
       await expect.poll(() => archiveToast.textContent()).toContain("Session archived");
+      await selectedRow.waitFor({ state: "detached", timeout: 10_000 });
+      await assertSelectedRoute();
       await gateway.emitGatewayEvent("sessions.changed", {
         ...selected,
         archived: true,
         reason: "update",
         sessionKey: selected.key,
       });
-      await expect.poll(() => selectedRow.textContent()).toContain("Archive refresh 2");
-
       await assertSelectedRoute();
-      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
-      await expect.poll(() => selectedRow.textContent()).toContain("Archive refresh 2");
+      await selectedRow.waitFor({ state: "detached" });
       expect(
         await page.evaluate(
           () => (window as Window & { archiveTitleHistory?: string[] }).archiveTitleHistory ?? [],
@@ -524,6 +533,7 @@ suite.define(() => {
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      await captureUiProof(page, "selected-archive-after.png");
 
       await archiveToast.getByRole("button", { name: "Dismiss" }).click();
       await archiveToast.waitFor({ state: "detached" });
@@ -540,6 +550,7 @@ suite.define(() => {
       });
 
       await assertSelectedRoute();
+      await assertSelectedSidebarRow();
       await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
       await expect
@@ -549,6 +560,7 @@ suite.define(() => {
           ),
         )
         .toBe(selected.key);
+      await captureUiProof(page, "selected-archive-restored.png");
     } finally {
       await context.close();
     }
@@ -653,7 +665,7 @@ suite.define(() => {
         .toBe(controlUiSessionPath(archived.key));
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
-      await archivedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
+      await archivedRow.waitFor({ state: "detached", timeout: 10_000 });
     } finally {
       await context.close();
     }
@@ -691,12 +703,8 @@ suite.define(() => {
       const selectedRow = page.locator(
         `.sidebar-recent-session[data-session-key="${archived.key}"]`,
       );
-      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
-      await expect
-        .poll(() => selectedRow.getAttribute("class"))
-        .toContain("sidebar-recent-session--active");
-      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
-      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(2);
+      await selectedRow.waitFor({ state: "detached", timeout: 10_000 });
+      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(1);
 
       const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
@@ -719,6 +727,10 @@ suite.define(() => {
       });
 
       await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => selectedRow.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
       await expect
         .poll(() =>

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -184,7 +184,7 @@ describe("resolveSessionNavigation", () => {
     );
   });
 
-  it("keeps the selected archived session ahead of an active-filtered result", () => {
+  it("keeps the selected archived session out of the active sidebar projection", () => {
     const selectedSession = {
       key: "agent:main:archived",
       kind: "direct" as const,
@@ -199,15 +199,8 @@ describe("resolveSessionNavigation", () => {
       archivedFilter: "active",
     });
 
-    expect(navigation.visibleSessions.map((row) => row.key)).toEqual([
-      selectedSession.key,
-      "agent:main:recent",
-    ]);
-    expect(navigation.visibleSessions[0]).toMatchObject({
-      key: selectedSession.key,
-      archived: true,
-    });
-    expect(navigation.activeRowKey).toBe(selectedSession.key);
+    expect(navigation.visibleSessions.map((row) => row.key)).toEqual(["agent:main:recent"]);
+    expect(navigation.activeRowKey).toBeNull();
     expect(navigation.selectedSession).toMatchObject({
       key: selectedSession.key,
       archived: true,

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -242,8 +242,8 @@ type VisibleSessionRowOptions = {
  * Accepted tradeoff: a profile-less client's unnamed `run` session (e.g. an
  * explicit `--session-key` CLI conversation without an operator profile) is
  * indistinguishable from a probe and hides by default too. It stays fully
- * reachable: the selected session always renders in the sidebar, the Sessions
- * page never applies this filter, and the sort-menu toggle reveals all rows.
+ * reachable: the selected active session always renders in the sidebar, the
+ * Sessions page never applies this filter, and the sort-menu toggle reveals all rows.
  */
 export function isSystemCreatedSessionRow(row: GatewaySessionRow): boolean {
   // Cron rows are owned by the automation toggle; cron creation stamps a
@@ -280,8 +280,7 @@ export function filterVisibleSessionRows(
   return rows.filter((row) => {
     if (
       row.key === options.currentSessionKey &&
-      ((options.archivedFilter ?? "active") === "active" ||
-        sessionMatchesArchivedFilter(row, options.archivedFilter))
+      sessionMatchesArchivedFilter(row, options.archivedFilter)
     ) {
       return true;
     }
@@ -362,8 +361,12 @@ export function resolveSessionNavigation(input: SessionNavigationInput): Session
   // hides another one behind a separate route.
   let visibleSessions = sortedSessions;
   let activeRow = visibleSessions.find(matchesCurrentSession);
-  if (!activeRow && activeSession && input.archivedFilter !== "archived") {
-    // Deep-linked and archived sessions still need a visible selected row.
+  if (
+    !activeRow &&
+    activeSession &&
+    sessionMatchesArchivedFilter(activeSession, input.archivedFilter)
+  ) {
+    // Deep-linked sessions matching this list's filter still need a selected row.
     activeRow = sortedSessions.find(matchesCurrentSession) ?? activeSession;
     visibleSessions = [activeRow, ...visibleSessions.filter((row) => row !== activeRow)];
   }

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -513,7 +513,7 @@ describe("AppSidebar agent chip", () => {
     );
   });
 
-  it("keeps the selected archived child when its archived parent is filtered out", async () => {
+  it("filters the selected archived child with its archived parent", async () => {
     const request = vi.fn(async (_method: string, params: { key: string }) => ({
       session:
         params.key === "agent:worker:child"
@@ -543,20 +543,9 @@ describe("AppSidebar agent chip", () => {
     sidebar.sessionKey = "agent:worker:child";
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
-    await waitForFast(() =>
-      expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
-    );
+    await sidebar.updateComplete;
     expect(sidebar.querySelector('[data-session-key="agent:main:parent"]')).toBeNull();
-    expect(
-      sidebar.querySelector(
-        '[data-session-key="agent:worker:child"] .sidebar-session__archive-glyph',
-      ),
-    ).not.toBeNull();
-    expect(
-      sidebar
-        .querySelector('[data-session-key="agent:worker:child"]')
-        ?.classList.contains("sidebar-recent-session--active"),
-    ).toBe(true);
+    expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).toBeNull();
   });
 
   it("retries a failed child load after collapsing and reopening the parent", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where archiving the currently selected session left it visible in the active sessions sidebar until navigation or refresh, even though the Sessions page already treated it as archived.

## Why This Change Was Made

The active sidebar projection now consistently honors the archive filter, including selected and lineage-derived rows. Canonical session rows also override stale child-lineage snapshots for lifecycle facts such as archive state. The selected archived route remains open in the main pane with its archived notice and Unarchive action, so recovery behavior is unchanged.

## User Impact

Archiving a session removes it from the sidebar immediately. Users can still view the archived conversation in the main pane, find it on the Sessions page, and unarchive it; restoring it returns the row and composer.

## Evidence

- Pre-fix owner-boundary regression reproduced on owned AWS Crabbox: the active sidebar projection still contained `agent:main:archived` after archive.
- Post-fix focused UI suite: 283 tests passed, including selected-archive and stale child-lineage regressions.
- Real Chromium mocked-Gateway flow on owned AWS Crabbox passed:
  - archive removes the selected sidebar row immediately;
  - URL, title, archived notice, and Unarchive control remain in the main pane;
  - unarchive restores the sidebar row and composer.
- Visual artifacts captured locally under `.artifacts/control-ui-e2e/thread-management/` (before, archived, restored, and WebM recording); they are validation artifacts and are not committed.
- Static proof passed: formatting, UI i18n verification, core-test and UI typechecks, oxlint, stylelint, and `git diff --check`.
- Autoreview: clean, no accepted/actionable findings (Codex `gpt-5.6-sol`, high reasoning; confidence 0.98).
- Production LOC: +15/-11 (net +4). Tests/test support: +30/-36 (net -6).

### Root cause and repair boundary

The selected row was deliberately reinserted into the active sidebar even when archived, and a retained child-lineage snapshot could override the canonical archived row after refresh. The repair keeps archive lifecycle truth at the canonical row owner, makes lineage snapshots fill only missing keys, and applies the same archive filter at every sidebar reinsertion point.

### Regression provenance

The behavior was made explicit by #113882, which added the selected archived-session fallback and a test requiring the archived row to remain in the active sidebar. This change preserves that PR's main-pane archived-session recovery while correcting only the sidebar projection.
