### PR TITLE
fix(agents): refuse silent add without an interactive terminal

### DIFF
--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -269,7 +269,7 @@ describe("agent command registration", () => {
     expect((alphaOptions as { workspace?: string }).workspace).toBeUndefined();
     expect((alphaOptions as { bind?: string[] }).bind).toEqual([]);
     expect(alphaRuntime).toBe(runtime);
-    expect(alphaFlags).toEqual({ hasFlags: false });
+    expect(alphaFlags).toEqual({ hasFlags: false, hasAutomationFlags: false });
 
     await runCli([
       "agents",
@@ -291,7 +291,7 @@ describe("agent command registration", () => {
     expect((betaOptions as { nonInteractive?: boolean }).nonInteractive).toBe(true);
     expect((betaOptions as { json?: boolean }).json).toBe(true);
     expect(betaRuntime).toBe(runtime);
-    expect(betaFlags).toEqual({ hasFlags: true });
+    expect(betaFlags).toEqual({ hasFlags: true, hasAutomationFlags: true });
   });
 
   it("keeps JSON-only agent creation non-interactive", async () => {
@@ -302,7 +302,7 @@ describe("agent command registration", () => {
       expect.objectContaining({ name: "alpha", json: true, nonInteractive: false }),
     );
     expect(callRuntime).toBe(runtime);
-    expect(flags).toEqual({ hasFlags: true });
+    expect(flags).toEqual({ hasFlags: true, hasAutomationFlags: false });
   });
 
   it("runs agents list when root agents command is invoked", async () => {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -184,6 +184,13 @@ export function registerAgentsCommands(program: Command): void {
           "nonInteractive",
           "json",
         ]);
+        const hasAutomationFlags = hasExplicitOptions(command, [
+          "workspace",
+          "model",
+          "agentDir",
+          "bind",
+          "nonInteractive",
+        ]);
         const agentsAddCommand = await loadAgentsAddCommand();
         await agentsAddCommand(
           {
@@ -196,7 +203,7 @@ export function registerAgentsCommands(program: Command): void {
             json: Boolean(opts.json),
           },
           runtime,
-          { hasFlags },
+          { hasFlags, hasAutomationFlags },
         );
       });
     });

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -16,6 +16,7 @@ import {
   type SessionPickerChoice,
 } from "../tui/tui-session-picker.js";
 import type { ResumeCliOptions } from "./resume-cli.js";
+import { isTerminalInteractive } from "./terminal-interactivity.js";
 
 const RESUME_INTERACTIVE_TERMINAL_GUIDANCE =
   "Attaching to a session requires an interactive terminal. Re-run `openclaw resume [query]` from an interactive terminal.";
@@ -115,7 +116,7 @@ function parseHandoffSessionResolveResult(value: unknown): ParsedHandoffSessionR
 }
 
 function requireInteractiveResumeTerminal() {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+  if (!isTerminalInteractive()) {
     throw new Error(RESUME_INTERACTIVE_TERMINAL_GUIDANCE);
   }
 }

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -73,6 +73,9 @@ const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
 const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
+const terminalMocks = vi.hoisted(() => ({
+  isTerminalInteractive: vi.fn(() => true),
+}));
 const authChoiceMocks = vi.hoisted(() => ({
   applyAuthChoice: vi.fn(),
   warnIfModelConfigLooksOff: vi.fn(async () => {}),
@@ -109,6 +112,11 @@ vi.mock("../plugins/install-record-commit.js", async () => ({
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("../cli/terminal-interactivity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../cli/terminal-interactivity.js")>()),
+  isTerminalInteractive: terminalMocks.isTerminalInteractive,
 }));
 
 vi.mock("./auth-choice.js", () => ({
@@ -192,6 +200,7 @@ describe("agents add command", () => {
       },
     );
     wizardMocks.createClackPrompter.mockClear();
+    terminalMocks.isTerminalInteractive.mockReset().mockReturnValue(true);
     authChoiceMocks.applyAuthChoice.mockClear();
     authChoiceMocks.warnIfModelConfigLooksOff.mockClear();
     onboardChannelsMocks.setupChannels.mockClear();
@@ -316,22 +325,51 @@ describe("agents add command", () => {
     expect(writeConfigFileMock).not.toHaveBeenCalled();
   });
 
+  it.each([{ json: false }, { json: true }])(
+    "refuses the interactive wizard without a usable terminal (json=$json)",
+    async ({ json }) => {
+      readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+      terminalMocks.isTerminalInteractive.mockReturnValue(false);
+      wizardMocks.createClackPrompter.mockReturnValue({
+        intro: vi.fn(),
+        text: vi.fn().mockRejectedValue(new WizardCancelledError()),
+        confirm: vi.fn(),
+        note: vi.fn(),
+        outro: vi.fn(),
+      });
+
+      await agentsAddCommand({ json }, runtime);
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(wizardMocks.createClackPrompter).not.toHaveBeenCalled();
+      expect(createAgentMock).not.toHaveBeenCalled();
+      expect(writeConfigFileMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("uses the explicit agent target and skips catalog validation", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       ...baseConfigSnapshot,
       config: { agents: { list: [{ id: "main", default: true }] } },
       sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
     });
-    wizardMocks.createClackPrompter.mockReturnValue({
+    const prompter = {
       intro: vi.fn(),
       text: vi.fn().mockResolvedValueOnce("Jon").mockResolvedValueOnce("/tmp/openclaw-jon"),
       confirm: vi.fn().mockResolvedValue(false),
       note: vi.fn(),
       outro: vi.fn(),
-    });
+    };
+    wizardMocks.createClackPrompter.mockReturnValue(prompter);
 
     await agentsAddCommand({}, runtime);
 
+    expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledOnce();
+    expect(prompter.intro).toHaveBeenCalledWith("Add OpenClaw agent");
     expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledOnce();
     expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledWith(
       expect.objectContaining({ agents: expect.any(Object) }),
@@ -474,16 +512,19 @@ describe("agents add command", () => {
   });
 
   describe("non-interactive config mutation", () => {
-    it("delegates creation to the canonical service", async () => {
+    it("creates with explicit non-interactive inputs without a usable terminal", async () => {
       readConfigFileSnapshotMock.mockResolvedValue({
         ...baseConfigSnapshot,
         config: { agents: { list: [{ id: "main", default: true }] } },
         sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
       });
+      terminalMocks.isTerminalInteractive.mockReturnValue(false);
 
-      await agentsAddCommand({ name: "Work", workspace: "/tmp/work" }, runtime, {
-        hasFlags: true,
-      });
+      await agentsAddCommand(
+        { name: "Work", workspace: "/tmp/work", nonInteractive: true },
+        runtime,
+        { hasFlags: false },
+      );
 
       expect(createAgentMock).toHaveBeenCalledWith({
         name: "Work",

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -32,6 +32,7 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { logConfigUpdated } from "../config/logging.js";
 import {
   commitConfigWithPendingPluginInstalls,
@@ -96,8 +97,19 @@ function formatSkippedOAuthProfilesMessage(
 export async function agentsAddCommand(
   opts: AgentsAddOptions,
   runtime: RuntimeEnv = defaultRuntime,
-  params?: { hasFlags?: boolean },
+  params?: { hasFlags?: boolean; hasAutomationFlags?: boolean },
 ) {
+  const hasFlags = params?.hasFlags === true;
+  const hasAutomationFlags = params?.hasAutomationFlags ?? hasFlags;
+  const nonInteractive = opts.nonInteractive === true || hasFlags;
+  if (!opts.nonInteractive && !hasAutomationFlags && !isTerminalInteractive()) {
+    runtime.error(
+      `Agent creation needs an interactive TTY. Use \`${formatCliCommand("openclaw agents add <id> --non-interactive --workspace <dir>")}\` for automation.`,
+    );
+    runtime.exit(1);
+    return;
+  }
+
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
   if (!configSnapshot) {
     return;
@@ -107,8 +119,6 @@ export async function agentsAddCommand(
 
   const workspaceFlag = opts.workspace?.trim();
   const nameInput = opts.name?.trim();
-  const hasFlags = params?.hasFlags === true;
-  const nonInteractive = opts.nonInteractive === true || hasFlags;
 
   if (nonInteractive) {
     if (!workspaceFlag) {

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -29,6 +29,7 @@ import {
 } from "../agents/workspace-state-store.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatCliJsonFailure } from "../cli/failure-output.js";
+import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { replaceConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import {
@@ -202,7 +203,7 @@ export async function agentsDeleteCommand(
   }
 
   if (!opts.force) {
-    if (!process.stdin.isTTY) {
+    if (!isTerminalInteractive()) {
       failAgentsDelete(opts, runtime, "Non-interactive session. Re-run with --force.");
       return;
     }

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -53,6 +53,13 @@ const workspaceStateMocks = vi.hoisted(() => ({
   prepareWorkspaceStateDeletion: vi.fn((workspaceDir: string) => ({ workspaceDir })),
 }));
 
+const terminalMocks = vi.hoisted(() => ({
+  isTerminalInteractive: vi.fn(() => true),
+}));
+const wizardMocks = vi.hoisted(() => ({
+  createClackPrompter: vi.fn(),
+}));
+
 vi.mock("../config/config.js", async () => ({
   ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
   readConfigFileSnapshot: configMocks.readConfigFileSnapshot,
@@ -79,6 +86,15 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
   )),
   deleteWorkspaceState: workspaceStateMocks.deleteWorkspaceState,
   prepareWorkspaceStateDeletion: workspaceStateMocks.prepareWorkspaceStateDeletion,
+}));
+
+vi.mock("../cli/terminal-interactivity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../cli/terminal-interactivity.js")>()),
+  isTerminalInteractive: terminalMocks.isTerminalInteractive,
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: wizardMocks.createClackPrompter,
 }));
 
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
@@ -211,6 +227,31 @@ describe("agents delete command", () => {
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
+    terminalMocks.isTerminalInteractive.mockReset().mockReturnValue(true);
+    wizardMocks.createClackPrompter.mockReset();
+  });
+
+  it("requires --force when confirmation cannot use an interactive terminal", async () => {
+    await withStateDirEnv("openclaw-agents-delete-non-tty-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", default: true, workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, deletedAgentId: "ops", sessions: {} });
+      terminalMocks.isTerminalInteractive.mockReturnValue(false);
+
+      await agentsDeleteCommand({ id: "ops" }, runtime);
+
+      expect(runtime.error).toHaveBeenCalledWith("Non-interactive session. Re-run with --force.");
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(wizardMocks.createClackPrompter).not.toHaveBeenCalled();
+      expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalled();
+    });
   });
 
   it("refuses deleting main even when another agent is default", async () => {

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -1,6 +1,6 @@
 // Entry points for the full configure wizard and section-limited runs.
-import process from "node:process";
 import { formatCliCommand } from "../cli/command-format.js";
+import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import type { WizardSection } from "./configure.shared.js";
@@ -34,7 +34,7 @@ const CONFIGURE_NON_TTY_HINT = [
  * Returns true when the wizard may proceed.
  */
 function assertInteractiveConfigureTerminal(runtime: RuntimeEnv, interactive?: boolean): boolean {
-  const interactiveTerminal = interactive ?? (process.stdin.isTTY && process.stdout.isTTY);
+  const interactiveTerminal = interactive ?? isTerminalInteractive();
   if (interactiveTerminal) {
     return true;
   }

--- a/src/commands/onboard-interactive-runner.ts
+++ b/src/commands/onboard-interactive-runner.ts
@@ -1,10 +1,11 @@
 // Shared lifecycle handling for interactive onboarding entrypoints.
 import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
+import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 
 export function hasInteractiveOnboardingTty(): boolean {
-  return process.stdin.isTTY && process.stdout.isTTY;
+  return isTerminalInteractive();
 }
 
 export async function runInteractiveOnboarding(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scripts running `openclaw agents add` with closed or piped stdin received exit 0 and a partial prompt frame on stdout, but no agent was created and stderr contained no explanation.

Before on base `de217e4990a35ac0f6c9569197e3a0d86bc97bdb`:

```text
$ openclaw agents add </dev/null
┌  Add OpenClaw agent
│
◆  Agent name
│  _
└
[exit 0]

$ openclaw agents list --json
[{ "id": "main", ... }]
```

The sibling behavior was already fail-closed:

| Command | Non-interactive outcome |
| --- | --- |
| `openclaw onboard` | exit 1 with the `--non-interactive --accept-risk` automation path |
| `openclaw configure` | exit 1 with non-interactive config subcommands |
| `openclaw plugins install <x>` | exit 1 with the explicit acknowledgement path |
| bare `openclaw` | exit 1 with the one-command automation path |
| `openclaw agents set-identity --agent main` | exit 1 with a domain reason |
| `openclaw agents delete main` | exit 1 with a domain reason and remedy |
| `openclaw agents add` | previously exit 0, prompt chrome, no agent, no explanation |

## Why This Change Was Made

The interactive branch now refuses before config loading or prompt construction unless both stdin and stdout are TTYs. It uses the existing process-terminal seam shared by channels and gateway CLI code, and points directly to `openclaw agents add <id> --non-interactive --workspace <dir>`.

The guard stays command-owned rather than introducing a generic refusal-message helper: onboarding, configure, resume, and the system agent have different remedies and error mechanisms. Their matching process-global TTY predicates now reuse the shared seam; the system agent keeps its local check because it validates caller-injected streams instead of `process.stdin`/`process.stdout`.

`--json` remains non-interactive. The registrar now distinguishes output-only `--json` from real automation flags, so JSON-only use without a TTY gets the same refusal and empty stdout, while complete non-interactive JSON invocations keep their existing contract.

The locked prompt dependency (`@clack/prompts` 1.7.0 / `@clack/core` 1.4.3) confirms both streams are required: it reads keypresses from stdin, creates readline with terminal behavior, and renders/resizes prompt frames through stdout. The dependency has no built-in non-TTY refusal.

## User Impact

Scripts and CI can no longer mistake a no-op interactive add for success. They receive exit 1, an actionable stderr message, and no stdout contamination. Existing explicit non-interactive creation and real-terminal wizard behavior are unchanged.

## Evidence

After, using built dist in isolated scratch profiles with explicit local gateway mode and a free non-18789 port:

```text
closed stdin: exit 1
stdout: ""
stderr: Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.

piped stdin: exit 1
stdout: ""
stderr: Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.

--json only: exit 1
stdout: ""
stderr: Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.

agents list after all refusals: main only

agents add scripted-agent --non-interactive --workspace <scratch> --json: exit 0
agents list after creation: main, scripted-agent

real PTY: rendered “Add OpenClaw agent” and “Agent name”; Ctrl-C cancellation exited 1
```

Prompt chrome remains on stdout for a real interactive TTY, matching Clack's contract. No stream rerouting was needed: prompt construction is unreachable in non-TTY and JSON-only refusal paths, and complete `--json` automation remains pure JSON.

Sweep:

| Surface | Decision |
| --- | --- |
| `agents add` | Changed: shared two-stream guard before prompt construction; actionable automation hint |
| `agents bind` / `unbind` | Left: these commands do not prompt |
| `agents delete` confirmation | Changed: shared two-stream predicate; existing `--force` remedy retained |
| `devices` pairing | Left: no interactive prompt; destructive clear already requires `--yes` |
| skills/plugin install acknowledgements | Left: their prompt callbacks are already gated on both stdin and stdout TTYs and non-TTY use returns an explicit refusal |
| plugin uninstall confirmation | Left: closed input already becomes exit 1 with `--force` guidance |
| onboarding / configure / resume | Changed only to reuse the shared process-terminal predicate; messages and behavior unchanged |
| system agent | Left local: it validates injected streams, not process-global streams |
| other update/model/migration prompt owners | Left: source sweep found separate command-specific confirmation contracts, but no evidence of this exact silent exit-0/no-op; widening those owners would be speculative |

Validation:

- Regression test failed pre-fix for both plain and `--json` refusal cases: no stderr guidance was emitted.
- `node scripts/run-vitest.mjs ...`: post-rebase 178 tests passed across CLI and commands shards; earlier complete focused run covered 200 tests across three shards.
- `node scripts/check-changed.mjs`: passed all selected core/core-test gates on Blacksmith Testbox `tbx_01m06g3xj7wdpmv995qa3yqem4`.
- `pnpm build`: passed on the same Testbox. Run: https://github.com/openclaw/openclaw/actions/runs/31980563880
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings.
- Production LOC: +29/-9 (net +20). Tests: +91/-9 (net +82). The production growth establishes the fail-closed command boundary, preserves JSON-only routing, and consolidates process-global predicate policy across sibling commands.

AI-assisted: yes. The implementation and evidence were reviewed and understood; no transcript is attached.
