### PR TITLE
fix(ui): keep file links and text size stable when expanding messages

### DIFF
--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -234,12 +234,11 @@ export function renderUserMessageMarkdown(
 
   const disclosureId = `user-message:${messageKey}`;
   const expanded = opts.isUserMessageExpanded?.(disclosureId) ?? false;
+  const visibleMarkdown = expanded ? markdown : preview;
   return html`
     <div class="chat-message-disclosure ${expanded ? "is-expanded" : ""}">
       <div class="chat-message-disclosure__content">
-        ${expanded
-          ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
-          : html`<div class="chat-message-disclosure__preview">${preview}</div>`}
+        ${renderMarkdownText(visibleMarkdown, opts.isStreaming, markdownRenderOptions)}
       </div>
       <button
         class="chat-message-disclosure__toggle"

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -903,10 +903,16 @@ describe("grouped chat rendering", () => {
 
   it("collapses long user messages and toggles their disclosure state", () => {
     const container = document.createElement("div");
-    const markdownContent = Array.from({ length: 13 }, (_, index) => `Prompt line ${index}`).join(
-      "\n",
-    );
+    const collapsedLines = [
+      "Inspect AGENTS.md:188 first.",
+      ...Array.from({ length: 11 }, (_, index) => `Prompt line ${index}`),
+    ];
+    const expandedTail = "Full prompt tail after the disclosure boundary.";
+    const markdownContent = [...collapsedLines, expandedTail].join("\n");
     const onToggleUserMessageExpanded = vi.fn();
+    markdownRenderMock
+      .mockImplementationOnce(renderMarkdownHtml)
+      .mockImplementationOnce(renderMarkdownHtml);
 
     renderGroupedMessage(
       container,
@@ -920,10 +926,17 @@ describe("grouped chat rendering", () => {
 
     const disclosure = expectElement(container, ".chat-message-disclosure", HTMLDivElement);
     const toggle = expectElement(disclosure, ".chat-message-disclosure__toggle", HTMLButtonElement);
+    const collapsedText = expectElement(disclosure, ".chat-text", HTMLDivElement);
+    const collapsedFileLink = expectElement(
+      collapsedText,
+      "a.markdown-file-link",
+      HTMLAnchorElement,
+    );
     expect(disclosure.classList.contains("is-expanded")).toBe(false);
-    expect(
-      expectElement(disclosure, ".chat-message-disclosure__preview", HTMLDivElement).textContent,
-    ).toBe(Array.from({ length: 12 }, (_, index) => `Prompt line ${index}`).join("\n") + "…");
+    expect(collapsedText.textContent?.trim()).toBe(`${collapsedLines.join("\n")}…`);
+    expect(collapsedText.textContent).not.toContain(expandedTail);
+    expect(collapsedFileLink.dataset.filePath).toBe("AGENTS.md");
+    expect(collapsedFileLink.dataset.fileLine).toBe("188");
     expect(toggle.textContent?.trim()).toBe("Show more");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
@@ -946,8 +959,12 @@ describe("grouped chat rendering", () => {
       ".chat-message-disclosure__toggle",
       HTMLButtonElement,
     );
+    const expandedText = expectElement(expandedDisclosure, ".chat-text", HTMLDivElement);
+    const expandedFileLink = expectElement(expandedText, "a.markdown-file-link", HTMLAnchorElement);
     expect(expandedDisclosure.classList.contains("is-expanded")).toBe(true);
-    expect(expandedDisclosure.querySelector(".chat-message-disclosure__preview")).toBeNull();
+    expect(expandedText.textContent).toContain(expandedTail);
+    expect(expandedFileLink.dataset.filePath).toBe("AGENTS.md");
+    expect(expandedFileLink.dataset.fileLine).toBe("188");
     expect(collapseToggle.textContent?.trim()).toBe("Show less");
     expect(collapseToggle.getAttribute("aria-expanded")).toBe("true");
   });
@@ -963,9 +980,9 @@ describe("grouped chat rendering", () => {
       { onToggleUserMessageExpanded: vi.fn() },
     );
 
-    expect(
-      expectElement(container, ".chat-message-disclosure__preview", HTMLDivElement).textContent,
-    ).toBe(`${"a".repeat(699)}…`);
+    expect(expectElement(container, ".chat-text", HTMLDivElement).textContent?.trim()).toBe(
+      `${"a".repeat(699)}…`,
+    );
   });
 
   it("does not add prompt disclosure controls to short user or assistant messages", () => {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -26,10 +26,6 @@
   word-break: break-word;
 }
 
-.chat-message-disclosure__preview {
-  white-space: pre-wrap;
-}
-
 .chat-message-disclosure__toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where expanding a long user message changed its text size and only then converted workspace file references into links. The collapsed and expanded states did not present the same message consistently.

## Why This Change Was Made

The disclosure now decides only whether to show the bounded preview or the full message, then routes either string through the same canonical Markdown renderer. This removes the duplicate plain-text presentation path while preserving the 12-line/700-character collapsed-rendering bound, so the hidden tail is still not parsed or rendered.

## User Impact

Long messages keep stable typography and workspace-file affordances when users select **Show more** or **Show less**. References such as `AGENTS.md:188` are interactive in both states rather than appearing only after expansion.

## Evidence

- Regression proof failed before the fix because collapsed content had no canonical `.chat-text` renderer, then passed after the refactor.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts`: 185 passed.
- Targeted oxlint and stylelint passed; formatting and `git diff --check` passed.
- Structured autoreview: no accepted/actionable findings.
- Production LOC: +2/-7 (net -5). Tests: +27/-10.
- Source-blind mocked-Gateway browser validation at 1700×900 covered collapsed, expanded, collapsed-again, reload, and a short-message control.

### Before

Collapsed content inherited 15px/23.25px body typography and had no file link; expanding switched to 14px/21px Markdown typography and linked the file reference.

| Collapsed | Expanded |
| --- | --- |
| ![Before: collapsed message without the file link](https://github.com/user-attachments/assets/abd6bf43-4e6e-4f4e-8a29-a13258d05e60) | ![Before: expanded message with smaller text and file link](https://github.com/user-attachments/assets/9fdede53-6b15-47f4-9f09-f909d4ce8625) |

### After

Both states use 14px/21px canonical chat typography and preserve the same file-link metadata.

| Collapsed | Expanded |
| --- | --- |
| ![After: collapsed message with stable typography and file link](https://github.com/user-attachments/assets/d8e25412-214f-49d5-98e9-7e885e4fb2b6) | ![After: expanded message with matching typography and file link](https://github.com/user-attachments/assets/66f39556-92e3-4181-ab6f-1ad265c1489b) |

AI-assisted; the implementation was manually reviewed and independently behavior-validated.
