### PR TITLE
fix: plugin tools disappear from Codex and restricted profiles

### DIFF
--- a/docs/concepts/standing-intents.md
+++ b/docs/concepts/standing-intents.md
@@ -24,9 +24,12 @@ Put aspirations in `MEMORY.md`, a project note, or another maintained Markdown f
 ## Create an event-based intent
 
 Standing intents are owner-directed memory. Channel owners recognized by
-`commands.ownerAllowFrom`, authenticated Gateway/Control UI administrators,
-and the local CLI can use the `intent` tool to create, list, or cancel them;
-other senders do not receive that tool.
+`commands.ownerAllowFrom` can use the `intent` tool to create, list, or cancel
+them; other senders do not receive that tool. Authenticated Gateway/Control UI
+administrators and the local CLI can inspect and cancel existing intents, but
+creation requires an authenticated channel and sender identity. If either is
+missing, OpenClaw refuses creation and asks the operator to retry from an
+authenticated channel conversation.
 
 Ask the agent to create the intent and name the event clearly:
 
@@ -36,7 +39,9 @@ When someone mentions the launch checklist, remind me to confirm the rollback ow
 
 The agent uses the `intent` tool with a description and trigger keywords. It can also narrow the intent to one conversation channel identifier or sender identifier, set an expiry, reduce or increase the fire budget, or change the cooldown.
 
-The default scope is the current channel and sender when those identities are available. On a local CLI turn without channel identities, the default is `anywhere` and `anyone`, so the owner can arm an intent that will fire on a later eligible interactive turn.
+The default scope is the current channel and sender. An explicit `anywhere` or
+`anyone` scope still requires the creating sender identity: the matching hook
+cannot safely enforce a senderless owner principal on later channel turns.
 
 Defaults are intentionally conservative:
 

--- a/docs/concepts/standing-intents.md
+++ b/docs/concepts/standing-intents.md
@@ -23,9 +23,10 @@ Put aspirations in `MEMORY.md`, a project note, or another maintained Markdown f
 
 ## Create an event-based intent
 
-Standing intents are owner-directed memory. Only command owners recognized by
-`commands.ownerAllowFrom` can see or use the `intent` tool to create, list, or
-cancel them; other senders do not receive that tool.
+Standing intents are owner-directed memory. Channel owners recognized by
+`commands.ownerAllowFrom`, authenticated Gateway/Control UI administrators,
+and the local CLI can use the `intent` tool to create, list, or cancel them;
+other senders do not receive that tool.
 
 Ask the agent to create the intent and name the event clearly:
 
@@ -34,6 +35,8 @@ When someone mentions the launch checklist, remind me to confirm the rollback ow
 ```
 
 The agent uses the `intent` tool with a description and trigger keywords. It can also narrow the intent to one conversation channel identifier or sender identifier, set an expiry, reduce or increase the fire budget, or change the cooldown.
+
+The default scope is the current channel and sender when those identities are available. On a local CLI turn without channel identities, the default is `anywhere` and `anyone`, so the owner can arm an intent that will fire on a later eligible interactive turn.
 
 Defaults are intentionally conservative:
 

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -304,6 +304,11 @@ Optional tools control whether a tool is exposed to the model. Use
 or hook should ask for approval after the model selects it and before the
 action runs.
 
+`toolMetadata.<tool>.profiles` adds a plugin tool to named built-in profile
+allowlists. For example, `"profiles": ["coding", "messaging"]` exposes it in
+those profiles without adding a core catalog entry. Explicit operator
+allowlists and deny rules remain authoritative.
+
 Use optional tools for side effects, unusual binaries, or capabilities that
 should not be exposed by default. Tool names must not conflict with core tool
 names; conflicts are skipped and reported in plugin diagnostics. Malformed

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -377,6 +377,7 @@ Each `providerBaseUrl` guard supports:
   },
   "toolMetadata": {
     "example_search": {
+      "profiles": ["coding", "full"],
       "authSignals": [
         {
           "provider": "example"
@@ -394,7 +395,14 @@ Each `providerBaseUrl` guard supports:
 }
 ```
 
-`toolMetadata` entries also accept `optional` (marks the tool as non-required for plugin activation), `replaySafe` (marks tool execution as safe to repeat after an incomplete model turn), and `sideEffecting` (marks execution as potentially changing durable or external state), on top of the shared `configSignals`/`authSignals` fields above.
+`toolMetadata` entries also accept:
+
+- `profiles`: built-in tool profiles that expose the plugin tool by default. Valid values are `minimal`, `coding`, `messaging`, and `full`. These contributions merge into the corresponding profile allowlist; explicit operator allowlists and deny rules remain authoritative.
+- `optional`: marks the tool as non-required for plugin activation.
+- `replaySafe`: marks tool execution as safe to repeat after an incomplete model turn.
+- `sideEffecting`: marks execution as potentially changing durable or external state.
+
+These fields supplement the shared `configSignals` and `authSignals` fields above.
 
 If a tool has no `toolMetadata`, OpenClaw preserves the existing behavior and loads the owning plugin when the tool contract matches policy. For hot-path tools whose factory depends on auth/config, plugin authors should declare `toolMetadata` instead of making core import runtime to ask.
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1500,22 +1500,29 @@ describe("Codex app-server dynamic tool build", () => {
     ).toBe("turn-capability-1");
   });
 
