### PR TITLE
docs: clarify model switching guidance

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -164,6 +164,21 @@ openclaw config set agents.defaults.modelPolicy.allow '["openai/gpt-5.4","anthro
 `openclaw models set`, provider setup, and `openclaw models aliases add` can add entries under `agents.defaults.models`, but they never change `modelPolicy.allow`. This keeps model metadata and aliases independent from override policy.
 </Accordion>
 
+## Choose a model for a session
+
+Choose the model when you create a session whenever possible. The Control UI's
+**New Chat** composer includes the model picker for this reason: a fresh session
+gives the selected model a clean conversation boundary.
+
+Changing the model for an established session is an advanced operation. The
+session transcript remains available, but the next model may have a different
+context window, prompt and tool behavior, or prompt-cache implementation. A
+mid-session switch can therefore reduce continuity, require earlier compaction,
+or lose prompt-cache reuse and increase latency or cost. For a planned model
+change, prefer a new session; use `/model` or the active-session model picker
+when you intentionally want the existing transcript to continue with another
+model.
+
 ## `/model` in chat
 
 Direct owner/admin `/model <model>` requests **default scope**: it changes this session and starts a best-effort configured-default update. Adding `-s` uses **session scope**: only this session changes. If the agent has no explicit primary model, its effective default is the shared global `agents.defaults.model` fallback.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -179,6 +179,13 @@ change, prefer a new session; use `/model` or the active-session model picker
 when you intentionally want the existing transcript to continue with another
 model.
 
+Keep the thinking or reasoning level stable for the session when cache reuse
+matters. On OpenAI, changing the reasoning effort changes the reusable request
+state and can force the next turn to process the full conversation again. Other
+providers may also include thinking configuration in their cache identity, so
+changing only the thinking level can increase latency and input-token cost even
+when the model itself stays the same.
+
 ## `/model` in chat
 
 Direct owner/admin `/model <model>` requests **default scope**: it changes this session and starts a best-effort configured-default update. Adding `-s` uses **session scope**: only this session changes. If the agent has no explicit primary model, its effective default is the shared global `agents.defaults.model` fallback.

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -16,6 +16,21 @@ Provider references:
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
 - [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching)
 
+## Keep model settings stable
+
+Prompt-cache reuse depends on provider request configuration as well as prompt
+text. Changing the model always starts a different cache lineage. Changing the
+thinking or reasoning level can also invalidate reuse even when the prompt and
+model stay the same. In particular, OpenAI reasoning-effort changes alter the
+reusable request state and can force the next turn to process the full prefix or
+conversation again. Anthropic likewise documents cache invalidation when its
+thinking budget, effort, or mode changes.
+
+If cache continuity matters, choose the model and thinking level when creating
+the session and keep both stable. Start a new session for a planned change.
+Invalidating reuse means the next request misses that cached state; it does not
+necessarily delete the provider's older cache entry before its normal expiry.
+
 ## Primary knobs
 
 ### `cacheRetention`

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -214,6 +214,8 @@ plugins.
 
       </Accordion>
       <Accordion title="Model switching details">
+        - Prefer choosing the model when creating a session. Changing it in an established session is an advanced operation because model context limits, prompt/tool behavior, and prompt-cache behavior can differ. See [Choose a model for a session](/concepts/models#choose-a-model-for-a-session).
+
         **Scope in one line:** a direct owner/admin `/model <model>` changes the session and requests a best-effort configured-default update; `-s` changes only the current session. When an agent inherits `agents.defaults.model`, the update target is that shared global fallback.
 
         Configured `/<alias>` shorthands accept the same trailing `--runtime`, `-s`, and `--session` options as `/model <alias>`.


### PR DESCRIPTION
## Summary

- recommend choosing a model and thinking level when creating a session
- describe mid-session model switching as an advanced operation
- document continuity, context-window, prompt/tool behavior, prompt-cache, latency, and cost implications
- warn that changing reasoning or thinking settings can invalidate cache reuse, including OpenAI reasoning-effort changes

## Validation

- `pnpm check:docs`
- `pnpm dlx node@22 scripts/docs-link-audit.mjs --anchors`
- `git diff --check`
