### PR TITLE
fix: deliver requested image artifacts across agent runtimes

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -420,6 +420,30 @@ describe("Codex app-server dynamic tool build", () => {
     ]);
   });
 
+  it.each([
+    { nativeToolSurfaceEnabled: true, expected: ["message"] },
+    { nativeToolSurfaceEnabled: false, expected: ["image", "message"] },
+  ])(
+    "uses the active native image loader when native tools are $nativeToolSurfaceEnabled",
+    async ({ nativeToolSurfaceEnabled, expected }) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.model = createCodexTestModel("codex", ["text", "image"]);
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      setOpenClawCodingToolsFactoryForTests(() => [
+        createRuntimeDynamicTool("image"),
+        createRuntimeDynamicTool("message"),
+      ]);
+
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        nativeToolSurfaceEnabled,
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(expected);
+    },
+  );
+
   it("removes managed web_search when domain-restricted Codex hosted search is active", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -49,7 +49,7 @@ import {
   createNodeProcessDynamicTool,
   isCodexDynamicToolExcluded,
 } from "./shell-dynamic-tools.js";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./web-search.js";
 
 type OpenClawCodingToolsOptions = NonNullable<
@@ -402,9 +402,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     nativeExecutionPolicy,
   );
   toolBuildStages.mark("codex-filtering");
