### PR TITLE
fix(codex): prevent app-server leaks after desktop fallback

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -25,7 +25,6 @@ describe("Codex native hook relay config", () => {
     const config = buildCodexNativeHookRelayConfig({
       relay: createRelay(),
       hookTimeoutSec: 7,
-      loopDetectionPreToolUseRelay: true,
     });
 
     expect(config).toEqual({
@@ -132,7 +131,6 @@ describe("Codex native hook relay config", () => {
       buildCodexNativeHookRelayConfig({
         relay: createRelay(),
         events: ["permission_request"],
-        loopDetectionPreToolUseRelay: true,
       }),
     ).toEqual({
       "features.hooks": true,
@@ -168,7 +166,6 @@ describe("Codex native hook relay config", () => {
       buildCodexNativeHookRelayConfig({
         relay: createRelay({ inactiveEvents: ["post_tool_use", "before_agent_finalize"] }),
         events: ["pre_tool_use", "post_tool_use", "before_agent_finalize"],
-        loopDetectionPreToolUseRelay: true,
       }),
     ).toEqual({
       "features.hooks": true,
@@ -201,50 +198,13 @@ describe("Codex native hook relay config", () => {
     });
   });
 
-  it("keeps selected no-policy PreToolUse installed with an unavailable no-op marker", () => {
-    expect(
-      buildCodexNativeHookRelayConfig({
-        relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
-        events: ["pre_tool_use"],
-        loopDetectionPreToolUseRelay: true,
-      }),
-    ).toEqual({
-      "features.hooks": true,
-      "hooks.PreToolUse": [
-        {
-          hooks: [
-            {
-              type: "command",
-              command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 9000",
-              timeout: 10,
-              async: false,
-              statusMessage: "OpenClaw native hook relay",
-            },
-          ],
-        },
-      ],
-      "hooks.state": {
-        "/<session-flags>/config.toml:pre_tool_use:0:0": {
-          enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
-        },
-        "<session-flags>/config.toml:pre_tool_use:0:0": {
-          enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
-        },
-      },
+  it("clears selected PreToolUse when the relay has no local work", () => {
+    const config = buildCodexNativeHookRelayConfig({
+      relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
+      events: ["pre_tool_use"],
     });
-  });
 
-  it("clears selected inactive PreToolUse when Codex loop relay installation is disabled", () => {
-    expect(
-      buildCodexNativeHookRelayConfig({
-        relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
-        events: ["pre_tool_use"],
-        loopDetectionPreToolUseRelay: false,
-      }),
-    ).toEqual({
+    expect(config).toEqual({
       "features.hooks": true,
       "hooks.PreToolUse": [],
       "hooks.state": {},
@@ -257,7 +217,6 @@ describe("Codex native hook relay config", () => {
         relay: createRelay(),
         events: ["permission_request"],
         clearOmittedEvents: true,
-        loopDetectionPreToolUseRelay: true,
       }),
     ).toEqual({
       "features.hooks": true,
@@ -301,7 +260,6 @@ describe("Codex native hook relay config", () => {
     const config = buildCodexNativeHookRelayConfig({
       relay: createRelay(),
       events: ["pre_tool_use", "post_tool_use"],
-      loopDetectionPreToolUseRelay: true,
     });
 
     expect((config["hooks.PreToolUse"] as Array<{ matcher?: unknown }>)[0]).not.toHaveProperty(
@@ -331,7 +289,6 @@ describe("Codex native hook relay config", () => {
         },
       }),
       events: ["pre_tool_use", "post_tool_use"],
-      loopDetectionPreToolUseRelay: false,
     });
 
     expect(config["hooks.PreToolUse"]).toEqual([
@@ -347,7 +304,6 @@ describe("Codex native hook relay config", () => {
     const config = buildCodexNativeHookRelayConfig({
       relay: createRelay({ matchers: { pre_tool_use: ["deploy"] } }),
       events: ["pre_tool_use"],
-      loopDetectionPreToolUseRelay: false,
     });
 
     expect(config["hooks.PreToolUse"]).toEqual([
@@ -360,7 +316,6 @@ describe("Codex native hook relay config", () => {
       buildCodexNativeHookRelayConfig({
         relay: createRelay({ matchers: { pre_tool_use: [] } }),
         events: ["pre_tool_use"],
-        loopDetectionPreToolUseRelay: false,
       }),
     ).toThrow("Codex native hook matcher requires at least one tool name");
   });

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -394,7 +394,6 @@ export function buildCodexNativeHookRelayConfig(params: {
   events?: readonly NativeHookRelayEvent[];
   hookTimeoutSec?: number;
   clearOmittedEvents?: boolean;
-  loopDetectionPreToolUseRelay: boolean;
 }): JsonObject {
   const events = params.events?.length ? params.events : CODEX_NATIVE_HOOK_RELAY_EVENTS;
   const selectedEvents = new Set<NativeHookRelayEvent>(events);
@@ -406,11 +405,7 @@ export function buildCodexNativeHookRelayConfig(params: {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const selected = selectedEvents.has(event);
     const shouldRelay = params.relay.shouldRelayEvent(event);
-    // The no-policy marker is part of the shipped Codex fallback contract.
-    // Only the Codex-owned loop relay opt-out may omit it.
-    const selectedNoopPreToolUse =
-      selected && event === "pre_tool_use" && !shouldRelay && params.loopDetectionPreToolUseRelay;
-    if (!selected || (!shouldRelay && !selectedNoopPreToolUse)) {
+    if (!selected || !shouldRelay) {
       if (selected || params.clearOmittedEvents) {
         config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
       }
@@ -427,9 +422,7 @@ export function buildCodexNativeHookRelayConfig(params: {
     const command = params.relay.commandForEvent(event, {
       timeoutMs: resolveCodexNativeHookRelayCommandTimeoutMs(timeout),
     });
-    const matcher = selectedNoopPreToolUse
-      ? undefined
-      : buildCodexNativeToolMatcher(params.relay.toolMatcherForEvent(event));
+    const matcher = buildCodexNativeToolMatcher(params.relay.toolMatcherForEvent(event));
     config[`hooks.${codexEvent}`] = [
       {
         ...(matcher ? { matcher } : {}),

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -271,7 +271,6 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
             relay: state.nativeHookRelay,
             events: nativeHookRelayEvents,
             hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-            loopDetectionPreToolUseRelay: appServer.loopDetectionPreToolUseRelay,
           })
         : options.nativeHookRelay?.enabled === false
           ? buildCodexNativeHookRelayDisabledConfig()

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -54,6 +54,12 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
+function createLoopRelayParams(sessionFile: string, workspaceDir: string) {
+  const params = createParams(sessionFile, workspaceDir);
+  params.config = { tools: { loopDetection: { enabled: true } } } as never;
+  return params;
+}
+
 function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
@@ -136,7 +142,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -206,7 +212,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
+    const params = createLoopRelayParams(sessionFile, workspaceDir);
     params.messageChannel = "discord";
     params.agentAccountId = "operations";
     params.currentChannelId = "channel:target";
@@ -407,7 +413,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const relayFloorMs = 30 * 60_000;
 
     const startedAtMs = Date.now();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -435,7 +441,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -500,7 +506,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const explicitTtlMs = 123_456;
 
     const startedAtMs = Date.now();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -529,7 +535,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       pluginConfig: {
         appServer: {
           mode: "guardian",
@@ -595,7 +601,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
+    const params = createLoopRelayParams(sessionFile, workspaceDir);
     const abortController = new AbortController();
     const attemptTimeoutMs = 45 * 60_000;
     const startupTimeoutMs = attemptTimeoutMs;
@@ -647,7 +653,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const firstHarness = createStartedThreadHarness();
 
-    const firstRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const firstRun = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -679,7 +685,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     ).resolves.toMatchObject({ exitCode: 0 });
 
     const secondHarness = createResumeHarness();
-    const secondParams = createParams(sessionFile, workspaceDir);
+    const secondParams = createLoopRelayParams(sessionFile, workspaceDir);
     secondParams.runId = "run-2";
     const secondRun = runCodexAppServerAttempt(secondParams, {
       nativeHookRelay: {
@@ -720,7 +726,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const firstHarness = createStartedThreadHarness();
 
-    const firstRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const firstRun = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -740,7 +746,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     );
 
     const secondHarness = createResumeHarness();
-    const secondParams = createParams(sessionFile, workspaceDir);
+    const secondParams = createLoopRelayParams(sessionFile, workspaceDir);
     secondParams.runId = "run-2";
     const secondRun = runCodexAppServerAttempt(secondParams, {
       nativeHookRelay: {
@@ -773,7 +779,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     const harness = createResumeHarness();
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -837,7 +843,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     const harness = createStartedThreadHarness();
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
@@ -893,7 +899,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       return undefined;
     });
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+    const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -186,6 +186,23 @@ function deferNextAuthProfileApplication(): () => void {
   return release;
 }
 
+function configureManagedDesktopFallback(): CodexAppServerStartOptions {
+  mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+    ...startOptions,
+    command: "/Applications/Codex.app/Contents/Resources/codex",
+    commandSource: "resolved-managed",
+    managedFallbackCommandPaths: ["/cache/openclaw/codex"],
+  }));
+  return {
+    transport: "stdio",
+    homeScope: "user",
+    command: "codex",
+    commandSource: "managed",
+    args: ["app-server", "--listen", "stdio://"],
+    headers: {},
+  };
+}
+
 describe("shared Codex app-server client", () => {
   beforeAll(async () => {
     ({ listCodexAppServerModels } = await import("./models.js"));
@@ -450,29 +467,32 @@ describe("shared Codex app-server client", () => {
     await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true));
   });
 
-  it("falls back to the next managed app-server when desktop initialize is unsupported", async () => {
+  it("reuses the successful managed fallback after desktop initialize is unsupported", async () => {
     const desktop = createClientHarness();
     const pluginLocal = createClientHarness();
     const startSpy = vi
       .spyOn(CodexAppServerClient, "start")
       .mockReturnValueOnce(desktop.client)
-      .mockReturnValueOnce(pluginLocal.client);
-    mocks.resolveManagedCodexAppServerStartOptions.mockImplementationOnce(async (startOptions) => ({
-      ...startOptions,
-      command: "/Applications/Codex.app/Contents/Resources/codex",
-      commandSource: "resolved-managed",
-      managedFallbackCommandPaths: ["/cache/openclaw/codex"],
-    }));
+      .mockReturnValueOnce(pluginLocal.client)
+      .mockImplementation(() => {
+        throw new Error("unexpected duplicate start");
+      });
+    const startOptions = configureManagedDesktopFallback();
 
-    const listPromise = listCodexAppServerModels({ timeoutMs: 1000 });
+    const firstAcquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
     await sendInitializeResult(desktop, "openclaw/0.124.9 (macOS; test)");
     await sendInitializeResult(pluginLocal, "openclaw/0.147.0 (macOS; test)");
-    await sendEmptyModelList(pluginLocal);
+    const firstClient = await firstAcquire;
 
-    await expect(listPromise).resolves.toEqual({ models: [] });
+    const secondClient = await getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
+
+    expect(secondClient).toBe(firstClient);
     expect(desktop.process.stdin.destroyed).toBe(true);
     expect(pluginLocal.process.stdin.destroyed).toBe(false);
     expect(startSpy).toHaveBeenCalledTimes(2);
+    const retained = retainSharedCodexAppServerClientByInstanceId(firstClient.getInstanceId());
+    expect(retained?.client).toBe(firstClient);
+    retained?.release();
     expect(startSpy.mock.calls[0]?.[0]).toMatchObject({
       command: "/Applications/Codex.app/Contents/Resources/codex",
       commandSource: "resolved-managed",
@@ -483,6 +503,37 @@ describe("shared Codex app-server client", () => {
       commandSource: "resolved-managed",
     });
     expect(startSpy.mock.calls[1]?.[0]).not.toHaveProperty("managedFallbackCommandPaths");
+
+    await clearSharedCodexAppServerClientAndWait({ exitTimeoutMs: 25, forceKillDelayMs: 5 });
+    expect(pluginLocal.process.stdin.destroyed).toBe(true);
+  });
+
+  it("shares a managed fallback with a waiter that arrives during fallback initialize", async () => {
+    const desktop = createClientHarness();
+    const fallback = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(desktop.client)
+      .mockReturnValueOnce(fallback.client)
+      .mockImplementation(() => {
+        throw new Error("unexpected duplicate start");
+      });
+    const options = {
+      timeoutMs: 1_000,
+      startOptions: configureManagedDesktopFallback(),
+    };
+
+    const firstAcquire = getSharedCodexAppServerClient(options);
+    await sendInitializeResult(desktop, "openclaw/0.124.9 (macOS; test)");
+    await vi.waitFor(() => expect(fallback.writes.length).toBeGreaterThanOrEqual(1));
+    const secondAcquire = getSharedCodexAppServerClient(options);
+    await sendInitializeResult(fallback, "openclaw/0.147.0 (macOS; test)");
+
+    const [firstClient, secondClient] = await Promise.all([firstAcquire, secondAcquire]);
+    expect(secondClient).toBe(firstClient);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(desktop.process.stdin.destroyed).toBe(true);
+    expect(fallback.process.stdin.destroyed).toBe(false);
   });
 
   it("keeps capture clients separate from ordinary shared clients", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -847,13 +847,14 @@ function createSharedCodexAppServerClientStartup(params: {
     onStartedClient: (startedClient) => {
       const state = getSharedCodexAppServerClientState();
       params.entry.client = startedClient;
-      state.entriesByClient.set(startedClient, params.entry);
       // Graceful retirement detaches active clients from the acquisition map,
       // so global teardown tracks physical lifetime until the close notification.
       state.liveClients.add(startedClient);
       startedClient.addCloseHandler((closedClient) => {
-        getSharedCodexAppServerClientState().liveClients.delete(closedClient);
-        clearSharedClientEntryIfCurrent(params.key, closedClient);
+        state.liveClients.delete(closedClient);
+        if (state.entriesByClient.get(closedClient) === params.entry) {
+          clearSharedClientEntryIfCurrent(params.key, closedClient);
+        }
       });
       for (const callback of params.entry.onStartedClientCallbacks) {
         callback(startedClient);
@@ -863,7 +864,9 @@ function createSharedCodexAppServerClientStartup(params: {
     onInitializedClient: () => initialized.resolve(),
   }).then(
     (client) => {
+      const state = getSharedCodexAppServerClientState();
       params.entry.client = client;
+      state.entriesByClient.set(client, params.entry);
       return client;
     },
     (error: unknown) => {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -400,6 +400,14 @@ function sideParams(overrides: Partial<SideQuestionParams> = {}): SideQuestionPa
   };
 }
 
+function sideLoopRelayParams(overrides: Partial<SideQuestionParams> = {}): SideQuestionParams {
+  return sideParams({
+    cfg: { tools: { loopDetection: { enabled: true } } } as never,
+    sessionKey: "agent:main:session-1",
+    ...overrides,
+  });
+}
+
 function platformPreparedRuntimeAuth(resolvedApiKey?: string) {
   return {
     plan: {
@@ -1419,7 +1427,7 @@ describe("runCodexAppServerSideQuestion", () => {
 
     await expect(
       runCodexAppServerSideQuestion(
-        sideParams({
+        sideLoopRelayParams({
           sessionKey: "agent:main:session-1",
           messageChannel: "discord",
           messageProvider: "discord-voice",
@@ -1532,7 +1540,7 @@ describe("runCodexAppServerSideQuestion", () => {
 
     await expect(
       runCodexAppServerSideQuestion(
-        sideParams({
+        sideLoopRelayParams({
           sessionKey: "agent:main:session-1",
           messageChannel: "discord",
           messageProvider: "discord-voice",
@@ -2081,7 +2089,7 @@ describe("runCodexAppServerSideQuestion", () => {
 
     try {
       await expect(
-        runCodexAppServerSideQuestion(sideParams(), {
+        runCodexAppServerSideQuestion(sideLoopRelayParams(), {
           nativeHookRelay: { enabled: true },
         }),
       ).rejects.toThrow("side turn start exploded");
@@ -2144,7 +2152,7 @@ describe("runCodexAppServerSideQuestion", () => {
 
     try {
       await expect(
-        runCodexAppServerSideQuestion(sideParams(), {
+        runCodexAppServerSideQuestion(sideLoopRelayParams(), {
           nativeHookRelay: { enabled: true },
         }),
       ).resolves.toEqual({ text: "Side answer." });
@@ -2222,7 +2230,7 @@ describe("runCodexAppServerSideQuestion", () => {
 
     try {
       await expect(
-        runCodexAppServerSideQuestion(sideParams(), {
+        runCodexAppServerSideQuestion(sideLoopRelayParams(), {
           nativeHookRelay: { enabled: true },
         }),
       ).resolves.toEqual({ text: "Side answer." });

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -647,7 +647,6 @@ export async function runCodexAppServerSideQuestion(
           events: nativeHookRelayEvents,
           hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
           clearOmittedEvents: true,
-          loopDetectionPreToolUseRelay: appServer.loopDetectionPreToolUseRelay,
         })
       : options.nativeHookRelay?.enabled === false
         ? buildCodexNativeHookRelayDisabledConfig()

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -7,6 +7,7 @@ import {
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError } from "./client.js";
+import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import type { CodexDynamicToolFunctionSpec } from "./protocol.js";
 import {
   createParams as createRunAttemptParams,
@@ -407,6 +408,83 @@ describe("Codex app-server thread lifecycle bindings", () => {
       action: "resume",
       binding: expect.objectContaining({ threadId: "thread-warm" }),
     });
+  });
+
+  it("cold-resumes a warm thread to clear stale enforcing PreToolUse hooks", async () => {
+    const sessionFile = path.join(tempDir, "warm-cleared-hooks-session.jsonl");
+    const workspaceDir = path.join(tempDir, "warm-cleared-hooks-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const fake = createFakeCodexAppServerClient(async (method: string) => {
+      if (method === "thread/start" || method === "thread/resume") {
+        return threadStartResult("thread-warm-cleared-hooks");
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const client = fake.client;
+    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const buildFinalConfigPatch = vi
+      .fn()
+      .mockReturnValueOnce({
+        configPatch: {
+          "features.hooks": true,
+          "hooks.PreToolUse": [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "openclaw hooks relay --event pre_tool_use",
+                },
+              ],
+            },
+          ],
+        },
+        nativeHookRelayGeneration: "generation-policy",
+      })
+      .mockReturnValueOnce({
+        configPatch: { "features.hooks": true, "hooks.PreToolUse": [] },
+        nativeHookRelayGeneration: "generation-no-policy",
+      });
+    const common = {
+      client,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      userMcpServersEnabled: false,
+      buildFinalConfigPatch,
+    };
+
+    const started = await startOrResumeThread(common);
+    await expect(
+      retainCodexAppServerLiveThread(
+        client,
+        started.threadId,
+        undefined,
+        started.liveThreadConfigFingerprint,
+      ),
+    ).resolves.toBe(true);
+    const resumed = await startOrResumeThread(common);
+
+    expect(resumed).toMatchObject({
+      threadId: "thread-warm-cleared-hooks",
+      nativeHookRelayGeneration: "generation-no-policy",
+      lifecycle: { action: "resumed" },
+    });
+    expect(fake.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/resume",
+    ]);
+    const resumeConfig = fake.request.mock.calls.find(
+      ([method]) => method === "thread/resume",
+    )?.[1];
+    expect(resumeConfig).toMatchObject({
+      config: { "features.hooks": true, "hooks.PreToolUse": [] },
+    });
+    expect(JSON.stringify(resumeConfig)).not.toContain("openclaw hooks relay");
   });
 
   it("cold-resumes a warm thread when final config adds an image-generation deny", async () => {

--- a/src/agents/harness/native-hook-relay-events.ts
+++ b/src/agents/harness/native-hook-relay-events.ts
@@ -51,7 +51,7 @@ function nativePreToolUseMayRunLoopDetection(
     cfg: registration.config,
     agentId: registration.agentId,
   });
-  return loopDetection?.enabled !== false;
+  return loopDetection?.enabled === true;
 }
 
 export function nativeHookRelayEventHasLocalWork(

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1246,7 +1246,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
-        `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
+        `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
 
@@ -1304,6 +1304,7 @@ describe("native hook relay registry", () => {
       preToolUseLoopDetection: false,
     });
 
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
     expect(relay.toolMatcherForEvent("pre_tool_use")).toEqual(["apply_patch", "exec"]);
   });
 
@@ -1324,12 +1325,24 @@ describe("native hook relay registry", () => {
     expect(relay.toolMatcherForEvent("pre_tool_use")).toEqual(["spawn_agent"]);
   });
 
-  it("keeps pre-tool relays active when native loop detection is not disabled", () => {
+  it("omits loop-detection-only pre-tool relays by default", () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       runId: "run-1",
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(false);
+  });
+
+  it("installs pre-tool relays when loop detection is explicitly enabled", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      config: { tools: { loopDetection: { enabled: true } } } as never,
       command: {
         executable: "/opt/Open Claw/openclaw.mjs",
         nodeExecutable: "/usr/local/bin/node",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -249,10 +249,6 @@ function registerNativeHookRelayInternal(
           stateDbPath,
           generation: registration.generation,
           event,
-          preToolUseUnavailable:
-            event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
-              ? "noop"
-              : undefined,
           nice: params.command?.nice,
           timeoutMs: resolveNativeHookRelayCommandTimeoutMs(
             params.command?.timeoutMs,


### PR DESCRIPTION
Closes #124855

## What Problem This Solves

Fixes an issue where long-lived Gateways using managed Codex app-server fallback could start a new app-server on every session-catalog refresh when the preferred desktop Codex version was unsupported. On an affected host this grew to roughly 600 logical app-servers / 1,200 OS processes, increased descriptor and CPU pressure, slowed catalog reads, and contributed to native tool-hook timeouts.

## Why This Change Was Made

The rejected provisional desktop client was allowed to clear the reusable keyed entry before the supported bundled fallback finished starting. This change makes only the final initialized/authenticated client own keyed cleanup, so provisional candidates remain globally disposable without evicting the successful fallback.

It also stops generating a per-tool OpenClaw relay when no local PreToolUse policy is active. Explicit loop detection and real hook policies still install the fail-closed relay, and a policy-to-no-policy transition forces the existing unsubscribe/cold-resume path so a warm Codex thread cannot retain stale enforcing hooks. Direct app-server host-policy callbacks remain a separate upstream protocol follow-up.

## User Impact

Repeated catalog refreshes now reuse one Codex app-server per exact home/auth/runtime identity instead of leaking a new process pair. Default sessions without local policy also avoid an unnecessary shell + Node + SQLite relay on every native tool call, while configured policy enforcement remains fail-closed.

## Evidence

- Regression coverage proves sequential and concurrent managed fallback acquisitions reuse the same successful client and global disposal closes it.
- Policy coverage proves default-disabled/no-policy sessions emit an empty `PreToolUse` hook array, explicit policy still relays, and policy removal cold-resumes with cleared hooks.
- Focused Vitest proof: 302 tests passed across shared-client, Codex relay, core relay, and thread-lifecycle suites; the final shared-client-only rerun passed 58/58.
- Real-process probe: four identical acquisitions reused one instance and PID; global cleanup terminated that process.
- `node scripts/check-changed.mjs`: all selected core, core-test, extension, extension-test, formatting, lint, schema, database, and import-cycle gates passed. A first remote Daytona run exited silently during core-test typecheck under a 10 GiB provider limit; the touched shard and all 14 core-test shards then passed locally, followed by the complete clean local changed gate under the repository fallback rule.
- Codex autoreview (`gpt-5.6-sol`, high): clean, 0 accepted/actionable findings, confidence 0.98.
- Exact-head CI first exposed 17 relay-focused fixtures that still relied on the removed default no-policy relay. A test-only follow-up opted those scenarios into explicit loop detection; the focused rerun passed 84/84 and the final exact-head CI gate passed.
- Production LOC: +9 / -19 (net -10). Tests: +193 / -82 (net +111).

AI-assisted: yes. The implementation, upstream contract reading, tests, process probe, and landing were reviewed by the maintainer.
