### PR TITLE
fix(android): drop strikethrough on completed plan steps

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -168,7 +168,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -2191,7 +2190,6 @@ private fun PlanChecklistPill(steps: List<ChatPlanStep>) {
                 text = step.step,
                 style = textStyle,
                 color = textColor,
-                textDecoration = if (step.status == ChatPlanStepStatus.Completed) TextDecoration.LineThrough else null,
               )
             }
           }


### PR DESCRIPTION
## What Problem This Solves

The Android plan checklist pill strikes through completed steps (`TextDecoration.LineThrough`), which makes finished step text hard to read. Android is the only client that does this — iOS/macOS (`ChatPlanPill.swift`) and the web Control UI use a success-colored `✓` plus muted text with no strikethrough.

## Why This Change Was Made

Cross-platform consistency pass following #124895 (web transcript plan card cleanup). The `✓` marker and muted color already communicate completion; the strikethrough only degrades readability. Pure deletion: the conditional `textDecoration` and its now-unused import are removed, nothing else about the pill changes (collapsed summary, `n/m` counter, expand/collapse all untouched).

## User Impact

Completed plan steps in the Android app stay legible. Production LOC net −2.

## Evidence

Live emulator proof (Pixel 8 AVD paired to an isolated dev gateway; real agent run emitting `update_plan` events; same 5-step plan, 2 completed / 1 in progress):

Before (strikethrough) / after (checkmark only):

![before](https://github.com/user-attachments/assets/717d0770-055b-480e-9064-37a99180e3e3)
![after](https://github.com/user-attachments/assets/9ffd7be8-96e2-4ef7-9147-067a3b792102)

Tap-to-expand video (after build):

https://github.com/user-attachments/assets/565ddd4d-2c02-4e8a-bf0a-d99ba4729f94

- `./gradlew :app:assemblePlayDebug` — BUILD SUCCESSFUL.
- `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatMessageViewsTest --tests ai.openclaw.app.chat.ChatControllerPlanStreamTest` — 9 passed.
- No new test: the pill is private with no existing Compose render fixture; exposing it would add a test-only production seam. Controller-level plan coverage unchanged.
- Codex autoreview clean.
