### PR TITLE
fix(gateway): honor selected model for worktree titles

### DIFF
--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -212,11 +212,14 @@ async function generateDashboardSessionTitle(params: {
 export function prepareWorktreeSessionTitle(params: {
   cfg: OpenClawConfig;
   agentId: string;
-  entry?: DashboardSessionTitleModelEntry;
+  entry?: DashboardSessionTitleModelEntry | null;
   userMessage: string;
   attachments?: readonly ChatAttachment[];
   onError: (error: unknown) => void;
 }) {
+  if (params.entry === null) {
+    return undefined;
+  }
   const source = buildDashboardSessionTitleSource({
     message: params.userMessage,
     attachments: params.attachments,

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -230,6 +230,7 @@ export function prepareWorktreeSessionTitle(params: {
   const generated = withTimeout(
     generateDashboardSessionTitle({
       ...params,
+      entry: params.entry ?? undefined,
       timeoutMs: WORKTREE_SESSION_TITLE_ATTEMPT_TIMEOUT_MS,
     }),
     WORKTREE_SESSION_TITLE_TIMEOUT_MS,

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -212,6 +212,7 @@ async function generateDashboardSessionTitle(params: {
 export function prepareWorktreeSessionTitle(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  entry?: DashboardSessionTitleModelEntry;
   userMessage: string;
   attachments?: readonly ChatAttachment[];
   onError: (error: unknown) => void;

--- a/src/gateway/server-methods/session-create-category.ts
+++ b/src/gateway/server-methods/session-create-category.ts
@@ -1,0 +1,22 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import { ensureSessionGroupRegistered } from "../session-groups.js";
+import { emitSessionsChanged } from "./session-change-event.js";
+import { sessionLog } from "./sessions-shared.js";
+
+export function registerCreatedSessionCategory(
+  category: string | undefined,
+  context: Parameters<typeof emitSessionsChanged>[0],
+): void {
+  if (!category) {
+    return;
+  }
+  try {
+    if (ensureSessionGroupRegistered(category)) {
+      // Catalog bookkeeping follows the authoritative session commit and has
+      // its own invalidation. Its failure must not make a durable create ambiguous.
+      emitSessionsChanged(context, { reason: "groups" });
+    }
+  } catch (error) {
+    sessionLog.warn(`failed to register created session category: ${formatErrorMessage(error)}`);
+  }
+}

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -34,8 +34,6 @@ import {
   createGatewaySession,
   resolveSessionCreateModelSelection as resolveCreateTitleEntry,
 } from "../session-create-service.js";
-import { ensureSessionGroupRegistered } from "../session-groups.js";
-import type { PrepareGatewaySessionLifecycle } from "../session-lifecycle-preparation.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { readSessionMessageCountAsync } from "../session-transcript-readers.js";
@@ -47,6 +45,7 @@ import { createAgentRuntimeAuthorityGuard } from "./agent-runtime-authority.js";
 import { chatHandlers } from "./chat.js";
 import { resolveRegisteredCatalogCreateTarget } from "./session-catalog.js";
 import { emitSessionsChanged } from "./session-change-event.js";
+import { registerCreatedSessionCategory } from "./session-create-category.js";
 import { captureCreatedSessionDiffBaseline } from "./session-create-diff-baseline.js";
 import {
   resolveSessionCreateInitialTurn,
@@ -57,24 +56,6 @@ import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 import { resolveWorkspacePathContainment } from "./workspace-path-containment.js";
-
-function registerCreatedSessionCategory(
-  category: string | undefined,
-  context: Parameters<typeof emitSessionsChanged>[0],
-): void {
-  if (!category) {
-    return;
-  }
-  try {
-    if (ensureSessionGroupRegistered(category)) {
-      // Catalog bookkeeping follows the authoritative session commit and has
-      // its own invalidation. Its failure must not make a durable create ambiguous.
-      emitSessionsChanged(context, { reason: "groups" });
-    }
-  } catch (error) {
-    sessionLog.warn(`failed to register created session category: ${formatErrorMessage(error)}`);
-  }
-}
 
 export const sessionCreateHandlers: GatewayRequestHandlers = {
   "sessions.create": async ({
@@ -90,6 +71,8 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params;
+    const parentSessionKey = normalizeOptionalString(p.parentSessionKey);
+    const requestedModel = normalizeOptionalString(p.model);
     const cfg = context.getRuntimeConfig();
     const authority = createAgentRuntimeAuthorityGuard(client, context, respond);
     const commitGuard =
@@ -236,17 +219,26 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     }
     const explicitSessionLabel = normalizeOptionalString(p.label);
     const titleAgentId = normalizeAgentId(explicitlyRequestedAgent.agentId);
-    // Start before repository resolution; the bounded request falls back to raw source after 8s.
-    const worktreeTitle =
-      p.worktree === true && !requestedWorktreeName && !explicitSessionLabel
+    const shouldPrepareWorktreeTitle =
+      p.worktree === true && !requestedWorktreeName && !explicitSessionLabel;
+    const deferWorktreeTitle =
+      shouldPrepareWorktreeTitle && Boolean(parentSessionKey) && !catalogTarget && !requestedModel;
+    const worktreeTitleParams = shouldPrepareWorktreeTitle
+      ? {
+          cfg,
+          agentId: titleAgentId,
+          userMessage: initialMessage ?? "",
+          attachments: initialAttachments,
+          onError: (error: unknown) =>
+            sessionLog.warn(`worktree title failed: ${formatErrorMessage(error)}`),
+        }
+      : undefined;
+    // Known routes start before repository resolution; inherited routes wait for parent validation.
+    let worktreeTitle =
+      worktreeTitleParams && !deferWorktreeTitle
         ? prepareWorktreeSessionTitle({
-            cfg,
-            agentId: titleAgentId,
+            ...worktreeTitleParams,
             entry: resolveCreateTitleEntry(cfg, titleAgentId, catalogTarget?.target ?? p.model),
-            userMessage: initialMessage ?? "",
-            attachments: initialAttachments,
-            onError: (error) =>
-              sessionLog.warn(`worktree title failed: ${formatErrorMessage(error)}`),
           })
         : undefined;
     let projectRoot: string | undefined;
@@ -289,7 +281,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     let sessionWorktree: Awaited<ReturnType<typeof managedWorktrees.create>> | undefined;
     const sessionExecCwd = requestedExecNode ? requestedCwd : undefined;
     let sessionCwd = requestedExecNode ? undefined : (projectRoot ?? requestedCwd);
-    let prepareLifecycle: PrepareGatewaySessionLifecycle | undefined;
+    let prepareLifecycle: Parameters<typeof createGatewaySession>[0]["prepareLifecycle"];
     if (sessionCwd && !requestedExecNode && (requestedProjectId || p.worktree !== true)) {
       const targetAgentId = normalizeAgentId(
         sessionAgentId ??
@@ -334,7 +326,6 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       );
       let targetKey = explicitKey;
       let preservesUnspecifiedKey = false;
-      const parentSessionKey = normalizeOptionalString(p.parentSessionKey);
       if (
         !targetKey &&
         parentSessionKey &&
@@ -396,6 +387,12 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
       prepareLifecycle = async (lifecycleTarget) => {
         try {
+          if (deferWorktreeTitle && worktreeTitleParams) {
+            worktreeTitle = prepareWorktreeSessionTitle({
+              ...worktreeTitleParams,
+              entry: lifecycleTarget.titleModelSelection,
+            });
+          }
           const boundId = normalizeOptionalString(lifecycleTarget.entry?.worktree?.id);
           let existing = boundId ? managedWorktrees.findLiveById(boundId) : undefined;
           if (
@@ -514,7 +511,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     if (
       sessionCreation.inheritedToolPolicy &&
       spawnActorSessionKey &&
-      normalizeOptionalString(p.parentSessionKey) !== spawnActorSessionKey
+      parentSessionKey !== spawnActorSessionKey
     ) {
       respond(
         false,
@@ -535,21 +532,20 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     if (!authority.ensureActive()) {
       return;
     }
-    const category = normalizeOptionalString(p.category);
     const created = await createGatewaySession({
       cfg,
       key: sessionKey,
       agentId: sessionAgentId,
       label: p.label,
       category: p.category,
-      ...(catalogTarget ? { catalogTarget: catalogTarget.target } : { model: p.model }),
+      ...(catalogTarget ? { catalogTarget: catalogTarget.target } : { model: requestedModel }),
       thinkingLevel: p.thinkingLevel,
       projectId: requestedProjectId,
       incognito: p.incognito,
       ...(client?.connect ? { requestingOperatorScopes: clientScopes } : {}),
       visibility: p.visibility,
       allowExistingModelSelection,
-      parentSessionKey: p.parentSessionKey,
+      parentSessionKey,
       spawnDepth: p.spawnDepth,
       spawnToolPolicy:
         sessionCreation.via === "spawn" && sessionCreation.inheritedToolPolicy
@@ -639,7 +635,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       respond(false, undefined, created.error);
       return;
     }
-    registerCreatedSessionCategory(category, context);
+    registerCreatedSessionCategory(p.category, context);
     if (created.resetExisting) {
       await captureCreatedSessionDiffBaseline({
         key: created.key,

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -29,7 +29,11 @@ import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-ke
 import { resolveUserPath } from "../../utils.js";
 import { prepareWorktreeSessionTitle } from "../dashboard-session-title.js";
 import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "../method-scopes.js";
-import { buildDashboardSessionKey, createGatewaySession } from "../session-create-service.js";
+import {
+  buildDashboardSessionKey,
+  createGatewaySession,
+  resolveSessionCreateModelSelection as resolveCreateTitleEntry,
+} from "../session-create-service.js";
 import { ensureSessionGroupRegistered } from "../session-groups.js";
 import type { PrepareGatewaySessionLifecycle } from "../session-lifecycle-preparation.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
@@ -96,19 +100,15 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
           }
         : undefined;
     const catalogId = normalizeOptionalString(p.catalogId);
-    if (catalogId && p.model) {
+    const catalogConflict = p.model ? "model" : p.key ? "key" : undefined;
+    if (catalogId && catalogConflict) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "sessions.create catalogId cannot include model"),
-      );
-      return;
-    }
-    if (catalogId && p.key) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "sessions.create catalogId cannot include key"),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `sessions.create catalogId cannot include ${catalogConflict}`,
+        ),
       );
       return;
     }
@@ -235,15 +235,14 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       return;
     }
     const explicitSessionLabel = normalizeOptionalString(p.label);
-    // Start before repository resolution, but cap the whole shared request: either
-    // naming gets a title within eight seconds or creation falls back to the raw source.
+    const titleAgentId = normalizeAgentId(explicitlyRequestedAgent.agentId);
+    // Start before repository resolution; the bounded request falls back to raw source after 8s.
     const worktreeTitle =
       p.worktree === true && !requestedWorktreeName && !explicitSessionLabel
         ? prepareWorktreeSessionTitle({
             cfg,
-            agentId: normalizeAgentId(
-              catalogAgentId ?? explicitlyRequestedAgent.agentId ?? explicitlyRequestedAgentId,
-            ),
+            agentId: titleAgentId,
+            entry: resolveCreateTitleEntry(cfg, titleAgentId, catalogTarget?.target ?? p.model),
             userMessage: initialMessage ?? "",
             attachments: initialAttachments,
             onError: (error) =>

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -635,7 +635,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       respond(false, undefined, created.error);
       return;
     }
-    registerCreatedSessionCategory(p.category, context);
+    registerCreatedSessionCategory(normalizeOptionalString(p.category), context);
     if (created.resetExisting) {
       await captureCreatedSessionDiffBaseline({
         key: created.key,

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1350,62 +1350,150 @@ test("sessions.create preserves a committed worktree when initial-turn setup fai
   }
 });
 
-test("sessions.create shares its generated title with the worktree and first chat send", async () => {
-  const openClawState = await createOpenClawTestState({
-    layout: "state-only",
-    prefix: "openclaw-session-worktree-title-",
-  });
-  const workspace = await initializeGitWorkspace(openClawState.root);
-  closeOpenClawStateDatabaseForTest();
-  testState.agentConfig = { workspace };
-  const { storePath } = await createSessionStoreDir();
-  const { ws } = await openClient({ scopes: ["operator.admin"] });
-  let worktreeId: string | undefined;
-  const pastedText = `Pasted deployment plan ${"x".repeat(2_000)}`;
-  const message = "Review this rollout [[reply_to_current]]";
-  const attachment = {
-    type: "file",
-    mimeType: "text/plain",
-    content: Buffer.from(pastedText).toString("base64"),
-  };
-  dashboardTitleGenerationMocks.generate.mockResolvedValueOnce("Attachment Repair");
-  dispatchInboundMessageMock.mockResolvedValueOnce({
-    queuedFinal: false,
-    counts: { block: 0, final: 0, tool: 0 },
-  });
-  try {
-    const created = await rpcReq<{
-      key: string;
-      worktree: { id: string; branch: string };
-    }>(ws, "sessions.create", {
-      agentId: "main",
-      worktree: true,
-      message,
-      attachments: [attachment],
+test.each([
+  {
+    name: "agent default",
+    request: {},
+    catalogTarget: undefined,
+    expectedEntry: {},
+    expectedTitleSelection: { regularModelRef: "openai/gpt-5.6-luna" },
+  },
+  {
+    name: "explicit model",
+    request: { model: "anthropic/sonnet-4.6@work" },
+    catalogTarget: undefined,
+    expectedEntry: {
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      authProfileOverride: "work",
+    },
+    expectedTitleSelection: {
+      regularModelRef: "anthropic/claude-sonnet-4-6@work",
+      preferredProfile: "work",
+    },
+  },
+  {
+    name: "registered catalog target",
+    request: { catalogId: "claude" },
+    catalogTarget: {
+      model: "anthropic/sonnet-4.6@catalog-work",
+      agentRuntime: "claude-cli",
+    },
+    expectedEntry: {
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      agentRuntimeOverride: "claude-cli",
+      authProfileOverride: "catalog-work",
+    },
+    expectedTitleSelection: {
+      regularModelRef: "anthropic/claude-sonnet-4-6@catalog-work",
+      agentHarnessRuntimeOverride: "claude-cli",
+      preferredProfile: "catalog-work",
+    },
+  },
+])(
+  "sessions.create shares a title routed through the $name selection with its worktree and first chat send",
+  async ({ request, catalogTarget, expectedEntry, expectedTitleSelection }) => {
+    const openClawState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-session-worktree-title-selection-",
     });
-
-    expect(created.ok, JSON.stringify(created.error)).toBe(true);
-    worktreeId = created.payload?.worktree.id;
-    expect(created.payload?.worktree.branch).toBe("openclaw/attachment-repair");
-    const sessionKey = requireNonEmptyString(created.payload?.key, "created session key");
-    await waitForFast(() => expect(dashboardTitleScheduleMocks.schedule).toHaveBeenCalled());
-    expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
-      displayName: "Attachment Repair",
-    });
-    expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 4_000 }),
-    );
-    expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledOnce();
-  } finally {
-    if (worktreeId) {
-      await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });
-    }
+    const workspace = await initializeGitWorkspace(openClawState.root);
     closeOpenClawStateDatabaseForTest();
-    testState.agentConfig = undefined;
-    ws.close();
-    await openClawState.cleanup();
-  }
-});
+    testState.agentConfig = {
+      workspace,
+      model: { primary: "openai/gpt-5.6-luna" },
+    };
+    agentDiscoveryMock.enabled = true;
+    agentDiscoveryMock.models = [
+      { id: "gpt-5.6-luna", name: "GPT 5.6 Luna", provider: "openai" },
+      { id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" },
+    ];
+    if (catalogTarget) {
+      const registry = createEmptyPluginRegistry();
+      registry.sessionCatalogs.push({
+        pluginId: "anthropic",
+        source: "test",
+        provider: {
+          id: "claude",
+          label: "Claude Code",
+          resolveCreateSession: () => catalogTarget,
+          list: vi.fn(async () => []),
+          read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+        },
+      });
+      registry.cliBackends.push({
+        pluginId: "anthropic",
+        source: "test",
+        backend: {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          config: { command: "claude" },
+          bundleMcp: false,
+        },
+      });
+      setActivePluginRegistry(registry);
+    }
+    const { storePath } = await createSessionStoreDir();
+    let worktreeId: string | undefined;
+    const pastedText = `Pasted deployment plan ${"x".repeat(2_000)}`;
+    const message = "Review this rollout [[reply_to_current]]";
+    const attachment = {
+      type: "file",
+      mimeType: "text/plain",
+      content: Buffer.from(pastedText).toString("base64"),
+    };
+    dashboardTitleGenerationMocks.generate.mockResolvedValueOnce("Attachment Repair");
+    dispatchInboundMessageMock.mockResolvedValueOnce({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+    try {
+      const created = await directSessionReq<{
+        key: string;
+        entry: {
+          providerOverride?: string;
+          modelOverride?: string;
+          agentRuntimeOverride?: string;
+          authProfileOverride?: string;
+        };
+        worktree: { id: string; branch: string };
+      }>(
+        "sessions.create",
+        {
+          agentId: "main",
+          worktree: true,
+          message,
+          attachments: [attachment],
+          ...request,
+        },
+        { client: { connect: { scopes: ["operator.admin"] } } as never },
+      );
+
+      expect(created.ok, JSON.stringify(created.error)).toBe(true);
+      worktreeId = created.payload?.worktree.id;
+      expect(created.payload?.worktree.branch).toBe("openclaw/attachment-repair");
+      expect(created.payload?.entry).toMatchObject(expectedEntry);
+      const sessionKey = requireNonEmptyString(created.payload?.key, "created session key");
+      await waitForFast(() => expect(dashboardTitleScheduleMocks.schedule).toHaveBeenCalled());
+      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+        displayName: "Attachment Repair",
+      });
+      expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 4_000, ...expectedTitleSelection }),
+      );
+      expect(dashboardTitleGenerationMocks.generate).toHaveBeenCalledOnce();
+    } finally {
+      if (worktreeId) {
+        await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });
+      }
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      closeOpenClawStateDatabaseForTest();
+      testState.agentConfig = undefined;
+      await openClawState.cleanup();
+    }
+  },
+);
 
 test.each([
   {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1355,6 +1355,7 @@ test.each([
     name: "agent default",
     request: {},
     catalogTarget: undefined,
+    parentEntry: undefined,
     expectedEntry: {},
     expectedTitleSelection: { regularModelRef: "openai/gpt-5.6-luna" },
   },
@@ -1362,6 +1363,7 @@ test.each([
     name: "explicit model",
     request: { model: "anthropic/sonnet-4.6@work" },
     catalogTarget: undefined,
+    parentEntry: undefined,
     expectedEntry: {
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet-4-6",
@@ -1379,6 +1381,7 @@ test.each([
       model: "anthropic/sonnet-4.6@catalog-work",
       agentRuntime: "claude-cli",
     },
+    parentEntry: undefined,
     expectedEntry: {
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet-4-6",
@@ -1391,9 +1394,33 @@ test.each([
       preferredProfile: "catalog-work",
     },
   },
+  {
+    name: "inherited parent",
+    request: { parentSessionKey: "main" },
+    catalogTarget: undefined,
+    parentEntry: {
+      providerOverride: "openai",
+      modelOverride: "gpt-5.6-sol",
+      modelOverrideSource: "user" as const,
+      agentRuntimeOverride: "codex",
+      authProfileOverride: "parent-work",
+      authProfileOverrideSource: "user" as const,
+    },
+    expectedEntry: {
+      providerOverride: "openai",
+      modelOverride: "gpt-5.6-sol",
+      agentRuntimeOverride: "codex",
+      authProfileOverride: "parent-work",
+    },
+    expectedTitleSelection: {
+      regularModelRef: "openai/gpt-5.6-sol@parent-work",
+      agentHarnessRuntimeOverride: "codex",
+      preferredProfile: "parent-work",
+    },
+  },
 ])(
   "sessions.create shares a title routed through the $name selection with its worktree and first chat send",
-  async ({ request, catalogTarget, expectedEntry, expectedTitleSelection }) => {
+  async ({ request, catalogTarget, parentEntry, expectedEntry, expectedTitleSelection }) => {
     const openClawState = await createOpenClawTestState({
       layout: "state-only",
       prefix: "openclaw-session-worktree-title-selection-",
@@ -1407,6 +1434,7 @@ test.each([
     agentDiscoveryMock.enabled = true;
     agentDiscoveryMock.models = [
       { id: "gpt-5.6-luna", name: "GPT 5.6 Luna", provider: "openai" },
+      { id: "gpt-5.6-sol", name: "GPT 5.6 Sol", provider: "openai" },
       { id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" },
     ];
     if (catalogTarget) {
@@ -1435,6 +1463,11 @@ test.each([
       setActivePluginRegistry(registry);
     }
     const { storePath } = await createSessionStoreDir();
+    if (parentEntry) {
+      await writeSessionStore({
+        entries: { main: sessionStoreEntry("worktree-title-parent", parentEntry) },
+      });
+    }
     let worktreeId: string | undefined;
     const pastedText = `Pasted deployment plan ${"x".repeat(2_000)}`;
     const message = "Review this rollout [[reply_to_current]]";

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1495,6 +1495,50 @@ test.each([
   },
 );
 
+test("sessions.create does not start title generation for a model denied by policy", async () => {
+  const openClawState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-session-worktree-title-denied-model-",
+  });
+  const workspace = await initializeGitWorkspace(openClawState.root);
+  closeOpenClawStateDatabaseForTest();
+  testState.agentConfig = {
+    workspace,
+    model: { primary: "openai/gpt-5.6-luna" },
+    models: { "openai/gpt-5.6-luna": {} },
+  };
+  agentDiscoveryMock.enabled = true;
+  agentDiscoveryMock.models = [
+    { id: "gpt-5.6-luna", name: "GPT 5.6 Luna", provider: "openai" },
+    { id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" },
+  ];
+  const { storePath } = await createSessionStoreDir();
+  const key = "agent:main:dashboard:denied-title-route";
+  try {
+    const created = await directSessionReq(
+      "sessions.create",
+      {
+        agentId: "main",
+        key,
+        model: "anthropic/sonnet-4.6@work",
+        worktree: true,
+        message: "Keep this title source on an allowed route",
+      },
+      { client: { connect: { scopes: ["operator.admin"] } } as never },
+    );
+
+    expect(created.ok).toBe(false);
+    expect(created.error?.message).toContain("model not allowed");
+    expect(dashboardTitleGenerationMocks.generate).not.toHaveBeenCalled();
+    expect(findLiveRegistryWorktreeByOwner(process.env, "session", key)).toBeUndefined();
+    expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })).toBeUndefined();
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = undefined;
+    await openClawState.cleanup();
+  }
+});
+
 test.each([
   {
     name: "generator error",

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -203,7 +203,7 @@ test("sessions.create assigns and registers its requested group", async () => {
     "sessions.create",
     {
       agentId: "main",
-      category: "Client work",
+      category: "  Client work  ",
     },
     {
       context: {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -18,12 +18,8 @@ import {
   normalizeInheritedToolDenylist,
 } from "../agents/inherited-tool-deny.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
-import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
-  buildModelAliasIndex,
-  inferUniqueProviderFromConfiguredModels,
   resolveDefaultModelForAgent,
-  resolveModelRefFromString,
   resolveSubagentConfiguredModelSelection,
 } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
@@ -103,35 +99,38 @@ export function resolveSessionCreateModelSelection(
   cfg: OpenClawConfig,
   agentId: string,
   input: string | { model: string; agentRuntime?: string } | undefined,
-) {
+):
+  | Pick<
+      SessionEntry,
+      "providerOverride" | "modelOverride" | "agentRuntimeOverride" | "authProfileOverride"
+    >
+  | null
+  | undefined {
   const model = normalizeOptionalString(typeof input === "string" ? input : input?.model);
   if (!model) {
     return undefined;
   }
   const defaults = resolveDefaultModelForAgent({ cfg, agentId });
-  const split = splitTrailingAuthProfile(model);
-  // Patch selection resolves this config-owned ref/profile before its catalog status check;
-  // the persisted create path remains the sole availability/allowlist validator.
-  const resolved = resolveModelRefFromString({
+  // Reuse patch policy with the config-owned catalog projection. Persisted creation
+  // remains the sole live-catalog availability validator.
+  const resolved = resolveSessionPatchModelSelection({
     cfg,
-    raw: split.model,
-    defaultProvider:
-      (!split.model.includes("/")
-        ? inferUniqueProviderFromConfiguredModels({ cfg, model: split.model })
-        : undefined) ?? defaults.provider,
-    aliasIndex: buildModelAliasIndex({ cfg, defaultProvider: defaults.provider }),
+    catalog: [],
+    raw: model,
+    defaultProvider: defaults.provider,
+    defaultModel: defaults.model,
   });
-  if (!resolved) {
-    return undefined;
+  if (!resolved.ok) {
+    return null;
   }
   const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(
     typeof input === "string" ? undefined : input?.agentRuntime,
   );
   return {
-    providerOverride: resolved.ref.provider,
-    modelOverride: resolved.ref.model,
+    providerOverride: resolved.provider,
+    modelOverride: resolved.model,
     ...(agentRuntimeOverride ? { agentRuntimeOverride } : {}),
-    ...(split.profile ? { authProfileOverride: split.profile } : {}),
+    ...(resolved.profile ? { authProfileOverride: resolved.profile } : {}),
   };
 }
 

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -18,8 +18,12 @@ import {
   normalizeInheritedToolDenylist,
 } from "../agents/inherited-tool-deny.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
+  buildModelAliasIndex,
+  inferUniqueProviderFromConfiguredModels,
   resolveDefaultModelForAgent,
+  resolveModelRefFromString,
   resolveSubagentConfiguredModelSelection,
 } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
@@ -94,6 +98,42 @@ type TrustedCatalogSessionTarget = {
 const loadSessionLifecycleRuntime = createLazyRuntimeModule(
   () => import("./server-methods/sessions.runtime.js"),
 );
+
+export function resolveSessionCreateModelSelection(
+  cfg: OpenClawConfig,
+  agentId: string,
+  input: string | { model: string; agentRuntime?: string } | undefined,
+) {
+  const model = normalizeOptionalString(typeof input === "string" ? input : input?.model);
+  if (!model) {
+    return undefined;
+  }
+  const defaults = resolveDefaultModelForAgent({ cfg, agentId });
+  const split = splitTrailingAuthProfile(model);
+  // Patch selection resolves this config-owned ref/profile before its catalog status check;
+  // the persisted create path remains the sole availability/allowlist validator.
+  const resolved = resolveModelRefFromString({
+    cfg,
+    raw: split.model,
+    defaultProvider:
+      (!split.model.includes("/")
+        ? inferUniqueProviderFromConfiguredModels({ cfg, model: split.model })
+        : undefined) ?? defaults.provider,
+    aliasIndex: buildModelAliasIndex({ cfg, defaultProvider: defaults.provider }),
+  });
+  if (!resolved) {
+    return undefined;
+  }
+  const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(
+    typeof input === "string" ? undefined : input?.agentRuntime,
+  );
+  return {
+    providerOverride: resolved.ref.provider,
+    modelOverride: resolved.ref.model,
+    ...(agentRuntimeOverride ? { agentRuntimeOverride } : {}),
+    ...(split.profile ? { authProfileOverride: split.profile } : {}),
+  };
+}
 
 async function existingModelSelectionWouldChange(params: {
   agentId: string;

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -72,6 +72,7 @@ import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.
 import { ADMIN_SCOPE } from "./operator-scopes.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
 import {
+  type GatewaySessionTitleModelSelection,
   type PreparedGatewaySessionLifecycle,
   type PrepareGatewaySessionLifecycle,
   rollbackGatewaySessionPreparation,
@@ -99,16 +100,17 @@ export function resolveSessionCreateModelSelection(
   cfg: OpenClawConfig,
   agentId: string,
   input: string | { model: string; agentRuntime?: string } | undefined,
-):
-  | Pick<
-      SessionEntry,
-      "providerOverride" | "modelOverride" | "agentRuntimeOverride" | "authProfileOverride"
-    >
-  | null
-  | undefined {
+  parentEntry?: SessionEntry,
+): GatewaySessionTitleModelSelection | null {
   const model = normalizeOptionalString(typeof input === "string" ? input : input?.model);
   if (!model) {
-    return undefined;
+    const inherited = inheritSessionSelection(parentEntry);
+    return {
+      providerOverride: inherited.providerOverride,
+      modelOverride: inherited.modelOverride,
+      agentRuntimeOverride: inherited.agentRuntimeOverride,
+      authProfileOverride: inherited.authProfileOverride,
+    };
   }
   const defaults = resolveDefaultModelForAgent({ cfg, agentId });
   // Reuse patch policy with the config-owned catalog projection. Persisted creation
@@ -849,12 +851,19 @@ export async function createGatewaySession(params: {
     const currentTargetEntry = loadGatewaySessionEntryReadOnly(target.canonicalKey, {
       agentId: target.agentId,
     }).entry;
+    const titleModelSelection = resolveSessionCreateModelSelection(
+      params.cfg,
+      target.agentId,
+      params.catalogTarget ?? params.model,
+      currentParentSessionEntry,
+    );
     const preparationResult = params.prepareLifecycle
       ? await params.prepareLifecycle({
           agentId: target.agentId,
           entry: currentTargetEntry,
           key: target.canonicalKey,
           storePath: target.storePath,
+          titleModelSelection,
         })
       : undefined;
     if (preparationResult && !preparationResult.ok) {

--- a/src/gateway/session-lifecycle-preparation.ts
+++ b/src/gateway/session-lifecycle-preparation.ts
@@ -2,6 +2,11 @@ import type { Result } from "@openclaw/normalization-core/result";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 
+export type GatewaySessionTitleModelSelection = Pick<
+  SessionEntry,
+  "agentRuntimeOverride" | "authProfileOverride" | "modelOverride" | "providerOverride"
+>;
+
 export type PreparedGatewaySessionLifecycle = {
   spawnedCwd?: string;
   worktree?: NonNullable<SessionEntry["worktree"]>;
@@ -13,6 +18,7 @@ export type PrepareGatewaySessionLifecycle = (target: {
   entry?: SessionEntry;
   key: string;
   storePath: string;
+  titleModelSelection?: GatewaySessionTitleModelSelection | null;
 }) => Promise<Result<PreparedGatewaySessionLifecycle, ErrorShape>>;
 
 export async function rollbackGatewaySessionPreparation(params: {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/124787

## What Problem This Solves

Fixes an issue where creating a managed-worktree session could generate its title and worktree name through the agent default route instead of the new session’s selected provider, model, runtime, and auth profile. This covered explicit models and registered session-catalog targets, and now also covers children that inherit their selection from a parent session.

## Why This Change Was Made

One create-time selection resolver now handles default, explicit, catalog, and inherited-parent routes. Explicit and catalog routes retain the config-policy validation added by this PR. Parent inheritance is projected only inside the canonical session-creation owner, after that owner validates the parent, its ownership, and its model lock, then carries the narrow provider/model/runtime/profile selection into lifecycle preparation.

Title work still starts before repository resolution whenever the route is knowable at dispatch: default sessions without a parent, explicit models, and catalog targets. Parent-only requests defer title preparation until the validated inherited selection reaches the lifecycle callback. Denied or invalid direct selections continue to suppress title preparation entirely. The persisted create path remains the sole live model-catalog availability validator, so this does not restore the blocking catalog load removed by #122471.

## User Impact

Create-time titles, managed-worktree branch names, persisted child selection, and the first chat turn now agree for default, explicit, catalog-backed, and parent-inherited sessions. A policy-rejected route cannot receive title content before the create request is rejected. Existing title persistence, timeout, and worktree fallback behavior is unchanged.

## Evidence

- Boundary regression: the new inherited-parent initial-message worktree case failed before the owner-boundary repair because the title generator received the agent default while the child persisted the parent selection. It now observes the inherited model reference, runtime, and preferred profile; the generated title names the branch and persists on the child; and the child entry carries the same inherited route.
- Existing explicit-model, registered-catalog, default-route, and denied-model cases remain covered. The denied route still observes no title completion, worktree, or session row.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/gateway/dashboard-session-title.test.ts src/gateway/server-methods/chat-send-command-replies.test.ts src/agents/worktrees/name.test.ts src/agents/worktrees/service.naming.test.ts` — 148 tests passed across five files.
- Blacksmith Testbox `tbx_01m06nnsvarh61z99z2028s8dx`: production types, all core test-type shards, and core oxlint passed. Run: https://github.com/openclaw/openclaw/actions/runs/31985343271
- Targeted oxfmt, targeted local oxlint, `git diff --check`, and the final mandatory uncommitted autoreview passed with no accepted/actionable findings.
- Production LOC: +126/-50 (net +76); tests: +207/-42 (net +165). The production growth is the canonical four-route selection projection plus the narrow lifecycle seam. The category helper is a pure extraction that keeps `sessions-create.ts` net -5 lines and under its max-lines budget without a suppression.
- No separate visual capture: this changes routing for the existing title/worktree UI flow rather than its rendered appearance; the isolated dev-Gateway visual proof remains on #124787.
- AI-assisted; maintainer reviewed and verified the final diff.
