### PR TITLE
fix: migrate default agent sessions during update

### DIFF
--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -15,6 +15,7 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import { printClawBanner } from "../cli/claw-banner.js";
+import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
@@ -190,7 +191,7 @@ export function applyWizardMetadata(
 ): OpenClawConfig {
   const commit =
     normalizeOptionalString(process.env.GIT_COMMIT) ?? normalizeOptionalString(process.env.GIT_SHA);
-  return {
+  return inheritLegacyDefaultAgentId(cfg, {
     ...cfg,
     wizard: {
       ...cfg.wizard,
@@ -200,7 +201,7 @@ export function applyWizardMetadata(
       lastRunCommand: params.command,
       lastRunMode: params.mode,
     },
-  };
+  });
 }
 
 /** Formats the no-GUI SSH tunnel hint for opening the Control UI remotely. */

--- a/src/commands/onboard-helpers.wizard-metadata.test.ts
+++ b/src/commands/onboard-helpers.wizard-metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyWizardMetadata } from "./onboard-helpers.js";
+
+describe("applyWizardMetadata", () => {
+  it("preserves the migrated legacy owner across the config replacement", () => {
+    const cfg = migratePersistedImplicitMainRoster({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    }).config as OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(cfg)).toBe("main");
+
+    const result = applyWizardMetadata(cfg, { command: "doctor", mode: "local" });
+
+    expect(result).not.toBe(cfg);
+    expect(tryResolveLegacyCompatibilityAgentId(result)).toBe("main");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating a published multi-agent configuration with a legacy default agent could leave unscoped top-level sessions behind instead of moving them into that default agent's SQLite database.

## Why This Change Was Made

Doctor's wizard-metadata update replaces the config object, so it now carries forward the transient migrated default-agent ownership sidecar. The owner remains compatibility-only: this does not persist `agents.defaults.sessionStore.agentId` or guess ownership for authored ambiguous configurations.

## User Impact

Updates can migrate legacy default-agent sessions and transcripts to SQLite in the same Doctor run instead of warning users to select an owner manually.

## Evidence

- Pre-fix regression: the published-style `agents.list` + `default: true` case failed with owner `undefined`; the focused regression now passes.
- Secretless full updater Doctor proof (empty environment) on a stable-generated fixture with two agents, Discord/Telegram/WhatsApp configuration, cron jobs, and 123 retired-store rows:
  - all three unscoped default-agent rows and transcripts imported into `main`
  - retired top-level store archived
  - no `select an agent owner` deferral
  - both agent SQLite databases: `PRAGMA integrity_check = ok`, zero foreign-key violations
- `node scripts/check-changed.mjs -- src/commands/onboard-helpers.ts src/commands/onboard-helpers.wizard-metadata.test.ts`
- `pnpm tsgo:core`
- focused Vitest and targeted Oxlint/Oxfmt passed
- structured autoreview: clean, correctness 0.99

The stress fixture also exposed a separate explicitly scoped Unicode-session import omission on current `main`; that independent importer defect is excluded from this focused ownership patch and is being isolated separately.
