### PR TITLE
fix(backup): give backup create actionable output errors

### DIFF
--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
@@ -410,6 +411,74 @@ describe("backup commands", () => {
         output: path.join(stateDir, "backups"),
       }),
     ).rejects.toThrow(/must not be written inside a source path/i);
+  });
+
+  it("creates missing output parent directories", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const outputPath = path.join(tempHome.home, "backups", "daily", "backup.tar.gz");
+    await mockStateOnlyBackupPlan(stateDir);
+
+    const result = await backupCreateCommand(createBackupTestRuntime(), { output: outputPath });
+
+    expect(result.archivePath).toBe(outputPath);
+    expect(await fs.readFile(outputPath, "utf8")).toBe("archive-bytes");
+  });
+
+  it.each([
+    {
+      code: "ENOENT",
+      detail: "Backup output directory could not be created",
+      recovery: "Check the path and run `openclaw backup create --output <archive>` again.",
+    },
+    {
+      code: "EACCES",
+      detail: "Backup output directory is not writable",
+      recovery:
+        "Check the path and directory permissions, then run `openclaw backup create --output <archive>` again.",
+    },
+    {
+      code: "ENOSPC",
+      detail: "The destination does not have enough free space",
+      recovery: "Free up disk space and run `openclaw backup create --output <archive>` again.",
+    },
+  ])("reports an actionable $code output-parent failure", async ({ code, detail, recovery }) => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const outputParent = path.join(tempHome.home, "missing-parent", "daily");
+    const outputPath = path.join(outputParent, "backup.tar.gz");
+    await mockStateOnlyBackupPlan(stateDir);
+    vi.spyOn(fs, "mkdir").mockRejectedValueOnce(
+      Object.assign(new Error(`${code}: filesystem error, mkdir '${outputParent}'`), {
+        code,
+        path: outputParent,
+        syscall: "mkdir",
+      }),
+    );
+
+    const error = await backupCreateCommand(createBackupTestRuntime(), {
+      output: outputPath,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(formatErrorMessage(error)).toBe(
+      `Backup archive creation failed: ${outputPath}. ${detail}: ${outputParent}. ${recovery}`,
+    );
+  });
+
+  it("does not describe an output parent file as a missing directory", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const outputParent = path.join(tempHome.home, "not-a-directory");
+    const outputPath = path.join(outputParent, "backup.tar.gz");
+    await fs.writeFile(outputParent, "file\n", "utf8");
+    await mockStateOnlyBackupPlan(stateDir);
+
+    const error = await backupCreateCommand(createBackupTestRuntime(), {
+      output: outputPath,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(formatErrorMessage(error)).toBe(
+      `Backup archive creation failed: ${outputPath}. Backup output parent is not a directory: ${outputParent}. Choose a directory path and run \`openclaw backup create --output <archive>\` again.`,
+    );
   });
 
   it("rejects symlinked output paths even when intermediate directories do not exist yet", async () => {

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { formatErrorMessage } from "../infra/errors.js";
+import { formatCliOperatorError } from "../cli/failure-output.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
@@ -441,6 +441,12 @@ describe("backup commands", () => {
       detail: "The destination does not have enough free space",
       recovery: "Free up disk space and run `openclaw backup create --output <archive>` again.",
     },
+    {
+      code: "EIO",
+      detail: "The output path could not be prepared",
+      recovery:
+        "Check the path and filesystem, then run `openclaw backup create --output <archive>` again.",
+    },
   ])("reports an actionable $code output-parent failure", async ({ code, detail, recovery }) => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const outputParent = path.join(tempHome.home, "missing-parent", "daily");
@@ -459,8 +465,11 @@ describe("backup commands", () => {
     }).catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(Error);
-    expect(formatErrorMessage(error)).toBe(
-      `Backup archive creation failed: ${outputPath}. ${detail}: ${outputParent}. ${recovery}`,
+    const operatorMessage = `Backup archive creation failed: ${outputPath}. ${detail}: ${outputParent}. ${recovery}`;
+    expect(formatCliOperatorError(error, { argv: [], env: {} })).toBe(operatorMessage);
+    const debugMessage = `${operatorMessage} | ${code}: filesystem error, mkdir '${outputParent}' | ${code}`;
+    expect(formatCliOperatorError(error, { argv: [], env: { OPENCLAW_DEBUG: "1" } })).toBe(
+      debugMessage,
     );
   });
 
@@ -476,8 +485,10 @@ describe("backup commands", () => {
     }).catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(Error);
-    expect(formatErrorMessage(error)).toBe(
-      `Backup archive creation failed: ${outputPath}. Backup output parent is not a directory: ${outputParent}. Choose a directory path and run \`openclaw backup create --output <archive>\` again.`,
+    const operatorMessage = `Backup archive creation failed: ${outputPath}. Backup output parent is not a directory: ${outputParent}. Choose a directory path and run \`openclaw backup create --output <archive>\` again.`;
+    expect(formatCliOperatorError(error, { argv: [], env: {} })).toBe(operatorMessage);
+    expect(formatCliOperatorError(error, { argv: [], env: { OPENCLAW_DEBUG: "1" } })).toMatch(
+      /\| EEXIST: .*mkdir.*\| EEXIST/u,
     );
   });
 

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -211,9 +211,9 @@ function formatBackupOutputFailure(
       detail = `The destination storage quota is exhausted: ${outputParent}. Free up space or choose another path, then ${retry}`;
       break;
     default:
-      detail = `The output path could not be prepared. ${formatErrorMessage(filesystemError)} Resolve the reported filesystem error and ${retry}`;
+      detail = `The output path could not be prepared: ${outputParent}. Check the path and filesystem, then ${retry}`;
   }
-  return new Error(`Backup archive creation failed: ${outputPath}. ${detail}`);
+  return new Error(`Backup archive creation failed: ${outputPath}. ${detail}`, { cause: error });
 }
 
 async function assertOutputPathReady(outputPath: string): Promise<void> {
@@ -803,6 +803,10 @@ export async function createBackupArchive(
     );
   }
 
+  if (!opts.dryRun) {
+    await assertOutputPathReady(outputPath);
+  }
+
   const createdAt = new Date(nowMs).toISOString();
   const stateAsset = plan.included.find((asset) => asset.kind === "state");
   const pluginSkillsPath = stateAsset
@@ -825,7 +829,6 @@ export async function createBackupArchive(
     return result;
   }
 
-  await assertOutputPathReady(outputPath);
   await prepareBackupOutputParent(outputPath);
   const tempRoot = await chooseBackupTempRoot({ assets: result.assets, outputPath });
   await fs.mkdir(tempRoot, { recursive: true });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -43,7 +43,7 @@ import {
   createBackupLinkCache,
   createBackupVolatileStatCache,
 } from "./backup-volatile-stat-cache.js";
-import { formatErrorMessage } from "./errors.js";
+import { formatErrorMessage, isErrno } from "./errors.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { writeJson } from "./json-files.js";
 import { createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
@@ -165,16 +165,75 @@ async function resolveOutputPath(params: {
   return resolved;
 }
 
+type BackupOutputFailurePhase = "parent" | "publication" | "write";
+
+function formatBackupOutputFailure(
+  error: unknown,
+  outputPath: string,
+  phase: BackupOutputFailurePhase,
+  ownedRoot?: string,
+): unknown {
+  const cause = phase === "write" && error instanceof Error ? error.cause : undefined;
+  const filesystemError = isErrno(error) ? error : isErrno(cause) ? cause : null;
+  if (!filesystemError) {
+    return error;
+  }
+  if (ownedRoot) {
+    const failedPath = filesystemError.path;
+    if (typeof failedPath !== "string" || !isPathWithin(path.resolve(failedPath), ownedRoot)) {
+      return error;
+    }
+  }
+
+  const outputParent = path.dirname(outputPath);
+  const retry = "run `openclaw backup create --output <archive>` again.";
+  let detail: string;
+  switch (filesystemError.code) {
+    case "ENOENT":
+      detail = `Backup output directory could not be created: ${outputParent}. Check the path and ${retry}`;
+      break;
+    case "EACCES":
+    case "EPERM":
+    case "EROFS":
+      detail = `Backup output directory is not writable: ${outputParent}. Check the path and directory permissions, then ${retry}`;
+      break;
+    case "EEXIST":
+    case "ENOTDIR":
+      if (phase !== "parent") {
+        return error;
+      }
+      detail = `Backup output parent is not a directory: ${outputParent}. Choose a directory path and ${retry}`;
+      break;
+    case "ENOSPC":
+      detail = `The destination does not have enough free space: ${outputParent}. Free up disk space and ${retry}`;
+      break;
+    case "EDQUOT":
+      detail = `The destination storage quota is exhausted: ${outputParent}. Free up space or choose another path, then ${retry}`;
+      break;
+    default:
+      detail = `The output path could not be prepared. ${formatErrorMessage(filesystemError)} Resolve the reported filesystem error and ${retry}`;
+  }
+  return new Error(`Backup archive creation failed: ${outputPath}. ${detail}`);
+}
+
 async function assertOutputPathReady(outputPath: string): Promise<void> {
   try {
     await fs.access(outputPath);
     throw new Error(`Refusing to overwrite existing backup archive: ${outputPath}`);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    if (code === "ENOENT") {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
       return;
     }
-    throw err;
+    throw formatBackupOutputFailure(error, outputPath, "parent");
+  }
+}
+
+async function prepareBackupOutputParent(outputPath: string): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  } catch (error) {
+    throw formatBackupOutputFailure(error, outputPath, "parent");
   }
 }
 
@@ -744,10 +803,6 @@ export async function createBackupArchive(
     );
   }
 
