### PR TITLE
feat(tts): add structured reply speech fields

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -333,6 +333,15 @@ export interface UserMessage {
 }
 
 /** Assistant turn, including provider identity and final stop state. */
+export type AssistantDeliveryTtsFacts = {
+  tagged: true;
+  text?: string;
+  directives?: Array<{
+    provider?: string;
+    values: Record<string, string>;
+  }>;
+};
+
 export interface AssistantMessage {
   role: "assistant";
   content: (TextContent | ThinkingContent | ToolCall)[];
@@ -340,6 +349,8 @@ export interface AssistantMessage {
     audioAsVoice?: true;
     replyToCurrent?: true;
     replyToId?: string;
+    /** Parsed once at the assistant write boundary; delivery resolves policy from these facts. */
+    tts?: AssistantDeliveryTtsFacts;
   };
   api: Api;
   provider: Provider;

--- a/src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { buildPayloads } from "./payloads.test-helpers.js";
 
 describe("buildEmbeddedRunPayloads delivery recovery", () => {
@@ -13,6 +14,10 @@ describe("buildEmbeddedRunPayloads delivery recovery", () => {
           audioAsVoice: true,
           replyToCurrent: true,
           replyToId: "message-7",
+          tts: {
+            tagged: true,
+            text: "Recovered speech",
+          },
         },
       } as AssistantMessage,
     });
@@ -25,6 +30,10 @@ describe("buildEmbeddedRunPayloads delivery recovery", () => {
         replyToId: "message-7",
       }),
     ]);
