### PR TITLE
fix(ci): derive plugin SDK boundary cache inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2414,6 +2414,15 @@ jobs:
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
           use-actions-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
 
+      - name: Compute extension boundary input fingerprint
+        id: extension-boundary-inputs
+        if: matrix.task == 'lint'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fingerprint="$(node --import tsx scripts/prepare-extension-package-boundary-artifacts.mts --print-input-fingerprint)"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
       - name: Cache extension package boundary artifacts for hosted lint
         if: matrix.task == 'lint' && (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid')
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -2423,9 +2432,9 @@ jobs:
             packages/plugin-sdk/dist
             extensions/*/dist/.boundary-tsc.tsbuildinfo
             extensions/*/dist/.boundary-tsc.stamp
-          key: ${{ runner.os }}-extension-package-boundary-v1-${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'packages/llm-core/package.json', 'packages/model-catalog-core/package.json', 'scripts/check-extension-package-tsc-boundary.mts', 'scripts/prepare-extension-package-boundary-artifacts.mts', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mts', 'src/plugin-sdk/**', 'src/agents/embedded-agent-runner/run/types.ts', 'src/plugins/types.ts', 'src/auto-reply/**', 'packages/llm-core/src/**', 'packages/model-catalog-core/src/**', 'src/video-generation/dashscope-compatible.ts', 'src/video-generation/types.ts', 'src/types/**', 'extensions/**', 'extensions/tsconfig.package-boundary*.json', 'package.json', 'pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-extension-package-boundary-v2-${{ steps.extension-boundary-inputs.outputs.fingerprint }}
           restore-keys: |
-            ${{ runner.os }}-extension-package-boundary-v1-
+            ${{ runner.os }}-extension-package-boundary-v2-
 
       # check-lint's shard runner rebuilds the same plugin-sdk boundary
       # artifacts the boundary lane snapshots (~72s cold); restore them from
@@ -2447,10 +2456,6 @@ jobs:
       - name: Restore extension boundary artifacts from sticky disk
         if: matrix.task == 'lint' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
         shell: bash
-        env:
-          # Config/toolchain inputs the tree-OID gate below cannot see; must
-          # stay identical to the boundary lane's fingerprint composition.
-          BOUNDARY_CONFIG_HASH: ${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mts', 'scripts/prepare-extension-package-boundary-artifacts.mts', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mts', 'package.json', 'pnpm-lock.yaml') }}
         run: |
           set -euo pipefail
           sticky_root=/var/tmp/openclaw-ext-boundary
@@ -2458,11 +2463,10 @@ jobs:
             echo "boundary artifact snapshot not seeded yet; lint prepares cold"
             exit 0
           fi
-          # Same tree-OID gate as the boundary lane: restore only artifacts
-          # produced from identical generative sources, so stale snapshots can
-          # neither false-skip rebuilds nor leave ghost declarations.
-          current_trees="$({ git rev-parse HEAD:src/plugin-sdk HEAD:src/agents/embedded-agent-runner/run/types.ts HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; echo "$BOUNDARY_CONFIG_HASH"; })"
-          if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
+          # The same canonical fingerprint keys the hosted cache and boundary
+          # lane, so no consumer can restore a snapshot from stale SDK inputs.
+          current_fingerprint="${{ steps.extension-boundary-inputs.outputs.fingerprint }}"
+          if [ ! -f "$sticky_root/.source-fingerprint" ] || [ "$current_fingerprint" != "$(cat "$sticky_root/.source-fingerprint")" ]; then
             echo "boundary source trees changed since snapshot; lint prepares cold"
             exit 0
           fi
@@ -2853,6 +2857,15 @@ jobs:
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
           use-actions-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
 
+      - name: Compute extension boundary input fingerprint
+        id: extension-boundary-inputs
+        if: matrix.group == 'extension-package-boundary'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fingerprint="$(node --import tsx scripts/prepare-extension-package-boundary-artifacts.mts --print-input-fingerprint)"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
       # Same-repo runs carry boundary artifacts on a Blacksmith sticky disk:
       # the GitHub cache below is evicted so quickly under the repo quota that
       # its prefix restore never hits, leaving every run to rebuild ~113s of
@@ -2882,10 +2895,6 @@ jobs:
         id: boundary-sticky-restore
         if: matrix.group == 'extension-package-boundary' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
         shell: bash
-        env:
-          # Config/toolchain inputs the tree-OID gate below cannot see; must
-          # stay identical to the seed step and check-lint's restore gate.
-          BOUNDARY_CONFIG_HASH: ${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mts', 'scripts/prepare-extension-package-boundary-artifacts.mts', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mts', 'package.json', 'pnpm-lock.yaml') }}
         run: |
           set -euo pipefail
           sticky_root=/var/tmp/openclaw-ext-boundary
@@ -2893,15 +2902,13 @@ jobs:
             echo "restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Restore only when the generative source trees AND the runner
-          # toolchain match the snapshotting run. Tree OIDs cover source
-          # content exactly; the node/pnpm versions and the config hash cover
-          # toolchain/config/scripts/lockfile changes the OIDs cannot see.
+          # Restore only when the canonical generative-input fingerprint
+          # matches the snapshotting run.
           # Restored artifacts are valid by construction: no clock-skew mtime
           # race can false-skip a rebuild, and deleted/renamed sources or a
           # toolchain bump build cold.
-          current_trees="$({ git rev-parse HEAD:src/plugin-sdk HEAD:src/agents/embedded-agent-runner/run/types.ts HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; echo "$BOUNDARY_CONFIG_HASH"; })"
-          if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
+          current_fingerprint="${{ steps.extension-boundary-inputs.outputs.fingerprint }}"
+          if [ ! -f "$sticky_root/.source-fingerprint" ] || [ "$current_fingerprint" != "$(cat "$sticky_root/.source-fingerprint")" ]; then
             echo "boundary source trees changed since snapshot; building cold"
             echo "restored=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -2923,9 +2930,9 @@ jobs:
             packages/plugin-sdk/dist
             extensions/*/dist/.boundary-tsc.tsbuildinfo
             extensions/*/dist/.boundary-tsc.stamp
-          key: ${{ runner.os }}-extension-package-boundary-v1-${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'packages/llm-core/package.json', 'packages/model-catalog-core/package.json', 'scripts/check-extension-package-tsc-boundary.mts', 'scripts/prepare-extension-package-boundary-artifacts.mts', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mts', 'src/plugin-sdk/**', 'src/agents/embedded-agent-runner/run/types.ts', 'src/plugins/types.ts', 'src/auto-reply/**', 'packages/llm-core/src/**', 'packages/model-catalog-core/src/**', 'src/video-generation/dashscope-compatible.ts', 'src/video-generation/types.ts', 'src/types/**', 'extensions/**', 'extensions/tsconfig.package-boundary*.json', 'package.json', 'pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-extension-package-boundary-v2-${{ steps.extension-boundary-inputs.outputs.fingerprint }}
           restore-keys: |
-            ${{ runner.os }}-extension-package-boundary-v1-
+            ${{ runner.os }}-extension-package-boundary-v2-
 
       - name: Preserve extension package boundary cache hit
         if: matrix.group == 'extension-package-boundary' && steps.extension-package-boundary-cache.outputs.cache-hit == 'true'
@@ -2950,25 +2957,6 @@ jobs:
               -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.mts' -o -name '*.cts' -o -name '*.js' -o -name '*.mjs' -o -name '*.json' \) \
               -exec touch -t 200001010000 {} +
           fi
-          cache_inputs=(
-            tsconfig.json \
-            tsconfig.plugin-sdk.dts.json \
-            packages/plugin-sdk/tsconfig.json \
-            packages/llm-core/package.json \
-            packages/model-catalog-core/package.json \
-            scripts/check-extension-package-tsc-boundary.mts \
-            scripts/prepare-extension-package-boundary-artifacts.mts \
-            scripts/write-plugin-sdk-entry-dts.ts \
-            scripts/lib/plugin-sdk-entrypoints.json \
-            scripts/lib/plugin-sdk-entries.mts \
-            package.json \
-            pnpm-lock.yaml
-          )
-          for cache_input in "${cache_inputs[@]}"; do
-            if [ -e "$cache_input" ]; then
-              touch -t 200001010000 "$cache_input"
-            fi
-          done
 
       - name: Run additional check shard
         env:
@@ -3109,15 +3097,12 @@ jobs:
       - name: Seed extension boundary sticky disk
         if: success() && steps.boundary-sticky-restore.outputs.restored == 'false' && matrix.group == 'extension-package-boundary' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' && github.repository == 'openclaw/openclaw'
         shell: bash
-        env:
-          # Must stay identical to the restore gates above.
-          BOUNDARY_CONFIG_HASH: ${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mts', 'scripts/prepare-extension-package-boundary-artifacts.mts', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mts', 'package.json', 'pnpm-lock.yaml') }}
         run: |
           set -euo pipefail
           sticky_root=/var/tmp/openclaw-ext-boundary
           # A stale marker must not survive a mid-seed failure: drop readiness
           # first so a partial payload can never be restored as valid.
-          rm -rf "$sticky_root/.snapshot-ready" "$sticky_root/.source-trees" "$sticky_root/dist" "$sticky_root/packages" "$sticky_root/extensions"
+          rm -rf "$sticky_root/.snapshot-ready" "$sticky_root/.source-trees" "$sticky_root/.source-fingerprint" "$sticky_root/dist" "$sticky_root/packages" "$sticky_root/extensions"
           if [ -d dist/plugin-sdk ]; then
             rsync -aR dist/plugin-sdk "$sticky_root/"
           fi
@@ -3126,7 +3111,7 @@ jobs:
           fi
           find extensions -maxdepth 3 \( -name '.boundary-tsc.tsbuildinfo' -o -name '.boundary-tsc.stamp' \) \
             -exec rsync -aR {} "$sticky_root/" \;
-          { git rev-parse HEAD:src/plugin-sdk HEAD:src/agents/embedded-agent-runner/run/types.ts HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; echo "$BOUNDARY_CONFIG_HASH"; } > "$sticky_root/.source-trees"
+          echo "${{ steps.extension-boundary-inputs.outputs.fingerprint }}" > "$sticky_root/.source-fingerprint"
           touch "$sticky_root/.snapshot-ready"
 
   # Validate docs (format, lint, broken links) only when docs files changed.

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -31,7 +31,16 @@ import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const runTsgoScript = path.join(repoRoot, "scripts/run-tsgo.mjs");
-const TYPE_INPUT_EXTENSIONS = new Set([".ts", ".tsx", ".d.ts", ".js", ".mjs", ".json"]);
+const TYPE_INPUT_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+]);
 const VALID_MODES = new Set(["all", "package-boundary"]);
 const ROOT_BOUNDARY_TIMEOUT_MS = resolveBoundaryRootShimsTimeoutMs(process.env);
 const ROOT_SHIMS_MAX_OLD_SPACE_SIZE =
@@ -158,38 +167,91 @@ function listSourceDtsOutputs(sourceDir: string, outputPrefix: string) {
   return outputs.toSorted((a, b) => a.localeCompare(b));
 }
 
-const PLUGIN_SDK_TYPE_INPUTS = [
+type TypeScriptBuildInfo = {
+  fileNames?: unknown;
+  packageJsons?: unknown;
+};
+
+function collapsePluginSdkTypeInput(relativePath: string) {
+  const parts = relativePath.split("/");
+  if (parts[0] === "src" && parts.length > 2) {
+    return `src/${parts[1]}`;
+  }
+  if (parts[0] === "packages" && parts.length > 3) {
+    return `packages/${parts[1]}/${parts[2]}`;
+  }
+  if ((parts[0] === "scripts" || parts[0] === "test") && parts.length > 2) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return relativePath;
+}
+
+function derivePluginSdkTypeInputs(entries: string[], baseDir: string, rootDir: string) {
+  const inputs = new Set<string>();
+  for (const entry of entries) {
+    const relativePath = path.relative(rootDir, resolve(baseDir, entry)).replaceAll("\\", "/");
+    if (
+      relativePath.startsWith("../") ||
+      relativePath === ".." ||
+      relativePath.startsWith("node_modules/") ||
+      relativePath.includes("/node_modules/") ||
+      relativePath.startsWith("dist/") ||
+      relativePath.startsWith("packages/plugin-sdk/dist/")
+    ) {
+      continue;
+    }
+    inputs.add(collapsePluginSdkTypeInput(relativePath));
+  }
+  if (fs.existsSync(resolve(rootDir, "package.json"))) {
+    inputs.add("package.json");
+  }
+  for (const input of inputs) {
+    const packageName = input.match(/^packages\/([^/]+)\//u)?.[1];
+    if (packageName && fs.existsSync(resolve(rootDir, `packages/${packageName}/package.json`))) {
+      inputs.add(`packages/${packageName}/package.json`);
+    }
+  }
+  return [...inputs].toSorted((a, b) => a.localeCompare(b));
+}
+
+/** Derives repository-owned declaration inputs from TypeScript's build record. */
+export function derivePluginSdkTypeInputsFromBuildInfo(buildInfoPath: string, rootDir = repoRoot) {
+  const parsed = JSON.parse(fs.readFileSync(buildInfoPath, "utf8")) as TypeScriptBuildInfo;
+  const fileNames = Array.isArray(parsed.fileNames) ? parsed.fileNames : [];
+  const packageJsons = Array.isArray(parsed.packageJsons) ? parsed.packageJsons : [];
+  const buildInfoDir = path.dirname(buildInfoPath);
+  const entries = [...fileNames, ...packageJsons];
+  if (entries.some((entry) => typeof entry !== "string")) {
+    throw new Error(`Invalid TypeScript build input in ${buildInfoPath}`);
+  }
+  return derivePluginSdkTypeInputs(entries as string[], buildInfoDir, rootDir);
+}
+
+/** Resolves declaration inputs from build metadata or the compiler on cold cache. */
+export function resolvePluginSdkTypeInputs(rootDir = repoRoot) {
+  const buildInfoPath = resolve(rootDir, "dist/plugin-sdk/.tsbuildinfo");
+  if (fs.existsSync(buildInfoPath)) {
+    return derivePluginSdkTypeInputsFromBuildInfo(buildInfoPath, rootDir);
+  }
+  const tsgoPath = resolveRepoToolBinPath("tsgo");
+  ensureRepoToolNodeModulesLink(tsgoPath);
+  const result = spawnSync(
+    tsgoPath,
+    ["-p", "tsconfig.plugin-sdk.dts.json", "--listFilesOnly", "--noEmit"],
+    { cwd: rootDir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (result.status !== 0 || result.error) {
+    throw new Error(`Failed to derive plugin SDK type inputs: ${result.stderr || result.error}`);
+  }
+  return derivePluginSdkTypeInputs(result.stdout.trim().split("\n"), rootDir, rootDir);
+}
+
+// Compiler configuration is not part of .tsbuildinfo's file input record.
+const resolveDtsInputs = (configPath: string) => [
   "tsconfig.json",
-  "src/plugin-sdk",
-  // agent-harness-runtime projects the host-prepared attempt contract.
-  "src/agents/embedded-agent-runner/run/types.ts",
-  // provider-auth re-exports these signatures into generated SDK declarations.
-  "src/agents/cli-credentials.ts",
-  "src/plugins/provider-runtime-model.types.ts",
-  // session-catalog re-exports provider params into generated SDK declarations.
-  "src/plugins/session-catalog.ts",
-  "src/plugins/types.ts",
-  "src/auto-reply",
-  // doctor-repair-runtime re-exports the state migration contract into the SDK.
-  "src/state/openclaw-state-db.ts",
-  "src/state/openclaw-state-db-contract.ts",
-  "packages/ai/src",
-  "packages/llm-core/src",
-  "packages/markdown-core/src",
-  "packages/media-core/src",
-  "packages/model-catalog-core/src",
-  "packages/memory-host-sdk/src",
-  "packages/media-generation-core/src",
-  "packages/media-understanding-common/src",
-  "packages/normalization-core/src",
-  "packages/retry/src",
-  "packages/acp-core/src",
-  "packages/terminal-core/src",
-  "src/video-generation/dashscope-compatible.ts",
-  "src/video-generation/types.ts",
-  "src/types",
+  configPath,
+  ...resolvePluginSdkTypeInputs(),
 ];
-const ROOT_DTS_INPUTS = ["tsconfig.plugin-sdk.dts.json", ...PLUGIN_SDK_TYPE_INPUTS];
 const ROOT_DTS_STAMP = "dist/plugin-sdk/.boundary-dts.stamp";
 const ACP_CORE_REQUIRED_DTS_OUTPUTS = listPackageDtsOutputsFromExports(
   "acp-core",
@@ -264,7 +326,6 @@ const ROOT_DTS_REQUIRED_OUTPUTS = [
   "dist/plugin-sdk/provider-auth.d.ts",
   "dist/plugin-sdk/video-generation.d.ts",
 ];
-const PACKAGE_DTS_INPUTS = ["packages/plugin-sdk/tsconfig.json", ...PLUGIN_SDK_TYPE_INPUTS];
 const PACKAGE_DTS_STAMP = "packages/plugin-sdk/dist/.boundary-dts.stamp";
 const ACP_CORE_REQUIRED_PACKAGE_DTS_OUTPUTS = listPackageDtsOutputsFromExports(
   "acp-core",
@@ -446,6 +507,10 @@ function collectInputFiles(
       return;
     }
     if (fs.statSync(entryPath).isDirectory()) {
+      const basename = path.basename(entryPath);
+      if (basename === "dist" || basename === "node_modules") {
+        return;
+      }
       for (const child of fs.readdirSync(entryPath)) {
         visit(path.join(entryPath, child));
       }
@@ -506,6 +571,40 @@ export function computeArtifactInputsDigest(
     digest.update(digestInputFile(filePath));
     digest.update("\n");
   }
+  return digest.digest("hex");
+}
+
+// These affect artifact generation or plugin compilation but TypeScript does
+// not record them as declaration-program file inputs.
+const EXTENSION_BOUNDARY_NON_TYPE_INPUTS = [
+  "tsconfig.json",
+  "tsconfig.plugin-sdk.dts.json",
+  "packages/plugin-sdk/package.json",
+  "packages/plugin-sdk/tsconfig.json",
+  "scripts/check-extension-package-tsc-boundary.mts",
+  "scripts/prepare-extension-package-boundary-artifacts.mts",
+  "scripts/write-plugin-sdk-entry-dts.ts",
+  "scripts/lib/plugin-sdk-entrypoints.json",
+  "scripts/lib/plugin-sdk-entries.mts",
+  "scripts/lib/plugin-sdk-private-local-only-subpaths.json",
+  "pnpm-lock.yaml",
+];
+
+/** Computes the single content fingerprint used by every boundary artifact cache. */
+export function computeExtensionBoundaryInputsFingerprint(rootDir = repoRoot) {
+  const digest = createHash("sha256");
+  digest.update(
+    computeArtifactInputsDigest({
+      rootDir,
+      inputPaths: resolvePluginSdkTypeInputs(rootDir),
+      includeFile: isRelevantTypeInput,
+    }),
+  );
+  digest.update(computeArtifactInputsDigest({ rootDir, inputPaths: ["extensions"] }));
+  digest.update(
+    computeArtifactInputsDigest({ rootDir, inputPaths: EXTENSION_BOUNDARY_NON_TYPE_INPUTS }),
+  );
+  digest.update(`\nnode=${process.versions.node}\n`);
   return digest.digest("hex");
 }
 
@@ -905,18 +1004,28 @@ export async function runNodeSteps(steps: NodeStep[], env: NodeJS.ProcessEnv = p
 
 async function main(argv: string[] = process.argv.slice(2)) {
   try {
+    if (argv.includes("--print-input-fingerprint")) {
+      process.stdout.write(`${computeExtensionBoundaryInputsFingerprint()}\n`);
+      return;
+    }
     const mode = parseMode(argv);
+    const rootDtsInputs = resolveDtsInputs("tsconfig.plugin-sdk.dts.json");
+    const packageDtsInputs = resolveDtsInputs("packages/plugin-sdk/tsconfig.json");
     const rootDtsFresh =
       isArtifactSetFresh({
-        inputPaths: ROOT_DTS_INPUTS,
-        outputPaths: [ROOT_DTS_STAMP, ...ROOT_DTS_REQUIRED_OUTPUTS],
+        inputPaths: rootDtsInputs,
+        outputPaths: [ROOT_DTS_STAMP, "dist/plugin-sdk/.tsbuildinfo", ...ROOT_DTS_REQUIRED_OUTPUTS],
         hashStampPath: ROOT_DTS_STAMP,
         includeFile: isRelevantTypeInput,
       }) && !hasMissingOutput(ROOT_DTS_REQUIRED_OUTPUTS);
     const packageDtsFresh =
       isArtifactSetFresh({
-        inputPaths: PACKAGE_DTS_INPUTS,
-        outputPaths: [PACKAGE_DTS_STAMP, ...PACKAGE_DTS_REQUIRED_OUTPUTS],
+        inputPaths: packageDtsInputs,
+        outputPaths: [
+          PACKAGE_DTS_STAMP,
+          "packages/plugin-sdk/dist/.tsbuildinfo",
+          ...PACKAGE_DTS_REQUIRED_OUTPUTS,
+        ],
         hashStampPath: PACKAGE_DTS_STAMP,
         includeFile: isRelevantTypeInput,
       }) && !hasMissingOutput(PACKAGE_DTS_REQUIRED_OUTPUTS);
@@ -1003,7 +1112,7 @@ async function main(argv: string[] = process.argv.slice(2)) {
           timeoutMs: ROOT_BOUNDARY_TIMEOUT_MS,
           stamp: {
             path: ROOT_DTS_STAMP,
-            inputPaths: ROOT_DTS_INPUTS,
+            inputPaths: rootDtsInputs,
             includeFile: isRelevantTypeInput,
           },
         });
@@ -1022,7 +1131,7 @@ async function main(argv: string[] = process.argv.slice(2)) {
         timeoutMs: ROOT_BOUNDARY_TIMEOUT_MS,
         stamp: {
           path: PACKAGE_DTS_STAMP,
-          inputPaths: PACKAGE_DTS_INPUTS,
+          inputPaths: packageDtsInputs,
           includeFile: isRelevantTypeInput,
         },
       });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4373,7 +4373,25 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     );
     expect(hostedLintCache.uses).toBe("actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae");
     expect(hostedLintCache.with).toEqual(boundaryCache.with);
-    expect(boundaryCache.with.key).toContain("src/agents/embedded-agent-runner/run/types.ts");
+    const fingerprintReference = "${{ steps.extension-boundary-inputs.outputs.fingerprint }}";
+    expect(boundaryCache.with.key).toBe(
+      "${{ runner.os }}-extension-package-boundary-v2-${{ steps.extension-boundary-inputs.outputs.fingerprint }}",
+    );
+    const fingerprintSteps = [additionalJob, checkShardJob].map((job) =>
+      expectDefined(
+        job.steps.find(
+          (step: WorkflowStep) => step.name === "Compute extension boundary input fingerprint",
+        ),
+        "extension boundary input fingerprint step",
+      ),
+    );
+    for (const step of fingerprintSteps) {
+      expect(step.id).toBe("extension-boundary-inputs");
+      expect(step.run).toContain(
+        "scripts/prepare-extension-package-boundary-artifacts.mts --print-input-fingerprint",
+      );
+    }
+    expect(fingerprintSteps[0]?.run).toBe(fingerprintSteps[1]?.run);
     // Single semantic writer: protected pushes commit explicitly (not
     // on-change/if-missing, whose allocated-byte heuristic can strand a stale
     // marker); PR clones and the lint consumer stay read-only.
@@ -4382,8 +4400,8 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     );
     expect(lintMount.with.commit).toBe("false");
 
-    // The key no longer hashes config/scripts/lockfile, so every gate must
-    // compose the identical marker fingerprint or restores silently tear.
+    // Every cache and sticky-disk consumer uses the script-owned fingerprint;
+    // no workflow-local source list can drift from declaration freshness.
     const restoreStep = additionalJob.steps.find(
       (step: WorkflowStep) => step.name === "Restore extension boundary artifacts from sticky disk",
     );
@@ -4393,14 +4411,11 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     const seedStep = additionalJob.steps.find(
       (step: WorkflowStep) => step.name === "Seed extension boundary sticky disk",
     );
-    const configHash = seedStep.env.BOUNDARY_CONFIG_HASH;
-    expect(configHash).toContain("hashFiles(");
-    expect(configHash).toContain("pnpm-lock.yaml");
-    expect(restoreStep.env.BOUNDARY_CONFIG_HASH).toBe(configHash);
-    expect(lintRestoreStep.env.BOUNDARY_CONFIG_HASH).toBe(configHash);
     for (const gate of [restoreStep, lintRestoreStep, seedStep]) {
-      expect(gate.run).toContain('echo "$BOUNDARY_CONFIG_HASH"');
-      expect(gate.run).toContain("HEAD:src/agents/embedded-agent-runner/run/types.ts");
+      expect(gate.run).toContain(fingerprintReference);
+      expect(gate.run).toContain(".source-fingerprint");
+      expect(gate.run).not.toContain("git rev-parse HEAD:");
+      expect(gate.run).not.toContain("BOUNDARY_CONFIG_HASH");
       expect(gate.if).toContain("vars.OPENCLAW_CI_RUNNER_BACKEND != 'github'");
     }
     // Seeding is writer-only work: PR mounts never commit, so seeding there

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -16,6 +16,7 @@ import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.m
 import {
   computeArtifactInputsDigest,
   createPrefixedOutputWriter,
+  derivePluginSdkTypeInputsFromBuildInfo,
   isArtifactSetFresh,
   parseMode,
   resolveBoundaryEntryShimRequiredOutputs,
@@ -105,6 +106,40 @@ async function waitForProcessExit(
 }
 
 describe("prepare-extension-package-boundary-artifacts", () => {
+  it("derives the historical SDK cache misses from TypeScript build inputs", () => {
+    const rootDir = makeTempDir(tempRoots, "openclaw-plugin-sdk-inputs-");
+    const buildInfoPath = path.join(rootDir, "dist", "plugin-sdk", ".tsbuildinfo");
+    fs.mkdirSync(path.dirname(buildInfoPath), { recursive: true });
+    fs.writeFileSync(
+      buildInfoPath,
+      JSON.stringify({
+        fileNames: [
+          "../../src/plugin-sdk/provider-auth.ts",
+          "../../src/agents/cli-credentials.ts",
+          "../../src/plugins/session-catalog.ts",
+          "../../src/agents/embedded-agent-runner/run/types.ts",
+        ],
+        packageJsons: ["../../package.json"],
+      }),
+      "utf8",
+    );
+
+    const inputs = derivePluginSdkTypeInputsFromBuildInfo(buildInfoPath, rootDir);
+
+    for (const historicalMiss of [
+      "src/agents/cli-credentials.ts",
+      "src/plugins/session-catalog.ts",
+      "src/agents/embedded-agent-runner/run/types.ts",
+    ]) {
+      expect(
+        inputs.some((input) => historicalMiss === input || historicalMiss.startsWith(`${input}/`)),
+        historicalMiss,
+      ).toBe(true);
+      expect(inputs).not.toContain(historicalMiss);
+    }
+    expect(inputs).toContain("package.json");
+  });
+
   it("resolves the tsx loader from the selected checkout toolchain", () => {
     const tsxBinPath = "/primary/node_modules/.bin/tsx";
     const loaderPath = "/primary/node_modules/tsx/dist/loader.mjs";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the extension package-boundary lane could restore stale generated Plugin SDK declarations when a transitive core type changed outside its hand-maintained cache-input list. This caused both loud false failures and silent false passes against yesterday's SDK surface.

## Why This Change Was Made

The boundary preparation script now derives its declaration inputs from TypeScript's own `.tsbuildinfo` record, with `tsgo --listFilesOnly` as the cold-cache source of truth. Repository-owned inputs are tracked at owner-directory granularity so additions under tsconfig include globs, renames, deletions, imported dependencies, and package-resolution inputs cannot reuse stale declarations.

Both Actions-cache consumers and all three sticky-disk restore/seed paths now use one script-owned content fingerprint. The workflow guard verifies that every consumer references that fingerprint instead of maintaining another source list.

AI-assisted change; implementation and evidence were reviewed with the repository autoreview workflow.

## User Impact

No product behavior changes. Plugin and core developers get reliable package-boundary CI: relevant core type changes rebuild declarations, while unchanged inputs still reuse the cache.

## Evidence

Cache-bust measurement over the same 1,000 first-parent commits ending at `add30d455d038f1321ce1f6dc8d71cfb348cbecb`:

- Current hand list: 282 / 1,000 commits (28.2%).
- Directory-derived inputs: 675 / 1,000 (67.5%, 2.39x current).
- Experimental hybrid: 620 / 1,000 (62.0%, 2.20x current, only 8.1% fewer busts than directory-derived). The hybrid passed its probes but was rejected because that reduction did not justify 6,960 mixed-granularity inputs and added classification semantics.

Probe results:

- Warm `.tsbuildinfo` and cold `tsgo --listFilesOnly` derivation produced the identical fingerprint `4d01e0684b74eac5617049be09749e45221fed3fef3a8f24117d20eb415d8fb0`.
- A temporary change to previously uncovered `src/config/types.ts` changed the fingerprint to `08dfbcb9c2404438d5f6c66468b5ce10ef0d9b3e19e2f32a2bb9f0625e7f1e9d`, forced a 16.97-second declaration rebuild, and returned to `fresh; skipping` after removal.
- The discarded hybrid was adversarially checked for: a new include-glob root file, a new import-reached file (covered by its changed importer), rename, deletion, and a newly relevant `packageJsons` entry. All invalidated correctly; the hybrid was rejected on the cost/complexity gate, not correctness.
- The three historical misses are covered without production path literals: `src/agents/cli-credentials.ts`, `src/plugins/session-catalog.ts`, and `src/agents/embedded-agent-runner/run/types.ts`.

`pnpm check:changed` initially could not provision its remote fallback because Daytona returned `Total memory limit exceeded. Maximum allowed: 10GiB.` Trusted-source proof therefore used the repository's equivalent local wrappers:

- `pnpm format:check --no-error-on-unmatched-pattern -- .github/workflows/ci.yml scripts/prepare-extension-package-boundary-artifacts.mts test/scripts/ci-workflow-guards.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/prepare-extension-package-boundary-artifacts.mts` — passed.
- `pnpm check:workflows` — passed (zizmor and composite interpolation guard).
- `pnpm tsgo:scripts` — passed.
- `pnpm tsgo:test:root` — passed.
- `pnpm test test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 20 passed.
- `pnpm test test/scripts/ci-workflow-guards.test.ts` — 119 passed, 2 skipped.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

LOC split: runtime production `+0/-0`; CI/tooling `+179/-85` (net +94); tests `+60/-10` (net +50). The tooling growth replaces the manual input list and three duplicated workflow fingerprints with one derived owner.
