### PR TITLE
refactor(types): discriminated unions for internal contracts — wave 2

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -280,7 +280,7 @@ extensions/cohere/provider-catalog.ts	3
 extensions/cohere/stream.ts	2
 extensions/comfy/workflow-runtime.ts	3
 extensions/copilot-proxy/index.ts	1
-extensions/copilot/harness.ts	9
+extensions/copilot/harness.ts	8
 extensions/copilot/src/attempt-config.ts	16
 extensions/copilot/src/attempt-execution.ts	4
 extensions/copilot/src/attempt-finalize.ts	5

--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -18,6 +18,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { AttemptParamsLike, ModelRefInputObject } from "./src/attempt-types.js";
 import type { CopilotSessionConfig } from "./src/attempt.js";
 import { createCopilotByokAuth, resolveCopilotAuth, tokenFingerprint } from "./src/auth-bridge.js";
 import { createCopilotByokProxy } from "./src/byok-proxy.js";
@@ -352,7 +353,15 @@ async function compactTrackedSdkSession(params: {
 // the token (see `tokenFingerprint` in `src/auth-bridge.ts`), so
 // rotating the token under the same profile id still invalidates
 // the compat key without ever serializing the raw credential.
-type CopilotSessionCompatParams = CopilotHarnessAttemptParams | AgentHarnessCompactParams;
+type CopilotCompactParamsLike = Omit<AgentHarnessCompactParams, "model"> &
+  Pick<AttemptParamsLike, "auth" | "copilotHome" | "profileVersion"> & {
+    model?: string | ModelRefInputObject;
+    modelId?: string;
+  };
+
+type CopilotSessionCompatInput =
+  | { kind: "attempt"; params: AttemptParamsLike }
+  | { kind: "compact"; params: CopilotCompactParamsLike };
 
 function readAgentIdFromSessionKey(sessionKey: unknown): string | undefined {
   if (typeof sessionKey !== "string") {
@@ -363,98 +372,31 @@ function readAgentIdFromSessionKey(sessionKey: unknown): string | undefined {
 }
 
 function computeSessionKey(
-  params: CopilotSessionCompatParams,
+  input: CopilotSessionCompatInput,
   options: { includeApi: boolean; includeAuth: boolean },
 ): string {
-  const p = params as CopilotSessionCompatParams & {
-    auth?: {
-      gitHubToken?: string;
-      profileId?: string;
-      profileVersion?: string;
-      useLoggedInUser?: boolean;
-    };
-    agentId?: string;
-    agentDir?: string;
-    authProfileId?: string;
-    copilotHome?: string;
-    cwd?: string;
-    modelId?: string;
-    model?:
-      | {
-          api?: string;
-          id?: string;
-          provider?: string;
-          baseUrl?: string;
-          azureApiVersion?: string;
-          headers?: Record<string, string | null | undefined>;
-          authHeader?: boolean;
-          params?: Record<string, unknown>;
-          request?: {
-            auth?: { mode?: unknown };
-            proxy?: unknown;
-            tls?: unknown;
-            allowPrivateNetwork?: unknown;
-          };
-          contextTokens?: number;
-          contextWindow?: number;
-          maxTokens?: number;
-        }
-      | string;
-    runtimeModel?: {
-      api?: string;
-      id?: string;
-      provider?: string;
-      baseUrl?: string;
-      azureApiVersion?: string;
-      headers?: Record<string, string | null | undefined>;
-      authHeader?: boolean;
-      params?: Record<string, unknown>;
-      request?: {
-        auth?: { mode?: unknown };
-        proxy?: unknown;
-        tls?: unknown;
-        allowPrivateNetwork?: unknown;
-      };
-      contextTokens?: number;
-      contextWindow?: number;
-      maxTokens?: number;
-    };
-    profileVersion?: string;
-    resolvedApiKey?: string;
-    sessionKey?: string;
-    workspaceDir?: string;
-  };
-  const modelObj: {
-    api?: string;
-    id?: string;
-    provider?: string;
-    baseUrl?: string;
-    azureApiVersion?: string;
-    headers?: Record<string, string | null | undefined>;
-    authHeader?: boolean;
-    params?: Record<string, unknown>;
-    request?: {
-      auth?: { mode?: unknown };
-      proxy?: unknown;
-      tls?: unknown;
-      allowPrivateNetwork?: unknown;
-    };
-    contextTokens?: number;
-    contextWindow?: number;
-    maxTokens?: number;
-  } =
-    p.model && typeof p.model === "object"
-      ? p.model
-      : p.runtimeModel && typeof p.runtimeModel === "object"
-        ? p.runtimeModel
-        : { id: typeof p.model === "string" ? p.model : undefined };
-  const provider = modelObj.provider ?? (typeof p.provider === "string" ? p.provider : "");
+  const attempt = input.kind === "attempt" ? input.params : undefined;
+  const compact = input.kind === "compact" ? input.params : undefined;
+  const attemptModel = attempt?.model;
+  const compactModel = compact?.model;
+  const rawModel: string | ModelRefInputObject | undefined = attemptModel ?? compactModel;
+  const modelObj: ModelRefInputObject =
+    rawModel && typeof rawModel === "object"
+      ? rawModel
+      : (compact?.runtimeModel ?? {
+          id: typeof rawModel === "string" ? rawModel : undefined,
+        });
+  const provider =
+    normalizeOptionalString(modelObj.provider) ?? attempt?.provider ?? compact?.provider ?? "";
   const modelId =
-    modelObj.id ??
-    (typeof p.modelId === "string" ? p.modelId : undefined) ??
-    (typeof p.model === "string" ? p.model : "");
+    normalizeOptionalString(modelObj.id) ??
+    attempt?.modelId ??
+    compact?.modelId ??
+    (typeof compactModel === "string" ? compactModel : "");
   const requestTransport =
-    p.model && typeof p.model === "object" ? getModelProviderRequestTransport(p.model) : undefined;
+    rawModel && typeof rawModel === "object"
+      ? getModelProviderRequestTransport(rawModel)
+      : undefined;
   const requestAuthMode = normalizeOptionalString(
     requestTransport?.auth?.mode ?? modelObj.request?.auth?.mode,
   );
@@ -475,20 +417,19 @@ function computeSessionKey(
   try {
     const resolved = !options.includeAuth
       ? resolveCopilotAuth({
-          agentId:
-            typeof p.agentId === "string" ? p.agentId : readAgentIdFromSessionKey(p.sessionKey),
-          agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
-          workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
-          copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
+          agentId: input.params.agentId ?? readAgentIdFromSessionKey(input.params.sessionKey),
+          agentDir: input.params.agentDir,
+          workspaceDir: input.params.workspaceDir,
+          copilotHome: input.params.copilotHome,
           auth: { useLoggedInUser: true },
         })
       : (() => {
           const modelProvider = resolveCopilotProvider({
             model: {
-              api: modelObj.api,
+              api: normalizeOptionalString(modelObj.api),
               id: modelId,
               provider,
-              baseUrl: modelObj.baseUrl,
+              baseUrl: normalizeOptionalString(modelObj.baseUrl),
               azureApiVersion,
               headers: modelObj.headers,
               authHeader: modelObj.authHeader,
@@ -501,33 +442,27 @@ function computeSessionKey(
               contextWindow: modelObj.contextWindow,
               maxTokens: modelObj.maxTokens,
             },
-            resolvedApiKey: typeof p.resolvedApiKey === "string" ? p.resolvedApiKey : undefined,
-            authProfileId: typeof p.authProfileId === "string" ? p.authProfileId : undefined,
+            resolvedApiKey: input.params.resolvedApiKey,
+            authProfileId: input.params.authProfileId,
           });
           return modelProvider.mode === "byok"
             ? createCopilotByokAuth({
-                agentId:
-                  typeof p.agentId === "string"
-                    ? p.agentId
-                    : readAgentIdFromSessionKey(p.sessionKey),
-                agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
-                workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
-                copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
+                agentId: input.params.agentId ?? readAgentIdFromSessionKey(input.params.sessionKey),
+                agentDir: input.params.agentDir,
+                workspaceDir: input.params.workspaceDir,
+                copilotHome: input.params.copilotHome,
                 authProfileId: modelProvider.authProfileId,
                 authProfileVersion: modelProvider.authProfileVersion,
               })
             : resolveCopilotAuth({
-                agentId:
-                  typeof p.agentId === "string"
-                    ? p.agentId
-                    : readAgentIdFromSessionKey(p.sessionKey),
-                agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
-                workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
-                copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
-                auth: p.auth,
-                resolvedApiKey: typeof p.resolvedApiKey === "string" ? p.resolvedApiKey : undefined,
-                authProfileId: typeof p.authProfileId === "string" ? p.authProfileId : undefined,
-                profileVersion: typeof p.profileVersion === "string" ? p.profileVersion : undefined,
+                agentId: input.params.agentId ?? readAgentIdFromSessionKey(input.params.sessionKey),
+                agentDir: input.params.agentDir,
+                workspaceDir: input.params.workspaceDir,
+                copilotHome: input.params.copilotHome,
+                auth: input.params.auth,
+                resolvedApiKey: input.params.resolvedApiKey,
+                authProfileId: input.params.authProfileId,
+                profileVersion: input.params.profileVersion,
               });
         })();
     resolvedAgentId = resolved.agentId;
@@ -546,14 +481,14 @@ function computeSessionKey(
   const parts = [
     `provider=${provider}`,
     `model=${modelId}`,
-    ...(options.includeApi ? [`api=${modelObj.api ?? ""}`] : []),
+    ...(options.includeApi ? [`api=${normalizeOptionalString(modelObj.api) ?? ""}`] : []),
     ...(options.includeApi
       ? [`baseUrlFingerprint=${fingerprintSessionValue(modelObj.baseUrl)}`]
       : []),
-    `cwd=${p.cwd ?? p.workspaceDir ?? ""}`,
+    `cwd=${input.params.cwd ?? input.params.workspaceDir ?? ""}`,
     `agentId=${resolvedAgentId}`,
-    `agentDir=${p.agentDir ?? ""}`,
-    `copilotHome=${p.copilotHome ?? ""}`,
+    `agentDir=${input.params.agentDir ?? ""}`,
+    `copilotHome=${input.params.copilotHome ?? ""}`,
     `resolvedCopilotHome=${resolvedCopilotHome}`,
     ...(options.includeAuth ? authParts : []),
   ];
@@ -564,12 +499,16 @@ function fingerprintSessionValue(value: unknown): string {
   return typeof value === "string" && value ? tokenFingerprint(value) : "";
 }
 
-function computeSessionCompatKey(params: CopilotSessionCompatParams): string {
-  return computeSessionKey(params, { includeApi: true, includeAuth: true });
+function computeSessionCompatKey(params: AttemptParamsLike): string {
+  return computeSessionKey({ kind: "attempt", params }, { includeApi: true, includeAuth: true });
 }
 
-function computeSessionCompactKey(params: CopilotSessionCompatParams): string {
-  return computeSessionKey(params, { includeApi: false, includeAuth: false });
+function computeAttemptCompactKey(params: AttemptParamsLike): string {
+  return computeSessionKey({ kind: "attempt", params }, { includeApi: false, includeAuth: false });
+}
+
+function computeCompactRequestKey(params: CopilotCompactParamsLike): string {
+  return computeSessionKey({ kind: "compact", params }, { includeApi: false, includeAuth: false });
 }
 
 function buildCopilotCompactionHookContext(params: AgentHarnessCompactParams) {
@@ -712,7 +651,7 @@ export function createCopilotAgentHarness(
       // Compatibility covers provider/model/cwd/auth; incompatible state starts
       // a fresh ordinary attempt but cannot be used for settled finalization.
       const currentCompatKey = computeSessionCompatKey(params);
-      const currentCompactKey = computeSessionCompactKey(params);
+      const currentCompactKey = computeAttemptCompactKey(params);
       const compactionCleanupPending =
         openclawSessionId !== undefined && hasPendingDeferredCompactionCleanup(openclawSessionId);
       const replayBlocked =
@@ -1044,7 +983,7 @@ export function createCopilotAgentHarness(
         };
       }
       const tracked = trackedSessions.get(openclawSessionId);
-      const currentCompactKey = computeSessionCompactKey(params);
+      const currentCompactKey = computeCompactRequestKey(params);
       const { resolvePoolAcquire } = await import("./src/attempt.js");
       let resolvedPoolAcquire: ReturnType<typeof resolvePoolAcquire> | undefined;
       let currentAuth: CopilotSessionAuth | undefined;

--- a/packages/ai/src/providers/clean-for-gemini.ts
+++ b/packages/ai/src/providers/clean-for-gemini.ts
@@ -208,10 +208,15 @@ function tryResolveLocalRef(ref: string, defs: SchemaDefs | undefined): unknown 
   return defs.get(name);
 }
 
-function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants: unknown[] }): {
-  variants: unknown[];
-  simplified?: unknown;
-} {
+function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants: unknown[] }):
+  | {
+      kind: "simplified";
+      value: unknown;
+    }
+  | {
+      kind: "variants";
+      value: unknown[];
+    } {
   const { obj, variants } = params;
 
   const { variants: nonNullVariants, stripped } = stripNullVariants(variants);
@@ -223,7 +228,7 @@ function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants:
       enum: flattened.enum,
     };
     copySchemaMeta(obj, result);
-    return { variants: nonNullVariants, simplified: result };
+    return { kind: "simplified", value: result };
   }
 
   if (stripped && nonNullVariants.length === 1) {
@@ -233,12 +238,12 @@ function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants:
         ...(lone as Record<string, unknown>),
       };
       copySchemaMeta(obj, result);
-      return { variants: nonNullVariants, simplified: result };
+      return { kind: "simplified", value: result };
     }
-    return { variants: nonNullVariants, simplified: lone };
+    return { kind: "simplified", value: lone };
   }
 
-  return { variants: stripped ? nonNullVariants : variants };
+  return { kind: "variants", value: stripped ? nonNullVariants : variants };
 }
 
 // Gemini rejects object schemas whose `required` entries do not exist in `properties`.
@@ -330,18 +335,18 @@ function cleanSchemaForGeminiWithDefs(
 
   if (hasAnyOf) {
     const simplified = simplifyUnionVariants({ obj, variants: cleanedAnyOf ?? [] });
-    cleanedAnyOf = simplified.variants;
-    if ("simplified" in simplified) {
-      return simplified.simplified;
+    if (simplified.kind === "simplified") {
+      return simplified.value;
     }
+    cleanedAnyOf = simplified.value;
   }
 
   if (hasOneOf) {
     const simplified = simplifyUnionVariants({ obj, variants: cleanedOneOf ?? [] });
-    cleanedOneOf = simplified.variants;
-    if ("simplified" in simplified) {
-      return simplified.simplified;
+    if (simplified.kind === "simplified") {
+      return simplified.value;
     }
+    cleanedOneOf = simplified.value;
   }
 
   const cleaned: Record<string, unknown> = {};

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -64,12 +64,10 @@ type RoutedAssembledChannelTurn = Omit<
 
 type AnyChannelDeliveryAdapter = ChannelEventDeliveryAdapter | ChannelTurnDeliveryAdapter;
 
-type PendingChannelDeliveryAttempt = {
-  payload: ReplyPayload;
-  info: ChannelDeliveryInfo;
-  result?: ChannelDeliveryResult | void;
-  error?: unknown;
-};
+type PendingChannelDeliveryAttempt = { payload: ReplyPayload; info: ChannelDeliveryInfo } & (
+  | { state: "fulfilled"; result: ChannelDeliveryResult | void }
+  | { state: "rejected"; error: unknown }
+);
 
 function resolvePartialChannelDeliveryResult(
   error: unknown,
@@ -230,11 +228,8 @@ async function settleChannelDeliveryAttempts(params: {
   }
 }
 
-// Failed-send custody policy: a permanent typed non-dispatch rejection is a
-// proven no-send (terminal suppression, no replay, no notice); an untyped error
-// after the pre-I/O claim affirms real ambiguity (unknown -> owed notice); a
-// retryable typed rejection restores prepared custody so recovery can replay —
-// the pre-claim already wrote unknown, and leaving it would fake ambiguity.
+// Permanent non-dispatch rejection proves no send; an untyped post-claim error stays ambiguous.
+// Retryable rejection restores prepared custody so recovery can replay instead of faking ambiguity.
 async function settleFailedPendingFinalDelivery(
   payload: ReplyPayload,
   error: unknown,
@@ -259,7 +254,7 @@ async function settleChannelDeliveryAttempt(params: {
   emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
 }): Promise<ChannelDeliveryResult | undefined> {
   const { attempt } = params;
-  if ("error" in attempt) {
+  if (attempt.state === "rejected") {
     const partial = resolvePartialChannelDeliveryResult(attempt.error);
     if (!isPlatformMessageNotDispatchedError(attempt.error)) {
       params.emitMessageSent?.({
@@ -398,8 +393,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
 ): Promise<ChannelTurnResult> {
   const [params, ownership] = args;
   const replyPipeline = resolveAssembledReplyPipeline(params);
-  const turnAdoptionLifecycle =
-    params.turnAdoptionLifecycle ?? params.replyOptions?.turnAdoptionLifecycle;
+  const adoption = params.turnAdoptionLifecycle ?? params.replyOptions?.turnAdoptionLifecycle;
   const delivery =
     params.admission?.kind === "observeOnly" ? createObserveOnlyDeliveryAdapter() : params.delivery;
   const pendingDeliveryAttempts: PendingChannelDeliveryAttempt[] = [];
@@ -465,11 +459,11 @@ async function dispatchChannelTurnWithDeliveryOwner(
       outboundEchoSourceId: params.outboundEchoSourceId,
       log: params.log,
       messageId: params.messageId,
-      ...(turnAdoptionLifecycle
+      ...(adoption
         ? {
             runDispatchLifecycle: {
-              turnAdoptionLifecycle,
-              onDispatchSkipped: async () => await turnAdoptionLifecycle.onAdopted(),
+              turnAdoptionLifecycle: adoption,
+              onDispatchSkipped: async () => await adoption.onAdopted(),
             },
           }
         : {}),
@@ -517,6 +511,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                     }
                     const { reason: _reason, ...deliveryInfo } = info;
                     normalizationSuppressionAttempts.push({
+                      state: "fulfilled",
                       payload,
                       info: deliveryInfo,
                       result: createSuppressedChannelDeliveryResult({ reason: info.reason }),
@@ -562,8 +557,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                       });
                       throwIfDurableInboundReplyDeliveryFailed(durable);
                       if (isDurableInboundReplyDeliveryHandled(durable)) {
-                        // Durable sends already emit canonical message_sent from
-                        // deliverOutboundPayloadsInternal after outbound hooks settle.
+                        // Durable sends emit canonical message_sent after outbound hooks settle.
                         await runChannelDeliveryObserver({
                           onDelivered: delivery.onDelivered,
                           payload: preparedPayload,
@@ -626,6 +620,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                       if (delivery.observeMessageSent) {
                         await settleChannelDeliveryAttempt({
                           attempt: {
+                            state: "rejected",
                             payload: effectivePayload,
                             info: directInfo,
                             error,
@@ -637,10 +632,10 @@ async function dispatchChannelTurnWithDeliveryOwner(
                       throw error;
                     }
                     if (result?.finalization) {
-                      // Finalization can reject while the buffered dispatcher is still unwinding.
-                      // Observe it now; settlement still awaits the original promise and its error.
+                      // Observe rejection while the dispatcher unwinds; settlement awaits the same promise.
                       void result.finalization.catch(() => undefined);
                       pendingDeliveryAttempts.push({
+                        state: "fulfilled",
                         payload: effectivePayload,
                         info: directInfo,
                         result,
@@ -648,6 +643,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                     } else {
                       const finalized = await settleChannelDeliveryAttempt({
                         attempt: {
+                          state: "fulfilled",
                           payload: effectivePayload,
                           info: directInfo,
                           result,
@@ -694,9 +690,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
         } catch (error: unknown) {
           settlementError = error;
         }
-        // Deferred settlement can carry the provider-visible receipt/content that the earlier
-        // dispatch failure lacks. Preserve that partial result so callers do not retry a send
-        // that the channel already accepted.
+        // Preserve deferred provider receipts so callers do not retry an accepted send.
         if (
           settlementError !== undefined &&
           resolvePartialChannelDeliveryResult(settlementError) !== undefined
@@ -734,9 +728,8 @@ export function dispatchRoutedChannelTurn(params: ChannelTurnPlan): Promise<Chan
 export async function dispatchRoutedChannelTurn(
   params: ChannelTurnPlan<ChannelTurnDeliveryAdapter>,
 ): Promise<ChannelTurnResult> {
-  const assembled = assembleResolvedChannelTurn(params);
   return await dispatchChannelTurnWithDeliveryOwner(
-    assembled as RoutedAssembledChannelTurn,
+    assembleResolvedChannelTurn(params) as RoutedAssembledChannelTurn,
     "routed-delivery",
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Three internal runtime contracts still encoded mutually exclusive variants through overlapping optional fields or broad intersection casts. Consumers had to rediscover producer intent with property-presence and repeated type probes, leaving impossible states representable.

## Why This Change Was Made

This wave follows #124845's internal-only retrofit pattern:

- Copilot session-key computation now receives an explicit `attempt` or `compact` arm and preserves the legacy compact input semantics through a narrow existing model-input contract. This removes 24 net structural probe/cast sites while retaining the four semantic model-shape checks.
- Gemini union simplification now returns `kind: "simplified" | "variants"`, removing two `"simplified" in` probes.
- Channel delivery settlement now records `state: "fulfilled" | "rejected"`, removing the error-presence probe and making result/error overlap impossible.
- The Memory Core candidate was intentionally stopped. Its five probes sit downstream of `MemoryFileEntry` and `SessionFileEntry`, which are exported through the Memory Host SDK and Plugin SDK. A local wrapper would remove only the session line-map probe while leaving the multimodal probes, so it would fail the deletion-payoff rule without changing a public contract.

The Copilot assertion-safety baseline shrinks from 9 to 8 with the deleted cast/probe path.

Production LOC: +103/-166 (net -63). Tests: +0/-0. Baseline: +1/-1.

## User Impact

No user-visible behavior changes. Internal producers now carry their variant facts directly, while public SDK, serialized, persisted, Gateway, and SQLite shapes remain unchanged.

## Evidence

- Post-rebase focused Vitest: 4 files, 156 tests passed (Gemini 25, channel delivery/finalization 36, Copilot 95).
- Full lint: `pnpm lint` passed across core, plugins, and scripts.
- `node scripts/check-changed.mjs`: passed all ratchets, formatting, core/plugin production and test typechecks, full lint, doctor contracts, dead exports, database-first/schema guards, and import cycles on Testbox `tbx_01m06m3qwgx4adbvys5aqj1g2p`; Actions run https://github.com/openclaw/openclaw/actions/runs/31983985072.
- Autoreview: 23,517-byte branch bundle; secret scan clean; no accepted/actionable findings.
