### PR TITLE
refactor(ui): give chat side-panel slots one definition

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -1,0 +1,129 @@
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import {
+  installMockGateway,
+  type ControlUiMockGatewayScenario,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "chat sidebar panel contract",
+  startServerBeforeBrowser: true,
+});
+
+type ColdOpenOutcome = {
+  outcome: "content" | "generic-empty";
+  emptyStateOffersAction: boolean;
+};
+
+const expectedColdOpenOutcomes: Record<string, ColdOpenOutcome> = {
+  Review: { outcome: "generic-empty", emptyStateOffersAction: false },
+  Terminal: { outcome: "content", emptyStateOffersAction: false },
+  Browser: { outcome: "generic-empty", emptyStateOffersAction: true },
+  Files: { outcome: "generic-empty", emptyStateOffersAction: false },
+  "Side chat": { outcome: "generic-empty", emptyStateOffersAction: false },
+  Tasks: { outcome: "generic-empty", emptyStateOffersAction: false },
+  Desktop: { outcome: "content", emptyStateOffersAction: false },
+  Discussion: { outcome: "generic-empty", emptyStateOffersAction: true },
+};
+
+function coldOpenScenario(): ControlUiMockGatewayScenario {
+  return {
+    featureMethods: [
+      "browser.request",
+      "chat.metadata",
+      "chat.startup",
+      "desktop.observe",
+      "environments.list",
+      "session.discussion.info",
+      "session.discussion.open",
+      "sessions.diff",
+      "sessions.files.list",
+      "tasks.list",
+      "terminal.open",
+    ],
+    methodResponses: {
+      "browser.request": {
+        cases: [
+          { match: { method: "GET", path: "/tabs" }, response: { running: false, tabs: [] } },
+        ],
+      },
+      "environments.list": { environments: [] },
+      "session.discussion.info": {
+        openUrl: "https://discussion.example/session",
+        state: "open",
+      },
+      "sessions.files.list": {
+        browser: { entries: [], path: "" },
+        files: [],
+        gitCheckout: false,
+        root: "/tmp/plain-workspace",
+        sessionKey: "main",
+      },
+      "tasks.list": { tasks: [] },
+      "terminal.open": {
+        agentId: "main",
+        confined: false,
+        cwd: "/tmp/plain-workspace",
+        sessionId: "cold-open-terminal",
+        shell: "/bin/zsh",
+      },
+    },
+    terminalEnabled: true,
+    workspace: "/tmp/plain-workspace",
+    workspaceGit: false,
+  };
+}
+
+async function openColdSidebar(page: Page) {
+  const gateway = await installMockGateway(page, coldOpenScenario());
+  await page.goto(`${suite.server.baseUrl}chat`);
+  await waitForControlUiGatewayReady(page);
+  await gateway.waitForRequest("session.discussion.info");
+  await gateway.waitForRequest("sessions.files.list");
+  await page.getByRole("button", { name: "Side panel", exact: true }).first().click();
+  const choices = page.locator(".side-panel-empty__type");
+  await choices.first().waitFor();
+  return choices;
+}
+
+async function readColdOpenOutcome(page: Page): Promise<ColdOpenOutcome> {
+  const activePanel = page.locator(".side-panel__panel:not([hidden])");
+  await activePanel.waitFor();
+  await activePanel.locator(":scope > *").first().waitFor();
+  const emptyState = activePanel.locator("openclaw-panel-empty-state").first();
+  const genericEmptyState = (await emptyState.count()) > 0;
+  return {
+    outcome: genericEmptyState ? "generic-empty" : "content",
+    emptyStateOffersAction:
+      genericEmptyState && (await emptyState.locator('[slot="action"]').count()) > 0,
+  };
+}
+
+suite.define(() => {
+  it("accounts for every offered slot when opened cold", async () => {
+    const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
+    const probePage = await probeContext.newPage();
+    const choices = await openColdSidebar(probePage);
+    const offered = await choices.locator(".side-panel-type-option__label").allTextContents();
+    await suite.closeBrowserContext(probeContext);
+
+    expect(offered).toEqual(Object.keys(expectedColdOpenOutcomes));
+
+    const outcomes: Record<string, ColdOpenOutcome> = {};
+    for (const label of offered) {
+      const context = await suite.newBrowserContext({ serviceWorkers: "block" });
+      const page = await context.newPage();
+      const coldChoices = await openColdSidebar(page);
+      await coldChoices.filter({ hasText: label }).click();
+      await expect
+        .poll(() => readColdOpenOutcome(page), { message: `${label} cold-open outcome` })
+        .toEqual(expectedColdOpenOutcomes[label]);
+      outcomes[label] = await readColdOpenOutcome(page);
+      await suite.closeBrowserContext(context);
+    }
+
+    expect(outcomes).toEqual(expectedColdOpenOutcomes);
+  });
+});

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import { icons } from "../../components/icons.ts";
@@ -6,90 +6,45 @@ import { t } from "../../i18n/index.ts";
 import { resolveAssistantAttachmentAuthToken } from "./chat-pane-state.ts";
 import type { ChatSessionCompanionThread } from "./chat-session-companion.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import type { SidebarPanelTemplates } from "./components/chat-sidebar-region-types.ts";
