### PR TITLE
fix(browser): stop node discovery when agent turns are cancelled

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2028,6 +2028,41 @@ describe("browser tool snapshot maxChars", () => {
     expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "explicit node discovery",
+      params: { action: "status", target: "node" },
+      configureUserProfile: false,
+    },
+    {
+      name: "automatic user-browser discovery",
+      params: { action: "status", profile: "user" },
+      configureUserProfile: true,
+    },
+  ])("cancels $name with the agent signal", async ({ params, configureUserProfile }) => {
+    if (configureUserProfile) {
+      setResolvedBrowserProfiles({
+        user: { driver: "existing-session", attachOnly: true, color: "#00AA00" },
+      });
+    }
+    const controller = new AbortController();
+    const abortError = new Error("agent turn cancelled");
+    nodesUtilsMocks.listNodes.mockImplementationOnce(async (...args: unknown[]) => {
+      if (args[1] !== controller.signal) {
+        throw new Error("browser node discovery did not receive the agent signal");
+      }
+      controller.abort(abortError);
+      controller.signal.throwIfAborted();
+      return [];
+    });
+
+    await expect(createBrowserTool().execute?.("call-1", params, controller.signal)).rejects.toBe(
+      abortError,
+    );
+    expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("falls back to the host for profile=user when node discovery errors", async () => {
     nodesUtilsMocks.listNodes.mockRejectedValueOnce(new Error("gateway unavailable"));
     setResolvedBrowserProfiles({

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -206,6 +206,7 @@ async function resolveBrowserToolNodeTarget(params: {
   target?: "sandbox" | "host" | "node";
   sandboxBridgeUrl?: string;
   allowHostControl?: boolean;
+  signal?: AbortSignal;
 }): Promise<BrowserNodeTarget | null> {
   if (params.allowHostControl === false) {
     if (params.target === "node" || params.requestedNode) {
@@ -232,7 +233,7 @@ async function resolveBrowserToolNodeTarget(params: {
     return null;
   }
   const node = resolveBrowserNodeTarget({
-    nodes: await browserToolDeps.listNodes({}),
+    nodes: await browserToolDeps.listNodes({}, params.signal),
     policy,
     requestedNode,
     explicitTarget,
@@ -448,8 +449,10 @@ export function createBrowserTool(opts?: {
           target,
           sandboxBridgeUrl: opts?.sandboxBridgeUrl,
           allowHostControl: opts?.allowHostControl,
+          signal,
         });
       } catch (error) {
+        signal?.throwIfAborted();
         // Keep the logged-in user browser usable on the host when auto-discovery
         // of browser nodes fails transiently. Explicit node requests still fail.
         if (!(isUserBrowserProfile && !target && !requestedNode && !configuredNode)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelled browser tool runs could remain blocked while discovering browser-capable nodes and, for automatic logged-in browser routing, could dispatch a local browser action after cancellation.

## Why This Change Was Made

Node discovery now receives the browser tool execution signal, and cancellation takes precedence over the existing automatic host fallback. Ordinary transient discovery failures still retain the intended logged-in browser fallback.

## User Impact

Cancelled or timed-out agent turns stop browser node discovery promptly and do not start a browser action afterward.

## Evidence

- Regression proved red before the fix: explicit discovery did not receive the execution signal; automatic `profile=user` discovery swallowed cancellation and ran local browser status.
- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts` — 178 passed.
- Extension production and test typechecks passed with `scripts/run-tsgo.mjs`.
- Type-aware oxlint: 0 warnings, 0 errors.
- Independent exact-diff review: prior cancellation/fallback P1 closed; no remaining P0–P2 findings.
