### PR TITLE
fix(plugins): isolate prepared metadata snapshots

### DIFF
--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -45,6 +45,7 @@ function preparePluginLoadContext(
       workspaceDir,
       metadataSnapshot: preparedMetadataSnapshot,
       manifestRegistry: metadataSnapshot.manifestRegistry,
+      publishCurrentMetadataSnapshot: false,
     }),
     metadataSnapshot,
     installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),

--- a/src/plugins/legacy-session-surfaces.ts
+++ b/src/plugins/legacy-session-surfaces.ts
@@ -168,6 +168,7 @@ export function prepareLegacySessionSurfaces(params: {
     resolvePluginRuntimeLoadContext({
       config: params.config,
       env: params.env,
+      publishCurrentMetadataSnapshot: false,
     });
   const manifestRecords = context.manifestRegistry?.plugins ?? [];
   const selectedPluginIds = new Set(

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -193,6 +193,21 @@ describe("resolvePluginRuntimeLoadContext", () => {
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
+  it("keeps owner-prepared workspace metadata out of the process snapshot", () => {
+    const config = { plugins: {} };
+    const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
+
+    resolvePluginRuntimeLoadContext({
+      config,
+      env,
+      metadataSnapshot: metadataSnapshot as never,
+      publishCurrentMetadataSnapshot: false,
+      workspaceDir: "/resolved-workspace",
+    });
+
+    expect(setCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+  });
+
   it("stores derived metadata as the reusable runtime snapshot", () => {
     const derivedSnapshot = { ...metadataSnapshot } as typeof metadataSnapshot & {
       registrySource: "derived";

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -163,6 +163,7 @@ type PluginRuntimeLoadContextOptions = {
   logger?: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
   metadataSnapshot?: PluginMetadataSnapshot;
+  publishCurrentMetadataSnapshot?: boolean;
 };
 
 /** Creates the default plugin runtime loader logger. */
@@ -252,7 +253,11 @@ export function resolvePluginRuntimeLoadContext(
   const installRecords = metadataSnapshot
     ? extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index)
     : undefined;
-  if (metadataSnapshot && metadataSnapshot.pluginIds === undefined) {
+  if (
+    options?.publishCurrentMetadataSnapshot !== false &&
+    metadataSnapshot &&
+    metadataSnapshot.pluginIds === undefined
+  ) {
     // Scoped graphs are request-local; publishing one would hide other installed
     // providers from process-wide model normalization and later runtime loads.
     setCurrentPluginMetadataSnapshot(metadataSnapshot, {


### PR DESCRIPTION
## Root cause

Read-only plugin metadata preparation called the shared runtime load-context resolver, which published its derived workspace inventory into the process-wide lifecycle snapshot. On the next Gateway restart, startup migration convergence compared the original persisted inventory with that newly published derived inventory and correctly refused readiness because the migration fingerprint had changed mid-startup.

## Fix

- Add an explicit opt-out for process-wide metadata publication.
- Use it for legacy-session migration preparation and lifecycle-owned prepared model runtime contexts.
- Keep the existing default publication behavior for normal runtime loaders.
- Add regression coverage for the non-publishing prepared-context contract.

## Proof

- Regression test fails on the pre-fix publication path and passes after the fix.
- Focused Vitest: 80 tests passed across Doctor, agents, plugin metadata, and legacy-session migration owners.
- Changed-file gate passed on Blacksmith Testbox, including formatting, lint, core/core-test typechecks, boundary guards, dead-code checks, and import-cycle checks.
- Exact Matrix restart QA passed: one reply before restart, one reply after restart, with no replay.
- Autoreview: clean, no accepted/actionable findings.

Production delta: +7 LOC. Test delta: +15 LOC.

No changelog entry: this repairs an unshipped same-day main regression.
