### PR TITLE
fix(ui): drop the duplicate summary row from the transcript plan card

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -73,6 +73,7 @@ const NARRATION_DEMO_SESSION_KEY = "agent:main:sidebar-narration-demo";
 const NARRATION_DEMO_RUN_ID = "mock-sidebar-narration-run";
 const OBSERVER_DEMO_SESSION_KEY = "agent:main:session-observer-demo";
 const OBSERVER_DEMO_RUN_ID = "mock-session-observer-run";
+const PLAN_DEMO_RUN_ID = "mock-plan-run";
 const CUSTODIAN_CHAT_REPLY_DELAY_MS = 600;
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -1295,7 +1296,9 @@ async function createChatPickerScenario(
       : [];
   const sessions = [
     sessionRow("agent:main:main", "Molty", baseTime - 1_000, {
+      activeRunIds: [PLAN_DEMO_RUN_ID],
       childSessions: ["agent:main:lisbon-trip", ...swarmChildRows.map((row) => row.key)],
+      hasActiveRun: true,
     }),
     ...swarmChildRows,
     sessionRow(OBSERVER_DEMO_SESSION_KEY, "Session observer demo", baseTime - 3_000, {
@@ -1477,6 +1480,7 @@ async function createChatPickerScenario(
     // gate the chat header's panel toggles, which stayed invisible here.
     featureMethods: [
       "browser.request",
+      "chat.abort",
       "chat.metadata",
       "chat.startup",
       "question.list",
@@ -1503,6 +1507,20 @@ async function createChatPickerScenario(
     // ui/src/lib/terminal-availability.ts).
     terminalEnabled: true,
     historyMessages: buildScrollableChatHistory(baseTime),
+    inFlightRun: {
+      runId: PLAN_DEMO_RUN_ID,
+      text: "",
+      plan: {
+        explanation: "Keep the Control UI change focused",
+        steps: [
+          { step: "Inspect the transcript renderer", status: "completed" },
+          { step: "Confirm the plan event contract", status: "completed" },
+          { step: "Remove the duplicate card summary", status: "in_progress" },
+          { step: "Run focused UI tests", status: "pending" },
+          { step: "Capture browser proof", status: "pending" },
+        ],
+      },
+    },
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.
     presenceUsers: [
@@ -2316,6 +2334,11 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
+    sessionInfo: {
+      activeRunIds: [PLAN_DEMO_RUN_ID],
+      hasActiveRun: true,
+      key: "agent:main:main",
+    },
     sessionKey: "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,

--- a/ui/src/pages/chat/components/chat-plan-checklist.test.ts
+++ b/ui/src/pages/chat/components/chat-plan-checklist.test.ts
@@ -14,9 +14,13 @@ const planStatus: PlanStatus = {
   ],
 };
 
-function renderChecklist(status: PlanStatus | null, active: boolean) {
+function renderChecklist(
+  status: PlanStatus | null,
+  active: boolean,
+  variant: "bar" | "card" = "card",
+) {
   const container = document.createElement("div");
-  render(renderChatPlanChecklist(status, { active, variant: "card" }), container);
+  render(renderChatPlanChecklist(status, { active, variant }), container);
   return container;
 }
 
@@ -27,8 +31,9 @@ describe("renderChatPlanChecklist", () => {
 
     expect(card).not.toBeNull();
     expect(card).not.toBeInstanceOf(HTMLDetailsElement);
-    expect(card?.querySelector(".plan-checklist__current")?.textContent).toBe("Wire the checklist");
-    expect(card?.querySelector(".plan-checklist__count")?.textContent).toBe("1/3");
+    expect(card?.getAttribute("aria-label")).toBe("Plan: 1 of 3 completed");
+    expect(card?.querySelector(".plan-checklist__summary")).toBeNull();
+    expect(card?.querySelector(".plan-checklist__count")).toBeNull();
     expect(card?.querySelector(".plan-checklist__explanation")?.textContent).toBe(
       "Keep the change focused",
     );
@@ -42,6 +47,15 @@ describe("renderChatPlanChecklist", () => {
       { label: "Wire the checklist, in progress", status: "plan-checklist__step--in_progress" },
       { label: "Run focused tests, pending", status: "plan-checklist__step--pending" },
     ]);
+  });
+
+  it("renders the bar as details with the current step summary and count", () => {
+    const container = renderChecklist(planStatus, true, "bar");
+    const bar = container.querySelector(".plan-checklist--bar");
+
+    expect(bar).toBeInstanceOf(HTMLDetailsElement);
+    expect(bar?.querySelector(".plan-checklist__current")?.textContent).toBe("Wire the checklist");
+    expect(bar?.querySelector(".plan-checklist__count")?.textContent).toBe("1/3");
   });
 
   it("hides the checklist without a plan or active run", () => {

--- a/ui/src/pages/chat/components/chat-plan-checklist.ts
+++ b/ui/src/pages/chat/components/chat-plan-checklist.ts
@@ -50,6 +50,16 @@ export function renderChatPlanChecklist(
     return nothing;
   }
   const completed = status.steps.filter((step) => step.status === "completed").length;
+  if (options.variant === "card") {
+    return html`
+      <section
+        class="plan-checklist plan-checklist--card"
+        aria-label=${`Plan: ${completed} of ${status.steps.length} completed`}
+      >
+        ${renderPlanChecklistBody(status)}
+      </section>
+    `;
+  }
   let current = status.steps.find((step) => step.status === "in_progress");
   if (!current) {
     for (let index = status.steps.length - 1; index >= 0; index -= 1) {
@@ -70,20 +80,10 @@ export function renderChatPlanChecklist(
     <span class="plan-checklist__current">${current.step}</span>
     <span class="plan-checklist__count">${completed}/${status.steps.length}</span>
   `;
-  const body = renderPlanChecklistBody(status);
-
-  if (options.variant === "card") {
-    return html`
-      <section class="plan-checklist plan-checklist--card" aria-label=${label}>
-        <div class="plan-checklist__summary">${summary}</div>
-        ${body}
-      </section>
-    `;
-  }
   return html`
     <details class="plan-checklist plan-checklist--bar">
       <summary class="plan-checklist__summary" aria-label=${label}>${summary}</summary>
-      ${body}
+      ${renderPlanChecklistBody(status)}
     </details>
   `;
 }

--- a/ui/src/styles/chat/plan-checklist.css
+++ b/ui/src/styles/chat/plan-checklist.css
@@ -19,13 +19,9 @@
   background: color-mix(in srgb, var(--card, var(--bg)) 55%, transparent);
 }
 
-.plan-checklist--card .plan-checklist__summary {
-  cursor: default;
-  user-select: text;
-}
-
 .plan-checklist--card .plan-checklist__body {
-  border-top-color: color-mix(in srgb, var(--border) 62%, transparent);
+  padding: 10px 11px 11px;
+  border-top: 0;
 }
 
 .agent-chat__composer-status-stack:has(.plan-checklist) {


### PR DESCRIPTION
## What Problem This Solves

The transcript plan card showed the current task twice: its summary row (current step + `n/m` counter) sat directly above the full step list, which repeats the same step with a `▸` marker. During an active run the current step was on screen three times (composer bar summary, card summary, card list row).

## Why This Change Was Made

The card and the sticky composer bar share one renderer, and the card inherited the bar's summary row even though it never collapses (the summary is a `<details>` affordance the card had to neutralize with `cursor: default` CSS). Survey of sibling products (Claude Code terminal, VS Code Copilot todos, Codex CLI plan cells): nobody stacks a current-task header on an expanded list that repeats it. The card's job is scroll-context — the list *is* the context; the collapsed-summary job already belongs to the composer bar.

The card variant now renders the step list only (explanation + steps, `✓`/`▸`/`▢` markers, no strikethrough). The `n/m` progress stays available on the card via `aria-label` and visibly in the composer bar. Bar variant unchanged. Dead card-summary CSS deleted; the card body carries its own padding with no divider. The mock dev scenario gains an active five-step plan fixture (plus `chat.abort` capability) so the plan surfaces render there — used for the proof below and available for future captures.

## User Impact

Cleaner transcript: each plan step appears exactly once in the card; the current step is bold with an accent `▸`. No behavior change to the composer bar.

Production LOC: net −4 (ui: +13/−17). Tests +18/−4; mock tooling +23.

## Evidence

Before / after (transcript card):

![before](https://github.com/user-attachments/assets/b0dcab8a-fe6d-4c57-a1ff-af98ae1efbdc)
![after](https://github.com/user-attachments/assets/3896952b-2abf-4aae-b5ca-d36f71a2a3d3)

Composer bar unchanged (collapsed / expanded):

![bar collapsed](https://github.com/user-attachments/assets/b4868e11-edfd-4a25-962c-672d3918d758)
![bar expanded](https://github.com/user-attachments/assets/2142f101-150a-4163-a6eb-9c25651e2b14)

Interaction videos (mocked dev server, Playwright):

before:

https://github.com/user-attachments/assets/f126556e-0a80-497c-9351-7c14f4e44450

after:

https://github.com/user-attachments/assets/bd4f017f-32f3-43c1-8529-c5e49e0f8e3e

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-plan-checklist.test.ts` — 3 passed; checklist/composer/thread/message suites 385 passed; plan reconnect e2e 3 passed.
- Regression check: updated card test fails on pre-fix code (duplicated summary present).
- `node scripts/check-changed.mjs` passed; dead-CSS audit shows only pre-existing unrelated findings; Codex autoreview clean.
