### PR TITLE
fix: scale Gateway RSS diagnostics to runtime limits

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -236,6 +236,7 @@ describe("diagnostic memory", () => {
       isBunRuntime: true,
       heapSizeLimitBytes: 280_657_920,
       processMemoryLimitBytes: 512 * 1024 ** 3,
+      physicalMemoryBytes: 512 * 1024 ** 3,
       samples: [{ rssGiB: 500 / 1024, heapUsedMiB: 80 }, { rssGiB: 4.1 }, { rssGiB: 6.1 }],
       expectedThresholdsGiB: { warning: 4, critical: 6 },
     },

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -94,6 +94,9 @@ describe("diagnostic memory", () => {
     emitDiagnosticMemorySample({
       now: 1000,
       uptimeMs: 0,
+      isBunRuntime: true,
+      heapSizeLimitBytes: 280_657_920,
+      processMemoryLimitBytes: 512 * 1024 ** 3,
       memoryUsage: memoryUsage({ rss: 2000 }),
       thresholds: {
         rssWarningBytes: 1000,
@@ -191,6 +194,90 @@ describe("diagnostic memory", () => {
     ).toEqual([
       { level: "warning", reason: "heap_threshold", threshold: 4 * gb },
       { level: "critical", reason: "heap_threshold", threshold: 6 * gb },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "an enlarged V8 limit",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 8 * 1024 ** 3,
+      processMemoryLimitBytes: 0,
+      samples: [{ rssGiB: 1.77, heapUsedMiB: 789.3 }, { rssGiB: 4.1 }, { rssGiB: 6.1 }],
+      expectedThresholdsGiB: { warning: 4, critical: 6 },
+    },
+    {
+      name: "a V8 limit above the pressure caps",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 16 * 1024 ** 3,
+      processMemoryLimitBytes: 0,
+      samples: [{ rssGiB: 4.1 }, { rssGiB: 6.1 }],
+      expectedThresholdsGiB: { warning: 4, critical: 6 },
+    },
+    {
+      name: "a constrained process limit",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 16 * 1024 ** 3,
+      processMemoryLimitBytes: 4 * 1024 ** 3,
+      samples: [{ rssGiB: 2.1 }, { rssGiB: 3.1 }],
+      expectedThresholdsGiB: { warning: 2, critical: 3 },
+    },
+    {
+      name: "Bun compatibility heap statistics",
+      isBunRuntime: true,
+      heapSizeLimitBytes: 280_657_920,
+      processMemoryLimitBytes: 512 * 1024 ** 3,
+      samples: [{ rssGiB: 500 / 1024, heapUsedMiB: 80 }, { rssGiB: 4.1 }, { rssGiB: 6.1 }],
+      expectedThresholdsGiB: { warning: 4, critical: 6 },
+    },
+    {
+      name: "Bun without a process limit",
+      isBunRuntime: true,
+      heapSizeLimitBytes: 280_657_920,
+      processMemoryLimitBytes: 0,
+      samples: [{ rssGiB: 1.4 }, { rssGiB: 1.6 }, { rssGiB: 3.1 }],
+      expectedThresholdsGiB: { warning: 1.5, critical: 3 },
+    },
+  ])("scales default RSS pressure thresholds with $name", (testCase) => {
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+    const gb = 1024 ** 3;
+
+    for (const [index, sample] of testCase.samples.entries()) {
+      emitDiagnosticMemorySample({
+        now: (index + 1) * 11 * 60 * 1000,
+        heapSizeLimitBytes: testCase.heapSizeLimitBytes,
+        processMemoryLimitBytes: testCase.processMemoryLimitBytes,
+        isBunRuntime: testCase.isBunRuntime,
+        memoryUsage: memoryUsage({
+          rss: Math.round(sample.rssGiB * gb),
+          ...("heapUsedMiB" in sample
+            ? { heapUsed: Math.round(sample.heapUsedMiB * 1024 ** 2) }
+            : {}),
+        }),
+      });
+    }
+    stop();
+
+    expect(
+      events
+        .filter((event) => event.type === "diagnostic.memory.pressure")
+        .map((event) => ({
+          level: event.level,
+          reason: event.reason,
+          threshold: event.thresholdBytes,
+        })),
+    ).toEqual([
+      {
+        level: "warning",
+        reason: "rss_threshold",
+        threshold: testCase.expectedThresholdsGiB.warning * gb,
+      },
+      {
+        level: "critical",
+        reason: "rss_threshold",
+        threshold: testCase.expectedThresholdsGiB.critical * gb,
+      },
     ]);
   });
 

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -244,6 +244,7 @@ describe("diagnostic memory", () => {
     const gb = 1024 ** 3;
 
     for (const [index, sample] of testCase.samples.entries()) {
+      const heapUsedMiB = "heapUsedMiB" in sample ? sample.heapUsedMiB : undefined;
       emitDiagnosticMemorySample({
         now: (index + 1) * 11 * 60 * 1000,
         heapSizeLimitBytes: testCase.heapSizeLimitBytes,
@@ -251,9 +252,7 @@ describe("diagnostic memory", () => {
         isBunRuntime: testCase.isBunRuntime,
         memoryUsage: memoryUsage({
           rss: Math.round(sample.rssGiB * gb),
-          ...("heapUsedMiB" in sample
-            ? { heapUsed: Math.round(sample.heapUsedMiB * 1024 ** 2) }
-            : {}),
+          ...(heapUsedMiB === undefined ? {} : { heapUsed: Math.round(heapUsedMiB * 1024 ** 2) }),
         }),
       });
     }

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -223,6 +223,15 @@ describe("diagnostic memory", () => {
       expectedThresholdsGiB: { warning: 2, critical: 3 },
     },
     {
+      name: "an unlimited process sentinel",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 16 * 1024 ** 3,
+      processMemoryLimitBytes: Number.MAX_SAFE_INTEGER,
+      physicalMemoryBytes: 4 * 1024 ** 3,
+      samples: [{ rssGiB: 2.1 }, { rssGiB: 3.1 }],
+      expectedThresholdsGiB: { warning: 2, critical: 3 },
+    },
+    {
       name: "Bun compatibility heap statistics",
       isBunRuntime: true,
       heapSizeLimitBytes: 280_657_920,
@@ -244,11 +253,16 @@ describe("diagnostic memory", () => {
     const gb = 1024 ** 3;
 
     for (const [index, sample] of testCase.samples.entries()) {
-      const heapUsedMiB = "heapUsedMiB" in sample ? sample.heapUsedMiB : undefined;
+      const heapUsedMiB =
+        "heapUsedMiB" in sample && typeof sample.heapUsedMiB === "number"
+          ? sample.heapUsedMiB
+          : undefined;
       emitDiagnosticMemorySample({
         now: (index + 1) * 11 * 60 * 1000,
         heapSizeLimitBytes: testCase.heapSizeLimitBytes,
         processMemoryLimitBytes: testCase.processMemoryLimitBytes,
+        physicalMemoryBytes:
+          "physicalMemoryBytes" in testCase ? testCase.physicalMemoryBytes : undefined,
         isBunRuntime: testCase.isBunRuntime,
         memoryUsage: memoryUsage({
           rss: Math.round(sample.rssGiB * gb),

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,3 +1,4 @@
+import { totalmem } from "node:os";
 // Diagnostic memory helpers capture process memory facts for support diagnostics.
 import { getHeapStatistics } from "node:v8";
 import {
@@ -27,6 +28,7 @@ const BYTE_UNITS = ["B", "KiB", "MiB", "GiB", "TiB"] as const;
 
 const DEFAULT_HEAP_SIZE_LIMIT_BYTES = getHeapStatistics().heap_size_limit;
 const DEFAULT_PROCESS_MEMORY_LIMIT_BYTES = process.constrainedMemory();
+const DEFAULT_PHYSICAL_MEMORY_BYTES = totalmem();
 const DEFAULT_IS_BUN_RUNTIME = typeof process.versions.bun === "string";
 
 const log = createSubsystemLogger("gateway").child("diagnostics/memory");
@@ -56,6 +58,18 @@ function isPositiveMemoryLimit(value: number | undefined): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+function resolveProcessMemoryLimitBytes(
+  processMemoryLimitBytes: number | undefined,
+  physicalMemoryBytes: number | undefined,
+): number | undefined {
+  if (!isPositiveMemoryLimit(processMemoryLimitBytes)) {
+    return undefined;
+  }
+  return isPositiveMemoryLimit(physicalMemoryBytes)
+    ? Math.min(processMemoryLimitBytes, physicalMemoryBytes)
+    : processMemoryLimitBytes;
+}
+
 const state: DiagnosticMemoryState = {
   lastSample: null,
   lastPressureAtByKey: new Map(),
@@ -76,6 +90,7 @@ function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
   heapSizeLimitBytes?: number,
   processMemoryLimitBytes?: number,
+  physicalMemoryBytes?: number,
   isBunRuntime = false,
 ): Required<DiagnosticMemoryThresholds> {
   const hasHeapLimit = isPositiveMemoryLimit(heapSizeLimitBytes);
@@ -93,7 +108,11 @@ function resolveThresholds(
         DEFAULT_HEAP_CRITICAL_MAX_BYTES,
       )
     : DEFAULT_HEAP_CRITICAL_BYTES;
-  const hasProcessMemoryLimit = isPositiveMemoryLimit(processMemoryLimitBytes);
+  const usableProcessMemoryLimitBytes = resolveProcessMemoryLimitBytes(
+    processMemoryLimitBytes,
+    physicalMemoryBytes,
+  );
+  const hasProcessMemoryLimit = usableProcessMemoryLimitBytes !== undefined;
   // Bun's node:v8 heap limit is compatibility metadata, not an RSS process budget.
   const useBunRssCaps = isBunRuntime && hasProcessMemoryLimit;
   const useHeapForRss = !isBunRuntime && hasHeapLimit;
@@ -108,10 +127,10 @@ function resolveThresholds(
       ? heapCriticalBytes
       : DEFAULT_RSS_CRITICAL_BYTES;
   const processWarningBytes = hasProcessMemoryLimit
-    ? Math.floor(processMemoryLimitBytes * DEFAULT_HEAP_WARNING_RATIO)
+    ? Math.floor(usableProcessMemoryLimitBytes * DEFAULT_HEAP_WARNING_RATIO)
     : rssWarningBase;
   const processCriticalBytes = hasProcessMemoryLimit
-    ? Math.floor(processMemoryLimitBytes * DEFAULT_HEAP_CRITICAL_RATIO)
+    ? Math.floor(usableProcessMemoryLimitBytes * DEFAULT_HEAP_CRITICAL_RATIO)
     : rssCriticalBase;
   return {
     rssWarningBytes: thresholds?.rssWarningBytes ?? Math.min(rssWarningBase, processWarningBytes),
@@ -318,6 +337,7 @@ export function emitDiagnosticMemorySample(options?: {
   memoryUsage?: NodeJS.MemoryUsage;
   heapSizeLimitBytes?: number;
   processMemoryLimitBytes?: number;
+  physicalMemoryBytes?: number;
   isBunRuntime?: boolean;
   uptimeMs?: number;
   thresholds?: DiagnosticMemoryThresholds;
@@ -334,6 +354,7 @@ export function emitDiagnosticMemorySample(options?: {
     options?.thresholds,
     options?.heapSizeLimitBytes ?? DEFAULT_HEAP_SIZE_LIMIT_BYTES,
     options?.processMemoryLimitBytes ?? DEFAULT_PROCESS_MEMORY_LIMIT_BYTES,
+    options?.physicalMemoryBytes ?? DEFAULT_PHYSICAL_MEMORY_BYTES,
     options?.isBunRuntime ?? DEFAULT_IS_BUN_RUNTIME,
   );
   const shouldEmitSample = options?.emitSample !== false;

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -25,6 +25,10 @@ const DEFAULT_GROWTH_WINDOW_MS = 10 * 60 * 1000;
 const DEFAULT_PRESSURE_REPEAT_MS = 5 * 60 * 1000;
 const BYTE_UNITS = ["B", "KiB", "MiB", "GiB", "TiB"] as const;
 
+const DEFAULT_HEAP_SIZE_LIMIT_BYTES = getHeapStatistics().heap_size_limit;
+const DEFAULT_PROCESS_MEMORY_LIMIT_BYTES = process.constrainedMemory();
+const DEFAULT_IS_BUN_RUNTIME = typeof process.versions.bun === "string";
+
 const log = createSubsystemLogger("gateway").child("diagnostics/memory");
 
 type DiagnosticMemoryThresholds = {
@@ -48,6 +52,10 @@ type DiagnosticMemoryState = {
   lastPressureAtByKey: Map<string, number>;
 };
 
+function isPositiveMemoryLimit(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
 const state: DiagnosticMemoryState = {
   lastSample: null,
   lastPressureAtByKey: new Map(),
@@ -67,11 +75,10 @@ function normalizeMemoryUsage(memory: NodeJS.MemoryUsage): DiagnosticMemoryUsage
 function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
   heapSizeLimitBytes?: number,
+  processMemoryLimitBytes?: number,
+  isBunRuntime = false,
 ): Required<DiagnosticMemoryThresholds> {
-  const hasHeapLimit =
-    typeof heapSizeLimitBytes === "number" &&
-    Number.isFinite(heapSizeLimitBytes) &&
-    heapSizeLimitBytes > 0;
+  const hasHeapLimit = isPositiveMemoryLimit(heapSizeLimitBytes);
   // Scale both directions with V8's effective limit, but keep a warning/critical
   // ceiling so very large heaps still surface actionable pressure diagnostics.
   const heapWarningBytes = hasHeapLimit
@@ -86,9 +93,30 @@ function resolveThresholds(
         DEFAULT_HEAP_CRITICAL_MAX_BYTES,
       )
     : DEFAULT_HEAP_CRITICAL_BYTES;
+  const hasProcessMemoryLimit = isPositiveMemoryLimit(processMemoryLimitBytes);
+  // Bun's node:v8 heap limit is compatibility metadata, not an RSS process budget.
+  const useBunRssCaps = isBunRuntime && hasProcessMemoryLimit;
+  const useHeapForRss = !isBunRuntime && hasHeapLimit;
+  const rssWarningBase = useBunRssCaps
+    ? DEFAULT_HEAP_WARNING_MAX_BYTES
+    : useHeapForRss
+      ? heapWarningBytes
+      : DEFAULT_RSS_WARNING_BYTES;
+  const rssCriticalBase = useBunRssCaps
+    ? DEFAULT_HEAP_CRITICAL_MAX_BYTES
+    : useHeapForRss
+      ? heapCriticalBytes
+      : DEFAULT_RSS_CRITICAL_BYTES;
+  const processWarningBytes = hasProcessMemoryLimit
+    ? Math.floor(processMemoryLimitBytes * DEFAULT_HEAP_WARNING_RATIO)
+    : rssWarningBase;
+  const processCriticalBytes = hasProcessMemoryLimit
+    ? Math.floor(processMemoryLimitBytes * DEFAULT_HEAP_CRITICAL_RATIO)
+    : rssCriticalBase;
   return {
-    rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
-    rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,
+    rssWarningBytes: thresholds?.rssWarningBytes ?? Math.min(rssWarningBase, processWarningBytes),
+    rssCriticalBytes:
+      thresholds?.rssCriticalBytes ?? Math.min(rssCriticalBase, processCriticalBytes),
     heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? heapWarningBytes,
     heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? heapCriticalBytes,
     rssGrowthWarningBytes: thresholds?.rssGrowthWarningBytes ?? DEFAULT_RSS_GROWTH_WARNING_BYTES,
@@ -289,6 +317,8 @@ export function emitDiagnosticMemorySample(options?: {
   now?: number;
   memoryUsage?: NodeJS.MemoryUsage;
   heapSizeLimitBytes?: number;
+  processMemoryLimitBytes?: number;
+  isBunRuntime?: boolean;
   uptimeMs?: number;
   thresholds?: DiagnosticMemoryThresholds;
   emitSample?: boolean;
@@ -302,7 +332,9 @@ export function emitDiagnosticMemorySample(options?: {
   const current = { ts: now, memory };
   const thresholds = resolveThresholds(
     options?.thresholds,
-    options?.heapSizeLimitBytes ?? getHeapStatistics().heap_size_limit,
+    options?.heapSizeLimitBytes ?? DEFAULT_HEAP_SIZE_LIMIT_BYTES,
+    options?.processMemoryLimitBytes ?? DEFAULT_PROCESS_MEMORY_LIMIT_BYTES,
+    options?.isBunRuntime ?? DEFAULT_IS_BUN_RUNTIME,
   );
   const shouldEmitSample = options?.emitSample !== false;
 


### PR DESCRIPTION
Closes #119189

Supersedes #119190 with the Bun-safe runtime boundary; thanks @Marvinthebored for the original report, live observations, and first repair. AI-assisted and maintainer-reviewed.

## What Problem This Solves

Fixes an issue where healthy large-heap Gateways repeatedly log RSS pressure and restart guidance once their normal working set crosses the fixed 1.5/3 GiB warning and critical thresholds. The current defaults conflict with the managed Gateway's adaptive heap sizing and make routine 1.5–1.8 GiB RSS look unhealthy on an otherwise stable process.

## Why This Change Was Made

Node/V8 RSS diagnostics now reuse the existing capped heap-pressure thresholds: 50% warning and 75% critical, capped at 4/6 GiB, and lowered when `process.constrainedMemory()` reports a positive OS process limit. Positive “unlimited” cgroup sentinels are bounded by physical memory, matching the managed Gateway heap owner, so diagnostics remain reachable before OOM. Bun is handled separately because its `node:v8` heap-size limit is compatibility metadata rather than a process RSS budget: Bun uses a positive process limit with the same 4/6 GiB caps, or retains the historical 1.5/3 GiB fallback when no limit is available. Explicit overrides, heap-used thresholds, rapid-growth detection, event schemas, and guidance are unchanged.

The production growth is +60/-7 (net +53). It expresses the concrete Node/Bun/process-limit/physical-limit safety boundary and avoids adding config, environment, protocol, or SDK surface.

## User Impact

Healthy large-heap Gateways stop emitting routine false RSS pressure guidance, while constrained processes still warn before their usable memory ceiling. Bun no longer inherits an artificially tiny RSS budget from its V8 compatibility layer. Small or unbounded Bun installations retain the shipped fallback thresholds.

## Evidence

- Exact rebased head: `node scripts/run-vitest.mjs src/logging/diagnostic-memory.test.ts src/logging/diagnostic.test.ts src/daemon/gateway-heap.test.ts` — 113 passed. This covers large V8 caps, genuine and unlimited-sentinel Node process limits, Bun positive/no process limits, explicit overrides, heartbeat sampling, and rapid-growth preservation.
- `node scripts/run-vitest.mjs src/daemon/diagnostics.test.ts` — 7 passed before the mechanical rebase.
- Node 24.19.0 source-boundary log probe with `--max-old-space-size=8192`: 1.77 GiB RSS was silent; 4.1 GiB warned at 4 GiB; 6.1 GiB was critical at 6 GiB.
- Bun 1.3.14 direct probe: `process.constrainedMemory()` reported 512 GiB while `node:v8` reported sub-1-GiB compatibility metadata; 500 MiB RSS was silent, 4.1 GiB warned at 4 GiB, and 6.1 GiB was critical at 6 GiB.
- Node 24's stable official contract says `process.constrainedMemory()` returns OS-constrained bytes and `0` when no constraint is known.
- Blacksmith Testbox `tbx_01m06d4q352wm8gdajxpawe27d` ([run 31978129784](https://github.com/openclaw/openclaw/actions/runs/31978129784)): a Node 24 container capped at 2 GiB reported both `process.constrainedMemory()` and cgroup `memory.max` as 2,147,483,648 bytes.
- Blacksmith Testbox `tbx_01m06g8c5hptr13d54p3z1wryz` ([run 31980672955](https://github.com/openclaw/openclaw/actions/runs/31980672955)): the host reported Node's finite unlimited sentinel (`18446744073709552000`) and 16,562,868,224 physical bytes; the repaired owner boundary bounded a synthetic 4 GiB host to 2/3 GiB warning/critical thresholds.
- Testbox completed `pnpm check:changed`: production/test types, changed-file lint and format, dead-export checks, and import cycles all passed before the mechanical rebase.
- `git diff --check` passed. Final rebased-head Codex autoreview reported no accepted/actionable findings.
- Final LOC: production +60/-7; tests +101/-0.

Not performed: no Gateway deployment or restart, by design. The behavior was proven at the diagnostic owner boundary and on real Node, Bun, and Linux-cgroup runtimes.
