### PR TITLE
fix(sessions): report self-archive before stopping the turn

### DIFF
--- a/src/agents/tools/sessions-tool.self-archive.test.ts
+++ b/src/agents/tools/sessions-tool.self-archive.test.ts
@@ -10,6 +10,81 @@ import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { createSessionsTool } from "./sessions-tool.js";
 
 describe("sessions tool self-archive", () => {
+  it("returns success before a detached dynamic-tool self-archive commits", async () => {
+    await withTestDir({ prefix: "openclaw-sessions-tool-detached-archive-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:detached-self-archive";
+      const sessionId = "session-detached-self-archive";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const runAbort = new AbortController();
+      const callGateway = vi.fn(async () => {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey, storePath },
+          { sessionId, updatedAt: 2, archivedAt: Date.now() },
+        );
+        runAbort.abort(new Error("archive stopped the active turn"));
+        return { ok: true };
+      });
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        agentSessionId: sessionId,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        const projected = await Promise.race([
+          tool.execute("archive-current", { action: "patch", archived: true }).then((result) => ({
+            success: true as const,
+            result,
+          })),
+          new Promise<{ success: false }>((resolve) => {
+            runAbort.signal.addEventListener("abort", () => resolve({ success: false }), {
+              once: true,
+            });
+          }),
+        ]);
+
+        expect(projected.success).toBe(true);
+        if (projected.success) {
+          expect(projected.result.details).toMatchObject({
+            status: "scheduled",
+            sessionKey,
+          });
+        }
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(
+          "archivedAt",
+        );
+      } finally {
+        admission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledExactlyOnceWith({
+          method: "sessions.patch",
+          params: {
+            key: sessionKey,
+            archived: true,
+            expectedSessionId: sessionId,
+          },
+        });
+        expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toHaveProperty(
+          "archivedAt",
+        );
+      });
+    });
+  });
+
   it("defers self-archiving until the current agent turn has completed", async () => {
     await withTestDir({ prefix: "openclaw-sessions-tool-self-archive-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -18,10 +18,7 @@ import { boundedJsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { isTransientNetworkError } from "../../infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isIncognitoSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
-import {
-  getCurrentSessionWorkAdmissionRelease,
-  getSessionWorkAdmissionRelease,
-} from "../../sessions/session-lifecycle-admission.js";
+import { getSessionWorkAdmissionRelease } from "../../sessions/session-lifecycle-admission.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
@@ -468,7 +465,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
         if (key !== resolveAgentMainSessionKey({ cfg, agentId })) {
           const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
           const currentEntry = loadSessionEntry({ agentId, sessionKey: key, storePath });
-          const released = getCurrentSessionWorkAdmissionRelease({
+          const released = getSessionWorkAdmissionRelease({
             scope: storePath,
             identities: [key, currentEntry?.sessionId],
           });

--- a/src/sessions/session-lifecycle-admission.test.ts
+++ b/src/sessions/session-lifecycle-admission.test.ts
@@ -13,7 +13,6 @@ import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
   consumeSessionWorkAdmissionHandoff,
-  getCurrentSessionWorkAdmissionRelease,
   getActiveSessionLifecycleMutationCount,
   getActiveSessionWorkAdmissionCount,
   getSessionWorkAdmissionRelease,
@@ -38,95 +37,6 @@ it("counts one multi-identity admission once", async () => {
   expect(getActiveSessionWorkAdmissionCount()).toBe(0);
 });
 
-it("exposes completion only to the matching admitted session turn", async () => {
-  const scope = "store-self-archive-release";
-  const sessionKey = "agent:main:self-archive";
-  const sessionId = "session-self-archive";
-  const admission = await beginSessionWorkAdmission({
-    scope,
-    identities: [sessionKey, sessionId],
-    assertAllowed: () => {},
-  });
-  let settled = false;
-  let release: Promise<void> | undefined;
-
-  try {
-    expect(
-      getCurrentSessionWorkAdmissionRelease({ scope, identities: [sessionKey] }),
-    ).toBeUndefined();
-
-    await admission.run(async () => {
-      expect(
-        getCurrentSessionWorkAdmissionRelease({ scope, identities: ["agent:main:other"] }),
-      ).toBeUndefined();
-      release = getCurrentSessionWorkAdmissionRelease({
-        scope,
-        identities: [sessionKey, sessionId],
-      });
-      expect(release).toBeInstanceOf(Promise);
-      void release?.then(() => {
-        settled = true;
-      });
-      await Promise.resolve();
-      expect(settled).toBe(false);
-    });
-
-    expect(settled).toBe(false);
-  } finally {
-    admission.release();
-  }
-
-  await release;
-  await Promise.resolve();
-  expect(settled).toBe(true);
-});
-
-it("waits for every nested admission that owns the same session", async () => {
-  const scope = "store-self-archive-nested";
-  const sessionKey = "agent:main:nested-self-archive";
-  const outerAdmission = await beginSessionWorkAdmission({
-    scope,
-    identities: [sessionKey, "outer-session"],
-    assertAllowed: () => {},
-  });
-  let release: Promise<void> | undefined;
-  let settled = false;
-
-  try {
-    await outerAdmission.run(async () => {
-      const innerAdmission = await beginSessionWorkAdmission({
-        scope,
-        identities: [sessionKey, "inner-session"],
-        assertAllowed: () => {},
-      });
-
-      try {
-        await innerAdmission.run(async () => {
-          release = getCurrentSessionWorkAdmissionRelease({
-            scope,
-            identities: [sessionKey],
-          });
-          void release?.then(() => {
-            settled = true;
-          });
-        });
-      } finally {
-        innerAdmission.release();
-      }
-
-      await Promise.resolve();
-      expect(settled).toBe(false);
-    });
-    expect(settled).toBe(false);
-  } finally {
-    outerAdmission.release();
-  }
-
-  await release;
-  await Promise.resolve();
-  expect(settled).toBe(true);
-});
-
 it("waits for a competing session admission outside the caller context", async () => {
   const scope = "store-competing-self-archive";
   const sessionKey = "agent:main:competing-self-archive";
@@ -139,9 +49,6 @@ it("waits for a competing session admission outside the caller context", async (
   let release: Promise<void> | undefined;
 
   try {
-    expect(
-      getCurrentSessionWorkAdmissionRelease({ scope, identities: [sessionKey] }),
-    ).toBeUndefined();
     release = getSessionWorkAdmissionRelease({ scope, identities: [sessionKey] });
     expect(release).toBeInstanceOf(Promise);
     void release?.then(() => {

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -356,16 +356,14 @@ type SessionWorkAdmissionReleaseParams = {
   identities: Iterable<string | undefined>;
 };
 
-function resolveSessionWorkAdmissionRelease(
+/** Completion of the currently active turns that own a session. */
+export function getSessionWorkAdmissionRelease(
   params: SessionWorkAdmissionReleaseParams,
-  ownedAdmissions?: ReadonlySet<SessionWorkAdmission>,
 ): Promise<void> | undefined {
   const matchingAdmissions = new Set<SessionWorkAdmission>();
   for (const identity of normalizeSessionIdentities(params.scope, params.identities)) {
     for (const admission of ACTIVE_SESSION_WORK_ADMISSIONS.get(identity) ?? []) {
-      if (!ownedAdmissions || ownedAdmissions.has(admission)) {
-        matchingAdmissions.add(admission);
-      }
+      matchingAdmissions.add(admission);
     }
   }
   if (matchingAdmissions.size === 0) {
@@ -377,24 +375,6 @@ function resolveSessionWorkAdmissionRelease(
   return Promise.all(Array.from(matchingAdmissions, (admission) => admission.released)).then(
     () => undefined,
   );
-}
-
-/** Completion of this caller's admitted turn for the requested session identities. */
-export function getCurrentSessionWorkAdmissionRelease(
-  params: SessionWorkAdmissionReleaseParams,
-): Promise<void> | undefined {
-  const currentAdmissions = CURRENT_SESSION_WORK_ADMISSIONS.getStore();
-  if (!currentAdmissions?.size) {
-    return undefined;
-  }
-  return resolveSessionWorkAdmissionRelease(params, currentAdmissions);
-}
-
-/** Completion of the currently active turns that own a session. */
-export function getSessionWorkAdmissionRelease(
-  params: SessionWorkAdmissionReleaseParams,
-): Promise<void> | undefined {
-  return resolveSessionWorkAdmissionRelease(params);
 }
 
 /** Active session identities for one store/lifecycle scope. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where asking an active coding session to archive itself could successfully archive the session while its Session Settings tool card reported “failed.” The archive stopped the active turn before the successful tool result reached the transcript, leaving operators with a false failure after a committed action.

## Why This Change Was Made

Self-archive now finds the authoritative active admissions for the exact session without relying on the dynamic tool callback’s async-local context. It returns a scheduled success first and commits the archive only after the active turn releases. The obsolete current-context-only release helper is removed so there is one canonical admission-completion path.

## User Impact

Archiving the current session now has a truthful outcome: the tool reports that archive is scheduled, the current turn finishes, and the session is then archived. Users no longer see an aborted/failed tool result for an archive that actually succeeded.

## Evidence

- Pre-fix regression: `sessions-tool.self-archive.test.ts` failed 1/10 because the archive-triggered abort won after persistence.
- Owner-boundary regression and lifecycle tests: 40/40 passed.
- Codex dynamic-tool abort/projection tests: 44/44 passed.
- Formatting and `git diff --check`: passed.
- Production typecheck and all changed-file guards through the core-test typecheck stage: passed; one pre-PR remote core-test typecheck process exited without a diagnostic, so exact-head hosted CI remains the merge authority.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +5/-28 (net -23). Tests: +75/-93 (net -18).

Visual proof is not attached because the available before capture contains private session metadata. This repair changes lifecycle sequencing rather than UI rendering; the regression test preserves the original operator-visible failure order.

AI-assisted: yes. The implementation and proof were reviewed against the affected session lifecycle, Gateway archive, Control UI projection, and upstream Codex dynamic-tool response contracts.
