### PR TITLE
fix: remove delivery markers from historical sessions

### DIFF
--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -114,6 +114,8 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.meeting-transcripts-files.ts",
     "src/infra/state-migrations.meeting-transcripts-verify.ts",
     "src/infra/state-migrations.media-persistence.ts",
+    "src/infra/state-migrations.transcript-directives-archives.ts",
+    "src/infra/state-migrations.transcript-directives.ts",
   ],
   "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
   "session entry cache connection-local validity counters": [

--- a/src/commands/doctor-state-migrations.ts
+++ b/src/commands/doctor-state-migrations.ts
@@ -8,6 +8,7 @@ export {
   autoMigrateLegacyState,
   detectLegacyStateMigrations,
   migrateLegacyAgentDir,
+  migrateHistoricalTranscriptDirectives,
   migrateLegacyMediaPersistence,
   resetAutoMigrateLegacyStateDirForTest,
   resetAutoMigrateLegacyTaskStateSidecarsForTest,

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -1,14 +1,22 @@
-import type { AgentMessage } from "../../agents/runtime/index.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 
+type AssistantDirectiveMessage = {
+  content?: unknown;
+  openclawDelivery?: unknown;
+  role?: unknown;
+};
+
 /** Strips final-answer directives in place so live state and persisted bytes stay identical. */
-export function applyAssistantDeliveryDirectives(message: AgentMessage): AgentMessage {
-  if (message.role !== "assistant") {
+export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMessage>(
+  message: T,
+): T {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
     return message;
   }
-  let facts: NonNullable<typeof message.openclawDelivery> | undefined;
+  let facts: { audioAsVoice?: true; replyToCurrent?: true; replyToId?: string } | undefined;
   for (const block of message.content) {
-    if (block.type !== "text") {
+    if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") {
       continue;
     }
     const parsed = parseInlineDirectives(block.text);
@@ -24,7 +32,7 @@ export function applyAssistantDeliveryDirectives(message: AgentMessage): AgentMe
     });
   }
   if (facts) {
-    message.openclawDelivery = facts;
+    Object.assign(message, { openclawDelivery: facts });
   }
   return message;
 }

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -164,6 +164,7 @@ import {
   detectLegacySubagentRegistry,
   migrateLegacySubagentRegistry,
 } from "./state-migrations.subagent-registry.js";
+import { migrateHistoricalTranscriptDirectives } from "./state-migrations.transcript-directives.js";
 import {
   detectLegacyTuiLastSessions,
   migrateLegacyTuiLastSessions,
@@ -1382,35 +1383,51 @@ export async function autoMigrateLegacyState(params: {
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
+  const configuredAgentDatabaseTargets = resolveSessionStoreTargets(
+    params.cfg,
+    { allAgents: true },
+    { env },
+  ).map((target) => ({
+    agentId: target.agentId,
+    path: resolveSqliteTargetFromSessionStorePath(target.storePath, {
+      agentId: target.agentId,
+      defaultAgentId: isPerAgentSessionStoreConfig(params.cfg.session?.store)
+        ? target.agentId
+        : resolveSessionStoreCompatibilityAgentId(params.cfg),
+      env,
+    }).path,
+  }));
+  const transcriptDirectives = migrateHistoricalTranscriptDirectives({
+    configuredAgentDatabaseTargets,
+    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+  });
   const mediaPersistence =
     params.doctorOnlyStateMigrations === true
       ? migrateLegacyMediaPersistence({
-          configuredAgentDatabaseTargets: resolveSessionStoreTargets(
-            params.cfg,
-            { allAgents: true },
-            { env },
-          ).map((target) => ({
-            agentId: target.agentId,
-            path: resolveSqliteTargetFromSessionStorePath(target.storePath, {
-              agentId: target.agentId,
-              defaultAgentId: isPerAgentSessionStoreConfig(params.cfg.session?.store)
-                ? target.agentId
-                : resolveSessionStoreCompatibilityAgentId(params.cfg),
-              env,
-            }).path,
-          })),
+          configuredAgentDatabaseTargets,
           env: { ...env, OPENCLAW_STATE_DIR: stateDir },
         })
       : { changes: [], warnings: [] };
-  if (mediaPersistence.warnings.length > 0) {
+  if (transcriptDirectives.warnings.length > 0 || mediaPersistence.warnings.length > 0) {
     return {
       migrated:
         stateDirResult.migrated ||
         stateSchema.changes.length > 0 ||
+        transcriptDirectives.changes.length > 0 ||
         mediaPersistence.changes.length > 0,
       skipped: false,
-      changes: [...stateDirResult.changes, ...stateSchema.changes, ...mediaPersistence.changes],
-      warnings: [...stateDirResult.warnings, ...stateSchema.warnings, ...mediaPersistence.warnings],
+      changes: [
+        ...stateDirResult.changes,
+        ...stateSchema.changes,
+        ...transcriptDirectives.changes,
+        ...mediaPersistence.changes,
+      ],
+      warnings: [
+        ...stateDirResult.warnings,
+        ...stateSchema.warnings,
+        ...transcriptDirectives.warnings,
+        ...mediaPersistence.warnings,
+      ],
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
@@ -1519,6 +1536,7 @@ export async function autoMigrateLegacyState(params: {
     stateDirResult,
     profileWorkspace,
     stateSchema,
+    transcriptDirectives,
     mediaPersistence,
     configMachineState,
     orphanKeys,

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -11,14 +11,14 @@ import {
 } from "../state/openclaw-agent-db-registry.js";
 import { isPathInside } from "./path-guards.js";
 
-type AgentDatabaseMediaMigrationTarget = {
+type AgentDatabaseMigrationTarget = {
   agentId: string;
   path: string;
   realPath: string;
   source: "configured" | "disk" | "registry";
 };
 
-type CandidateTarget = Omit<AgentDatabaseMediaMigrationTarget, "realPath">;
+type CandidateTarget = Omit<AgentDatabaseMigrationTarget, "realPath">;
 
 function listDefaultAgentDatabaseTargets(
   env: NodeJS.ProcessEnv,
@@ -40,12 +40,12 @@ function listDefaultAgentDatabaseTargets(
   }
 }
 
-export function resolveAgentDatabaseMediaMigrationTargets(params: {
+export function resolveAgentDatabaseMigrationTargets(params: {
   changes: string[];
   configuredAgentDatabaseTargets: readonly { agentId: string; path: string }[];
   env: NodeJS.ProcessEnv;
   warnings: string[];
-}): AgentDatabaseMediaMigrationTarget[] {
+}): AgentDatabaseMigrationTarget[] {
   let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases> = [];
   try {
     registered = listOpenClawRegisteredAgentDatabases({
@@ -54,7 +54,7 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
     });
   } catch (error) {
     params.warnings.push(
-      `Failed enumerating registered agent databases for media migration: ${String(error)}`,
+      `Failed enumerating registered agent databases for state migration: ${String(error)}`,
     );
   }
   // Owner authority is explicit config, then the recorded registry fact, then
@@ -84,7 +84,7 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
     }
   }
   const configuredPathMatcher = createOpenClawAgentDatabasePathMatcher();
-  const targets: AgentDatabaseMediaMigrationTarget[] = [];
+  const targets: AgentDatabaseMigrationTarget[] = [];
   const seenRealPaths = new Set<string>();
   for (const candidate of candidates) {
     // Preserve the original locator: lexical normalization of `link/../file`

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -43,7 +43,7 @@ import { replaceFileAtomicSync } from "./replace-file.js";
 import { repairCanonicalSqliteIndexes } from "./sqlite-index-schema.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
-import { resolveAgentDatabaseMediaMigrationTargets } from "./state-migrations.media-persistence-targets.js";
+import { resolveAgentDatabaseMigrationTargets } from "./state-migrations.media-persistence-targets.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
@@ -601,7 +601,7 @@ export function migrateLegacyMediaPersistence(
   const env = params.env ?? process.env;
   const changes: string[] = [];
   const warnings: string[] = [];
-  const targets = resolveAgentDatabaseMediaMigrationTargets({
+  const targets = resolveAgentDatabaseMigrationTargets({
     changes,
     configuredAgentDatabaseTargets: params.configuredAgentDatabaseTargets ?? [],
     env,

--- a/src/infra/state-migrations.transcript-directives-archives.ts
+++ b/src/infra/state-migrations.transcript-directives-archives.ts
@@ -1,0 +1,346 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  decodeSessionArchiveBytes,
+  encodeSessionArchiveContent,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
+import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+import { replaceFileAtomicSync } from "./replace-file.js";
+import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
+import { transformHistoricalTranscriptEvent } from "./state-migrations.transcript-directives-transform.js";
+
+export const TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE = 32;
+
+type TranscriptArchiveMigrationDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_transcript_archives"
+>;
+
+type ArchiveCursor = { generation: string; sessionId: string };
+
+type ArchiveRowPlan = {
+  archiveName: string;
+  archiveSha256: string;
+  bytes: Buffer;
+  changed: boolean;
+  encoding: "identity" | "zstd";
+  generation: string;
+  nextBytes: Buffer;
+  nextSha256: string;
+  publishedAt: number | null;
+  sessionId: string;
+};
+
+function parseTranscriptEvent(raw: string, owner: string): TranscriptEvent {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${owner} contains invalid transcript JSON`, { cause: error });
+  }
+}
+
+function transformArchiveContent(
+  content: string,
+  owner: string,
+): {
+  changed: boolean;
+  content: string;
+} {
+  if (!content) {
+    return { changed: false, content };
+  }
+  const trailingNewline = content.endsWith("\n");
+  const lines = trailingNewline ? content.slice(0, -1).split("\n") : content.split("\n");
+  let changed = false;
+  const rewritten = lines.map((line, index) => {
+    if (!line) {
+      throw new Error(`${owner} contains a blank JSONL record at line ${index + 1}`);
+    }
+    const event = parseTranscriptEvent(line, `${owner}:${index + 1}`);
+    const transformed = transformHistoricalTranscriptEvent(event);
+    changed ||= transformed.changed;
+    return transformed.changed ? JSON.stringify(transformed.event) : line;
+  });
+  return {
+    changed,
+    content: `${rewritten.join("\n")}${trailingNewline ? "\n" : ""}`,
+  };
+}
+
+function encodeArchiveContent(
+  content: string,
+  encoding: "identity" | "zstd",
+  owner: string,
+): Buffer {
+  if (encoding === "identity") {
+    return Buffer.from(content, "utf8");
+  }
+  const encoded = encodeSessionArchiveContent(content);
+  if (encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
+    throw new Error(`${owner} could not be re-encoded with its zstd codec`);
+  }
+  return encoded.bytes;
+}
+
+function readArchiveEncoding(value: string, owner: string): "identity" | "zstd" {
+  if (value === "identity" || value === "zstd") {
+    return value;
+  }
+  throw new Error(`${owner} has unsupported transcript archive encoding ${value}`);
+}
+
+function listArchiveBatch(database: DatabaseSync, cursor: ArchiveCursor): ArchiveRowPlan[] {
+  const db = getNodeSqliteKysely<TranscriptArchiveMigrationDatabase>(database);
+  let query = db
+    .selectFrom("session_transcript_archives")
+    .select([
+      "archive_blob",
+      "archive_name",
+      "archive_sha256",
+      "encoding",
+      "generation",
+      "published_at",
+      "session_id",
+    ])
+    .orderBy("session_id", "asc")
+    .orderBy("generation", "asc")
+    .limit(TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE);
+  if (cursor.sessionId) {
+    query = query.where((eb) =>
+      eb.or([
+        eb("session_id", ">", cursor.sessionId),
+        eb.and([eb("session_id", "=", cursor.sessionId), eb("generation", ">", cursor.generation)]),
+      ]),
+    );
+  }
+  return executeSqliteQuerySync(database, query).rows.map((row) => {
+    const owner = `${row.session_id}:${row.generation}`;
+    const encoding = readArchiveEncoding(row.encoding, owner);
+    const bytes = Buffer.from(row.archive_blob);
+    if (createHash("sha256").update(bytes).digest("hex") !== row.archive_sha256) {
+      throw new Error(`Canonical SQLite transcript archive is corrupt for ${row.session_id}`);
+    }
+    const content = decodeSessionArchiveBytes(bytes, encoding === "zstd");
+    const transformed = transformArchiveContent(content, owner);
+    const nextBytes = transformed.changed
+      ? encodeArchiveContent(transformed.content, encoding, owner)
+      : bytes;
+    return {
+      archiveName: row.archive_name,
+      archiveSha256: row.archive_sha256,
+      bytes,
+      changed: transformed.changed,
+      encoding,
+      generation: row.generation,
+      nextBytes,
+      nextSha256: createHash("sha256").update(nextBytes).digest("hex"),
+      publishedAt: row.published_at,
+      sessionId: row.session_id,
+    };
+  });
+}
+
+function assertArchiveSourceUnchanged(database: DatabaseSync, planned: ArchiveRowPlan): boolean {
+  const db = getNodeSqliteKysely<TranscriptArchiveMigrationDatabase>(database);
+  const current = executeSqliteQueryTakeFirstSync(
+    database,
+    db
+      .selectFrom("session_transcript_archives")
+      .select(["archive_blob", "archive_name", "archive_sha256", "encoding"])
+      .where("session_id", "=", planned.sessionId)
+      .where("generation", "=", planned.generation),
+  );
+  if (!current) {
+    return false;
+  }
+  if (
+    current.archive_name !== planned.archiveName ||
+    current.archive_sha256 !== planned.archiveSha256 ||
+    current.encoding !== planned.encoding ||
+    !Buffer.from(current.archive_blob).equals(planned.bytes)
+  ) {
+    throw new Error(
+      `Transcript archive source changed before migration commit for ${planned.sessionId}`,
+    );
+  }
+  return true;
+}
+
+function rewriteArchiveRow(database: DatabaseSync, planned: ArchiveRowPlan): boolean {
+  if (!assertArchiveSourceUnchanged(database, planned)) {
+    return false;
+  }
+  if (!planned.changed) {
+    return true;
+  }
+  const db = getNodeSqliteKysely<TranscriptArchiveMigrationDatabase>(database);
+  const result = executeSqliteQuerySync(
+    database,
+    db
+      .updateTable("session_transcript_archives")
+      .set({
+        archive_blob: planned.nextBytes,
+        archive_sha256: planned.nextSha256,
+        published_at: null,
+      })
+      .where("session_id", "=", planned.sessionId)
+      .where("generation", "=", planned.generation)
+      .where("archive_sha256", "=", planned.archiveSha256),
+  );
+  if (result.numAffectedRows !== 1n) {
+    throw new Error(`Transcript archive changed before rewrite for ${planned.sessionId}`);
+  }
+  return true;
+}
+
+function repairPublishedArchiveFile(params: {
+  archiveDirectory: string;
+  planned: ArchiveRowPlan;
+}): boolean {
+  const archiveDirectory = path.resolve(params.archiveDirectory);
+  const archivePath = path.resolve(archiveDirectory, params.planned.archiveName);
+  if (
+    path.dirname(archivePath) !== archiveDirectory ||
+    path.basename(archivePath) !== params.planned.archiveName
+  ) {
+    throw new Error(`Cannot migrate transcript archive outside ${archiveDirectory}`);
+  }
+  if (!fs.existsSync(archivePath)) {
+    return false;
+  }
+  if (
+    createHash("sha256").update(fs.readFileSync(archivePath)).digest("hex") ===
+    params.planned.nextSha256
+  ) {
+    return true;
+  }
+  replaceFileAtomicSync({
+    beforeRename: ({ tempPath }) => {
+      const stagedHash = createHash("sha256").update(fs.readFileSync(tempPath)).digest("hex");
+      if (stagedHash !== params.planned.nextSha256) {
+        throw new Error(`Transcript archive staging verification failed for ${archivePath}`);
+      }
+    },
+    content: params.planned.nextBytes,
+    filePath: archivePath,
+    preserveExistingMode: true,
+    syncParentDir: true,
+    syncTempFile: true,
+    tempPrefix: `${path.basename(archivePath)}.directive-migration`,
+  });
+  if (
+    createHash("sha256").update(fs.readFileSync(archivePath)).digest("hex") !==
+    params.planned.nextSha256
+  ) {
+    throw new Error(`Transcript archive verification failed for ${archivePath}`);
+  }
+  return true;
+}
+
+function finalizeArchiveCursor(params: {
+  database: DatabaseSync;
+  fileCurrent: boolean;
+  planned: ArchiveRowPlan;
+  writeCursor: (cursor: ArchiveCursor | { phase: "complete" }) => void;
+}): void {
+  const db = getNodeSqliteKysely<TranscriptArchiveMigrationDatabase>(params.database);
+  const current = executeSqliteQueryTakeFirstSync(
+    params.database,
+    db
+      .selectFrom("session_transcript_archives")
+      .select(["archive_blob", "archive_sha256"])
+      .where("session_id", "=", params.planned.sessionId)
+      .where("generation", "=", params.planned.generation),
+  );
+  if (current) {
+    if (
+      current.archive_sha256 !== params.planned.nextSha256 ||
+      !Buffer.from(current.archive_blob).equals(params.planned.nextBytes)
+    ) {
+      throw new Error(
+        `Transcript archive changed before migration commit for ${params.planned.sessionId}`,
+      );
+    }
+    if (params.planned.changed && params.planned.publishedAt !== null && params.fileCurrent) {
+      executeSqliteQuerySync(
+        params.database,
+        db
+          .updateTable("session_transcript_archives")
+          .set({ published_at: params.planned.publishedAt })
+          .where("session_id", "=", params.planned.sessionId)
+          .where("generation", "=", params.planned.generation)
+          .where("archive_sha256", "=", params.planned.nextSha256),
+      );
+    }
+  }
+  params.writeCursor({
+    generation: params.planned.generation,
+    sessionId: params.planned.sessionId,
+  });
+}
+
+export function migrateTranscriptDirectiveArchives(params: {
+  agentId: string;
+  database: DatabaseSync;
+  pathname: string;
+  start: ArchiveCursor;
+  writeCursor: (cursor: ArchiveCursor | { phase: "complete" }) => void;
+}): number {
+  let rewrittenArchives = 0;
+  let cursor = params.start;
+  const archiveDirectory = resolveSqliteTranscriptArchiveDirectory({
+    agentId: params.agentId,
+    path: params.pathname,
+  });
+  while (true) {
+    const batch = listArchiveBatch(params.database, cursor);
+    if (batch.length === 0) {
+      runSqliteImmediateTransactionSync(params.database, () => {
+        params.writeCursor({ phase: "complete" });
+      });
+      return rewrittenArchives;
+    }
+    for (const planned of batch) {
+      const rowPresent = runSqliteImmediateTransactionSync(
+        params.database,
+        () => rewriteArchiveRow(params.database, planned),
+        {
+          busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+          databaseLabel: params.pathname,
+          operationLabel: "historical-transcript-archive-directives",
+        },
+      );
+      const fileCurrent = rowPresent
+        ? repairPublishedArchiveFile({ archiveDirectory, planned })
+        : false;
+      runSqliteImmediateTransactionSync(
+        params.database,
+        () =>
+          finalizeArchiveCursor({
+            database: params.database,
+            fileCurrent,
+            planned,
+            writeCursor: params.writeCursor,
+          }),
+        {
+          busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+          databaseLabel: params.pathname,
+          operationLabel: "historical-transcript-archive-cursor",
+        },
+      );
+      rewrittenArchives += planned.changed && rowPresent ? 1 : 0;
+      cursor = { generation: planned.generation, sessionId: planned.sessionId };
+    }
+  }
+}

--- a/src/infra/state-migrations.transcript-directives-archives.ts
+++ b/src/infra/state-migrations.transcript-directives-archives.ts
@@ -10,6 +10,7 @@ import {
 import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
 import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import { SESSION_TRANSCRIPT_ARCHIVES_TABLE } from "../state/openclaw-agent-session-transcript-archive-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
 import {
   executeSqliteQuerySync,
@@ -101,6 +102,13 @@ function readArchiveEncoding(value: string, owner: string): "identity" | "zstd" 
 }
 
 function listArchiveBatch(database: DatabaseSync, cursor: ArchiveCursor): ArchiveRowPlan[] {
+  // The archive table was added lazily at agent schema v17, so valid v17 databases may omit it.
+  const hasArchiveTable = database
+    .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+    .get(SESSION_TRANSCRIPT_ARCHIVES_TABLE);
+  if (!hasArchiveTable) {
+    return [];
+  }
   const db = getNodeSqliteKysely<TranscriptArchiveMigrationDatabase>(database);
   let query = db
     .selectFrom("session_transcript_archives")

--- a/src/infra/state-migrations.transcript-directives-transform.ts
+++ b/src/infra/state-migrations.transcript-directives-transform.ts
@@ -1,0 +1,46 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
+import { applyAssistantDeliveryDirectives } from "../config/sessions/transcript-assistant-delivery.js";
+import { replaceOutsideCodeRegions } from "../utils/directive-tags.js";
+
+// Historical reaction directives were transient actions, not durable delivery facts.
+const LEGACY_REACTION_DIRECTIVE_RE =
+  /\[\[\s*(?:react|react_to_current)\s*:\s*([^\]\n]+?)\s*\]\]/giu;
+
+function stripLegacyReactionDirectives(message: Record<string, unknown>): void {
+  if (!Array.isArray(message.content)) {
+    return;
+  }
+  for (const part of message.content) {
+    if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
+      continue;
+    }
+    let changed = false;
+    const stripped = replaceOutsideCodeRegions(part.text, LEGACY_REACTION_DIRECTIVE_RE, () => {
+      changed = true;
+      return "";
+    });
+    if (changed) {
+      part.text = stripped.trimStart();
+    }
+  }
+}
+
+export function transformHistoricalTranscriptEvent(event: TranscriptEvent): {
+  changed: boolean;
+  event: TranscriptEvent;
+} {
+  if (
+    !isRecord(event) ||
+    event.type !== "message" ||
+    !isRecord(event.message) ||
+    event.message.role !== "assistant" ||
+    !Array.isArray(event.message.content)
+  ) {
+    return { changed: false, event };
+  }
+  const before = JSON.stringify(event.message);
+  stripLegacyReactionDirectives(event.message);
+  applyAssistantDeliveryDirectives(event.message);
+  return { changed: JSON.stringify(event.message) !== before, event };
+}

--- a/src/infra/state-migrations.transcript-directives.test.ts
+++ b/src/infra/state-migrations.transcript-directives.test.ts
@@ -114,6 +114,35 @@ function readGeneration(databasePath: string, sessionId: string): string {
   }
 }
 
+function readMigrationCursor(databasePath: string): unknown {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database
+      .prepare(
+        "SELECT app_version FROM schema_meta WHERE meta_key = 'historical-transcript-directives-v1'",
+      )
+      .get() as { app_version: string };
+    return JSON.parse(row.app_version);
+  } finally {
+    database.close();
+  }
+}
+
+function hasTranscriptArchivesTable(databasePath: string): boolean {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return Boolean(
+      database
+        .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("session_transcript_archives"),
+    );
+  } finally {
+    database.close();
+  }
+}
+
 function parseArchive(content: string): FixtureEvent[] {
   return content
     .trimEnd()
@@ -384,5 +413,73 @@ describe("historical transcript directive migration", () => {
         openclawDelivery: { audioAsVoice: true },
       },
     });
+  });
+
+  it("completes an old-schema database without the optional archives table", () => {
+    const stateDir = makeTempDir(tempDirs, "transcript-directive-old-schema-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    insertSession(opened.db, {
+      events: [
+        messageEvent({
+          id: "old-schema-tagged",
+          role: "assistant",
+          timestamp: 1,
+          content: [{ type: "text", text: "[[audio_as_voice]] Pending" }],
+        }),
+      ],
+      generation: "before",
+      sessionId: "old-schema-session",
+    });
+    opened.db.exec("DROP TABLE session_transcript_archives");
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(migrateHistoricalTranscriptDirectives({ env })).toEqual({
+      changes: [expect.stringContaining("1 active session(s), 0 archived transcript(s)")],
+      warnings: [],
+    });
+    expect(readMigrationCursor(databasePath)).toEqual({ phase: "complete" });
+    expect(hasTranscriptArchivesTable(databasePath)).toBe(false);
+    expect(JSON.parse(readEventJson(databasePath, "old-schema-session", 0))).toMatchObject({
+      message: {
+        content: [{ type: "text", text: "Pending" }],
+        openclawDelivery: { audioAsVoice: true },
+      },
+    });
+    expect(migrateHistoricalTranscriptDirectives({ env })).toEqual({
+      changes: [],
+      warnings: [],
+    });
+  });
+
+  it("completes a pre-stuck archives cursor when the optional table is absent", () => {
+    const stateDir = makeTempDir(tempDirs, "transcript-directive-stuck-archives-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    opened.db.exec("DROP TABLE session_transcript_archives");
+    opened.db
+      .prepare(
+        `INSERT INTO schema_meta(meta_key,role,schema_version,agent_id,app_version,created_at,updated_at)
+         VALUES(?,?,?,?,?,?,?)`,
+      )
+      .run(
+        "historical-transcript-directives-v1",
+        "agent",
+        1,
+        "main",
+        JSON.stringify({ generation: "", phase: "archives", sessionId: "" }),
+        1,
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(migrateHistoricalTranscriptDirectives({ env })).toEqual({
+      changes: [],
+      warnings: [],
+    });
+    expect(readMigrationCursor(databasePath)).toEqual({ phase: "complete" });
+    expect(hasTranscriptArchivesTable(databasePath)).toBe(false);
   });
 });

--- a/src/infra/state-migrations.transcript-directives.test.ts
+++ b/src/infra/state-migrations.transcript-directives.test.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { readSessionArchiveContentSync } from "../config/sessions/archive-compression.js";
+import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
+import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { migrateHistoricalTranscriptDirectives } from "./state-migrations.transcript-directives.js";
+
+const tempDirs: string[] = [];
+
+type FixtureEvent = Record<string, unknown>;
+
+function messageEvent(params: {
+  content: unknown;
+  id: string;
+  parentId?: string | null;
+  role: "assistant" | "toolResult" | "user";
+  timestamp: number;
+}): FixtureEvent {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId ?? null,
+    timestamp: params.timestamp,
+    message: {
+      role: params.role,
+      content: params.content,
+      timestamp: params.timestamp,
+      ...(params.role === "assistant"
+        ? {
+            api: "messages",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+          }
+        : {}),
+    },
+  };
+}
+
+function insertSession(
+  database: import("node:sqlite").DatabaseSync,
+  params: { events: FixtureEvent[]; generation: string; sessionId: string },
+): void {
+  const sessionKey = `agent:main:${params.sessionId}`;
+  database
+    .prepare(
+      `INSERT INTO session_nodes(session_key,current_session_id,entry_json,updated_at)
+       VALUES(?,?,?,?)`,
+    )
+    .run(sessionKey, params.sessionId, "{}", 1);
+  database
+    .prepare(
+      `INSERT INTO session_windows(session_id,session_key,created_at,updated_at,transcript_updated_at)
+       VALUES(?,?,?,?,?)`,
+    )
+    .run(params.sessionId, sessionKey, 1, 1, 1);
+  database
+    .prepare(
+      `INSERT INTO transcript_rewrite_watermarks(session_id,generation,updated_at)
+       VALUES(?,?,?)`,
+    )
+    .run(params.sessionId, params.generation, 1);
+  for (const [seq, event] of params.events.entries()) {
+    database
+      .prepare(
+        `INSERT INTO transcript_events(session_id,seq,event_json,created_at)
+         VALUES(?,?,?,?)`,
+      )
+      .run(params.sessionId, seq, JSON.stringify(event), Number(event.timestamp ?? 1));
+  }
+  reconcileSessionTranscriptIndexInTransaction(database, params.sessionId);
+}
+
+function readEventJson(databasePath: string, sessionId: string, seq: number): string {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = ?")
+      .get(sessionId, seq) as { event_json: string };
+    return row.event_json;
+  } finally {
+    database.close();
+  }
+}
+
+function readGeneration(databasePath: string, sessionId: string): string {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database
+      .prepare("SELECT generation FROM transcript_rewrite_watermarks WHERE session_id = ?")
+      .get(sessionId) as { generation: string };
+    return row.generation;
+  } finally {
+    database.close();
+  }
+}
+
+function parseArchive(content: string): FixtureEvent[] {
+  return content
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line) as FixtureEvent);
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("historical transcript directive migration", () => {
+  it("migrates assistant rows and archives while preserving code and derived indexes", () => {
+    const stateDir = makeTempDir(tempDirs, "transcript-directive-migration-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    const tagged = messageEvent({
+      id: "tagged-assistant",
+      role: "assistant",
+      timestamp: 10,
+      content: [
+        {
+          type: "text",
+          text: "[[reply_to_current]]\n[[reply_to: message-7 ]]\n[[audio_as_voice]]\nFinal answer [[react: 👍]]",
+        },
+      ],
+    });
+    const user = messageEvent({
+      id: "user-marker",
+      parentId: "tagged-assistant",
+      role: "user",
+      timestamp: 11,
+      content: "Keep [[reply_to_current]] and [[react: 👍]]",
+    });
+    const tool = messageEvent({
+      id: "tool-marker",
+      parentId: "user-marker",
+      role: "toolResult",
+      timestamp: 12,
+      content: [{ type: "text", text: "Keep [[audio_as_voice]]" }],
+    });
+    const codeText = [
+      "Use `[[reply_to_current]]` and `[[react: 👍]]` literally.",
+      "```text",
+      "[[audio_as_voice]]",
+      "[[react_to_current: ✅]]",
+      "```",
+    ].join("\n");
+    const code = messageEvent({
+      id: "code-assistant",
+      role: "assistant",
+      timestamp: 20,
+      content: [{ type: "text", text: codeText }],
+    });
+    const reaction = messageEvent({
+      id: "reaction-assistant",
+      role: "assistant",
+      timestamp: 30,
+      content: [{ type: "text", text: "Reacted [[react_to_current: ✅]] without a fact" }],
+    });
+    insertSession(opened.db, {
+      events: [tagged, user, tool],
+      generation: "tagged-before",
+      sessionId: "tagged-session",
+    });
+    insertSession(opened.db, {
+      events: [code],
+      generation: "code-before",
+      sessionId: "code-session",
+    });
+    insertSession(opened.db, {
+      events: [reaction],
+      generation: "reaction-before",
+      sessionId: "reaction-session",
+    });
+
+    const archivedTagged = messageEvent({
+      id: "archived-tagged",
+      role: "assistant",
+      timestamp: 40,
+      content: [{ type: "text", text: "[[reply_to: archive-2]] Archived answer" }],
+    });
+    const archivedCode = messageEvent({
+      id: "archived-code",
+      role: "assistant",
+      timestamp: 41,
+      content: [{ type: "text", text: "`[[reply_to_current]]`" }],
+    });
+    const archivedUser = messageEvent({
+      id: "archived-user",
+      role: "user",
+      timestamp: 42,
+      content: "[[audio_as_voice]]",
+    });
+    const archiveContent = `${[archivedTagged, archivedCode, archivedUser]
+      .map((event) => JSON.stringify(event))
+      .join("\n")}\n`;
+    const archiveBytes = Buffer.from(archiveContent, "utf8");
+    const archiveName = "archived-session.jsonl.deleted.2026-01-01T00-00-00.000Z.archive-gen";
+    opened.db
+      .prepare(
+        `INSERT INTO session_transcript_archives(
+          session_id,generation,session_key,reason,encoding,archive_blob,archive_sha256,
+          archive_name,created_at,published_at
+        ) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+      )
+      .run(
+        "archived-session",
+        "archive-gen",
+        "agent:main:archived-session",
+        "deleted",
+        "identity",
+        archiveBytes,
+        createHash("sha256").update(archiveBytes).digest("hex"),
+        archiveName,
+        40,
+        50,
+      );
+    const archiveDirectory = resolveSqliteTranscriptArchiveDirectory({
+      agentId: "main",
+      path: databasePath,
+    });
+    fs.mkdirSync(archiveDirectory, { recursive: true });
+    const archivePath = path.join(archiveDirectory, archiveName);
+    fs.writeFileSync(archivePath, archiveBytes);
+
+    const codeEventJson = JSON.stringify(code);
+    const userEventJson = JSON.stringify(user);
+    const toolEventJson = JSON.stringify(tool);
+    const archivedCodeJson = JSON.stringify(archivedCode);
+    const archivedUserJson = JSON.stringify(archivedUser);
+    closeOpenClawAgentDatabasesForTest();
+
+    const result = migrateHistoricalTranscriptDirectives({ env });
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+
+    const migratedTagged = JSON.parse(readEventJson(databasePath, "tagged-session", 0)) as {
+      message: Record<string, unknown>;
+    };
+    expect(migratedTagged.message).toMatchObject({
+      content: [{ type: "text", text: "Final answer" }],
+      openclawDelivery: {
+        audioAsVoice: true,
+        replyToCurrent: true,
+        replyToId: "message-7",
+      },
+    });
+    expect(readEventJson(databasePath, "tagged-session", 1)).toBe(userEventJson);
+    expect(readEventJson(databasePath, "tagged-session", 2)).toBe(toolEventJson);
+    expect(readEventJson(databasePath, "code-session", 0)).toBe(codeEventJson);
+    const migratedReaction = JSON.parse(readEventJson(databasePath, "reaction-session", 0)) as {
+      message: Record<string, unknown>;
+    };
+    expect(migratedReaction.message).toMatchObject({
+      content: [{ type: "text", text: "Reacted  without a fact" }],
+    });
+    expect(migratedReaction.message).not.toHaveProperty("openclawDelivery");
+
+    expect(readGeneration(databasePath, "tagged-session")).not.toBe("tagged-before");
+    expect(readGeneration(databasePath, "reaction-session")).not.toBe("reaction-before");
+    expect(readGeneration(databasePath, "code-session")).toBe("code-before");
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const migratedDb = new DatabaseSync(databasePath, { readOnly: true });
+    let archivedRow: { archive_blob: Uint8Array; archive_sha256: string };
+    try {
+      expect(
+        migratedDb
+          .prepare(
+            "SELECT session_id FROM session_transcript_fts WHERE session_transcript_fts MATCH ?",
+          )
+          .all("Final"),
+      ).toContainEqual({ session_id: "tagged-session" });
+      archivedRow = migratedDb
+        .prepare(
+          "SELECT archive_blob,archive_sha256 FROM session_transcript_archives WHERE session_id = ?",
+        )
+        .get("archived-session") as typeof archivedRow;
+    } finally {
+      migratedDb.close();
+    }
+    expect(createHash("sha256").update(archivedRow.archive_blob).digest("hex")).toBe(
+      archivedRow.archive_sha256,
+    );
+    const migratedArchiveContent = Buffer.from(archivedRow.archive_blob).toString("utf8");
+    const migratedArchive = parseArchive(migratedArchiveContent);
+    expect(migratedArchive[0]).toMatchObject({
+      message: {
+        content: [{ type: "text", text: "Archived answer" }],
+        openclawDelivery: { replyToId: "archive-2" },
+      },
+    });
+    expect(migratedArchiveContent).toContain(archivedCodeJson);
+    expect(migratedArchiveContent).toContain(archivedUserJson);
+    expect(readSessionArchiveContentSync(archivePath)).toBe(migratedArchiveContent);
+
+    const generationsAfterFirstRun = {
+      tagged: readGeneration(databasePath, "tagged-session"),
+      reaction: readGeneration(databasePath, "reaction-session"),
+    };
+    const archiveBytesAfterFirstRun = fs.readFileSync(archivePath);
+    expect(migrateHistoricalTranscriptDirectives({ env })).toEqual({
+      changes: [],
+      warnings: [],
+    });
+    expect(readGeneration(databasePath, "tagged-session")).toBe(generationsAfterFirstRun.tagged);
+    expect(readGeneration(databasePath, "reaction-session")).toBe(
+      generationsAfterFirstRun.reaction,
+    );
+    expect(fs.readFileSync(archivePath)).toEqual(archiveBytesAfterFirstRun);
+  });
+
+  it("resumes after the committed transcript cursor", () => {
+    const stateDir = makeTempDir(tempDirs, "transcript-directive-resume-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    insertSession(opened.db, {
+      events: [
+        messageEvent({
+          id: "already-migrated",
+          role: "assistant",
+          timestamp: 1,
+          content: [{ type: "text", text: "Already clean" }],
+        }),
+      ],
+      generation: "already-bumped",
+      sessionId: "resume-a",
+    });
+    insertSession(opened.db, {
+      events: [
+        messageEvent({
+          id: "still-pending",
+          role: "assistant",
+          timestamp: 2,
+          content: [{ type: "text", text: "[[audio_as_voice]] Pending" }],
+        }),
+      ],
+      generation: "pending-before",
+      sessionId: "resume-b",
+    });
+    opened.db
+      .prepare(
+        `INSERT INTO schema_meta(meta_key,role,schema_version,agent_id,app_version,created_at,updated_at)
+         VALUES(?,?,?,?,?,?,?)`,
+      )
+      .run(
+        "historical-transcript-directives-v1",
+        "agent",
+        1,
+        "main",
+        JSON.stringify({ phase: "transcripts", sessionId: "resume-a" }),
+        1,
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(migrateHistoricalTranscriptDirectives({ env }).warnings).toEqual([]);
+    expect(readGeneration(databasePath, "resume-a")).toBe("already-bumped");
+    expect(readGeneration(databasePath, "resume-b")).not.toBe("pending-before");
+    expect(JSON.parse(readEventJson(databasePath, "resume-b", 0))).toMatchObject({
+      message: {
+        content: [{ type: "text", text: "Pending" }],
+        openclawDelivery: { audioAsVoice: true },
+      },
+    });
+  });
+});

--- a/src/infra/state-migrations.transcript-directives.ts
+++ b/src/infra/state-migrations.transcript-directives.ts
@@ -1,0 +1,345 @@
+import type { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
+import { updateSqliteTranscriptEventJsonInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import {
+  assertOpenClawAgentDatabaseForMaintenance,
+  migrateOpenClawAgentDatabaseForMaintenance,
+} from "../state/openclaw-agent-db-maintenance.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
+import { resolveAgentDatabaseMigrationTargets } from "./state-migrations.media-persistence-targets.js";
+import {
+  migrateTranscriptDirectiveArchives,
+  TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE,
+} from "./state-migrations.transcript-directives-archives.js";
+import { transformHistoricalTranscriptEvent } from "./state-migrations.transcript-directives-transform.js";
+import type { MigrationMessages } from "./state-migrations.types.js";
+
+const MIGRATION_META_KEY = "historical-transcript-directives-v1";
+
+type TranscriptDirectiveMigrationDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "schema_meta" | "transcript_events"
+>;
+
+type MigrationCursor =
+  | { phase: "transcripts"; sessionId: string }
+  | { generation: string; phase: "archives"; sessionId: string }
+  | { phase: "complete" };
+
+type TranscriptRowPlan = {
+  eventJson: string;
+  rewrittenEventJson: string;
+  seq: number;
+};
+
+type DatabaseMigrationResult = {
+  archivedTranscripts: number;
+  transcriptSessions: number;
+};
+
+function createMigrationDatabaseHandle(
+  database: DatabaseSync,
+  agentId: string,
+  pathname: string,
+): OpenClawAgentDatabase {
+  return {
+    agentId,
+    db: database,
+    path: pathname,
+    walMaintenance: { checkpoint: () => false, close: () => false },
+  };
+}
+
+function parseMigrationCursor(value: string | null | undefined, pathname: string): MigrationCursor {
+  if (!value) {
+    return { phase: "transcripts", sessionId: "" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error(`${pathname} has an invalid historical transcript migration cursor`, {
+      cause: error,
+    });
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${pathname} has an invalid historical transcript migration cursor`);
+  }
+  if (parsed.phase === "complete") {
+    return { phase: "complete" };
+  }
+  if (parsed.phase === "transcripts" && typeof parsed.sessionId === "string") {
+    return { phase: "transcripts", sessionId: parsed.sessionId };
+  }
+  if (
+    parsed.phase === "archives" &&
+    typeof parsed.sessionId === "string" &&
+    typeof parsed.generation === "string"
+  ) {
+    return {
+      generation: parsed.generation,
+      phase: "archives",
+      sessionId: parsed.sessionId,
+    };
+  }
+  throw new Error(`${pathname} has an invalid historical transcript migration cursor`);
+}
+
+function readMigrationCursor(database: DatabaseSync, pathname: string): MigrationCursor {
+  const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
+  const row = executeSqliteQueryTakeFirstSync(
+    database,
+    db.selectFrom("schema_meta").select("app_version").where("meta_key", "=", MIGRATION_META_KEY),
+  );
+  return parseMigrationCursor(row?.app_version, pathname);
+}
+
+function writeMigrationCursor(
+  database: DatabaseSync,
+  agentId: string,
+  cursor: MigrationCursor,
+): void {
+  const now = Date.now();
+  const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
+  executeSqliteQuerySync(
+    database,
+    db
+      .insertInto("schema_meta")
+      .values({
+        agent_id: agentId,
+        app_version: JSON.stringify(cursor),
+        created_at: now,
+        meta_key: MIGRATION_META_KEY,
+        role: "agent",
+        schema_version: 1,
+        updated_at: now,
+      })
+      .onConflict((conflict) =>
+        conflict.column("meta_key").doUpdateSet({
+          agent_id: agentId,
+          app_version: JSON.stringify(cursor),
+          role: "agent",
+          schema_version: 1,
+          updated_at: now,
+        }),
+      ),
+  );
+}
+
+function parseTranscriptEvent(raw: string, owner: string): TranscriptEvent {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${owner} contains invalid transcript JSON`, { cause: error });
+  }
+}
+
+function listTranscriptSessionBatch(database: DatabaseSync, afterSessionId: string): string[] {
+  const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
+  return executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("transcript_events")
+      .select("session_id")
+      .distinct()
+      .where("session_id", ">", afterSessionId)
+      .where("event_json", "like", "%[[%")
+      .orderBy("session_id", "asc")
+      .limit(TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE),
+  ).rows.map((row) => row.session_id);
+}
+
+function planTranscriptSession(
+  database: DatabaseSync,
+  pathname: string,
+  sessionId: string,
+): TranscriptRowPlan[] {
+  const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
+  return executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json", "seq"])
+      .where("session_id", "=", sessionId)
+      .where("event_json", "like", "%[[%")
+      .orderBy("seq", "asc"),
+  ).rows.map((row) => {
+    const event = parseTranscriptEvent(row.event_json, `${pathname}:${sessionId}:${row.seq}`);
+    const transformed = transformHistoricalTranscriptEvent(event);
+    return {
+      eventJson: row.event_json,
+      rewrittenEventJson: transformed.changed ? JSON.stringify(transformed.event) : row.event_json,
+      seq: row.seq,
+    };
+  });
+}
+
+function assertTranscriptSessionSourceUnchanged(
+  database: DatabaseSync,
+  sessionId: string,
+  planned: readonly TranscriptRowPlan[],
+): void {
+  const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
+  const current = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json", "seq"])
+      .where("session_id", "=", sessionId)
+      .where("event_json", "like", "%[[%")
+      .orderBy("seq", "asc"),
+  ).rows;
+  if (
+    current.length !== planned.length ||
+    current.some(
+      (row, index) =>
+        row.seq !== planned[index]?.seq || row.event_json !== planned[index]?.eventJson,
+    )
+  ) {
+    throw new Error(`Transcript source changed before migration commit for ${sessionId}`);
+  }
+}
+
+function migrateTranscriptSessions(params: {
+  agentId: string;
+  database: DatabaseSync;
+  owner: OpenClawAgentDatabase;
+  pathname: string;
+  start: Extract<MigrationCursor, { phase: "transcripts" }>;
+}): number {
+  let rewrittenSessions = 0;
+  let afterSessionId = params.start.sessionId;
+  while (true) {
+    const sessionIds = listTranscriptSessionBatch(params.database, afterSessionId);
+    if (sessionIds.length === 0) {
+      runSqliteImmediateTransactionSync(params.database, () => {
+        writeMigrationCursor(params.database, params.agentId, {
+          generation: "",
+          phase: "archives",
+          sessionId: "",
+        });
+      });
+      return rewrittenSessions;
+    }
+    for (const sessionId of sessionIds) {
+      const planned = planTranscriptSession(params.database, params.pathname, sessionId);
+      const changedRows = planned.filter((row) => row.rewrittenEventJson !== row.eventJson);
+      runSqliteImmediateTransactionSync(
+        params.database,
+        () => {
+          assertTranscriptSessionSourceUnchanged(params.database, sessionId, planned);
+          updateSqliteTranscriptEventJsonInTransaction(
+            params.owner,
+            sessionId,
+            changedRows.map((row) => ({
+              eventJson: row.rewrittenEventJson,
+              seq: row.seq,
+            })),
+          );
+          writeMigrationCursor(params.database, params.agentId, {
+            phase: "transcripts",
+            sessionId,
+          });
+        },
+        {
+          busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+          databaseLabel: params.pathname,
+          operationLabel: "historical-transcript-directives",
+        },
+      );
+      rewrittenSessions += changedRows.length > 0 ? 1 : 0;
+      afterSessionId = sessionId;
+    }
+  }
+}
+
+function migrateAgentDatabase(params: {
+  agentId: string;
+  pathname: string;
+}): DatabaseMigrationResult {
+  migrateOpenClawAgentDatabaseForMaintenance(params);
+  const database = openNodeSqliteDatabase(params.pathname);
+  try {
+    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    assertOpenClawAgentDatabaseForMaintenance(database, params);
+    const cursor = readMigrationCursor(database, params.pathname);
+    if (cursor.phase === "complete") {
+      return { archivedTranscripts: 0, transcriptSessions: 0 };
+    }
+    const owner = createMigrationDatabaseHandle(database, params.agentId, params.pathname);
+    const transcriptSessions =
+      cursor.phase === "transcripts"
+        ? migrateTranscriptSessions({
+            agentId: params.agentId,
+            database,
+            owner,
+            pathname: params.pathname,
+            start: cursor,
+          })
+        : 0;
+    const archiveCursor = readMigrationCursor(database, params.pathname);
+    const archivedTranscripts =
+      archiveCursor.phase === "archives"
+        ? migrateTranscriptDirectiveArchives({
+            agentId: params.agentId,
+            database,
+            pathname: params.pathname,
+            start: archiveCursor,
+            writeCursor: (next) =>
+              writeMigrationCursor(
+                database,
+                params.agentId,
+                "phase" in next ? next : { ...next, phase: "archives" },
+              ),
+          })
+        : 0;
+    return { archivedTranscripts, transcriptSessions };
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(database);
+    database.close();
+  }
+}
+
+/** One-time startup migration from inline assistant directives to typed delivery facts. */
+export function migrateHistoricalTranscriptDirectives(
+  params: {
+    configuredAgentDatabaseTargets?: readonly { agentId: string; path: string }[];
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): MigrationMessages {
+  const env = params.env ?? process.env;
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const targets = resolveAgentDatabaseMigrationTargets({
+    changes,
+    configuredAgentDatabaseTargets: params.configuredAgentDatabaseTargets ?? [],
+    env,
+    warnings,
+  });
+  for (const target of targets) {
+    try {
+      const result = migrateAgentDatabase({ agentId: target.agentId, pathname: target.path });
+      if (result.transcriptSessions > 0 || result.archivedTranscripts > 0) {
+        changes.push(
+          `Migrated historical transcript directives in ${target.path}: ${result.transcriptSessions} active session(s), ${result.archivedTranscripts} archived transcript(s).`,
+        );
+      }
+    } catch (error) {
+      warnings.push(
+        `Skipped historical transcript directive migration for ${target.path}: ${String(error)}`,
+      );
+    }
+  }
+  return { changes, warnings };
+}

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -9,6 +9,7 @@ export {
 } from "./state-migrations.doctor.js";
 export { migrateLegacyAgentDir } from "./state-migrations.legacy-sessions.js";
 export { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+export { migrateHistoricalTranscriptDirectives } from "./state-migrations.transcript-directives.js";
 export {
   autoMigrateLegacyStateDir,
   autoMigrateLegacyTaskStateSidecars,

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -47,7 +47,7 @@ function createBlockSentinel(text: string): string {
   return sentinel;
 }
 
-function replaceOutsideCode(
+export function replaceOutsideCodeRegions(
   text: string,
   regex: RegExp,
   replacement: (match: string, captures: unknown[], offset: number, source: string) => string,
@@ -117,8 +117,8 @@ export function stripInlineDirectiveTagsForDisplay(text: string): StripInlineDir
   if (!text) {
     return { text, changed: false };
   }
-  const withoutAudio = replaceOutsideCode(text, AUDIO_TAG_RE, () => "");
-  const stripped = replaceOutsideCode(withoutAudio, REPLY_TAG_RE, () => "");
+  const withoutAudio = replaceOutsideCodeRegions(text, AUDIO_TAG_RE, () => "");
+  const stripped = replaceOutsideCodeRegions(withoutAudio, REPLY_TAG_RE, () => "");
   return {
     text: stripped,
     changed: stripped !== text,
@@ -163,7 +163,7 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   if (!text) {
     return { text, changed: false };
   }
-  const stripped = replaceOutsideCode(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
+  const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
   const changed = stripped !== text;
   return {
     text: changed ? stripped.trim() : text,
@@ -236,13 +236,13 @@ export function parseInlineDirectives(
   let sawCurrent = false;
   let lastExplicitId: string | undefined;
 
-  cleaned = replaceOutsideCode(cleaned, AUDIO_TAG_RE, (match, _captures, offset, source) => {
+  cleaned = replaceOutsideCodeRegions(cleaned, AUDIO_TAG_RE, (match, _captures, offset, source) => {
     audioAsVoice = true;
     hasAudioTag = true;
     return stripAudioTag ? replacementPreservesWordBoundary(source, offset, match.length) : match;
   });
 
-  cleaned = replaceOutsideCode(cleaned, REPLY_TAG_RE, (match, captures, offset, source) => {
+  cleaned = replaceOutsideCodeRegions(cleaned, REPLY_TAG_RE, (match, captures, offset, source) => {
     const idRaw = typeof captures[0] === "string" ? captures[0] : undefined;
     hasReplyTag = true;
     if (idRaw === undefined) {


### PR DESCRIPTION
## What Problem This Solves

Historical transcript rows still embed inline delivery directives. Once display surfaces stop re-stripping them in the campaign follow-up, old sessions would render raw markers.

Campaign siblings: #124755, #124793, #124830.

## Why This Change Was Made

This establishes one database-first migration owner: an idempotent, resumable startup state migration, following the media-persistence precedent, rewrites historical assistant rows with the canonical code-region-aware parser. It strips delivery directives outside code regions, backfills typed `openclawDelivery` facts, strips the deleted reaction DSL without facts, rotates the transcript rewrite generation once per mutated session, rebuilds FTS and projections, and repairs archives across canonical blobs and published files.

The migration uses 32-unit batches, synchronous immediate transactions, and a resume cursor in per-agent `schema_meta`. `session_transcript_archives` is a lazy additive v17 surface, so the archives phase treats a missing table as empty and completes; without the second commit, real old-schema databases would remain stuck in a warning loop forever.

## User Impact

Historical sessions become clean at the data layer. Quoted marker examples inside code stay byte-identical, while user messages and tool calls remain untouched. Each migrated session receives one prompt-cache invalidation, which maintainers accepted.

There is no config, protocol, or schema-version change.

## Evidence

- 186 focused tests plus 4 new regressions covering missing-table and stuck-cursor recovery; both new regressions fail on the pre-fix code.
- Post-rebase focused proof: `node scripts/run-vitest.mjs src/infra/state-migrations.transcript-directives.test.ts src/infra/state-migrations.media-persistence.test.ts` — 17/17 passed.
- Live proof on a 457 MB VACUUM snapshot of a real production agent database: leading markers stripped with fact backfill; in-code quoted markers byte-identical; tool-call arguments and user rows untouched; generation rotated; full run completed in under one second; second run was a no-op.
- Separate real old-schema database: the previously stuck cursor completes with zero warnings in approximately 100 ms.
- Autoreview clean on both commits.
