### PR TITLE
fix(buzz): keep agent replies at thread root

### DIFF
--- a/extensions/buzz/src/buzz-bus.lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.lifecycle.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { finalizeEvent, getPublicKey, type Event, type Filter } from "nostr-tools";
+import { finalizeEvent, getPublicKey, verifyEvent, type Event, type Filter } from "nostr-tools";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const relayMocks = vi.hoisted(() => ({
@@ -111,11 +112,15 @@ vi.mock("nostr-tools", async (importOriginal) => {
 });
 
 import { sendBuzzTextOneShot, startBuzzBus, type BuzzBus } from "./buzz-bus.js";
+import { handleBuzzInbound } from "./inbound.js";
 import {
   BUZZ_DIFF_MESSAGE_KIND,
   BUZZ_INBOUND_MESSAGE_KINDS,
+  BUZZ_TYPING_INDICATOR_KIND,
   type BuzzInboundMessage,
 } from "./message-event.js";
+import { setBuzzRuntime } from "./runtime.js";
+import type { ResolvedBuzzAccount } from "./types.js";
 
 const BUZZ_RICH_MESSAGE_KIND = 40_002;
 const PRIVATE_KEY = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -344,6 +349,80 @@ describe("Buzz bus lifecycle", () => {
     relayMocks.send.mockClear();
     await bus.sendTyping({ channelId: CHANNEL_ID });
     expect(relayMocks.send).not.toHaveBeenCalled();
+  });
+
+  it("anchors signed threaded replies and typing while preserving top-level replies", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    const runtime = createPluginRuntimeMock();
+    setBuzzRuntime(runtime);
+    const account: ResolvedBuzzAccount = {
+      accountId: ACCOUNT_ID,
+      name: "OpenClaw",
+      enabled: true,
+      configured: true,
+      relayUrl: "wss://buzz.example.com",
+      privateKey: PRIVATE_KEY,
+      authTag: "",
+      publicKey: BOT_PUBLIC_KEY,
+      config: {
+        groupPolicy: "open",
+        groups: { [CHANNEL_ID]: { requireMention: false } },
+      },
+    };
+    const bus = await startTestBus({
+      onMessage: async (message, activeBus, signal) =>
+        await handleBuzzInbound({ account, cfg: {}, bus: activeBus, message, signal }),
+    });
+
+    try {
+      const rootId = "a".repeat(64);
+      const messageSubscription = relayMocks.subscriptions.find((entry) =>
+        subscriptionIncludesKind(entry, 9),
+      );
+      for (const [index, parentId] of ["b".repeat(64), "c".repeat(64), undefined].entries()) {
+        const inbound = signSenderEvent({
+          kind: 9,
+          created_at: 1_700_000_000 + index,
+          content: `follow-up ${index + 1}`,
+          tags: [
+            ["h", CHANNEL_ID],
+            ...(parentId
+              ? [
+                  ["e", rootId, "", "root"],
+                  ["e", parentId, "", "reply"],
+                ]
+              : []),
+          ],
+        });
+        messageSubscription?.handlers.onevent(inbound);
+        await vi.waitFor(() =>
+          expect(runtime.channel.inbound.dispatch).toHaveBeenCalledTimes(index + 1),
+        );
+        const dispatch = vi.mocked(runtime.channel.inbound.dispatch).mock.calls[index]?.[0];
+        await dispatch?.delivery.deliver({ text: `reply ${index + 1}` }, { kind: "final" });
+        await dispatch?.replyPipeline?.typing?.start();
+
+        const published = relayMocks.publish.mock.calls.find(
+          ([event]) => event.kind === 9 && event.content === `reply ${index + 1}`,
+        )?.[0];
+        const typing = relayMocks.send.mock.calls
+          .map(([frame]) => JSON.parse(frame) as [string, Event])
+          .filter(
+            ([frameType, event]) =>
+              frameType === "EVENT" && event.kind === BUZZ_TYPING_INDICATOR_KIND,
+          )[index]?.[1];
+        const expectedTags = [
+          ["h", CHANNEL_ID],
+          ["e", parentId ? rootId : inbound.id, "", "reply"],
+        ];
+        expect(published?.tags).toEqual(expectedTags);
+        expect(typing?.tags).toEqual(expectedTags);
+        expect(published && verifyEvent(published)).toBe(true);
+        expect(typing && verifyEvent(typing)).toBe(true);
+      }
+    } finally {
+      await bus.close();
+    }
   });
 
   it("drops typing while the active relay is disconnected", async () => {

--- a/extensions/buzz/src/inbound.test.ts
+++ b/extensions/buzz/src/inbound.test.ts
@@ -296,7 +296,7 @@ describe("handleBuzzInbound", () => {
     expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
   });
 
-  it("preserves Buzz thread and reply identifiers for agent replies", async () => {
+  it("anchors Buzz agent replies and typing to the original thread root", async () => {
     const runtime = createPluginRuntimeMock();
     setBuzzRuntime(runtime);
     const bus = createBus();
@@ -329,7 +329,7 @@ describe("handleBuzzInbound", () => {
       channelId: ROOM_ID,
       text: "threaded reply to @Alice",
       threadId: "event-root",
-      replyToId: "event-reply",
+      replyToId: "event-root",
     });
 
     const typing = dispatch.replyPipeline?.typing;
@@ -338,7 +338,7 @@ describe("handleBuzzInbound", () => {
     expect(bus.sendTyping).toHaveBeenCalledWith({
       channelId: ROOM_ID,
       threadId: "event-root",
-      replyToId: "event-reply",
+      replyToId: "event-root",
     });
   });
 

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -138,6 +138,11 @@ export async function handleBuzzInbound(params: {
       BuzzEventKind: message.kind,
     },
   });
+  const replyTarget = {
+    channelId,
+    threadId: message.threadId,
+    replyToId: message.threadId ?? message.id,
+  };
 
   await runtime.channel.inbound.dispatch({
     cfg,
@@ -158,12 +163,7 @@ export async function handleBuzzInbound(params: {
         if (!text.trim()) {
           return;
         }
-        await bus.sendText({
-          channelId,
-          text,
-          threadId: message.threadId,
-          replyToId: message.id,
-        });
+        await bus.sendText({ ...replyTarget, text });
       },
       onError: (error) => {
         throw error instanceof Error ? error : new Error(String(error));
@@ -175,11 +175,7 @@ export async function handleBuzzInbound(params: {
     replyPipeline: {
       typing: {
         start: async () => {
-          await bus.sendTyping({
-            channelId,
-            threadId: message.threadId,
-            replyToId: message.id,
-          });
+          await bus.sendTyping(replyTarget);
         },
         keepaliveIntervalMs: 3_000,
         onStartError: (error: unknown) => {


### PR DESCRIPTION
Closes #124873

Related: #120339 (separate opt-out/configuration request; not resolved here).

## What problem this solves

Buzz users holding a multi-turn conversation with an agent currently see every response open one level deeper inside the existing thread. Each automatic response and typing indicator incorrectly names the latest inbound message as its direct parent even when that message already belongs to an established thread.

## Architectural repair

The Buzz inbound owner now computes one canonical reply target and shares it between final delivery and typing. For an established thread, its direct parent is the original thread root; for a top-level message, its direct parent remains the triggering message. The agent still receives the latest inbound message identity, thread-scoped sessions remain unchanged, and callers explicitly requesting nested outbound ancestry retain their existing contract.

This maintainer rewrite deliberately removes the contributor version's unrelated shared QA scenario changes and its self-contained synthetic transport test. Instead, a Buzz-local lifecycle regression drives real signed Nostr messages through the production inbound owner and BuzzBus, checks actual serialized text and typing relation tags across consecutive threaded turns, and preserves top-level coverage. Production code is smaller: **+7/-11, net -4 lines**; focused tests are **+83/-4** across two existing Buzz files.

## Product decision and client tradeoff

This follows Buzz's desktop/group root-anchored thread presentation: automatic agent responses remain together beneath the original root rather than progressively nesting. Some Buzz mobile client discussions instead prefer the latest message as direct parent; those presentation expectations conflict. This change intentionally chooses the requested desktop/group root-anchor behavior for automatic agent delivery while leaving explicit nested outbound calls and the separate configurable-mode request in #120339 untouched.

## Evidence

Reviewed candidate: `e6c24320667cc1d5f59374cf299f924f89c65b67`.

- Pre-fix red reproduction: the new signed BuzzBus lifecycle regression failed on current main because the first threaded reply emitted separate root and latest-parent tags instead of one direct-root reply tag.
- Post-fix full Buzz plugin lane: `node scripts/run-vitest.mjs extensions/buzz` — **29 files, 168 tests passed**.
- Focused owner/sibling coverage: `node scripts/run-vitest.mjs extensions/buzz/src/inbound.test.ts extensions/buzz/src/buzz-bus.lifecycle.test.ts extensions/buzz/src/buzz-bus.test.ts extensions/buzz/src/gateway.lifecycle.test.ts` — **4 files, 54 tests passed**.
- Exact changed-file type-aware lint, Buzz TypeScript project check, formatting check, and whitespace check passed.
- Independent pre-commit review found no accepted or actionable findings.

### Real authenticated Buzz behavior proof

An isolated real Gateway loaded an officially built Buzz package produced from the exact reviewed plugin source; plugin inventory confirmed `origin=config`, the Gateway log confirmed the candidate package entry, and the candidate `inbound.ts` SHA-256 was `cd0cad331e8015bdfa0ecd14e9b608b635f80739c03a51bcecbbe7dabc9e3904`. The Gateway connected to an ephemeral real WebSocket Nostr relay with cryptographically verified NIP-42 authentication, signed roster/profile events, generated task-local identities, and a mocked model provider. No production account, relay credentials, or long-lived identity was accessed.

Three real signed inbound turns were delivered to the live Gateway: one top-level root and two successive replies with distinct latest-message parents. Every actual signed agent text response carried exactly one root-parent relation tag; both current-scenario typing frames independently carried the same root-parent relation. Gateway shutdown completed cleanly.

```json
{
  "candidateHead": "e6c24320667cc1d5f59374cf299f924f89c65b67",
  "harness": "real isolated Gateway + authenticated NIP-42 WebSocket relay + generated identities + mock model provider",
  "candidatePluginOrigin": "config",
  "rootEvent": "a717ea4b...",
  "topLevelReply": { "directParent": "a717ea4b...", "relation": "reply", "passed": true },
  "threadReply1": { "inboundParent": "6a89460a...", "directParent": "a717ea4b...", "relation": "reply", "passed": true },
  "threadReply2": { "inboundParent": "6c992c1b...", "directParent": "a717ea4b...", "relation": "reply", "passed": true },
  "currentScenarioTypingFrames": ["cf815d4c...", "4d7be2c..."],
  "typingFramesDirectParent": "a717ea4b...",
  "realRelayAuthentication": "NIP-42 verified",
  "verdict": "PASS"
}
```

This replaces the previous synthetic-only evidence and directly addresses the latest ClawSweeper review's authenticated relay proof and two-later-turn root-anchoring requirements.
