### PR TITLE
refactor(channels): split signal approval routes and align persisted approval-target validation

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -211,7 +211,6 @@ extensions/qa-lab/src/suite-launch.runtime.test.ts
 extensions/qa-lab/src/suite-launch.runtime.ts
 extensions/qa-lab/src/test-file-scenario-runner.test.ts
 extensions/qa-lab/web/src/app.ts
-extensions/signal/src/approval-reactions.ts
 extensions/signal/src/client-container.test.ts
 extensions/signal/src/client-container.ts
 extensions/signal/src/core.test.ts

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -15,6 +15,7 @@ import {
   resolveIMessageApprovalReactionTargetWithPersistence,
 } from "./approval-reactions.js";
 import type { IMessagePayload } from "./monitor/types.js";
+import { getOptionalIMessageRuntime } from "./runtime.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
 const resolverMocks = vi.hoisted(() => ({
@@ -589,6 +590,40 @@ describe("iMessage approval reactions", () => {
         conversation: expect.objectContaining({ chatId: 42, chatGuid: "iMessage;+;restart" }),
       }),
     ]);
+  });
+
+  it("rejects persisted targets containing an invalid approval decision", async () => {
+    installIMessageStateRuntimeForTest();
+    clearIMessageApprovalReactionTargetsForTest();
+    const store = getOptionalIMessageRuntime()?.state.openKeyedStore({
+      namespace: "imessage.approval-reactions",
+      maxEntries: 1000,
+      defaultTtlMs: 24 * 60 * 60 * 1000,
+    });
+    if (!store) {
+      throw new Error("Expected iMessage approval reaction state store");
+    }
+    await store.register(
+      "default:handle:+15551230000:corrupt-message",
+      {
+        version: 1,
+        target: {
+          approvalId: "exec-corrupt",
+          approvalKind: "exec",
+          allowedDecisions: ["allow-once", "invalid"],
+        },
+      },
+      { ttlMs: 60_000 },
+    );
+
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        conversation: { handle: "+15551230000" },
+        messageId: "corrupt-message",
+        reactionKey: "👍",
+      }),
+    ).resolves.toBeNull();
   });
 
   it("resolves a registered group reaction target keyed by chat_guid", async () => {

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -4,13 +4,14 @@ import {
   addApprovalReactionHintToText,
   approvalReactionDecisionSetsMatch,
   buildApprovalReactionHint,
+  buildApprovalReactionDeliveredBindingMarker,
   createApprovalReactionTargetStore,
   listApprovalReactionBindings,
   normalizeApprovalReactionDecision,
+  readApprovalReactionDecisionList,
   readApprovalReactionDeliveredBinding,
   readApprovalReactionPresentationBinding,
   resolveTypedApprovalReactionTarget,
-  type ApprovalReactionDecisionBinding,
   type ApprovalReactionDeliveryBinding,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
@@ -43,8 +44,6 @@ import { normalizeIMessageHandle } from "./targets.js";
 const PERSISTENT_NAMESPACE = "imessage.approval-reactions";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
-
-type IMessageApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type IMessageApprovalReactionResolution = {
   approvalId: string;
@@ -101,17 +100,12 @@ function readPersistedTarget(value: unknown): IMessageApprovalReactionTarget | n
   if (
     !target ||
     typeof target.approvalId !== "string" ||
-    !Array.isArray(target.allowedDecisions) ||
     (target.approvalKind !== "exec" && target.approvalKind !== "plugin")
   ) {
     return null;
   }
-  const allowedDecisions = target.allowedDecisions
-    .map((valueValue) =>
-      typeof valueValue === "string" ? normalizeApprovalReactionDecision(valueValue) : null,
-    )
-    .filter((valueLocal): valueLocal is ExecApprovalReplyDecision => Boolean(valueLocal));
-  if (allowedDecisions.length === 0) {
+  const allowedDecisions = readApprovalReactionDecisionList(target.allowedDecisions);
+  if (!allowedDecisions) {
     return null;
   }
   return {
@@ -130,12 +124,6 @@ const imessageApprovalReactionTargets =
     logPersistentError: reportPersistentApprovalReactionError,
     readPersistedTarget,
   });
-
-function listIMessageApprovalReactionBindings(
-  allowedDecisions: readonly ExecApprovalReplyDecision[],
-): IMessageApprovalReactionBinding[] {
-  return listApprovalReactionBindings({ allowedDecisions });
-}
 
 type IMessageApprovalDeliveryBinding = ApprovalReactionDeliveryBinding & {
   approvalSlug: string;
@@ -222,13 +210,12 @@ export function addIMessageApprovalReactionHintToStructuredPayload(params: {
     }),
     channelData: {
       ...params.payload.channelData,
-      [IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY]: {
-        version: 1,
+      [IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY]: buildApprovalReactionDeliveredBindingMarker({
         approvalId: metadata.approvalId,
         approvalSlug: metadata.approvalSlug,
         approvalKind: metadata.approvalKind,
         allowedDecisions: metadata.allowedDecisions,
-      },
+      }),
     },
   };
 }
@@ -247,9 +234,9 @@ export function registerIMessageApprovalReactionTarget(params: {
   const accountId = params.accountId.trim();
   const messageId = params.messageId.trim();
   const approvalId = params.approvalId.trim();
-  const allowedDecisions = listIMessageApprovalReactionBindings(params.allowedDecisions).map(
-    (binding) => binding.decision,
-  );
+  const allowedDecisions = listApprovalReactionBindings({
+    allowedDecisions: params.allowedDecisions,
+  }).map((binding) => binding.decision);
   if (
     !accountId ||
     !messageId ||

--- a/extensions/signal/src/approval-reaction-routes.ts
+++ b/extensions/signal/src/approval-reaction-routes.ts
@@ -1,0 +1,195 @@
+import { matchesApprovalRequestFilters } from "openclaw/plugin-sdk/approval-client-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveSignalTarget } from "./aliases.js";
+import { normalizeSignalMessagingTarget } from "./normalize.js";
+
+type ApprovalForwardingConfig = NonNullable<NonNullable<OpenClawConfig["approvals"]>["exec"]>;
+type ApprovalForwardingMode = NonNullable<ApprovalForwardingConfig["mode"]>;
+
+export type SignalApprovalReactionRoute =
+  | {
+      deliveryMode: "session";
+      agentId?: string;
+      sessionKey?: string;
+    }
+  | {
+      deliveryMode: "target";
+      to: string;
+      accountId?: string;
+      agentId?: string;
+      sessionKey?: string;
+    };
+
+function resolveApprovalForwardingConfig(params: {
+  cfg: OpenClawConfig;
+  approvalKind: "exec" | "plugin";
+}): ApprovalForwardingConfig | undefined {
+  return params.approvalKind === "plugin"
+    ? params.cfg.approvals?.plugin
+    : params.cfg.approvals?.exec;
+}
+
+function normalizeApprovalForwardingMode(
+  mode: ApprovalForwardingConfig["mode"] | undefined,
+): ApprovalForwardingMode {
+  return mode ?? "session";
+}
+
+function approvalModeIncludesSession(mode: ApprovalForwardingMode): boolean {
+  return mode === "session" || mode === "both";
+}
+
+function approvalModeIncludesTargets(mode: ApprovalForwardingMode): boolean {
+  return mode === "targets" || mode === "both";
+}
+
+function matchesSignalApprovalReactionFilters(params: {
+  config: ApprovalForwardingConfig;
+  route: Pick<SignalApprovalReactionRoute, "agentId" | "sessionKey">;
+}): boolean {
+  return matchesApprovalRequestFilters({
+    request: {
+      agentId: params.route.agentId,
+      sessionKey: params.route.sessionKey,
+    },
+    agentFilter: params.config.agentFilter,
+    sessionFilter: params.config.sessionFilter,
+    fallbackAgentIdFromSessionKey: true,
+  });
+}
+
+function targetAccountMatches(params: {
+  routeAccountId?: string | null;
+  configuredAccountId?: string | null;
+}): boolean {
+  const configuredAccountId = normalizeOptionalString(params.configuredAccountId);
+  if (!configuredAccountId) {
+    return true;
+  }
+  const routeAccountId = normalizeOptionalString(params.routeAccountId);
+  return Boolean(
+    routeAccountId &&
+    normalizeAccountId(routeAccountId) === normalizeAccountId(configuredAccountId),
+  );
+}
+
+function resolveSignalApprovalRouteTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  to: string;
+}): string | null {
+  try {
+    return (
+      resolveSignalTarget({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        input: params.to,
+      })?.to ??
+      normalizeSignalMessagingTarget(params.to) ??
+      null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function hasMatchingSignalApprovalReactionTarget(params: {
+  cfg: OpenClawConfig;
+  config: ApprovalForwardingConfig;
+  route: Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }>;
+}): boolean {
+  return (params.config.targets ?? []).some((target) => {
+    if (normalizeLowercaseStringOrEmpty(target.channel) !== "signal") {
+      return false;
+    }
+    const configuredTo = resolveSignalApprovalRouteTarget({
+      cfg: params.cfg,
+      accountId: target.accountId ?? params.route.accountId,
+      to: target.to,
+    });
+    if (!configuredTo || configuredTo !== params.route.to) {
+      return false;
+    }
+    return targetAccountMatches({
+      routeAccountId: params.route.accountId,
+      configuredAccountId: target.accountId,
+    });
+  });
+}
+
+export function isSignalApprovalReactionRouteStillEnabled(params: {
+  cfg: OpenClawConfig;
+  target: {
+    approvalKind: "exec" | "plugin";
+    route: SignalApprovalReactionRoute;
+  };
+}): boolean {
+  const config = resolveApprovalForwardingConfig({
+    cfg: params.cfg,
+    approvalKind: params.target.approvalKind,
+  });
+  if (!config?.enabled) {
+    return false;
+  }
+  const mode = normalizeApprovalForwardingMode(config.mode);
+  if (params.target.route.deliveryMode === "target") {
+    return (
+      approvalModeIncludesTargets(mode) &&
+      matchesSignalApprovalReactionFilters({ config, route: params.target.route }) &&
+      hasMatchingSignalApprovalReactionTarget({
+        cfg: params.cfg,
+        config,
+        route: params.target.route,
+      })
+    );
+  }
+  if (!approvalModeIncludesSession(mode)) {
+    return false;
+  }
+  return matchesSignalApprovalReactionFilters({ config, route: params.target.route });
+}
+
+export function buildTargetRoute(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  to: string;
+  approvalKind: "exec" | "plugin";
+  agentId?: string | null;
+  sessionKey?: string | null;
+}): Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }> | null {
+  const to = resolveSignalApprovalRouteTarget({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    to: params.to,
+  });
+  if (!to) {
+    return null;
+  }
+  const route: Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }> = {
+    deliveryMode: "target",
+    to,
+    ...(normalizeOptionalString(params.accountId)
+      ? { accountId: normalizeOptionalString(params.accountId) }
+      : {}),
+    ...(normalizeOptionalString(params.agentId)
+      ? { agentId: normalizeOptionalString(params.agentId) }
+      : {}),
+    ...(normalizeOptionalString(params.sessionKey)
+      ? { sessionKey: normalizeOptionalString(params.sessionKey) }
+      : {}),
+  };
+  return isSignalApprovalReactionRouteStillEnabled({
+    cfg: params.cfg,
+    target: {
+      approvalKind: params.approvalKind,
+      route,
+    },
+  })
+    ? route
+    : null;
+}

--- a/extensions/signal/src/approval-reactions.test.ts
+++ b/extensions/signal/src/approval-reactions.test.ts
@@ -13,6 +13,7 @@ import {
   registerSignalApprovalReactionTarget,
   resolveSignalApprovalReactionTargetWithPersistence,
 } from "./approval-reactions.js";
+import * as signalRuntime from "./runtime.js";
 
 const resolverMocks = vi.hoisted(() => ({
   resolveSignalApproval: vi.fn(),
@@ -171,6 +172,42 @@ describe("Signal approval reactions", () => {
         targetAuthor: "+15550009999",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("rejects persisted targets containing an invalid approval decision", async () => {
+    const runtime = vi.spyOn(signalRuntime, "getOptionalSignalRuntime").mockReturnValue({
+      state: {
+        openKeyedStore: () => ({
+          register: async () => {},
+          lookup: async () => ({
+            version: 1,
+            target: {
+              approvalId: "exec-corrupt",
+              approvalKind: "exec",
+              allowedDecisions: ["allow-once", "invalid"],
+              targetAuthorKeys: ["+15550009999"],
+              route: { deliveryMode: "session" },
+            },
+          }),
+          delete: async () => false,
+        }),
+      },
+    } as never);
+    try {
+      clearSignalApprovalReactionTargetsForTest();
+      await expect(
+        resolveSignalApprovalReactionTargetWithPersistence({
+          accountId: "default",
+          conversationKey: "+15551230000",
+          messageId: "corrupt-message",
+          reactionKey: "👍",
+          targetAuthor: "+15550009999",
+        }),
+      ).resolves.toBeNull();
+    } finally {
+      clearSignalApprovalReactionTargetsForTest();
+      runtime.mockRestore();
+    }
   });
 
   it("registers only delivered chunks that contain visible reaction hints", async () => {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -1,13 +1,12 @@
 // Signal plugin module implements approval reactions behavior.
-import { matchesApprovalRequestFilters } from "openclaw/plugin-sdk/approval-client-runtime";
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import {
   addApprovalReactionHintToText,
   createApprovalReactionTargetStore,
   hasApprovalReactionHintText,
   listApprovalReactionBindings,
+  readApprovalReactionDecisionList,
   resolveTypedApprovalReactionTarget,
-  type ApprovalReactionDecisionBinding,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import {
@@ -27,6 +26,11 @@ import {
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveSignalTarget } from "./aliases.js";
 import { getSignalApprovalApprovers, signalApprovalAuth } from "./approval-auth.js";
+import {
+  buildTargetRoute,
+  isSignalApprovalReactionRouteStillEnabled,
+  type SignalApprovalReactionRoute,
+} from "./approval-reaction-routes.js";
 import { looksLikeUuid } from "./identity.js";
 import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { getOptionalSignalRuntime } from "./runtime.js";
@@ -34,8 +38,6 @@ import { getOptionalSignalRuntime } from "./runtime.js";
 const PERSISTENT_NAMESPACE = "signal.approval-reactions.v2";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
-
-type SignalApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type SignalApprovalReactionResolution = {
   approvalId: string;
@@ -45,23 +47,6 @@ type SignalApprovalReactionResolution = {
 };
 
 type ApprovalKind = "exec" | "plugin";
-type ApprovalForwardingConfig = NonNullable<NonNullable<OpenClawConfig["approvals"]>["exec"]>;
-type ApprovalForwardingMode = NonNullable<ApprovalForwardingConfig["mode"]>;
-
-type SignalApprovalReactionRoute =
-  | {
-      deliveryMode: "session";
-      agentId?: string;
-      sessionKey?: string;
-    }
-  | {
-      deliveryMode: "target";
-      to: string;
-      accountId?: string;
-      agentId?: string;
-      sessionKey?: string;
-    };
-
 type SignalApprovalReactionTarget = ApprovalReactionTargetRecord<SignalApprovalReactionRoute> & {
   approvalKind: ApprovalKind;
   targetAuthorKeys: readonly string[];
@@ -102,132 +87,6 @@ const signalApprovalReactionTargets =
     logPersistentError: reportPersistentApprovalReactionError,
     readPersistedTarget,
   });
-
-function resolveApprovalForwardingConfig(params: {
-  cfg: OpenClawConfig;
-  approvalKind: ApprovalKind;
-}): ApprovalForwardingConfig | undefined {
-  return params.approvalKind === "plugin"
-    ? params.cfg.approvals?.plugin
-    : params.cfg.approvals?.exec;
-}
-
-function normalizeApprovalForwardingMode(
-  mode: ApprovalForwardingConfig["mode"] | undefined,
-): ApprovalForwardingMode {
-  return mode ?? "session";
-}
-
-function approvalModeIncludesSession(mode: ApprovalForwardingMode): boolean {
-  return mode === "session" || mode === "both";
-}
-
-function approvalModeIncludesTargets(mode: ApprovalForwardingMode): boolean {
-  return mode === "targets" || mode === "both";
-}
-
-function matchesSignalApprovalReactionFilters(params: {
-  config: ApprovalForwardingConfig;
-  route: Pick<SignalApprovalReactionRoute, "agentId" | "sessionKey">;
-}): boolean {
-  return matchesApprovalRequestFilters({
-    request: {
-      agentId: params.route.agentId,
-      sessionKey: params.route.sessionKey,
-    },
-    agentFilter: params.config.agentFilter,
-    sessionFilter: params.config.sessionFilter,
-    fallbackAgentIdFromSessionKey: true,
-  });
-}
-
-function targetAccountMatches(params: {
-  routeAccountId?: string | null;
-  configuredAccountId?: string | null;
-}): boolean {
-  const configuredAccountId = normalizeOptionalString(params.configuredAccountId);
-  if (!configuredAccountId) {
-    return true;
-  }
-  const routeAccountId = normalizeOptionalString(params.routeAccountId);
-  return Boolean(
-    routeAccountId &&
-    normalizeAccountId(routeAccountId) === normalizeAccountId(configuredAccountId),
-  );
-}
-
-function resolveSignalApprovalRouteTarget(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  to: string;
-}): string | null {
-  try {
-    return (
-      resolveSignalTarget({
-        cfg: params.cfg,
-        accountId: params.accountId,
-        input: params.to,
-      })?.to ??
-      normalizeSignalMessagingTarget(params.to) ??
-      null
-    );
-  } catch {
-    return null;
-  }
-}
-
-function hasMatchingSignalApprovalReactionTarget(params: {
-  cfg: OpenClawConfig;
-  config: ApprovalForwardingConfig;
-  route: Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }>;
-}): boolean {
-  return (params.config.targets ?? []).some((target) => {
-    if (normalizeLowercaseStringOrEmpty(target.channel) !== "signal") {
-      return false;
-    }
-    const configuredTo = resolveSignalApprovalRouteTarget({
-      cfg: params.cfg,
-      accountId: target.accountId ?? params.route.accountId,
-      to: target.to,
-    });
-    if (!configuredTo || configuredTo !== params.route.to) {
-      return false;
-    }
-    return targetAccountMatches({
-      routeAccountId: params.route.accountId,
-      configuredAccountId: target.accountId,
-    });
-  });
-}
-
-function isSignalApprovalReactionRouteStillEnabled(params: {
-  cfg: OpenClawConfig;
-  target: Pick<SignalApprovalReactionTarget, "approvalKind" | "route">;
-}): boolean {
-  const config = resolveApprovalForwardingConfig({
-    cfg: params.cfg,
-    approvalKind: params.target.approvalKind,
-  });
-  if (!config?.enabled) {
-    return false;
-  }
-  const mode = normalizeApprovalForwardingMode(config.mode);
-  if (params.target.route.deliveryMode === "target") {
-    return (
-      approvalModeIncludesTargets(mode) &&
-      matchesSignalApprovalReactionFilters({ config, route: params.target.route }) &&
-      hasMatchingSignalApprovalReactionTarget({
-        cfg: params.cfg,
-        config,
-        route: params.target.route,
-      })
-    );
-  }
-  if (!approvalModeIncludesSession(mode)) {
-    return false;
-  }
-  return matchesSignalApprovalReactionFilters({ config, route: params.target.route });
-}
 
 export function resolveSignalApprovalConversationKey(to: string): string | null {
   return normalizeSignalMessagingTarget(to) ?? null;
@@ -307,9 +166,12 @@ function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | nu
     (value.approvalKind !== "exec" && value.approvalKind !== "plugin") ||
     !value.route ||
     (value.route.deliveryMode !== "session" && value.route.deliveryMode !== "target") ||
-    !Array.isArray(value.targetAuthorKeys) ||
-    !Array.isArray(value.allowedDecisions)
+    !Array.isArray(value.targetAuthorKeys)
   ) {
+    return null;
+  }
+  const allowedDecisions = readApprovalReactionDecisionList(value.allowedDecisions);
+  if (!allowedDecisions) {
     return null;
   }
   const targetRouteTo =
@@ -342,57 +204,10 @@ function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | nu
   return {
     approvalId: value.approvalId,
     approvalKind: value.approvalKind,
-    allowedDecisions: value.allowedDecisions,
+    allowedDecisions,
     targetAuthorKeys: value.targetAuthorKeys,
     route,
   };
-}
-
-function listSignalApprovalReactionBindings(
-  allowedDecisions: readonly ExecApprovalReplyDecision[],
-): SignalApprovalReactionBinding[] {
-  return listApprovalReactionBindings({ allowedDecisions });
-}
-
-function buildTargetRoute(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  to: string;
-  approvalId: string;
-  approvalKind: ApprovalKind;
-  agentId?: string | null;
-  sessionKey?: string | null;
-}): Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }> | null {
-  const to = resolveSignalApprovalRouteTarget({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    to: params.to,
-  });
-  if (!to) {
-    return null;
-  }
-  const route: Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }> = {
-    deliveryMode: "target",
-    to,
-    ...(normalizeOptionalString(params.accountId)
-      ? { accountId: normalizeOptionalString(params.accountId) }
-      : {}),
-    ...(normalizeOptionalString(params.agentId)
-      ? { agentId: normalizeOptionalString(params.agentId) }
-      : {}),
-    ...(normalizeOptionalString(params.sessionKey)
-      ? { sessionKey: normalizeOptionalString(params.sessionKey) }
-      : {}),
-  };
-  return isSignalApprovalReactionRouteStillEnabled({
-    cfg: params.cfg,
-    target: {
-      approvalKind: params.approvalKind,
-      route,
-    },
-  })
-    ? route
-    : null;
 }
 
 export function hasSignalApprovalReactionApprovers(params: {
@@ -423,9 +238,9 @@ export function registerSignalApprovalReactionTarget(params: {
         .filter((entry): entry is string => Boolean(entry)),
     ),
   );
-  const allowedDecisions = listSignalApprovalReactionBindings(params.allowedDecisions).map(
-    (binding) => binding.decision,
-  );
+  const allowedDecisions = listApprovalReactionBindings({
+    allowedDecisions: params.allowedDecisions,
+  }).map((binding) => binding.decision);
   if (
     !params.routeAllowed ||
     (params.approvalKind !== "exec" && params.approvalKind !== "plugin") ||
@@ -500,7 +315,6 @@ export function addSignalApprovalReactionHintToStructuredPayload(params: {
     cfg: params.cfg,
     accountId: params.accountId,
     to: params.to,
-    approvalId: metadata.approvalId,
     approvalKind: metadata.approvalKind,
     agentId: metadata.agentId,
     sessionKey: metadata.sessionKey,
@@ -583,7 +397,6 @@ export function registerSignalApprovalReactionTargetForDeliveredPayload(params: 
     cfg: params.cfg,
     accountId: params.target.accountId,
     to: params.target.to,
-    approvalId: metadata.approvalId,
     approvalKind: metadata.approvalKind,
     agentId: metadata.agentId,
     sessionKey: metadata.sessionKey,
@@ -795,4 +608,3 @@ export function clearSignalApprovalReactionTargetsForTest(): void {
   signalApprovalReactionTargets.clearForTest();
   loadResolveApprovalOverGateway.clear();
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -6,6 +6,7 @@ import {
   registerWhatsAppApprovalReactionTarget,
   resolveWhatsAppApprovalReactionTargetWithPersistence,
 } from "./approval-reactions.js";
+import * as whatsappRuntime from "./runtime.js";
 import { resolveEquivalentWhatsAppDirectChatJids } from "./text-runtime.js";
 
 type LidLookup = NonNullable<
@@ -148,6 +149,39 @@ describe("WhatsApp approval reactions", () => {
       approvalKind: "exec",
       decision: "deny",
     });
+  });
+
+  it("rejects persisted targets containing an invalid approval decision", async () => {
+    const runtime = vi.spyOn(whatsappRuntime, "getOptionalWhatsAppRuntime").mockReturnValue({
+      state: {
+        openKeyedStore: () => ({
+          register: async () => {},
+          lookup: async () => ({
+            version: 1,
+            target: {
+              approvalId: "exec-corrupt",
+              approvalKind: "exec",
+              allowedDecisions: ["allow-once", "invalid"],
+            },
+          }),
+          delete: async () => false,
+        }),
+      },
+    } as never);
+    try {
+      clearWhatsAppApprovalReactionTargetsForTest();
+      await expect(
+        resolveWhatsAppApprovalReactionTargetWithPersistence({
+          accountId: "default",
+          remoteJid: "15551230000@s.whatsapp.net",
+          messageId: "corrupt-message",
+          reactionKey: "👍",
+        }),
+      ).resolves.toBeNull();
+    } finally {
+      clearWhatsAppApprovalReactionTargetsForTest();
+      runtime.mockRestore();
+    }
   });
 
   it("authorizes group reactions using the participant, not the group chat", async () => {

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -2,13 +2,13 @@
 import type { WAMessage } from "baileys";
 import {
   approvalReactionDecisionSetsMatch,
+  buildApprovalReactionDeliveredBindingMarker,
   createApprovalReactionTargetStore,
   listApprovalReactionBindings,
   readApprovalReactionDecisionList,
   readApprovalReactionDeliveredBinding,
   readApprovalReactionPresentationBinding,
   resolveTypedApprovalReactionTarget,
-  type ApprovalReactionDecisionBinding,
   type ApprovalReactionDeliveryBinding,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
@@ -32,8 +32,6 @@ const DELIVERY_BINDING_CHANNEL_DATA_KEY = "whatsappApprovalReactionBindingV1";
 type WhatsAppApprovalKind = "exec" | "plugin";
 
 type WhatsAppApprovalDeliveryBinding = ApprovalReactionDeliveryBinding;
-
-type WhatsAppApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type WhatsAppApprovalReactionResolution = {
   approvalId: string;
@@ -122,22 +120,19 @@ function readPersistedTarget(target: unknown): WhatsAppApprovalReactionTarget | 
   if (
     !value ||
     typeof value.approvalId !== "string" ||
-    !Array.isArray(value.allowedDecisions) ||
     (value.approvalKind !== "exec" && value.approvalKind !== "plugin")
   ) {
+    return null;
+  }
+  const allowedDecisions = readApprovalReactionDecisionList(value.allowedDecisions);
+  if (!allowedDecisions) {
     return null;
   }
   return {
     approvalId: value.approvalId,
     approvalKind: value.approvalKind,
-    allowedDecisions: value.allowedDecisions,
+    allowedDecisions,
   };
-}
-
-function listWhatsAppApprovalReactionBindings(
-  allowedDecisions: readonly ExecApprovalReplyDecision[],
-): WhatsAppApprovalReactionBinding[] {
-  return listApprovalReactionBindings({ allowedDecisions });
 }
 
 const APPROVAL_ID_LINE_RE = /^\s*ID:\s*(\S(?:.*\S)?)\s*$/i;
@@ -191,11 +186,9 @@ function visibleApprovalBindingMatches(
     decisionLines.push(decisionLine);
     cursor += 1;
   }
-  const knownBindings = listWhatsAppApprovalReactionBindings([
-    "allow-once",
-    "allow-always",
-    "deny",
-  ]);
+  const knownBindings = listApprovalReactionBindings({
+    allowedDecisions: ["allow-once", "allow-always", "deny"],
+  });
   const visibleDecisions = decisionLines.map(
     (line) => knownBindings.find((entry) => `${entry.emoji} ${entry.label}` === line)?.decision,
   );
@@ -223,7 +216,7 @@ export function prepareWhatsAppApprovalPayloadForDelivery(params: {
     ...params.payload,
     channelData: {
       ...params.payload.channelData,
-      [DELIVERY_BINDING_CHANNEL_DATA_KEY]: { version: 1, ...binding },
+      [DELIVERY_BINDING_CHANNEL_DATA_KEY]: buildApprovalReactionDeliveredBindingMarker(binding),
     },
   };
 }
@@ -239,9 +232,9 @@ export function registerWhatsAppApprovalReactionTarget(params: {
 }): WhatsAppApprovalReactionTarget | null {
   const key = buildReactionTargetKey(params);
   const approvalId = params.approvalId.trim();
-  const allowedDecisions = listWhatsAppApprovalReactionBindings(params.allowedDecisions).map(
-    (binding) => binding.decision,
-  );
+  const allowedDecisions = listApprovalReactionBindings({
+    allowedDecisions: params.allowedDecisions,
+  }).map((binding) => binding.decision);
   if (
     !key ||
     !approvalId ||

--- a/src/plugin-sdk/approval-reaction-binding.ts
+++ b/src/plugin-sdk/approval-reaction-binding.ts
@@ -12,6 +12,13 @@ export type ApprovalReactionDeliveryBinding = {
   approvalSlug?: string;
 };
 
+/** Build the private marker revalidated after channel delivery. */
+export function buildApprovalReactionDeliveredBindingMarker(
+  binding: ApprovalReactionDeliveryBinding,
+): { version: 1 } & ApprovalReactionDeliveryBinding {
+  return { version: 1, ...binding };
+}
+
 /** Read a nonempty, duplicate-free list without accepting unrecognized decisions. */
 export function readApprovalReactionDecisionList(
   value: unknown,

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -7,6 +7,7 @@ import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
   APPROVAL_REACTION_BINDINGS,
   buildApprovalPendingPromptPayload,
+  buildApprovalReactionDeliveredBindingMarker,
   buildApprovalReactionPendingContentForRequest,
   buildApprovalReactionPromptPayloadForRequest,
   buildApprovalReactionHint,
@@ -117,9 +118,13 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       presentation,
       channelData: {
         execApproval: metadata,
-        privateBinding: { version: 1, ...metadata },
+        privateBinding: buildApprovalReactionDeliveredBindingMarker({
+          ...metadata,
+          allowedDecisions: [...metadata.allowedDecisions],
+        }),
       },
     };
+    expect(payload.channelData.privateBinding).toEqual({ version: 1, ...metadata });
     expect(readApprovalReactionPresentationBinding({ payload })).toMatchObject(metadata);
     expect(
       readApprovalReactionDeliveredBinding({

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -23,6 +23,7 @@ import type { ReplyPayload } from "./reply-payload.js";
 export { shouldSuppressLocalNativeExecApprovalPrompt } from "./approval-native-helpers.js";
 export {
   approvalReactionDecisionSetsMatch,
+  buildApprovalReactionDeliveredBindingMarker,
   normalizeApprovalReactionDecision,
   readApprovalReactionDecisionList,
   readApprovalReactionDeliveredBinding,


### PR DESCRIPTION
## What Problem This Solves

Third and final follow-up in the approval-typed-bindings series (#124742, #124841). Three pieces of debt remained on the approval-reaction surface:

- `extensions/signal/src/approval-reactions.ts` was 798 lines with a grandfathered `oxlint-disable max-lines` suppression and a `config/max-lines-baseline.txt` entry.
- Persisted approval-target validation was inconsistent across siblings: iMessage normalized each stored decision, while Signal and WhatsApp accepted any array contents (`Array.isArray` only), so a corrupt persisted record could round-trip unvalidated entries.
- Three identical one-line `list<Channel>ApprovalReactionBindings` wrappers survived, and iMessage/WhatsApp both hand-wrote the `{version: 1, ...}` delivered-binding channelData marker that the SDK's `readApprovalReactionDeliveredBinding` later validates — a two-sided contract with only one owned side.

## Why This Change Was Made

- **Signal split**: the route concept (`SignalApprovalReactionRoute`, forwarding-config resolution, mode checks, filter matching, target matching, `buildTargetRoute`, `isSignalApprovalReactionRouteStillEnabled`) moved to concept-named `approval-reaction-routes.ts` (195 lines); `approval-reactions.ts` is now 610 lines. The suppression comment and the max-lines baseline entry are removed — same shape as the iMessage poll-targets split in #124742. Dependency direction is one-way (reactions imports routes).
- **Validation alignment**: all three plugins' `readPersistedTarget` now run stored decisions through the SDK's `readApprovalReactionDecisionList` (nonempty, unique, canonical — else null). Intentional tightening: iMessage previously dropped invalid entries and kept the rest; now a partially-invalid persisted record is rejected whole. Persisted targets are ≤24h transient cache, so rejecting a corrupt record entirely is the correct fail-closed behavior — the user re-approves via the manual `/approve` path that remains in the prompt.
- **Wrapper deletion + marker writer**: the three pass-through binding wrappers are gone (call sites use SDK `listApprovalReactionBindings` directly; repo-wide grep proves zero references). The delivered-binding marker now has one owner: `buildApprovalReactionDeliveredBindingMarker` added to `src/plugin-sdk/approval-reaction-binding.ts` next to its reader and re-exported through the existing `approval-reaction-runtime` block (no new subpath; two real consumers — iMessage preserves `approvalSlug` in the marker exactly as before, WhatsApp preserves its spread bytes).

## User Impact

No behavior change on valid state. Corrupt persisted reaction targets (invalid/duplicate decision entries) now fail closed on lookup in Signal and WhatsApp instead of flowing downstream, matching iMessage.

## Evidence

- Regression tests fail pre-change for the intended reason: Signal/WhatsApp persisted records with an invalid decision entry previously resolved `allow-once`; now rejected on lookup (one focused test per plugin, plus an SDK marker round-trip assertion).
- Focused suites: 84 tests green; broad Testbox matrix all 7 shards green — https://github.com/openclaw/openclaw/actions/runs/31980951488
- oxlint clean (no suppression), SDK surface check clean, routed `check-changed` green, `pnpm build` clean (no `INEFFECTIVE_DYNAMIC_IMPORT`).
- Independent Codex autoreview clean (0.98, no findings).
- Production LOC net −6 (split is move-only; SDK writer +5 justified by single-owner marker contract with two consumers); tests +111.
- Split file line counts: 610 + 195, both under the 700 limit with no suppression; exactly one `max-lines-baseline.txt` entry removed.
