### PR TITLE
fix: prevent archive lifecycle test flakes under load

### DIFF
--- a/src/gateway/server.sessions.archive-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-lifecycle.test.ts
@@ -310,14 +310,12 @@ test("sessions.patch cancels active work and commits only after admission and te
   await writeSessionStore({
     entries: { [sessionKey]: sessionStoreEntry(sessionId) },
   });
-  let interrupted = false;
+  const interrupted = createDeferredCore();
   const admission = await beginSessionWorkAdmission({
     scope: storePath,
     identities: [sessionKey, sessionId],
     assertAllowed: () => {},
-    onInterrupt: () => {
-      interrupted = true;
-    },
+    onInterrupt: () => interrupted.resolve(),
   });
   const persistence = createDeferredCore();
   const active = activeRunContext({
@@ -336,10 +334,8 @@ test("sessions.patch cancels active work and commits only after admission and te
         client: { connId: "archive-writer", connect: { scopes: ["operator.write"] } } as never,
       },
     );
-    await vi.waitFor(() => {
-      expect(interrupted).toBe(true);
-      expect(active.controller.signal.aborted).toBe(true);
-    });
+    await interrupted.promise;
+    expect(active.controller.signal.aborted).toBe(true);
     expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
 
     let replacementAdmitted = false;

--- a/src/gateway/server.sessions.archive-worker-placement.test.ts
+++ b/src/gateway/server.sessions.archive-worker-placement.test.ts
@@ -89,8 +89,10 @@ test("sessions.patch reclaims the exact active cloud placement before archive me
   const sessionId = "session-archive-cloud-active";
   await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
   let placement = workerPlacement({ sessionId, sessionKey, state: "active" });
+  const reclaimStarted = createDeferredCore();
   const reclaimGate = createDeferredCore();
   const reclaim = vi.fn(async () => {
+    reclaimStarted.resolve();
     await reclaimGate.promise;
     placement = workerPlacement({ sessionId, sessionKey, state: "reclaimed" });
     return placement as Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
@@ -107,7 +109,8 @@ test("sessions.patch reclaims the exact active cloud placement before archive me
     },
   );
 
-  await vi.waitFor(() => expect(reclaim).toHaveBeenCalledOnce());
+  await reclaimStarted.promise;
+  expect(reclaim).toHaveBeenCalledOnce();
   expect(reclaim).toHaveBeenCalledWith({ sessionId, sessionKey, agentId: "main" });
   expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
   reclaimGate.resolve();


### PR DESCRIPTION
AI-assisted: Yes — prepared and verified with Codex.

## What Problem This Solves

Fixes a load-sensitive Gateway archive lifecycle test failure on shared hosts, where the test could report a false failure even though archive interruption and worker reclaim behavior were correct.

## Why This Change Was Made

The tests now wait for the exact admission interruption and worker reclaim owner callbacks instead of polling wall-clock state. Production behavior is unchanged; there are no timeout increases, sleeps, forced serialization, or runtime changes.

## User Impact

There is no runtime behavior change. CI and maintainer verification of archive lifecycle behavior become deterministic under host contention.

## Evidence

- Pre-fix focused reproduction failed with `expected false to be true`; module transform took 16.32s.
- Post-fix exact test passed in 3156ms while module transform took 21.34s and the full command took 21.82s.
- Archive lifecycle suite: 16/16 passed.
- Worker placement suite: 20/20 passed.
- Session lifecycle admission suite: 32/32 passed.
- `oxfmt`, `git diff --check`, and targeted `oxlint` passed.
- Fresh Codex autoreview of the uncommitted patch was clean with no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +8/-9.
- The full local `check:changed` allocation was infrastructure-blocked first by Blacksmith readiness and then by the Daytona organization 10 GiB memory limit. This is a remote-capacity gap, not a code failure; exact-head hosted CI is required before landing.
