### PR TITLE
fix(cli): keep internal error causes out of operator output

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -40,7 +40,7 @@ describe("waitForever", () => {
 });
 
 describe("runCommandWithRuntime", () => {
-  it("surfaces cause chains and error codes through the default runtime", async () => {
+  it("keeps cause chains and error codes behind debug intent", async () => {
     const messages: string[] = [];
     const exits: number[] = [];
     const cause = Object.assign(new Error("invalid onRequestStart method"), {
@@ -48,22 +48,36 @@ describe("runCommandWithRuntime", () => {
     });
     const fetchError = Object.assign(new TypeError("fetch failed"), { cause });
 
-    await runCommandWithRuntime(
-      {
-        error: (message) => messages.push(message),
-        exit: (code) => exits.push(code),
-      },
-      async () => {
-        throw fetchError;
-      },
-    );
+    const run = async () =>
+      await runCommandWithRuntime(
+        {
+          error: (message) => messages.push(message),
+          exit: (code) => exits.push(code),
+        },
+        async () => {
+          throw fetchError;
+        },
+      );
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toContain("fetch failed");
-    expect(messages[0]).not.toContain("TypeError:");
-    expect(messages[0]).toContain("invalid onRequestStart method");
-    expect(messages[0]).toContain("UND_ERR_INVALID_ARG");
-    expect(exits).toEqual([1]);
+    const originalDebug = process.env.OPENCLAW_DEBUG;
+    delete process.env.OPENCLAW_DEBUG;
+    try {
+      await run();
+      process.env.OPENCLAW_DEBUG = "1";
+      await run();
+    } finally {
+      if (originalDebug === undefined) {
+        delete process.env.OPENCLAW_DEBUG;
+      } else {
+        process.env.OPENCLAW_DEBUG = originalDebug;
+      }
+    }
+
+    expect(messages).toEqual([
+      "fetch failed",
+      "fetch failed | invalid onRequestStart method | UND_ERR_INVALID_ARG",
+    ]);
+    expect(exits).toEqual([1, 1]);
   });
 
   it("bubbles JSON-mode failures to the process-level owner", async () => {

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,6 +1,7 @@
 // Shared CLI execution wrappers and inherited Commander option lookup.
 import type { Command } from "commander";
 import { formatErrorMessage } from "../infra/errors.js";
+import { formatCliOperatorError } from "./failure-output.js";
 import { isJsonOutputModeActive } from "./json-output-mode.js";
 
 export { formatErrorMessage };
@@ -48,7 +49,7 @@ export async function runCommandWithRuntime(
       onError(err);
       return;
     }
-    runtime.error(formatErrorMessage(err));
+    runtime.error(formatCliOperatorError(err));
     runtime.exit(1);
   }
 }

--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -16,13 +16,28 @@ describe("formatCliJsonFailure", () => {
     });
     expect(payload.error.message).not.toContain(token);
   });
+
+  it("keeps nested causes behind the debug gate", () => {
+    const error = new Error("Promotion is not available.", {
+      cause: new Error("ClawHub /api/v1/promotions/nope failed (404)"),
+    });
+
+    expect(formatCliJsonFailure(error, { env: {} }).error.message).toBe(
+      "Promotion is not available.",
+    );
+    expect(formatCliJsonFailure(error, { env: { OPENCLAW_DEBUG: "1" } }).error.message).toBe(
+      "Promotion is not available. | ClawHub /api/v1/promotions/nope failed (404)",
+    );
+  });
 });
 
 describe("formatCliFailureLines", () => {
   it("shows a concise reason and recovery commands by default", () => {
     const lines = formatCliFailureLines({
       title: "Could not start the CLI.",
-      error: new Error("config file is invalid"),
+      error: new Error("config file is invalid", {
+        cause: new Error("unexpected token at /internal/config.json:12"),
+      }),
       argv: ["node", "openclaw", "status"],
       env: {},
     });
@@ -55,11 +70,12 @@ describe("formatCliFailureLines", () => {
   it.each(["--debug", "--verbose"])("prints stack details for the root %s option", (debugFlag) => {
     const lines = formatCliFailureLines({
       title: "The CLI command failed.",
-      error: new Error("boom"),
+      error: new Error("boom", { cause: new Error("transport detail") }),
       argv: ["node", "openclaw", "proxy", "run", debugFlag],
       env: {},
     });
 
+    expect(lines).toContain("[openclaw] Reason: boom | transport detail");
     expect(lines).toContain("[openclaw] Stack:");
     expect(lines).toContain("[openclaw] Error: boom");
   });

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -11,6 +11,8 @@ type FormatCliFailureOptions = {
   includeDoctorHint?: boolean;
 };
 
+type CliFailureDebugOptions = Pick<FormatCliFailureOptions, "argv" | "env">;
+
 export type CliJsonFailure = {
   ok: false;
   error: {
@@ -20,12 +22,15 @@ export type CliJsonFailure = {
 };
 
 /** Canonical machine-readable failure envelope for CLI-owned errors. */
-export function formatCliJsonFailure(error: unknown): CliJsonFailure {
+export function formatCliJsonFailure(
+  error: unknown,
+  options: CliFailureDebugOptions = {},
+): CliJsonFailure {
   return {
     ok: false,
     error: {
       type: "cli_error",
-      message: formatErrorMessage(error),
+      message: formatCliOperatorError(error, options),
     },
   };
 }
@@ -43,8 +48,21 @@ function hasDebugArg(argv: string[] | undefined): boolean {
   return false;
 }
 
-function shouldShowStack(argv: string[] | undefined, env: NodeJS.ProcessEnv): boolean {
+function shouldShowDebugDetails(
+  argv: string[] | undefined = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
   return hasDebugArg(argv) || isTruthyEnvValue(env.OPENCLAW_DEBUG);
+}
+
+export function formatCliOperatorError(
+  error: unknown,
+  options: CliFailureDebugOptions = {},
+): string {
+  const includeCause = shouldShowDebugDetails(options.argv, options.env);
+  const value =
+    !includeCause && error instanceof Error ? error.message || error.name || "Error" : error;
+  return formatErrorMessage(value);
 }
 
 function pushPrefixed(out: string[], value: string): void {
@@ -56,14 +74,18 @@ function pushPrefixed(out: string[], value: string): void {
 }
 
 export function formatCliFailureLines(options: FormatCliFailureOptions): string[] {
-  // Default output stays terse; stack traces require explicit debug intent.
+  // Default output stays terse; causes and stack traces require explicit debug intent.
   const env = options.env ?? process.env;
+  const showDebugDetails = shouldShowDebugDetails(options.argv, env);
   const lines = [
     `[openclaw] ${options.title}`,
-    `[openclaw] Reason: ${formatErrorMessage(options.error)}`,
+    `[openclaw] Reason: ${formatCliOperatorError(options.error, {
+      argv: options.argv,
+      env,
+    })}`,
   ];
 
-  if (shouldShowStack(options.argv, env)) {
+  if (showDebugDetails) {
     lines.push("[openclaw] Stack:");
     pushPrefixed(lines, formatUncaughtError(options.error));
   } else {

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -128,8 +128,7 @@ describe("error helpers", () => {
       cause: rootCause,
     });
     const formatted = formatErrorMessage(httpError);
-    expect(formatted).toContain("Network request for 'sendMessage' failed!");
-    expect(formatted).toContain("ECONNRESET");
+    expect(formatted).toBe("Network request for 'sendMessage' failed! | ECONNRESET");
   });
 
   it("handles circular .cause references without infinite loop", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a CLI command that wrapped a clean domain error around a technical `{ cause }` would see the entire internal cause chain in ordinary operator output. For example, a missing promotion exposed the ClawHub API route and transport response after the already-actionable domain message.

## Why This Change Was Made

CLI-owned failure rendering now has one narrow operator formatter: normal output renders only an `Error`'s top-level message, while the existing `--debug` / `--verbose` / `OPENCLAW_DEBUG=1` gate retains the complete redacted cause chain. Both root failure lines and the canonical JSON failure envelope use it, and `runCommandWithRuntime` now routes its human failure path through the same owner (this is the path used by `promos claim`).

The shared `formatErrorMessage` contract is deliberately unchanged. Logs, diagnostics, retry classification, TUI errors, and channel transport/status surfaces still receive nested causes.

### Changed vs. left intact

| Surface | Decision | Reason |
| --- | --- | --- |
| Root CLI failure lines (`formatCliFailureLines`) | Changed | Default reason is operator-safe; debug still includes cause plus stack. |
| Shared command wrapper (`runCommandWithRuntime`) | Changed | It is the actual human renderer for `promos claim` and other wrapped commands. |
| Canonical JSON failure envelope (`formatCliJsonFailure`) | Changed | `error.message` follows the same debug gate as human output. |
| Shared `formatErrorMessage` | Left intact | Cause traversal is required by diagnostics and behavioral classifiers. |
| Gateway `formatForLog` | Left intact | Diagnostic output intentionally retains names, codes, and cause chains. |
| TUI `formatTuiErrorMessage` | Left intact | Inline TUI failures have no equivalent debug mode and nested detail can be the only actionable context. |
| Channel delivery/plugin status formatting | Left intact | These are transport/status records and diagnostic inputs, not the CLI failure renderer. |
| Command-owned bespoke CLI status/recovery messages | Left intact | They own their surrounding domain text; sweeping their many call sites would be a separate policy change. |

## User Impact

Routine CLI failures no longer expose internal API paths or transport messages after a good domain explanation. Operators can still opt into the complete redacted chain with the existing debug controls, and no `{ cause }` data is removed from any error.

Some paths intentionally store their only low-level detail in the cause (for example secure Gateway join failures). That information is preserved and visible under debug; TUI, channel, retry, and logging consumers were not trimmed.

## Evidence

### Before

```text
$ openclaw promos claim NOPE
Promotion "nope" was not found or is not live. See openclaw promos list. | ClawHub /api/v1/promotions/nope failed (404): Promotion not found
[exit 1]
```

Root cause: `packages/normalization-core/src/error-coercion.ts:76-110` correctly walks causes for diagnostics, but `src/cli/failure-output.ts` and `src/cli/cli-utils.ts` previously used that diagnostic rendering directly for operators.

### After: built CLI, isolated Testbox profile

```text
$ openclaw promos claim NOPE
Promotion "nope" was not found or is not live. See openclaw promos list.
[exit 1]

$ OPENCLAW_DEBUG=1 openclaw promos claim NOPE
Promotion "nope" was not found or is not live. See openclaw promos list. | ClawHub /api/v1/promotions/nope failed (404): Promotion not found
[exit 1]
```

The built canonical JSON formatter, exercised with the same domain-plus-transport error shape:

```json
{"ok":false,"error":{"type":"cli_error","message":"Promotion is not available."}}
{"ok":false,"error":{"type":"cli_error","message":"Promotion is not available. | ClawHub /api/v1/promotions/nope failed (404)"}}
```

`promos claim` does not currently expose a `--json` success contract, so adding that option would be a separate feature. The JSON envelope itself is covered at its owning boundary and in the built artifact without broadening this fix.

### Regression and diagnostic preservation

- Pre-fix mutation proof: the new human and JSON assertions failed because both default messages included the transport cause; the command-wrapper assertion independently failed for the same reason.
- `node scripts/run-vitest.mjs src/cli/failure-output.test.ts src/cli/cli-utils.test.ts src/infra/errors.test.ts src/gateway/ws-log.test.ts packages/normalization-core/src/error-coercion.test.ts`: 120/120 green after rebase.
- `src/infra/errors.test.ts` asserts exact shared output `Network request ... | ECONNRESET`.
- `src/gateway/ws-log.test.ts:46-66` asserts logging retains the top-level name/code and all nested messages/codes.
- `node scripts/check-changed.mjs`: green on Blacksmith Testbox ([run 31976973289](https://github.com/openclaw/openclaw/actions/runs/31976973289)); patch-equivalent pre-rebase validation.
- `pnpm build`: green on the rebased exact head ([run 31977502204](https://github.com/openclaw/openclaw/actions/runs/31977502204)).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings.

Production LOC: +30/-7 (net +23) | Tests: +49/-20 (net +29). The production growth is the single CLI ownership boundary plus routing the existing command wrapper through it; no throw sites, compatibility paths, or diagnostic formatters were added.

AI-assisted: yes. I understand and verified the operator/debug ownership boundary and the unchanged diagnostic consumers.
