### PR TITLE
fix(doctor): surface legacy-config copy failures

### DIFF
--- a/src/commands/doctor-config-preflight.legacy-copy.test.ts
+++ b/src/commands/doctor-config-preflight.legacy-copy.test.ts
@@ -1,0 +1,82 @@
+// A failing legacy-config copy must surface, not silently leave doctor
+// looking like a clean fresh install while the operator's config exists.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
+
+const envKeys = ["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+function setEnv(values: Partial<Record<(typeof envKeys)[number], string>>) {
+  for (const key of envKeys) {
+    if (!savedEnv.has(key)) {
+      savedEnv.set(key, process.env[key]);
+    }
+    const value = values[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  savedEnv.clear();
+});
+
+describe("doctor legacy config migration failures", () => {
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "surfaces a copy failure instead of proceeding as a fresh install",
+    async () => {
+      await withTempDir("openclaw-doctor-legacy-copy-", async (home) => {
+        const legacyDir = path.join(home, ".clawdbot");
+        await fs.mkdir(legacyDir, { recursive: true });
+        await fs.writeFile(path.join(legacyDir, "clawdbot.json"), "{}\n", "utf-8");
+        const targetDir = path.join(home, "readonly-state");
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.chmod(targetDir, 0o555);
+        setEnv({
+          HOME: home,
+          OPENCLAW_CONFIG_PATH: path.join(targetDir, "openclaw.json"),
+          OPENCLAW_STATE_DIR: path.join(home, "state"),
+        });
+
+        try {
+          await expect(
+            runDoctorConfigPreflight({ migrateState: false, invalidConfigNote: false }),
+          ).rejects.toThrow(/Failed to migrate legacy config/);
+        } finally {
+          await fs.chmod(targetDir, 0o755);
+        }
+      });
+    },
+  );
+
+  it("migrates the legacy config and reports the change when the copy works", async () => {
+    await withTempDir("openclaw-doctor-legacy-copy-", async (home) => {
+      const legacyDir = path.join(home, ".clawdbot");
+      await fs.mkdir(legacyDir, { recursive: true });
+      await fs.writeFile(path.join(legacyDir, "clawdbot.json"), "{}\n", "utf-8");
+      const targetPath = path.join(home, "state-root", "openclaw.json");
+      setEnv({
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: targetPath,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+      });
+
+      await runDoctorConfigPreflight({ migrateState: false, invalidConfigNote: false });
+
+      await expect(fs.readFile(targetPath, "utf-8")).resolves.toBe("{}\n");
+    });
+  });
+});

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -16,6 +16,7 @@ import { resolveCanonicalConfigPath } from "../config/paths.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
@@ -99,8 +100,16 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
   try {
     await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
     changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
-  } catch {
-    // If it already exists, skip silently.
+  } catch (err) {
+    // EEXIST means a config already lives at the target — nothing to migrate.
+    // Any other failure (EACCES, ENOSPC) must surface: doctor would otherwise
+    // proceed as a fresh install while the operator's legacy config exists.
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw new Error(
+        `Failed to migrate legacy config ${legacyPath} -> ${targetPath}: ${formatErrorMessage(err)}`,
+        { cause: err },
+      );
+    }
   }
 
   return changes;

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -104,6 +104,7 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
     // EEXIST means a config already lives at the target — nothing to migrate.
     // Any other failure (EACCES, ENOSPC) must surface: doctor would otherwise
     // proceed as a fresh install while the operator's legacy config exists.
+    // SAFETY: fs.copyFile rejections are Node errno errors; code is optional-read only.
     if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
       throw new Error(
         `Failed to migrate legacy config ${legacyPath} -> ${targetPath}: ${formatErrorMessage(err)}`,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -104,8 +104,8 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
     // EEXIST means a config already lives at the target — nothing to migrate.
     // Any other failure (EACCES, ENOSPC) must surface: doctor would otherwise
     // proceed as a fresh install while the operator's legacy config exists.
-    // SAFETY: fs.copyFile rejections are Node errno errors; code is optional-read only.
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+    const code = err && typeof err === "object" && "code" in err ? err.code : undefined;
+    if (code !== "EEXIST") {
       throw new Error(
         `Failed to migrate legacy config ${legacyPath} -> ${targetPath}: ${formatErrorMessage(err)}`,
         { cause: err },


### PR DESCRIPTION
## What Problem This Solves

Doctor's legacy-config migration (`~/.clawdbot/clawdbot.json` → the canonical config path) swallowed every `copyFile` failure with a bare catch whose comment claimed "if it already exists, skip silently." The catch also ate `EACCES`, `ENOSPC`, and cross-device failures. Result: the operator's legacy config exists, the migration was attempted and failed, and doctor proceeded as a clean fresh install — no config, no change note, no warning. The run ends looking healthy while the operator's channels/auth silently vanished.

## Why This Change Was Made

Root cause: failure collapsed into the skip-silently success shape at the one place that owns the copy. The catch now inspects the error code: `EEXIST` (a config already lives at the target — genuinely nothing to migrate) keeps its skip semantics; anything else rethrows with the source and target paths in the message, surfacing through doctor's existing error path.

## User Impact

A permissions or disk-space problem during first-run migration now fails loudly with the exact paths instead of silently discarding the operator's legacy configuration.

## Evidence

- New `doctor-config-preflight.legacy-copy.test.ts`: a read-only target dir makes the preflight reject with `Failed to migrate legacy config …` — **fails pre-fix** (resolved as a clean run); companion test proves the successful copy still migrates and reports.
- Sibling suite `doctor-config-preflight.state-migration.test.ts` 30/30.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +11 −2, test +82.
