### PR TITLE
fix(ui): keep steer ordering proof stable on macOS

### DIFF
--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -1,3 +1,4 @@
+import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import {
@@ -11,6 +12,37 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+
+async function expectChatBubbleAbove(page: Page, upperText: string, lowerText: string) {
+  const thread = page.locator(".chat-thread-inner");
+  await expect
+    .poll(() =>
+      thread.evaluate(
+        (element, texts) => {
+          const bubbles = Array.from(element.querySelectorAll<HTMLElement>(".chat-bubble"));
+          const matches = texts.map((text) =>
+            bubbles.filter((bubble) => bubble.textContent?.includes(text)),
+          );
+          const counts = matches.map((matchingBubbles) => matchingBubbles.length);
+          const upperBubble = matches[0]?.[0];
+          const lowerBubble = matches[1]?.[0];
+          if (counts.some((count) => count !== 1) || !upperBubble || !lowerBubble) {
+            return { counts, lowerTop: null, ordered: false, upperTop: null };
+          }
+          const upperTop = upperBubble.getBoundingClientRect().top;
+          const lowerTop = lowerBubble.getBoundingClientRect().top;
+          return { counts, lowerTop, ordered: upperTop < lowerTop, upperTop };
+        },
+        [upperText, lowerText],
+      ),
+    )
+    .toEqual({
+      counts: [1, 1],
+      lowerTop: expect.any(Number),
+      ordered: true,
+      upperTop: expect.any(Number),
+    });
+}
 
 suite.define(() => {
   it("opens a git-backed agent draft from the sidebar new-session action", async () => {
@@ -574,19 +606,7 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".chat-thread .chat-group.user", { hasText: followUp }).count())
         .toBe(1);
-      await expect
-        .poll(() =>
-          page.locator(".chat-thread-inner").evaluate(
-            (thread, texts) => {
-              const bubbles = Array.from(thread.querySelectorAll(".chat-bubble"));
-              return texts.map((text) =>
-                bubbles.findIndex((bubble) => bubble.textContent?.includes(text)),
-              );
-            },
-            [originalPrompt, followUp],
-          ),
-        )
-        .toEqual([0, 1]);
+      await expectChatBubbleAbove(page, originalPrompt, followUp);
       if (artifactDir) {
         await page.screenshot({
           path: `${artifactDir}/steer-after-persistence.png`,
@@ -952,7 +972,9 @@ suite.define(() => {
         sessionKey: "main",
         state: "final",
       });
-      await page.waitForTimeout(250);
+      await row.waitFor({ state: "detached", timeout: 10_000 });
+      await page.getByText(steerText, { exact: true }).waitFor({ timeout: 10_000 });
+      await expectChatBubbleAbove(page, "keep this run active", steerText);
       if (artifactDir) {
         await page.screenshot({ path: `${artifactDir}/steer-landed.png`, fullPage: true });
       }
@@ -962,21 +984,6 @@ suite.define(() => {
         backgroundColor: pendingPresentation.infoSubtle,
         iconPoints: "15 10 20 15 15 20",
       });
-      expect(await row.count()).toBe(0);
-      await page.getByText(steerText, { exact: true }).waitFor({ timeout: 10_000 });
-      await expect
-        .poll(() =>
-          page.locator(".chat-thread-inner").evaluate(
-            (thread, texts) => {
-              const bubbles = Array.from(thread.querySelectorAll(".chat-bubble"));
-              return texts.map((text) =>
-                bubbles.findIndex((bubble) => bubble.textContent?.includes(text)),
-              );
-            },
-            ["keep this run active", steerText],
-          ),
-        )
-        .toEqual([0, 1]);
       await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
     } finally {
       await suite.closeBrowserContext(context);


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #123908

AI-assisted with Codex; the diagnosis, implementation, and evidence were inspected by the maintainer agent.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the Control UI landed-steer E2E could fail deterministically on macOS with transcript indexes `[1, 0]` even though Linux CI was green and the visible transcript settled in the correct order. The test was treating virtualized DOM stamp order as transcript order, producing a platform-sensitive false regression signal.

## Why This Change Was Made

The steering lifecycle and shared session projection already materialize the original active prompt before the later steer. The E2E now verifies the actual rendered contract instead: both bubbles must exist exactly once and the original prompt's bounding rectangle must be strictly above the steer. The landed screenshot also waits for notice dismissal, text visibility, and settled visual chronology instead of a fixed delay.

No production path or virtualizer behavior changes.

## User Impact

There is no shipped UI behavior change. Maintainers get a macOS-stable regression test that still fails if the user-visible transcript order is genuinely reversed, and proof screenshots can no longer capture a transient pre-settled frame.

## Evidence

- Pre-fix macOS reproduction at `65922f95070`: `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.follow-ups.e2e.test.ts` failed four times across two revisions with `[1, 0]`; Linux CI for that base was green.
- Focused macOS scenario after the change: 1 passed, 13 skipped.
- Full macOS file after the change: 14 passed.
- Codex worker validation: two additional focused passes plus one full-file pass.
- Blacksmith Testbox changed gate: succeeded (`exitCode=0`) in [run 31978453142](https://github.com/openclaw/openclaw/actions/runs/31978453142).
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +36/-29.

Pending steer presentation:

![Pending steer presentation](https://github.com/user-attachments/assets/eecf8f07-1c59-42e6-887b-72521110859c)

Landed steer with the original prompt visibly above it:

![Landed steer transcript order](https://github.com/user-attachments/assets/5131b139-95ff-40d9-8585-38f4526321ef)

https://github.com/user-attachments/assets/bf4b0c64-73f1-4aae-9061-b76f5c4bfcf8
