### PR TITLE
perf(test): reuse postpublish file-cap fixture

### DIFF
--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1180,7 +1180,7 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     }
   });
 
-  it("refuses unbounded root dist dependency scans", () => {
+  it("excludes bundled extension modules from root dist dependency scans", () => {
     const packageRoot = makeInstalledPackageRoot();
 
     try {
@@ -1188,10 +1188,16 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
         version: "2026.4.22",
         dependencies: {},
       });
-      writeDistJavaScriptFiles(packageRoot, INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT + 1);
+      mkdirSync(join(packageRoot, "dist", "extensions", "telegram"), { recursive: true });
+      writeFileSync(join(packageRoot, "dist", "root-runtime.js"), 'import "root-only";\n', "utf8");
+      writeFileSync(
+        join(packageRoot, "dist", "extensions", "telegram", "runtime-api.js"),
+        'import "extension-only";\n',
+        "utf8",
+      );
 
       expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual([
-        `installed package root dist contains more than ${INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT} JavaScript files; refusing to scan unbounded package contents.`,
+        "installed package root is missing declared runtime dependency 'root-only' for dist importers: root-runtime.js. Add it to package.json dependencies/optionalDependencies.",
       ]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

The postpublish verifier contract suite built two separate 10,001-file fixtures to exercise the same shared scanner cap. That duplicated expensive filesystem setup in an already broad release-verifier test without adding distinct coverage.

## Why This Change Was Made

This keeps the canonical 10,001-file cap fixture and replaces the root-wrapper duplicate with a realistic root runtime import plus a bundled plugin runtime import. The focused assertion still proves the root dependency error while independently proving that bundled plugin files under `dist/extensions` are excluded from the root dependency scan.

## User Impact

There is no production or release behavior change. Maintainers get a faster postpublish verifier test while retaining the scanner cap, plugin-exclusion, and root dependency diagnostics contracts.

## Evidence

- Exact approved head: `bb550726093c856b4e656ed13f98330b3f3197a5` on base `2d3612da6bd28f6a7956d82b0795c31fd18bab8a`.
- Test-only diff: one file, +9/-3; production +0/-0.
- Testbox `tbx_01m06abn3qb4y3fgatr8jxvz14`: target 47/47, focused 3/3, direct release consumers 84/84, executable `--help` exact contract, and complete changed gate `testRoot+tooling` green. Run: https://github.com/openclaw/openclaw/actions/runs/31975893806
- Controlled A/B for the target file: wall 3.90s -> 3.67s (-5.9%), Vitest -20.2%, test body -33.2%.
- Mutation proof: a scanner off-by-one change fails the retained 10,001-file cap test; disabling the `dist/extensions` exclusion fails the downsized root/plugin test.
- Both contract tests were inspected; fresh autoreview was clean at 0.99 confidence with zero findings.
- AI-assisted: yes.

No changelog or release action is required for this test-only optimization.
