### PR TITLE
fix(cli): show actionable guidance for mistyped commands

### DIFF
--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -37,7 +37,9 @@ describe("formatCliJsonFailure", () => {
       new CliParseError({
         message: 'OpenClaw sessions has no command "lst".',
         humanOutput:
-          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\n',
+          '\u001B[31mOpenClaw sessions has no command "lst".\u001B[39m\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: \u001B]8;;https://docs.openclaw.ai/cli\u0007docs.openclaw.ai/cli\u001B]8;;\u0007\n',
+        machineOutput:
+          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli\n',
       }),
       { cause: new Error("internal parse cause") },
     );
@@ -48,7 +50,7 @@ describe("formatCliJsonFailure", () => {
       error: {
         type: "cli_error",
         message:
-          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help',
+          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli',
       },
     });
     expect(payload.error.message).not.toContain("internal parse cause");
@@ -60,15 +62,20 @@ describe("formatCliFailureLines", () => {
     { label: "default output", env: {} },
     { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
   ])("emits parse guidance only when not already written in $label", ({ env }) => {
-    const pending = new CliParseError({ message: "bad input", humanOutput: "first\nsecond\n" });
+    const pending = new CliParseError({
+      message: "bad input",
+      humanOutput: "\u001B[31mfirst\u001B[39m\nsecond\n",
+      machineOutput: "first\nsecond\n",
+    });
     const written = new CliParseError({
       message: "bad input",
-      humanOutput: "first\nsecond\n",
+      humanOutput: "\u001B[31mfirst\u001B[39m\nsecond\n",
       humanOutputWritten: true,
+      machineOutput: "first\nsecond\n",
     });
 
     expect(formatCliFailureLines({ title: "ignored", error: pending, env })).toEqual([
-      "first",
+      "\u001B[31mfirst\u001B[39m",
       "second",
     ]);
     expect(formatCliFailureLines({ title: "ignored", error: written, env })).toEqual([]);

--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,6 +1,6 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
-import { formatCliFailureLines, formatCliJsonFailure } from "./failure-output.js";
+import { CliParseError, formatCliFailureLines, formatCliJsonFailure } from "./failure-output.js";
 
 describe("formatCliJsonFailure", () => {
   it("uses the canonical typed envelope and redacts the message", () => {
@@ -16,7 +16,6 @@ describe("formatCliJsonFailure", () => {
     });
     expect(payload.error.message).not.toContain(token);
   });
-
   it("keeps nested causes behind the debug gate", () => {
     const error = new Error("Promotion is not available.", {
       cause: new Error("ClawHub /api/v1/promotions/nope failed (404)"),
@@ -29,9 +28,52 @@ describe("formatCliJsonFailure", () => {
       "Promotion is not available. | ClawHub /api/v1/promotions/nope failed (404)",
     );
   });
+
+  it.each([
+    { label: "default output", env: {} },
+    { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
+  ])("keeps the full parse guidance unchanged in $label", ({ env }) => {
+    const error = Object.assign(
+      new CliParseError({
+        message: 'OpenClaw sessions has no command "lst".',
+        humanOutput:
+          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\n',
+      }),
+      { cause: new Error("internal parse cause") },
+    );
+    const payload = formatCliJsonFailure(error, { env });
+
+    expect(payload).toEqual({
+      ok: false,
+      error: {
+        type: "cli_error",
+        message:
+          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help',
+      },
+    });
+    expect(payload.error.message).not.toContain("internal parse cause");
+  });
 });
 
 describe("formatCliFailureLines", () => {
+  it.each([
+    { label: "default output", env: {} },
+    { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
+  ])("emits parse guidance only when not already written in $label", ({ env }) => {
+    const pending = new CliParseError({ message: "bad input", humanOutput: "first\nsecond\n" });
+    const written = new CliParseError({
+      message: "bad input",
+      humanOutput: "first\nsecond\n",
+      humanOutputWritten: true,
+    });
+
+    expect(formatCliFailureLines({ title: "ignored", error: pending, env })).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(formatCliFailureLines({ title: "ignored", error: written, env })).toEqual([]);
+  });
+
   it("shows a concise reason and recovery commands by default", () => {
     const lines = formatCliFailureLines({
       title: "Could not start the CLI.",

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -21,16 +21,32 @@ export type CliJsonFailure = {
   };
 };
 
+export class CliParseError extends Error {
+  readonly humanOutput: string;
+  readonly humanOutputWritten: boolean;
+
+  constructor(params: { message: string; humanOutput: string; humanOutputWritten?: boolean }) {
+    super(params.message);
+    this.name = "CliParseError";
+    this.humanOutput = params.humanOutput;
+    this.humanOutputWritten = params.humanOutputWritten ?? false;
+  }
+}
+
 /** Canonical machine-readable failure envelope for CLI-owned errors. */
 export function formatCliJsonFailure(
   error: unknown,
   options: CliFailureDebugOptions = {},
 ): CliJsonFailure {
+  const message =
+    error instanceof CliParseError
+      ? formatErrorMessage(error.humanOutput.trimEnd())
+      : formatCliOperatorError(error, options);
   return {
     ok: false,
     error: {
       type: "cli_error",
-      message: formatCliOperatorError(error, options),
+      message,
     },
   };
 }
@@ -74,6 +90,10 @@ function pushPrefixed(out: string[], value: string): void {
 }
 
 export function formatCliFailureLines(options: FormatCliFailureOptions): string[] {
+  if (options.error instanceof CliParseError) {
+    return options.error.humanOutputWritten ? [] : options.error.humanOutput.trimEnd().split("\n");
+  }
+
   // Default output stays terse; causes and stack traces require explicit debug intent.
   const env = options.env ?? process.env;
   const showDebugDetails = shouldShowDebugDetails(options.argv, env);

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -24,12 +24,19 @@ export type CliJsonFailure = {
 export class CliParseError extends Error {
   readonly humanOutput: string;
   readonly humanOutputWritten: boolean;
+  readonly machineOutput: string;
 
-  constructor(params: { message: string; humanOutput: string; humanOutputWritten?: boolean }) {
+  constructor(params: {
+    message: string;
+    humanOutput: string;
+    humanOutputWritten?: boolean;
+    machineOutput: string;
+  }) {
     super(params.message);
     this.name = "CliParseError";
     this.humanOutput = params.humanOutput;
     this.humanOutputWritten = params.humanOutputWritten ?? false;
+    this.machineOutput = params.machineOutput;
   }
 }
 
@@ -40,7 +47,7 @@ export function formatCliJsonFailure(
 ): CliJsonFailure {
   const message =
     error instanceof CliParseError
-      ? formatErrorMessage(error.humanOutput.trimEnd())
+      ? formatErrorMessage(error.machineOutput.trimEnd())
       : formatCliOperatorError(error, options);
   return {
     ok: false,

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -5,7 +5,11 @@ import {
   getCommanderErrorCommandNames,
   getCommanderErrorCommandPath,
 } from "./commander-parse-facts.js";
-import { formatCliParseErrorOutput } from "./error-output.js";
+import {
+  createCliParseError,
+  createCliUnknownCommandError,
+  formatCliParseErrorOutput,
+} from "./error-output.js";
 import { OpenClawCommand } from "./openclaw-command.js";
 import { registerLazyCommand } from "./register-lazy-command.js";
 
@@ -61,6 +65,29 @@ async function parseLazyGroupError(params: {
 }
 
 describe("formatCliParseErrorOutput", () => {
+  it("uses the same structured root diagnostic as the human renderer", () => {
+    const error = createCliUnknownCommandError("pairng", {
+      argv: ["node", "openclaw", "pairng", "--json"],
+    });
+
+    expect(error.message).toBe('OpenClaw does not know the command "pairng".');
+    expect(error.humanOutput).toBe(
+      'OpenClaw does not know the command "pairng".\nDid you mean this?\n  openclaw pairing\nTry: openclaw --help\nPlugin command? openclaw plugins list\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("strips Commander framing from structured nested diagnostics", () => {
+    const error = createCliParseError("error: unknown command 'lst'", {
+      argv: ["node", "openclaw", "sessions", "lst", "--json"],
+      commandPath: ["sessions"],
+      commandNames: ["list"],
+    });
+
+    expect(error.message).toBe('OpenClaw sessions has no command "lst".');
+    expect(error.message).not.toMatch(/^error:/i);
+    expect(error.humanOutput).toContain("Did you mean this?\n  openclaw sessions list\n");
+  });
+
   it("explains unknown commands with root help and plugin hints", () => {
     const output = formatCliParseErrorOutput("error: unknown command 'wat'\n", {
       argv: ["node", "openclaw", "wat"],
@@ -104,6 +131,19 @@ describe("formatCliParseErrorOutput", () => {
     expect(error.code).toBe("commander.unknownCommand");
     expect(output).toBe(
       'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("suggests a live child command when later arguments follow the typo", async () => {
+    const { error, output } = await parseLazyGroupError({
+      argv: ["config", "gett", "gateway.port"],
+      group: "config",
+      subcommands: [{ name: "get" }, { name: "set" }],
+    });
+
+    expect(error.code).toBe("commander.unknownCommand");
+    expect(output).toBe(
+      'OpenClaw config has no command "gett".\nDid you mean this?\n  openclaw config get\nTry: openclaw config --help\nDocs: https://docs.openclaw.ai/cli\n',
     );
   });
 

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -3,6 +3,7 @@ import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { getCommandPathWithRootOptions } from "../argv.js";
 import { formatCliCommand } from "../command-format.js";
+import { CliParseError } from "../failure-output.js";
 import { formatCliCommandSuggestions } from "./command-suggestions.js";
 
 type FormatCliParseErrorOptions = {
@@ -45,6 +46,63 @@ function formatDocsHint(): string {
   return `${theme.muted("Docs:")} ${formatDocsLink("/cli", "docs.openclaw.ai/cli")}`;
 }
 
+function formatUnknownCommandMessage(command: string, commandPath: readonly string[]): string {
+  return commandPath.length > 0
+    ? `OpenClaw ${commandPath.join(" ")} has no command ${quote(command)}.`
+    : `OpenClaw does not know the command ${quote(command)}.`;
+}
+
+function formatCliUnknownCommandOutput(
+  command: string,
+  options: FormatCliParseErrorOptions = {},
+): string {
+  const commandPath = options.commandPath ?? [];
+  const hasParentCommand = commandPath.length > 0;
+  return lines(
+    theme.error(formatUnknownCommandMessage(command, commandPath)),
+    formatCliCommandSuggestions(command, commandPath, options.commandNames),
+    formatHelpHint(options.argv, { commandPath }),
+    hasParentCommand
+      ? undefined
+      : `${theme.muted("Plugin command?")} ${theme.command(formatCliCommand("openclaw plugins list"))}`,
+    formatDocsHint(),
+  );
+}
+
+export function createCliParseError(
+  raw: string,
+  options: FormatCliParseErrorOptions = {},
+  errorOptions: { humanOutputWritten?: boolean } = {},
+): CliParseError {
+  const message = stripCommanderErrorPrefix(raw);
+  const unknownCommand = message.match(/^unknown command ['"`](.+?)['"`]/i);
+  if (unknownCommand) {
+    const command = unknownCommand[1] ?? "";
+    const commandPath = options.commandPath ?? [];
+    return new CliParseError({
+      message: formatUnknownCommandMessage(command, commandPath),
+      humanOutput: formatCliUnknownCommandOutput(command, options),
+      humanOutputWritten: errorOptions.humanOutputWritten,
+    });
+  }
+  return new CliParseError({
+    message,
+    humanOutput: formatCliParseErrorOutput(raw, options),
+    humanOutputWritten: errorOptions.humanOutputWritten,
+  });
+}
+
+export function createCliUnknownCommandError(
+  command: string,
+  options: FormatCliParseErrorOptions = {},
+): CliParseError {
+  const commandPath = options.commandPath ?? [];
+  return new CliParseError({
+    message: formatUnknownCommandMessage(command, commandPath),
+    humanOutput: formatCliUnknownCommandOutput(command, options),
+  });
+}
+
 /** Convert Commander parse errors into OpenClaw-specific help and docs guidance. */
 export function formatCliParseErrorOutput(
   raw: string,
@@ -53,22 +111,7 @@ export function formatCliParseErrorOutput(
   const message = stripCommanderErrorPrefix(raw);
   const unknownCommand = message.match(/^unknown command ['"`](.+?)['"`]/i);
   if (unknownCommand) {
-    const command = unknownCommand[1] ?? "";
-    const commandPath = options.commandPath ?? [];
-    const hasParentCommand = commandPath.length > 0;
-    return lines(
-      theme.error(
-        hasParentCommand
-          ? `OpenClaw ${commandPath.join(" ")} has no command ${quote(command)}.`
-          : `OpenClaw does not know the command ${quote(command)}.`,
-      ),
-      formatCliCommandSuggestions(command, commandPath, options.commandNames),
-      formatHelpHint(options.argv, { commandPath }),
-      hasParentCommand
-        ? undefined
-        : `${theme.muted("Plugin command?")} ${theme.command(formatCliCommand("openclaw plugins list"))}`,
-      formatDocsHint(),
-    );
+    return formatCliUnknownCommandOutput(unknownCommand[1] ?? "", options);
   }
 
   const unknownOption = message.match(/^unknown option ['"`](.+?)['"`]/i);

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -1,4 +1,5 @@
 // Friendly parse-error formatter for Commander errors and root CLI recovery hints.
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { getCommandPathWithRootOptions } from "../argv.js";
@@ -39,11 +40,17 @@ function lines(...items: Array<string | undefined>): string {
 }
 
 function formatHelpHint(argv: string[] | undefined, options?: { commandPath?: string[] }): string {
-  return `${theme.muted("Try:")} ${theme.command(resolveHelpCommand(argv, options))}`;
+  const command = resolveHelpCommand(argv, options);
+  return `${theme.muted("Try:")} ${theme.command(command)}`;
 }
 
 function formatDocsHint(): string {
   return `${theme.muted("Docs:")} ${formatDocsLink("/cli", "docs.openclaw.ai/cli")}`;
+}
+
+function formatCliMachineOutput(humanOutput: string): string {
+  const docs = `Docs: ${formatDocsLink("/cli", "docs.openclaw.ai/cli", { force: false })}`;
+  return stripAnsi(humanOutput).replace(/^Docs:.*$/mu, docs);
 }
 
 function formatUnknownCommandMessage(command: string, commandPath: readonly string[]): string {
@@ -79,16 +86,20 @@ export function createCliParseError(
   if (unknownCommand) {
     const command = unknownCommand[1] ?? "";
     const commandPath = options.commandPath ?? [];
+    const humanOutput = formatCliUnknownCommandOutput(command, options);
     return new CliParseError({
       message: formatUnknownCommandMessage(command, commandPath),
-      humanOutput: formatCliUnknownCommandOutput(command, options),
+      humanOutput,
       humanOutputWritten: errorOptions.humanOutputWritten,
+      machineOutput: formatCliMachineOutput(humanOutput),
     });
   }
+  const humanOutput = formatCliParseErrorOutput(raw, options);
   return new CliParseError({
     message,
-    humanOutput: formatCliParseErrorOutput(raw, options),
+    humanOutput,
     humanOutputWritten: errorOptions.humanOutputWritten,
+    machineOutput: formatCliMachineOutput(humanOutput),
   });
 }
 
@@ -97,9 +108,11 @@ export function createCliUnknownCommandError(
   options: FormatCliParseErrorOptions = {},
 ): CliParseError {
   const commandPath = options.commandPath ?? [];
+  const humanOutput = formatCliUnknownCommandOutput(command, options);
   return new CliParseError({
     message: formatUnknownCommandMessage(command, commandPath),
-    humanOutput: formatCliUnknownCommandOutput(command, options),
+    humanOutput,
+    machineOutput: formatCliMachineOutput(humanOutput),
   });
 }
 
@@ -117,8 +130,9 @@ export function formatCliParseErrorOutput(
   const unknownOption = message.match(/^unknown option ['"`](.+?)['"`]/i);
   if (unknownOption) {
     const option = unknownOption[1] ?? "";
+    const output = `OpenClaw does not recognize option ${quote(option)}.`;
     return lines(
-      theme.error(`OpenClaw does not recognize option ${quote(option)}.`),
+      theme.error(output),
       formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
@@ -126,8 +140,9 @@ export function formatCliParseErrorOutput(
   const missingArgument = message.match(/^missing required argument ['"`](.+?)['"`]/i);
   if (missingArgument) {
     const argument = missingArgument[1] ?? "";
+    const output = `Missing required argument ${quote(argument)}.`;
     return lines(
-      theme.error(`Missing required argument ${quote(argument)}.`),
+      theme.error(output),
       formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
@@ -135,21 +150,24 @@ export function formatCliParseErrorOutput(
   const missingOption = message.match(/^required option ['"`](.+?)['"`] not specified/i);
   if (missingOption) {
     const option = missingOption[1] ?? "";
+    const output = `Missing required option ${quote(option)}.`;
     return lines(
-      theme.error(`Missing required option ${quote(option)}.`),
+      theme.error(output),
       formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
 
   if (/^too many arguments\b/i.test(message)) {
+    const output = "Too many arguments for this command.";
     return lines(
-      theme.error("Too many arguments for this command."),
+      theme.error(output),
       formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
 
+  const output = `OpenClaw could not parse this command: ${message}`;
   return lines(
-    theme.error(`OpenClaw could not parse this command: ${message}`),
+    theme.error(output),
     formatHelpHint(options.argv, { commandPath: options.commandPath }),
   );
 }

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -1,6 +1,13 @@
 // Commander subclass that preserves the exact failing command for parse-error guidance.
-import { Command, type ErrorOptions } from "commander";
-import { getCommanderSubcommandFact, setCommanderErrorCommand } from "./commander-parse-facts.js";
+import { Command, CommanderError, type ErrorOptions } from "commander";
+import { isJsonOutputModeActive } from "../json-output-mode.js";
+import {
+  getCommanderErrorCommandNames,
+  getCommanderErrorCommandPath,
+  getCommanderSubcommandFact,
+  setCommanderErrorCommand,
+} from "./commander-parse-facts.js";
+import { createCliParseError } from "./error-output.js";
 
 // Commander 15 declares this help hook only in its runtime class, not its types.
 // Declaring it here lets the subclass override and delegate through `super`
@@ -20,6 +27,23 @@ export class OpenClawCommand extends Command {
     const restoreErrorCommand = setCommanderErrorCommand(this);
     try {
       return super.error(message, errorOptions);
+    } catch (error) {
+      if (
+        error instanceof CommanderError &&
+        error.exitCode !== 0 &&
+        isJsonOutputModeActive(process.argv)
+      ) {
+        throw createCliParseError(
+          message,
+          {
+            argv: process.argv,
+            commandPath: getCommanderErrorCommandPath(this),
+            commandNames: getCommanderErrorCommandNames(this),
+          },
+          { humanOutputWritten: true },
+        );
+      }
+      throw error;
     } finally {
       restoreErrorCommand();
     }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -12,6 +12,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { CliParseError } from "./failure-output.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 import { registerSignalExitBarrier } from "./signal-exit-barrier.js";
@@ -2766,7 +2767,7 @@ describe("runCli exit behavior", () => {
 
   it("rejects unowned command roots before proxy and plugin runtime registration", async () => {
     await expect(runCli(["node", "openclaw", "foo"])).rejects.toThrow(
-      'No built-in command or plugin CLI metadata owns "foo"',
+      'OpenClaw does not know the command "foo".',
     );
 
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -2819,7 +2820,7 @@ describe("runCli exit behavior", () => {
     const target = "https://gateway.example/dashboard/main/movies-a1166b81";
 
     await expect(runCli(["node", "openclaw", "unknown-owner", target])).rejects.toThrow(
-      "Unknown command: openclaw unknown-owner",
+      'OpenClaw does not know the command "unknown-owner".',
     );
 
     expect(runTuiCliActionMock).not.toHaveBeenCalled();
@@ -2914,7 +2915,7 @@ describe("runCli exit behavior", () => {
 
   it("does not claim a bare session ref as root-command sugar", async () => {
     await expect(runCli(["node", "openclaw", "movies-a1166b81"])).rejects.toThrow(
-      "Unknown command: openclaw movies-a1166b81",
+      'OpenClaw does not know the command "movies-a1166b81".',
     );
 
     expect(runTuiCliActionMock).not.toHaveBeenCalled();
@@ -2922,15 +2923,18 @@ describe("runCli exit behavior", () => {
 
   it("does not claim host shorthand as root-command sugar", async () => {
     await expect(runCli(["node", "openclaw", "gateway.example/main/a1166b81"])).rejects.toThrow(
-      "Unknown command: openclaw gateway.example/main/a1166b81",
+      'OpenClaw does not know the command "gateway.example/main/a1166b81".',
     );
 
     expect(runTuiCliActionMock).not.toHaveBeenCalled();
   });
 
   it("suggests close known commands for unowned command roots before proxy startup", async () => {
-    await expect(runCli(["node", "openclaw", "upate"])).rejects.toThrow(
-      "Did you mean this?\n  openclaw update",
+    const error = await runCli(["node", "openclaw", "upate"]).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(CliParseError);
+    expect((error as CliParseError).humanOutput).toContain(
+      "Did you mean this?\n  openclaw update\n",
     );
 
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -2943,7 +2947,7 @@ describe("runCli exit behavior", () => {
     const primary = "bad\u001b[31m-red\u001b[0m\nforged\tline";
 
     await expect(runCli(["node", "openclaw", primary])).rejects.toThrow(
-      'Unknown command: openclaw bad-red\\nforged\\tline. No built-in command or plugin CLI metadata owns "bad-red\\nforged\\tline".',
+      'OpenClaw does not know the command "bad-red\\nforged\\tline".',
     );
 
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -2966,7 +2970,7 @@ describe("runCli exit behavior", () => {
     const message = (error as Error).message;
     const displayPrimary = `${"🦞".repeat(63)}…`;
     expect(displayPrimary.length).toBeLessThanOrEqual(128);
-    expect(message).toContain(`Unknown command: openclaw ${displayPrimary}`);
+    expect(message).toContain(`OpenClaw does not know the command "${displayPrimary}".`);
     expect(message).not.toContain("�");
     expect(message.length).toBeLessThan(500);
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -3001,7 +3005,7 @@ describe("runCli exit behavior", () => {
 
   it("rejects unowned command roots even when --help is appended (regression for #81077)", async () => {
     await expect(runCli(["node", "openclaw", "foo", "--help"])).rejects.toThrow(
-      'No built-in command or plugin CLI metadata owns "foo"',
+      'OpenClaw does not know the command "foo".',
     );
 
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -3012,7 +3016,7 @@ describe("runCli exit behavior", () => {
 
   it("rejects unowned command roots even when --version is appended", async () => {
     await expect(runCli(["node", "openclaw", "foo", "--version"])).rejects.toThrow(
-      'No built-in command or plugin CLI metadata owns "foo"',
+      'OpenClaw does not know the command "foo".',
     );
 
     expect(startProxyMock).not.toHaveBeenCalled();
@@ -3034,7 +3038,7 @@ describe("runCli exit behavior", () => {
     }
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain(
-      'No built-in command or plugin CLI metadata owns "totally-unknown"',
+      'OpenClaw does not know the command "totally-unknown".',
     );
     expect((error as Error).message).not.toContain("plugins.allow");
     expect(startProxyMock).not.toHaveBeenCalled();

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -52,7 +52,6 @@ import { isMachineOutputStdoutTTY } from "./machine-output-argv.js";
 import { requestExitAfterOneShotOutput } from "./one-shot-exit.js";
 import { tryOutputPrecomputedCommandHelp } from "./precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
-import { formatCliCommandSuggestions } from "./program/command-suggestions.js";
 import {
   getCoreCliCommandDescriptors,
   getCoreCliCommandNamesCore,
@@ -996,10 +995,11 @@ async function resolveUnownedCliPrimary(params: {
   return primary;
 }
 
-async function resolveUnownedCliPrimaryMessage(params: {
+async function resolveUnownedCliPrimaryError(params: {
+  argv: string[];
   primary: string;
   config: OpenClawConfig;
-}): Promise<string> {
+}): Promise<Error> {
   const { resolveManifestCommandAliasOwner, resolveManifestToolOwner } =
     await loadManifestCommandAliasesRuntimeModule();
   const cliCommandSurfaceOwner = await resolveCliCommandSurfaceOwner(params);
@@ -1009,21 +1009,18 @@ async function resolveUnownedCliPrimaryMessage(params: {
     resolveCliCommandSurfaceOwner: () => cliCommandSurfaceOwner,
   });
   if (pluginPolicyMessage) {
-    return pluginPolicyMessage;
+    return new Error(pluginPolicyMessage);
   }
   const sanitizedPrimary = sanitizeTerminalText(params.primary);
   const displayPrimary =
     sanitizedPrimary.length <= UNKNOWN_COMMAND_DISPLAY_LIMIT
       ? sanitizedPrimary
       : `${truncateUtf16Safe(sanitizedPrimary, UNKNOWN_COMMAND_DISPLAY_LIMIT - 1)}…`;
-  const suggestion =
-    displayPrimary === params.primary ? formatCliCommandSuggestions(params.primary) : "";
-  return [
-    `Unknown command: openclaw ${displayPrimary}. No built-in command or plugin CLI metadata owns "${displayPrimary}".`,
-    suggestion,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const { createCliUnknownCommandError } = await import("./program/error-output.js");
+  return createCliUnknownCommandError(displayPrimary, {
+    argv: params.argv,
+    ...(displayPrimary === params.primary ? {} : { commandNames: [] }),
+  });
 }
 
 async function bootstrapCliProxyCaptureAndDispatcher(
@@ -1312,7 +1309,11 @@ async function runCliWithPreparedOutputMode(
     if (!bareSessionInvocation) {
       const unownedPrimary = await resolveUnownedCliPrimary({ argv: normalizedArgv, config });
       if (unownedPrimary) {
-        throw new Error(await resolveUnownedCliPrimaryMessage({ primary: unownedPrimary, config }));
+        throw await resolveUnownedCliPrimaryError({
+          argv: normalizedArgv,
+          primary: unownedPrimary,
+          config,
+        });
       }
     }
     await replaceStartedProxy(config?.proxy ?? undefined);
@@ -1385,9 +1386,11 @@ async function runCliWithPreparedOutputMode(
         const config = await readBestEffortCliConfig();
         const unownedPrimary = await resolveUnownedCliPrimary({ argv: normalizedArgv, config });
         if (unownedPrimary) {
-          throw new Error(
-            await resolveUnownedCliPrimaryMessage({ primary: unownedPrimary, config }),
-          );
+          throw await resolveUnownedCliPrimaryError({
+            argv: normalizedArgv,
+            primary: unownedPrimary,
+            config,
+          });
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@
 // Package executable entrypoint that forwards to the CLI bootstrap.
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { formatCliFailureLines, formatCliJsonFailure } from "./cli/failure-output.js";
+import {
+  CliParseError,
+  formatCliFailureLines,
+  formatCliJsonFailure,
+} from "./cli/failure-output.js";
 import { isJsonOutputModeActive } from "./cli/json-output-mode.js";
 import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
@@ -151,8 +155,10 @@ if (isMain && !handledRootVersion) {
       })) {
         console.error(line);
       }
-      for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
-        console.error("[openclaw]", message);
+      if (!(err instanceof CliParseError)) {
+        for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
+          console.error("[openclaw]", message);
+        }
       }
       restoreRuntimeTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
       process.exitCode = 1;

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -307,16 +307,112 @@ describe("cli json stdout contract", () => {
         ]);
 
         expect(result.status).toBe(1);
-        expect(JSON.parse(result.stdout)).toMatchObject({
+        const payload = JSON.parse(result.stdout) as {
+          ok: boolean;
+          error: { type: string; message: string };
+        };
+        expect(payload).toMatchObject({
           ok: false,
           error: {
             type: "cli_error",
             message: expect.stringContaining("--not-a-real-option"),
           },
         });
+        expect(payload.error.message).not.toMatch(/^error:/i);
         expect(result.stderr).toContain("--not-a-real-option");
       },
       { prefix: "openclaw-json-parse-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    {
+      name: "unknown root",
+      args: ["pairng"],
+      diagnostic: 'OpenClaw does not know the command "pairng".',
+      suggestion: "openclaw pairing",
+    },
+    {
+      name: "unknown nested command",
+      args: ["sessions", "lst"],
+      diagnostic: 'OpenClaw sessions has no command "lst".',
+      suggestion: "openclaw sessions list",
+    },
+    {
+      name: "unknown nested command with a later argument",
+      args: ["config", "gett", "gateway.port"],
+      diagnostic: 'OpenClaw config has no command "gett".',
+      suggestion: "openclaw config get",
+    },
+    {
+      name: "unknown root before help",
+      args: ["pairng", "--help"],
+      diagnostic: 'OpenClaw does not know the command "pairng".',
+      suggestion: "openclaw pairing",
+    },
+  ])("renders $name as actionable guidance", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runSourceCli(tempHome, testCase.args);
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain(testCase.diagnostic);
+        expect(result.stderr).toContain(`Did you mean this?\n  ${testCase.suggestion}`);
+        expect(result.stderr.split(testCase.diagnostic)).toHaveLength(2);
+        expect(result.stderr.split(testCase.suggestion)).toHaveLength(2);
+        expect(result.stderr).not.toContain("The CLI command failed.");
+        expect(result.stderr).not.toContain("Could not start the CLI.");
+        expect(result.stderr).not.toContain("OPENCLAW_DEBUG");
+        expect(result.stderr).not.toContain("openclaw doctor");
+        if (testCase.args.includes("--help")) {
+          expect(result.stdout).not.toContain("Usage: openclaw [options] [command]");
+        }
+      },
+      { prefix: "openclaw-unknown-command-e2e-" },
+    );
+  });
+
+  it.each([
+    {
+      name: "unknown root",
+      args: ["pairng", "--json"],
+      diagnostic: 'OpenClaw does not know the command "pairng".',
+      suggestion: "openclaw pairing",
+    },
+    {
+      name: "unknown nested command",
+      args: ["sessions", "lst", "--json"],
+      diagnostic: 'OpenClaw sessions has no command "lst".',
+      suggestion: "openclaw sessions list",
+    },
+  ])("reports $name once with structured JSON guidance", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runSourceCli(tempHome, testCase.args);
+
+        expect(result.status).toBe(1);
+        const payload = JSON.parse(result.stdout) as {
+          ok: boolean;
+          error: { type: string; message: string };
+        };
+        expect(payload.ok).toBe(false);
+        expect(payload.error.type).toBe("cli_error");
+        expect(payload.error.message).toContain(testCase.diagnostic);
+        expect(payload.error.message).not.toMatch(/^error:/i);
+        expect(payload.error.message).toContain(`Did you mean this?\n  ${testCase.suggestion}`);
+        expect(payload.error.message).not.toContain("OPENCLAW_DEBUG");
+        expect(payload.error.message).not.toContain("openclaw doctor");
+        expect(result.stderr).toContain(testCase.diagnostic);
+        expect(result.stderr).toContain(`Did you mean this?\n  ${testCase.suggestion}`);
+        expect(result.stderr.split(testCase.diagnostic)).toHaveLength(2);
+        expect(result.stderr.split(testCase.suggestion)).toHaveLength(2);
+        expect(result.stderr).not.toContain("The CLI command failed.");
+        expect(result.stderr).not.toContain("Could not start the CLI.");
+        expect(result.stderr).not.toContain("OPENCLAW_DEBUG");
+        expect(result.stderr).not.toContain("openclaw doctor");
+      },
+      { prefix: "openclaw-unknown-command-json-e2e-" },
     );
   });
 

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -416,6 +416,28 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it("keeps parse-error JSON free of terminal controls when color is forced", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runSourceCli(tempHome, ["sessions", "lst", "--json"], {
+          FORCE_COLOR: "1",
+        });
+
+        expect(result.status).toBe(1);
+        const payload = JSON.parse(result.stdout) as {
+          error: { message: string };
+        };
+        expect(payload.error.message).toBe(
+          'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli',
+        );
+        expect(payload.error.message).not.toMatch(/[\u001B\u0007]/u);
+        expect(result.stdout).not.toContain("\\u001b");
+        expect(result.stderr).toContain("\u001B[");
+      },
+      { prefix: "openclaw-unknown-command-color-json-e2e-" },
+    );
+  });
+
   it("keeps representative success payload bytes unchanged", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a mistyped CLI command root was presented as a runtime crash, including a stack-trace hint and an `openclaw doctor` recommendation that could not help. Commander already rendered nested typos as actionable parse guidance for humans, but JSON mode serialized Commander's raw error and omitted the same path-aware suggestion.

### Before

Fresh pre-fix proof against the original branch base refined the reported routing premise:

| Invocation | Pre-fix result |
| --- | --- |
| `openclaw pairng` | Crash framing, stack hint, doctor hint; suggested `openclaw pairing` |
| `openclaw sessions lst` | Already used the good Commander renderer and suggested `openclaw sessions list` |
| `openclaw config gett foo` | Already used the good Commander renderer and suggested `openclaw config get` |
| `openclaw sessions lst --json` | `{ ok: false, error: { type: "cli_error", message: "error: unknown command 'lst'" } }` |
| `openclaw pairng --help` | Rejected the typo, but through crash framing rather than parse guidance |

The earlier whole-string Levenshtein explanation does not match current source behavior. `resolveUnownedCliPrimaryCandidate` only returns the first root token and declines known built-in roots, so `sessions lst` and `config gett foo` proceed to Commander. Their parent path and live child candidates come from the active Commander node through `getCommanderErrorCommandPath` and `getCommanderErrorCommandNames`.

## Why This Change Was Made

The change converges both producers on `formatCliParseErrorOutput` rather than adding another renderer. A typed `CliParseError` carries the canonical human diagnostic and whether Commander already wrote it. The pre-Commander unowned-root guard now creates that expected parse error, while `OpenClawCommand` converts non-zero JSON parse exits while it still owns the exact command path and visible child set.

The top-level failure formatter recognizes `CliParseError`, so expected input errors bypass crash/debug/doctor framing. JSON keeps the existing `{ ok, error: { type, message } }` shape and puts the full diagnostic—including suggestions and the next help command—in `error.message`; no new envelope fields were added.

After rebasing over #124887, ordinary failures continue through `formatCliOperatorError`, including its debug-gated cause chain. `CliParseError` bypasses cause traversal in both modes because its machine document is already complete operator text. `formatCliFailureLines` still returns before all cause/stack logic, so an already-written parse error emits nothing even under `OPENCLAW_DEBUG=1`, and a pending parse error emits its guidance without a stack.

The human parse document may contain SGR color and OSC-8 hyperlinks when stdout is a TTY. `CliParseError` therefore records a machine document at the same producer: the canonical renderer output is stripped of terminal controls, and its docs line is normalized through `formatDocsLink(..., { force: false })`. This preserves styled stderr while making JSON identical across a pipe, a real PTY, and `FORCE_COLOR=1`.

`resolveMissingPluginCommandMessage` remains separate. A disabled, excluded, runtime-only, or tool-only plugin surface is an ownership/configuration diagnosis, not an unknown-command typo, so it keeps its specific policy wording and does not receive fuzzy suggestions.

`collectShellCompletionCommandTree` was not reused: nested diagnostics already consume the live Commander node, including aliases and visibility filtering, while the pre-Commander guard only handles an unknown root. Traversing the completion tree here would duplicate the existing owner and require building command state the early guard intentionally avoids.

Production LOC: +165/-44 (net +121) | Tests: +226/-15 (net +211). The production growth establishes one typed expected-parse boundary across the pre-Commander guard, Commander JSON handling, both executable entrypoints, the cause-chain owner, and terminal-vs-machine rendering. A larger dual-style rendering scaffold was considered and removed; the final machine normalization adds only +25 net production lines beyond the accepted pre-rebase change.

## User Impact

Typos now produce one actionable diagnostic with the correct command depth, relevant sibling suggestion, and help command. The exit code remains 1. `openclaw <typo> --help` still rejects the typo rather than falling through to generic top-level help, preserving #81077.

The canonical parse renderer is intentionally unprefixed as a block, so `Did you mean this?` is now consistent with every sibling line instead of appearing inside a separately prefixed crash `Reason:` field. JSON contains the same plain text regardless of terminal color capability.

### After

| Invocation | Human result | JSON `error.message` |
| --- | --- | --- |
| `openclaw pairng` | `OpenClaw does not know the command "pairng".` + `openclaw pairing` + root help/docs | Same full plain diagnostic |
| `openclaw sessions lst` | `OpenClaw sessions has no command "lst".` + `openclaw sessions list` | Same full plain diagnostic |
| `openclaw config gett foo` | `OpenClaw config has no command "gett".` + `openclaw config get` | Same full plain diagnostic |
| `openclaw pairng --help` | Same unknown-root diagnostic; no generic help | Same full plain diagnostic with `--json` |

Every form exits 1. No form suggests `openclaw doctor` or `OPENCLAW_DEBUG`.

### ANSI / TTY verdict

Before terminal normalization, a real PTY produced SGR and OSC-8 controls inside parsed `error.message`; a pipe did not, and `FORCE_COLOR=1` independently reproduced SGR controls. After the fix:

| Probe | JSON equals piped bytes | JSON controls | stderr controls |
| --- | --- | --- | --- |
| real PTY via `script` | yes | none | present |
| `FORCE_COLOR=1` | yes | none | present |

## Evidence

- Pre-fix process regression: 4 failures captured for root human/help and root/nested JSON; nested human cases passed, disproving the stale whole-invocation routing premise.
- Focused tests after the rebase: `node scripts/run-vitest.mjs src/cli/failure-output.test.ts src/cli/cli-utils.test.ts src/cli/program/error-output.test.ts src/cli/run-main.exit.test.ts` — 309 passed.
- Process boundary: `node scripts/run-vitest.mjs test/cli-json-stdout.e2e.test.ts` — 29 passed on Blacksmith Testbox `tbx_01m06dvfq8vphn74vd92dax2yp` ([run](https://github.com/openclaw/openclaw/actions/runs/31978717405)).
- Build: `pnpm build` — passed on the same Testbox, including the CLI bootstrap import guard.
- Changed gate: `node scripts/check-changed.mjs` — passed the full core/type/lint/architecture plan on Blacksmith Testbox `tbx_01m06gxnxmn8jgec2m0nb1qvpd` ([run](https://github.com/openclaw/openclaw/actions/runs/31981247916)).
- Built CLI proof used isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` and `OPENCLAW_SKIP_CHANNELS=1`; `pairng`, `sessions lst`, `config gett foo`, `agents create`, and `pairng --help`, each in human and JSON form, all exited 1 with correct stream separation and no crash framing.
- Real PTY (`script`) and `FORCE_COLOR=1` probes both proved byte equality with piped JSON, no terminal controls in parsed `error.message`, and retained terminal controls on stderr.
- Autoreview: uncommitted follow-up and complete rebased branch both clean; no accepted/actionable findings.
