### PR TITLE
fix(qa): keep QA Lab startup off operator state

### DIFF
--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -146,20 +146,22 @@ const captureMock = vi.hoisted(() => {
   };
 
   return {
+    acquire: vi.fn(() => ({
+      store,
+      release: store.close,
+    })),
     store,
     reset() {
       sessions.splice(0);
       events.splice(0);
+      captureMock.acquire.mockClear();
       store.close.mockClear();
     },
   };
 });
 
 vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
-  acquireDebugProxyCaptureStore: () => ({
-    store: captureMock.store,
-    release: captureMock.store.close,
-  }),
+  acquireDebugProxyCaptureStore: captureMock.acquire,
   getDebugProxyCaptureStore: () => captureMock.store,
   resolveDebugProxySettings: () => ({
     proxyUrl: process.env.OPENCLAW_DEBUG_PROXY_URL ?? "",
@@ -863,7 +865,7 @@ describe("qa-lab server", () => {
     expect(suiteLaunchMock.runQaSuite).not.toHaveBeenCalled();
   });
 
-  it("cleans up capture state when embedded gateway setup fails", async () => {
+  it("does not open capture state when embedded gateway setup fails", async () => {
     qaChannelMock.resolveAccount.mockImplementationOnce(() => {
       throw new Error("embedded setup failed");
     });
@@ -875,10 +877,11 @@ describe("qa-lab server", () => {
       }),
     ).rejects.toThrow("embedded setup failed");
 
-    expect(captureMock.store.close).toHaveBeenCalledTimes(1);
+    expect(captureMock.acquire).not.toHaveBeenCalled();
+    expect(captureMock.store.close).not.toHaveBeenCalled();
   });
 
-  it("closes the server and capture state when embedded gateway stop fails", async () => {
+  it("closes the server and acquired capture state when embedded gateway stop fails", async () => {
     qaChannelMock.startAccount.mockImplementationOnce(
       async ({ abortSignal }: { abortSignal?: AbortSignal }) =>
         await new Promise<void>((_resolve, reject) => {
@@ -899,9 +902,11 @@ describe("qa-lab server", () => {
       host: "127.0.0.1",
       port: 0,
     });
+    await fetchWithRetry(`${lab.baseUrl}/api/capture/sessions`);
 
     await expect(lab.stop()).rejects.toThrow("gateway stop failed");
 
+    expect(captureMock.acquire).toHaveBeenCalledTimes(1);
     expect(captureMock.store.close).toHaveBeenCalledTimes(1);
     await expect(fetch(`${lab.baseUrl}/healthz`)).rejects.toThrow();
   });
@@ -1812,14 +1817,22 @@ describe("qa-lab server", () => {
       host: "127.0.0.1",
       port: 0,
     });
+    let stopped = false;
     cleanups.push(async () => {
-      await lab.stop();
+      if (!stopped) {
+        await lab.stop();
+      }
     });
+
+    await fetchWithRetry(`${lab.baseUrl}/healthz`);
+    await fetchWithRetry(`${lab.baseUrl}/api/bootstrap`);
+    expect(captureMock.acquire).not.toHaveBeenCalled();
 
     const sessions = (await (
       await fetchWithRetry(`${lab.baseUrl}/api/capture/sessions`)
     ).json()) as { sessions: Array<{ id: string }> };
     expect(sessions.sessions.map((session) => session.id)).toContain("qa-capture-session");
+    expect(captureMock.acquire).toHaveBeenCalledTimes(1);
 
     const events = (await (
       await fetchWithRetry(`${lab.baseUrl}/api/capture/events?sessionId=qa-capture-session`)
@@ -1871,6 +1884,11 @@ describe("qa-lab server", () => {
     expect(query.rows).toHaveLength(1);
     expect(query.rows[0]?.host).toBe("api.example.com");
     expect(query.rows[0]?.duplicateCount).toBe(2);
+    expect(captureMock.acquire).toHaveBeenCalledTimes(1);
+
+    await lab.stop();
+    stopped = true;
+    expect(captureMock.store.close).toHaveBeenCalledTimes(1);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -301,8 +301,8 @@ export async function startQaLabServer(
 ): Promise<QaLabServerHandle> {
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
   const captureSettings = resolveDebugProxySettings();
-  const captureStoreLease = acquireDebugProxyCaptureStore();
-  const captureStore = captureStoreLease.store;
+  let captureStoreLease: ReturnType<typeof acquireDebugProxyCaptureStore> | undefined;
+  const getCaptureStore = () => (captureStoreLease ??= acquireDebugProxyCaptureStore()).store;
   const state = createQaBusState();
   let latestReport: QaLabLatestReport | null = null;
   let latestScenarioRun: QaLabScenarioRun | null = null;
@@ -375,7 +375,6 @@ export async function startQaLabServer(
     | undefined;
   const embeddedGatewayEnabled = params?.embeddedGateway !== "disabled";
   let labHandle: QaLabServerHandle | null = null;
-  let captureStoreReleased = false;
   let serverListening = false;
 
   let listenUrl = "";
@@ -592,7 +591,7 @@ export async function startQaLabServer(
         }
         if (req.method === "GET" && url.pathname === "/api/capture/sessions") {
           writeJson(res, 200, {
-            sessions: captureStore.listSessions(50),
+            sessions: getCaptureStore().listSessions(50),
           });
           return;
         }
@@ -626,7 +625,7 @@ export async function startQaLabServer(
           const sessionId = url.searchParams.get("sessionId")?.trim();
           writeJson(res, 200, {
             events: sessionId
-              ? captureStore.getSessionEvents(sessionId, 200).map(mapCaptureEventForQa)
+              ? getCaptureStore().getSessionEvents(sessionId, 200).map(mapCaptureEventForQa)
               : [],
           });
           return;
@@ -638,7 +637,7 @@ export async function startQaLabServer(
             return;
           }
           writeJson(res, 200, {
-            coverage: captureStore.summarizeSessionCoverage(sessionId),
+            coverage: getCaptureStore().summarizeSessionCoverage(sessionId),
           });
           return;
         }
@@ -654,7 +653,7 @@ export async function startQaLabServer(
             return;
           }
           writeJson(res, 200, {
-            rows: captureStore.queryPreset(preset, sessionId),
+            rows: getCaptureStore().queryPreset(preset, sessionId),
           });
           return;
         }
@@ -664,7 +663,7 @@ export async function startQaLabServer(
             writeError(res, 400, "Missing blob id");
             return;
           }
-          const content = captureStore.readBlob(blobId);
+          const content = getCaptureStore().readBlob(blobId);
           if (content == null) {
             writeError(res, 404, "Blob not found");
             return;
@@ -678,13 +677,13 @@ export async function startQaLabServer(
             ? body.sessionIds.filter((value): value is string => typeof value === "string")
             : [];
           writeJson(res, 200, {
-            result: captureStore.deleteSessions(sessionIds),
+            result: getCaptureStore().deleteSessions(sessionIds),
           });
           return;
         }
         if (req.method === "POST" && url.pathname === "/api/capture/purge") {
           writeJson(res, 200, {
-            result: captureStore.purgeAll(),
+            result: getCaptureStore().purgeAll(),
           });
           return;
         }
@@ -938,11 +937,8 @@ export async function startQaLabServer(
   });
 
   const releaseCaptureStore = () => {
-    if (captureStoreReleased) {
-      return;
-    }
-    captureStoreReleased = true;
-    captureStoreLease.release();
+    captureStoreLease?.release();
+    captureStoreLease = undefined;
   };
 
   const stopLabServerResources = async (): Promise<Error | undefined> => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting QA Lab or a QA suite would eagerly open the operator's shared capture database even when no capture API was used. On a newer source checkout, that open could migrate operator state before the QA Gateway's isolated state directory existed.

## Why This Change Was Made

QA Lab now acquires the shared capture store only when a capture API endpoint is actually requested, reuses that lease across capture requests, and releases it during the existing server shutdown lifecycle. Explicit capture inspection keeps its existing ambient-store behavior; ordinary QA startup no longer touches it.

## User Impact

Maintainers can run ordinary QA Lab and QA suite commands without those commands opening or migrating their configured OpenClaw state merely by starting the Lab server.

## Evidence

- Pre-fix focused regression failed because capture acquisition occurred during server startup, before health/bootstrap requests.
- Post-fix focused regression passed and proved zero acquisition through startup/health/bootstrap, one acquisition across repeated capture endpoints, and one release on shutdown.
- Full `extensions/qa-lab/src/lab-server.test.ts`: 29 passed.
- Changed gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31982835547
- Autoreview: clean, correctness 0.98.
- Production delta: +11/-15 (net -4); tests: +26/-8.