+import type {
+  SidebarPanelDefinition,
+  SidebarPanelTemplates,
+} from "./components/chat-sidebar-region-types.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import type { SidebarSlotId } from "./sidebar-layout-types.ts";
 
-/**
- * Templates for the gateway-backed surfaces embedded in the side panel.
- * Each surface appears only while its capability is advertised, so a closed
- * tab can never reopen into a dead panel.
- */
-export function embeddedSurfaceTemplates(params: {
+type SidebarPanelDefinitionParams = {
   state: ChatPageHost;
   agentId: string | null;
   desktopAvailable: boolean;
-}): Partial<SidebarPanelTemplates> {
-  const { state } = params;
-  return {
-    ...(state.terminalAvailable
-      ? {
-          terminal: html`<openclaw-terminal-panel
-            embedded
-            .client=${state.connected ? state.client : null}
-            .available=${state.terminalAvailable}
-            .agentId=${params.agentId}
-            .themeMode=${document.documentElement.dataset.theme === "light" ? "light" : "dark"}
-            .basePath=${state.basePath}
-          ></openclaw-terminal-panel>`,
-        }
-      : {}),
-    ...(state.browserPanelAvailable
-      ? {
-          browser: html`<openclaw-browser-panel
-            embedded
-            data-chat-autotype-exempt
-            .client=${state.connected ? state.client : null}
-            .available=${state.browserPanelAvailable}
-            .basePath=${state.basePath}
-            .authToken=${resolveAssistantAttachmentAuthToken(state)}
-          ></openclaw-browser-panel>`,
-        }
-      : {}),
-    ...(params.desktopAvailable
-      ? {
-          desktop: html`<openclaw-desktop-panel
-            embedded
-            data-chat-autotype-exempt
-            .client=${state.connected ? state.client : null}
-            .available=${params.desktopAvailable}
-          ></openclaw-desktop-panel>`,
-        }
-      : {}),
-  };
-}
-
-/** Side-chat companion rail, embedded as a regular side-panel tab. */
-export function companionRailTemplate(params: {
-  state: ChatPageHost;
+  hasBoard: boolean;
+  chat: TemplateResult;
+  workspace: TemplateResult | typeof nothing;
+  tasks: TemplateResult | typeof nothing;
+  detail: TemplateResult | null;
   digest: SessionObserverDigest | null;
   activeRunId: string | null;
   startedAt: number | undefined;
   lastReadAt: number | undefined;
   pullRequests: ControlUiSessionPullRequest[];
   companion: ChatSessionCompanionThread;
-  onSubmit: (question: string) => void;
-  onDraftChange: (draft: string) => void;
-  onVisibilityChange: (visible: boolean) => void;
-}) {
-  const { state } = params;
-  return html`<openclaw-chat-session-rail
-    embedded
-    .sessionKey=${state.sessionKey}
-    .digest=${params.digest}
-    .running=${Boolean(params.activeRunId)}
-    .activeRunId=${params.activeRunId}
-    .startedAt=${params.startedAt}
-    .lastReadAt=${params.lastReadAt}
-    .planStatus=${state.planStatus ?? null}
-    .pullRequests=${params.pullRequests}
-    .companion=${params.companion}
-    .connected=${state.connected}
-    .onSubmit=${params.onSubmit}
-    .onDraftChange=${params.onDraftChange}
-    .onVisibilityChange=${params.onVisibilityChange}
-  ></openclaw-chat-session-rail>`;
-}
+  onCompanionSubmit: (question: string) => void;
+  onCompanionDraftChange: (draft: string) => void;
+  onCompanionVisibilityChange: (visible: boolean) => void;
+  discussion: SessionDiscussionPanelConfig | null;
+  discussionSourceGeneration: number;
+};
+
+type SidebarPanelTextKey =
+  | "boardChat"
+  | "browser"
+  | "companion"
+  | "desktop"
+  | "discussion"
+  | "files"
+  | "review"
+  | "tasks"
+  | "terminal";
 
 /**
  * Header actions contributed by the panels that own content actions. Panels
@@ -146,42 +101,124 @@ export function sidePanelHeaderActions(params: {
   };
 }
 
-/** Discussion tab template; absent while the session has no discussion. */
-export function discussionPanelTemplate(
-  discussion: SessionDiscussionPanelConfig | null,
-  sourceGeneration: number,
-): Partial<SidebarPanelTemplates> {
-  if (!discussion) {
-    return {};
-  }
-  return {
-    discussion: html`<openclaw-session-discussion
-      .sessionKey=${discussion.sessionKey}
-      .canOpen=${discussion.canOpen}
-      .sourceGeneration=${sourceGeneration}
-      .loadInfo=${discussion.loadInfo}
-      .openDiscussion=${discussion.openDiscussion}
-      .onStateChange=${discussion.onStateChange}
-    ></openclaw-session-discussion>`,
-  };
+/** One ordered declaration for every chat side-panel slot. */
+export function sidebarPanelDefinitions(
+  params?: SidebarPanelDefinitionParams,
+): SidebarPanelDefinition[] {
+  const state = params?.state;
+  const terminalAvailable = state?.terminalAvailable === true;
+  const browserAvailable = state?.browserPanelAvailable === true;
+  const desktopAvailable = params?.desktopAvailable === true;
+  const definePanel = (
+    slot: SidebarSlotId,
+    textKey: SidebarPanelTextKey,
+    icon: TemplateResult,
+    content: TemplateResult | typeof nothing | null,
+    options?: { available?: boolean; shortcut?: string },
+  ): SidebarPanelDefinition => ({
+    slot,
+    label: t(`chat.sidePanel.${textKey}`),
+    icon,
+    available: options?.available ?? params !== undefined,
+    content,
+    empty: { description: t(`chat.sidePanel.${textKey}Empty`) },
+    ...(options?.shortcut ? { shortcut: options.shortcut } : {}),
+  });
+  const terminal =
+    state && terminalAvailable
+      ? html`<openclaw-terminal-panel
+          embedded
+          .client=${state.connected ? state.client : null}
+          .available=${state.terminalAvailable}
+          .agentId=${params?.agentId ?? null}
+          .themeMode=${document.documentElement.dataset.theme === "light" ? "light" : "dark"}
+          .basePath=${state.basePath}
+        ></openclaw-terminal-panel>`
+      : null;
+  const browser =
+    state && browserAvailable
+      ? html`<openclaw-browser-panel
+          embedded
+          data-chat-autotype-exempt
+          .client=${state.connected ? state.client : null}
+          .available=${state.browserPanelAvailable}
+          .basePath=${state.basePath}
+          .authToken=${resolveAssistantAttachmentAuthToken(state)}
+        ></openclaw-browser-panel>`
+      : null;
+  const companion = params
+    ? html`<openclaw-chat-session-rail
+        embedded
+        .sessionKey=${state?.sessionKey}
+        .digest=${params.digest}
+        .running=${Boolean(params.activeRunId)}
+        .activeRunId=${params.activeRunId}
+        .startedAt=${params.startedAt}
+        .lastReadAt=${params.lastReadAt}
+        .planStatus=${state?.planStatus ?? null}
+        .pullRequests=${params.pullRequests}
+        .companion=${params.companion}
+        .connected=${state?.connected === true}
+        .onSubmit=${params.onCompanionSubmit}
+        .onDraftChange=${params.onCompanionDraftChange}
+        .onVisibilityChange=${params.onCompanionVisibilityChange}
+      ></openclaw-chat-session-rail>`
+    : null;
+  const desktop =
+    state && desktopAvailable
+      ? html`<openclaw-desktop-panel
+          embedded
+          data-chat-autotype-exempt
+          .client=${state.connected ? state.client : null}
+          .available=${desktopAvailable}
+        ></openclaw-desktop-panel>`
+      : null;
+  const discussion = params?.discussion
+    ? html`<openclaw-session-discussion
+        .sessionKey=${params.discussion.sessionKey}
+        .canOpen=${params.discussion.canOpen}
+        .sourceGeneration=${params.discussionSourceGeneration}
+        .loadInfo=${params.discussion.loadInfo}
+        .openDiscussion=${params.discussion.openDiscussion}
+        .onStateChange=${params.discussion.onStateChange}
+      ></openclaw-session-discussion>`
+    : null;
+  return [
+    definePanel("detail", "review", icons.diff, params?.detail ?? null),
+    definePanel("terminal", "terminal", icons.terminal, terminal, {
+      available: terminalAvailable,
+      shortcut: "Ctrl+`",
+    }),
+    definePanel("browser", "browser", icons.globe, browser, { available: browserAvailable }),
+    definePanel("workspace", "files", icons.fileText, params?.workspace ?? null, {
+      shortcut: "⇧⌘B",
+    }),
+    definePanel("companion", "companion", icons.bot, companion),
+    definePanel("tasks", "tasks", icons.listChecks, params?.tasks ?? null),
+    definePanel("desktop", "desktop", icons.monitor, desktop, { available: desktopAvailable }),
+    definePanel("discussion", "discussion", icons.messageSquare, discussion, {
+      available: discussion !== null,
+    }),
+    definePanel("chat", "boardChat", icons.messageSquare, params?.chat ?? null, {
+      available: params?.hasBoard === true,
+    }),
+  ];
 }
 
-/** Slot order for the add-tab menu; capability-gated surfaces are hidden. */
-export function availableSidebarSlots(params: {
-  state: ChatPageHost;
-  desktopAvailable: boolean;
-  hasDiscussion: boolean;
-  hasBoard: boolean;
-}): SidebarSlotId[] {
-  return [
-    "detail",
-    ...(params.state.terminalAvailable ? (["terminal"] as const) : []),
-    ...(params.state.browserPanelAvailable ? (["browser"] as const) : []),
-    "workspace",
-    "companion",
-    "tasks",
-    ...(params.desktopAvailable ? (["desktop"] as const) : []),
-    ...(params.hasDiscussion ? (["discussion"] as const) : []),
-    ...(params.hasBoard ? (["chat"] as const) : []),
-  ];
+export function availableSidebarSlots(definitions: SidebarPanelDefinition[]): SidebarSlotId[] {
+  return definitions
+    .filter((definition) => definition.available)
+    .map((definition) => definition.slot);
+}
+
+export function sidebarPanelTemplates(
+  definitions: SidebarPanelDefinition[],
+): SidebarPanelTemplates {
+  const templates: SidebarPanelTemplates = {};
+  for (const definition of definitions) {
+    if (definition.content !== null) {
+      templates[definition.slot] = definition.content;
+    }
+  }
+  return templates;
 }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -28,9 +28,8 @@ import { requiresChatModelSetup } from "./chat-model-setup.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
 import {
   availableSidebarSlots,
-  companionRailTemplate,
-  discussionPanelTemplate,
-  embeddedSurfaceTemplates,
+  sidebarPanelDefinitions,
+  sidebarPanelTemplates,
   sidePanelHeaderActions,
 } from "./chat-pane-embedded-panels.ts";
 import {
@@ -69,7 +68,6 @@ import {
   renderSessionWorkspaceRail,
   revealSessionWorkspaceFile,
 } from "./components/chat-session-workspace.ts";
-import type { SidebarPanelTemplates } from "./components/chat-sidebar-region-types.ts";
 import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
@@ -630,49 +628,40 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
     const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
     const desktopAvailable = isDesktopPanelAvailable(gatewaySnapshot);
     const companionThread = this.sessionCompanionThreads.view(state.sessionKey, currentAgentId);
-    const panelTemplates: SidebarPanelTemplates = {
+    const panelDefinitions = sidebarPanelDefinitions({
+      state,
+      agentId: currentAgentId,
+      desktopAvailable,
+      hasBoard: board.hasBoard,
       chat,
       workspace: renderSessionWorkspaceRail(sessionWorkspace, { embedded: true }),
       tasks: renderBackgroundTasksRail(backgroundTasks, { embedded: true }),
-      companion: companionRailTemplate({
-        state,
-        digest: observerDigest ?? null,
-        activeRunId: observerRunId ?? null,
-        startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,
-        lastReadAt: selectedSession?.lastReadAt,
-        pullRequests: this.sessionPullRequests,
-        companion: companionThread,
-        onSubmit: (question) => void this.submitSessionCompanionQuestion(question),
-        onDraftChange: (draft) =>
-          this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
-        onVisibilityChange: this.setSessionObserverVisibility,
-      }),
-      ...embeddedSurfaceTemplates({
-        state,
-        agentId: currentAgentId,
-        desktopAvailable,
-      }),
-      ...(state.sidebarContent
-        ? {
-            detail: renderChatDetailSlot({
-              backgroundTasks,
-              chat: props,
-              content: state.sidebarContent,
-              fullMessageLoader,
-              host: state,
-              layout: sidebarLayout,
-              transcript: this.taskSidebarTranscript,
-            }),
-          }
-        : {}),
-      ...discussionPanelTemplate(discussion, this.connectionGeneration),
-    };
-    const availableSlots = availableSidebarSlots({
-      state,
-      desktopAvailable,
-      hasDiscussion: discussion !== null,
-      hasBoard: board.hasBoard,
+      detail: state.sidebarContent
+        ? renderChatDetailSlot({
+            backgroundTasks,
+            chat: props,
+            content: state.sidebarContent,
+            fullMessageLoader,
+            host: state,
+            layout: sidebarLayout,
+            transcript: this.taskSidebarTranscript,
+          })
+        : null,
+      digest: observerDigest ?? null,
+      activeRunId: observerRunId ?? null,
+      startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,
+      lastReadAt: selectedSession?.lastReadAt,
+      pullRequests: this.sessionPullRequests,
+      companion: companionThread,
+      onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
+      onCompanionDraftChange: (draft) =>
+        this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
+      onCompanionVisibilityChange: this.setSessionObserverVisibility,
+      discussion,
+      discussionSourceGeneration: this.connectionGeneration,
     });
+    const availableSlots = availableSidebarSlots(panelDefinitions);
+    const panelTemplates = sidebarPanelTemplates(panelDefinitions);
     const content = renderSidebarRegion({
       availableWidth: this.paneWidth,
       availableSlots,
@@ -687,6 +676,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
         setPanelOpen: (open) => this.setChatSidePanelOpen(open),
       }),
       layout: sidebarLayout,
+      panelDefinitions,
       panelActions: sidePanelHeaderActions({
         connected: state.connected,
         pendingQuestion: companionThread.pendingQuestion,

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -1,8 +1,10 @@
 import { html, type TemplateResult } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { sidebarPanelDefinitions } from "./chat-pane-embedded-panels.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import type {
+  SidebarPanelDefinition,
   SidebarPanelTemplates,
   SidebarRegionCallbacks,
 } from "./components/chat-sidebar-region-types.ts";
@@ -95,6 +97,7 @@ export function renderSidebarRegion(params: {
   availableSlots: SidebarSlotId[];
   layout: SidebarLayout;
   narrow: boolean;
+  panelDefinitions?: SidebarPanelDefinition[];
   panelActions: SidebarPanelTemplates;
   panelTemplates: SidebarPanelTemplates;
   primary: TemplateResult;
@@ -123,6 +126,7 @@ export function renderSidebarRegion(params: {
   >
     <openclaw-chat-sidebar-region
       .layout=${params.layout}
+      .panelDefinitions=${params.panelDefinitions ?? sidebarPanelDefinitions()}
       .panelTemplates=${params.panelTemplates}
       .panelActions=${params.panelActions}
       .availableSlots=${params.availableSlots}

--- a/ui/src/pages/chat/components/chat-sidebar-region-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region-types.ts
@@ -3,6 +3,19 @@ import type { SidebarDock, SidebarSlotId } from "../sidebar-layout.ts";
 
 export type SidebarPanelTemplates = Partial<Record<SidebarSlotId, TemplateResult | typeof nothing>>;
 
+export type SidebarPanelDefinition = {
+  slot: SidebarSlotId;
+  label: string;
+  icon: TemplateResult;
+  shortcut?: string;
+  available: boolean;
+  content: TemplateResult | typeof nothing | null;
+  empty: {
+    description: string;
+    action?: TemplateResult;
+  };
+};
+
 export type SidebarRegionCallbacks = {
   activatePanel: (panelId: string) => void;
   closeSlot: (slot: SidebarSlotId) => void;

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -13,6 +13,7 @@ import {
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
+import { sidebarPanelDefinitions } from "../chat-pane-embedded-panels.ts";
 import {
   SIDEBAR_MIN_HEIGHT_PX,
   SIDEBAR_MIN_WIDTH_PX,
@@ -23,88 +24,24 @@ import {
   type SidebarSlotId,
 } from "../sidebar-layout.ts";
 import { renderChatResizableDivider } from "./chat-resizable-divider.ts";
-import type { SidebarPanelTemplates, SidebarRegionCallbacks } from "./chat-sidebar-region-types.ts";
+import type {
+  SidebarPanelDefinition,
+  SidebarPanelTemplates,
+  SidebarRegionCallbacks,
+} from "./chat-sidebar-region-types.ts";
 
-type PanelType = {
-  slot: SidebarSlotId;
-  label: string;
-  description: string;
-  icon: TemplateResult;
-  shortcut?: string;
-};
-
-function panelType(slot: SidebarSlotId): PanelType {
-  switch (slot) {
-    case "browser":
-      return {
-        slot,
-        label: t("chat.sidePanel.browser"),
-        description: t("chat.sidePanel.browserEmpty"),
-        icon: icons.globe,
-      };
-    case "chat":
-      return {
-        slot,
-        label: t("chat.sidePanel.boardChat"),
-        description: t("chat.sidePanel.boardChatEmpty"),
-        icon: icons.messageSquare,
-      };
-    case "companion":
-      return {
-        slot,
-        label: t("chat.sidePanel.companion"),
-        description: t("chat.sidePanel.companionEmpty"),
-        icon: icons.bot,
-      };
-    case "desktop":
-      return {
-        slot,
-        label: t("chat.sidePanel.desktop"),
-        description: t("chat.sidePanel.desktopEmpty"),
-        icon: icons.monitor,
-      };
-    case "detail":
-      return {
-        slot,
-        label: t("chat.sidePanel.review"),
-        description: t("chat.sidePanel.reviewEmpty"),
-        icon: icons.diff,
-      };
-    case "discussion":
-      return {
-        slot,
-        label: t("chat.sidePanel.discussion"),
-        description: t("chat.sidePanel.discussionEmpty"),
-        icon: icons.messageSquare,
-      };
-    case "tasks":
-      return {
-        slot,
-        label: t("chat.sidePanel.tasks"),
-        description: t("chat.sidePanel.tasksEmpty"),
-        icon: icons.listChecks,
-      };
-    case "terminal":
-      return {
-        slot,
-        label: t("chat.sidePanel.terminal"),
-        description: t("chat.sidePanel.terminalEmpty"),
-        icon: icons.terminal,
-        shortcut: "Ctrl+`",
-      };
-    // Exhaustive over SidebarSlotId; "workspace" is the remaining member.
-    default:
-      return {
-        slot,
-        label: t("chat.sidePanel.files"),
-        description: t("chat.sidePanel.filesEmpty"),
-        icon: icons.fileText,
-        shortcut: "⇧⌘B",
-      };
+function panelType(
+  definitions: SidebarPanelDefinition[],
+  slot: SidebarSlotId,
+): SidebarPanelDefinition {
+  const definition = definitions.find((candidate) => candidate.slot === slot);
+  if (!definition) {
+    throw new Error(`Missing sidebar panel definition for ${slot}`);
   }
+  return definition;
 }
 
-function renderPanelTypeOption(type: PanelType, slotted = false) {
+function renderPanelTypeOption(type: SidebarPanelDefinition, slotted = false) {
   return html`
     <span slot=${slotted ? "icon" : nothing} class="side-panel-type-option__icon" aria-hidden="true"
       >${type.icon}</span
@@ -124,6 +61,7 @@ function panelsOf(layout: SidebarLayout): SidebarPanel[] {
 
 class ChatSidebarRegion extends OpenClawLightDomElement {
   @property({ attribute: false }) layout: SidebarLayout = { columns: [] };
+  @property({ attribute: false }) panelDefinitions = sidebarPanelDefinitions();
   @property({ attribute: false }) panelTemplates: SidebarPanelTemplates = {};
   // Header actions owned by the active panel. The tabbed model gives a panel no
   // header of its own, so an action on its content (open externally, clear the
@@ -148,8 +86,8 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     return true;
   }
 
-  private panelTypes(): PanelType[] {
-    return this.availableSlots.map(panelType);
+  private panelTypes(): SidebarPanelDefinition[] {
+    return this.availableSlots.map((slot) => panelType(this.panelDefinitions, slot));
   }
 
   private renderTypeMenu() {
@@ -200,7 +138,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
 
   private renderHeader(column: SidebarColumn) {
     const tabs = column.panels.map((panel) => {
-      const type = panelType(panel.slot);
+      const type = panelType(this.panelDefinitions, panel.slot);
       return {
         id: panel.id,
         domId: `side-panel-tab-${panel.id}`,
@@ -308,12 +246,13 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
 
   private renderEmpty(panel?: SidebarPanel) {
     if (panel) {
-      const type = panelType(panel.slot);
+      const type = panelType(this.panelDefinitions, panel.slot);
       return html`<div class="side-panel-empty side-panel-empty--type">
         ${renderPanelEmptyState({
           icon: type.icon,
           heading: type.label,
-          description: type.description,
+          description: type.empty.description,
+          action: type.empty.action,
         })}
       </div>`;
     }


### PR DESCRIPTION
## What Problem This Solves

A chat side-panel slot's identity was spread across four independent places: `panelType()` in
`chat-sidebar-region.runtime.ts` (label, icon, description, shortcut), the `panelTemplates` map in
`chat-pane-render.ts` (content), `availableSidebarSlots` in `chat-pane-embedded-panels.ts` (whether the slot
is offered at all), and `sidePanelHeaderActions` (header controls). Nothing tied "offered" to "has content"
to "what the operator does when it's empty", and a slot missing from the templates map silently fell through
to a generic empty state whose description came from a different file.

That scattering is not theoretical. It produced #124824, where making the Review slot user-openable gave it
a front door with no default document, so opening it showed "Open a change, file, image, or tool result to
review it here." on sessions that had changes.

## Why This Change Was Made

This is step 1 of a series that gives every slot one declaration — availability, content, empty state with
its action, and (in a follow-up) header actions — so the four consumers derive from a single source instead
of drifting apart. This PR introduces `SidebarPanelDefinition`, builds the definitions once per pane, and
derives `availableSidebarSlots` and `panelTemplates` from them. `panelType()`'s parallel switch is deleted;
label, icon, description, and shortcut now come from the same declaration as everything else.

The PR opens with a characterization e2e that records today's cold-open outcome for every offered slot —
including the wrong answers, such as Files rendering a generic empty state with no action. It passed before
the refactor and after it. That test is the guard for the rest of the series: later PRs flip its
expectations deliberately, and a refactor step that changes behavior by accident fails it.

## User Impact

None intended, and none observed. This is a pure refactor: same slots offered, same content, same copy, same
gating. Operator-visible behavior changes arrive in later PRs of this series.

## Evidence

No existing test file was modified — the diff adds one new e2e and touches only production modules, which is
the structural proof that the refactor preserved behavior rather than having its expectations adjusted to fit.

```
ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts | 129 +++++++++++   (new)
ui/src/pages/chat/chat-pane-embedded-panels.ts     | 255 ++++++++++++---------
ui/src/pages/chat/chat-pane-render.ts              |  76 +++---
ui/src/pages/chat/chat-pane-sidebar-layout.ts      |   4 +
ui/src/pages/chat/components/chat-sidebar-region-types.ts   |  13 ++
ui/src/pages/chat/components/chat-sidebar-region.runtime.ts | 105 ++-------
```

Local suites run by the worker: sidebar region + panel contract units 31 passed; Control UI e2e trio
(panel contract, session diff, terminal open) 11 passed; the characterization test additionally passed
against pre-refactor code. `pnpm format` clean, Codex autoreview clean.

Local re-verification on the maintainer machine was blocked by the repository's machine-global heavy-check
lock, held by unrelated concurrent worktrees; per repo policy that lock was not recovered. Exact-head CI is
the gate for this PR.

**reviewMetrics — production vs test LOC**: production `+218 / −235` (net **−17**), tests `+129 / −0`. The
production diff is net-negative because four construction sites collapse into one; the series should keep
trending negative as the remaining parallel paths are deleted.

No `CHANGELOG.md` edit — release-only per repo policy, and this step is behavior-neutral.
