### PR TITLE
fix(ui): replace the broken terminal tab underline

### DIFF
--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -424,6 +424,14 @@ export function renderPanelTabStrip(params: {
 }
 
 export const panelTabStripStyles = css`
+  :where(.tp-header, .bp-header) {
+    --rail-header-height: 46px;
+    --rail-header-padding-start: 8px;
+  }
+  :where(.tp-actions, .bp-actions) {
+    padding-left: 8px;
+    border-left: 1px solid var(--border, #262b34);
+  }
   .tabstrip {
     --track-width: 0;
     display: block;
@@ -435,7 +443,7 @@ export const panelTabStripStyles = css`
   }
   .tabstrip::part(nav) {
     display: flex;
-    align-items: stretch;
+    align-items: center;
   }
   .tabstrip::part(body) {
     display: none;
@@ -447,15 +455,17 @@ export const panelTabStripStyles = css`
     display: flex;
     align-items: center;
     gap: 7px;
-    padding: 0 4px 0 10px;
-    height: 36px;
+    height: 30px;
+    padding: 0 34px 0 10px;
+    border: 0;
+    border-radius: 7px;
     color: var(--muted, #8a919e);
     white-space: nowrap;
     font-size: 12.5px;
-    border-bottom: 2px solid transparent;
     transition:
       color 0.12s ease,
-      background 0.12s ease;
+      background 0.12s ease,
+      box-shadow 0.12s ease;
   }
   .tabstrip-tab:hover::part(base) {
     color: var(--text, #d7dae0);
@@ -463,9 +473,10 @@ export const panelTabStripStyles = css`
   }
   .tabstrip-tab[active]::part(base) {
     color: var(--text, #d7dae0);
-    border-bottom-color: var(--accent, #ff5c5c);
+    background: var(--bg-hover, #1f2330);
+    box-shadow: inset 0 0 0 1px var(--border-strong, #2e3040);
   }
-  .tabstrip-tab.is-exited::part(base) {
+  .tabstrip-tab.is-exited:not([active])::part(base) {
     opacity: 0.55;
   }
   .tabstrip-tab.is-connecting .tabstrip-tab__icon {
@@ -504,12 +515,14 @@ export const panelTabStripStyles = css`
     padding: 0 5px;
     text-transform: uppercase;
   }
-  /* Each close button sits right after its tab in the nav slot. The tab keeps
-     the active surface; the action itself follows the bare rail-control contract. */
+  /* Keep the close action inside the tab surface without nesting it in wa-tab;
+     wa-tab-group still owns the direct tab children for keyboard navigation. */
   .tabstrip-tab__close {
     flex: 0 0 auto;
     align-self: center;
-    margin-right: 1px;
+    z-index: 1;
+    margin-left: -32px;
+    margin-right: 4px;
     opacity: 0;
     transition: opacity 0.12s ease;
   }
@@ -529,6 +542,7 @@ export const panelTabStripStyles = css`
   .tabstrip-new {
     flex: none;
     align-self: center;
+    margin-left: 2px;
   }
   .tabstrip-new-control {
     display: inline-flex;

--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -29,28 +29,6 @@ export const terminalPanelStyles = css`
     width: 100%;
     height: 100%;
   }
-  /* The strip and its tabs stretch to the rail height so a tab's underline lands
-     on the rail's bottom edge. Management actions keep their shared 28px size. */
-  .tp-header .tabstrip,
-  .tp-header .tabstrip::part(base),
-  .tp-header .tabstrip::part(nav),
-  .tp-header .tabstrip::part(tabs),
-  .tp-header .tabstrip-tab,
-  .tp-header .tabstrip-new {
-    height: 100%;
-    align-self: stretch;
-  }
-  .tp-header .tabstrip::part(nav),
-  .tp-header .tabstrip::part(tabs) {
-    align-items: stretch;
-  }
-  .tp-header .tabstrip-tab::part(base) {
-    box-sizing: border-box;
-    height: 100%;
-    /* Offset the underline so the label centres on the same line as the
-       management icons instead of riding 2px high. */
-    padding-top: 2px;
-  }
   .tp-header .tabstrip-tab__icon {
     color: var(--muted, #8a919e);
   }
@@ -68,31 +46,6 @@ export const terminalPanelStyles = css`
     width: 15px;
     height: 15px;
     stroke-width: 1.6px;
-  }
-  .tp-header .tabstrip-tab[active]::part(base) {
-    border-bottom-color: var(--text, #d7dae0);
-  }
-  .tp-header .tabstrip-tab__close {
-    box-sizing: border-box;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
-  }
-  .tp-header .tabstrip-tab[active] + .tabstrip-tab__close {
-    border-bottom-color: var(--text, #d7dae0);
-  }
-  .tp-header .tabstrip-new {
-    position: relative;
-    margin-left: 6px;
-  }
-  .tp-header .tabstrip-tab[active] + .tabstrip-tab__close + .tabstrip-new::before {
-    position: absolute;
-    top: 50%;
-    left: -4px;
-    width: 1px;
-    height: 14px;
-    background: color-mix(in srgb, var(--muted, #8a919e) 20%, transparent);
-    content: "";
-    transform: translateY(-50%);
   }
   .tp-dock-modes {
     display: flex;

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -254,11 +254,13 @@ suite.define(() => {
           const headerBounds = header.getBoundingClientRect();
           const closeBounds = close.getBoundingClientRect();
           const tabBounds = tabBase.getBoundingClientRect();
+          const closeStyle = getComputedStyle(close);
           const tabStyle = getComputedStyle(tabBase);
           return {
             backgroundColor: tabStyle.backgroundColor,
             borderBottomWidth: tabStyle.borderBottomWidth,
             borderRadius: tabStyle.borderRadius,
+            closeBorderBottomWidth: closeStyle.borderBottomWidth,
             centerOffset: Math.abs(
               closeBounds.top +
                 closeBounds.height / 2 -
@@ -266,13 +268,16 @@ suite.define(() => {
             ),
             closeInset: tabBounds.right - closeBounds.right,
             height: closeBounds.height,
+            tabHeight: tabBounds.height,
             width: closeBounds.width,
           };
         });
       expect(closeControlMetrics.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
       expect(closeControlMetrics.borderBottomWidth).toBe("0px");
       expect(closeControlMetrics.borderRadius).not.toBe("0px");
+      expect(closeControlMetrics.closeBorderBottomWidth).toBe("0px");
       expect(closeControlMetrics.closeInset).toBeGreaterThanOrEqual(-0.5);
+      expect(closeControlMetrics.tabHeight).toBe(30);
       expect(closeControlMetrics.width).toBe(28);
       expect(closeControlMetrics.height).toBe(28);
       expect(closeControlMetrics.centerOffset).toBeLessThanOrEqual(0.5);

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -243,21 +243,36 @@ suite.define(() => {
         .locator(".tabstrip-tab__close")
         .evaluate((close) => {
           const header = close.closest<HTMLElement>(".tp-header");
+          const tab = close.previousElementSibling;
+          const tabBase = tab?.shadowRoot?.querySelector<HTMLElement>("[part~='base']");
           if (!header) {
             throw new Error("Terminal close control must stay inside the tab header");
           }
+          if (!tabBase) {
+            throw new Error("Terminal close control must follow a rendered tab surface");
+          }
           const headerBounds = header.getBoundingClientRect();
           const closeBounds = close.getBoundingClientRect();
+          const tabBounds = tabBase.getBoundingClientRect();
+          const tabStyle = getComputedStyle(tabBase);
           return {
+            backgroundColor: tabStyle.backgroundColor,
+            borderBottomWidth: tabStyle.borderBottomWidth,
+            borderRadius: tabStyle.borderRadius,
             centerOffset: Math.abs(
               closeBounds.top +
                 closeBounds.height / 2 -
                 (headerBounds.top + headerBounds.height / 2),
             ),
+            closeInset: tabBounds.right - closeBounds.right,
             height: closeBounds.height,
             width: closeBounds.width,
           };
         });
+      expect(closeControlMetrics.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+      expect(closeControlMetrics.borderBottomWidth).toBe("0px");
+      expect(closeControlMetrics.borderRadius).not.toBe("0px");
+      expect(closeControlMetrics.closeInset).toBeGreaterThanOrEqual(-0.5);
       expect(closeControlMetrics.width).toBe(28);
       expect(closeControlMetrics.height).toBe(28);
       expect(closeControlMetrics.centerOffset).toBeLessThanOrEqual(0.5);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal sidebar tabs used a short accent underline beneath the label while the close control floated outside it, making the active tab look broken and visually disconnected.

The same shared dock tab strip also serves Browser tabs, so the repair keeps both consumers coherent.

## Why This Change Was Made

The shared tab-strip owner now renders the active tab as one compact, rounded 30px surface, reserves space for the close action, and overlays that action inside the surface without nesting it inside wa-tab. This preserves Web Awesome tab-group keyboard ownership, drag/reorder behavior, overflow handling, and existing close-focus recovery.

The header is tightened to 46px and dock utility actions receive a subtle divider. The old shared underline path and the later Terminal-only stretch, active-border, close-border, and new-tab separator overrides are removed.

Existing-solutions preflight: the repository already has the correct shared PanelTabStrip abstraction and Web Awesome tab primitives; an external tab library or custom parallel component would duplicate established behavior.

## User Impact

Terminal and Browser dock tabs now have a clear contained active state. The close button reads as part of the selected tab, exited active sessions stay legible, and utility controls are visually separated.

Production LOC: +24/-57 (net -33)
Tests: +20/-0

The owner cleanup is production net-negative: shared contained-tab geometry replaces both the old underline and the obsolete Terminal override stack.

## Evidence

- Before-fix browser regression: failed on direct AWS because the Terminal close control retained a 2px bottom border: [run_a8926e5d8b69](https://crabbox.openclaw.ai/portal/runs/run_a8926e5d8b69).
- After-fix browser proof: all 5 terminal embedded E2E scenarios passed on direct AWS, including a 30px active base and 0px close border: [run_04fda087cc88](https://crabbox.openclaw.ai/portal/runs/run_04fda087cc88).
- Shared strip unit/browser coverage, stylelint, and repository formatting passed.
- Fresh autoreview on a7d7f02bf865e04e4aaa6792969b16a3b9772823: gpt-5.6-sol, high reasoning; no accepted/actionable findings.
- Codex contract check: sibling Codex runtime source was inspected at codex-rs/core/src/agent/control/execution.rs:31-118. The inspected execution-control behavior is independent of this Control UI-only presentation change.
- Exact-head hosted CI is the remaining landing gate.
