### PR TITLE
feat(agents): show creation hierarchy in Control UI

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12976,6 +12976,9 @@ public struct WebLoginWaitParams: Codable, Sendable {
 public struct AgentSummary: Codable, Sendable {
     public let id: String
     public let kind: AgentKind?
+    public let createdvia: AnyCodable?
+    public let creatoragentid: AnyCodable?
+    public let createdat: Int?
     public let name: String?
     public let identity: [String: AnyCodable]?
     public let workspace: String?
@@ -12989,6 +12992,9 @@ public struct AgentSummary: Codable, Sendable {
     public init(
         id: String,
         kind: AgentKind? = nil,
+        createdvia: AnyCodable? = nil,
+        creatoragentid: AnyCodable? = nil,
+        createdat: Int? = nil,
         name: String? = nil,
         identity: [String: AnyCodable]? = nil,
         workspace: String? = nil,
@@ -13001,6 +13007,9 @@ public struct AgentSummary: Codable, Sendable {
     {
         self.id = id
         self.kind = kind
+        self.createdvia = createdvia
+        self.creatoragentid = creatoragentid
+        self.createdat = createdat
         self.name = name
         self.identity = identity
         self.workspace = workspace
@@ -13015,6 +13024,9 @@ public struct AgentSummary: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case kind
+        case createdvia = "createdVia"
+        case creatoragentid = "creatorAgentId"
+        case createdat = "createdAt"
         case name
         case identity
         case workspace

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -627,7 +627,7 @@ methods. Treat this as feature discovery, not a full enumeration of
   </Accordion>
 
   <Accordion title="Agent and workspace helpers">
-    - `agents.list` returns gateway-visible agent entries, including effective model/runtime metadata and optional semantic `kind` (`agent` or `system`). Clients advertise the `agent-kind` handshake capability to receive the complete typed roster; clients without it keep the legacy selector-safe roster without system rows. Kind-aware clients exclude `system` rows from ordinary selectors while retaining them in diagnostic views. Older v4 gateways may return rows without `kind`.
+    - `agents.list` returns gateway-visible agent entries, including effective model/runtime metadata and optional semantic `kind` (`agent` or `system`). Entries with recorded creation provenance also include `createdVia` (`operator`, `agent`, or `claw`), nullable `creatorAgentId`, and millisecond `createdAt`; entries without provenance omit those fields. Clients advertise the `agent-kind` handshake capability to receive the complete typed roster; clients without it keep the legacy selector-safe roster without system rows. Kind-aware clients exclude `system` rows from ordinary selectors while retaining them in diagnostic views. Older v4 gateways may return rows without `kind`.
     - `agents.create`, `agents.update`, and `agents.delete` manage agent records and workspace wiring.
     - `agents.files.list`, `agents.files.get`, and `agents.files.set` manage the bootstrap workspace files exposed for an agent.
     - `audit.activity.list` returns the versioned metadata-only activity ledger; `audit.run.inspect` discovers execution ids or inspects one exact execution identity context; `audit.list` remains the compatibility-safe run/tool RPC.

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -136,6 +136,9 @@ describe("AgentsListResultSchema", () => {
         {
           id: "investment-master",
           kind: "agent",
+          createdVia: "agent",
+          creatorAgentId: "main",
+          createdAt: 42,
           name: "Investment Master",
           workspaceGit: true,
           model: { primary: "deepseek/deepseek-v4-flash" },

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -64,10 +64,19 @@ export const ModelChoiceSchema = closedObject({
 /** Semantic owner of an agent roster entry. */
 export const AgentKindSchema = Type.Union([Type.Literal("agent"), Type.Literal("system")]);
 
+const AgentCreatedViaSchema = Type.Union([
+  Type.Literal("operator"),
+  Type.Literal("agent"),
+  Type.Literal("claw"),
+]);
+
 /** Condensed agent record returned by list APIs. */
 export const AgentSummarySchema = closedObject({
   id: NonEmptyString,
   kind: Type.Optional(AgentKindSchema),
+  createdVia: Type.Optional(AgentCreatedViaSchema),
+  creatorAgentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  createdAt: Type.Optional(Type.Integer({ minimum: 0 })),
   name: Type.Optional(NonEmptyString),
   identity: Type.Optional(
     closedObject({

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -93,6 +93,7 @@ import {
   readAgentDeletionJournal,
   type AgentDeletionJournalCleanupPath,
 } from "../../state/agent-deletion-journal.js";
+import { listAgentProvenance } from "../../state/agent-provenance.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -901,7 +902,26 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const result = listAgentsForGateway(cfg, modelCatalog, {
       includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
     });
-    respond(true, result, undefined);
+    const provenanceById = new Map(
+      listAgentProvenance().map((record) => [record.agentId, record] as const),
+    );
+    respond(
+      true,
+      {
+        ...result,
+        agents: result.agents.map((agent) => {
+          const provenance = provenanceById.get(agent.id);
+          return provenance
+            ? Object.assign({}, agent, {
+                createdVia: provenance.createdVia,
+                creatorAgentId: provenance.creatorAgentId,
+                createdAt: provenance.createdAtMs,
+              })
+            : agent;
+        }),
+      },
+      undefined,
+    );
   },
   "agents.create": async ({ params, respond }) => {
     if (!validateAgentsCreateParams(params)) {

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -2,9 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../../packages/gateway-protocol/src/client-info.js";
+import type { AgentsListResult } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionStorePathCore as resolveStorePath } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import { recordAgentProvenance } from "../../state/agent-provenance.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
@@ -43,18 +45,18 @@ function expectAgentStoreAbsent(agentId: string): void {
   );
 }
 
-async function listAgentIdsViaRpc(
+async function listAgentsViaRpc(
   includeSystem = false,
   catalogContext: Partial<GatewayRequestContext> = {},
-): Promise<string[]> {
+): Promise<AgentsListResult> {
   const { getRuntimeConfig } = await getGatewayConfigModule();
-  let ids: string[] | undefined;
+  let result: AgentsListResult | undefined;
   await agentsHandlers["agents.list"]?.({
     req: {} as never,
     params: {},
     respond: (ok, payload) => {
       if (ok) {
-        ids = (payload as { agents: Array<{ id: string }> }).agents.map((agent) => agent.id);
+        result = payload as AgentsListResult;
       }
     },
     context: {
@@ -68,7 +70,18 @@ async function listAgentIdsViaRpc(
       : null,
     isWebchatConnect: () => false,
   });
-  return ids ?? [];
+  if (!result) {
+    throw new Error("agents.list did not return a result");
+  }
+  return result;
+}
+
+async function listAgentIdsViaRpc(
+  includeSystem = false,
+  catalogContext: Partial<GatewayRequestContext> = {},
+): Promise<string[]> {
+  const result = await listAgentsViaRpc(includeSystem, catalogContext);
+  return result.agents.map((agent) => agent.id);
 }
 
 async function setAgentsConfig(agentsConfig: Record<string, unknown> | undefined): Promise<void> {
@@ -112,6 +125,23 @@ test("agents.list returns the roster when optional prepared model facts are unav
   ]);
 
   expect(readPreparedGatewayModelCatalog).toHaveBeenCalledOnce();
+});
+
+test("agents.list includes durable provenance only for matching roster rows", async () => {
+  await setAgentsConfig({ ownership: "explicit", entries: { ops: {}, research: {} } });
+  recordAgentProvenance("research", { createdVia: "agent", creatorAgentId: "ops" }, { nowMs: 42 });
+
+  const result = await listAgentsViaRpc();
+
+  expect(result.agents.map((agent) => agent.id)).toEqual(["ops", "research"]);
+  expect(result.agents[0]).not.toHaveProperty("createdVia");
+  expect(result.agents[0]).not.toHaveProperty("creatorAgentId");
+  expect(result.agents[0]).not.toHaveProperty("createdAt");
+  expect(result.agents[1]).toMatchObject({
+    createdVia: "agent",
+    creatorAgentId: "ops",
+    createdAt: 42,
+  });
 });
 
 beforeEach(async () => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1100,6 +1100,7 @@ export const en: TranslationMap = {
   },
   agents: {
     noAgents: "No agents",
+    createdBy: "Created by {id}",
     defaults: {
       title: "Agent defaults",
       description: "Defaults every agent inherits unless overridden.",

--- a/ui/src/pages/agents/view.agent-selector.test.ts
+++ b/ui/src/pages/agents/view.agent-selector.test.ts
@@ -31,4 +31,92 @@ describe("renderAgents agent selector", () => {
     createButton?.click();
     expect(onCreateAgent).toHaveBeenCalledOnce();
   });
+
+  it("groups agent-created children while leaving provenance-free and dangling rows unchanged", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const main = { id: "main", name: "Main" };
+    const orphan = { id: "orphan", name: "Orphan" };
+    const research = { id: "research", name: "Research" };
+    const baseAgents = [main, orphan, research];
+
+    try {
+      render(
+        renderAgents(
+          createProps({
+            agentsList: {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "per-sender",
+              agents: baseAgents,
+            },
+            selectedAgentId: "main",
+          }),
+        ),
+        container,
+      );
+      const select = container.querySelector("openclaw-agent-select") as
+        | (HTMLElement & {
+            options: Array<{
+              value: string;
+              description?: string;
+            }>;
+            updateComplete: Promise<boolean>;
+          })
+        | null;
+      await select?.updateComplete;
+
+      expect(select?.options).toMatchObject([
+        { value: "main" },
+        { value: "orphan" },
+        { value: "research" },
+      ]);
+      expect(select?.options.every((option) => !option.description)).toBe(true);
+      expect(select?.querySelector(".agent-select__option-description")).toBeNull();
+
+      render(
+        renderAgents(
+          createProps({
+            agentsList: {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "per-sender",
+              agents: [
+                { ...main, createdVia: "operator", creatorAgentId: null, createdAt: 1 },
+                {
+                  ...orphan,
+                  createdVia: "agent",
+                  creatorAgentId: "deleted",
+                  createdAt: 2,
+                },
+                {
+                  ...research,
+                  createdVia: "agent",
+                  creatorAgentId: "main",
+                  createdAt: 3,
+                },
+              ],
+            },
+            selectedAgentId: "main",
+          }),
+        ),
+        container,
+      );
+      await select?.updateComplete;
+
+      const createdByMain = t("agents.createdBy", { id: "main" });
+      expect(select?.options).toMatchObject([
+        { value: "main" },
+        { value: "research", description: createdByMain },
+        { value: "orphan" },
+      ]);
+      const rows = select?.querySelectorAll("wa-dropdown-item[data-agent-option]") ?? [];
+      expect(rows[1]?.querySelector(".agent-select__option-description")?.textContent?.trim()).toBe(
+        createdByMain,
+      );
+      expect(rows[2]?.querySelector(".agent-select__option-description")).toBeNull();
+    } finally {
+      container.remove();
+    }
+  });
 });

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -162,6 +162,45 @@ type AgentsProps = {
   onSetDefault: (agentId: string) => void;
 };
 
+type AgentRosterRow = AgentsListResult["agents"][number];
+
+function buildAgentRosterTree(agents: AgentRosterRow[]) {
+  const agentById = new Map(agents.map((agent) => [agent.id, agent]));
+  const childrenById = new Map<string, AgentRosterRow[]>();
+  const roots: AgentRosterRow[] = [];
+
+  for (const agent of agents) {
+    const creatorAgentId = agent.creatorAgentId;
+    if (creatorAgentId && creatorAgentId !== agent.id && agentById.has(creatorAgentId)) {
+      const children = childrenById.get(creatorAgentId) ?? [];
+      children.push(agent);
+      childrenById.set(creatorAgentId, children);
+    } else {
+      roots.push(agent);
+    }
+  }
+
+  const entries: Array<{ agent: AgentRosterRow; creatorAgentId?: string }> = [];
+  const visited = new Set<string>();
+  const append = (agent: AgentRosterRow, depth: number): void => {
+    if (visited.has(agent.id)) {
+      return;
+    }
+    visited.add(agent.id);
+    entries.push({
+      agent,
+      ...(depth > 0 && agent.creatorAgentId ? { creatorAgentId: agent.creatorAgentId } : {}),
+    });
+    for (const child of childrenById.get(agent.id) ?? []) {
+      append(child, depth + 1);
+    }
+  };
+  roots.forEach((agent) => append(agent, 0));
+  // Match the CLI tree: malformed cycles cannot make configured agents disappear.
+  agents.forEach((agent) => append(agent, 0));
+  return entries;
+}
+
 export function renderAgents(props: AgentsProps) {
   const agents = props.agentsList?.agents ?? [];
   const defaultId = props.agentsList?.defaultId ?? null;
@@ -169,10 +208,11 @@ export function renderAgents(props: AgentsProps) {
   const selectedAgent = selectedId
     ? (agents.find((agent) => agent.id === selectedId) ?? null)
     : null;
-  const agentOptions = agents.map((agent) => ({
+  const agentOptions = buildAgentRosterTree(agents).map(({ agent, creatorAgentId }) => ({
     value: agent.id,
     label: normalizeAgentLabel(agent),
     agent,
+    description: creatorAgentId ? t("agents.createdBy", { id: creatorAgentId }) : undefined,
     badge: agentBadgeText(agent.id, defaultId) ?? undefined,
   }));
   const selectedSkillCount =


### PR DESCRIPTION
## What Problem This Solves

Agents created by other agents currently appear as a flat roster in the Control UI, so operators cannot see the creation hierarchy that is already available through `openclaw agents list --tree` after phase 1 in #124828.

## Why This Change Was Made

This change adds optional `createdVia`, `creatorAgentId`, and `createdAt` fields to the `agents.list` protocol response and uses them to place created agents beneath their creator in the agent switcher. The protocol change is strictly additive: agents without provenance keep the existing response shape and rendering, while dangling creator references stay visible at the root.

## User Impact

Operators can now understand agent provenance directly in the Control UI. Created agents appear under their creator with a quiet “Created by <id>” secondary line; existing rosters without provenance render exactly as before.

## Evidence

Roster without provenance (unchanged rendering):

![Agent roster without provenance](https://github.com/user-attachments/assets/cf9b0297-d4d7-43b2-baf9-536bfbc6372f)

Roster with a created child and a dangling-creator root entry:

![Agent roster with provenance hierarchy](https://github.com/user-attachments/assets/31e9f780-6531-4ed8-8da2-40255bed44cf)

Local verification on the rebased head:

- focused Vitest coverage: 3 shards / 47 tests passed
- Gateway rerun: 15/15 passed
- core and UI type-check lanes passed
- oxlint and format checks passed
- `pnpm build` passed after rebasing onto `origin/main`
- autoreview clean with no accepted/actionable findings
- source-blind behavior validation passed for provenance-present, provenance-absent, child ordering, and dangling-creator behavior