-  if (!opts.dryRun) {
-    await assertOutputPathReady(outputPath);
-  }
-
   const createdAt = new Date(nowMs).toISOString();
   const stateAsset = plan.included.find((asset) => asset.kind === "state");
   const pluginSkillsPath = stateAsset
@@ -770,7 +825,8 @@ export async function createBackupArchive(
     return result;
   }
 
-  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await assertOutputPathReady(outputPath);
+  await prepareBackupOutputParent(outputPath);
   const tempRoot = await chooseBackupTempRoot({ assets: result.assets, outputPath });
   await fs.mkdir(tempRoot, { recursive: true });
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
@@ -780,7 +836,7 @@ export async function createBackupArchive(
     publication = await createBackupArchivePublication(outputPath);
   } catch (error) {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
-    throw error;
+    throw formatBackupOutputFailure(error, outputPath, "publication");
   }
   const tempArchivePath = publication.tempArchivePath;
   const preservedStatePaths = [
@@ -992,6 +1048,8 @@ export async function createBackupArchive(
         }
         return prepared;
       },
+    }).catch((error: unknown) => {
+      throw formatBackupOutputFailure(error, outputPath, "write", publication.stagingDir);
     });
     result.skippedVolatileCount = skippedVolatileCount;
     if (pluginSkillsPath && skippedPluginSkills) {
@@ -1009,11 +1067,15 @@ export async function createBackupArchive(
         } (live sessions, cron logs, queues, sockets, pid/tmp).`,
       );
     }
-    await publishPreparedBackupArchive({
-      plan: publication,
-      prepared: completedArchive,
-      log: opts.log,
-    });
+    try {
+      await publishPreparedBackupArchive({
+        plan: publication,
+        prepared: completedArchive,
+        log: opts.log,
+      });
+    } catch (error) {
+      throw formatBackupOutputFailure(error, outputPath, "publication");
+    }
   } finally {
     await cleanupBackupArchivePublication(publication, opts.log);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw backup create --output <archive>` could print a raw Node filesystem error when its output parent could not be prepared. The common root-level or permission-denied case exposed `ENOENT`/`EACCES`, a syscall name, and no recovery step, while the neighboring `backup verify` command already gave an actionable domain answer.

Before:

```text
$ openclaw backup create --output /nonexistent-dir-xyz/backup.tar
ENOENT: no such file or directory, mkdir '/nonexistent-dir-xyz'
[exit 1]
```

Closest sibling:

```text
$ openclaw backup verify /nonexistent/path.tar
Backup archive verification failed: /nonexistent/path.tar. Archive does not exist. Check the path
and run `openclaw backup verify <archive>` again.
[exit 1]
```

AI-assisted: yes.

## Why This Change Was Made

The create path already used recursive parent creation, including at the measured source revision and since the original backup CLI in #40163. A writable nested target such as `~/backups/today/openclaw.tar` therefore already expressed the right product behavior: create exactly the requested parent chain, then write exactly where requested. The defect was the unclassified failure when that provisioning or later output-owned publication failed.

This keeps recursive provisioning and classifies errors at the output owner rather than in the command wrapper. Missing/raced paths, permission/read-only failures, parent-as-file failures, disk exhaustion, and quota exhaustion stay distinct. Output-write errors are translated only when the errno path belongs to the private publication staging directory, so a source-file read error is not mislabeled as an output problem. Existing-archive refusal remains unchanged.

The classified domain error preserves the original filesystem error as its `cause`. The CLI formatter from #124887 keeps that cause out of default operator output and restores it under `OPENCLAW_DEBUG=1`, so ordinary failures stay concise while diagnosis retains the exact syscall and failed path. The generic errno branch therefore uses the same short path/filesystem recovery sentence as the known branches; its technical detail now belongs exclusively to the debug cause chain.

### Backup filesystem sweep

| Surface | Decision | Reason |
| --- | --- | --- |
| `backup create` | Changed | Parent preparation, staging, archive write, and final publication could leak raw output-owned errno values. These now name the destination and give a code-specific next step. |
| `backup verify` | Left | `src/commands/backup-verify.ts` already maps missing archives, non-files, inspection failures, and parse failures to actionable archive-specific answers; this is the wording model for the change. |
| `backup restore` | Left; follow-up candidate | Fresh-target `lstat`/`mkdir` failures can still expose errno values, but restore target lifecycle and rollback cleanup need restore-specific remediation rather than create-output wording. |
| backup health/status | Left | Non-`ENOENT` failures reading the existing state database intentionally propagate instead of being misreported as “no backups”; actionable status wording is a separate owner. |
| `backup enable` / `disable` | Left | The schedule module has no direct filesystem boundary; its Git remote preflight already gives a command-specific recovery step. |
| `backup git *` | Left; follow-up candidate | Selected-database, repository staging, and restore-target failures have Git/source/restore-specific remedies and should not share archive-output policy. Repository initialization already wraps ownership/admission failures. |
| `backup sqlite *` | Left; follow-up candidate | Missing snapshots/repositories and private-directory rules are already provider-owned domain errors. Selected source-database and host-I/O failures need a separate provider-specific pass. |

`src/infra/errno.ts` provides exact classifiers only (`isErrno`, `hasErrnoCode`, and `isMissingPathError`), not an operator-text mapper. This change reuses `isErrno`; it deliberately does not use `isMissingPathError` because that helper groups `ENOENT` with `ENOTDIR`, which would flatten a parent file into a missing-directory answer.

## User Impact

Operators can point `--output` under a missing writable directory and have the directory created automatically. If the requested parent cannot be used, text and JSON modes preserve their existing shapes and exit codes while returning a path-specific next step. Default output hides internal errno/syscall text; `OPENCLAW_DEBUG=1` reveals the original filesystem cause and stack for diagnosis.

After:

```text
$ openclaw backup create --only-config --output <scratch>/missing/text/backup.tar.gz
Backup archive: <scratch>/missing/text/backup.tar.gz
Included 1 path:
- config: <scratch>/state/openclaw.json
Created <scratch>/missing/text/backup.tar.gz
[exit 0; stderr empty]

$ openclaw backup create --only-config --output <scratch>/parent-file/backup.tar.gz
Backup archive creation failed: <scratch>/parent-file/backup.tar.gz. Backup output parent is not a directory: <scratch>/parent-file. Choose a directory path and run `openclaw backup create --output <archive>` again.
[exit 1; stdout empty]

$ openclaw backup create --only-config --output <scratch>/read-only/backup.tar.gz
Backup archive creation failed: <scratch>/read-only/backup.tar.gz. Backup output directory is not writable: <scratch>/read-only. Check the path and directory permissions, then run `openclaw backup create --output <archive>` again.
[exit 1; stdout empty]
```

The matching `--json` missing-parent run retained the successful `BackupCreateResult` object. Both failure runs retained the existing `{ "ok": false, "error": { "type": "cli_error", "message": ... } }` shape. Without debug, no raw syscall or errno code appeared. With `OPENCLAW_DEBUG=1`, text and JSON both retained the same domain sentence and appended the original `EEXIST ... mkdir` or `EACCES ... mkdtemp` cause; JSON mode also emitted the existing debug stack on stderr.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/commands/backup.test.ts` failed with raw `ENOTDIR ... mkdir` / `ENOTDIR ... access` output before the owner repair.
- Focused final proof: `node scripts/run-vitest.mjs src/commands/backup.test.ts src/commands/backup.atomic.test.ts src/commands/backup.create-verify.test.ts src/cli/failure-output.test.ts src/cli/cli-utils.test.ts` — 5 files, 84 tests passed across 3 shards.
- Changed gate: `node scripts/check-changed.mjs` — passed core production/test types, changed-file lint/format, architecture, dead-code, database-first, dependency, and repository ratchets on [Testbox run 31979131133](https://github.com/openclaw/openclaw/actions/runs/31979131133).
- Build: `pnpm build` — passed on [Testbox run 31978872441](https://github.com/openclaw/openclaw/actions/runs/31978872441).
- Built CLI: isolated `OPENCLAW_STATE_DIR`, explicit `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_SKIP_CHANNELS=1`; stdout/stderr captured separately for missing parent, parent-as-file, and read-only parent, in text and `--json` modes, both with and without `OPENCLAW_DEBUG=1`. All 12 cases matched the contract, including clean defaults and visible debug causes.
- Dry-run ordering: `assertOutputPathReady` is back at its original `if (!opts.dryRun)` position. The temporary moved position had the same invocation set and only result construction between them, but restoring it preserves established overwrite-error precedence and minimizes the diff.
- Source-blind behavior contract: pass for recursive provisioning, distinct actionable failures, unchanged JSON schemas/exit codes, clean default output, and debug-only errno/syscall detail.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- LOC: production `+77/-12` (net `+65`); tests `+80/-0`. Production growth is the explicit output-owner error contract across preparation, staging, write, and publication phases; tests cover provisioned parents, distinct `ENOENT`/`EACCES`/`ENOSPC`/parent-file behavior, the generic `EIO` branch, and default-versus-debug rendering.