-  it("passes owner identity into Codex dynamic tool construction", async () => {
+  it("materializes an owner-gated prepared plugin tool for Codex", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
     params.senderIsOwner = true;
+    params.preparedModelRuntime = { metadataSnapshot: { plugins: [] } } as never;
     params.runtimePlan = createCodexRuntimePlanFixture();
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {
       factoryOptions.push(options);
-      return [];
+      return options?.senderIsOwner && options.preparedModelRuntime
+        ? [createRuntimeDynamicTool("intent")]
+        : [];
     });
 
-    await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
 
-    expect(factoryOptions[0]).toMatchObject({ senderIsOwner: true });
+    expect(tools.map((tool) => tool.name)).toContain("intent");
+    expect(factoryOptions[0]).toMatchObject({
+      senderIsOwner: true,
+      preparedModelRuntime: params.preparedModelRuntime,
+    });
   });
 
   it("passes native and routable channel targets into Codex dynamic tools", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -289,6 +289,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         runId: params.runId,
         approvalReviewerDeviceId: params.approvalReviewerDeviceId,
         agentDir,
+        preparedModelRuntime: params.preparedModelRuntime,
         cwd: input.effectiveCwd ?? input.effectiveWorkspace,
         workspaceDir: input.effectiveWorkspace,
         spawnWorkspaceDir:

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -189,7 +189,7 @@ function configureFakeMcp(params: ReturnType<typeof createParams>): void {
   params.cleanupBundleMcpOnRunEnd = true;
   params.runtimePlan = createCodexRuntimePlanFixture();
   params.preparedModelRuntime = {
-    metadataSnapshot: { manifestRegistry: { plugins: [] } },
+    metadataSnapshot: { manifestRegistry: { plugins: [] }, plugins: [] },
   } as never;
   params.config = {
     ...params.config,
@@ -232,7 +232,7 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     configureFakeMcp(params);
     const manifestRegistry = { plugins: [] };
     params.preparedModelRuntime = {
-      metadataSnapshot: { manifestRegistry, pluginIds: ["codex"] },
+      metadataSnapshot: { manifestRegistry, pluginIds: ["codex"], plugins: [] },
     } as never;
 
     const harness = createStartedThreadHarness();

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -2261,7 +2261,30 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(activeDiagnosticToolKeys(diagnosticEvents)).toEqual(new Set());
   });
 
-  it("bridges side-thread dynamic tool requests to OpenClaw tools", async () => {
+  it("bridges prepared restricted-profile tools into side threads", async () => {
+    const preparedModelRuntime = {
+      metadataSnapshot: {
+        plugins: [
+          {
+            id: "profiled-plugin",
+            contracts: { tools: ["wiki_status"] },
+            toolMetadata: { wiki_status: { profiles: ["coding"] } },
+          },
+        ],
+      },
+    };
+    createOpenClawCodingToolsMock.mockImplementation((options) =>
+      (options as { preparedModelRuntime?: unknown }).preparedModelRuntime === preparedModelRuntime
+        ? [
+            {
+              name: "wiki_status",
+              description: "Check wiki status",
+              parameters: { type: "object", properties: {} },
+              execute: toolExecuteMock,
+            },
+          ]
+        : [],
+    );
     const client = createFakeClient();
     let toolResponse: unknown;
     client.request.mockImplementation(async (method: string) => {
@@ -2297,7 +2320,12 @@ describe("runCodexAppServerSideQuestion", () => {
     });
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
 
-    const result = await runCodexAppServerSideQuestion(sideParams());
+    const result = await runCodexAppServerSideQuestion(
+      sideParams({
+        cfg: { tools: { profile: "coding" } } as never,
+        preparedModelRuntime,
+      } as never),
+    );
 
     expect(result).toEqual({ text: "Tool answer." });
     const [toolCallId, toolArguments, toolSignal, toolOptions] = mockCall(toolExecuteMock);

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -982,6 +982,7 @@ function buildSideRunAttemptParams(
     authStorage: params.preparedRuntimeAuth.authStorage,
     authProfileStore: params.preparedRuntimeAuth.authProfileStore,
     modelRegistry: params.preparedRuntimeAuth.modelRegistry,
+    preparedModelRuntime: params.preparedModelRuntime,
     ...(params.preparedRuntimeAuth.resolvedApiKey
       ? { resolvedApiKey: params.preparedRuntimeAuth.resolvedApiKey }
       : {}),
@@ -1048,6 +1049,7 @@ async function createCodexSideToolBridge(input: {
         resolvedWorkspace: input.params.workspaceDir ?? input.cwd,
       }),
       config: input.params.cfg,
+      preparedModelRuntime: input.params.preparedModelRuntime,
       abortSignal: input.signal,
       modelProvider: runtimeModel.provider,
       modelId: input.params.model,

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -171,6 +171,7 @@ describe("memory-core plugin runtime registration", () => {
   });
 
   it("hides intent create, list, and cancel from non-owner turns", () => {
+    const warn = vi.fn();
     let intentFactory:
       | ((ctx: { config?: OpenClawConfig; senderIsOwner?: boolean }) => unknown)
       | undefined;
@@ -178,6 +179,7 @@ describe("memory-core plugin runtime registration", () => {
       createTestPluginApi({
         config: {},
         runtime: hostRuntime,
+        logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn },
         registerTool(factory, options) {
           if (options?.names?.includes("intent") && typeof factory === "function") {
             intentFactory = factory as typeof intentFactory;
@@ -191,7 +193,17 @@ describe("memory-core plugin runtime registration", () => {
 
     expect(intentFactory({ config: {}, senderIsOwner: false })).toBeNull();
     expect(intentFactory({ config: {} })).toBeNull();
-    expect(intentFactory({ config: {}, senderIsOwner: true })).toMatchObject({ name: "intent" });
+    const ownerTool = intentFactory({ config: {}, senderIsOwner: true }) as {
+      name?: string;
+      parameters?: {
+        properties?: Record<string, { default?: string }>;
+      };
+    };
+    expect(ownerTool).toMatchObject({ name: "intent" });
+    expect(ownerTool.parameters?.properties?.scope?.default).toBe("anywhere");
+    expect(ownerTool.parameters?.properties?.senderScope?.default).toBe("anyone");
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("owner authorization"));
   });
 
   it("keeps memory manager initialization demand-driven", () => {

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -200,8 +200,8 @@ describe("memory-core plugin runtime registration", () => {
       };
     };
     expect(ownerTool).toMatchObject({ name: "intent" });
-    expect(ownerTool.parameters?.properties?.scope?.default).toBe("anywhere");
-    expect(ownerTool.parameters?.properties?.senderScope?.default).toBe("anyone");
+    expect(ownerTool.parameters?.properties?.scope?.default).toBe("channel");
+    expect(ownerTool.parameters?.properties?.senderScope?.default).toBe("sender");
     expect(warn).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("owner authorization"));
   });

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -152,14 +152,21 @@ function createLazyMemoryGetTool(options: MemoryToolOptions): AnyAgentTool | nul
   });
 }
 
-function createLazyStandingIntentTool(ctx: OpenClawPluginToolContext): AnyAgentTool | null {
+function createLazyStandingIntentTool(
+  ctx: OpenClawPluginToolContext,
+  reportUnavailable: (reason: string) => void,
+): AnyAgentTool | null {
   if (ctx.senderIsOwner !== true) {
+    reportUnavailable("owner authorization is unavailable for this turn");
     return null;
   }
   const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
   const provider = ctx.messageChannel?.trim();
   const senderId = ctx.requesterSenderId?.trim();
+  const defaultScope = provider ? "channel" : "anywhere";
+  const defaultSenderScope = provider && senderId ? "sender" : "anyone";
   if (!cfg) {
+    reportUnavailable("runtime config is unavailable for this turn");
     return null;
   }
   const { sessionAgentId: agentId } = resolveSessionAgentIds({
@@ -172,6 +179,7 @@ function createLazyStandingIntentTool(ctx: OpenClawPluginToolContext): AnyAgentT
     toolPromise ??= loadStandingIntentToolModule().then((module: StandingIntentToolModule) =>
       module.createStandingIntentTool({
         agentId,
+        creatorPrincipal: senderId || "owner",
         ...(ctx.sessionId ? { sourceSessionId: ctx.sessionId } : {}),
         ...(ctx.nativeChannelId ? { conversationId: ctx.nativeChannelId } : {}),
         ...(provider ? { provider } : {}),
@@ -196,12 +204,12 @@ function createLazyStandingIntentTool(ctx: OpenClawPluginToolContext): AnyAgentT
         scope: {
           type: "string",
           enum: ["conversation", "channel", "anywhere"],
-          default: "channel",
+          default: defaultScope,
         },
         senderScope: {
           type: "string",
           enum: ["sender", "anyone"],
-          default: "sender",
+          default: defaultSenderScope,
         },
         expiresAt: { type: "string" },
         maxFires: { type: "integer", minimum: 1 },
@@ -302,9 +310,13 @@ export default definePluginEntry({
       names: ["memory_get"],
     });
 
-    api.registerTool((ctx) => createLazyStandingIntentTool(ctx), {
-      names: ["intent"],
-    });
+    api.registerTool(
+      (ctx) =>
+        createLazyStandingIntentTool(ctx, (reason) => {
+          api.logger.warn(`memory-core: intent tool unavailable: ${reason}`);
+        }),
+      { names: ["intent"] },
+    );
 
     api.on("before_prompt_build", async (event, ctx) => {
       if (ctx.trigger !== "user") {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -163,8 +163,6 @@ function createLazyStandingIntentTool(
   const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
   const provider = ctx.messageChannel?.trim();
   const senderId = ctx.requesterSenderId?.trim();
-  const defaultScope = provider ? "channel" : "anywhere";
-  const defaultSenderScope = provider && senderId ? "sender" : "anyone";
   if (!cfg) {
     reportUnavailable("runtime config is unavailable for this turn");
     return null;
@@ -179,7 +177,6 @@ function createLazyStandingIntentTool(
     toolPromise ??= loadStandingIntentToolModule().then((module: StandingIntentToolModule) =>
       module.createStandingIntentTool({
         agentId,
-        creatorPrincipal: senderId || "owner",
         ...(ctx.sessionId ? { sourceSessionId: ctx.sessionId } : {}),
         ...(ctx.nativeChannelId ? { conversationId: ctx.nativeChannelId } : {}),
         ...(provider ? { provider } : {}),
@@ -204,12 +201,12 @@ function createLazyStandingIntentTool(
         scope: {
           type: "string",
           enum: ["conversation", "channel", "anywhere"],
-          default: defaultScope,
+          default: "channel",
         },
         senderScope: {
           type: "string",
           enum: ["sender", "anyone"],
-          default: defaultSenderScope,
+          default: "sender",
         },
         expiresAt: { type: "string" },
         maxFires: { type: "integer", minimum: 1 },

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -19,6 +19,9 @@
     "tools": ["intent", "memory_get", "memory_search"]
   },
   "toolMetadata": {
+    "intent": {
+      "profiles": ["coding", "messaging"]
+    },
     "memory_get": {
       "replaySafe": true
     }

--- a/extensions/memory-core/src/standing-intents-tool.ts
+++ b/extensions/memory-core/src/standing-intents-tool.ts
@@ -19,7 +19,7 @@ const INTENT_KEYWORD_MAX_CHARS = 120;
 const STANDING_INTENT_AUTOMATION_GUIDANCE =
   "The system injects the reminder automatically when it triggers. Do not deliver it early or cancel it unless the user asks.";
 const STANDING_INTENT_SCOPE_GUIDANCE =
-  'Use "channel" for any "whenever I mention X" request when channel identity is available. Use "conversation" only when the user explicitly limits the reminder to the current thread. Use "anywhere" when the user asks for it everywhere or the turn has no channel identity.';
+  'Use "channel" (the default) for any "whenever I mention X" request. Use "conversation" only when the user explicitly limits the reminder to the current thread. Use "anywhere" when the user asks for it everywhere.';
 
 type IntentSenderScope = "sender" | "anyone";
 type IntentToolParams = {
@@ -139,16 +139,12 @@ function parseScope<T extends string>(
 
 export function createStandingIntentTool(options: {
   agentId: string;
-  creatorPrincipal: string;
   sourceSessionId?: string;
   conversationId?: string;
   provider?: string;
   accountId?: string;
   senderId?: string;
 }): AnyAgentTool {
-  const defaultScope: IntentScope = options.provider?.trim() ? "channel" : "anywhere";
-  const defaultSenderScope: IntentSenderScope =
-    options.provider?.trim() && options.senderId?.trim() ? "sender" : "anyone";
   return {
     label: "Standing Intent",
     name: "intent",
@@ -167,13 +163,13 @@ export function createStandingIntentTool(options: {
         scope: {
           type: "string",
           enum: ["conversation", "channel", "anywhere"],
-          default: defaultScope,
+          default: "channel",
           description: STANDING_INTENT_SCOPE_GUIDANCE,
         },
         senderScope: {
           type: "string",
           enum: ["sender", "anyone"],
-          default: defaultSenderScope,
+          default: "sender",
         },
         expiresAt: { type: "string" },
         maxFires: { type: "integer", minimum: 1 },
@@ -189,18 +185,30 @@ export function createStandingIntentTool(options: {
     execute: async (_toolCallId, rawParams) => {
       const params = (rawParams ?? {}) as IntentToolParams;
       if (params.action === "create") {
+        const provider = options.provider?.trim();
+        const senderId = options.senderId?.trim();
+        if (!provider || !senderId) {
+          const missingIdentity = !provider
+            ? senderId
+              ? "channel"
+              : "channel and sender"
+            : "sender";
+          throw new Error(
+            `authenticated ${missingIdentity} identity is unavailable for this turn; retry from an authenticated channel conversation`,
+          );
+        }
         const nowMs = Date.now();
         const scope = parseScope<IntentScope>(
           params.scope,
           "scope",
           ["conversation", "channel", "anywhere"],
-          defaultScope,
+          "channel",
         );
         const senderScope = parseScope<IntentSenderScope>(
           params.senderScope,
           "senderScope",
           ["sender", "anyone"],
-          defaultSenderScope,
+          "sender",
         );
         const intent = createStandingIntent({
           agentId: options.agentId,
@@ -227,7 +235,7 @@ export function createStandingIntentTool(options: {
                   accountId: options.accountId,
                   senderId: options.senderId ?? "",
                 }),
-          creatorSender: options.creatorPrincipal,
+          creatorSender: senderId,
           expiresAt: parseExpiry(params.expiresAt, nowMs),
           maxFires: positiveInteger(params.maxFires, "maxFires", DEFAULT_INTENT_MAX_FIRES),
           cooldownSeconds: nonNegativeInteger(

--- a/extensions/memory-core/src/standing-intents-tool.ts
+++ b/extensions/memory-core/src/standing-intents-tool.ts
@@ -19,7 +19,7 @@ const INTENT_KEYWORD_MAX_CHARS = 120;
 const STANDING_INTENT_AUTOMATION_GUIDANCE =
   "The system injects the reminder automatically when it triggers. Do not deliver it early or cancel it unless the user asks.";
 const STANDING_INTENT_SCOPE_GUIDANCE =
-  'Use "channel" (the default) for any "whenever I mention X" request. Use "conversation" only when the user explicitly limits the reminder to the current thread. Use "anywhere" when the user asks for it everywhere.';
+  'Use "channel" for any "whenever I mention X" request when channel identity is available. Use "conversation" only when the user explicitly limits the reminder to the current thread. Use "anywhere" when the user asks for it everywhere or the turn has no channel identity.';
 
 type IntentSenderScope = "sender" | "anyone";
 type IntentToolParams = {
@@ -139,12 +139,16 @@ function parseScope<T extends string>(
 
 export function createStandingIntentTool(options: {
   agentId: string;
+  creatorPrincipal: string;
   sourceSessionId?: string;
   conversationId?: string;
   provider?: string;
   accountId?: string;
   senderId?: string;
 }): AnyAgentTool {
+  const defaultScope: IntentScope = options.provider?.trim() ? "channel" : "anywhere";
+  const defaultSenderScope: IntentSenderScope =
+    options.provider?.trim() && options.senderId?.trim() ? "sender" : "anyone";
   return {
     label: "Standing Intent",
     name: "intent",
@@ -163,13 +167,13 @@ export function createStandingIntentTool(options: {
         scope: {
           type: "string",
           enum: ["conversation", "channel", "anywhere"],
-          default: "channel",
+          default: defaultScope,
           description: STANDING_INTENT_SCOPE_GUIDANCE,
         },
         senderScope: {
           type: "string",
           enum: ["sender", "anyone"],
-          default: "sender",
+          default: defaultSenderScope,
         },
         expiresAt: { type: "string" },
         maxFires: { type: "integer", minimum: 1 },
@@ -190,13 +194,13 @@ export function createStandingIntentTool(options: {
           params.scope,
           "scope",
           ["conversation", "channel", "anywhere"],
-          "channel",
+          defaultScope,
         );
         const senderScope = parseScope<IntentSenderScope>(
           params.senderScope,
           "senderScope",
           ["sender", "anyone"],
-          "sender",
+          defaultSenderScope,
         );
         const intent = createStandingIntent({
           agentId: options.agentId,
@@ -223,7 +227,7 @@ export function createStandingIntentTool(options: {
                   accountId: options.accountId,
                   senderId: options.senderId ?? "",
                 }),
-          creatorSender: options.senderId ?? "",
+          creatorSender: options.creatorPrincipal,
           expiresAt: parseExpiry(params.expiresAt, nowMs),
           maxFires: positiveInteger(params.maxFires, "maxFires", DEFAULT_INTENT_MAX_FIRES),
           cooldownSeconds: nonNegativeInteger(

--- a/extensions/memory-core/src/standing-intents.test.ts
+++ b/extensions/memory-core/src/standing-intents.test.ts
@@ -81,6 +81,7 @@ describe("standing intents", () => {
   it("creates, lists, and explicitly cancels through the agent tool", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
+      creatorPrincipal: "alice",
       sourceSessionId: "session-1",
       conversationId: "qa-dm-5",
       provider: "qa-channel",
@@ -110,7 +111,7 @@ describe("standing intents", () => {
     );
     expect(tool.description).toContain("system injects the reminder automatically");
     expect(tool.description).toContain(
-      'Use "channel" (the default) for any "whenever I mention X" request.',
+      'Use "channel" for any "whenever I mention X" request when channel identity is available.',
     );
     expect(tool.description).toContain(
       'Use "conversation" only when the user explicitly limits the reminder to the current thread.',
@@ -131,6 +132,7 @@ describe("standing intents", () => {
   it("injects owner-created intents and skips rows without a known creator", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
+      creatorPrincipal: "owner-1",
       conversationId: "qa-dm-5",
       provider: "qa-channel",
       senderId: "owner-1",
@@ -191,6 +193,7 @@ describe("standing intents", () => {
   it("derives typed conversation, channel, anywhere, sender, and anyone scopes", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
+      creatorPrincipal: "alice",
       conversationId: "QA-DM-5",
       provider: "QA-CHANNEL",
       senderId: "alice",
@@ -245,28 +248,27 @@ describe("standing intents", () => {
     expect(anywhereResult.message).toContain("Intent is armed everywhere.");
   });
 
-  it("keeps identity-free operations available while enforcing selected create scopes", async () => {
-    const tool = createStandingIntentTool({ agentId: "main" });
+  it("creates a durable owner intent without channel or sender identity", async () => {
+    const tool = createStandingIntentTool({ agentId: "main", creatorPrincipal: "owner" });
 
     expect(parseToolJson(await tool.execute("list-empty", { action: "list" }))).toEqual({
       intents: [],
     });
-    await expect(
-      tool.execute("create-default", {
-        action: "create",
-        description: "Missing identity reminder.",
-        triggerKeywords: ["missing identity"],
-      }),
-    ).rejects.toThrow("channel identity is unavailable for this creating turn");
-    await expect(
-      tool.execute("create-anywhere", {
+    const created = parseToolJson(
+      await tool.execute("create-default", {
         action: "create",
         description: "Identity-free reminder.",
         triggerKeywords: ["identity free"],
-        scope: "anywhere",
-        senderScope: "anyone",
       }),
-    ).rejects.toThrow("creating sender is unavailable for this turn");
+    ).intent;
+
+    expect(created).toMatchObject({
+      channelScope: null,
+      senderScope: null,
+      creatorSender: "owner",
+      status: "armed",
+    });
+    expect(listStandingIntents({ agentId: "main" })).toHaveLength(1);
   });
 
   it("applies scope, cooldown, fire-budget, and expiry transitions", () => {

--- a/extensions/memory-core/src/standing-intents.test.ts
+++ b/extensions/memory-core/src/standing-intents.test.ts
@@ -81,7 +81,6 @@ describe("standing intents", () => {
   it("creates, lists, and explicitly cancels through the agent tool", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
-      creatorPrincipal: "alice",
       sourceSessionId: "session-1",
       conversationId: "qa-dm-5",
       provider: "qa-channel",
@@ -111,7 +110,7 @@ describe("standing intents", () => {
     );
     expect(tool.description).toContain("system injects the reminder automatically");
     expect(tool.description).toContain(
-      'Use "channel" for any "whenever I mention X" request when channel identity is available.',
+      'Use "channel" (the default) for any "whenever I mention X" request.',
     );
     expect(tool.description).toContain(
       'Use "conversation" only when the user explicitly limits the reminder to the current thread.',
@@ -132,7 +131,6 @@ describe("standing intents", () => {
   it("injects owner-created intents and skips rows without a known creator", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
-      creatorPrincipal: "owner-1",
       conversationId: "qa-dm-5",
       provider: "qa-channel",
       senderId: "owner-1",
@@ -193,7 +191,6 @@ describe("standing intents", () => {
   it("derives typed conversation, channel, anywhere, sender, and anyone scopes", async () => {
     const tool = createStandingIntentTool({
       agentId: "main",
-      creatorPrincipal: "alice",
       conversationId: "QA-DM-5",
       provider: "QA-CHANNEL",
       senderId: "alice",
@@ -248,27 +245,30 @@ describe("standing intents", () => {
     expect(anywhereResult.message).toContain("Intent is armed everywhere.");
   });
 
-  it("creates a durable owner intent without channel or sender identity", async () => {
-    const tool = createStandingIntentTool({ agentId: "main", creatorPrincipal: "owner" });
+  it("refuses senderless creation instead of exposing it to unrelated channel users", async () => {
+    const tool = createStandingIntentTool({ agentId: "main" });
 
     expect(parseToolJson(await tool.execute("list-empty", { action: "list" }))).toEqual({
       intents: [],
     });
-    const created = parseToolJson(
-      await tool.execute("create-default", {
+    await expect(
+      tool.execute("create-default", {
         action: "create",
         description: "Identity-free reminder.",
         triggerKeywords: ["identity free"],
       }),
-    ).intent;
+    ).rejects.toThrow("authenticated channel and sender identity is unavailable");
 
-    expect(created).toMatchObject({
-      channelScope: null,
-      senderScope: null,
-      creatorSender: "owner",
-      status: "armed",
-    });
-    expect(listStandingIntents({ agentId: "main" })).toHaveLength(1);
+    expect(listStandingIntents({ agentId: "main" })).toEqual([]);
+    expect(
+      matchStandingIntents({
+        agentId: "main",
+        prompt: "identity free",
+        provider: "qa-channel",
+        channel: "unrelated-room",
+        senderId: "unrelated-user",
+      }),
+    ).toEqual([]);
   });
 
   it("applies scope, cooldown, fire-budget, and expiry transitions", () => {

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -1207,6 +1207,56 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("includes plugin tools declared for the active built-in profile", () => {
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([
+        {
+          name: "profiled_plugin_tool",
+          label: "Profiled plugin tool",
+          description: "Profiled plugin tool test fixture",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          execute: async () => ({
+            content: [{ type: "text" as const, text: "ok" }],
+            details: {},
+          }),
+        },
+      ]);
+    const preparedModelRuntime = {
+      metadataSnapshot: {
+        plugins: [
+          {
+            id: "profiled-plugin",
+            contracts: { tools: ["profiled_plugin_tool"] },
+            toolMetadata: { profiled_plugin_tool: { profiles: ["coding"] } },
+          },
+        ],
+      },
+    } as never;
+
+    try {
+      const tools = createOpenClawCodingTools({
+        config: { tools: { profile: "coding" } },
+        includeCoreTools: false,
+        preparedModelRuntime,
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(["profiled_plugin_tool"]);
+      expect(resolvePluginToolsSpy.mock.calls[0]?.[0].options?.pluginToolAllowlist).toContain(
+        "profiled_plugin_tool",
+      );
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
   it("wraps plugin-only tools with scheduled creator authority and live routing context", async () => {
     let observedIdentity: unknown;
     const resolvePluginToolsSpy = vi

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -429,6 +429,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       inputProvenance: options?.inputProvenance,
       trustedInternalHandoff: options?.trustedInternalHandoff,
       scheduledToolPolicy: options?.scheduledToolPolicy,
+      pluginMetadataSnapshot: options?.preparedModelRuntime?.metadataSnapshot,
     });
   const { agentId, runtimePluginToolGrant } = capabilityProfile.policy;
 

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -994,6 +994,13 @@ describe("runBtwSideQuestion", () => {
         }),
       }),
     );
+    const preparedModelRuntime = (
+      mockArg(resolveModelAsyncMock, 0, 4) as { preparedModelRuntime?: unknown }
+    ).preparedModelRuntime;
+    expect(mockArg(codexSideQuestionMock, 0, 0)).toHaveProperty(
+      "preparedModelRuntime",
+      preparedModelRuntime,
+    );
     expect(
       (mockArg(codexSideQuestionMock, 0, 0) as { sessionFile?: string }).sessionFile,
     ).toContain("session-1.jsonl");

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1029,6 +1029,7 @@ export async function runBtwSideQuestion(
         provider: runtimeModel.provider,
         model: runtimeModel.id,
         runtimeModel,
+        preparedModelRuntime,
         preparedRuntimeAuth: {
           plan: runtimeAuthPlan,
           authProfileStore: scopeAuthProfileStoreToPreparedPlan(

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -15,6 +15,38 @@ import { projectConversationToolNames } from "./conversation-tool-policy-pipelin
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 
 describe("resolveConversationCapabilityProfile", () => {
+  it("intersects base and provider profile contributions from plugin manifests", () => {
+    const profile = resolveConversationCapabilityProfile({
+      config: {
+        tools: {
+          profile: "coding",
+          byProvider: { openai: { profile: "messaging" } },
+        },
+      },
+      modelProvider: "openai",
+      pluginMetadataSnapshot: {
+        plugins: [
+          {
+            contracts: { tools: ["coding_only", "messaging_only", "shared"] },
+            toolMetadata: {
+              coding_only: { profiles: ["coding"] },
+              messaging_only: { profiles: ["messaging"] },
+              shared: { profiles: ["coding", "messaging"] },
+            },
+          },
+        ],
+      } as never,
+    });
+
+    expect(
+      projectConversationToolNames({
+        capabilityProfile: profile,
+        toolNames: ["coding_only", "messaging_only", "shared"],
+        warn: () => undefined,
+      }),
+    ).toEqual(["shared"]);
+  });
+
   it("intersects a prepared direct policy with existing tool policy", () => {
     const profile = resolveConversationCapabilityProfile({
       config: { tools: { deny: ["write"] } },

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -8,6 +8,7 @@ import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GroupToolPolicyConfig } from "../config/types.tools.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { SkillSnapshot } from "../skills/types.js";
@@ -30,12 +31,29 @@ import type { PromptMode } from "./system-prompt.types.js";
 import {
   collectExplicitAllowlist,
   collectExplicitDenylist,
+  mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
   type ToolPolicyLike,
 } from "./tool-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 type ConversationCapabilityScope = "direct" | "shared" | "unknown";
+
+function resolveManifestToolProfileNames(
+  snapshot: Pick<PluginMetadataSnapshot, "plugins"> | undefined,
+  profile: string | undefined,
+): string[] {
+  if (!profile) {
+    return [];
+  }
+  return uniqueStrings(
+    (snapshot?.plugins ?? []).flatMap((plugin) =>
+      (plugin.contracts?.tools ?? []).filter((toolName) =>
+        plugin.toolMetadata?.[toolName]?.profiles?.some((candidate) => candidate === profile),
+      ),
+    ),
+  );
+}
 
 export type ConversationCapabilityProfileParams = {
   config?: OpenClawConfig;
@@ -85,6 +103,7 @@ export type ConversationCapabilityProfileParams = {
   /** Persist the runtime allowlist as real parent authority on spawned children. */
   inheritRuntimeToolAllowlist?: boolean;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
   inputProvenance?: InputProvenance;
   /** Consumed in-process completion capability; public callers cannot set this fact. */
   trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
@@ -242,8 +261,14 @@ export function resolveConversationCapabilityProfile(
     conversationPolicy: pickSandboxToolPolicy(params.conversationToolPolicy),
   });
   const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
-  const profilePolicy = resolveToolProfilePolicy(effective.profile);
-  const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(effective.profile),
+    resolveManifestToolProfileNames(params.pluginMetadataSnapshot, effective.profile),
+  );
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(effective.providerProfile),
+    resolveManifestToolProfileNames(params.pluginMetadataSnapshot, effective.providerProfile),
+  );
   const configuredOverridePolicies = [
     effective.globalPolicy,
     effective.globalProviderPolicy,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1095,6 +1095,79 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
+  it("keeps manifest-profiled plugin tools executable during compaction", async () => {
+    const toolName = "profiled_plugin_tool";
+    const metadataSnapshot = {
+      ...getCurrentPluginMetadataSnapshotMock(),
+      workspaceDir: "/tmp/workspace",
+      plugins: [
+        {
+          id: "profiled-plugin",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "workspace",
+          rootDir: "/tmp/workspace/profiled-plugin",
+          source: "/tmp/workspace/profiled-plugin/index.js",
+          manifestPath: "/tmp/workspace/profiled-plugin/openclaw.plugin.json",
+          contracts: { tools: [toolName] },
+          toolMetadata: { [toolName]: { profiles: ["coding"] } },
+        } satisfies PluginManifestRecord,
+      ],
+    };
+    const preparedModelRuntime = {
+      agentId: "main",
+      agentDir: "/tmp/agents/main/agent",
+      config: { tools: { profile: "coding" } },
+      workspaceDir: "/tmp/workspace",
+      metadataSnapshot,
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      createStores: () => ({ authStorage: {}, modelRegistry: {} }),
+    } as never;
+    acquireAgentRunPreparedModelRuntimeMock.mockResolvedValueOnce({
+      snapshot: preparedModelRuntime,
+      release: vi.fn(),
+    });
+    createOpenClawCodingToolsMock.mockReturnValueOnce([
+      {
+        name: toolName,
+        label: "Profiled plugin tool",
+        description: "Profiled plugin tool test fixture",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+      },
+    ] as never);
+
+    const result = await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: TEST_SESSION_KEY,
+      workspaceDir: "/tmp/workspace",
+      config: { tools: { profile: "coding" } },
+    });
+
+    expect(result.ok).toBe(true);
+    const toolOptions = expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {});
+    expect(
+      (toolOptions.preparedModelRuntime as { metadataSnapshot?: unknown }).metadataSnapshot,
+    ).toBe(metadataSnapshot);
+    expect(
+      (
+        toolOptions.conversationCapabilityProfile as {
+          policy?: { explicitToolAllowlist?: string[] };
+        }
+      ).policy?.explicitToolAllowlist,
+    ).toContain(toolName);
+    const sessionOptions = expectRecordFields(mockCallArg(createAgentSessionMock), {});
+    expect(sessionOptions.tools).toContain(toolName);
+    expect(
+      (sessionOptions.customTools as Array<{ name: string }>).map((tool) => tool.name),
+    ).toContain(toolName);
+  });
+
   it.each([
     { input: ["text"], modelHasVision: false },
     { input: ["text", "image"], modelHasVision: true },

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -290,6 +290,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       sandboxToolPolicy: sandbox?.tools,
       inputProvenance: params.inputProvenance,
       trustedInternalHandoff: params.trustedInternalHandoff,
+      pluginMetadataSnapshot: params.preparedModelRuntime.metadataSnapshot,
     });
     const toolsEnabled = supportsModelTools(effectiveModel);
     const toolsRaw = toolsEnabled
@@ -338,6 +339,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
           skillsSnapshot: skillsSnapshotForRun,
           skillUsagePaths,
           conversationCapabilityProfile: runtimeCapabilityProfile,
+          preparedModelRuntime: params.preparedModelRuntime,
           modelAuthMode: resolveModelAuthMode(effectiveModel.provider, params.config, undefined, {
             workspaceDir: effectiveWorkspace,
           }),

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -180,6 +180,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     inputProvenance: attempt.inputProvenance,
     trustedInternalHandoff: attempt.trustedInternalHandoff,
     scheduledToolPolicy: attempt.scheduledToolPolicy,
+    pluginMetadataSnapshot: attempt.preparedModelRuntime?.metadataSnapshot,
   });
   const localModelLeanEnabled = isLocalModelLeanEnabled({
     config: attempt.config,

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -206,6 +206,8 @@ export type AgentHarnessSideQuestionParams = {
   hostCapabilities?: AgentHarnessHostCapabilities;
   /** Host-resolved sandbox snapshot for this side execution. */
   sandbox?: import("../sandbox/types.js").SandboxContext | null;
+  /** Prepared plugin/model generation that owns this side execution. */
+  preparedModelRuntime?: import("../prepared-model-runtime.types.js").PreparedModelRuntimeSnapshot;
   cfg: import("../../config/types.openclaw.js").OpenClawConfig;
   agentDir: string;
   provider: string;

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -73,7 +73,11 @@ export function getReadPathVariants(filePath: string): string[] {
     const curlyQuotes = spaced.replace(/['\u2018]/g, "\u2019");
     for (const quoted of [straightQuotes, curlyQuotes]) {
       variants.add(quoted.normalize("NFC"));
-      variants.add(quoted.normalize("NFD"));
+      // macOS filesystems resolve NFC/NFD spellings to the same entry; probing both
+      // makes one file look ambiguous. Other platforms can store both distinctly.
+      if (process.platform !== "darwin") {
+        variants.add(quoted.normalize("NFD"));
+      }
     }
   }
   variants.delete(filePath);

--- a/src/plugins/manifest-capability-normalizers.ts
+++ b/src/plugins/manifest-capability-normalizers.ts
@@ -19,7 +19,14 @@ import type {
   PluginManifestSecretInputContracts,
   PluginManifestSecretInputPath,
   PluginManifestToolMetadata,
+  PluginManifestToolProfile,
 } from "./manifest-types.js";
+
+function isPluginToolProfile(profile: string): profile is PluginManifestToolProfile {
+  return (
+    profile === "minimal" || profile === "coding" || profile === "messaging" || profile === "full"
+  );
+}
 
 export function normalizeStringListRecord(value: unknown): Record<string, string[]> | undefined {
   if (!isRecord(value)) {
@@ -315,9 +322,11 @@ export function normalizePluginToolMetadata(
 ): Record<string, PluginManifestToolMetadata> | undefined {
   return normalizeNamedMetadataRecord(value, (rawMetadata) => {
     const providerMetadata = normalizeCapabilityProviderMetadataEntry(rawMetadata);
+    const profiles = normalizeTrimmedStringList(rawMetadata.profiles).filter(isPluginToolProfile);
     const metadata = {
       ...providerMetadata,
       ...(rawMetadata.optional === true ? { optional: true } : {}),
+      ...(profiles.length > 0 ? { profiles } : {}),
       ...(rawMetadata.replaySafe === true ? { replaySafe: true } : {}),
       ...(rawMetadata.sideEffecting === true ? { sideEffecting: true } : {}),
     } satisfies PluginManifestToolMetadata;

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2471,6 +2471,7 @@ describe("loadPluginManifestRegistry", () => {
         },
         memory_get: {
           replaySafe: true,
+          profiles: ["coding", "messaging", "invalid"],
         },
         memory_store: {
           sideEffecting: true,
@@ -2553,6 +2554,7 @@ describe("loadPluginManifestRegistry", () => {
       },
       memory_get: {
         replaySafe: true,
+        profiles: ["coding", "messaging"],
       },
       memory_store: {
         sideEffecting: true,

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -534,11 +534,15 @@ export type PluginManifestCapabilityProviderMetadata = {
 
 export type PluginManifestToolMetadata = PluginManifestCapabilityProviderMetadata & {
   optional?: boolean;
+  /** Built-in tool profiles that expose this plugin tool by default. */
+  profiles?: PluginManifestToolProfile[];
   /** Tool execution is safe to repeat after an incomplete model turn. */
   replaySafe?: boolean;
   /** Tool execution can change durable state and failed attempts must remain visible. */
   sideEffecting?: boolean;
 };
+
+export type PluginManifestToolProfile = "minimal" | "coding" | "messaging" | "full";
 
 export type PluginManifestProviderAuthChoice = {
   /** Provider id owned by this manifest entry. */


### PR DESCRIPTION
## What Problem This Solves

Fixes a general issue where prepared plugin metadata disappeared at several agent-runtime boundaries. Codex dynamic tools, direct compaction, and native `/btw` side questions could construct tools without the prepared plugin snapshot, so a plugin tool declared for a restricted built-in profile could silently disappear.

`intent` made the broader failure visible. In the original live reproduction, Codex never materialized the tool, emitted no model-visible tool result, then confabulated “Standing intent saved” while the `standing_intents` table still contained zero rows.

The final repair covers all three affected boundaries and keeps standing-intent creation fail-closed:

1. Normal Codex dynamic-tool construction receives the prepared runtime snapshot.
2. Direct compaction forwards the snapshot into both capability-profile resolution and tool construction.
3. Native `/btw` side questions carry the same prepared generation through the harness contract, side-run params, and Codex tool bridge.
4. Senderless standing-intent creation remains refused. The prompt-injection hook has channel/account/sender facts but no enforceable authenticated owner principal, so persisting a NULL/NULL scope would make the reminder eligible for unrelated users. The tool now returns an actionable error naming the missing channel/sender identity and asks the operator to retry from an authenticated channel conversation.

## Why This Change Was Made

The fix carries one prepared generation across every tool-construction boundary instead of rediscovering ambient plugin state. A generic, manifest-owned `toolMetadata.<tool>.profiles` contract contributes plugin tools to the existing built-in profile policy; no plugin id or tool name is hardcoded in core.

This does not widen authority. Prepared metadata contributes tool-profile membership and runtime factories only. Explicit operator allowlists and deny rules, runtime grants, harness authority, and the independent `senderIsOwner` gate remain authoritative.

The Codex dependency contract was checked directly in sibling `openai/codex` source:

- `codex-rs/protocol/src/dynamic_tools.rs:18-27` defines the dynamic function tool shape.
- `codex-rs/core/src/tools/handlers/dynamic.rs:50-81` converts that prepared shape and assigns direct/deferred exposure.
- `codex-rs/core/src/tools/spec_plan.rs:1221-1247` registers supplied dynamic tools as external tools.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:503-580` shows `thread/fork` has no dynamic-tool override.
- `codex-rs/core/src/session/mod.rs:660-665,684-714` restores an empty fork tool list from inherited conversation metadata.

`toolMetadata.<tool>.profiles` is additive plugin-facing metadata. It invalidates no existing plugin manifest or operator config, changes no configuration default, and needs no `openclaw doctor --fix` migration. Plugins that omit it retain their current behavior. The optional prepared-runtime field added to the side-question harness contract is likewise source-compatible.

The Unicode read-path fix remains a separate bounded Pathfinder cleanup: proof exposed a pre-existing macOS normalization ambiguity in `src/agents/sessions/tools/path-utils.ts`, and its focused read/path tests remain green.

## User Impact

Owner-gated plugin tools now remain available under their declared profile in normal Codex turns, direct compaction, and native `/btw` side questions.

Standing intents still default to the current channel and sender. Authenticated senderless surfaces such as a local CLI turn can list or cancel existing intents, but creation is refused until the turn has both channel and sender identity. This prevents owner-authored reminder text from becoming match-all and entering an unrelated channel user's model context.

## Evidence

The new regressions failed before their owner-boundary fixes:

- senderless creation successfully wrote a NULL/NULL-scoped row instead of rejecting;
- compaction omitted a manifest-profiled plugin tool because both prepared metadata forwards were absent;
- `/btw` omitted the prepared runtime at the harness handoff;
- the Codex side-thread bridge returned `Unknown OpenClaw tool` for the restricted-profile plugin tool.

Post-fix focused proof:

- Memory Core: 35/35;
- Codex dynamic tools, configured MCP, and side questions: 142/142;
- agent/profile/plugin: 253/253;
- `/btw`: 56/56;
- path/read sibling coverage: 31 passed, 1 skipped;
- compaction boundary regression: passed (the broad file also encountered an unrelated shared `/tmp/openclaw-agent.sqlite` schema-16 artifact owned by another worktree, so no shared state was deleted or migrated);
- `node scripts/check-changed.mjs`: remote providers were unavailable, so the documented local fallback ran selected formatting, guards, typechecks, lint, plugin boundaries, database-first, import-cycle, and architecture checks;
- fresh autoreview of both the uncommitted repair and the complete branch: clean, no accepted/actionable findings.

Judged LOC split against the current base:

- production: +84/-8 (net +76);
- tests: +233/-20 (net +213);
- docs: +25/-4 (net +21).

The positive production delta is the generic plugin-profile metadata contract and normalization, complete prepared-generation propagation across three runtime boundaries, the fail-closed identity diagnostic, and the bounded Unicode path correction. It adds no plugin-specific core policy, configuration key, fallback path, or schema migration.

AI-assisted: yes. The maintainer inspected the final diff, dependency contract, failing/passing regressions, and validation output.
