### PR TITLE
fix(tui): report the first last-session write failure

### DIFF
--- a/src/tui/tui-last-session.test.ts
+++ b/src/tui/tui-last-session.test.ts
@@ -7,6 +7,7 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import {
   buildTuiLastSessionScopeKey,
   clearTuiLastSessionPointers,
+  createRememberSessionKeyWriter,
   readTuiLastSessionKey,
   resolveRememberedTuiSessionKey,
   writeTuiLastSessionKey,
@@ -173,5 +174,49 @@ describe("tui last session state", () => {
     await expect(readTuiLastSessionKey({ scopeKey: "remote", stateDir })).resolves.toBe(
       "agent:main:telegram:thread",
     );
+  });
+});
+
+describe("createRememberSessionKeyWriter", () => {
+  it("reports the first write failure once and keeps later writes silent", async () => {
+    const failures: string[] = [];
+    const write = async () => {
+      throw new Error("SQLITE_CORRUPT: database disk image is malformed");
+    };
+    const remember = createRememberSessionKeyWriter({
+      buildScopeKey: (sessionKey) => `scope:${sessionKey}`,
+      reportFailure: (message) => failures.push(message),
+      write,
+    });
+
+    remember("agent:main:one");
+    remember("agent:main:two");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(failures).toEqual(["SQLITE_CORRUPT: database disk image is malformed"]);
+  });
+
+  it("skips empty and unknown session keys without touching the writer", async () => {
+    let writes = 0;
+    const remember = createRememberSessionKeyWriter({
+      buildScopeKey: (sessionKey) => sessionKey,
+      reportFailure: () => {
+        throw new Error("must not report");
+      },
+      write: async () => {
+        writes += 1;
+      },
+    });
+
+    remember("  ");
+    remember("unknown");
+    remember("agent:main:kept");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(writes).toBe(1);
   });
 });

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -117,6 +117,35 @@ export async function writeTuiLastSessionKey(params: {
   }, stateDatabaseOptions(params.stateDir));
 }
 
+/**
+ * Wraps writeTuiLastSessionKey for fire-and-forget callers: a failing state DB
+ * means the next launch silently loses session restore, so the first failure
+ * is reported once instead of spamming every session switch.
+ */
+export function createRememberSessionKeyWriter(params: {
+  buildScopeKey: (sessionKey: string) => string;
+  reportFailure: (message: string) => void;
+  write?: typeof writeTuiLastSessionKey;
+}): (sessionKey: string) => void {
+  const write = params.write ?? writeTuiLastSessionKey;
+  let failureReported = false;
+  return (sessionKey: string) => {
+    const trimmed = sessionKey.trim();
+    if (!trimmed || trimmed === "unknown") {
+      return;
+    }
+    void write({ scopeKey: params.buildScopeKey(trimmed), sessionKey: trimmed }).catch(
+      (err: unknown) => {
+        if (failureReported) {
+          return;
+        }
+        failureReported = true;
+        params.reportFailure(err instanceof Error ? err.message : String(err));
+      },
+    );
+  };
+}
+
 /** Removes restore pointers that target sessions retired by doctor repair. */
 export function clearTuiLastSessionPointers(params: {
   sessionKeys: ReadonlySet<string>;

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -125,9 +125,9 @@ export async function writeTuiLastSessionKey(params: {
 export function createRememberSessionKeyWriter(params: {
   buildScopeKey: (sessionKey: string) => string;
   reportFailure: (message: string) => void;
-  write?: typeof writeTuiLastSessionKey;
+  write: typeof writeTuiLastSessionKey;
 }): (sessionKey: string) => void {
-  const write = params.write ?? writeTuiLastSessionKey;
+  const write = params.write;
   let failureReported = false;
   return (sessionKey: string) => {
     const trimmed = sessionKey.trim();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -60,9 +60,9 @@ import {
 } from "./tui-formatters.js";
 import {
   buildTuiLastSessionScopeKey,
+  createRememberSessionKeyWriter,
   readTuiLastSessionKey,
   resolveRememberedTuiSessionKey,
-  writeTuiLastSessionKey,
 } from "./tui-last-session.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
@@ -1018,16 +1018,13 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     });
   };
 
-  const rememberCurrentSessionKey = (sessionKey: string) => {
-    const trimmed = sessionKey.trim();
-    if (!trimmed || trimmed === "unknown") {
-      return;
-    }
-    void writeTuiLastSessionKey({
-      scopeKey: buildLastSessionScopeKeyFor(trimmed),
-      sessionKey: trimmed,
-    }).catch(() => undefined);
-  };
+  const rememberCurrentSessionKey = createRememberSessionKeyWriter({
+    buildScopeKey: buildLastSessionScopeKeyFor,
+    reportFailure: (message) => {
+      chatLog.addSystem(`session memory write failed: ${message}`);
+      tui.requestRender();
+    },
+  });
 
   const restoreRememberedSession = async (expectedConnectionGeneration: number) => {
     if (initialSessionInput || rememberedSessionApplied) {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -63,6 +63,7 @@ import {
   createRememberSessionKeyWriter,
   readTuiLastSessionKey,
   resolveRememberedTuiSessionKey,
+  writeTuiLastSessionKey,
 } from "./tui-last-session.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
@@ -1024,6 +1025,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       chatLog.addSystem(`session memory write failed: ${message}`);
       tui.requestRender();
     },
+    write: writeTuiLastSessionKey,
   });
 
   const restoreRememberedSession = async (expectedConnectionGeneration: number) => {


### PR DESCRIPTION
## What Problem This Solves

`rememberCurrentSessionKey` in the TUI swallowed `writeTuiLastSessionKey` failures with `.catch(() => undefined)`. A corrupt or locked state DB silently disabled session restore: the operator only discovers it on the next launch, landing in the wrong session with no clue why — a recorded-nowhere failure of a persistence feature.

## Why This Change Was Made

Root cause: fire-and-forget with no recorded failure. The write wrapper moved to its owner, `tui-last-session.ts`, as `createRememberSessionKeyWriter`: the first failure surfaces via the chat log (`session memory write failed: …`) and repeats stay silent — one line per TUI run, not one per session switch, since a corrupt DB fails every write identically. Empty/`unknown` keys keep skipping without touching the writer. The tui.ts call site shrinks to a factory call, and the previously untestable inline closure gains colocated tests.

## User Impact

A failing state DB now announces itself in the session where it happens, instead of silently losing the restore pointer.

## Evidence

- Colocated regressions in `src/tui/tui-last-session.test.ts`: first-failure-once reporting across two writes, and empty/unknown-key skip — fail pre-fix (factory absent; call site swallowed everything). Suite 9/9; tui.test.ts 85/85.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +37 −11 (factory + docs comment; call-site shrink), test +45.
