### PR TITLE
fix(install): reject invalid PowerShell installer options

### DIFF
--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -262,6 +262,50 @@ jobs:
         with:
           node-version: 24
 
+      - name: install.ps1 strict option binding
+        shell: pwsh
+        run: |
+          $scriptPath = (Resolve-Path ".\scripts\install.ps1").Path
+          $env:OPENCLAW_DRY_RUN = "1"
+          $env:OPENCLAW_NO_ONBOARD = "1"
+
+          function Invoke-InstallerProbe {
+            param(
+              [string]$HostCommand,
+              [string[]]$InstallerArgs
+            )
+
+            $output = @(& $HostCommand -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $scriptPath @InstallerArgs 2>&1 | ForEach-Object { $_.ToString() })
+            return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = ($output -join "`n") }
+          }
+
+          foreach ($hostCommand in @("powershell.exe", "pwsh.exe")) {
+            if (-not (Get-Command $hostCommand -ErrorAction SilentlyContinue)) {
+              throw "Required PowerShell host is unavailable: $hostCommand"
+            }
+
+            $invalidCases = @(
+              @{ Label = "unknown option"; Args = @("-DryRnu") },
+              @{ Label = "positional argument"; Args = @("-DryRun", "beta") }
+            )
+            foreach ($invalidCase in $invalidCases) {
+              $result = Invoke-InstallerProbe -HostCommand $hostCommand -InstallerArgs $invalidCase.Args
+              if ($result.ExitCode -eq 0 -or $result.Output -match '\[OK\] Windows detected') {
+                throw "$hostCommand accepted $($invalidCase.Label).`n$($result.Output)"
+              }
+            }
+
+            $help = Invoke-InstallerProbe -HostCommand $hostCommand -InstallerArgs @("-?")
+            if ($help.ExitCode -ne 0 -or $help.Output -match '\[OK\] Windows detected') {
+              throw "$hostCommand failed to handle -? before installer startup.`n$($help.Output)"
+            }
+
+            $valid = Invoke-InstallerProbe -HostCommand $hostCommand -InstallerArgs @("-DryRun", "-NoOnboard", "-InstallMethod", "npm")
+            if ($valid.ExitCode -ne 0 -or $valid.Output -notmatch '\[OK\] Install method: npm') {
+              throw "$hostCommand rejected documented named options.`n$($valid.Output)"
+            }
+          }
+
       - name: install.ps1 dry run
         shell: pwsh
         run: .\scripts\install.ps1 -DryRun -NoOnboard -InstallMethod npm

--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -295,6 +295,16 @@ jobs:
               }
             }
 
