### PR TITLE
fix(sandbox): surface list probe failures instead of empty results

### DIFF
--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -169,12 +169,15 @@ describe("sandboxListCommand", () => {
   });
 
   describe("error handling", () => {
-    it("should handle errors gracefully", async () => {
+    it("propagates backend probe failures instead of rendering an empty list", async () => {
       mocks.listSandboxContainers.mockRejectedValue(new Error("Docker not available"));
 
-      await sandboxListCommand({ browser: false, json: false }, runtime as never);
-
-      expect(runtime.log).toHaveBeenCalledWith("No sandbox runtimes found.");
+      // A failing probe must reach the CLI error path (message + exit 1),
+      // not masquerade as "No sandbox runtimes found."
+      await expect(
+        sandboxListCommand({ browser: false, json: false }, runtime as never),
+      ).rejects.toThrow("Docker not available");
+      expect(runtime.log).not.toHaveBeenCalledWith("No sandbox runtimes found.");
     });
   });
 });

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -51,8 +51,10 @@ export async function sandboxListCommand(
   opts: SandboxListOptions,
   runtime: RuntimeEnv,
 ): Promise<void> {
-  const containers = opts.browser ? [] : await listSandboxContainers().catch(() => []);
-  const browsers = opts.browser ? await listSandboxBrowsers().catch(() => []) : [];
+  // A failing backend/registry probe must surface, not render as an empty
+  // list that reads as "no sandboxes".
+  const containers = opts.browser ? [] : await listSandboxContainers();
+  const browsers = opts.browser ? await listSandboxBrowsers() : [];
 
   if (opts.json) {
     writeRuntimeJson(runtime, { containers, browsers });
@@ -121,8 +123,8 @@ function validateRecreateOptions(opts: SandboxRecreateOptions, runtime: RuntimeE
 }
 
 async function fetchAndFilterContainers(opts: SandboxRecreateOptions): Promise<FilteredContainers> {
-  const allContainers = await listSandboxContainers().catch(() => []);
-  const allBrowsers = await listSandboxBrowsers().catch(() => []);
+  const allContainers = await listSandboxContainers();
+  const allBrowsers = await listSandboxBrowsers();
 
   let containers = opts.browser ? [] : allContainers;
   let browsers = opts.browser ? allBrowsers : [];


### PR DESCRIPTION
## What Problem This Solves

`openclaw sandbox list` and `sandbox recreate` swallowed backend/registry probe failures with `.catch(() => [])`. A broken Docker daemon or corrupt sandbox registry rendered as "No sandbox runtimes found." — indistinguishable from a genuinely clean state — and `--json` emitted a success envelope for a failed probe. Worse in `recreate`: a probe failure filtered the whole fleet down to nothing, so the command reported nothing matched instead of failing.

## Why This Change Was Made

Root cause: failure collapsed into the empty success shape at the consumer. The listers now propagate; the sandbox CLI's `createRunner` already owns the error path (message + exit 1), and the freshly-landed unified `--json` failure contract (#124849) emits the JSON error envelope. Net: the failure surfaces through existing owners with zero new error plumbing.

## User Impact

A failing Docker daemon or registry now produces an actionable error and exit 1 instead of a false "no sandboxes" answer that would send an operator debugging the wrong thing.

## Evidence

- Replaced the test that enshrined the masking (`should handle errors gracefully` asserting the empty-state message) with the propagation contract: a rejecting probe throws `Docker not available` and never logs "No sandbox runtimes found." — fails pre-fix. Sandbox suites 33/33.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +6 −4, test +7 −4.
