### PR TITLE
refactor(webui): read slash commands through the chat metadata store

### DIFF
--- a/ui/src/pages/chat/chat-commands.test.ts
+++ b/ui/src/pages/chat/chat-commands.test.ts
@@ -3,12 +3,20 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import {
+  invalidateChatMetadataStore,
+  rememberChatMetadata,
+} from "../../lib/chat/chat-metadata-store.ts";
+import {
   SLASH_COMMANDS,
   getSlashCommandCategoryLabel,
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../lib/chat/commands.ts";
-import { dispatchChatSlashCommand, refreshSlashCommands } from "./chat-commands.ts";
+import {
+  applyRemoteSlashCommandsResult,
+  dispatchChatSlashCommand,
+  refreshSlashCommands,
+} from "./chat-commands.ts";
 
 function requireCommandByName(name: string): Record<string, unknown> {
   const command = SLASH_COMMANDS.find((entry) => entry.name === name);
@@ -33,6 +41,17 @@ function legacyConnectedSessionAccess() {
     client: { request: vi.fn() } as unknown as GatewayBrowserClient,
     connected: true,
     hello: null,
+  };
+}
+
+function remoteCommand(name: string, description: string) {
+  return {
+    name,
+    textAliases: [`/${name}`],
+    description,
+    source: "plugin" as const,
+    scope: "text" as const,
+    acceptsArgs: false,
   };
 }
 
@@ -250,6 +269,67 @@ describe("refreshSlashCommands", () => {
     expectRecordFields(requireCommandByName("pair"), "pair command", {
       name: "pair",
       description: "Generate setup codes.",
+    });
+  });
+
+  it("reads commands from the chat metadata store without requesting commands.list", async () => {
+    const request = vi.fn();
+    const client = { request } as never;
+    rememberChatMetadata(client, "main", {
+      commands: [remoteCommand("metadata-command", "Loaded from chat metadata.")],
+    });
+
+    await refreshSlashCommands({ client, agentId: "main" });
+
+    expect(request).not.toHaveBeenCalled();
+    expectRecordFields(requireCommandByName("metadata-command"), "metadata command", {
+      description: "Loaded from chat metadata.",
+      executeLocal: false,
+    });
+  });
+
+  it("prefers stored metadata after the commands.list cache expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue({
+        commands: [remoteCommand("cached-command", "Loaded from commands.list.")],
+      });
+      const client = { request } as never;
+
+      await refreshSlashCommands({ client, agentId: "main" });
+      vi.advanceTimersByTime(60_001);
+      rememberChatMetadata(client, "main", {
+        commands: [remoteCommand("metadata-command", "Loaded from chat metadata.")],
+      });
+
+      await refreshSlashCommands({ client, agentId: "main" });
+
+      expect(request).toHaveBeenCalledOnce();
+      expectRecordFields(requireCommandByName("metadata-command"), "metadata command", {
+        description: "Loaded from chat metadata.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retain applied metadata commands in the commands.list cache", async () => {
+    const request = vi.fn().mockResolvedValue({
+      commands: [remoteCommand("requested-command", "Loaded after metadata invalidation.")],
+    });
+    const client = { request } as never;
+    const metadata = {
+      commands: [remoteCommand("metadata-command", "Loaded from chat metadata.")],
+    };
+    rememberChatMetadata(client, "main", metadata);
+    applyRemoteSlashCommandsResult({ client, agentId: "main", result: metadata });
+
+    invalidateChatMetadataStore(client);
+    await refreshSlashCommands({ client, agentId: "main" });
+
+    expect(request).toHaveBeenCalledOnce();
+    expectRecordFields(requireCommandByName("requested-command"), "requested command", {
+      description: "Loaded after metadata invalidation.",
     });
   });
 });

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -3,6 +3,7 @@ import type { CommandsListResult } from "../../../../packages/gateway-protocol/s
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
+import { peekChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import {
   buildFallbackSlashCommands,
@@ -200,17 +201,6 @@ function getRemoteSlashCommandCache(
   return cache;
 }
 
-function storeRemoteSlashCommands(
-  client: GatewayBrowserClient,
-  agentId: string | undefined,
-  commands: SlashCommandDef[],
-) {
-  getRemoteSlashCommandCache(client).set(remoteSlashCommandCacheKey(agentId), {
-    commands,
-    expiresAt: Date.now() + REMOTE_SLASH_COMMAND_CACHE_TTL_MS,
-  });
-}
-
 async function requestRemoteSlashCommands(
   client: GatewayBrowserClient,
   agentId: string | undefined,
@@ -226,7 +216,10 @@ async function requestRemoteSlashCommands(
       return buildFallbackSlashCommands();
     }
     const commands = buildSlashCommandsFromEntries(getRemoteCommandEntries(result));
-    storeRemoteSlashCommands(client, agentId, commands);
+    getRemoteSlashCommandCache(client).set(remoteSlashCommandCacheKey(agentId), {
+      commands,
+      expiresAt: Date.now() + REMOTE_SLASH_COMMAND_CACHE_TTL_MS,
+    });
     return commands;
   } catch {
     return fallback ?? buildFallbackSlashCommands();
@@ -237,6 +230,12 @@ function loadRemoteSlashCommands(
   client: GatewayBrowserClient,
   agentId: string | undefined,
 ): Promise<SlashCommandDef[]> {
+  const metadata = peekChatMetadata(client, agentId);
+  // Store-held metadata carries app-level invalidation on config changes and logical reconnects,
+  // so no TTL applies here. The cache below owns only commands.list-derived entries.
+  if (Array.isArray(metadata?.commands)) {
+    return Promise.resolve(buildSlashCommandsFromEntries(getRemoteCommandEntries(metadata)));
+  }
   const cache = getRemoteSlashCommandCache(client);
   const key = remoteSlashCommandCacheKey(agentId);
   const cached = cache.get(key);
@@ -269,11 +268,7 @@ export function applyRemoteSlashCommandsResult(params: {
   if (!Array.isArray(params.result?.commands)) {
     return false;
   }
-  const agentId = params.agentId?.trim();
   const commands = buildSlashCommandsFromEntries(getRemoteCommandEntries(params.result));
-  if (params.client) {
-    storeRemoteSlashCommands(params.client, agentId, commands);
-  }
   refreshSeq += 1;
   replaceSlashCommands(commands);
   return true;


### PR DESCRIPTION
## What Problem This Solves

Completes the cache-ownership unification from #124794/#124868 for the slash-commands lane. `chat.metadata` results were stored twice: the shared chat-metadata store held the full result, and `applyRemoteSlashCommandsResult` wrote a transformed copy into the separate 60-second-TTL `remoteSlashCommandCache`. Because that TTL is meaningless for metadata-derived data (the store already invalidates on `config.changed` and logical reconnects), cached commands spuriously "expired" after a minute and `refreshSlashCommands` re-issued `commands.list` round-trips for data the client already held fresh.

## Why This Change Was Made

`loadRemoteSlashCommands` now reads the store first: when the store holds metadata for the agent, its commands are transformed and returned directly — no TTL read, no network. The TTL cache now owns exactly one thing: genuinely live `commands.list` results (the compatibility/fallback lane for gateways predating `chat.metadata`, which shipped in the 2026.7 train). The metadata double-write in `applyRemoteSlashCommandsResult` is deleted.

Faithfulness is contract-verified, not assumed: the gateway builds `chat.metadata`'s prepared commands with the identical `buildCommandsListResult({includeArgs: true, scope: "text"})` call that serves the UI's `commands.list` request (`src/gateway/server-methods/chat-metadata-runtime.ts:204`), so store-first reads return the same shape with the same arg metadata.

## User Impact

No visual change — the "/" palette shows identical content either way, which is why this PR carries no before/after screenshots (the observable change is eliminated redundant `commands.list` requests, covered by request-count regression tests). Slash commands stop silently refetching once per minute per pane and instead follow the store's event-driven invalidation.

## Evidence

Three regression tests, each verified failing pre-change: store-seeded reads issue no `commands.list` request; a store hit bypasses an *expired* TTL entry without a request; and after `applyRemoteSlashCommandsResult` + store invalidation, `commands.list` is requested (proving no stale second copy survives). Full suites: 9,344 tests passed (`ui/src/pages/chat` + `ui/src/lib/chat` plus isolated shard), `tsgo:ui` and `check:test-types` clean, assertion ratchet OK (no prune needed), oxlint/format clean. Autoreview (Codex `gpt-5.6-sol`, high): clean, no actionable findings.

Production LOC +11/−16 (net −5); tests +81/−1.