+            $env:OPENCLAW_INSTALL_METHOD = "bogus"
+            try {
+              $invalidEnvironment = Invoke-InstallerProbe -HostCommand $hostCommand -InstallerArgs @("-NoOnboard")
+              if ($invalidEnvironment.ExitCode -eq 0 -or $invalidEnvironment.Output -match '\[OK\] Windows detected') {
+                throw "$hostCommand accepted invalid OPENCLAW_INSTALL_METHOD.`n$($invalidEnvironment.Output)"
+              }
+            } finally {
+              Remove-Item Env:OPENCLAW_INSTALL_METHOD -ErrorAction SilentlyContinue
+            }
+
             $help = Invoke-InstallerProbe -HostCommand $hostCommand -InstallerArgs @("-?")
             if ($help.ExitCode -ne 0 -or $help.Output -match '\[OK\] Windows detected') {
               throw "$hostCommand failed to handle -? before installer startup.`n$($help.Output)"

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -442,8 +442,7 @@ Use non-interactive flags/env vars for predictable runs.
   </Accordion>
 
   <Accordion title="Windows: how to get verbose installer output">
-    `install.ps1` does not expose a `-Verbose` switch.
-    Use PowerShell tracing for script-level diagnostics:
+    `install.ps1` uses `CmdletBinding`, so it accepts PowerShell's common `-Verbose` parameter. The installer does not currently write a dedicated verbose stream. For script-level diagnostics, use PowerShell tracing:
 
     ```powershell
     Set-PSDebug -Trace 1

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -365,6 +365,7 @@ by default, plus git-checkout installs under the same prefix flow.
 | `-NoOnboard`                | Skip onboarding                                            |
 | `-NoGitUpdate`              | Skip `git pull`                                            |
 | `-DryRun`                   | Print actions only                                         |
+| `-Help`                     | Show usage for downloaded scriptblock invocation           |
 
   </Accordion>
 
@@ -380,6 +381,10 @@ by default, plus git-checkout installs under the same prefix flow.
 
   </Accordion>
 </AccordionGroup>
+
+<Note>
+Pass installer options by name. Unknown options and positional arguments are rejected before downloads, PATH changes, or installation begin. Use `-?` with a saved `install.ps1` file, or `-Help` with the downloaded scriptblock form.
+</Note>
 
 <Note>
 If `-InstallMethod git` is used and Git is missing, the script tries a user-local MinGit bootstrap before printing the Git for Windows link.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,6 +2,7 @@
 # Usage: powershell -c "irm https://openclaw.ai/install.ps1 | iex"
 #        powershell -c "& ([scriptblock]::Create((irm https://openclaw.ai/install.ps1))) -Tag beta -NoOnboard -DryRun"
 
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [string]$Tag = "latest",
     [ValidateSet("npm", "git")]
@@ -9,10 +10,29 @@ param(
     [string]$GitDir,
     [switch]$NoOnboard,
     [switch]$NoGitUpdate,
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$Help
 )
 
 $ErrorActionPreference = "Stop"
+
+if ($Help) {
+    @"
+Usage:
+  powershell -File install.ps1 [options]
+  & ([scriptblock]::Create((irm https://openclaw.ai/install.ps1))) [options]
+
+Options:
+  -InstallMethod npm|git  Install method (default: npm)
+  -Tag <tag|version>      OpenClaw version or dist-tag (default: latest)
+  -GitDir <path>          Git checkout directory
+  -NoOnboard              Skip onboarding
+  -NoGitUpdate            Skip git pull
+  -DryRun                 Print actions only
+  -Help                   Show this help
+"@ | Write-Output
+    return
+}
 
 $script:InstallExitCode = 0
 
@@ -180,20 +200,12 @@ function Initialize-InstallerTempDirectory {
     $env:TMP = $tempDirectory
 }
 
-Initialize-InstallerTempDirectory
-
-Write-Host ""
-Write-Host "  OpenClaw Installer" -ForegroundColor Cyan
-Write-Host ""
-
 # Check if running in PowerShell
 if ($PSVersionTable.PSVersion.Major -lt 5) {
     Write-Host "Error: PowerShell 5+ required" -ForegroundColor Red
     Complete-Install -Succeeded:$false
     return
 }
-
-Write-Host "[OK] Windows detected" -ForegroundColor Green
 
 if (-not $PSBoundParameters.ContainsKey("InstallMethod")) {
     if (-not [string]::IsNullOrWhiteSpace($env:OPENCLAW_INSTALL_METHOD)) {
@@ -225,6 +237,13 @@ if ([string]::IsNullOrWhiteSpace($GitDir)) {
     $userHome = [Environment]::GetFolderPath("UserProfile")
     $GitDir = (Join-Path $userHome "openclaw")
 }
+
+Initialize-InstallerTempDirectory
+
+Write-Host ""
+Write-Host "  OpenClaw Installer" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "[OK] Windows detected" -ForegroundColor Green
 
 # Check for Node.js
 function Test-NodeVersionSupported {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -74,6 +74,19 @@ describe("install.ps1 failure handling", () => {
     }
     return spawnSync(powershell, args, { encoding: "utf8" });
   };
+  const runInstallerFile = (args: string[], env: NodeJS.ProcessEnv = {}) => {
+    if (!powershell) {
+      throw new Error("PowerShell is not available");
+    }
+    return spawnSync(
+      powershell,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-File", SCRIPT_PATH, ...args],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      },
+    );
+  };
   const runPowerShellAsync = (args: string[]) => {
     if (!powershell) {
       throw new Error("PowerShell is not available");
@@ -576,6 +589,73 @@ describe("install.ps1 failure handling", () => {
   function expectBatchedPowerShellCase(name: string): void {
     expect(batchedPowerShellResults.get(name)).toEqual({ error: "", ok: true });
   }
+
+  runIfPowerShell("rejects unknown and positional options before starting the installer", () => {
+    const cases = [
+      ["-Frobnicate"],
+      ["-DryRnu"],
+      ["-NoOnbord"],
+      ["-InstallMthod", "git"],
+      ["-DryRun", "beta"],
+      ["beta", "git"],
+    ];
+
+    for (const args of cases) {
+      const result = runInstallerFile(args, {
+        OPENCLAW_DRY_RUN: "1",
+        OPENCLAW_NO_ONBOARD: "1",
+      });
+      expect(result.status, args.join(" ")).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain("[OK] Windows detected");
+    }
+  });
+
+  runIfPowerShell("validates environment options before starting the installer", () => {
+    const result = runInstallerFile(["-NoOnboard"], {
+      OPENCLAW_DRY_RUN: "1",
+      OPENCLAW_INSTALL_METHOD: "bogus",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("[OK] Windows detected");
+  });
+
+  runIfPowerShell("shows help without starting the installer", () => {
+    const fileResult = runInstallerFile(["-?"]);
+    expect(fileResult.status).toBe(0);
+    expect(`${fileResult.stdout}\n${fileResult.stderr}`).toContain("install.ps1");
+    expect(`${fileResult.stdout}\n${fileResult.stderr}`).not.toContain("[OK] Windows detected");
+
+    const scriptPath = toPowerShellSingleQuotedLiteral(join(process.cwd(), SCRIPT_PATH));
+    const scriptblockResult = runPowerShell([
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `& ([scriptblock]::Create((Get-Content -LiteralPath ${scriptPath} -Raw))) -Help`,
+    ]);
+    expect(scriptblockResult.status).toBe(0);
+    expect(scriptblockResult.stdout).toContain("Usage:");
+    expect(scriptblockResult.stdout).toContain("-DryRun");
+    expect(scriptblockResult.stdout).not.toContain("[OK] Windows detected");
+  });
+
+  runIfPowerShell("accepts the documented named options", () => {
+    const result = runInstallerFile([
+      "-DryRun",
+      "-NoOnboard",
+      "-InstallMethod",
+      "git",
+      "-NoGitUpdate",
+      "-Tag",
+      "main",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("[OK] Install method: git");
+    expect(result.stdout).toContain("[OK] Git update: disabled");
+    expect(result.stdout).toContain("[OK] Onboard: skipped");
+  });
 
   it("does not exit directly from inside Main", () => {
     const mainBody = extractFunctionBody(source, "Main");


### PR DESCRIPTION
## Summary

- enable advanced-function parameter binding with positional arguments disabled
- reject unknown switches, typoed safety switches, and positional values before the installer body starts
- add explicit `-Help` support for downloaded scriptblock invocation while preserving direct-file `-?`
- validate environment-derived installer options before banner/temp initialization
- require the Windows website-sync gate to prove strict binding with both Windows PowerShell 5.1 and pwsh 7 before publication

## Root cause

The top-level script used a plain `param(...)` block. PowerShell left unknown and positional arguments in `$args`, so invocations such as `-Frobnicate`, `-DryRnu`, and a positional `beta` continued into the mutating installer body. Environment-derived install-method validation also happened only after installer initialization and banner output.

`[CmdletBinding(PositionalBinding = $false)]` makes the native parameter binder own the command-line contract, so invalid input fails before body execution. The explicit help path covers the downloaded-scriptblock form, where `-?` is not a reliable script parameter.

## User-visible behavior

Before this change:

- `install.ps1 -Frobnicate -DryRun -NoOnboard` entered the installer and exited successfully
- `install.ps1 -DryRun beta` accepted the positional value and entered the installer
- an invalid `OPENCLAW_INSTALL_METHOD` printed the installer banner before failing

After this change, unknown/typoed switches, positional values, and invalid environment options fail before the installer body. Documented named options continue to work.

## Verification

- `node scripts/run-vitest.mjs test/scripts/install-ps1.test.ts test/scripts/website-installer-sync-workflow.test.ts` — 38 passed
- `CI=1 pnpm check:changed` — passed (`testRoot`, `docs`, `tooling` lanes)
- PowerShell AST parser check — `syntax=ok`
- `pnpm docs:list` — passed
- `git diff origin/main...HEAD --check` — passed

The updated website-installer workflow provides the authentic native Windows PowerShell 5.1 and pwsh 7 publication proof.