### PR TITLE
fix(agents): flush memory after CLI and gateway turns

### DIFF
--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import { defaultRuntime } from "../runtime.js";
 import type { runAgentAttempt } from "./command/attempt-execution.runtime.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
 import type { loadManifestModelCatalog } from "./model-catalog.js";
@@ -41,6 +42,10 @@ const state = vi.hoisted(() => ({
   runCliTurnCompactionLifecycleMock: vi.fn(
     async (params: CliCompactionParams) => params.sessionEntry,
   ),
+  runMemoryFlushIfNeededMock: vi.fn(async (params: { sessionEntry?: SessionEntry }) => ({
+    sessionEntry: params.sessionEntry,
+    outcome: "completed" as const,
+  })),
   deliverAgentCommandResultMock: vi.fn(),
   emitAgentEventMock: vi.fn(),
   deliveryFreshEntries: [] as Array<SessionEntry | undefined>,
@@ -181,6 +186,11 @@ vi.mock("./command/cli-compaction.js", () => ({
     state.runCliTurnCompactionLifecycleMock(params),
 }));
 
+vi.mock("../auto-reply/reply/agent-runner-memory.js", () => ({
+  runMemoryFlushIfNeeded: (params: { sessionEntry?: SessionEntry }) =>
+    state.runMemoryFlushIfNeededMock(params),
+}));
+
 vi.mock("../infra/agent-events.js", async () => {
   const actual = await vi.importActual<typeof import("../infra/agent-events.js")>(
     "../infra/agent-events.js",
@@ -199,9 +209,12 @@ vi.mock("./command/delivery.runtime.js", () => ({
 }));
 
 let agentCommand: typeof import("./agent-command.js").agentCommand;
+let agentCommandFromGatewayIngress: typeof import("./agent-command.js").agentCommandFromGatewayIngress;
 
 beforeAll(async () => {
-  agentCommand = (await import("./agent-command.js")).agentCommand;
+  const command = await import("./agent-command.js");
+  agentCommand = command.agentCommand;
+  agentCommandFromGatewayIngress = command.agentCommandFromGatewayIngress;
 });
 
 beforeEach(async () => {
@@ -462,10 +475,20 @@ describe("agentCommand compaction transcript rotation", () => {
     ).resolves.toContainEqual(expect.objectContaining({ role: "assistant" }));
   });
 
-  it("keeps embedded assistant transcript ownership when visible text is projected", async () => {
+  it("keeps embedded transcript ownership and flushes once for gateway ingress", async () => {
     const storePath = requireStorePath();
     const sessionId = "embedded-projected-final";
     const sessionKey = `agent:main:explicit:${sessionId}`;
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: Date.now(),
+        totalTokens: 180_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+    );
     state.runAgentAttemptMock.mockImplementationOnce(async (attempt) => {
       if (!attempt.userTurnTranscriptRecorder) {
         throw new Error("missing embedded user-turn transcript recorder");
@@ -500,12 +523,18 @@ describe("agentCommand compaction transcript rotation", () => {
       });
     });
 
-    await agentCommand({
-      message: "Reply with exactly: OVERRIDE-OK",
-      sessionId,
-      sessionKey,
-      cwd: state.workspaceDir,
-    });
+    await agentCommandFromGatewayIngress(
+      {
+        message: "Reply with exactly: OVERRIDE-OK",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        allowModelOverride: false,
+      },
+      defaultRuntime,
+      undefined,
+      {},
+    );
 
     const events = (await loadTranscriptEvents({
       agentId: "main",
@@ -527,6 +556,10 @@ describe("agentCommand compaction transcript rotation", () => {
           event.type === "custom" && event.customType === "openclaw:bootstrap-context:full",
       ),
     ).toHaveLength(1);
+    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledOnce();
+    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionEntry: expect.objectContaining({ totalTokens: 180_000 }) }),
+    );
   });
 
   it("persists the pending final before CLI compaction failure and still delivers", async () => {

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -24,6 +24,7 @@ type ProviderModelNormalizationParams = { provider: string; context: { modelId: 
 type LoadManifestModelCatalogParams = Parameters<typeof loadManifestModelCatalog>[0];
 type RunAgentAttempt = typeof runAgentAttempt;
 type CliCompactionParams = {
+  sessionId: string;
   sessionEntry?: SessionEntry;
   sessionKey: string;
   sessionStore?: Record<string, SessionEntry>;
@@ -559,6 +560,37 @@ describe("agentCommand compaction transcript rotation", () => {
     expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledOnce();
     expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledWith(
       expect.objectContaining({ sessionEntry: expect.objectContaining({ totalTokens: 180_000 }) }),
+    );
+  });
+
+  it("compacts the session successor returned by CLI memory flush", async () => {
+    const sessionId = "cli-memory-flush-predecessor";
+    const successorSessionId = "cli-memory-flush-successor";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    state.runAgentAttemptMock.mockResolvedValueOnce(
+      makeResult({ sessionId, text: "answer before maintenance rotation", runner: "cli" }),
+    );
+    state.runMemoryFlushIfNeededMock.mockImplementationOnce(
+      async (params: { sessionEntry?: SessionEntry }) => ({
+        sessionEntry: params.sessionEntry
+          ? { ...params.sessionEntry, sessionId: successorSessionId }
+          : undefined,
+        outcome: "completed" as const,
+      }),
+    );
+
+    await agentCommand({
+      message: "rotate during memory maintenance",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+    });
+
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: successorSessionId,
+        sessionEntry: expect.objectContaining({ sessionId: successorSessionId }),
+      }),
     );
   });
 

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -563,37 +563,6 @@ describe("agentCommand compaction transcript rotation", () => {
     );
   });
 
-  it("compacts the session successor returned by CLI memory flush", async () => {
-    const sessionId = "cli-memory-flush-predecessor";
-    const successorSessionId = "cli-memory-flush-successor";
-    const sessionKey = `agent:main:explicit:${sessionId}`;
-    state.runAgentAttemptMock.mockResolvedValueOnce(
-      makeResult({ sessionId, text: "answer before maintenance rotation", runner: "cli" }),
-    );
-    state.runMemoryFlushIfNeededMock.mockImplementationOnce(
-      async (params: { sessionEntry?: SessionEntry }) => ({
-        sessionEntry: params.sessionEntry
-          ? { ...params.sessionEntry, sessionId: successorSessionId }
-          : undefined,
-        outcome: "completed" as const,
-      }),
-    );
-
-    await agentCommand({
-      message: "rotate during memory maintenance",
-      sessionId,
-      sessionKey,
-      cwd: state.workspaceDir,
-    });
-
-    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: successorSessionId,
-        sessionEntry: expect.objectContaining({ sessionId: successorSessionId }),
-      }),
-    );
-  });
-
   it("persists the pending final before CLI compaction failure and still delivers", async () => {
     const sessionId = "cli-compaction-failure";
     const sessionKey = `agent:main:explicit:${sessionId}`;
@@ -965,7 +934,7 @@ describe("agentCommand compaction transcript rotation", () => {
     const payloads = [{ mediaUrl: "/tmp/reply.ogg", audioAsVoice: true }];
     state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "", payloads }));
 
-    const result = await agentCommand({
+    await agentCommand({
       message: "room message",
       sessionId,
       sessionKey,
@@ -977,13 +946,9 @@ describe("agentCommand compaction transcript rotation", () => {
     });
 
     expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
-    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
       expect.objectContaining({ payloads }),
     );
-    expect(result).toMatchObject({ deliverySucceeded: true });
-    const storedEntry = findStoredSessionEntry(sessionKey);
-    expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
   });
 
   it("skips post-turn compaction when a recoverable final cannot persist a pending marker", async () => {
@@ -1017,7 +982,10 @@ describe("agentCommand compaction transcript rotation", () => {
     const sessionId = "unrecoverable-media-no-delivery";
     const sessionKey = `agent:main:explicit:${sessionId}`;
     const payloads = [{ mediaUrl: "/tmp/reply.ogg", audioAsVoice: true }];
+    const successor = { sessionId: "unrecoverable-media-post-flush" } as SessionEntry;
     state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "", payloads }));
+    const flush = state.runMemoryFlushIfNeededMock;
+    flush.mockResolvedValueOnce({ sessionEntry: successor, outcome: "completed" });
 
     await agentCommand({
       message: "local model run",
@@ -1030,7 +998,8 @@ describe("agentCommand compaction transcript rotation", () => {
       deliver: false,
     });
 
-    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
+    const compaction = state.runCliTurnCompactionLifecycleMock.mock.calls[0]?.[0];
+    expect(compaction?.sessionId).toBe(successor.sessionId);
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
   });
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1595,7 +1595,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     ["lifecycle replacement", "Agent run belongs to a stale gateway lifecycle"],
   ] as const)("stops finalization when memory maintenance sees a %s", async (mode, error) => {
     setupSingleAttemptFallback();
-    const { store } = setupStoredSession();
+    const { store } = setupStoredSession({
+      authProfileOverride: "openai:work",
+      authProfileOverrideSource: "user",
+    });
     const controller = new AbortController();
     const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
       typeof makeSuccessResult
@@ -1632,6 +1635,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       | undefined;
     const flushRun = flushParams?.followupRun?.run;
     expect(flushRun).toBeDefined();
+    expect(flushRun).toMatchObject({
+      authProfileId: "openai:work",
+      authProfileIdSource: "user",
+    });
     for (const field of [
       "runtimePluginToolGrant",
       "scheduledToolPolicy",

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1593,6 +1593,53 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it.each([
     ["restart abort", "agent run aborted for restart"],
     ["lifecycle replacement", "Agent run belongs to a stale gateway lifecycle"],
+  ] as const)(
+    "does not start memory maintenance when %s closes after persistence",
+    async (mode, error) => {
+      setupSingleAttemptFallback();
+      setupStoredSession();
+      const controller = new AbortController();
+      const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+        typeof makeSuccessResult
+      > & { meta: Record<string, unknown> };
+      result.meta.executionTrace = {
+        runner: "cli",
+        fallbackUsed: false,
+        winnerProvider: "openai",
+        winnerModel: "gpt-5.4",
+      };
+      state.runAgentAttemptMock.mockResolvedValue(result);
+      state.persistCliTurnTranscriptMock.mockImplementationOnce(
+        async (params: { sessionEntry?: SessionEntry }) => {
+          if (mode === "restart abort") {
+            controller.abort(createAgentRunRestartAbortError());
+          } else {
+            state.assertLifecycleCurrentMock.mockImplementationOnce(() => {
+              throw new Error(error);
+            });
+          }
+          return { kind: "persisted", sessionEntry: params.sessionEntry };
+        },
+      );
+
+      await expect(
+        agentCommand({
+          message: "hello",
+          to: "+1234567890",
+          abortSignal: controller.signal,
+        }),
+      ).rejects.toThrow(error);
+
+      expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledOnce();
+      expect(state.runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
+      expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+      expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["restart abort", "agent run aborted for restart"],
+    ["lifecycle replacement", "Agent run belongs to a stale gateway lifecycle"],
   ] as const)("stops finalization when memory maintenance sees a %s", async (mode, error) => {
     setupSingleAttemptFallback();
     const { store } = setupStoredSession({

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -64,6 +64,10 @@ const state = vi.hoisted(() => ({
   persistAcpTurnTranscriptMock: vi.fn(),
   appendExactAssistantMessageMock: vi.fn(),
   runCliTurnCompactionLifecycleMock: vi.fn(),
+  runMemoryFlushIfNeededMock: vi.fn(async ({ sessionEntry }: { sessionEntry?: SessionEntry }) => ({
+    sessionEntry,
+    outcome: "skipped" as const,
+  })),
   resolveAcpAgentPolicyErrorMock: vi.fn(),
   resolveAcpDispatchPolicyErrorMock: vi.fn(),
   resolveAcpExplicitTurnPolicyErrorMock: vi.fn(),
@@ -196,10 +200,8 @@ vi.mock("./command/cli-compaction.js", () => ({
 }));
 
 vi.mock("../auto-reply/reply/agent-runner-memory.js", () => ({
-  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: SessionEntry }) => ({
-    sessionEntry,
-    outcome: "skipped" as const,
-  }),
+  runMemoryFlushIfNeeded: (params: { sessionEntry?: SessionEntry }) =>
+    state.runMemoryFlushIfNeededMock(params),
 }));
 
 vi.mock("./command/run-context.js", () => ({
@@ -2138,6 +2140,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     await runBasicAgentCommand();
 
     expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
     expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
   });
@@ -2179,6 +2182,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(findPersistedTranscriptRepair()).toEqual([
       expect.objectContaining({ text: "ok", provider: "openai", model: "gpt-5.4" }),
     ]);
+    expect(state.runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
   });
 
   it("does not queue repair for a final owned by another transcript writer", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -64,10 +64,16 @@ const state = vi.hoisted(() => ({
   persistAcpTurnTranscriptMock: vi.fn(),
   appendExactAssistantMessageMock: vi.fn(),
   runCliTurnCompactionLifecycleMock: vi.fn(),
-  runMemoryFlushIfNeededMock: vi.fn(async ({ sessionEntry }: { sessionEntry?: SessionEntry }) => ({
-    sessionEntry,
-    outcome: "skipped" as const,
-  })),
+  runMemoryFlushIfNeededMock: vi.fn(
+    async ({
+      sessionEntry,
+    }: {
+      sessionEntry?: SessionEntry;
+    }): Promise<{ sessionEntry?: SessionEntry; outcome: "skipped" | "failed" }> => ({
+      sessionEntry,
+      outcome: "skipped",
+    }),
+  ),
   resolveAcpAgentPolicyErrorMock: vi.fn(),
   resolveAcpDispatchPolicyErrorMock: vi.fn(),
   resolveAcpExplicitTurnPolicyErrorMock: vi.fn(),
@@ -1563,6 +1569,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         message: "hello",
         to: "+1234567890",
         abortSignal: controller.signal,
+        runtimePluginToolGrant: { pluginId: "owner-tools", toolNames: ["owner-only"] },
       }),
     ).rejects.toThrow("agent run aborted for restart");
 
@@ -1581,6 +1588,61 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       ]),
     );
     expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["restart abort", "agent run aborted for restart"],
+    ["lifecycle replacement", "Agent run belongs to a stale gateway lifecycle"],
+  ] as const)("stops finalization when memory maintenance sees a %s", async (mode, error) => {
+    setupSingleAttemptFallback();
+    const { store } = setupStoredSession();
+    const controller = new AbortController();
+    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+      typeof makeSuccessResult
+    > & { meta: Record<string, unknown> };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.runMemoryFlushIfNeededMock.mockImplementationOnce(async (params) => {
+      if (mode === "restart abort") {
+        controller.abort(createAgentRunRestartAbortError());
+      } else {
+        state.assertLifecycleCurrentMock.mockImplementationOnce(() => {
+          throw new Error(error);
+        });
+      }
+      return { sessionEntry: params.sessionEntry, outcome: "failed" as const };
+    });
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledOnce();
+    const flushParams = state.runMemoryFlushIfNeededMock.mock.calls[0]?.[0] as
+      | { followupRun?: { run?: Record<string, unknown> } }
+      | undefined;
+    const flushRun = flushParams?.followupRun?.run;
+    expect(flushRun).toBeDefined();
+    for (const field of [
+      "runtimePluginToolGrant",
+      "scheduledToolPolicy",
+      "trustedInternalHandoff",
+      "bashElevated",
+    ]) {
+      expect(flushRun).not.toHaveProperty(field);
+    }
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+    expect(store["agent:main:main"]?.pendingFinalDelivery).toBeUndefined();
   });
 
   it("preserves restart ownership when an aborted ACP turn resolves normally", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -195,6 +195,13 @@ vi.mock("./command/cli-compaction.js", () => ({
     state.runCliTurnCompactionLifecycleMock(...args),
 }));
 
+vi.mock("../auto-reply/reply/agent-runner-memory.js", () => ({
+  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: SessionEntry }) => ({
+    sessionEntry,
+    outcome: "skipped" as const,
+  }),
+}));
+
 vi.mock("./command/run-context.js", () => ({
   resolveAgentRunContext: (opts: {
     accountId?: string;

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -277,7 +277,11 @@ export async function finalizeEmbeddedAgentCommand(params: {
           senderIsOwner: false,
         },
       };
+      throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+      assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
       const { runMemoryFlushIfNeeded } = await loadAgentRunnerMemoryRuntime();
+      throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+      assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
       const memoryFlushResult = await runMemoryFlushIfNeeded({
         cfg,
         followupRun,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -1,6 +1,7 @@
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { FollowupRun } from "../../auto-reply/reply/queue.js";
 import type { CliDeps } from "../../cli/deps.types.js";
+import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../../config/sessions/restart-recovery-types.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -265,6 +266,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
           config: cfg,
           provider: flushProvider,
           model: flushModel,
+          authProfileId: sessionEntry.authProfileOverride?.trim() || undefined,
+          authProfileIdSource: resolveSessionAuthProfileOverrideSource(sessionEntry),
           blockReplyBreak: "message_end",
           skillsSnapshot,
           thinkLevel: effectiveTurnThinkLevel,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -237,7 +237,16 @@ export async function finalizeEmbeddedAgentCommand(params: {
       }
     }
 
-    if (sessionEntry && sessionStore && sessionKey && !params.suppressVisibleSessionEffects) {
+    // Embedded runs own transcript persistence; CLI runs must prove their explicit append succeeded.
+    const turnTranscriptPersisted =
+      transcriptPersistenceRunner === "embedded" || persistedCliTurnTranscript;
+    if (
+      turnTranscriptPersisted &&
+      sessionEntry &&
+      sessionStore &&
+      sessionKey &&
+      !params.suppressVisibleSessionEffects
+    ) {
       const flushProvider = result.meta.agentMeta?.provider ?? fallbackProvider;
       const flushModel = result.meta.agentMeta?.model ?? fallbackModel;
       const followupRun: FollowupRun = {

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -329,7 +329,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
           await loadCliCompactionRuntime()
         ).runCliTurnCompactionLifecycle({
           cfg,
-          sessionId: effectiveSessionId,
+          sessionId: sessionEntry?.sessionId ?? effectiveSessionId,
           sessionKey: sessionKey ?? effectiveSessionId,
           sessionEntry,
           sessionStore,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -1,4 +1,5 @@
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import type { FollowupRun } from "../../auto-reply/reply/queue.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../../config/sessions/restart-recovery-types.js";
@@ -24,6 +25,7 @@ import { persistAgentSession } from "./attempt-execution.shared.js";
 import type { PreparedAgentCommandExecution } from "./prepare.js";
 import type { EmbeddedAgentAttempt } from "./run-embedded-attempt.js";
 import {
+  loadAgentRunnerMemoryRuntime,
   loadCliCompactionRuntime,
   loadDeliveryRuntime,
   loadSessionStoreRuntime,
@@ -90,7 +92,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
     terminal,
     lifecycleGeneration,
   } = params.attempt;
-  const { skillsSnapshot, runContext } = params.embeddedSessionState;
+  const { resolvedVerboseLevel, skillsSnapshot, runContext } = params.embeddedSessionState;
   const effectiveCwd = cwd ?? workspaceDir;
   let sessionEntry = params.sessionEntry;
   let result = params.attempt.result;
@@ -232,6 +234,60 @@ export async function finalizeEmbeddedAgentCommand(params: {
             runOwnedSessionId,
           });
         }
+      }
+    }
+
+    if (sessionEntry && sessionStore && sessionKey && !params.suppressVisibleSessionEffects) {
+      const flushProvider = result.meta.agentMeta?.provider ?? fallbackProvider;
+      const flushModel = result.meta.agentMeta?.model ?? fallbackModel;
+      const followupRun: FollowupRun = {
+        prompt: "",
+        enqueuedAt: Date.now(),
+        run: {
+          ...params.prepared,
+          ...params.opts,
+          agentId: sessionAgentId,
+          sessionId: sessionEntry.sessionId,
+          sessionFile: sessionKey,
+          workspaceDir,
+          runtimePolicySessionKey: sessionKey,
+          config: cfg,
+          provider: flushProvider,
+          model: flushModel,
+          blockReplyBreak: "message_end",
+          groupId: params.opts.groupId ?? undefined,
+          groupChannel: params.opts.groupChannel ?? undefined,
+          groupSpace: params.opts.groupSpace ?? undefined,
+          spawnedBy: params.opts.spawnedBy ?? undefined,
+          skillsSnapshot,
+          thinkLevel: effectiveTurnThinkLevel,
+          verboseLevel: resolvedVerboseLevel ?? "off",
+          agentAccountId: runContext.accountId,
+          senderIsOwner: params.opts.senderIsOwner,
+          cwd: effectiveCwd,
+        },
+      };
+      const { runMemoryFlushIfNeeded } = await loadAgentRunnerMemoryRuntime();
+      const memoryFlushResult = await runMemoryFlushIfNeeded({
+        cfg,
+        followupRun,
+        promptForEstimate: "",
+        sessionCtx: {},
+        defaultModel: flushModel,
+        resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        runtimePolicySessionKey: sessionKey,
+        storePath,
+        isHeartbeat: isHeartbeatLifecycleRunKind(params.opts.bootstrapContextRunKind),
+        abortSignal: params.opts.abortSignal,
+        onSessionIdChanged: params.opts.onSessionIdChanged,
+      });
+      sessionEntry = memoryFlushResult.sessionEntry ?? sessionEntry;
+      if (sessionEntry.sessionId !== runOwnedSessionId) {
+        runOwnedSessionId = sessionEntry.sessionId;
+        publishSessionOwnership();
       }
     }
 

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -72,6 +72,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
     workspaceDir,
     cwd,
     agentDir,
+    timeoutMs,
     outboundSession,
     runId,
   } = params.prepared;
@@ -253,27 +254,24 @@ export async function finalizeEmbeddedAgentCommand(params: {
         prompt: "",
         enqueuedAt: Date.now(),
         run: {
-          ...params.prepared,
-          ...params.opts,
           agentId: sessionAgentId,
+          agentDir,
           sessionId: sessionEntry.sessionId,
+          sessionKey,
           sessionFile: sessionKey,
           workspaceDir,
+          cwd: effectiveCwd,
           runtimePolicySessionKey: sessionKey,
           config: cfg,
           provider: flushProvider,
           model: flushModel,
           blockReplyBreak: "message_end",
-          groupId: params.opts.groupId ?? undefined,
-          groupChannel: params.opts.groupChannel ?? undefined,
-          groupSpace: params.opts.groupSpace ?? undefined,
-          spawnedBy: params.opts.spawnedBy ?? undefined,
           skillsSnapshot,
           thinkLevel: effectiveTurnThinkLevel,
           verboseLevel: resolvedVerboseLevel ?? "off",
-          agentAccountId: runContext.accountId,
-          senderIsOwner: params.opts.senderIsOwner,
-          cwd: effectiveCwd,
+          timeoutMs,
+          // Maintenance is system-owned and must not inherit completed-turn authority.
+          senderIsOwner: false,
         },
       };
       const { runMemoryFlushIfNeeded } = await loadAgentRunnerMemoryRuntime();
@@ -298,6 +296,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
         runOwnedSessionId = sessionEntry.sessionId;
         publishSessionOwnership();
       }
+      throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+      assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
     }
 
     const payloads = result.payloads ?? [];

--- a/src/agents/command/runtime-loaders.ts
+++ b/src/agents/command/runtime-loaders.ts
@@ -12,6 +12,7 @@ type AcpSessionIdentifiersRuntime = typeof import("@openclaw/acp-core/runtime/se
 type DeliveryRuntime = typeof import("./delivery.runtime.js");
 type SessionStoreRuntime = typeof import("./session-store.runtime.js");
 type CliCompactionRuntime = typeof import("./cli-compaction.js");
+type AgentRunnerMemoryRuntime = typeof import("../../auto-reply/reply/agent-runner-memory.js");
 type TranscriptResolveRuntime =
   typeof import("../../config/sessions/transcript-resolve.runtime.js");
 type TranscriptAppendRuntime = typeof import("../../config/sessions/transcript.runtime.js");
@@ -45,6 +46,9 @@ const sessionStoreRuntimeLoader = createLazyImportLoader<SessionStoreRuntime>(
 );
 const cliCompactionRuntimeLoader = createLazyImportLoader<CliCompactionRuntime>(
   () => import("./cli-compaction.js"),
+);
+const agentRunnerMemoryRuntimeLoader = createLazyImportLoader<AgentRunnerMemoryRuntime>(
+  () => import("../../auto-reply/reply/agent-runner-memory.js"),
 );
 const transcriptResolveRuntimeLoader = createLazyImportLoader<TranscriptResolveRuntime>(
   () => import("../../config/sessions/transcript-resolve.runtime.js"),
@@ -99,6 +103,10 @@ export function loadSessionStoreRuntime(): Promise<SessionStoreRuntime> {
 
 export function loadCliCompactionRuntime(): Promise<CliCompactionRuntime> {
   return cliCompactionRuntimeLoader.load();
+}
+
+export function loadAgentRunnerMemoryRuntime(): Promise<AgentRunnerMemoryRuntime> {
+  return agentRunnerMemoryRuntimeLoader.load();
 }
 
 export function loadTranscriptResolveRuntime(): Promise<TranscriptResolveRuntime> {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -431,7 +431,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await fs.rm(rootDir, { recursive: true, force: true });
   });
 
-  it("runs a memory flush turn, rotates after compaction, and persists metadata", async () => {
+  it("runs exactly one auto-reply memory flush turn, rotates, and persists metadata", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionKey = "main";
     const sessionEntry: SessionEntry = {
@@ -487,6 +487,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(result.outcome).toBe("completed");
     expect(result.sessionEntry?.sessionId).toBe("session-rotated");
     expect(followupRun.run.sessionId).toBe("session-rotated");
+    expect(runEmbeddedAgentEntryMock).toHaveBeenCalledTimes(1);
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(requireModelFallbackCall().userLockedAuthProfileId).toBe("anthropic:work");
     const flushCall = requireEmbeddedAgentCall();

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1042,9 +1042,16 @@ export async function runMemoryFlushIfNeeded(params: {
   runtimePolicySessionKey?: string;
   storePath?: string;
   isHeartbeat: boolean;
-  replyOperation: ReplyOperation;
+  replyOperation?: ReplyOperation;
+  abortSignal?: AbortSignal;
+  onSessionIdChanged?: (sessionId: string) => void;
   onVisibleErrorPayloads?: (payloads: ReplyPayload[]) => void;
 }): Promise<MemoryFlushResult> {
+  const abortSignal = params.replyOperation?.abortSignal ?? params.abortSignal;
+  const updateSessionId = (sessionId: string) => {
+    params.replyOperation?.updateSessionId(sessionId);
+    params.onSessionIdChanged?.(sessionId);
+  };
   const memoryFlushWritable = (() => {
     if (!params.sessionKey) {
       return true;
@@ -1273,7 +1280,7 @@ export async function runMemoryFlushIfNeeded(params: {
   );
 
   activeSessionEntry = entry ?? params.sessionEntry;
-  params.replyOperation.setPhase("memory_flushing");
+  params.replyOperation?.setPhase("memory_flushing");
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     activeSessionEntry?.systemPromptReport ??
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.systemPromptReport : undefined),
@@ -1395,7 +1402,7 @@ export async function runMemoryFlushIfNeeded(params: {
       },
       behavior: { kind: "maintenance" },
       sessionOverride: { kind: "preserve" },
-      abortSignal: params.replyOperation.abortSignal,
+      abortSignal,
       runCandidate: async (provider, model, runOptions) => {
         const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
           provider,
@@ -1445,7 +1452,7 @@ export async function runMemoryFlushIfNeeded(params: {
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature:
             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-          abortSignal: params.replyOperation.abortSignal,
+          abortSignal,
           replyOperation: params.replyOperation,
           contextEngineLogicalTurnLease: runOptions.contextEngineLogicalTurnLease,
           onContextEngineTurnCandidate: runOptions.onContextEngineTurnCandidate,
@@ -1505,7 +1512,7 @@ export async function runMemoryFlushIfNeeded(params: {
       if (updatedEntry) {
         activeSessionEntry = updatedEntry;
         params.followupRun.run.sessionId = updatedEntry.sessionId;
-        params.replyOperation.updateSessionId(updatedEntry.sessionId);
+        updateSessionId(updatedEntry.sessionId);
         const queueKey = params.followupRun.run.sessionKey ?? params.sessionKey;
         if (queueKey) {
           params.followupRun.run.sessionFile = queueKey;
@@ -1537,7 +1544,7 @@ export async function runMemoryFlushIfNeeded(params: {
         if (updatedEntry) {
           activeSessionEntry = updatedEntry;
           params.followupRun.run.sessionId = updatedEntry.sessionId;
-          params.replyOperation.updateSessionId(updatedEntry.sessionId);
+          updateSessionId(updatedEntry.sessionId);
           const refreshedSessionKey = params.sessionKey ?? params.followupRun.run.sessionKey;
           if (refreshedSessionKey) {
             params.followupRun.run.sessionFile = refreshedSessionKey;

--- a/src/gateway/worker-environments/provider-provisioning-node.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning-node.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { admitWorkerConnection } from "./admission.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import * as support from "./service.test-support.js";
+
+describe("node worker provider provisioning", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("commits an installed Gateway bundle receipt and credential for a node lease", async () => {
+    const workerBuild = structuredClone(support.BOOTSTRAP_RECEIPT);
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const placementGate = createWorkerSessionPlacementGate(placements);
+    const workerService = support.createService(
+      support.createProvider({
+        provisionBeforeInstallation: true,
+        provision: async () => ({
+          leaseId: "device-lease-1",
+          node: { deviceId: "device-1" },
+          sharedHost: true,
+        }),
+      }),
+      { ensureNodeWorkerBundle: async () => workerBuild, placementStore: placementGate },
+    );
+
+    const result = await workerService.create("development", "request-device");
+
+    expect(result).toMatchObject({
+      state: "ready",
+      leaseId: "device-lease-1",
+      sshEndpoint: null,
+      bootstrapReceipt: { ...workerBuild, installKind: "bundle" },
+      sharedHost: true,
+      ownerEpoch: 1,
+    });
+    expect(support.testState.prepareInstallation).not.toHaveBeenCalled();
+    expect(support.testState.bootstrapWorker).not.toHaveBeenCalled();
+    const credential = workerService.takeMintedCredential({
+      environmentId: result.environmentId,
+      ownerEpoch: result.ownerEpoch,
+      sessionId: null,
+    });
+    expect(credential).toMatchObject({
+      credential: support.CREDENTIAL,
+      bundleHash: support.BUNDLE_HASH,
+    });
+    await workerService.attachSession({
+      environmentId: result.environmentId,
+      ownerEpoch: result.ownerEpoch,
+      sessionId: REQUEST.sessionId,
+    });
+    const attached = support.testState.store.get(result.environmentId)!;
+    seedActivePlacement(placements, {
+      environmentId: result.environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    const turnClaim = placements.claimTurn({
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+      claimId: "claim-device",
+      runId: "run-device",
+      owner: {
+        kind: "worker",
+        environmentId: result.environmentId,
+        ownerEpoch: attached.ownerEpoch,
+      },
+    });
+    const turnCredential = await workerService.acquireTurnCredential(turnClaim);
+    const admission = {
+      environmentId: result.environmentId,
+      credential: turnCredential.credential,
+      ownerEpoch: attached.ownerEpoch,
+      rpcSetVersion: 1,
+      sessionId: REQUEST.sessionId,
+      runId: turnClaim.runId,
+      handshake: workerBuild,
+    } as const;
+    expect(
+      admitWorkerConnection({
+        store: support.testState.store,
+        admission,
+        expectedBuild: workerBuild,
+        nowMs: support.testState.nowMs,
+        turnClaim,
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      admitWorkerConnection({
+        store: support.testState.store,
+        admission: {
+          ...admission,
+          handshake: { ...workerBuild, bundleHash: "d".repeat(64) },
+        },
+        expectedBuild: workerBuild,
+        nowMs: support.testState.nowMs,
+        turnClaim,
+      }),
+    ).toEqual({ ok: false, reason: "bundle-mismatch" });
+  });
+});

--- a/src/gateway/worker-environments/provider-provisioning.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.test.ts
@@ -10,12 +10,9 @@ import {
 import type { GatewaySessionRow } from "../session-utils.types.js";
 import { writeSessionStore } from "../test-helpers.js";
 import { directSessionReq } from "../test/server-sessions.test-helpers.js";
-import { admitWorkerConnection } from "./admission.js";
 import { hashWorkerCredential } from "./credential.js";
-import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
-import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
 import { createWorkerEnvironmentStore } from "./store.js";
 import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -121,101 +118,6 @@ describe("worker environment service", () => {
     const workerService = support.createService(provider);
 
     await expect(workerService.listMachineOptions("development")).resolves.toBeUndefined();
-  });
-
-  it("commits an installed Gateway bundle receipt and credential for a node lease", async () => {
-    const workerBuild = structuredClone(support.BOOTSTRAP_RECEIPT);
-    const placements = createWorkerSessionPlacementStore({
-      database: support.testState.stateDb,
-      now: () => support.testState.nowMs,
-    });
-    const placementGate = createWorkerSessionPlacementGate(placements);
-    const workerService = support.createService(
-      support.createProvider({
-        provisionBeforeInstallation: true,
-        provision: async () => ({
-          leaseId: "device-lease-1",
-          node: { deviceId: "device-1" },
-          sharedHost: true,
-        }),
-      }),
-      { ensureNodeWorkerBundle: async () => workerBuild, placementStore: placementGate },
-    );
-
-    const result = await workerService.create("development", "request-device");
-
-    expect(result).toMatchObject({
-      state: "ready",
-      leaseId: "device-lease-1",
-      sshEndpoint: null,
-      bootstrapReceipt: { ...workerBuild, installKind: "bundle" },
-      sharedHost: true,
-      ownerEpoch: 1,
-    });
-    expect(support.testState.prepareInstallation).not.toHaveBeenCalled();
-    expect(support.testState.bootstrapWorker).not.toHaveBeenCalled();
-    const credential = workerService.takeMintedCredential({
-      environmentId: result.environmentId,
-      ownerEpoch: result.ownerEpoch,
-      sessionId: null,
-    });
-    expect(credential).toMatchObject({
-      credential: support.CREDENTIAL,
-      bundleHash: support.BUNDLE_HASH,
-    });
-    await workerService.attachSession({
-      environmentId: result.environmentId,
-      ownerEpoch: result.ownerEpoch,
-      sessionId: REQUEST.sessionId,
-    });
-    const attached = support.testState.store.get(result.environmentId)!;
-    seedActivePlacement(placements, {
-      environmentId: result.environmentId,
-      ownerEpoch: attached.ownerEpoch,
-    });
-    const turnClaim = placements.claimTurn({
-      sessionId: REQUEST.sessionId,
-      sessionKey: REQUEST.sessionKey,
-      agentId: REQUEST.agentId,
-      claimId: "claim-device",
-      runId: "run-device",
-      owner: {
-        kind: "worker",
-        environmentId: result.environmentId,
-        ownerEpoch: attached.ownerEpoch,
-      },
-    });
-    const turnCredential = await workerService.acquireTurnCredential(turnClaim);
-    const admission = {
-      environmentId: result.environmentId,
-      credential: turnCredential.credential,
-      ownerEpoch: attached.ownerEpoch,
-      rpcSetVersion: 1,
-      sessionId: REQUEST.sessionId,
-      runId: turnClaim.runId,
-      handshake: workerBuild,
-    } as const;
-    expect(
-      admitWorkerConnection({
-        store: support.testState.store,
-        admission,
-        expectedBuild: workerBuild,
-        nowMs: support.testState.nowMs,
-        turnClaim,
-      }),
-    ).toMatchObject({ ok: true });
-    expect(
-      admitWorkerConnection({
-        store: support.testState.store,
-        admission: {
-          ...admission,
-          handshake: { ...workerBuild, bundleHash: "d".repeat(64) },
-        },
-        expectedBuild: workerBuild,
-        nowMs: support.testState.nowMs,
-        turnClaim,
-      }),
-    ).toEqual({ ok: false, reason: "bundle-mismatch" });
   });
 
   it("fails node provisioning visibly when Gateway bundle installation fails", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators driving OpenClaw through `openclaw agent` or the Gateway `agent` RPC could silently accumulate unflushed short-term memory forever.

The verified live reproduction showed that `runMemoryFlushIfNeeded` was wired only into the auto-reply pipeline, so memory flush never happened for CLI or Gateway `agent` RPC turns on either runtime. Four consecutive over-threshold CLI turns produced no flush at all; the first `chat.send` turn on the same session flushed immediately. There was no diagnostic for the skipped maintenance.

This is the same architectural shape as #124784: a facility was wired to one entry point while the product exposed several equivalent entry points. It is a recurring bug class worth naming.

## Why This Change Was Made

The trigger now lives at the shared turn-completion owner, `finalizeEmbeddedAgentCommand`, where CLI and Gateway RPC runtimes converge after transcript persistence. That gives those runtimes one canonical decision point instead of adding a second call site that duplicates threshold policy; the policy remains owned by `runMemoryFlushIfNeeded`.

The existing auto-reply pre-turn trigger remains unchanged. The new paths had no prior flush timing to preserve; they now evaluate after the completed turn has been persisted. The regression coverage verifies that the auto-reply memory-flush path still executes one maintenance turn, not a double flush.

The intentional skip for runtimes that own native compaction is preserved. Direct verification in the sibling Codex source found pre-turn context-limit compaction at `codex-rs/core/src/session/turn.rs:1004` and mid-turn compaction at `codex-rs/core/src/session/turn.rs:443`.

Codex sessions may therefore still never run OpenClaw memory flush. A separate lane finding is that Codex context-pressure recovery also leaves no durable record; that is a follow-up, not something this PR claims to fix.

The prepared fix was production +78/-7 and tests +43/-9. The final reviewed diff is production +87/-7 and tests +116/-9 after exact-head CI exposed an unrelated narrow test mock and ClawSweeper identified transcript, authority, abort, and lifecycle boundaries. The production growth is the shared-owner move plus the exactly-once/session-rotation and persisted-transcript guards needed to reuse the existing memory-flush owner without duplicating policy; the authority repair replaced a broad option spread with an explicit minimal maintenance input.

## User Impact

CLI and webhook/Gateway RPC operators now get the same configured short-term-memory maintenance behavior instead of silently bypassing it. Auto-reply behavior and native-compaction ownership remain unchanged.

## Evidence

- Live pre-fix reproduction: four consecutive over-threshold `openclaw agent` turns produced no flush; the first `chat.send` turn on the same session flushed immediately.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts src/agents/agent-command.compaction-rotation.test.ts` — 70/70 memory-runner tests and 25/25 command-rotation tests passed.
- The Gateway ingress regression verifies one flush at the shared completion owner after persisted session state is available.
- The auto-reply regression asserts the memory-flush maintenance entry and embedded run are each invoked exactly once.
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts` — 120/120 tests passed after isolating the unrelated memory-flush dependency and adding abort/lifecycle boundary coverage.
- Failed CLI transcript persistence and session rebound now assert that memory maintenance is not entered; embedded-runtime ownership remains covered by the Gateway ingress regression.
- An authority-bearing command verifies that plugin grants, scheduled policy, trusted handoff, and elevation do not reach maintenance; abort and lifecycle replacement both stop before pending-final persistence or delivery.
- `node scripts/check-changed.mjs` — passed after the configured remote backends were unavailable and the repository wrapper used its permitted local fallback.
- Fresh branch autoreview: clean, with no accepted/actionable findings.
