### PR TITLE
fix(tui): close selection overlays and report rejected handlers

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -741,6 +741,28 @@ describe("tui command handlers", () => {
     expect(closeOverlay).toHaveBeenCalledWith(overlayHandle);
   });
 
+  it("closes the overlay and reports the cause when a selection handler rejects", async () => {
+    const setSession = vi
+      .fn()
+      .mockRejectedValue(new Error("gateway unavailable")) as SetSessionMock;
+    const { handleCommand, openOverlay, closeOverlay, overlayHandle, addSystem } = createHarness({
+      setSession,
+      agents: [{ id: "work" }],
+    });
+
+    await handleCommand("/agent");
+    const selector = firstMockArg(openOverlay, "openOverlay") as SelectableOverlay;
+    selector?.onSelect?.({ value: "work", label: "work" });
+    await flushAsyncSelect();
+
+    // The selector must not stay stranded open on a rejected selection, and
+    // the failure must reach the chat log instead of an unhandled rejection.
+    expect(closeOverlay).toHaveBeenCalledWith(overlayHandle);
+    expect(
+      addSystem.mock.calls.some(([line]) => String(line).includes("gateway unavailable")),
+    ).toBe(true);
+  });
+
   it("forwards /context list directly", async () => {
     const { handleCommand, sendChat, openOverlay } = createHarness();
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -304,7 +304,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   ) => {
     selector.onSelect = (item) => {
       void (async () => {
-        await onSelect(item.value);
+        try {
+          await onSelect(item.value);
+        } catch (err) {
+          // A rejected selection must not strand the overlay open with an
+          // unhandled rejection; close it and surface the cause in chat.
+          chatLog.addSystem(`selection failed: ${formatTuiErrorMessage(err)}`);
+        }
         closeOverlayAndRender(overlayHandle);
       })();
     };


### PR DESCRIPTION
## What Problem This Solves

TUI selection overlays (agent picker, model picker, session picker, context mode) fired their async selection handler as `void (async () => { await onSelect(...); closeOverlay(...) })()` — the overlay only closed after a successful await, and a rejecting handler produced an unhandled rejection. Pick an agent while the gateway is failing and the TUI freezes on the stuck selector with no visible cause: a silent dead-end, the repo's worst bug class.

## Why This Change Was Made

Root cause: the overlay lifecycle had no failure path. The handler now catches, reports the cause through the chat log (`selection failed: …`, same convention as the surrounding handlers), and always closes the overlay. One try/catch at the single owner (`openSelector`) covers every selector.

## User Impact

A failing selection (gateway down, session patch rejected) now returns you to the chat with an error line instead of freezing the TUI on the picker.

## Evidence

- New regression in `src/tui/tui-command-handlers.test.ts`: `/agent` selection with a rejecting `setSession` asserts the overlay closes and the cause reaches the chat log — fails pre-fix (overlay never closed, rejection unhandled). Suite 146/146.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +7 −1, test +22.
