### PR TITLE
fix(ui): add spacing between suggested task actions

### DIFF
--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -37,6 +37,7 @@ suite.define(() => {
   });
 
   it("starts a model-suggested follow-up in a fresh worktree session", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -83,6 +84,16 @@ suite.define(() => {
       await startButton.waitFor({ state: "visible", timeout: 10_000 });
       const moreActions = page.getByRole("button", { name: "More ways to start this task" });
       expect(await moreActions.count()).toBe(1);
+      if (artifactDir) {
+        await page.locator('.task-suggestion[data-task-id="task_123"]').screenshot({
+          path: `${artifactDir}/task-card-button-spacing.png`,
+        });
+      }
+      const startBox = await startButton.boundingBox();
+      const moreActionsBox = await moreActions.boundingBox();
+      expect(startBox).not.toBeNull();
+      expect(moreActionsBox).not.toBeNull();
+      expect(moreActionsBox!.x - (startBox!.x + startBox!.width)).toBeGreaterThanOrEqual(4);
       await moreActions.click();
       await page
         .getByText("Copy prompt", { exact: true })

--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -37,7 +37,6 @@ suite.define(() => {
   });
 
   it("starts a model-suggested follow-up in a fresh worktree session", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -84,16 +83,15 @@ suite.define(() => {
       await startButton.waitFor({ state: "visible", timeout: 10_000 });
       const moreActions = page.getByRole("button", { name: "More ways to start this task" });
       expect(await moreActions.count()).toBe(1);
-      if (artifactDir) {
-        await page.locator('.task-suggestion[data-task-id="task_123"]').screenshot({
-          path: `${artifactDir}/task-card-button-spacing.png`,
-        });
-      }
-      const startBox = await startButton.boundingBox();
-      const moreActionsBox = await moreActions.boundingBox();
+      const [startBox, moreActionsBox] = await Promise.all([
+        startButton.boundingBox(),
+        moreActions.boundingBox(),
+      ]);
       expect(startBox).not.toBeNull();
       expect(moreActionsBox).not.toBeNull();
-      expect(moreActionsBox!.x - (startBox!.x + startBox!.width)).toBeGreaterThanOrEqual(4);
+      expect(
+        (moreActionsBox?.x ?? 0) - ((startBox?.x ?? 0) + (startBox?.width ?? 0)),
+      ).toBeGreaterThanOrEqual(4);
       await moreActions.click();
       await page
         .getByText("Copy prompt", { exact: true })

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1872,11 +1872,12 @@ button.chat-reply-preview--message:disabled {
   justify-self: end;
 }
 
-/* Compact split control pinned to the card's top-right; both halves share one
-   fixed height so the chevron cap can never overhang the primary segment. */
+/* Paired actions stay pinned to the card's top-right and share one fixed height
+   while remaining visibly separate, independently rounded controls. */
 .task-suggestion__split {
   display: inline-flex;
   align-items: stretch;
+  gap: 4px;
   height: 26px;
 }
 
@@ -1886,14 +1887,10 @@ button.chat-reply-preview--message:disabled {
   gap: 5px;
   height: 26px;
   padding: 0 10px;
-  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  border-radius: var(--radius-md);
   font-size: 12px;
   line-height: 1;
   white-space: nowrap;
-}
-
-.task-suggestion__start:only-child {
-  border-radius: var(--radius-md);
 }
 
 .task-suggestion__start svg {
@@ -1906,10 +1903,9 @@ button.chat-reply-preview--message:disabled {
   width: 26px;
   min-width: 26px;
   height: 26px;
-  margin-left: -1px;
   padding: 0;
   place-items: center;
-  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  border-radius: var(--radius-md);
 }
 
 .task-suggestion__menu-trigger svg {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a suggested task card would see the primary start action and its dropdown trigger overlap with no visible spacing.

## Why This Change Was Made

The card now renders the two actions as independently rounded controls with a 4px gap while preserving their shared height and existing interactions. A browser-level geometry assertion protects the visible separation.

## User Impact

Suggested task cards now have clearer, easier-to-distinguish action buttons without changing how tasks are started or how alternate actions are opened.

## Evidence

**Before**

![Suggested task actions touching](https://github.com/user-attachments/assets/e41bdf1b-941c-487a-8aa5-c949445ebaa3)

**After**

![Suggested task actions separated](https://github.com/user-attachments/assets/2f821e50-2dea-4cbc-b5db-f24f02ee9748)

- Browser regression: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.follow-ups.e2e.test.ts -t "starts a model-suggested follow-up in a fresh worktree session"` (1 passed; assertion failed before at -1px and passes after at >=4px)
- Component behavior: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-task-suggestions.test.ts` (9 passed)
- Styles: `pnpm lint:ui:styles -- ui/src/styles/chat/layout.css` (passed)
- Bundle: `pnpm ui:build` (passed)
- Review: mandatory autoreview clean; source-blind behavior validation passed all four clauses
- Changed gate: all early checks passed; the delegated 4GB remote host then exited the broad core-test typecheck without a compiler diagnostic ([run](https://crabbox.openclaw.ai/portal/runs/run_afae556ebc38)). Exact-head PR CI remains the authoritative full gate.

AI-assisted; the maintainer reviewed the complete diff and behavior proof.