-  const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
+  const visionFilteredTools = filterCodexVisionTools(codexFilteredTools, {
     modelHasVision,
-    hasInboundImages: (params.images?.length ?? 0) > 0,
+    nativeImageInspectionEnabled: input.nativeToolSurfaceEnabled === true,
   });
   toolBuildStages.mark("vision-filtering");
   const webSearchPresent = visionFilteredTools.some((tool) => tool.name === "web_search");

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -1,14 +1,14 @@
 // Codex tests cover run attempt.vision tools plugin behavior.
 import { describe, expect, it } from "vitest";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 
 describe("Codex dynamic tool filtering", () => {
-  it("drops the image tool when the model already has inbound vision input", () => {
-    const toolNames = filterToolsForVisionInputs(
+  it("drops the image tool when native Codex image inspection is active", () => {
+    const toolNames = filterCodexVisionTools(
       [{ name: "image" }, { name: "read" }, { name: "write" }],
       {
         modelHasVision: true,
-        hasInboundImages: true,
+        nativeImageInspectionEnabled: true,
       },
     ).map((tool) => tool.name);
 
@@ -17,19 +17,19 @@ describe("Codex dynamic tool filtering", () => {
     expect(toolNames).not.toContain("image");
   });
 
-  it("keeps the image tool unless both model vision and inbound images are present", () => {
+  it("keeps the image tool when the model lacks vision or native image inspection is disabled", () => {
     const tools = [{ name: "image" }, { name: "read" }];
 
     expect(
-      filterToolsForVisionInputs(tools, {
+      filterCodexVisionTools(tools, {
         modelHasVision: false,
-        hasInboundImages: true,
+        nativeImageInspectionEnabled: true,
       }),
     ).toBe(tools);
     expect(
-      filterToolsForVisionInputs(tools, {
+      filterCodexVisionTools(tools, {
         modelHasVision: true,
-        hasInboundImages: false,
+        nativeImageInspectionEnabled: false,
       }),
     ).toBe(tools);
   });

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -124,7 +124,7 @@ import {
   resolveCodexBindingModelProviderFallback,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
   type CodexNativeWebSearchSupport,
@@ -1107,9 +1107,9 @@ async function createCodexSideToolBridge(input: {
       requireExplicitMessageTarget: true,
     });
     const codexFilteredTools = filterCodexDynamicTools(allTools, input.pluginConfig);
-    tools = filterToolsForVisionInputs(codexFilteredTools, {
+    tools = filterCodexVisionTools(codexFilteredTools, {
       modelHasVision: runtimeModel.input?.includes("image") ?? false,
-      hasInboundImages: false,
+      nativeImageInspectionEnabled: input.nativeToolSurfaceEnabled,
     });
   }
   const requestedWebSearchPlan = resolveCodexWebSearchPlan({

--- a/extensions/codex/src/app-server/vision-tools.ts
+++ b/extensions/codex/src/app-server/vision-tools.ts
@@ -1,16 +1,15 @@
 /**
- * Filters Codex dynamic tools for turns that already contain image inputs so
- * models with native vision do not get redundant image-inspection tools.
+ * Codex's enabled native surface includes its stable view_image loader. Keep
+ * OpenClaw's image tool only when that surface or model vision is unavailable.
  */
-/** Removes the image tool when the model can directly consume inbound images. */
-export function filterToolsForVisionInputs<T extends { name?: string }>(
+export function filterCodexVisionTools<T extends { name?: string }>(
   tools: T[],
   params: {
     modelHasVision: boolean;
-    hasInboundImages: boolean;
+    nativeImageInspectionEnabled: boolean;
   },
 ): T[] {
-  if (!params.modelHasVision || !params.hasInboundImages) {
+  if (!params.modelHasVision || !params.nativeImageInspectionEnabled) {
     return tools;
   }
   return tools.filter((tool) => tool.name !== "image");

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -54,6 +54,10 @@ export type CliOutput = {
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
+  /** Trust-filtered explicit outbound media captured before CLI result normalization. */
+  toolMediaUrls?: string[];
+  toolAudioAsVoice?: boolean;
+  toolTrustedLocalMedia?: boolean;
   yielded?: true;
 };
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1033,6 +1033,89 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
   });
 
+  it("projects explicit outbound MCP media without retaining echoed image bytes", async () => {
+    const echoedBase64 = "private-echoed-base64";
+    const mediaUrls = [
+      "https://example.test/one.png",
+      "https://example.test/two.png",
+      "https://example.test/three.png",
+    ];
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureKey = input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "";
+      for (const [index, mediaUrl] of mediaUrls.entries()) {
+        const captureHandle = markMcpLoopbackToolCallStarted({
+          captureKey,
+          toolName: "image_generate",
+          args: { prompt: `image ${index + 1}` },
+        });
+        if (!captureHandle) {
+          throw new Error("Expected outbound media capture");
+        }
+        recordMcpLoopbackToolCallResult({
+          captureHandle,
+          toolName: "image_generate",
+          args: { prompt: `image ${index + 1}` },
+          result: {
+            content: [
+              {
+                type: "image",
+                data: echoedBase64,
+                mimeType: "image/png",
+              },
+            ],
+            details: { media: { mediaUrls: [mediaUrl] } },
+          },
+          outcome: "completed",
+        });
+        markMcpLoopbackToolCallFinished(captureHandle);
+      }
+      for (const [toolName, media] of [
+        ["image", { mediaUrls: ["/tmp/private.png"], outbound: false }],
+        ["untrusted_tool", { mediaUrls: ["/tmp/untrusted.png"] }],
+      ] as const) {
+        const captureHandle = markMcpLoopbackToolCallStarted({
+          captureKey,
+          toolName,
+          args: {},
+        });
+        if (!captureHandle) {
+          throw new Error("Expected private media capture");
+        }
+        recordMcpLoopbackToolCallResult({
+          captureHandle,
+          toolName,
+          args: {},
+          result: {
+            content: [{ type: "image", data: echoedBase64, mimeType: "image/png" }],
+            details: { media },
+          },
+          outcome: "completed",
+        });
+        markMcpLoopbackToolCallFinished(captureHandle);
+      }
+      return makeManagedRun({ stdout: "done" });
+    });
+    const context = makeClaudePreparedContext({
+      sessionKey: "agent:main:outbound-media",
+      runId: "run-outbound-media",
+    });
+    context.mcpDeliveryCapture = true;
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toEqual([
+      {
+        text: "done",
+        mediaUrls,
+        mediaUrl: mediaUrls[0],
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain(echoedBase64);
+    expect(JSON.stringify(result)).not.toContain("/tmp/private.png");
+    expect(JSON.stringify(result)).not.toContain("/tmp/untrusted.png");
+  });
+
   it("surfaces a CLI failure after a delivered progress reply", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
@@ -3077,6 +3160,7 @@ describe("runCliAgent reliability", () => {
       expect(result.payloads).toEqual([{ text: "hello from cli" }]);
       expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
         assistantTranscriptOwned: true,
+        assistantTranscriptIdempotencyKey: "cli-assistant:run-persist-cli",
       });
       expect(onUserMessagePersisted).toHaveBeenCalledOnce();
       expect(onUserMessagePersisted).toHaveBeenCalledWith(

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -575,6 +575,7 @@ export async function runPreparedCliAgent(
           effectiveCliSessionId,
           bindingFlushOk,
           assistantTranscriptOwned: assistantTranscript.owned,
+          assistantTranscriptIdempotencyKey: assistantTranscript.idempotencyKey,
           usedHistoryPrompt,
           userTurnHandled,
           sessionBindingDisabled,

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -19,6 +19,7 @@ import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
 import { resolveExplicitFinalSourceReplyDeliveryEvidence } from "../embedded-agent-runner/delivery-evidence.js";
 import { resolveAuthProfileFailureReason } from "../embedded-agent-runner/run/auth-profile-failure-policy.js";
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
+import { mergeAttemptToolMediaPayloads } from "../embedded-agent-runner/run/tool-media-payloads.js";
 import { coerceToFailoverError, isFailoverError } from "../failover-error.js";
 import { CliAuthProfilePreparationError } from "./auth-profile-preparation-error.js";
 import { hashCliReseedPrompt } from "./reseed-envelope.js";
@@ -425,6 +426,7 @@ export function buildCliRunResult(params: {
   effectiveCliSessionId?: string;
   bindingFlushOk?: boolean;
   assistantTranscriptOwned?: boolean;
+  assistantTranscriptIdempotencyKey?: string;
   usedHistoryPrompt: boolean;
   userTurnHandled: boolean;
   sessionBindingDisabled: boolean;
@@ -432,6 +434,7 @@ export function buildCliRunResult(params: {
 }): EmbeddedAgentRunResult {
   const {
     assistantTranscriptOwned,
+    assistantTranscriptIdempotencyKey,
     bindingFlushOk,
     context,
     effectiveCliSessionId,
@@ -460,12 +463,27 @@ export function buildCliRunResult(params: {
         : text
           ? [
               assistantTranscriptOwned
-                ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
+                ? setReplyPayloadMetadata(
+                    { text },
+                    {
+                      assistantTranscriptOwned: true,
+                      ...(assistantTranscriptIdempotencyKey
+                        ? { assistantTranscriptIdempotencyKey }
+                        : {}),
+                    },
+                  )
                 : { text },
             ]
           : runParams.allowEmptyAssistantReplyAsSilent === true
             ? [{ text: SILENT_REPLY_TOKEN }]
             : undefined;
+  const payloadsWithToolMedia = mergeAttemptToolMediaPayloads({
+    payloads,
+    toolMediaUrls: output.toolMediaUrls,
+    toolAudioAsVoice: output.toolAudioAsVoice,
+    toolTrustedLocalMedia: output.toolTrustedLocalMedia,
+    sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
+  });
   const unflushedCliSessionId =
     !sessionBindingDisabled && effectiveCliSessionId && bindingFlushOk === false
       ? effectiveCliSessionId
@@ -524,7 +542,7 @@ export function buildCliRunResult(params: {
   });
 
   return {
-    payloads,
+    payloads: payloadsWithToolMedia,
     meta: {
       durationMs: Date.now() - context.started,
       ...(output.finalPromptText ? { finalPromptText: output.finalPromptText } : {}),

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -146,6 +146,7 @@ export async function persistCliAssistantTranscript(params: {
   };
 }): Promise<{
   owned: boolean;
+  idempotencyKey?: string;
   terminalAnchor?: import("../../config/sessions/session-accessor.js").TranscriptEntryAnchor;
 }> {
   const { runParams } = params;
@@ -167,6 +168,7 @@ export async function persistCliAssistantTranscript(params: {
     return { owned: false };
   }
   try {
+    const idempotencyKey = `cli-assistant:${runParams.runId}`;
     const result = await appendExactAssistantMessageToSessionTranscript({
       sessionKey: runParams.sessionKey,
       agentId: runParams.agentId,
@@ -178,7 +180,7 @@ export async function persistCliAssistantTranscript(params: {
         ? { expectedWriterRunId: runParams.expectedWriterRunId }
         : {}),
       storePath: runParams.storePath,
-      idempotencyKey: `cli-assistant:${runParams.runId}`,
+      idempotencyKey,
       config: runParams.config,
       beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
       message: buildAssistantMessage({
@@ -202,7 +204,11 @@ export async function persistCliAssistantTranscript(params: {
       log.warn(`CLI assistant transcript persistence skipped: ${result.reason}`);
       return { owned: result.code === "blocked" || result.code === "session-rebound" };
     }
-    return { owned: true, ...(result.anchor ? { terminalAnchor: result.anchor } : {}) };
+    return {
+      owned: true,
+      idempotencyKey,
+      ...(result.anchor ? { terminalAnchor: result.anchor } : {}),
+    };
   } catch (error) {
     log.warn(`CLI assistant transcript persistence failed: ${formatErrorMessage(error)}`);
     return { owned: false };

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -26,6 +26,10 @@ import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
 } from "../embedded-agent-messaging.types.js";
+import {
+  extractToolResultMediaArtifact,
+  filterToolResultMediaUrls,
+} from "../embedded-agent-tool-media.js";
 import { closeClaudeSession } from "./claude-live-registry.js";
 import { attachCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import {
@@ -85,6 +89,10 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   const messagingToolSentTargets: MessagingToolSend[] = [];
   const messagingToolSentTargetKeys = new Set<string>();
   const messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[] = [];
+  const toolMediaUrls: string[] = [];
+  const toolMediaUrlKeys = new Set<string>();
+  let toolAudioAsVoice = false;
+  let toolTrustedLocalMedia = false;
   const matchesCliLoopbackCall = (
     toolName: string,
     toolArgs: Record<string, unknown>,
@@ -422,6 +430,16 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
             result: "result" in call ? call.result : undefined,
             isError: call.outcome !== "completed",
           });
+        } else if (call.outcome === "completed" && "result" in call) {
+          const artifact = extractToolResultMediaArtifact(call.result);
+          const mediaUrls = artifact
+            ? filterToolResultMediaUrls(toolName, artifact.mediaUrls, call.result)
+            : [];
+          appendUniqueCliMessagingEvidence(toolMediaUrls, toolMediaUrlKeys, mediaUrls);
+          if (mediaUrls.length > 0) {
+            toolAudioAsVoice ||= artifact?.audioAsVoice === true;
+            toolTrustedLocalMedia ||= artifact?.trustedLocalMedia === true;
+          }
         }
       },
     });
@@ -591,6 +609,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     messagingToolSentMediaUrls,
     messagingToolSentTargets,
     messagingToolSourceReplyPayloads,
+    toolMediaUrls,
+    toolAudioAsVoice,
+    toolTrustedLocalMedia,
   });
   return {
     beginGatewayCapture,
@@ -620,6 +641,11 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         ...(current.messagingToolSourceReplyPayloads.length > 0
           ? { messagingToolSourceReplyPayloads: current.messagingToolSourceReplyPayloads.slice() }
           : {}),
+        ...(current.toolMediaUrls.length > 0
+          ? { toolMediaUrls: current.toolMediaUrls.slice() }
+          : {}),
+        ...(current.toolAudioAsVoice ? { toolAudioAsVoice: true } : {}),
+        ...(current.toolTrustedLocalMedia ? { toolTrustedLocalMedia: true } : {}),
       };
     },
     attachDeliveryEvidence(error: unknown) {

--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -33,6 +33,10 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     expect(buildGrant().sourceReplyOnly).toBe(true);
   });
 
+  it("carries the prepared model vision capability into the loopback grant", () => {
+    expect(buildGrant({ modelHasVision: true }).modelHasVision).toBe(true);
+  });
+
   it.each([
     { label: "the provider", overrides: { messageProvider: undefined } },
     { label: "the destination", overrides: { currentChannelId: undefined } },

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -151,6 +151,7 @@ export function buildCliMcpGrantContext(params: {
       : {}),
     modelProvider: params.modelProvider,
     modelId: params.modelId,
+    modelHasVision: params.run.modelHasVision,
     messageProvider,
     clientCaps: clientCaps.length > 0 ? clientCaps : undefined,
     currentChannelId,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -125,6 +125,8 @@ export type RunCliAgentParams = {
   inputProvenance?: InputProvenance;
   /** Selected model provider used for tool policy; distinct from a CLI runtime id. */
   modelProvider?: string;
+  /** Vision capability resolved by the run owner from its prepared model catalog. */
+  modelHasVision?: boolean;
   provider: string;
   model?: string;
   thinkLevel?: ThinkLevel;

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1159,6 +1159,7 @@ export function runAgentAttempt(params: {
     clientTools: params.opts.clientTools,
     provider: embeddedAgentProvider,
     model: params.modelOverride,
+    modelHasVision: params.modelHasVision,
     modelFallbacksOverride: params.modelFallbacksOverride,
     authProfileId,
     authProfileIdSource: authProfileId ? harnessAuthSelection.authProfileIdSource : undefined,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -487,6 +487,7 @@ export function runAgentAttempt(params: {
   preparedRunAdmission: PreparedAgentRunAdmission;
   providerOverride: string;
   modelOverride: string;
+  modelHasVision?: boolean;
   configuredAuthProfileId?: string;
   originalProvider: string;
   cfg: OpenClawConfig;
@@ -922,6 +923,7 @@ export function runAgentAttempt(params: {
             prompt: cliPrompt,
             transcriptPrompt: cliTranscriptPrompt,
             modelProvider: params.providerOverride,
+            modelHasVision: params.modelHasVision,
             provider: cliExecutionProvider,
             model: params.modelOverride,
             thinkLevel: params.resolvedThinkLevel,

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -30,6 +30,7 @@ import { resolveFastModeState } from "../fast-mode.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
 import { prepareInternalSessionEffectsSession } from "../internal-session-effects.js";
 import { LiveSessionModelSwitchError } from "../live-model-switch.js";
+import { findModelInCatalog, modelSupportsInput } from "../model-catalog-lookup.js";
 import { modelKey, resolveThinkingDefault } from "../model-selection.js";
 import { resolveConfiguredThinkingDefault } from "../model-thinking-default.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
@@ -450,6 +451,10 @@ export async function runEmbeddedAgentAttempt(params: {
             preparedRunAdmission: params.preparedRunAdmission,
             providerOverride,
             modelOverride,
+            modelHasVision: modelSupportsInput(
+              findModelInCatalog(thinkingCatalog ?? [], providerOverride, modelOverride),
+              "image",
+            ),
             configuredAuthProfileId,
             modelFallbacksOverride: effectiveFallbacksOverride,
             originalProvider: provider,

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
@@ -411,15 +411,18 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
     expect(onExecutionStarted).toHaveBeenCalledWith({ lifecycleGeneration: "gen-1" });
   });
 
-  it("retains ordered prompt images and media facts through the embedded-to-CLI bridge", async () => {
+  it("retains the prepared vision capability with ordered prompt images and media", async () => {
     const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
     const imageOrder = ["inline" as const];
     const media = [{ path: "/tmp/recall.png", contentType: "image/png" }];
 
-    await runEmbeddedAgentViaCliBackendIfEligible(baseRunParams({ images, imageOrder, media }));
+    await runEmbeddedAgentViaCliBackendIfEligible(
+      baseRunParams({ modelHasVision: true, images, imageOrder, media }),
+    );
 
     expect(runCliAgent.mock.calls[0]?.[0]).toMatchObject({
       prompt: "recall prompt",
+      modelHasVision: true,
       images,
       imageOrder,
       media,

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -229,6 +229,7 @@ async function runEmbeddedAgentViaCliBackend(
       media: params.media,
       provider: dispatch.provider,
       model: params.model,
+      modelHasVision: params.modelHasVision,
       thinkLevel: params.thinkLevel,
       timeoutMs: params.timeoutMs,
       runTimeoutOverrideMs: params.runTimeoutOverrideMs ?? params.timeoutMs,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -237,6 +237,8 @@ export type RunEmbeddedAgentParams = {
   disableTools?: boolean;
   provider?: string;
   model?: string;
+  /** Vision capability resolved by the run owner from its prepared model catalog. */
+  modelHasVision?: boolean;
   /** Effective model fallback chain for this session attempt. Undefined uses config defaults. */
   modelFallbacksOverride?: string[];
   /** Session-pinned embedded harness id. Prevents runtime hot-switching. */

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
@@ -48,7 +48,7 @@ async function executeNativeImageTool(imageCount: number): Promise<AgentMessage>
   });
   const content = result.content as ContentBlock[];
   expect(content[0]?.text).toBe(
-    `Loaded ${imageCount} image${imageCount === 1 ? "" : "s"} for direct visual inspection.`,
+    `Loaded ${imageCount} image${imageCount === 1 ? "" : "s"} into private model context for inspection; not displayed, attached, or sent to the user.`,
   );
   expect(content.filter((block) => block.type === "image")).toHaveLength(imageCount);
   expect(content.filter((block) => block.type === "image")).toEqual(

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -67,6 +67,13 @@ describe("read tool", () => {
     decodeWindowsTextFileBufferMock.mockImplementation(({ buffer }) => buffer.toString("utf8"));
   });
 
+  it("describes image reads as private model context", () => {
+    const description = createReadToolDefinition("/workspace").description;
+
+    expect(description).toContain("images attach to model context");
+    expect(description).not.toContain("images attach.");
+  });
+
   it("reads managed inbound media refs as image files", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-media-"));
     const mediaId = `read-tool-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -441,7 +441,7 @@ export function createReadToolDefinition(
   return {
     name: "read",
     label: "read",
-    description: `Read text/image file (jpg/png/gif/webp/bmp); images attach. Text caps ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB. Large/full file: continue offset/limit.`,
+    description: `Read text/image file (jpg/png/gif/webp/bmp); images attach to model context. Text caps ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB. Large/full file: continue offset/limit.`,
     promptSnippet: "Read file contents",
     promptGuidelines: ["Use read to examine files instead of cat or sed."],
     parameters: readSchema,

--- a/src/agents/tools/image-tool.result.ts
+++ b/src/agents/tools/image-tool.result.ts
@@ -36,7 +36,7 @@ export async function buildNativeImageToolResult(
     content: [
       {
         type: "text",
-        text: `Loaded ${images.length} image${images.length === 1 ? "" : "s"} for direct visual inspection.`,
+        text: `Loaded ${images.length} image${images.length === 1 ? "" : "s"} into private model context for inspection; not displayed, attached, or sent to the user.`,
       },
       ...images.map((image) => ({
         type: "image" as const,

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1845,9 +1845,10 @@ describe("image tool implicit imageModel config", () => {
       testing.setProviderDepsForTest({ describeImageWithModel, describeImagesWithModel });
 
       const tool = createRequiredImageTool({ config: cfg, agentDir, modelHasVision: true });
-      expect(tool.label).toBe("View Image");
+      expect(tool.label).toBe("Inspect Image");
       expect(tool.catalogMode).toBe("direct-only");
-      expect(tool.description).toContain("direct visual inspection");
+      expect(tool.description).toContain("private model context");
+      expect(tool.description).toContain("Does not display, attach, or send");
 
       const result = await tool.execute("native-image", {
         prompt: "Read the screenshot error.",
@@ -1861,7 +1862,10 @@ describe("image tool implicit imageModel config", () => {
       ).content;
 
       expect(content).toEqual([
-        { type: "text", text: "Loaded 1 image for direct visual inspection." },
+        {
+          type: "text",
+          text: "Loaded 1 image into private model context for inspection; not displayed, attached, or sent to the user.",
+        },
         expect.objectContaining({ type: "image", mimeType: "image/jpeg" }),
       ]);
       expect((result as { details?: Record<string, unknown> }).details).toMatchObject({

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -896,13 +896,13 @@ export function createImageTool(options?: {
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   const description = modelHasVision
-    ? "Load image(s) for direct visual inspection: image one path/URL, images max 20. Prompt images already visible; use only for images not provided."
+    ? "Load image(s) into private model context for inspection: image one path/URL, images max 20. Does not display, attach, or send files to the user. Prompt images are already visible."
     : explicitImageModelConfig
-      ? "Analyze image(s) with configured model: image one path/URL, images max 20; prompt says inspection."
-      : "Analyze image(s) with available vision: image one path/URL, images max 20; prompt says inspection.";
+      ? "Inspect image(s) in private model context with the configured model: image one path/URL, images max 20. Does not display, attach, or send files to the user."
+      : "Inspect image(s) in private model context with available vision: image one path/URL, images max 20. Does not display, attach, or send files to the user.";
 
   return {
-    label: modelHasVision ? "View Image" : "Image",
+    label: "Inspect Image",
     name: "image",
     description,
     ...(modelHasVision ? { catalogMode: "direct-only" as const } : {}),

--- a/src/agents/tools/media-tool-file-url.windows.test.ts
+++ b/src/agents/tools/media-tool-file-url.windows.test.ts
@@ -94,7 +94,10 @@ describe.runIf(process.platform === "win32")("host-local media tool file URLs", 
           image: imageUrl,
         });
         expect(imageResult.content).toEqual([
-          { type: "text", text: "Loaded 1 image for direct visual inspection." },
+          {
+            type: "text",
+            text: "Loaded 1 image into private model context for inspection; not displayed, attached, or sent to the user.",
+          },
           expect.objectContaining({ type: "image" }),
         ]);
 

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { PreparedAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import type { BootstrapContextRunKind } from "../../agents/bootstrap-mode.js";
@@ -90,6 +91,15 @@ export async function runCliFallbackCandidate(params: {
   bootstrapPromptWarningSignaturesSeen: string[];
 }> {
   const turn = params.turn;
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const modelHasVision = Boolean(
+    turn.followupRun.run.thinkingCatalog
+      ?.find(
+        (entry) =>
+          normalizeProviderId(entry.provider) === normalizedProvider && entry.id === params.model,
+      )
+      ?.input?.includes("image"),
+  );
   const sessionKey = turn.sessionKey ?? turn.followupRun.run.sessionKey;
   const sessionTarget =
     sessionKey && turn.storePath
@@ -382,6 +392,7 @@ export async function runCliFallbackCandidate(params: {
             currentInboundContext: turn.followupRun.currentInboundContext,
             inputProvenance: turn.followupRun.run.inputProvenance,
             modelProvider: params.provider,
+            modelHasVision,
             provider: params.cliExecutionProvider,
             execOverrides: turn.followupRun.run.execOverrides,
             bashElevated: turn.followupRun.run.bashElevated,

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -92,6 +92,7 @@ describe("executeAgentTurn: CLI session routing", () => {
       suppressedFactIndexes: [],
     };
     state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
+      expect(params.modelHasVision).toBe(true);
       const internalParams = params as RunCliAgentParams & {
         mediaImageLayout?: typeof mediaImageLayout;
       };
@@ -128,6 +129,13 @@ describe("executeAgentTurn: CLI session routing", () => {
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";
     followupRun.run.model = "claude-opus-5";
+    followupRun.run.thinkingCatalog = [
+      {
+        provider: "claude-cli",
+        id: "claude-opus-5",
+        input: ["text", "image"],
+      },
+    ];
     const preparedFollowupRun = followupRun as typeof followupRun & {
       currentTurnImagesPrepared?: true;
       mediaImageLayout?: typeof mediaImageLayout;

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -31,6 +31,7 @@ export type ThinkingCatalogEntry = {
   id: string;
   api?: string;
   reasoning?: boolean;
+  input?: readonly ("text" | "image" | "audio" | "video" | "document")[];
   params?: Record<string, unknown>;
   compat?: {
     thinkingFormat?: string;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -15,6 +15,7 @@ import {
 } from "../../agents/harness/context-engine-turn-attempt.js";
 import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
+import { findModelInCatalog, modelSupportsInput } from "../../agents/model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { resolveConfiguredThinkingDefault } from "../../agents/model-thinking-default.js";
@@ -569,6 +570,10 @@ function createCronPromptExecutor(params: {
                 prompt: promptText,
                 finalizePromptForResolvedTools,
                 modelProvider: providerOverride,
+                modelHasVision: modelSupportsInput(
+                  findModelInCatalog(thinkingCatalog ?? [], providerOverride, modelOverride),
+                  "image",
+                ),
                 provider: executionProvider,
                 model: modelOverride,
                 thinkLevel: candidateThinkLevel,

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -29,6 +29,7 @@ export type McpLoopbackRequestContext = {
   cwd?: string;
   modelProvider?: string;
   modelId?: string;
+  modelHasVision?: boolean;
   messageProvider?: string;
   clientCaps?: string[];
   currentChannelId?: string;

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -212,6 +212,23 @@ describe("McpLoopbackToolCache", () => {
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
   });
 
+  it("does not share loopback tools across prepared vision capabilities", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    cache.resolve(scopeParams({ cfg, modelHasVision: true }));
+    cache.resolve(scopeParams({ cfg, modelHasVision: false }));
+    cache.resolve(scopeParams({ cfg, modelHasVision: true }));
+
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+    expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).toMatchObject({
+      modelHasVision: true,
+    });
+    expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({
+      modelHasVision: false,
+    });
+  });
+
   it("evicts only the revoked grant's cached tool closures", () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -189,6 +189,7 @@ export class McpLoopbackToolCache {
       params.cwd ?? "",
       params.modelProvider ?? "",
       params.modelId ?? "",
+      params.modelHasVision === true ? "vision" : "text-only",
       params.yieldContextCacheKey ?? "",
       params.messageProvider ?? "",
       clientCapsCacheKey,

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -90,6 +90,23 @@ describe("resolveGatewayScopedTools", () => {
     expect(grantBound.tools.some((tool) => tool.name === "image")).toBe(true);
   });
 
+  it("uses the prepared vision fact for the loopback image loader", () => {
+    const result = resolveGatewayScopedTools({
+      cfg: {} as OpenClawConfig,
+      agentDir: "/agents/cli",
+      sessionKey: "agent:main:main",
+      modelHasVision: true,
+      surface: "loopback",
+    });
+
+    const imageTool = result.tools.find((tool) => tool.name === "image");
+    expect(imageTool).toMatchObject({
+      label: "Inspect Image",
+      catalogMode: "direct-only",
+    });
+    expect(imageTool?.description).toContain("private model context");
+  });
+
   it("applies a borrowed runtime policy without reassigning session tools", () => {
     const cfg = {
       agents: {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -74,6 +74,7 @@ export function resolveGatewayScopedTools(params: {
   cwd?: string;
   modelProvider?: string;
   modelId?: string;
+  modelHasVision?: boolean;
   onYield?: (message: string) => Promise<void> | void;
   messageProvider?: string;
   currentChannelId?: string;
@@ -312,6 +313,7 @@ export function resolveGatewayScopedTools(params: {
     authProfileStore: params.authProfileStore,
     modelProvider: params.modelProvider,
     modelId: params.modelId,
+    modelHasVision: params.modelHasVision,
     clientCaps: params.clientCaps,
     workspaceDir,
     sandboxed: sandboxRuntime.sandboxed,
@@ -370,6 +372,7 @@ export function resolveGatewayScopedTools(params: {
           cwd: params.cwd?.trim() || workspaceDir,
           modelProvider: params.modelProvider,
           modelId: params.modelId,
+          modelHasVision: params.modelHasVision,
           messageProvider: params.messageProvider,
           messageChannel: params.messageProvider,
           clientCaps: params.clientCaps,


### PR DESCRIPTION
Related: #124908

## What Problem This Solves

Fixes an issue where users asking coding agents to create and show visual renderings could receive a completed reply with image-inspection activity but no attached image. It also fixes the sibling Claude CLI path where explicit outbound tool media could be dropped before final reply delivery.

## Why This Change Was Made

Image inspection and user delivery are separate facts. The change makes inspection-only tools explicitly private, prefers Codex's native image loader when available, carries the prepared vision capability into Claude CLI tool construction, and captures only trusted explicit outbound media through the canonical reply and transcript path. Private image results remain non-outbound; the UI does not infer delivery from file paths or tool names.

## User Impact

Agents no longer see a redundant OpenClaw image-inspection tool when native Codex inspection is active, and the remaining inspection descriptions no longer imply user attachment. Explicit outbound images produced through Claude CLI-backed tools are delivered once and remain visible after chat history reload.

## Evidence

- Focused Vitest coverage passed for Claude/MCP media capture, CLI vision propagation, Gateway tool resolution, transcript identity, native image privacy, coding read wording, and Codex native image-tool filtering.
- `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts -- -t 'describes image reads as private model context'` passed.
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts` passed (171 tests across routed shards).
- `git diff --check` and changed-file `oxfmt --check` passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts` passed (43 tests), covering the subscription-auth handoff of the prepared vision capability.
- Fresh uncommitted Codex autoreview after the propagation fix reported no accepted/actionable findings.
- Final exact-head CI run [31983872633](https://github.com/openclaw/openclaw/actions/runs/31983872633) passed on `10e0d233b675543f2f46932fe851576bd1a27d26`.
- Direct inspection of the pinned `@openai/codex` `rust-v0.147.0` source confirms `view_image` is stable and default-enabled (`features/src/lib.rs:862-865`), registered on enabled native tool surfaces (`core/src/tools/spec_plan.rs:836-842`, `1031-1038`), and returns an `InputImage` model content item (`core/src/tools/handlers/view_image.rs:219-224`).
- Final ClawSweeper review reported no actionable findings; its remaining dependency-contract owner decision is resolved by the pinned-source proof above.

AI-assisted: yes. The implementation and tests were reviewed against the affected OpenClaw and upstream Codex runtime contracts.


