### PR TITLE
fix(test): create sessions in default Control UI mock

### DIFF
--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
+  controlUiSessionPath,
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   installMockGateway,
@@ -23,6 +24,67 @@ async function captureProof(page: import("playwright").Page, fileName: string) {
 }
 
 suite.define(() => {
+  it("creates and lists a session with the default mock Gateway", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.locator(".new-session-page__message").fill("verify the default mock");
+      await page.getByRole("button", { name: "Start session" }).click();
+
+      await expect(gateway.waitForRequest("sessions.create")).resolves.toMatchObject({
+        params: { agentId: "main", message: "verify the default mock" },
+      });
+      const sessionKeys = ["agent:main:mock-created-1", "agent:main:mock-created-2"] as const;
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(controlUiSessionPath(sessionKeys[0]));
+
+      await page.getByRole("button", { name: "New session" }).first().click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
+      await page.locator(".new-session-page__message").fill("verify another default mock");
+      await page.getByRole("button", { name: "Start session" }).click();
+      await expect.poll(async () => (await gateway.getRequests("sessions.create")).length).toBe(2);
+      expect((await gateway.getRequests("sessions.create")).at(-1)).toMatchObject({
+        params: { agentId: "main", message: "verify another default mock" },
+      });
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(controlUiSessionPath(sessionKeys[1]));
+      for (const sessionKey of sessionKeys) {
+        await expect
+          .poll(() =>
+            page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`).count(),
+          )
+          .toBe(1);
+      }
+      await expect.poll(() => page.locator(".new-session-page__error").count()).toBe(0);
+      await captureProof(page, "default-mock-created.png");
+
+      const listRequestsBeforeReconnect = (await gateway.getRequests("sessions.list")).length;
+      await gateway.closeLatest(1006, "mock reconnect");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(1);
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBeGreaterThan(listRequestsBeforeReconnect);
+      for (const sessionKey of sessionKeys) {
+        await expect
+          .poll(() =>
+            page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`).count(),
+          )
+          .toBe(1);
+      }
+      await captureProof(page, "default-mock-reconnected.png");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps the new-session view live until the focused chat is ready", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1795,6 +1795,19 @@ function installControlUiMockGateway(
         };
       case "models.list":
         return { models: scenario.models };
+      case "sessions.create": {
+        const agentId =
+          isRecord(params) && typeof params.agentId === "string"
+            ? params.agentId
+            : scenario.defaultAgentId;
+        const requestedKey =
+          isRecord(params) && typeof params.key === "string" ? params.key.trim() : "";
+        const response = {
+          key: requestedKey || `agent:${agentId}:mock-created-${createdSessions.size + 1}`,
+        };
+        recordMaterializedSession(params, response);
+        return response;
+      }
       case "sessions.list":
         return applySessionPatches(
           {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI browser tests using the default mock Gateway could advertise `sessions.create` but receive an empty response when starting a session. The real New Session flow then rejected the missing session key and remained on `/new`.

The mismatch was introduced when #117920 added `sessions.create` to the default advertised method catalog without adding its default mock response.

## Why This Change Was Made

The serialized mock Gateway now handles unconfigured `sessions.create` requests in its default dispatcher, generates a distinct session key, and records the created session through the existing materialization owner. Configured and deferred responses keep precedence, while replacement WebSockets continue to list the shared materialized sessions.

The regression test crosses the real browser submission, request, route, sidebar reconciliation, disconnect, replacement socket, and post-reconnect `sessions.list` flow. It creates two sessions to prove key uniqueness and requires a fresh list request before accepting rehydrated rows.

## User Impact

Developers can use the default Control UI mock Gateway for real New Session browser flows without adding a scenario-specific `sessions.create` fixture. Mocked reconnect tests now retain those created sessions consistently.

No production Gateway behavior or protocol surface changes.

## Evidence

Before the fix, the focused browser regression observed the create request but remained at `/new` instead of navigating to `/chat/main/mock-created-1` because the default mock response was `{}`.

After the fix, exact head `5c72b746ba803b5d5c3847c209612f884343635c` passed:

- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.transition.e2e.test.ts` — 2/2 tests
- `node scripts/run-vitest.mjs ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts` — 13/13 tests
- UI production typecheck and focused E2E test typecheck
- focused oxlint, stylelint, oxfmt, and `git diff --check`
- independent exact-head P0-P2 review — clean; the reviewer specifically verified unique keys and post-reconnect canonical list rehydration
- structured autoreview preflight/TruffleHog scan — clean; the external Codex review engine then failed before returning a verdict, so this is not claimed as a green autoreview result
- exact-head hosted CI [run 31979569350](https://github.com/openclaw/openclaw/actions/runs/31979569350) — green; the initial UI E2E shard timed out in an unrelated Claude-history test that passed locally in isolation, and the exact hosted shard rerun passed

Created sessions before reconnect:

![Two distinct default mock sessions listed in the Control UI](https://ampcode.com/user-content/artifacts/c738dbcd278aa4bc887690432e95fd92933ab42c523f1d5a963f651e9e56ccf6-file.png)

The same sessions after a replacement WebSocket and a fresh `sessions.list` request:

![Both default mock sessions retained after reconnect](https://ampcode.com/user-content/artifacts/042ee1e5b548568424b9e9364e48080a24545c3406a35fdae3ceac5fb8983c26-file.png)

AI-assisted: yes. The implementation, owner boundary, test value, and visual proof were inspected directly.
