### PR TITLE
fix(ui): align update status card spacing

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1149,7 +1149,6 @@ openclaw-settings-save-indicator {
 
 .sidebar-update-card__actions {
   display: flex;
-  align-items: stretch;
   gap: 5px;
 }
 
@@ -1246,8 +1245,7 @@ html.openclaw-native-macos
   cursor: wait;
 }
 
-/* The install outlives the request that started it, so the card keeps moving
-   for the whole wait instead of reading as a dead disabled button. */
+/* Keep the card moving while its install outlives the initiating request. */
 .sidebar-update-card__action--busy .sidebar-update-card__icon svg {
   animation: sidebar-update-card-spin 1s linear infinite;
 }
@@ -1264,20 +1262,22 @@ html.openclaw-native-macos
   }
 }
 
-/* The update outcome belongs beside the control that started it, not over the
-   top of the shell where it covers unrelated chrome. While the update dialog is
-   open it owns the report, so the ambient copy would only duplicate it. */
+/* Keep the outcome beside its control, except while the dialog owns the report. */
 body.update-dialog-open .sidebar-update-card__status {
   display: none;
 }
 
 .sidebar-update-card__status {
-  padding: 8px 10px;
+  padding: 8px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--secondary);
   font-size: 12px;
   line-height: 1.45;
+}
+
+.sidebar-update-card__status + .sidebar-update-card__actions {
+  margin-top: 6px;
 }
 
 .sidebar-update-card__status--danger {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the update status card shown in the live Team Control UI used roomier horizontal padding and sat too close to its action controls, making the stack look inconsistent with the surrounding update actions.

## Why This Change Was Made

The status surface now uses 8px padding to align with the action controls and an explicit 6px adjacent-sibling gap before the actions. Redundant default CSS and comments were simplified at the same time, keeping the production change at +7/-7 lines (net zero).

## User Impact

Update outcomes in the sidebar now align cleanly with the controls beneath them and retain a consistent, intentional vertical rhythm.

## Evidence

### Before

![Update card before the spacing fix](https://github.com/user-attachments/assets/3b32380a-a102-460a-accc-e1773417c324)

### After

![Update card after the spacing fix](https://github.com/user-attachments/assets/8becc7f0-dd3c-4239-88a8-f32a767b1507)

- Deterministic mocked Control UI comparison at 1280x900.
- `ui/src/components/sidebar-update-card.test.ts`: 24/24 passed.
- `oxfmt`: clean.
- Targeted stylelint: clean.
- `git diff --check`: clean.
- Fresh Codex autoreview: clean, with no accepted/actionable findings.
