### PR TITLE
fix(doctor): stop reporting shared auth migration on fresh installs

### DIFF
--- a/src/commands/doctor-auth.hints.test.ts
+++ b/src/commands/doctor-auth.hints.test.ts
@@ -1,6 +1,8 @@
 // Doctor auth hint tests cover OAuth refresh failure formatting and auth repair guidance.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
+import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import {
@@ -68,11 +70,31 @@ describe("doctor auth hints", () => {
     );
   });
 
-  it("reports the legacy shared auth owner with the migration command", () => {
-    noteSharedAuthStoreStatus({
+  it("does not report a legacy shared auth owner without stored credentials", () => {
+    const env = {
       ...process.env,
       OPENCLAW_STATE_DIR: tempDirs.make("openclaw-doctor-shared-auth-"),
-    });
+    };
+    noteSharedAuthStoreStatus(env);
+
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
+  it("reports the legacy shared auth owner with stored credentials", () => {
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: tempDirs.make("openclaw-doctor-shared-auth-"),
+    };
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": { type: "api_key", provider: "openai", key: "test-key" },
+        },
+      },
+      resolveSharedMainAuthAgentDir(env),
+    );
+    noteSharedAuthStoreStatus(env);
 
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("openclaw doctor --fix"),

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -34,6 +34,7 @@ import {
   resolveAuthStorePathForDisplay,
   resolveSharedAuthStoreOwnership,
 } from "../agents/auth-profiles/path-resolve.js";
+import { inspectPersistedSharedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
 import { buildProviderAuthRecoveryHint } from "../agents/provider-auth-recovery-hint.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
@@ -54,7 +55,10 @@ const DOCTOR_REAUTH_PROVIDER_ALIASES: Readonly<Record<string, string>> = {
 
 /** Surface the one-time relocation while the legacy shared owner is still active. */
 export function noteSharedAuthStoreStatus(env: NodeJS.ProcessEnv = process.env): void {
-  if (resolveSharedAuthStoreOwnership(env).location !== "legacy-main") {
+  if (
+    resolveSharedAuthStoreOwnership(env).location !== "legacy-main" ||
+    inspectPersistedSharedAuthProfileStoreRaw(env).status !== "readable"
+  ) {
     return;
   }
   note(

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -952,8 +952,35 @@ describe("doctor legacy state migrations", () => {
 
     expect(result.warnings).toEqual([]);
     expect(result.changes).toContain("Relocated shared auth profiles into shared SQLite state.");
+    expect(result.notices).toContain(
+      "The main agent no longer owns shared credentials and can now be deleted.",
+    );
     expect(readPersistedSharedAuthProfileStoreRaw(env)).toEqual(store);
     expect(readPersistedAuthProfileStoreRaw(mainAgentDir)).toBeNull();
+  });
+
+  it("records fresh shared auth ownership without reporting a relocation", async () => {
+    const stateDir = makeDoctorStateDir();
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+    const result = await autoMigrateLegacyState({
+      cfg: {},
+      env,
+      doctorOnlyStateMigrations: true,
+    });
+
+    expect(result.changes).not.toContain(
+      "Relocated shared auth profiles into shared SQLite state.",
+    );
+    expect(result.notices ?? []).not.toContain(
+      "The main agent no longer owns shared credentials and can now be deleted.",
+    );
+    const database = openOpenClawStateDatabase({ env }).db;
+    expect(
+      database
+        .prepare("SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'")
+        .get(),
+    ).toEqual({ value_json: JSON.stringify({ location: "state-db" }) });
   });
 
   it("removes stale transcript paths left by a shipped legacy migration", async () => {

--- a/src/infra/state-migrations.shared-auth-store.test.ts
+++ b/src/infra/state-migrations.shared-auth-store.test.ts
@@ -77,6 +77,49 @@ describe("shared auth store relocation", () => {
     };
   }
 
+  async function createEmptyFixture(createSourceDatabase: boolean) {
+    const stateDir = tempDirs.make("openclaw-shared-auth-empty-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", "");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: undefined };
+    const [paths, ownership, sqlite, migration] = await Promise.all([
+      import("../agents/auth-profiles/shared-main-dir.js"),
+      import("../agents/auth-profiles/path-resolve.js"),
+      import("../agents/auth-profiles/sqlite.js"),
+      import("./state-migrations.shared-auth-store.js"),
+    ]);
+    const mainAgentDir = paths.resolveSharedMainAuthAgentDir(env);
+    const sourcePath = sqlite.resolveAuthProfileDatabasePath(mainAgentDir);
+    if (createSourceDatabase) {
+      sqlite.writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} }, mainAgentDir);
+      sqlite.deletePersistedAuthProfileStoreRaw(mainAgentDir);
+    }
+    return { env, stateDir, sourcePath, ownership, migration };
+  }
+
+  it.each([
+    { label: "fresh profile", createSourceDatabase: false },
+    { label: "legacy profile with an empty source database", createSourceDatabase: true },
+  ])("records ownership without reporting relocation for a $label", async (testCase) => {
+    const fixture = await createEmptyFixture(testCase.createSourceDatabase);
+    expect(fs.existsSync(fixture.sourcePath)).toBe(testCase.createSourceDatabase);
+
+    const detected = fixture.migration.detectSharedAuthStoreMigration({
+      stateDir: fixture.stateDir,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(detected.hasLegacy).toBe(true);
+    expect(
+      await fixture.migration.migrateSharedAuthStore({
+        detected,
+        stateDir: fixture.stateDir,
+      }),
+    ).toEqual({ changes: [], warnings: [] });
+    expect(fixture.ownership.resolveSharedAuthStoreOwnership(fixture.env)).toEqual({
+      location: "state-db",
+    });
+  });
+
   it("moves exact rows, preserves every effective agent store, and records receipts", async () => {
     const fixture = await createFixture();
     const effectiveBytes = (agentDir: string) => {

--- a/src/infra/state-migrations.shared-auth-store.ts
+++ b/src/infra/state-migrations.shared-auth-store.ts
@@ -599,6 +599,7 @@ export async function migrateSharedAuthStore(params: {
         now,
       });
       const sourceCleaned = cleanupSourceRows({ env, sourcePath: params.detected.sourcePath });
+      const relocatedRows = rows.store !== null || rows.state !== null || sourceCleaned;
       finalizeMigration({
         env,
         sourcePath: params.detected.sourcePath,
@@ -608,13 +609,15 @@ export async function migrateSharedAuthStore(params: {
       });
       return {
         changes: [
-          ...(ownershipFlipped ? ["Relocated shared auth profiles into shared SQLite state."] : []),
+          ...(ownershipFlipped && relocatedRows
+            ? ["Relocated shared auth profiles into shared SQLite state."]
+            : []),
           ...(sourceCleaned && !ownershipFlipped
             ? ["Completed legacy shared auth row cleanup."]
             : []),
         ],
         warnings: [],
-        ...(ownershipFlipped
+        ...(ownershipFlipped && rows.store !== null
           ? {
               notices: ["The main agent no longer owns shared credentials and can now be deleted."],
             }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a brand-new or skip-auth-onboarded installation running `openclaw doctor --fix` reported that shared auth profiles had been relocated even though no auth rows or legacy source existed. The same run advised that the main agent could be deleted, despite it commonly being the operator's only agent.

Before this change, a fresh isolated profile produced:

```text
[state-migrations] Auto-migrated legacy state:
- Relocated shared auth profiles into shared SQLite state.
[state-migrations] Legacy state migration notes:
- The main agent no longer owns shared credentials and can now be deleted.
```

AI-assisted: yes. The patch was reviewed with the repository autoreview workflow and independently validated against the built CLI.

## Why This Change Was Made

The absent ownership marker deliberately remains `legacy-main`; changing that compatibility default would make a genuine unmarked upgrade unsafe. Instead, the migration owner now reports relocation only when it observed canonical auth rows or cleaned a real source, and emits the deletion notice only when a credential-store row exists. The ownership marker is still committed on empty profiles so future reads use shared SQLite state.

Doctor's earlier auth-status note had the same marker-only inference, so it now requires an actual readable legacy credential row. Routing, creation, deletion, stale-order repair, and state-integrity consumers keep their fail-closed ownership behavior. No schema or schema-version change is involved.

Root cause: `src/agents/auth-profiles/path-resolve.ts:35-38` correctly maps a missing marker to `legacy-main`, but `src/infra/state-migrations.shared-auth-store.ts:611-623` used the administrative ownership flip as proof that data moved. The repaired reporter uses the rows and cleanup result already produced by the migration at `src/infra/state-migrations.shared-auth-store.ts:586-602`.

## User Impact

Fresh and skip-auth-onboarded users no longer see a phantom credential migration or destructive-sounding deletion advice on their first Doctor repair. Genuine legacy upgrades keep the same relocation line and deletion notice as before.

## Evidence

Pre-Doctor observations from three isolated built-dist profiles, each with a private home/state directory and an explicit verified-free non-default port:

| Profile | Ownership | Marker | Legacy source | Source rows | Pending cleanup |
| --- | --- | --- | --- | --- | --- |
| Brand new | `legacy-main` | absent | missing | store null, state null | false |
| Onboarded with auth skipped | `legacy-main` | absent | missing | store null, state null | false |
| Synthetic legacy | `legacy-main` | absent | present | store row, state row | false |

`openclaw onboard` does not write the ownership marker. Both fresh variants therefore exercise the same deliberate upgrade-compatible default; the source rows are the fact that distinguishes a real relocation.

Built CLI after the fix:

```text
fresh:                 exit 0, relocation absent, deletion notice absent, marker = state-db
onboarded skip-auth:   exit 0, relocation absent, deletion notice absent, marker = state-db
synthetic legacy:      exit 0, relocation present, deletion notice present, marker = state-db
```

The synthetic legacy profile retained the exact messages:

```text
- Relocated shared auth profiles into shared SQLite state.
- The main agent no longer owns shared credentials and can now be deleted.
```

A second Doctor run on all three profiles emitted neither shared-auth message, proving the marker persisted and the result was not static output.

Consumer sweep:

- Changed `src/commands/doctor-auth.ts` because it independently claimed credentials still lived in main from marker absence alone.
- Left `src/commands/agents.commands.delete.ts` and the Gateway deletion guard fail-closed: both compare ownership with the actual shared DB path, and the independent sole-agent guard still prevents deletion.
- Left auth path routing, agent creation, flat-profile repair, stale auth order, and state-integrity cleanup ownership-based because those are safety/routing decisions rather than claims that migration work occurred.

Validation:

- Pre-fix regression: both new migration-owner cases failed with the phantom change and notice; the fresh Doctor auth-note case also failed with the false note.
- `node scripts/run-vitest.mjs src/infra/state-migrations.shared-auth-store.test.ts src/commands/doctor-state-migrations.test.ts src/commands/doctor-auth.hints.test.ts` — 111 tests passed.
- `node scripts/check-changed.mjs` — `core, coreTests` gate passed.
- `pnpm build` — passed; no ineffective dynamic import warning.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no actionable findings.
- Source-blind built-CLI validation — all three clauses and repeat-run probes passed on https://github.com/openclaw/openclaw/actions/runs/31979343085.

LOC: production +10/-3 (net +7); tests +95/-3. The production growth is the source-evidence guard at the two operator-visible reporting boundaries; the migration/storage shape and ownership marker flow are unchanged.
