### PR TITLE
feat(agents): preserve create request provenance

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -110,6 +110,12 @@ Starting a guided setup flow also runs immediately: channel setup (`connect tele
 
 Persistent operations require conversational approval (or `--yes` for a direct command): write config, `config set`, `config set-ref`, setup/onboarding bootstrap, change the default model, start/stop/restart the Gateway, create agents, and install plugins.
 
+Configured agents can ask OpenClaw to create another agent through their
+`openclaw` tool. The request enters the same typed create-agent operation and
+operator approval flow used by Ask OpenClaw; the approval summary names the
+requesting agent. OpenClaw remains the executor, and approved creation records
+that requesting agent as the new agent's creator.
+
 Doctor repairs are unavailable inside OpenClaw because they can rewrite the provider, authentication, or default-agent inference route powering the session. Exit OpenClaw and run `openclaw doctor --fix` in a terminal. Read-only `doctor` remains available inside OpenClaw.
 
 New agents inherit the live-verified default inference route. The agent ids `openclaw` and `crestodian` are reserved for the system agent and cannot be created as normal agents. The retired id remains blocked so an old config cannot claim it.

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -87,7 +87,10 @@ openclaw agents list --bindings
 OpenClaw records how each configured agent was created: `operator` for CLI,
 onboarding, and Gateway requests; `agent` when the system agent requested it;
 and `claw` when a Claw install added it. Agent-created entries also retain the
-requesting agent id. Inspect the current creation hierarchy with:
+requesting agent id. A configured agent can ask OpenClaw to create another
+agent through its `openclaw` tool. The system agent files the typed operation,
+shows the requesting agent id to the operator, and creates the agent only after
+operator approval. Inspect the current creation hierarchy with:
 
 ```bash
 openclaw agents list --tree

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -337,6 +337,7 @@ describe("resolveSubagentToolPolicyForSession", () => {
       const hardDeniedTools = [
         "gateway",
         "agents_list",
+        "openclaw",
         "session_status",
         "automations",
         "cron",

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -53,6 +53,7 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   // System admin - dangerous from subagent
   "gateway",
   "agents_list",
+  "openclaw",
   // Status/scheduling - main agent coordinates
   "session_status",
   AUTOMATIONS_TOOL_NAME,

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -70,14 +70,19 @@ function makeEngine(): FakeEngine {
 }
 
 const createdEngines = vi.hoisted(() => [] as FakeEngine[]);
+const createdEngineOptions = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 
 vi.mock("../../system-agent/chat-engine.js", () => {
   class FakeSystemAgentWizardAnswerError extends Error {}
   return {
     SystemAgentWizardAnswerError: FakeSystemAgentWizardAnswerError,
-    SystemAgentChatEngine: function FakeSystemAgentChatEngine(this: FakeEngine) {
+    SystemAgentChatEngine: function FakeSystemAgentChatEngine(
+      this: FakeEngine,
+      options: Record<string, unknown>,
+    ) {
       const engine = makeEngine();
       createdEngines.push(engine);
+      createdEngineOptions.push(options);
       Object.assign(this, engine);
     },
   };
@@ -142,6 +147,7 @@ async function callChat(
 
 beforeEach(() => {
   createdEngines.length = 0;
+  createdEngineOptions.length = 0;
   inferenceFallbackMocks.verifySystemAgentInferenceWithFallback.mockResolvedValue({
     ok: true,
     binding: {},
@@ -315,6 +321,11 @@ describe("openclaw.chat session ownership", () => {
     expect(inferenceFallbackMocks.verifySystemAgentInferenceWithFallback).toHaveBeenCalledWith({
       requestingAgentId: "main",
       runtime: expect.anything(),
+    });
+    expect(createdEngineOptions[0]).toMatchObject({
+      operatorApprovalOnly: true,
+      requesterAgentId: "main",
+      surface: "gateway",
     });
     const handle = expectDefined(createdEngines[0], "created delegated engine").handle;
 

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -602,6 +602,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             surface: "gateway",
             verifiedInference: inference.binding,
             operatorApprovalOnly: params.delegation !== undefined,
+            ...(params.delegation?.agentId ? { requesterAgentId: params.delegation.agentId } : {}),
           });
           // `reset: true` keeps the durable logbook but deliberately starts
           // model context clean; only ordinary fresh sessions receive its tail.

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -51,6 +51,8 @@ export type SystemAgentChatEngineOptions = {
   surface?: "cli" | "gateway";
   readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
   operatorApprovalOnly?: boolean;
+  /** Host-recorded origin for delegated create-agent proposals. */
+  requesterAgentId?: string;
 };
 
 type SystemAgentChatEngineInternals = {

--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./chat-engine.test-support.js";
 import { ChatTurnRouter } from "./chat-turn-router.js";
 import { ChatWizardHost } from "./chat-wizard-host.js";
+import { describeSystemAgentPersistentOperation } from "./operations.js";
 
 function createRouterHarness(options: ConstructorParameters<typeof ChatTurnRouter>[0]) {
   const verifiedInference = expectDefined(
@@ -43,6 +44,36 @@ function createRouterHarness(options: ConstructorParameters<typeof ChatTurnRoute
 }
 
 describe("SystemAgentChatEngine approval", () => {
+  it("records the delegated requester before hashing a model-tool proposal", async () => {
+    const unrecordedOperation = {
+      kind: "create-agent" as const,
+      agentId: "researcher",
+      workspace: "/tmp/researcher",
+    };
+    const unrecordedHash = hashSystemAgentOperation(unrecordedOperation);
+    const router = createRouterHarness({
+      operatorApprovalOnly: true,
+      requesterAgentId: "research",
+      runAgentTurn: async ({ session }) => {
+        session.proposalRef.current = unrecordedHash;
+        session.proposalRef.operation = unrecordedOperation;
+        return { text: "Creation needs operator approval." };
+      },
+    });
+
+    await router.resolveTurn("Create a research agent.");
+    const proposal = expectDefined(router.getPendingOperatorProposal(), "delegated proposal");
+
+    expect(proposal.operation).toEqual({
+      ...unrecordedOperation,
+      requesterAgentId: "research",
+    });
+    expect(proposal.hash).not.toBe(unrecordedHash);
+    expect(describeSystemAgentPersistentOperation(proposal.operation)).toContain(
+      "requested by agent research",
+    );
+  });
+
   it("lets only an operator arm delegated persistent writes", async () => {
     useTempStateDir();
     const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
@@ -211,37 +242,72 @@ describe("SystemAgentChatEngine approval", () => {
     expect(reply.text).toContain("Settings → Ask OpenClaw");
   });
 
-  it("hatches into a newly created agent and carries its id", async () => {
-    useTempStateDir();
-    const createAgent = vi.fn(async () => ({
-      status: "created" as const,
-      agentId: "researcher",
-      name: "researcher",
-      workspace: "/tmp/researcher",
-      agentDir: "/tmp/agent-researcher",
-      bootstrapPending: true,
-    }));
-    const engine = new SystemAgentChatEngine({
-      runAgentTurn: async () => null,
-      planWithAssistant: async () => null,
-      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
-      deps: { createAgent, loadOverview: fakeOverviewLoader() },
-    });
-    engine.propose({ kind: "create-agent", agentId: "researcher" });
+  it.each([
+    {
+      origin: "custodian",
+      requesterAgentId: undefined,
+      expectedCreatorAgentId: "openclaw",
+      expectedDescription: "create agent researcher with workspace /tmp/researcher",
+    },
+    {
+      origin: "delegated agent",
+      requesterAgentId: "research",
+      expectedCreatorAgentId: "research",
+      expectedDescription:
+        "create agent researcher with workspace /tmp/researcher, requested by agent research",
+    },
+  ])(
+    "hatches an agent requested by the $origin with approval-bound provenance",
+    async ({ requesterAgentId, expectedCreatorAgentId, expectedDescription }) => {
+      useTempStateDir();
+      const createAgent = vi.fn(async () => ({
+        status: "created" as const,
+        agentId: "researcher",
+        name: "researcher",
+        workspace: "/tmp/researcher",
+        agentDir: "/tmp/agent-researcher",
+        bootstrapPending: true,
+      }));
+      const engine = new SystemAgentChatEngine({
+        runAgentTurn: async () => null,
+        planWithAssistant: async () => null,
+        classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+        deps: { createAgent, loadOverview: fakeOverviewLoader() },
+        ...(requesterAgentId ? { requesterAgentId, operatorApprovalOnly: true } : {}),
+      });
+      engine.propose({
+        kind: "create-agent",
+        agentId: "researcher",
+        workspace: "/tmp/researcher",
+      });
+      const proposal = expectDefined(engine.getPendingOperatorProposal(), "create-agent proposal");
 
-    const reply = await engine.handle("yes");
+      expect(proposal.operation).toEqual({
+        kind: "create-agent",
+        agentId: "researcher",
+        workspace: "/tmp/researcher",
+        ...(requesterAgentId ? { requesterAgentId } : {}),
+      });
+      expect(describeSystemAgentPersistentOperation(proposal.operation)).toBe(expectedDescription);
 
-    expect(createAgent).toHaveBeenCalledWith({
-      name: "researcher",
-      provenance: { createdVia: "agent", creatorAgentId: "openclaw" },
-    });
-    expect(reply.action).toBe("open-tui");
-    expect(reply.handoff).toMatchObject({
-      kind: "open-tui",
-      agentId: "researcher",
-      agentDraft: "hatch",
-    });
-  });
+      const reply = expectDefined(
+        await engine.resolveOperatorApproval("allow-once", proposal.hash),
+        "approved create-agent reply",
+      );
+
+      expect(createAgent).toHaveBeenCalledWith({
+        name: "researcher",
+        workspace: "/tmp/researcher",
+        provenance: { createdVia: "agent", creatorAgentId: expectedCreatorAgentId },
+      });
+      expect(reply.action).toBe("open-tui");
+      expect(reply.handoff).toMatchObject({
+        kind: "open-tui",
+        agentId: "researcher",
+        agentDraft: "hatch",
+      });
+    },
+  );
 
   it("stays in setup when an established workspace has no bootstrap pending", async () => {
     useTempStateDir();

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -56,6 +56,7 @@ type ChatTurnRouterOptions = {
   classifyApproval?: SystemAgentApprovalClassifier;
   surface?: "cli" | "gateway";
   operatorApprovalOnly?: boolean;
+  requesterAgentId?: string;
 };
 
 type CaptureRuntime = RuntimeEnv & { read: () => string };
@@ -153,8 +154,8 @@ export class ChatTurnRouter {
 
   propose(operation: SystemAgentOperation): string {
     this.clearPendingProposals();
-    this.pending = operation;
-    return describeSystemAgentPersistentOperation(operation);
+    this.pending = this.recordCreateAgentRequester(operation);
+    return describeSystemAgentPersistentOperation(this.pending);
   }
 
   hasPendingProposal(): boolean {
@@ -162,6 +163,16 @@ export class ChatTurnRouter {
   }
 
   getPendingOperatorProposal(): { operation: SystemAgentOperation; hash: string } | null {
+    const proposalOperation = this.agentSession.proposalRef.operation;
+    if (proposalOperation) {
+      const recordedOperation = this.recordCreateAgentRequester(proposalOperation);
+      if (recordedOperation !== proposalOperation) {
+        // Request provenance is part of the exact approval-bound operation.
+        // Replace the model-tool hash before exposing the proposal to the operator.
+        this.agentSession.proposalRef.current = undefined;
+        this.agentSession.proposalRef.operation = recordedOperation;
+      }
+    }
     return resolvePendingOperatorProposal(this.pending, this.agentSession.proposalRef);
   }
 
@@ -524,16 +535,17 @@ export class ChatTurnRouter {
     operation: SystemAgentOperation,
     provenance: string | undefined,
   ): Promise<SystemAgentChatReply> {
+    const recordedOperation = this.recordCreateAgentRequester(operation);
     await this.callbacks.requireVerifiedInference();
-    if (operation.kind === "open-tui") {
+    if (recordedOperation.kind === "open-tui") {
       this.clearPendingProposals();
       return {
         text: "Opening your normal agent TUI. Use /openclaw there to come back.",
         action: "open-tui",
-        handoff: operation,
+        handoff: recordedOperation,
       };
     }
-    if (operation.kind === "open-setup") {
+    if (recordedOperation.kind === "open-setup") {
       this.clearPendingProposals();
       if (this.options.surface === "gateway") {
         return {
@@ -541,13 +553,13 @@ export class ChatTurnRouter {
           action: "none",
         };
       }
-      if (!["channels", "search", "gateway"].includes(operation.target)) {
+      if (!["channels", "search", "gateway"].includes(recordedOperation.target)) {
         return {
           text: "Setup can replace the inference route powering this session. Exit OpenClaw and run `openclaw onboard`; it saves only a route that passes a live test. Then start OpenClaw again.",
           action: "none",
         };
       }
-      let handoff = operation;
+      let handoff = recordedOperation;
       if (handoff.target === "channels" && !handoff.channel) {
         if (!this.lastSensitiveChannel) {
           this.awaitingSetupChannel = true;
@@ -568,44 +580,44 @@ export class ChatTurnRouter {
             : "Gateway setup";
       return { text: `Opening the ${label} wizard.`, action: "open-setup", handoff };
     }
-    if (operation.kind === "channel-setup") {
-      return await this.startWizard(this.wizard.startChannel(operation.channel));
+    if (recordedOperation.kind === "channel-setup") {
+      return await this.startWizard(this.wizard.startChannel(recordedOperation.channel));
     }
-    if (operation.kind === "skills-setup") {
+    if (recordedOperation.kind === "skills-setup") {
       return await this.startWizard(this.wizard.startSkills());
     }
-    if (operation.kind === "search-setup") {
+    if (recordedOperation.kind === "search-setup") {
       return await this.startWizard(this.wizard.startSearch());
     }
-    if (operation.kind === "gateway-config-setup") {
+    if (recordedOperation.kind === "gateway-config-setup") {
       return await this.startWizard(this.wizard.startGateway());
     }
-    if (operation.kind === "memory-import") {
+    if (recordedOperation.kind === "memory-import") {
       return await this.startWizard(this.wizard.startMemoryImport());
     }
-    if (operation.kind === "model-setup") {
+    if (recordedOperation.kind === "model-setup") {
       return this.startModelSetup();
     }
 
     const capture = createCaptureRuntime();
-    if (isPersistentSystemAgentOperation(operation) && !this.options.yes) {
+    if (isPersistentSystemAgentOperation(recordedOperation) && !this.options.yes) {
       this.clearPendingProposals();
-      this.pending = operation;
-      await executeSystemAgentOperation(operation, capture, {
+      this.pending = recordedOperation;
+      await executeSystemAgentOperation(recordedOperation, capture, {
         approved: false,
         deps: this.commandDeps(),
       });
       return {
-        text: [provenance, capture.read(), approvalQuestion(operation)]
+        text: [provenance, capture.read(), approvalQuestion(recordedOperation)]
           .filter(Boolean)
           .join("\n\n"),
         action: "none",
       };
     }
     const result = await this.executeOperation(
-      operation,
+      recordedOperation,
       capture,
-      this.options.yes === true || !isPersistentSystemAgentOperation(operation),
+      this.options.yes === true || !isPersistentSystemAgentOperation(recordedOperation),
     );
     const verify = result?.applied ? await this.callbacks.verifyConfigAfterWrite() : null;
     const followUp = this.armFollowUp(result?.followUp);
@@ -689,6 +701,18 @@ export class ChatTurnRouter {
     this.pending = null;
     this.agentSession.proposalRef.current = undefined;
     this.agentSession.proposalRef.operation = undefined;
+  }
+
+  private recordCreateAgentRequester(operation: SystemAgentOperation): SystemAgentOperation {
+    const requesterAgentId = this.options.requesterAgentId?.trim();
+    if (
+      operation.kind !== "create-agent" ||
+      !requesterAgentId ||
+      operation.requesterAgentId === requesterAgentId
+    ) {
+      return operation;
+    }
+    return { ...operation, requesterAgentId };
   }
 
   private armFollowUp(operation: SystemAgentOperation | undefined): string | null {

--- a/src/system-agent/operation-types.ts
+++ b/src/system-agent/operation-types.ts
@@ -47,6 +47,12 @@ export type SystemAgentOperation =
   | { kind: "plugin-install"; spec: string }
   | { kind: "plugin-uninstall"; pluginId: string }
   | { kind: "audit" }
-  | { kind: "create-agent"; agentId: string; workspace?: string; model?: string }
+  | {
+      kind: "create-agent";
+      agentId: string;
+      workspace?: string;
+      model?: string;
+      requesterAgentId?: string;
+    }
   | { kind: "open-tui"; agentId?: string; workspace?: string; agentDraft?: "hatch" }
   | { kind: "set-default-model"; model: string; agentId?: string };

--- a/src/system-agent/operations-execute.ts
+++ b/src/system-agent/operations-execute.ts
@@ -413,7 +413,10 @@ export async function executeSystemAgentOperation(
             return await createAgentForOperation({
               name: operation.agentId,
               ...(operation.workspace ? { workspace: operation.workspace } : {}),
-              provenance: { createdVia: "agent", creatorAgentId: SYSTEM_AGENT_ID },
+              provenance: {
+                createdVia: "agent",
+                creatorAgentId: operation.requesterAgentId ?? SYSTEM_AGENT_ID,
+              },
             });
           });
           if (result.status === "error") {

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -545,7 +545,12 @@ export function describeSystemAgentPersistentOperation(operation: SystemAgentOpe
     case "plugin-uninstall":
       return `uninstall plugin ${operation.pluginId}`;
     case "create-agent":
-      return `create agent ${operation.agentId} with workspace ${formatCreateAgentWorkspace(operation.workspace)}`;
+      return [
+        `create agent ${operation.agentId} with workspace ${formatCreateAgentWorkspace(operation.workspace)}`,
+        operation.requesterAgentId ? `requested by agent ${operation.requesterAgentId}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(", ");
     case "gateway-start":
       return "start the Gateway";
     case "gateway-stop":


### PR DESCRIPTION
## What Problem This Solves

Phase 1 in #124828 added durable agent provenance and `openclaw agents list --tree`, but agent creation initiated through the delegated `openclaw` tool still appeared to originate from the custodian. Operators could approve the right creation request while the resulting provenance lost the non-custodian agent that actually requested it.

## Why This Change Was Made

This threads the authenticated requesting agent ID into create-agent operations before their approval hash is computed, includes that requester in the operator-facing approval text, and records it as the new agent's creator. The custodian remains the sole executor, the existing operator approval gate is unchanged, custodian-originated creation still records the system agent, and subagents are hard-denied access to the `openclaw` tool.

## User Impact

Operators can now see which non-custodian agent requested a new agent both while approving the request and later in provenance/tree views. No creation authority moves to the requesting agent: the custodian still executes the operation only after operator approval.

## Evidence

- Focused Vitest coverage passed for the three touched behavior shards: `src/system-agent/chat-turn-router.approval.test.ts` (110 tests), `src/gateway/server-methods/system-agent-session-ownership.test.ts` (16 tests), and `src/agents/agent-tools.policy.test.ts` (36 tests).
- `pnpm tsgo`, `pnpm check:test-types`, `pnpm oxlint`, and `pnpm format:check` passed.
- The full changed gate passed.
- Fresh post-rebase branch autoreview passed with TruffleHog clean and no accepted/actionable findings.