+    expect(getReplyPayloadMetadata(payloads[0]!)?.tts).toEqual({
+      tagged: true,
+      text: "Recovered speech",
+    });
   });
 
   it("does not recover delivery facts by parsing a pre-upgrade assistant", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -9,6 +9,8 @@ import {
   type HeartbeatToolResponse,
 } from "../../../auto-reply/heartbeat-tool-response.js";
 import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
   type ReplyPayload,
@@ -206,7 +208,7 @@ export function buildEmbeddedRunPayloads(params: {
   const assistantForPayload =
     currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);
   // Pre-upgrade recovered messages have no stored facts, and recovery intentionally does not
-  // reparse text; one in-flight reply can lose its target across this upgrade boundary.
+  // reparse text; one in-flight reply can lose delivery or speech intent across this boundary.
   const storedDelivery = assistantForPayload?.openclawDelivery;
   const lastAssistantStopReason = assistantForPayload?.stopReason;
   const lastAssistantErrored = lastAssistantStopReason === "error";
@@ -379,20 +381,31 @@ export function buildEmbeddedRunPayloads(params: {
       replyToTag,
       replyToCurrent,
     } = parseReplyDirectives(text);
+    const ttsFacts = shouldUseCanonicalFinalAnswer ? storedDelivery?.tts : undefined;
     const delivery = shouldUseCanonicalFinalAnswer
       ? {
-          ...storedDelivery,
+          audioAsVoice: storedDelivery?.audioAsVoice,
+          replyToCurrent: storedDelivery?.replyToCurrent,
+          replyToId: storedDelivery?.replyToId,
           replyToTag: Boolean(storedDelivery?.replyToCurrent || storedDelivery?.replyToId),
         }
       : { audioAsVoice, replyToId, replyToTag, replyToCurrent };
-    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !delivery.audioAsVoice) {
+    if (
+      !cleanedText &&
+      (!mediaUrls || mediaUrls.length === 0) &&
+      !delivery.audioAsVoice &&
+      !ttsFacts
+    ) {
       continue;
     }
-    replyItems.push({
+    const replyPayload = {
       text: cleanedText,
       media: mediaUrls,
       ...delivery,
-    });
+    };
+    replyItems.push(
+      ttsFacts ? setReplyPayloadMetadata(replyPayload, { tts: ttsFacts }) : replyPayload,
+    );
     hasUserFacingAssistantReply = true;
     if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
       hasUserFacingFailureAcknowledgement = true;
@@ -438,9 +451,9 @@ export function buildEmbeddedRunPayloads(params: {
   const hasAudioAsVoiceTag = replyItems.some((item) => item.audioAsVoice);
   return replyItems
     .map((item) => {
-      const payload: ReplyPayload = {
+      const payload: ReplyPayload = copyReplyPayloadMetadata(item, {
         text: normalizeOptionalString(item.text),
-      };
+      });
       const mediaUrl = item.mediaUrl ?? item.media?.[0];
       if (mediaUrl) {
         payload.mediaUrl = mediaUrl;
@@ -547,7 +560,7 @@ export function buildEmbeddedRunPayloads(params: {
       return payload;
     })
     .filter((p) => {
-      if (!hasReplyPayloadContent(p)) {
+      if (!hasReplyPayloadContent(p) && !getReplyPayloadMetadata(p)?.tts) {
         return false;
       }
       if (p.text && isSilentReplyPayloadText(p.text, SILENT_REPLY_TOKEN)) {

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -48,12 +48,20 @@ describe("SessionManager persistence compatibility", () => {
 
     const manager = SessionManager.open(scope, dir);
     const tagged = buildAssistantMessage(
-      "[[reply_to_current]]\n[[reply_to:message-7]]\n[[audio_as_voice]]\nFinal answer",
+      [
+        "[[reply_to_current]]",
+        "[[reply_to:message-7]]",
+        "[[audio_as_voice]]",
+        "[[tts:provider=mock voiceId=voice-7]]",
+        "Final answer [[tts:text]]Spoken answer[[/tts:text]]",
+      ].join("\n"),
     );
     const codeExampleText = [
       "Use `[[reply_to_current]]` literally.",
+      "Use `[[tts:text]]spoken[[/tts:text]]` literally.",
       "```text",
       "[[audio_as_voice]]",
+      "[[tts:provider=mock voiceId=voice-7]]",
       "```",
     ].join("\n");
     const codeExample = buildAssistantMessage(codeExampleText);
@@ -68,6 +76,16 @@ describe("SessionManager persistence compatibility", () => {
         audioAsVoice: true,
         replyToCurrent: true,
         replyToId: "message-7",
+        tts: {
+          tagged: true,
+          text: "Spoken answer",
+          directives: [
+            {
+              provider: "mock",
+              values: { voiceid: "voice-7" },
+            },
+          ],
+        },
       },
     });
     expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);

--- a/src/agents/system-prompt-config.ts
+++ b/src/agents/system-prompt-config.ts
@@ -49,8 +49,9 @@ function buildModelAliasLines(cfg?: OpenClawConfig) {
 function resolveAgentSystemPromptConfig(params: {
   config?: OpenClawConfig;
   agentId?: string;
+  sourceReplyDeliveryMode?: AgentSystemPromptRenderParams["sourceReplyDeliveryMode"];
 }): ResolvedAgentSystemPromptConfig {
-  const { config, agentId } = params;
+  const { config, agentId, sourceReplyDeliveryMode } = params;
   const ownerDisplay = resolveOwnerDisplaySetting(config);
   const agentSubagents =
     config && agentId ? resolveAgentConfig(config, agentId)?.subagents : undefined;
@@ -61,7 +62,11 @@ function resolveAgentSystemPromptConfig(params: {
       agentSubagents?.delegationMode ??
       config?.agents?.defaults?.subagents?.delegationMode ??
       "suggest",
-    ttsHint: config ? buildTtsSystemPromptHint(config, agentId) : undefined,
+    ttsHint: config
+      ? buildTtsSystemPromptHint(config, agentId, {
+          messageToolOnly: sourceReplyDeliveryMode === "message_tool_only",
+        })
+      : undefined,
     modelAliasLines: buildModelAliasLines(config),
     memoryCitationsMode: config?.memory?.citations,
     fsWorkspaceOnly: resolveEffectiveToolFsWorkspaceOnly({ cfg: config, agentId }),
@@ -71,7 +76,13 @@ function resolveAgentSystemPromptConfig(params: {
 /** Builds the agent system prompt after applying config-derived prompt fields. */
 export function buildConfiguredAgentSystemPrompt(params: ConfiguredAgentSystemPromptParams) {
   const { config, agentId, ...renderParams } = params;
-  const configParams = config ? resolveAgentSystemPromptConfig({ config, agentId }) : {};
+  const configParams = config
+    ? resolveAgentSystemPromptConfig({
+        config,
+        agentId,
+        sourceReplyDeliveryMode: renderParams.sourceReplyDeliveryMode,
+      })
+    : {};
   return buildAgentSystemPrompt({
     ...renderParams,
     ...configParams,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -385,6 +385,19 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Directives stripped before render");
   });
 
+  it("teaches structured speech fields for message-tool-only replies", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      sourceReplyDeliveryMode: "message_tool_only",
+      toolNames: ["message"],
+    });
+
+    expect(prompt).toContain("voiceText");
+    expect(prompt).toContain("voiceProvider");
+    expect(prompt).toContain("voiceId");
+    expect(prompt).not.toContain("[[tts:");
+  });
+
   it("omits the heartbeat section when no heartbeat prompt is provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -499,7 +499,8 @@ function buildAssistantOutputDirectivesSection(params: {
       "## Assistant Output Directives",
       "- Visible source output: `message(action=send)`.",
       "- Media paths = attachments, not prose. One: `media`; many: `attachments: [{media: ...}]`.",
-      "- No legacy `MEDIA:` here. Voice note: `asVoice`. Explicit native reply: `replyTo`.",
+      "- Synthesized speech: `voiceText`; optional `voiceProvider`, `voiceId`; voice note: `asVoice`.",
+      "- No legacy `MEDIA:` here. Explicit native reply: `replyTo`.",
       "",
     ];
   }

--- a/src/agents/tools/message-tool-schema.ts
+++ b/src/agents/tools/message-tool-schema.ts
@@ -170,7 +170,16 @@ function buildSendSchema(options: {
     ),
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
-    asVoice: Type.Optional(Type.Boolean()),
+    asVoice: Type.Optional(
+      Type.Boolean({ description: "Send audio as a voice note; combines with voiceText." }),
+    ),
+    voiceText: Type.Optional(
+      Type.String({ description: "Text to synthesize; message remains visible." }),
+    ),
+    voiceProvider: Type.Optional(
+      Type.String({ description: "Per-send speech provider override." }),
+    ),
+    voiceId: Type.Optional(Type.String({ description: "Per-send speech voice override." })),
     silent: Type.Optional(Type.Boolean()),
     quoteText: Type.Optional(Type.String({ description: "Telegram reply quote text." })),
     gifPlayback: Type.Optional(Type.Boolean()),

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3043,6 +3043,14 @@ describe("message tool schema scoping", () => {
         .map((variant) => variant.required);
 
       expect(properties).toHaveProperty("presentation");
+      expect(properties).toMatchObject({
+        voiceText: { type: "string" },
+        voiceProvider: { type: "string" },
+        voiceId: { type: "string" },
+      });
+      expect(JSON.stringify(properties.voiceText)).not.toContain("anyOf");
+      expect(JSON.stringify(properties.voiceProvider)).not.toContain("anyOf");
+      expect(JSON.stringify(properties.voiceId)).not.toContain("anyOf");
       expect(presentationSchemaJson).toContain('"action"');
       expect(presentationSchemaJson).toContain('"command"');
       expect(presentationSchemaJson).toContain('"const":"url"');

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -11,6 +11,7 @@ import type {
   MessagePresentation,
   ReplyPayloadDelivery,
 } from "../interactive/payload.js";
+import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
 
 export type ReplyMediaAttachment = {
   type?: "image" | "audio" | "video" | "file";
@@ -238,6 +239,10 @@ export function buildTtsSupplementMediaPayload(payload: ReplyPayload): ReplyPayl
 /** WeakMap-backed metadata attached to payload objects without changing wire shape. */
 export type ReplyPayloadMetadata = {
   assistantMessageIndex?: number;
+  /** Persisted assistant speech facts; never serialized into channel payloads. */
+  tts?: AssistantDeliveryTtsFacts;
+  /** Structured message-tool speech is an explicit request, independent of auto-TTS mode. */
+  ttsExplicit?: true;
   /** Original runtime MEDIA references used to identify the persisted assistant row. */
   assistantTranscriptMediaUrls?: string[];
   /** The runtime owns the transcript decision for this assistant payload. */

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AssistantDeliveryTtsFacts } from "../../llm/types.js";
-import { extractTtsDirectiveFacts } from "../../tts/directives.js";
+import { extractTtsDirectiveFacts } from "../../tts/directive-facts.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 
 type AssistantDirectiveMessage = {

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -1,4 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AssistantDeliveryTtsFacts } from "../../llm/types.js";
+import { extractTtsDirectiveFacts } from "../../tts/directives.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 
 type AssistantDirectiveMessage = {
@@ -7,6 +9,26 @@ type AssistantDirectiveMessage = {
   role?: unknown;
 };
 
+type AssistantDeliveryFacts = {
+  audioAsVoice?: true;
+  replyToCurrent?: true;
+  replyToId?: string;
+  tts?: AssistantDeliveryTtsFacts;
+};
+
+function mergeTtsFacts(
+  current: AssistantDeliveryTtsFacts | undefined,
+  next: AssistantDeliveryTtsFacts,
+): AssistantDeliveryTtsFacts {
+  return {
+    tagged: true,
+    ...((current?.text ?? next.text) != null ? { text: current?.text ?? next.text } : {}),
+    ...(current?.directives || next.directives
+      ? { directives: [...(current?.directives ?? []), ...(next.directives ?? [])] }
+      : {}),
+  };
+}
+
 /** Strips final-answer directives in place so live state and persisted bytes stay identical. */
 export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMessage>(
   message: T,
@@ -14,21 +36,23 @@ export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMes
   if (message.role !== "assistant" || !Array.isArray(message.content)) {
     return message;
   }
-  let facts: { audioAsVoice?: true; replyToCurrent?: true; replyToId?: string } | undefined;
+  let facts: AssistantDeliveryFacts | undefined;
   for (const block of message.content) {
     if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") {
       continue;
     }
     const parsed = parseInlineDirectives(block.text);
-    if (!parsed.hasAudioTag && !parsed.hasReplyTag) {
+    const tts = extractTtsDirectiveFacts(parsed.text);
+    if (!parsed.hasAudioTag && !parsed.hasReplyTag && !tts.facts) {
       continue;
     }
     facts ??= {};
-    block.text = parsed.text;
+    block.text = tts.facts ? tts.cleanedText.trim() : tts.cleanedText;
     Object.assign(facts, {
       ...(parsed.audioAsVoice ? { audioAsVoice: true as const } : {}),
       ...(parsed.replyToCurrent ? { replyToCurrent: true as const } : {}),
       ...(parsed.replyToExplicitId ? { replyToId: parsed.replyToExplicitId } : {}),
+      ...(tts.facts ? { tts: mergeTtsFacts(facts.tts, tts.facts) } : {}),
     });
   }
   if (facts) {

--- a/src/infra/outbound/message-action-send.core.test.ts
+++ b/src/infra/outbound/message-action-send.core.test.ts
@@ -1,6 +1,7 @@
 // Covers core message-action send fallback, TTS application, and durable send
 // policy after plugin preparation is absent.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
@@ -412,7 +413,7 @@ describe("runMessageAction core send routing", () => {
     expect(firstMockArg(sendText, "send text").text).toBe("hello world");
   });
 
-  it("applies TTS to message-tool sends before core outbound delivery", async () => {
+  it("maps structured speech fields to TTS facts before core outbound delivery", async () => {
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "voice-1",
@@ -455,7 +456,11 @@ describe("runMessageAction core send routing", () => {
       params: {
         channel: "testchat",
         target: "channel:abc",
-        message: "[[tts:text]]hello there[[/tts:text]]",
+        message: "Visible greeting",
+        voiceText: "hello there",
+        voiceProvider: "mock",
+        voiceId: "voice-7",
+        asVoice: true,
       },
       sessionKey: "agent:main:testchat:channel:abc",
       dryRun: false,
@@ -466,10 +471,24 @@ describe("runMessageAction core send routing", () => {
         kind: "final",
         channel: "testchat",
         payload: expect.objectContaining({
-          text: "[[tts:text]]hello there[[/tts:text]]",
+          text: "Visible greeting",
+          audioAsVoice: true,
         }),
       }),
     );
+    const ttsCall = firstMockArg(ttsMocks.maybeApplyTtsToPayload, "TTS payload");
+    const ttsPayload = ttsCall.payload;
+    expect(typeof ttsPayload === "object" && ttsPayload !== null).toBe(true);
+    expect(getReplyPayloadMetadata(ttsPayload as object)?.tts).toEqual({
+      tagged: true,
+      text: "hello there",
+      directives: [
+        {
+          provider: "mock",
+          values: { voiceid: "voice-7" },
+        },
+      ],
+    });
     expect(sendMedia).toHaveBeenCalledOnce();
     const mediaInput = firstMockArg(sendMedia, "send media");
     expect(mediaInput.text).toBe("");

--- a/src/infra/outbound/message-action-send.core.test.ts
+++ b/src/infra/outbound/message-action-send.core.test.ts
@@ -413,7 +413,7 @@ describe("runMessageAction core send routing", () => {
     expect(firstMockArg(sendText, "send text").text).toBe("hello world");
   });
 
-  it("maps structured speech fields to TTS facts before core outbound delivery", async () => {
+  it("preserves structured speech through response prefixes when automatic TTS is off", async () => {
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "voice-1",
@@ -446,10 +446,11 @@ describe("runMessageAction core send routing", () => {
         channels: {
           testchat: {
             enabled: true,
+            responsePrefix: "[Nexus]",
           },
         },
         tts: {
-          auto: "tagged",
+          auto: "off",
         },
       } as OpenClawConfig,
       action: "send",
@@ -471,7 +472,7 @@ describe("runMessageAction core send routing", () => {
         kind: "final",
         channel: "testchat",
         payload: expect.objectContaining({
-          text: "Visible greeting",
+          text: "[Nexus] Visible greeting",
           audioAsVoice: true,
         }),
       }),

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -3,7 +3,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
 import { resolveAgentIdentity, resolveResponsePrefix } from "../../agents/identity.js";
 import { readStringArrayParam, readToolStringParam } from "../../agents/tools/common.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { setReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { normalizeOutboundLocation } from "../../channels/location.js";
 import { normalizeConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
@@ -17,6 +17,7 @@ import {
   normalizeMessagePresentation,
   type ReplyPayloadDelivery,
 } from "../../interactive/payload.js";
+import type { AssistantDeliveryTtsFacts } from "../../llm/types.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
@@ -165,9 +166,12 @@ export async function buildMessagePayload(params: {
       ? undefined
       : normalizeOutboundLocation(rawLocation);
   const caption = readToolStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
+  const voiceText = readToolStringParam(actionParams, "voiceText");
+  const voiceProvider = readToolStringParam(actionParams, "voiceProvider");
+  const voiceId = readToolStringParam(actionParams, "voiceId");
   let message =
     readToolStringParam(actionParams, "message", {
-      required: !hasMediaHint && !hasPresentation && !hasInteractive && !location,
+      required: !hasMediaHint && !hasPresentation && !hasInteractive && !location && !voiceText,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {
@@ -225,6 +229,7 @@ export async function buildMessagePayload(params: {
   const hasLocationConflict = Boolean(
     location &&
     (message.trim() ||
+      voiceText ||
       hasBuffer ||
       mergedMediaUrls.length > 0 ||
       hasPresentation ||
@@ -263,6 +268,7 @@ export async function buildMessagePayload(params: {
 
   const mediaUrl = readToolStringParam(actionParams, "media", { trim: false });
   if (
+    !voiceText &&
     !hasReplyPayloadContent({
       text: message,
       mediaUrl,
@@ -305,20 +311,40 @@ export async function buildMessagePayload(params: {
       : undefined;
   const presentation = normalizeMessagePresentation(actionParams.presentation);
   const interactive = normalizeLegacyInteractiveReply(actionParams.interactive);
+  const payload: ReplyPayload = {
+    text: message,
+    ...(mediaUrl ? { mediaUrl } : {}),
+    ...(mergedMediaUrls.length ? { mediaUrls: mergedMediaUrls } : {}),
+    ...(asVoice ? { audioAsVoice: true } : {}),
+    ...(asVideoNote ? { videoAsNote: true } : {}),
+    ...(location ? { location } : {}),
+    ...(presentation ? { presentation } : {}),
+    ...(interactive ? { interactive } : {}),
+    ...(delivery ? { delivery } : {}),
+    ...(channelData ? { channelData } : {}),
+  };
+  const ttsFacts: AssistantDeliveryTtsFacts | undefined =
+    voiceText || voiceProvider || voiceId
+      ? {
+          tagged: true as const,
+          ...(voiceText ? { text: voiceText } : {}),
+          ...(voiceProvider || voiceId
+            ? {
+                directives: [
+                  {
+                    ...(voiceProvider ? { provider: voiceProvider.toLowerCase() } : {}),
+                    values: voiceId ? { voiceid: voiceId } : {},
+                  },
+                ],
+              }
+            : {}),
+        }
+      : undefined;
   return {
     message,
-    payload: {
-      text: message,
-      ...(mediaUrl ? { mediaUrl } : {}),
-      ...(mergedMediaUrls.length ? { mediaUrls: mergedMediaUrls } : {}),
-      ...(asVoice ? { audioAsVoice: true } : {}),
-      ...(asVideoNote ? { videoAsNote: true } : {}),
-      ...(location ? { location } : {}),
-      ...(presentation ? { presentation } : {}),
-      ...(interactive ? { interactive } : {}),
-      ...(delivery ? { delivery } : {}),
-      ...(channelData ? { channelData } : {}),
-    },
+    payload: ttsFacts
+      ? setReplyPayloadMetadata(payload, { tts: ttsFacts, ttsExplicit: true })
+      : payload,
     ...(mediaUrl ? { mediaUrl } : {}),
     ...(mirrorMediaUrls ? { mediaUrls: mirrorMediaUrls } : {}),
     asVoice,
@@ -443,6 +469,9 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     sendPayload = updateSendPayloadPartsFromReplyPayload(sendPayload, ttsPayload);
     applySendPayloadPartsToActionParams(params, sendPayload);
   }
+  delete params.voiceText;
+  delete params.voiceProvider;
+  delete params.voiceId;
   throwIfAborted(abortSignal);
   const mediaAccess = resolveAgentScopedOutboundMediaAccess({
     cfg,

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -3,7 +3,11 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
 import { resolveAgentIdentity, resolveResponsePrefix } from "../../agents/identity.js";
 import { readStringArrayParam, readToolStringParam } from "../../agents/tools/common.js";
-import { setReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { normalizeOutboundLocation } from "../../channels/location.js";
 import { normalizeConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
@@ -413,7 +417,10 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     sendPayload = {
       ...sendPayload,
       message: prefixedMessage,
-      payload: { ...sendPayload.payload, text: prefixedMessage },
+      payload: copyReplyPayloadMetadata(sendPayload.payload, {
+        ...sendPayload.payload,
+        text: prefixedMessage,
+      }),
     };
     applySendPayloadPartsToActionParams(params, sendPayload);
   }

--- a/src/infra/outbound/message-action-tts.ts
+++ b/src/infra/outbound/message-action-tts.ts
@@ -1,6 +1,6 @@
 // Message-action TTS helpers lazily apply session/config driven speech output
 // to send payloads without loading TTS providers for ordinary sends.
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveSessionStorePathCore } from "../../config/sessions.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -57,7 +57,9 @@ export async function maybeApplyTtsToMessageActionSendPayload(params: {
     sessionKey: params.sessionKey,
     agentId: params.agentId,
   });
+  const explicitTts = getReplyPayloadMetadata(params.payload)?.ttsExplicit === true;
   if (
+    !explicitTts &&
     !shouldAttemptTtsPayload({
       cfg: params.cfg,
       ttsAuto,

--- a/src/tts/directive-facts.ts
+++ b/src/tts/directive-facts.ts
@@ -1,0 +1,128 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
+
+type TextRange = {
+  start: number;
+  end: number;
+};
+
+function collectMarkdownCodeRanges(text: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  const addMatches = (regex: RegExp) => {
+    for (const match of text.matchAll(regex)) {
+      if (match.index == null) {
+        continue;
+      }
+      ranges.push({ start: match.index, end: match.index + match[0].length });
+    }
+  };
+
+  addMatches(/```[\s\S]*?```/g);
+  addMatches(/~~~[\s\S]*?~~~/g);
+  addMatches(/^(?: {4}|\t).*(?:\n|$)/gm);
+  addMatches(/`+[^`\n]*`+/g);
+
+  return ranges.toSorted((left, right) => left.start - right.start);
+}
+
+function isInsideRange(index: number, ranges: readonly TextRange[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function replaceOutsideMarkdownCode(
+  text: string,
+  regex: RegExp,
+  replace: (match: string, captures: readonly string[]) => string,
+): string {
+  const codeRanges = collectMarkdownCodeRanges(text);
+  return text.replace(regex, (...args: unknown[]) => {
+    const match = String(args[0]);
+    const offset = args.at(-2);
+    if (typeof offset === "number" && isInsideRange(offset, codeRanges)) {
+      return match;
+    }
+    // String.replace passes captures before offset/input; keep the callback
+    // typed without depending on the exact regexp arity for each directive.
+    const captures = args.slice(1, -2).map((capture) => String(capture));
+    return replace(match, captures);
+  });
+}
+
+/** Extract final-text TTS syntax into persisted facts, leaving markdown code spans unchanged. */
+export function extractTtsDirectiveFacts(text: string): {
+  cleanedText: string;
+  facts?: AssistantDeliveryTtsFacts;
+} {
+  if (!/\[\[\s*\/?\s*tts(?:\s*:|\s*\]\])/iu.test(text)) {
+    return { cleanedText: text };
+  }
+  let cleanedText = text;
+  let facts: AssistantDeliveryTtsFacts | undefined;
+  const markTagged = () => {
+    facts ??= { tagged: true };
+    return facts;
+  };
+
+  const blockRegex = /\[\[\s*tts\s*:\s*text\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*:\s*text\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, blockRegex, (_match, [inner = ""]) => {
+    const next = markTagged();
+    if (next.text == null) {
+      next.text = inner.trim();
+    }
+    return "";
+  });
+
+  const plainBlockRegex = /\[\[\s*tts\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, plainBlockRegex, (_match, [inner = ""]) => {
+    const next = markTagged();
+    const visible = inner.trim();
+    if (next.text == null) {
+      next.text = visible;
+    }
+    return visible;
+  });
+
+  const directiveRegex = /\[\[\s*tts\s*:\s*([^\]]+)\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, directiveRegex, (_match, [body = ""]) => {
+    const next = markTagged();
+    const tokens = body.split(/\s+/).filter(Boolean);
+    let provider: string | undefined;
+    const values: Record<string, string> = {};
+    for (const token of tokens) {
+      const eqIndex = token.indexOf("=");
+      if (eqIndex === -1) {
+        continue;
+      }
+      const rawKey = token.slice(0, eqIndex).trim();
+      const rawValue = token.slice(eqIndex + 1).trim();
+      if (!rawKey || !rawValue) {
+        continue;
+      }
+      const key = normalizeLowercaseStringOrEmpty(rawKey);
+      if (key === "provider") {
+        provider = normalizeLowercaseStringOrEmpty(rawValue) || undefined;
+        continue;
+      }
+      values[key] = rawValue;
+    }
+    if (provider || Object.keys(values).length > 0) {
+      next.directives ??= [];
+      next.directives.push({ ...(provider ? { provider } : {}), values });
+    }
+    return "";
+  });
+
+  const bareTagRegex = /\[\[\s*tts\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, bareTagRegex, () => {
+    markTagged();
+    return "";
+  });
+
+  const closingTagRegex = /\[\[\s*\/\s*tts(?:\s*:\s*[^\]]*)?\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, closingTagRegex, () => {
+    markTagged();
+    return "";
+  });
+
+  return { cleanedText, ...(facts ? { facts } : {}) };
+}

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -320,5 +320,3 @@ export function parseTtsDirectives(
     ...resolved,
   };
 }
-
-export { extractTtsDirectiveFacts };

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -1,6 +1,7 @@
 // TTS directive helpers parse inline speech directives from text.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.js";
+import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { listSpeechProviders } from "./provider-registry.js";
 import type {
@@ -239,18 +240,93 @@ export function createTtsDirectiveTextStreamCleaner(): TtsDirectiveTextStreamCle
   };
 }
 
-/** Parse TTS directives from final message text, leaving markdown code spans unchanged. */
-export function parseTtsDirectives(
-  text: string,
+/** Extract final-text TTS syntax into persisted facts, leaving markdown code spans unchanged. */
+export function extractTtsDirectiveFacts(text: string): {
+  cleanedText: string;
+  facts?: AssistantDeliveryTtsFacts;
+} {
+  if (!/\[\[\s*\/?\s*tts(?:\s*:|\s*\]\])/iu.test(text)) {
+    return { cleanedText: text };
+  }
+  let cleanedText = text;
+  let facts: AssistantDeliveryTtsFacts | undefined;
+  const markTagged = () => {
+    facts ??= { tagged: true };
+    return facts;
+  };
+
+  const blockRegex = /\[\[\s*tts\s*:\s*text\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*:\s*text\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, blockRegex, (_match, [inner = ""]) => {
+    const next = markTagged();
+    if (next.text == null) {
+      next.text = inner.trim();
+    }
+    return "";
+  });
+
+  const plainBlockRegex = /\[\[\s*tts\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, plainBlockRegex, (_match, [inner = ""]) => {
+    const next = markTagged();
+    const visible = inner.trim();
+    if (next.text == null) {
+      next.text = visible;
+    }
+    return visible;
+  });
+
+  const directiveRegex = /\[\[\s*tts\s*:\s*([^\]]+)\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, directiveRegex, (_match, [body = ""]) => {
+    const next = markTagged();
+    const tokens = body.split(/\s+/).filter(Boolean);
+    let provider: string | undefined;
+    const values: Record<string, string> = {};
+    for (const token of tokens) {
+      const eqIndex = token.indexOf("=");
+      if (eqIndex === -1) {
+        continue;
+      }
+      const rawKey = token.slice(0, eqIndex).trim();
+      const rawValue = token.slice(eqIndex + 1).trim();
+      if (!rawKey || !rawValue) {
+        continue;
+      }
+      const key = normalizeLowercaseStringOrEmpty(rawKey);
+      if (key === "provider") {
+        provider = normalizeLowercaseStringOrEmpty(rawValue) || undefined;
+        continue;
+      }
+      values[key] = rawValue;
+    }
+    if (provider || Object.keys(values).length > 0) {
+      next.directives ??= [];
+      next.directives.push({ ...(provider ? { provider } : {}), values });
+    }
+    return "";
+  });
+
+  const bareTagRegex = /\[\[\s*tts\s*\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, bareTagRegex, () => {
+    markTagged();
+    return "";
+  });
+
+  const closingTagRegex = /\[\[\s*\/\s*tts(?:\s*:\s*[^\]]*)?\]\]/gi;
+  cleanedText = replaceOutsideMarkdownCode(cleanedText, closingTagRegex, () => {
+    markTagged();
+    return "";
+  });
+
+  return { cleanedText, ...(facts ? { facts } : {}) };
+}
+
+/** Resolve persisted TTS facts against the active model/provider policy. */
+export function resolveTtsDirectiveFacts(
+  facts: AssistantDeliveryTtsFacts | undefined,
   policy: SpeechModelOverridePolicy,
   options?: ParseTtsDirectiveOptions,
-): TtsDirectiveParseResult {
-  if (!policy.enabled) {
-    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
-  }
-
-  if (!/\[\[\s*\/?\s*tts(?:\s*:|\s*\]\])/iu.test(text)) {
-    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
+): Omit<TtsDirectiveParseResult, "cleanedText"> {
+  if (!facts || !policy.enabled) {
+    return { overrides: {}, warnings: [], hasDirective: false };
   }
 
   let providers: SpeechProviderPlugin[] | undefined;
@@ -260,58 +336,15 @@ export function parseTtsDirectives(
   };
   const overrides: TtsDirectiveOverrides = {};
   const warnings: string[] = [];
-  let cleanedText = text;
-  let hasDirective = false;
+  if (policy.allowText && facts.text != null) {
+    overrides.ttsText = facts.text;
+  }
 
-  const blockRegex = /\[\[\s*tts\s*:\s*text\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*:\s*text\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, blockRegex, (_match, [inner = ""]) => {
-    hasDirective = true;
-    if (policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = inner.trim();
+  for (const directive of facts.directives ?? []) {
+    const declaredProviderId = policy.allowProvider ? directive.provider : undefined;
+    if (declaredProviderId) {
+      overrides.provider = declaredProviderId;
     }
-    return "";
-  });
-
-  const plainBlockRegex = /\[\[\s*tts\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, plainBlockRegex, (_match, [inner = ""]) => {
-    hasDirective = true;
-    const visible = inner.trim();
-    if (policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = visible;
-    }
-    return visible;
-  });
-
-  const directiveRegex = /\[\[\s*tts\s*:\s*([^\]]+)\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, directiveRegex, (_match, [body = ""]) => {
-    hasDirective = true;
-    const tokens = body.split(/\s+/).filter(Boolean);
-
-    let declaredProviderId: string | undefined;
-    if (policy.allowProvider) {
-      for (const token of tokens) {
-        const eqIndex = token.indexOf("=");
-        if (eqIndex === -1) {
-          continue;
-        }
-        const rawKey = token.slice(0, eqIndex).trim();
-        if (!rawKey || normalizeLowercaseStringOrEmpty(rawKey) !== "provider") {
-          continue;
-        }
-        const rawValue = token.slice(eqIndex + 1).trim();
-        if (!rawValue) {
-          continue;
-        }
-        const providerId = normalizeLowercaseStringOrEmpty(rawValue);
-        if (!providerId) {
-          warnings.push("invalid provider id");
-          continue;
-        }
-        declaredProviderId = providerId;
-        overrides.provider = providerId;
-      }
-    }
-
     let directiveProviders: SpeechProviderPlugin[] | undefined;
     const getDirectiveProviders = () => {
       if (directiveProviders) {
@@ -334,27 +367,13 @@ export function parseTtsDirectives(
       return directiveProviders;
     };
 
-    for (const token of tokens) {
-      const eqIndex = token.indexOf("=");
-      if (eqIndex === -1) {
-        continue;
-      }
-      const rawKey = token.slice(0, eqIndex).trim();
-      const rawValue = token.slice(eqIndex + 1).trim();
-      if (!rawKey || !rawValue) {
-        continue;
-      }
-      const key = normalizeLowercaseStringOrEmpty(rawKey);
-      if (key === "provider") {
-        continue;
-      }
-
+    for (const [key, value] of Object.entries(directive.values)) {
       let handled = false;
       const directiveProvidersLocal = getDirectiveProviders();
       for (const provider of directiveProvidersLocal) {
         const genericSpeakerOverrides = parseGenericSpeakerDirective({
           key,
-          value: rawValue,
+          value,
           policy,
           currentOverrides: overrides.providerOverrides?.[provider.id],
         });
@@ -371,7 +390,7 @@ export function parseTtsDirectives(
         }
         const parsed = provider.parseDirectiveToken?.({
           key,
-          value: rawValue,
+          value,
           policy,
           selectedProvider: declaredProviderId ? provider.id : undefined,
           providerConfig: resolveDirectiveProviderConfig(provider, options),
@@ -396,31 +415,33 @@ export function parseTtsDirectives(
         break;
       }
       if (!handled && declaredProviderId && directiveProvidersLocal.length > 0) {
-        // Unknown keys are only actionable when the user explicitly selected a
-        // provider; auto-selected providers may not support each other's knobs.
         warnings.push(`unsupported ${declaredProviderId} directive key "${key}"`);
       }
     }
-    return "";
-  });
-
-  const bareTagRegex = /\[\[\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, bareTagRegex, () => {
-    hasDirective = true;
-    return "";
-  });
-
-  const closingTagRegex = /\[\[\s*\/\s*tts(?:\s*:\s*[^\]]*)?\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, closingTagRegex, () => {
-    hasDirective = true;
-    return "";
-  });
+  }
 
   return {
-    cleanedText,
     ttsText: overrides.ttsText,
-    hasDirective,
+    hasDirective: true,
     overrides,
     warnings,
+  };
+}
+
+/** Parse TTS directives from final message text, leaving markdown code spans unchanged. */
+export function parseTtsDirectives(
+  text: string,
+  policy: SpeechModelOverridePolicy,
+  options?: ParseTtsDirectiveOptions,
+): TtsDirectiveParseResult {
+  if (!policy.enabled) {
+    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
+  }
+  const extracted = extractTtsDirectiveFacts(text);
+  const resolved = resolveTtsDirectiveFacts(extracted.facts, policy, options);
+
+  return {
+    cleanedText: extracted.cleanedText,
+    ...resolved,
   };
 }

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { OpenClawConfig } from "../config/types.js";
 import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { extractTtsDirectiveFacts } from "./directive-facts.js";
 import { listSpeechProviders } from "./provider-registry.js";
 import type {
   SpeechModelOverridePolicy,
@@ -17,11 +18,6 @@ type ParseTtsDirectiveOptions = {
   providers?: readonly SpeechProviderPlugin[];
   providerConfigs?: Record<string, SpeechProviderConfig>;
   preferredProviderId?: string;
-};
-
-type TextRange = {
-  start: number;
-  end: number;
 };
 
 /** Streaming cleaner used to strip TTS tags before final text parsing is available. */
@@ -116,48 +112,6 @@ function parseGenericSpeakerDirective(params: {
   }
 }
 
-function collectMarkdownCodeRanges(text: string): TextRange[] {
-  const ranges: TextRange[] = [];
-  const addMatches = (regex: RegExp) => {
-    for (const match of text.matchAll(regex)) {
-      if (match.index == null) {
-        continue;
-      }
-      ranges.push({ start: match.index, end: match.index + match[0].length });
-    }
-  };
-
-  addMatches(/```[\s\S]*?```/g);
-  addMatches(/~~~[\s\S]*?~~~/g);
-  addMatches(/^(?: {4}|\t).*(?:\n|$)/gm);
-  addMatches(/`+[^`\n]*`+/g);
-
-  return ranges.toSorted((left, right) => left.start - right.start);
-}
-
-function isInsideRange(index: number, ranges: readonly TextRange[]): boolean {
-  return ranges.some((range) => index >= range.start && index < range.end);
-}
-
-function replaceOutsideMarkdownCode(
-  text: string,
-  regex: RegExp,
-  replace: (match: string, captures: readonly string[]) => string,
-): string {
-  const codeRanges = collectMarkdownCodeRanges(text);
-  return text.replace(regex, (...args: unknown[]) => {
-    const match = String(args[0]);
-    const offset = args.at(-2);
-    if (typeof offset === "number" && isInsideRange(offset, codeRanges)) {
-      return match;
-    }
-    // String.replace passes captures before offset/input; keep the callback
-    // typed without depending on the exact regexp arity for each directive.
-    const captures = args.slice(1, -2).map((capture) => String(capture));
-    return replace(match, captures);
-  });
-}
-
 function normalizeTtsTagBody(body: string): string {
   return body.trim().replace(/\s+/g, "").toLowerCase();
 }
@@ -238,85 +192,6 @@ export function createTtsDirectiveTextStreamCleaner(): TtsDirectiveTextStreamCle
       return pending.length > 0 || insideHiddenTextBlock;
     },
   };
-}
-
-/** Extract final-text TTS syntax into persisted facts, leaving markdown code spans unchanged. */
-export function extractTtsDirectiveFacts(text: string): {
-  cleanedText: string;
-  facts?: AssistantDeliveryTtsFacts;
-} {
-  if (!/\[\[\s*\/?\s*tts(?:\s*:|\s*\]\])/iu.test(text)) {
-    return { cleanedText: text };
-  }
-  let cleanedText = text;
-  let facts: AssistantDeliveryTtsFacts | undefined;
-  const markTagged = () => {
-    facts ??= { tagged: true };
-    return facts;
-  };
-
-  const blockRegex = /\[\[\s*tts\s*:\s*text\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*:\s*text\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, blockRegex, (_match, [inner = ""]) => {
-    const next = markTagged();
-    if (next.text == null) {
-      next.text = inner.trim();
-    }
-    return "";
-  });
-
-  const plainBlockRegex = /\[\[\s*tts\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, plainBlockRegex, (_match, [inner = ""]) => {
-    const next = markTagged();
-    const visible = inner.trim();
-    if (next.text == null) {
-      next.text = visible;
-    }
-    return visible;
-  });
-
-  const directiveRegex = /\[\[\s*tts\s*:\s*([^\]]+)\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, directiveRegex, (_match, [body = ""]) => {
-    const next = markTagged();
-    const tokens = body.split(/\s+/).filter(Boolean);
-    let provider: string | undefined;
-    const values: Record<string, string> = {};
-    for (const token of tokens) {
-      const eqIndex = token.indexOf("=");
-      if (eqIndex === -1) {
-        continue;
-      }
-      const rawKey = token.slice(0, eqIndex).trim();
-      const rawValue = token.slice(eqIndex + 1).trim();
-      if (!rawKey || !rawValue) {
-        continue;
-      }
-      const key = normalizeLowercaseStringOrEmpty(rawKey);
-      if (key === "provider") {
-        provider = normalizeLowercaseStringOrEmpty(rawValue) || undefined;
-        continue;
-      }
-      values[key] = rawValue;
-    }
-    if (provider || Object.keys(values).length > 0) {
-      next.directives ??= [];
-      next.directives.push({ ...(provider ? { provider } : {}), values });
-    }
-    return "";
-  });
-
-  const bareTagRegex = /\[\[\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, bareTagRegex, () => {
-    markTagged();
-    return "";
-  });
-
-  const closingTagRegex = /\[\[\s*\/\s*tts(?:\s*:\s*[^\]]*)?\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, closingTagRegex, () => {
-    markTagged();
-    return "";
-  });
-
-  return { cleanedText, ...(facts ? { facts } : {}) };
 }
 
 /** Resolve persisted TTS facts against the active model/provider policy. */
@@ -445,3 +320,5 @@ export function parseTtsDirectives(
     ...resolved,
   };
 }
+
+export { extractTtsDirectiveFacts };

--- a/src/tts/tts-payload.ts
+++ b/src/tts/tts-payload.ts
@@ -1,4 +1,8 @@
-import { markReplyPayloadAsTtsSupplement, type ReplyPayload } from "../auto-reply/reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  markReplyPayloadAsTtsSupplement,
+  type ReplyPayload,
+} from "../auto-reply/reply-payload.js";
 import { getChannelPlugin } from "../channels/plugins/registry.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isVerbose, logVerbose } from "../globals.js";
@@ -6,7 +10,7 @@ import { resolveSendableOutboundReplyParts } from "../infra/outbound/reply-paylo
 import { hasReplyPayloadContent } from "../interactive/payload.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
-import { parseTtsDirectives } from "./directives.js";
+import { parseTtsDirectives, resolveTtsDirectiveFacts } from "./directives.js";
 import { canonicalizeSpeechProviderId, getSpeechProvider } from "./provider-registry.js";
 import type { SpeechVoiceOption } from "./provider-types.js";
 import { assertSpeechRuntimeAvailable, isSpeechRuntimeAvailable } from "./runtime-availability.js";
@@ -106,18 +110,26 @@ export async function maybeApplyTtsToPayloadCore(
     channelId: params.channel,
     accountId: params.accountId,
   });
-  if (autoMode === "off") {
+  const ttsMetadata = getReplyPayloadMetadata(params.payload);
+  const explicitTts = ttsMetadata?.ttsExplicit === true;
+  if (autoMode === "off" && !explicitTts) {
     return params.payload;
   }
   const activeProvider = resolveTtsProvider(config, prefsPath);
 
   const reply = resolveSendableOutboundReplyParts(params.payload);
   const text = reply.text;
-  const directives = parseTtsDirectives(text, config.modelOverrides, {
+  const directiveOptions = {
     cfg,
     providerConfigs: config.providerConfigs,
     preferredProviderId: activeProvider,
-  });
+  };
+  const directives = ttsMetadata?.tts
+    ? {
+        cleanedText: text,
+        ...resolveTtsDirectiveFacts(ttsMetadata.tts, config.modelOverrides, directiveOptions),
+      }
+    : parseTtsDirectives(text, config.modelOverrides, directiveOptions);
   if (directives.warnings.length > 0) {
     logVerbose(`TTS: ignored directive overrides (${directives.warnings.join("; ")})`);
   }
@@ -145,10 +157,10 @@ export async function maybeApplyTtsToPayloadCore(
           text: visibleText.length > 0 ? visibleText : undefined,
         };
 
-  if (autoMode === "tagged" && !directives.hasDirective) {
+  if (!explicitTts && autoMode === "tagged" && !directives.hasDirective) {
     return nextPayload;
   }
-  if (autoMode === "inbound" && params.inboundAudio !== true) {
+  if (!explicitTts && autoMode === "inbound" && params.inboundAudio !== true) {
     return nextPayload;
   }
 

--- a/src/tts/tts-payload.ts
+++ b/src/tts/tts-payload.ts
@@ -83,6 +83,17 @@ function hasLegacyFinalMediaDirective(text: string): boolean {
   return /(?:^|\n)\s*MEDIA\s*:/i.test(text);
 }
 
+// A voice-only send (structured voiceText, empty visible text) must still end in a visible
+// outcome when speech cannot be attempted at all; otherwise delivery normalizes the empty
+// payload to null and the send silently vanishes. Mirrors the synthesis-failure fallback.
+function applyExplicitSpeechVisibleFallback(payload: ReplyPayload): ReplyPayload {
+  const explicitText = getReplyPayloadMetadata(payload)?.tts?.text?.trim();
+  if (!explicitText || hasReplyPayloadContent(payload, {})) {
+    return payload;
+  }
+  return { ...payload, text: explicitText };
+}
+
 export async function maybeApplyTtsToPayloadCore(
   params: {
     payload: ReplyPayload;
@@ -97,7 +108,7 @@ export async function maybeApplyTtsToPayloadCore(
   persistTtsAudio: TtsAudioPersistence,
 ): Promise<ReplyPayload> {
   if (!isSpeechRuntimeAvailable()) {
-    return params.payload;
+    return applyExplicitSpeechVisibleFallback(params.payload);
   }
   if (params.payload.isCompactionNotice) {
     return params.payload;

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -790,3 +790,57 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
     });
   });
 });
+
+describe("cold speech runtime visible fallback", () => {
+  it("materializes voice-only structured speech as visible text when the runtime is unavailable", async () => {
+    const { setSpeechRuntimeAvailabilityGuard } = await import("./runtime-availability.js");
+    setSpeechRuntimeAvailabilityGuard(() => {
+      throw new Error("speech runtime configured cold");
+    });
+    try {
+      const payload: ReplyPayload = { text: "" };
+      setReplyPayloadMetadata(payload, {
+        ttsExplicit: true,
+        tts: { tagged: true, text: "Spoken greeting" },
+      });
+      const result = await maybeApplyTtsToPayloadCore(
+        {
+          payload,
+          cfg: createTtsConfig("openclaw-speech-cold-runtime-fallback-test"),
+          channel: "slack",
+          kind: "final",
+        },
+        async () => "unused",
+      );
+      expect(result.text).toBe("Spoken greeting");
+    } finally {
+      setSpeechRuntimeAvailabilityGuard(undefined);
+    }
+  });
+
+  it("keeps payloads with visible text unchanged when the runtime is unavailable", async () => {
+    const { setSpeechRuntimeAvailabilityGuard } = await import("./runtime-availability.js");
+    setSpeechRuntimeAvailabilityGuard(() => {
+      throw new Error("speech runtime configured cold");
+    });
+    try {
+      const payload: ReplyPayload = { text: "Visible answer" };
+      setReplyPayloadMetadata(payload, {
+        ttsExplicit: true,
+        tts: { tagged: true, text: "Spoken greeting" },
+      });
+      const result = await maybeApplyTtsToPayloadCore(
+        {
+          payload,
+          cfg: createTtsConfig("openclaw-speech-cold-runtime-unchanged-test"),
+          channel: "slack",
+          kind: "final",
+        },
+        async () => "unused",
+      );
+      expect(result).toBe(payload);
+    } finally {
+      setSpeechRuntimeAvailabilityGuard(undefined);
+    }
+  });
+});

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { routeReply } from "../auto-reply/reply/route-reply.js";
 import * as bundledChannelPlugins from "../channels/plugins/bundled.js";
@@ -98,6 +99,35 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
     transcodeAudioBufferMock.mockClear();
     routedPayloads.length = 0;
     installSpeechProviders([createMockSpeechProvider()]);
+  });
+
+  it("synthesizes persisted TTS facts after the visible text has been stripped", async () => {
+    const payload = setReplyPayloadMetadata(
+      { text: "Visible answer" },
+      {
+        tts: {
+          tagged: true,
+          text: "Spoken answer",
+          directives: [{ provider: "mock", values: {} }],
+        },
+      },
+    );
+
+    const result = await maybeApplyTtsToPayload({
+      payload,
+      cfg: createTtsConfig("openclaw-speech-core-persisted-facts"),
+      channel: "telegram",
+      kind: "final",
+      ttsAuto: "tagged",
+    });
+
+    expect(requireFirstSynthesisRequest("persisted TTS facts")).toMatchObject({
+      text: "Spoken answer",
+    });
+    expect(result).toMatchObject({
+      text: "Visible answer",
+      spokenText: "Spoken answer",
+    });
   });
 
   it("ignores voiceModel refs that are not speech models", async () => {

--- a/src/tts/tts-runtime-routing.test.ts
+++ b/src/tts/tts-runtime-routing.test.ts
@@ -81,6 +81,18 @@ describe("TTS runtime native voice-note routing", () => {
     );
   });
 
+  it("uses structured speech guidance for message-tool-only replies", () => {
+    const hint = buildTtsSystemPromptHint(
+      createTtsConfig("openclaw-speech-core-structured-tts-hint-test"),
+      undefined,
+      { messageToolOnly: true },
+    );
+
+    expect(hint).toContain("message(action=send) with voiceText");
+    expect(hint).toContain("voiceProvider/voiceId");
+    expect(hint).not.toContain("[[tts:");
+  });
+
   it("prepares deep-merged surface config and directive inputs", () => {
     const cfg: OpenClawConfig = {
       tts: {

--- a/src/tts/tts-settings.ts
+++ b/src/tts/tts-settings.ts
@@ -350,16 +350,20 @@ export function resolveTtsSettingsSnapshot(params: {
 export function buildTtsSystemPromptHint(
   cfg: OpenClawConfig,
   agentId?: string,
+  options?: { messageToolOnly?: boolean },
 ): string | undefined {
   const settings = resolveTtsSettingsSnapshot({ cfg, agentId });
   if (settings.autoMode === "off") {
     return undefined;
   }
+  const structured = options?.messageToolOnly === true;
   const autoHint =
     settings.autoMode === "inbound"
       ? "Only use TTS when the user's last message includes audio/voice."
       : settings.autoMode === "tagged"
-        ? "Only use TTS when you include [[tts:key=value]] directives or a [[tts:text]]...[[/tts:text]] block."
+        ? structured
+          ? "Use TTS only through message(action=send) speech fields."
+          : "Only use TTS when you include [[tts:key=value]] directives or a [[tts:text]]...[[/tts:text]] block."
         : undefined;
   return [
     "Voice (TTS) is enabled.",
@@ -368,8 +372,12 @@ export function buildTtsSystemPromptHint(
       ? `Active TTS persona: ${settings.persona.label ?? settings.persona.id}${settings.persona.description ? ` - ${settings.persona.description}` : ""}.`
       : undefined,
     `Keep spoken text ≤${settings.maxLength} chars to avoid auto-summary (summary ${settings.summarize ? "on" : "off"}).`,
-    "If workspace context (especially MEMORY.md) tells you not to use [[tts:...]] or to use a local/non-tagged voice workflow, follow that workspace instruction instead.",
-    "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
+    structured
+      ? "If workspace context (especially MEMORY.md) tells you not to use TTS or to use a local voice workflow, follow that workspace instruction instead."
+      : "If workspace context (especially MEMORY.md) tells you not to use [[tts:...]] or to use a local/non-tagged voice workflow, follow that workspace instruction instead.",
+    structured
+      ? "Use message(action=send) with voiceText and optional voiceProvider/voiceId."
+      : "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
   ]
     .filter(Boolean)
     .join("\n");

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -27,6 +27,7 @@
           "type": "boolean"
         },
         "asVoice": {
+          "description": "Send audio as a voice note; combines with voiceText.",
           "type": "boolean"
         },
         "attachments": {
@@ -129,6 +130,18 @@
         "timeoutMs": {
           "minimum": 1,
           "type": "integer"
+        },
+        "voiceId": {
+          "description": "Per-send speech voice override.",
+          "type": "string"
+        },
+        "voiceProvider": {
+          "description": "Per-send speech provider override.",
+          "type": "string"
+        },
+        "voiceText": {
+          "description": "Text to synthesize; message remains visible.",
+          "type": "string"
         }
       },
       "required": ["action"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49330,
-    "roughTokens": 12333
+    "chars": 49792,
+    "roughTokens": 12448
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78194,
-    "roughTokens": 19549
+    "chars": 78656,
+    "roughTokens": 19664
   },
   "userInputText": {
     "chars": 1300,
@@ -576,6 +576,7 @@ Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dyna
           "type": "boolean"
         },
         "asVoice": {
+          "description": "Send audio as a voice note; combines with voiceText.",
           "type": "boolean"
         },
         "attachments": {
@@ -678,6 +679,18 @@ Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dyna
         "timeoutMs": {
           "minimum": 1,
           "type": "integer"
+        },
+        "voiceId": {
+          "description": "Per-send speech voice override.",
+          "type": "string"
+        },
+        "voiceProvider": {
+          "description": "Per-send speech provider override.",
+          "type": "string"
+        },
+        "voiceText": {
+          "description": "Text to synthesize; message remains visible.",
+          "type": "string"
         }
       },
       "required": ["action"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49022,
-    "roughTokens": 12256
+    "chars": 49484,
+    "roughTokens": 12371
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76406,
-    "roughTokens": 19102
+    "chars": 76868,
+    "roughTokens": 19217
   },
   "userInputText": {
     "chars": 929,
@@ -570,6 +570,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "asVoice": {
+          "description": "Send audio as a voice note; combines with voiceText.",
           "type": "boolean"
         },
         "attachments": {
@@ -672,6 +673,18 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
         "timeoutMs": {
           "minimum": 1,
           "type": "integer"
+        },
+        "voiceId": {
+          "description": "Per-send speech voice override.",
+          "type": "string"
+        },
+        "voiceProvider": {
+          "description": "Per-send speech provider override.",
+          "type": "string"
+        },
+        "voiceText": {
+          "description": "Text to synthesize; message remains visible.",
+          "type": "string"
         }
       },
       "required": ["action"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50556,
-    "roughTokens": 12639
+    "chars": 51018,
+    "roughTokens": 12755
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78356,
-    "roughTokens": 19589
+    "chars": 78818,
+    "roughTokens": 19705
   },
   "userInputText": {
     "chars": 1271,
@@ -566,6 +566,7 @@ Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dyn
           "type": "boolean"
         },
         "asVoice": {
+          "description": "Send audio as a voice note; combines with voiceText.",
           "type": "boolean"
         },
         "attachments": {
@@ -668,6 +669,18 @@ Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dyn
         "timeoutMs": {
           "minimum": 1,
           "type": "integer"
+        },
+        "voiceId": {
+          "description": "Per-send speech voice override.",
+          "type": "string"
+        },
+        "voiceProvider": {
+          "description": "Per-send speech provider override.",
+          "type": "string"
+        },
+        "voiceText": {
+          "description": "Text to synthesize; message remains visible.",
+          "type": "string"
         }
       },
       "required": ["action"],


### PR DESCRIPTION
## What Problem This Solves

`[[tts]]` directive blocks are the last marker family whose capability—spoken-versus-visible text and per-reply provider/voice selection—had no structured API. Tool-mode sessions therefore had no way to express speech control without text markers.

Campaign siblings: #124755, #124793, #124830, #124888.

## Why This Change Was Made

`message(action=send)` gains flat, provider-safe `voiceText`, `voiceProvider`, and `voiceId` fields that compose with `asVoice`.

`[[tts]]` blocks now parse once at the assistant write boundary into typed `openclawDelivery.tts` facts while persisted text is stripped. `ttsAuto` and delivery consume those facts and never reparse persisted final text. The streaming cleaner remains in place, and automatic-mode bracket guidance is unchanged as a transitional adapter until the `visibleReplies` default flips. Tool-only prompts teach the structured fields.

Provider-specific model, speed, and style knobs intentionally remain directive-only because they do not have a portable contract.

## User Impact

Tool-mode sessions get first-class speech control, and persisted transcripts stay clean of TTS markup. There is no config, protocol, or schema change.

## Evidence

- Maintainer-reviewed pre-rebase campaign: 861 tests across 7 focused shards.
- Exact post-rebase proof on `8443d7427bfe7177cd6f401d0efdca8be1145395`: 280 tests passed across 4 routed Vitest shards; `src/config/sessions/transcript-assistant-delivery.test.ts` was absent on current `main` and was dropped per the landing contract.
- Boundary regressions cover strip-plus-facts behavior, code-span survival, and structured-versus-directive parity at the TTS boundary.
- CI repair proof: prompt snapshot generator/check clean; Madge reports 0 cycles after extracting the provider-free fact parser into a leaf module.
- Fresh post-rebase branch and CI-repair autoreviews clean; TruffleHog clean; no accepted/actionable findings.
