### PR TITLE
fix(ui): dashboard session cards underline all content

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2400,6 +2400,10 @@ openclaw-chat-session-rail {
   transition: border-color var(--duration-fast) ease;
 }
 
+.list-item-clickable {
+  text-decoration: none;
+}
+
 .list-item-clickable:hover {
   border-color: var(--border-strong);
 }


### PR DESCRIPTION
Closes #124937

## What Problem This Solves

Fixes an issue where users opening the Control UI Dashboards page would see the session title, session key, and relative timestamp underlined on every card.

## Why This Change Was Made

Clickable list rows now explicitly suppress anchor text decoration while retaining the existing border-color hover affordance shared by card rows.

## User Impact

Dashboard session cards are easier to scan and visually consistent with neighboring clickable card surfaces in both light and dark themes.

## Evidence

Focused mock reproduction: `node --import tsx scripts/control-ui-mock-dev.ts -- --host 127.0.0.1 --port 5196`, route `/dashboards`.

Before, the dashboard card computed `text-decoration-line: underline` in both themes. After, it computes `none` in both themes.

### Light theme

Before:

![Dashboard cards underlined in light theme](https://github.com/user-attachments/assets/48c8de9f-54d8-40d1-9414-0f7cbf9e6883)

After:

![Dashboard cards without underlines in light theme](https://github.com/user-attachments/assets/07ec778a-eeb1-45c1-ae75-ac76dadc6cba)

### Dark theme

Before:

![Dashboard cards underlined in dark theme](https://github.com/user-attachments/assets/f58aaf9c-9d47-4a2c-8d2f-630ef4ff717b)

After:

![Dashboard cards without underlines in dark theme](https://github.com/user-attachments/assets/a71f23da-57ab-4784-8e81-a14cf2cf78d4)

Validation:

- `../../node_modules/.bin/stylelint --config ../../config/stylelint.config.mjs ui/src/styles/components.css`
- `git diff --check`
