### PR TITLE
fix(ui): stop duplicate dashboard session queries

### DIFF
--- a/ui/src/components/session-data-controller-events.ts
+++ b/ui/src/components/session-data-controller-events.ts
@@ -20,6 +20,16 @@ type SidebarSessionListOwner = {
   requestSessionDataUpdate(): void;
 };
 
+function filteredSidebarSessionQuery(agentId: string, archivedFilter: SidebarSessionStatusFilter) {
+  return {
+    agentId,
+    archivedFilter,
+    limit: SIDEBAR_AGENT_SESSION_LIST_LIMIT,
+    includeDerivedTitles: true,
+    includeLastMessage: true,
+  } as const;
+}
+
 export function publishSidebarSessionList(
   owner: SidebarSessionListOwner,
   snapshot: SessionListSnapshot,
@@ -43,7 +53,7 @@ export function subscribeFilteredSidebarSessions(
   archivedFilter: Exclude<SidebarSessionStatusFilter, "active">,
   isCurrent: () => boolean,
 ): () => void {
-  const scope = { agentId, archivedFilter };
+  const scope = filteredSidebarSessionQuery(agentId, archivedFilter);
   const apply = (snapshot: SessionListSnapshot) => {
     if (!isCurrent()) {
       return;
@@ -85,11 +95,7 @@ export function refreshSidebarSessionList(
     return Promise.resolve();
   }
   return owner.context.sessions.refreshList({
-    agentId,
-    archivedFilter,
-    limit: SIDEBAR_AGENT_SESSION_LIST_LIMIT,
-    includeDerivedTitles: true,
-    includeLastMessage: true,
+    ...filteredSidebarSessionQuery(agentId, archivedFilter),
     ...(append && typeof offset === "number" ? { offset, append: true } : {}),
     force: true,
   });

--- a/ui/src/e2e/dashboards-list-demand.e2e.test.ts
+++ b/ui/src/e2e/dashboards-list-demand.e2e.test.ts
@@ -1,0 +1,223 @@
+// Control UI E2E proves dashboard tabs do not multiply server-owned session-list demand.
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  installMockGateway,
+  waitForControlUiRoute,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI dashboard session-list demand",
+});
+
+const DASHBOARD_REQUEST_PARAMS = {
+  archived: "all",
+  boardFace: "dashboard",
+  configuredAgentsOnly: true,
+  includeGlobal: true,
+  includeUnknown: true,
+  limit: 50,
+} as const;
+
+function sessionsResult(key: string, label: string, updatedAt: number) {
+  return {
+    count: 1,
+    defaults: { contextTokens: null, model: null, modelProvider: null },
+    path: "",
+    sessions: [
+      {
+        boardFace: "dashboard",
+        key,
+        kind: "direct",
+        label,
+        updatedAt,
+      },
+    ],
+    ts: updatedAt,
+  };
+}
+
+function isDashboardRequest(request: { params?: unknown }): boolean {
+  return (
+    typeof request.params === "object" &&
+    request.params !== null &&
+    "boardFace" in request.params &&
+    request.params.boardFace === "dashboard"
+  );
+}
+
+async function requestCounts(gateways: MockGatewayControls[]) {
+  const requests = (
+    await Promise.all(gateways.map((gateway) => gateway.getRequests("sessions.list")))
+  ).flat();
+  const dashboard = requests.filter(isDashboardRequest).length;
+  return { canonical: requests.length - dashboard, dashboard, total: requests.length };
+}
+
+suite.define(() => {
+  it("keeps dashboard query demand at one request per real browser tab", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const tabs: Array<{
+      gateway: MockGatewayControls;
+      page: Page;
+      canonicalLabel: string;
+      dashboardLabel: string;
+      updatedDashboardLabel: string;
+    }> = [];
+    try {
+      for (const index of [1, 2]) {
+        const page = await context.newPage();
+        const dashboardLabel = `Dashboard tab ${index}`;
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["sessions.list"],
+          methodResponses: {
+            "sessions.list": {
+              cases: [
+                {
+                  match: { archived: "all", boardFace: "dashboard" },
+                  response: sessionsResult(`agent:main:dashboard-${index}`, dashboardLabel, index),
+                },
+              ],
+            },
+          },
+        });
+        const canonicalLabel = `Older canonical tab ${index}`;
+        const updatedDashboardLabel = `Updated dashboard tab ${index}`;
+        tabs.push({ gateway, page, canonicalLabel, dashboardLabel, updatedDashboardLabel });
+      }
+
+      await Promise.all(
+        tabs.map(async ({ gateway, page }) => {
+          await page.goto(suite.server.baseUrl);
+          const canonical = await gateway.waitForRequest("sessions.list");
+          expect(isDashboardRequest(canonical)).toBe(false);
+          await page.waitForFunction(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: { context: { agents: { state: { agentsList: unknown } } } };
+            };
+            return app.runtime?.context.agents.state.agentsList != null;
+          });
+          await page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: {
+                context: {
+                  navigate: (routeId: string) => void;
+                  agentSelection: {
+                    state: { scopeId: string | null };
+                    setScope: (agentId: string | null) => void;
+                  };
+                };
+              };
+            };
+            if (!app.runtime) {
+              throw new Error("OpenClaw application runtime is unavailable");
+            }
+            app.runtime.context.agentSelection.setScope(null);
+            if (app.runtime.context.agentSelection.state.scopeId !== null) {
+              throw new Error("Control UI did not enter all-agent scope");
+            }
+            app.runtime.context.navigate("dashboards");
+          });
+          await waitForControlUiRoute(page, { pathname: "/dashboards", routeId: "dashboards" });
+        }),
+      );
+      await Promise.all(
+        tabs.map(({ page, dashboardLabel }) =>
+          page.getByText(dashboardLabel, { exact: true }).waitFor(),
+        ),
+      );
+      expect(await requestCounts(tabs.map(({ gateway }) => gateway))).toEqual({
+        canonical: 2,
+        dashboard: 2,
+        total: 4,
+      });
+      for (const tabGateway of tabs.map(({ gateway }) => gateway)) {
+        const dashboardRequest = (await tabGateway.getRequests("sessions.list")).find(
+          isDashboardRequest,
+        );
+        expect(dashboardRequest?.params).toEqual(DASHBOARD_REQUEST_PARAMS);
+        expect(dashboardRequest?.params).not.toHaveProperty("agentId");
+      }
+      await Promise.all(
+        tabs.map(async ({ canonicalLabel, gateway, page }, index) => {
+          await gateway.resolveDeferred(
+            "sessions.list",
+            sessionsResult(`agent:main:canonical-${index + 1}`, canonicalLabel, 10 + index),
+          );
+          await page.getByText(canonicalLabel, { exact: true }).first().waitFor();
+        }),
+      );
+
+      expect(await requestCounts(tabs.map(({ gateway }) => gateway))).toEqual({
+        canonical: 2,
+        dashboard: 2,
+        total: 4,
+      });
+
+      const beforeWave = await Promise.all(
+        tabs.map(({ gateway }) => gateway.getRequests("sessions.list")),
+      );
+      await Promise.all(
+        tabs.map(async ({ gateway, updatedDashboardLabel }, index) => {
+          await gateway.setMethodResponse("sessions.list", {
+            cases: [
+              {
+                match: { archived: "all", boardFace: "dashboard" },
+                response: sessionsResult(
+                  `agent:main:updated-dashboard-${index + 1}`,
+                  updatedDashboardLabel,
+                  20 + index,
+                ),
+              },
+            ],
+          });
+          await gateway.emitGatewayEvent("sessions.changed", {
+            agentId: "main",
+            key: `agent:main:changed-${index + 1}`,
+            kind: "direct",
+            reason: "update",
+            sessionKey: `agent:main:changed-${index + 1}`,
+            updatedAt: 20 + index,
+          });
+        }),
+      );
+      await Promise.all(
+        tabs.map(({ gateway }, index) =>
+          expect
+            .poll(async () => {
+              const added = (await gateway.getRequests("sessions.list")).slice(
+                beforeWave[index]?.length ?? 0,
+              );
+              const dashboard = added.filter(isDashboardRequest).length;
+              return { canonical: added.length - dashboard, dashboard };
+            })
+            .toEqual({ canonical: 1, dashboard: 1 }),
+        ),
+      );
+
+      const afterWave = await Promise.all(
+        tabs.map(({ gateway }) => gateway.getRequests("sessions.list")),
+      );
+      for (const [index, requests] of afterWave.entries()) {
+        const added = requests.slice(beforeWave[index]?.length ?? 0);
+        expect(added.filter(isDashboardRequest)).toHaveLength(1);
+        expect(added.filter((request) => !isDashboardRequest(request))).toHaveLength(1);
+      }
+      const dashboardRequests = afterWave.flat().filter(isDashboardRequest);
+      expect(dashboardRequests).toHaveLength(4);
+      for (const request of dashboardRequests) {
+        expect(request.params).toEqual(DASHBOARD_REQUEST_PARAMS);
+        expect(request.params).not.toHaveProperty("agentId");
+      }
+      await Promise.all(
+        tabs.map(({ page, updatedDashboardLabel }) =>
+          page.getByText(updatedDashboardLabel, { exact: true }).waitFor(),
+        ),
+      );
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -3,7 +3,15 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
 
-type ListParams = { archived?: true | "all"; limit?: number; offset?: number };
+type ListParams = {
+  agentId?: string;
+  archived?: true | "all";
+  boardFace?: "chat" | "dashboard";
+  includeDerivedTitles?: boolean;
+  includeLastMessage?: boolean;
+  limit?: number;
+  offset?: number;
+};
 
 function listResult(keys: string[] = [], totalCount = keys.length, offset = 0): SessionsListResult {
   const nextOffset = offset + keys.length;
@@ -112,8 +120,8 @@ describe("session list requests", () => {
       return listResult(keys.slice(offset, offset + (params?.limit ?? 50)), 4, offset);
     });
     const { sessions } = sessionHarness(request);
-    const archivedScope = { agentId: "main", archivedFilter: "archived" as const };
-    const allScope = { agentId: "main", archivedFilter: "all" as const };
+    const archivedScope = { agentId: "main", archivedFilter: "archived" as const, limit: 2 };
+    const allScope = { agentId: "main", archivedFilter: "all" as const, limit: 1 };
     const observeSnapshot = vi.fn();
     const unsubscribe = sessions.subscribeList(archivedScope, observeSnapshot);
     await sessions.refreshList({ agentId: "main", limit: 1, force: true });
@@ -132,6 +140,68 @@ describe("session list requests", () => {
     expect(sessions.canonicalListRevision).toBe(1);
     expect(observeSnapshot).toHaveBeenCalledWith(expect.objectContaining({ loading: true }));
     unsubscribe();
+    sessions.dispose();
+  });
+
+  it("keeps dashboard and sidebar queries distinct without inventing a dashboard agent", async () => {
+    const request = vi.fn(async (_method: string, params?: ListParams) =>
+      listResult([
+        params?.boardFace === "dashboard"
+          ? "agent:main:dashboard-result"
+          : "agent:main:sidebar-result",
+      ]),
+    );
+    const { sessions } = sessionHarness(request);
+    const dashboardQuery = {
+      limit: 50,
+      boardFace: "dashboard" as const,
+      archivedFilter: "all" as const,
+    };
+    const sidebarQuery = {
+      agentId: "main",
+      limit: 60,
+      includeDerivedTitles: true,
+      includeLastMessage: true,
+      archivedFilter: "all" as const,
+    };
+    const stopDashboard = sessions.subscribeList(dashboardQuery, () => undefined);
+    const stopSidebar = sessions.subscribeList(sidebarQuery, () => undefined);
+
+    await sessions.refreshList({
+      ...dashboardQuery,
+      includeGlobal: true,
+      includeUnknown: true,
+      configuredAgentsOnly: true,
+      includeDerivedTitles: false,
+      includeLastMessage: false,
+      force: true,
+    });
+    await sessions.refreshList({ ...sidebarQuery, force: true });
+
+    expect(sessions.listSnapshot(dashboardQuery).result?.sessions[0]?.key).toBe(
+      "agent:main:dashboard-result",
+    );
+    expect(sessions.listSnapshot(sidebarQuery).result?.sessions[0]?.key).toBe(
+      "agent:main:sidebar-result",
+    );
+    expect(request.mock.calls[0]?.[1]).toEqual({
+      includeGlobal: true,
+      includeUnknown: true,
+      configuredAgentsOnly: true,
+      limit: 50,
+      archived: "all",
+      boardFace: "dashboard",
+    });
+    expect(request.mock.calls[0]?.[1]).not.toHaveProperty("agentId");
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      agentId: "main",
+      archived: "all",
+      includeDerivedTitles: true,
+      includeLastMessage: true,
+      limit: 60,
+    });
+    stopDashboard();
+    stopSidebar();
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -59,6 +59,109 @@ function createHarness(request: GatewayBrowserClient["request"]) {
 }
 
 describe("event-driven session list refresh", () => {
+  it("refreshes exact managed queries by agent and retains appended dashboard windows", async () => {
+    vi.useFakeTimers();
+    const dashboardRows = Array.from({ length: 4 }, (_, index) => ({
+      key: `agent:main:dashboard-${index}`,
+      kind: "direct" as const,
+      boardFace: "dashboard" as const,
+      updatedAt: index + 1,
+    }));
+    const request = vi.fn(
+      async (
+        method: string,
+        params?: {
+          agentId?: string;
+          archived?: "all";
+          boardFace?: "dashboard";
+          includeDerivedTitles?: boolean;
+          includeLastMessage?: boolean;
+          limit?: number;
+          offset?: number;
+        },
+      ) => {
+        if (method !== "sessions.list") {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        if (params?.boardFace !== "dashboard") {
+          return sessionsResult(1);
+        }
+        const rows = params.agentId
+          ? [{ ...dashboardRows[0]!, key: `agent:${params.agentId}:dashboard` }]
+          : dashboardRows;
+        const offset = params.offset ?? 0;
+        const page = rows.slice(offset, offset + (params.limit ?? 50));
+        return {
+          ...sessionsResult(1, page),
+          totalCount: rows.length,
+          hasMore: offset + page.length < rows.length,
+          nextOffset: offset + page.length < rows.length ? offset + page.length : null,
+        };
+      },
+    );
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+    const allAgentsQuery = {
+      boardFace: "dashboard" as const,
+      archivedFilter: "all" as const,
+      includeDerivedTitles: true,
+      includeLastMessage: true,
+      limit: 2,
+    };
+    const writerQuery = { ...allAgentsQuery, agentId: "writer" };
+    const stopAll = sessions.subscribeList(allAgentsQuery, () => undefined);
+    const stopWriter = sessions.subscribeList(writerQuery, () => undefined);
+
+    try {
+      await sessions.refreshList({ ...allAgentsQuery, force: true });
+      await sessions.refreshList({ ...allAgentsQuery, offset: 2, append: true, force: true });
+      await sessions.refreshList({ ...writerQuery, force: true });
+      expect(sessions.listSnapshot(allAgentsQuery).result?.sessions).toHaveLength(4);
+      request.mockClear();
+
+      emitEvent(sessionChangedEvent("agent:research:changed"));
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      const researchDashboardRequests = request.mock.calls.filter(
+        ([, params]) => (params as { boardFace?: unknown } | undefined)?.boardFace === "dashboard",
+      );
+      expect(researchDashboardRequests).toHaveLength(1);
+      expect(researchDashboardRequests[0]?.[1]).toEqual({
+        includeGlobal: true,
+        includeUnknown: true,
+        configuredAgentsOnly: true,
+        limit: 4,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+        archived: "all",
+        boardFace: "dashboard",
+      });
+      expect(researchDashboardRequests[0]?.[1]).not.toHaveProperty("offset");
+      expect(researchDashboardRequests[0]?.[1]).not.toHaveProperty("agentId");
+      expect(sessions.listSnapshot(allAgentsQuery).result?.sessions).toHaveLength(4);
+      request.mockClear();
+
+      emitEvent(sessionChangedEvent("agent:writer:changed"));
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      const writerDashboardRequests = request.mock.calls.filter(
+        ([, params]) => (params as { boardFace?: unknown } | undefined)?.boardFace === "dashboard",
+      );
+      expect(writerDashboardRequests).toHaveLength(2);
+      expect(
+        writerDashboardRequests.map(
+          ([, params]) => (params as { agentId?: string } | undefined)?.agentId ?? null,
+        ),
+      ).toEqual([null, "writer"]);
+    } finally {
+      stopAll();
+      stopWriter();
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("retains every loaded page when a session event replaces the canonical list", async () => {
     vi.useFakeTimers();
     const rows = Array.from({ length: 120 }, (_, index) => ({

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -400,6 +400,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
             backgroundHydrate: true,
             force: true,
           });
+          if (connection.isCurrent(scope)) {
+            await roster.refreshManagedLists();
+          }
         }
       })();
     }
@@ -480,7 +483,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     list: roster.list,
     listSnapshot: (scope) => roster.listSnapshot(scope),
     subscribeList(scope, listener) {
-      if (scope.archivedFilter && scope.archivedFilter !== "active") {
+      if (!roster.isPrimaryList(scope)) {
         return roster.subscribeList(scope, listener);
       }
       const notify = () => listener(roster.listSnapshot(scope));

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -70,7 +70,7 @@ export type SessionRefreshOptions = SessionListOptions & {
   backgroundHydrate?: boolean;
 };
 
-export type SessionListScope = Pick<SessionListOptions, "agentId" | "archivedFilter">;
+export type SessionListScope = Readonly<Omit<SessionListOptions, "offset" | "append">>;
 
 export type SessionListSnapshot = Pick<SessionState, "result" | "agentId" | "loading" | "error">;
 

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -60,7 +60,7 @@ function buildTranscriptMutationParams(
   };
 }
 
-function buildSessionListParams(options: SessionListOptions = {}): Record<string, unknown> {
+export function buildSessionListParams(options: SessionListOptions = {}): Record<string, unknown> {
   const params: Record<string, unknown> = { ...SESSION_LIST_PARAMS };
   if (options.limit === undefined) {
     params.limit = DEFAULT_SESSION_LIST_QUERY.limit;
@@ -125,10 +125,14 @@ export async function requestSessionList(
   client: SessionRequestClient,
   options: SessionListOptions = {},
 ): Promise<SessionsListResult | null> {
-  const result = await client.request<SessionsListResult | undefined>(
-    "sessions.list",
-    buildSessionListParams(options),
-  );
+  return requestSessionListParams(client, buildSessionListParams(options));
+}
+
+export async function requestSessionListParams(
+  client: SessionRequestClient,
+  params: Readonly<Record<string, unknown>>,
+): Promise<SessionsListResult | null> {
+  const result = await client.request<SessionsListResult | undefined>("sessions.list", params);
   return result ?? null;
 }
 

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -18,7 +18,12 @@ import {
   resolveUiSelectedGlobalAgentId,
   uiSessionRowMatchesSelectedChat,
 } from "./session-key.ts";
-import { DEFAULT_SESSION_LIST_QUERY, requestSessionList } from "./session-requests.ts";
+import {
+  buildSessionListParams,
+  DEFAULT_SESSION_LIST_QUERY,
+  requestSessionList,
+  requestSessionListParams,
+} from "./session-requests.ts";
 
 type SessionRosterRefreshHost = {
   connection: SessionConnectionOwner;
@@ -30,17 +35,52 @@ type SessionRosterRefreshHost = {
   onCanonicalList: (result: SessionsListResult | null) => void;
 };
 
-type FilteredSessionList = {
+type ManagedSessionListRefresh = {
+  append: boolean;
+  offset?: number;
+};
+
+type ManagedSessionListQuery = Readonly<Record<string, unknown>> & { readonly limit: number };
+
+type ManagedSessionList = {
   key: string;
-  agentId: string;
-  archivedFilter: "archived" | "all";
+  query: ManagedSessionListQuery;
+  retainedLimit: number;
+  connectionEpoch: number | null;
   snapshot: SessionListSnapshot;
-  options: SessionListOptions;
   listeners: Set<(snapshot: SessionListSnapshot) => void>;
   coordinator: ReturnType<typeof createSessionEventRefreshCoordinator>;
   pending: Promise<void> | null;
-  queued: SessionRefreshOptions | null;
+  queued: ManagedSessionListRefresh | null;
 };
+
+function normalizeManagedSessionListQuery(options: SessionListOptions): ManagedSessionListQuery {
+  const { offset: _offset, append: _append, ...queryOptions } = options;
+  const limit =
+    typeof options.limit === "number" && options.limit > 0
+      ? Math.floor(options.limit)
+      : DEFAULT_SESSION_LIST_QUERY.limit;
+  return Object.freeze({ ...buildSessionListParams({ ...queryOptions, limit }), limit });
+}
+
+function managedSessionListAgentId(entry: ManagedSessionList): string | undefined {
+  return typeof entry.query.agentId === "string" ? entry.query.agentId : undefined;
+}
+
+function isPrimarySessionListQuery(options: SessionListScope): boolean {
+  const query = normalizeManagedSessionListQuery(options);
+  return (
+    query.archived === undefined &&
+    !query.spawnedBy &&
+    !query.boardFace &&
+    !query.activeMinutes &&
+    !query.search &&
+    !query.creatorId &&
+    query.includeGlobal === true &&
+    query.includeUnknown === true &&
+    query.configuredAgentsOnly === true
+  );
+}
 
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let inFlight: Promise<void> | null = null;
@@ -49,109 +89,90 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let lastListOptions: SessionListOptions = {};
   let hasForegroundListOptions = false;
   let hasSeededListOptions = false;
-  const filteredLists = new Map<string, FilteredSessionList>();
+  const managedLists = new Map<string, ManagedSessionList>();
 
-  const filteredListKey = (scope: SessionListScope): string => {
-    const agentId = normalizeAgentId(
-      scope.agentId ?? host.readState().agentId ?? resolveUiSelectedGlobalAgentId(host.snapshot()),
-    );
-    return `${agentId}:${scope.archivedFilter}`;
-  };
-
-  const publishFilteredList = (entry: FilteredSessionList, snapshot: SessionListSnapshot): void => {
+  const publishManagedList = (entry: ManagedSessionList, snapshot: SessionListSnapshot): void => {
     entry.snapshot = snapshot;
     entry.listeners.forEach((listener) => listener(snapshot));
   };
 
-  const filteredList = (scope: SessionListScope): FilteredSessionList => {
-    const key = filteredListKey(scope);
-    const current = filteredLists.get(key);
+  const managedList = (scope: SessionListScope): ManagedSessionList => {
+    const query = normalizeManagedSessionListQuery(scope);
+    const key = JSON.stringify(query);
+    const current = managedLists.get(key);
     if (current) {
       return current;
     }
-    const agentId = key.slice(0, key.lastIndexOf(":"));
-    const archivedFilter = scope.archivedFilter === "archived" ? "archived" : "all";
-    const entry: FilteredSessionList = {
+    const entry: ManagedSessionList = {
       key,
-      agentId,
-      archivedFilter,
+      query,
+      retainedLimit: query.limit,
+      connectionEpoch: null,
       snapshot: { result: null, agentId: null, loading: false, error: null },
-      options: { agentId, archivedFilter },
       listeners: new Set(),
       coordinator: createSessionEventRefreshCoordinator({
         canRefresh: () =>
-          filteredLists.get(key) === entry &&
+          managedLists.get(key) === entry &&
           entry.listeners.size > 0 &&
           host.connection.capture() !== null,
-        refresh: () => refreshFilteredList({ ...entry.options, force: true }),
+        refresh: () => refreshManagedList(entry, { append: false }),
       }),
       pending: null,
       queued: null,
     };
-    filteredLists.set(key, entry);
+    managedLists.set(key, entry);
     return entry;
   };
 
-  const refreshFilteredList = (options: SessionRefreshOptions): Promise<void> => {
+  const refreshManagedList = (
+    entry: ManagedSessionList,
+    refresh: ManagedSessionListRefresh,
+  ): Promise<void> => {
     const scope = host.connection.capture();
     if (!scope) {
       return Promise.resolve();
     }
-    const entry = filteredList(options);
     if (entry.pending) {
-      if (!options.append) {
-        entry.queued = options;
+      if (!refresh.append) {
+        entry.queued = refresh;
       }
       return entry.pending;
     }
-    if (options.append && !entry.snapshot.result) {
+    if (refresh.append && !entry.snapshot.result) {
       return Promise.resolve();
     }
-    if (!options.append) {
+    if (!refresh.append) {
       entry.coordinator.absorb();
     }
     const isCurrent = () =>
-      filteredLists.get(entry.key) === entry && host.connection.isCurrent(scope);
+      managedLists.get(entry.key) === entry && host.connection.isCurrent(scope);
     const drain = async () => {
-      let next: SessionRefreshOptions | null = options;
+      let next: ManagedSessionListRefresh | null = refresh;
       while (next && isCurrent()) {
-        const { append = false, ...requestOptions } = next;
-        delete requestOptions.force;
-        delete requestOptions.backgroundHydrate;
-        Object.assign(requestOptions, {
-          agentId: entry.agentId,
-          archivedFilter: entry.archivedFilter,
-        });
-        if (!append && entry.snapshot.result) {
-          // Replacement refreshes retain pages owned by this exact agent/filter scope.
-          requestOptions.limit = Math.max(
-            requestOptions.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
-            entry.snapshot.result.sessions.length,
-          );
-        }
-        entry.options = { ...requestOptions };
-        delete entry.options.offset;
-        publishFilteredList(entry, { ...entry.snapshot, loading: true, error: null });
+        const requestParams = {
+          ...entry.query,
+          limit: next.append ? entry.query.limit : entry.retainedLimit,
+          ...(next.append && next.offset !== undefined ? { offset: next.offset } : {}),
+        };
+        publishManagedList(entry, { ...entry.snapshot, loading: true, error: null });
         try {
-          const result = await requestSessionList(scope.client, requestOptions);
+          const result = await requestSessionListParams(scope.client, requestParams);
           if (!isCurrent()) {
             return;
           }
           const previous = entry.snapshot.result;
           const nextResult =
-            result && append && requestOptions.offset && previous
+            result && next.append && requestParams.offset && previous
               ? appendSessionResults(previous, result)
               : reconcileRosterPresentationMetadata(result, previous);
           const decorated = host.decorate(nextResult);
-          if (append && decorated) {
-            entry.options.limit = Math.max(
-              entry.options.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
-              decorated.sessions.length,
-            );
+          if (decorated) {
+            entry.retainedLimit = Math.max(entry.retainedLimit, decorated.sessions.length);
           }
-          publishFilteredList(entry, {
+          entry.connectionEpoch = scope.epoch;
+          publishManagedList(entry, {
             result: decorated,
-            agentId: entry.agentId,
+            agentId: managedSessionListAgentId(entry) ?? null,
             loading: false,
             error: null,
           });
@@ -159,7 +180,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           if (!isCurrent()) {
             return;
           }
-          publishFilteredList(entry, {
+          publishManagedList(entry, {
             ...entry.snapshot,
             loading: false,
             error: formatUiError(error),
@@ -417,12 +438,12 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   return {
     list,
     listSnapshot(scope: SessionListScope): SessionListSnapshot {
-      if (!scope.archivedFilter || scope.archivedFilter === "active") {
+      if (isPrimarySessionListQuery(scope)) {
         const { result, agentId, loading, error } = host.readState();
         return { result, agentId, loading, error };
       }
       return (
-        filteredLists.get(filteredListKey(scope))?.snapshot ?? {
+        managedLists.get(JSON.stringify(normalizeManagedSessionListQuery(scope)))?.snapshot ?? {
           result: null,
           agentId: null,
           loading: false,
@@ -431,20 +452,37 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
     },
     subscribeList(scope: SessionListScope, listener: (snapshot: SessionListSnapshot) => void) {
-      const entry = filteredList(scope);
+      const entry = managedList(scope);
       entry.listeners.add(listener);
       return () => {
         entry.listeners.delete(listener);
-        if (entry.listeners.size === 0 && filteredLists.get(entry.key) === entry) {
+        if (entry.listeners.size === 0 && managedLists.get(entry.key) === entry) {
           entry.coordinator.dispose();
-          filteredLists.delete(entry.key);
+          managedLists.delete(entry.key);
         }
       };
     },
     refreshList(options: SessionRefreshOptions = {}): Promise<void> {
-      return !options.archivedFilter || options.archivedFilter === "active"
-        ? refresh(options)
-        : refreshFilteredList(options);
+      if (isPrimarySessionListQuery(options)) {
+        return refresh(options);
+      }
+      const entry = managedList(options);
+      return refreshManagedList(entry, {
+        append: options.append === true,
+        ...(options.offset !== undefined ? { offset: options.offset } : {}),
+      });
+    },
+    isPrimaryList: isPrimarySessionListQuery,
+    async refreshManagedLists() {
+      const scope = host.connection.capture();
+      if (!scope) {
+        return;
+      }
+      await Promise.all(
+        [...managedLists.values()]
+          .filter((entry) => entry.listeners.size > 0 && entry.connectionEpoch !== scope.epoch)
+          .map((entry) => refreshManagedList(entry, { append: false })),
+      );
     },
     refresh,
     refreshReplacement,
@@ -457,7 +495,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       if (primary) {
         return primary;
       }
-      for (const entry of filteredLists.values()) {
+      for (const entry of managedLists.values()) {
         const row = entry.snapshot.result?.sessions.find((candidate) => candidate.key === key);
         if (row) {
           return row;
@@ -473,10 +511,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       if (result !== state.result) {
         host.publish({ ...state, result });
       }
-      for (const entry of filteredLists.values()) {
+      for (const entry of managedLists.values()) {
         const decorated = host.decorate(entry.snapshot.result);
         if (decorated !== entry.snapshot.result) {
-          publishFilteredList(entry, { ...entry.snapshot, result: decorated });
+          publishManagedList(entry, { ...entry.snapshot, result: decorated });
         }
       }
     },
@@ -492,8 +530,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         return;
       }
       const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;
-      for (const entry of filteredLists.values()) {
-        if (!agentId || entry.agentId === agentId) {
+      for (const entry of managedLists.values()) {
+        const queryAgentId = managedSessionListAgentId(entry);
+        if (!agentId || !queryAgentId || normalizeAgentId(queryAgentId) === agentId) {
           entry.coordinator.schedule();
         }
       }
@@ -503,18 +542,16 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       inFlight = null;
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
-      for (const entry of filteredLists.values()) {
+      for (const entry of managedLists.values()) {
         entry.coordinator.reset();
         entry.pending = entry.queued = null;
-        entry.options = { agentId: entry.agentId, archivedFilter: entry.archivedFilter };
         if (entry.listeners.size === 0) {
           entry.coordinator.dispose();
-          filteredLists.delete(entry.key);
+          managedLists.delete(entry.key);
           continue;
         }
-        if (entry.snapshot.result || entry.snapshot.loading || entry.snapshot.error) {
-          // Disconnect clears ownership once; reconnect must not flash preserved sidebar rows.
-          publishFilteredList(entry, { result: null, agentId: null, loading: false, error: null });
+        if (entry.snapshot.loading || entry.snapshot.error) {
+          publishManagedList(entry, { ...entry.snapshot, loading: false, error: null });
         }
       }
     },
@@ -529,11 +566,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       inFlight = null;
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
-      for (const entry of filteredLists.values()) {
+      for (const entry of managedLists.values()) {
         entry.coordinator.dispose();
         entry.listeners.clear();
       }
-      filteredLists.clear();
+      managedLists.clear();
     },
   };
 }

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
+import type { SessionListOptions, SessionListSnapshot } from "../../lib/sessions/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
-import { page as dashboardsRoute } from "./route.ts";
 import type { DashboardsRouteData } from "./view.ts";
 import "./dashboards-page.ts";
 
@@ -13,13 +13,6 @@ type DashboardsPageElement = HTMLElement & {
   routeData?: DashboardsRouteData;
   updateComplete: Promise<boolean>;
 };
-
-async function loadDashboards(
-  context: ApplicationContext,
-  options: Parameters<NonNullable<typeof dashboardsRoute.loader>>[1],
-): Promise<DashboardsRouteData> {
-  return (await Promise.resolve(dashboardsRoute.loader!(context, options))) as DashboardsRouteData;
-}
 
 function result(sessionRow: GatewaySessionRow): SessionsListResult {
   return {
@@ -41,6 +34,16 @@ function row(key: string, displayName: string): GatewaySessionRow {
   };
 }
 
+function routeData(sessionRow: GatewaySessionRow): DashboardsRouteData {
+  return {
+    result: result(sessionRow),
+    error: null,
+    basePath: "",
+    fallbackAgentId: "main",
+    mainKey: "main",
+  };
+}
+
 describe("DashboardsPage", () => {
   beforeEach(async () => {
     await i18n.setLocale("en");
@@ -51,30 +54,32 @@ describe("DashboardsPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("reloads rendered rows once per canonical revision or agent scope change", async () => {
-    const sessionListeners = new Set<() => void>();
+  it("subscribes to the exact query and preserves rows while a new agent scope loads", async () => {
     const selectionListeners = new Set<() => void>();
-    let canonicalListRevision = 1;
+    const listListeners = new Map<string, (snapshot: SessionListSnapshot) => void>();
+    const snapshots = new Map<string, SessionListSnapshot>();
+    const queryKey = (options: SessionListOptions) => options.agentId ?? "all";
+    const allResult = result(row("agent:main:before", "Before"));
+    snapshots.set("all", { result: allResult, agentId: null, loading: false, error: null });
+    snapshots.set("writer", { result: null, agentId: null, loading: false, error: null });
+    const refreshList = vi.fn(async () => undefined);
+    const subscribeList = vi.fn(
+      (query: SessionListOptions, listener: (snapshot: SessionListSnapshot) => void) => {
+        const key = queryKey(query);
+        listListeners.set(key, listener);
+        return () => listListeners.delete(key);
+      },
+    );
     const selectionState = { selectedId: "main", scopeId: null as string | null };
-    const client = {};
-    const gateway = { snapshot: { client, phase: "connected", hello: null } };
-    const list = vi
-      .fn<() => Promise<SessionsListResult | null>>()
-      .mockResolvedValueOnce(result(row("agent:main:before", "Before")))
-      .mockResolvedValueOnce(result(row("agent:main:after", "After")))
-      .mockResolvedValueOnce(result(row("agent:writer:scoped", "Writer dashboard")));
     const context = {
       basePath: "",
-      gateway,
+      gateway: { snapshot: { client: {}, phase: "connected", hello: null } },
       sessions: {
-        get canonicalListRevision() {
-          return canonicalListRevision;
+        listSnapshot(query: SessionListOptions) {
+          return snapshots.get(queryKey(query))!;
         },
-        list,
-        subscribe(listener: () => void) {
-          sessionListeners.add(listener);
-          return () => sessionListeners.delete(listener);
-        },
+        subscribeList,
+        refreshList,
       },
       agentSelection: {
         state: selectionState,
@@ -85,106 +90,45 @@ describe("DashboardsPage", () => {
       },
       agents: { state: { agentsList: null } },
     } as unknown as ApplicationContext;
-    if (!dashboardsRoute.loader) {
-      throw new Error("dashboards route has no loader");
-    }
-    const loaderOptions = {
-      signal: new AbortController().signal,
-      shouldRun: () => true,
-      revalidating: false,
-      location: { pathname: "/dashboards", search: "", hash: "" },
-      deps: "",
-      cause: "navigation" as const,
-    };
     const element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
-    element.routeData = await loadDashboards(context, loaderOptions);
+    element.routeData = routeData(row("agent:main:before", "Before"));
     const provider = createApplicationContextProvider(context);
     provider.append(element);
     document.body.append(provider);
     await element.updateComplete;
 
-    expect(list).toHaveBeenCalledTimes(1);
-    expect(element.textContent).toContain("Before");
-
-    canonicalListRevision += 1;
-    sessionListeners.forEach((listener) => listener());
-    await vi.waitFor(() => expect(element.textContent).toContain("After"));
-    expect(list).toHaveBeenCalledTimes(2);
-
-    sessionListeners.forEach((listener) => listener());
-    await Promise.resolve();
-    expect(list).toHaveBeenCalledTimes(2);
+    expect(subscribeList).toHaveBeenCalledWith(
+      { limit: 50, boardFace: "dashboard", archivedFilter: "all" },
+      expect.any(Function),
+    );
+    expect(refreshList).not.toHaveBeenCalled();
 
     selectionState.scopeId = "writer";
     selectionListeners.forEach((listener) => listener());
-    await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
-    expect(list).toHaveBeenCalledTimes(3);
-    expect(list).toHaveBeenLastCalledWith({
+    await vi.waitFor(() => expect(refreshList).toHaveBeenCalledTimes(1));
+    expect(refreshList).toHaveBeenCalledWith({
       limit: 50,
       boardFace: "dashboard",
       archivedFilter: "all",
       agentId: "writer",
+      force: true,
     });
-  });
+    expect(element.textContent).toContain("Before");
 
-  it("ignores a retired refresh after the replacement connection renders", async () => {
-    const sessionListeners = new Set<() => void>();
-    let canonicalListRevision = 1;
-    const clientA = {};
-    const clientB = {};
-    const gateway = { snapshot: { client: clientA, phase: "connected", hello: null } };
-    let resolveRetired!: (value: SessionsListResult | null) => void;
-    const retiredResult = new Promise<SessionsListResult | null>((resolve) => {
-      resolveRetired = resolve;
-    });
-    const list = vi
-      .fn<() => Promise<SessionsListResult | null>>()
-      .mockImplementationOnce(() => retiredResult)
-      .mockResolvedValueOnce(result(row("agent:main:current", "Current")));
-    const context = {
-      basePath: "",
-      gateway,
-      sessions: {
-        get canonicalListRevision() {
-          return canonicalListRevision;
-        },
-        list,
-        subscribe(listener: () => void) {
-          sessionListeners.add(listener);
-          return () => sessionListeners.delete(listener);
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main", scopeId: null },
-        subscribe: () => () => undefined,
-      },
-      agents: { state: { agentsList: null } },
-    } as unknown as ApplicationContext;
-    const element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
-    element.routeData = {
-      result: result(row("agent:main:before", "Before")),
+    listListeners.get("writer")?.({
+      result: result(row("agent:writer:current", "Writer dashboard")),
+      agentId: "writer",
+      loading: false,
       error: null,
-      basePath: "",
-      fallbackAgentId: "main",
-      mainKey: "main",
-    };
-    const provider = createApplicationContextProvider(context);
-    provider.append(element);
-    document.body.append(provider);
+    });
+    await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
+    listListeners.get("all")?.({
+      result: result(row("agent:main:retired", "Retired")),
+      agentId: null,
+      loading: false,
+      error: null,
+    });
     await element.updateComplete;
-
-    canonicalListRevision = 2;
-    sessionListeners.forEach((listener) => listener());
-    await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(1));
-    gateway.snapshot = { client: clientB, phase: "connected", hello: null };
-    canonicalListRevision = 3;
-    sessionListeners.forEach((listener) => listener());
-    await vi.waitFor(() => expect(element.textContent).toContain("Current"));
-
-    resolveRetired(result(row("agent:main:retired", "Retired")));
-    await Promise.resolve();
-    await element.updateComplete;
-    expect(element.textContent).toContain("Current");
     expect(element.textContent).not.toContain("Retired");
   });
 });

--- a/ui/src/pages/dashboards/dashboards-page.ts
+++ b/ui/src/pages/dashboards/dashboards-page.ts
@@ -4,7 +4,7 @@ import { property } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { loadDashboardsRoute } from "./route.ts";
+import { dashboardSessionListQuery, dashboardsRouteData } from "./route.ts";
 import { renderDashboards, type DashboardsRouteData } from "./view.ts";
 
 class DashboardsPage extends OpenClawLightDomElement {
@@ -14,29 +14,22 @@ class DashboardsPage extends OpenClawLightDomElement {
   @property({ attribute: false }) routeData?: DashboardsRouteData;
 
   private observedSessions?: ApplicationContext["sessions"];
-  private observedAgentSelection?: ApplicationContext["agentSelection"];
-  private observedDependencies = "";
-  private dependenciesInitialized = false;
-  private refreshGeneration = 0;
+  private observedScopeId?: string | null;
+  private unsubscribeList?: () => void;
   private data?: DashboardsRouteData;
-  private readonly subscriptions = new SubscriptionsController(this)
-    .effect(
-      () => this.context?.sessions,
-      (sessions) => {
-        this.synchronizeDependencies();
-        return sessions.subscribe(() => this.synchronizeDependencies());
-      },
-    )
-    .effect(
-      () => this.context?.agentSelection,
-      (agentSelection) => {
-        this.synchronizeDependencies();
-        return agentSelection.subscribe(() => this.synchronizeDependencies());
-      },
-    );
+  private readonly subscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.agentSelection,
+    (agentSelection) => {
+      this.bindList();
+      return agentSelection.subscribe(() => this.bindList());
+    },
+  );
 
   override disconnectedCallback() {
-    this.refreshGeneration += 1;
+    this.unsubscribeList?.();
+    this.unsubscribeList = undefined;
+    this.observedSessions = undefined;
+    this.observedScopeId = undefined;
     this.subscriptions.clear();
     super.disconnectedCallback();
   }
@@ -45,68 +38,41 @@ class DashboardsPage extends OpenClawLightDomElement {
     if (changed.has("routeData")) {
       this.data = this.routeData;
     }
+    this.bindList();
   }
 
-  private synchronizeDependencies(): void {
+  private bindList(): void {
     const context = this.context;
     if (!context) {
       return;
     }
     const sessions = context.sessions;
-    const agentSelection = context.agentSelection;
-    const dependencies = `${agentSelection.state.scopeId ?? "all"}\u0000${
-      sessions.canonicalListRevision
-    }`;
-    const sourceChanged =
-      sessions !== this.observedSessions || agentSelection !== this.observedAgentSelection;
-    if (
-      this.dependenciesInitialized &&
-      !sourceChanged &&
-      dependencies === this.observedDependencies
-    ) {
+    const scopeId = context.agentSelection.state.scopeId?.trim() || null;
+    if (sessions === this.observedSessions && scopeId === this.observedScopeId) {
       return;
     }
-    const shouldRefresh =
-      context.gateway.snapshot.phase === "connected" &&
-      (this.dependenciesInitialized ||
-        (this.routeData?.result === null && this.routeData.error === null));
-    this.dependenciesInitialized = true;
+    this.unsubscribeList?.();
     this.observedSessions = sessions;
-    this.observedAgentSelection = agentSelection;
-    this.observedDependencies = dependencies;
-    if (shouldRefresh) {
-      void this.refresh(context, sessions, agentSelection, dependencies);
+    this.observedScopeId = scopeId;
+    const query = dashboardSessionListQuery(context);
+    const apply = (snapshot: ReturnType<typeof sessions.listSnapshot>) => {
+      if (
+        this.context !== context ||
+        this.observedSessions !== sessions ||
+        this.observedScopeId !== scopeId ||
+        (!snapshot.result && !snapshot.error)
+      ) {
+        return;
+      }
+      this.data = dashboardsRouteData(context, snapshot);
+      this.requestUpdate();
+    };
+    this.unsubscribeList = sessions.subscribeList(query, apply);
+    const snapshot = sessions.listSnapshot(query);
+    apply(snapshot);
+    if (!snapshot.result && !snapshot.loading && context.gateway.snapshot.phase === "connected") {
+      void sessions.refreshList({ ...query, force: true });
     }
-  }
-
-  private async refresh(
-    context: ApplicationContext,
-    sessions: ApplicationContext["sessions"],
-    agentSelection: ApplicationContext["agentSelection"],
-    dependencies: string,
-  ): Promise<void> {
-    const gateway = context.gateway;
-    const client = gateway.snapshot.phase === "connected" ? gateway.snapshot.client : null;
-    if (!client) {
-      return;
-    }
-    const generation = ++this.refreshGeneration;
-    const data = await loadDashboardsRoute(context);
-    if (
-      generation !== this.refreshGeneration ||
-      this.context !== context ||
-      context.sessions !== sessions ||
-      context.agentSelection !== agentSelection ||
-      this.observedDependencies !== dependencies ||
-      context.gateway !== gateway ||
-      gateway.snapshot.phase !== "connected" ||
-      gateway.snapshot.client !== client ||
-      (data.result === null && data.error === null)
-    ) {
-      return;
-    }
-    this.data = data;
-    this.requestUpdate();
   }
 
   override render() {

--- a/ui/src/pages/dashboards/route.test.ts
+++ b/ui/src/pages/dashboards/route.test.ts
@@ -22,11 +22,28 @@ async function loadDashboards(
 }
 
 describe("dashboards route", () => {
-  it("requests the dashboard face from the server before pagination", async () => {
-    const list = vi.fn(async () => null);
+  it("seeds the exact managed dashboard query without calling the raw list API", async () => {
+    const result = {
+      ts: 1,
+      path: "",
+      count: 0,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [],
+    };
+    let snapshot = {
+      result: null as typeof result | null,
+      agentId: null,
+      loading: false,
+      error: null,
+    };
+    const list = vi.fn();
+    const listSnapshot = vi.fn(() => snapshot);
+    const refreshList = vi.fn(async () => {
+      snapshot = { ...snapshot, result };
+    });
     const context = {
       basePath: "",
-      sessions: { list, canonicalListRevision: 4 },
+      sessions: { list, listSnapshot, refreshList },
       agentSelection: { state: { selectedId: "main", scopeId: null } },
       agents: { state: { agentsList: null } },
       gateway: { snapshot: { hello: null } },
@@ -37,10 +54,17 @@ describe("dashboards route", () => {
 
     await loadDashboards(context, loaderOptions);
 
-    expect(list).toHaveBeenCalledWith({
+    expect(refreshList).toHaveBeenCalledWith({
+      limit: 50,
+      boardFace: "dashboard",
+      archivedFilter: "all",
+      force: true,
+    });
+    expect(listSnapshot).toHaveBeenLastCalledWith({
       limit: 50,
       boardFace: "dashboard",
       archivedFilter: "all",
     });
+    expect(list).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -2,32 +2,33 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { formatUiError } from "../../lib/format-error.ts";
-import { DEFAULT_SESSION_LIST_QUERY } from "../../lib/sessions/index.ts";
+import {
+  DEFAULT_SESSION_LIST_QUERY,
+  type SessionListOptions,
+  type SessionListSnapshot,
+} from "../../lib/sessions/index.ts";
 import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-navigation.ts";
 import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
 import type { DashboardsRouteData } from "./view.ts";
 
-export async function loadDashboardsRoute(
-  context: ApplicationContext,
-): Promise<DashboardsRouteData> {
-  let value = null;
-  let error: string | null = null;
-  try {
-    value = await context.sessions.list({
-      ...DEFAULT_SESSION_LIST_QUERY,
-      boardFace: "dashboard",
-      archivedFilter: "all",
-      ...(context.agentSelection.state.scopeId
-        ? { agentId: context.agentSelection.state.scopeId }
-        : {}),
-    });
-  } catch (cause) {
-    error = formatUiError(cause);
-  }
+export function dashboardSessionListQuery(context: ApplicationContext): SessionListOptions {
   return {
-    result: value,
-    error,
+    ...DEFAULT_SESSION_LIST_QUERY,
+    boardFace: "dashboard",
+    archivedFilter: "all",
+    ...(context.agentSelection.state.scopeId
+      ? { agentId: context.agentSelection.state.scopeId }
+      : {}),
+  };
+}
+
+export function dashboardsRouteData(
+  context: ApplicationContext,
+  snapshot: SessionListSnapshot,
+): DashboardsRouteData {
+  return {
+    result: snapshot.result,
+    error: snapshot.result ? null : snapshot.error,
     basePath: context.basePath,
     fallbackAgentId: resolveSessionNavigationAgentId(context),
     mainKey: resolveUiConfiguredMainKey({
@@ -35,6 +36,16 @@ export async function loadDashboardsRoute(
       hello: context.gateway.snapshot.hello,
     }),
   };
+}
+
+async function loadDashboardsRoute(context: ApplicationContext): Promise<DashboardsRouteData> {
+  const query = dashboardSessionListQuery(context);
+  let snapshot = context.sessions.listSnapshot(query);
+  if (!snapshot.result && !snapshot.loading) {
+    await context.sessions.refreshList({ ...query, force: true });
+    snapshot = context.sessions.listSnapshot(query);
+  }
+  return dashboardsRouteData(context, snapshot);
 }
 
 export const page = definePage({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Dashboards page caused each browser tab to issue a duplicate server-filtered dashboard session-list round-trip after an older canonical session-list request completed.

## Why This Change Was Made

The dashboard page treated `canonicalListRevision`—a list-completion counter—as a push invalidation signal, so completion of an older canonical request triggered another identical dashboard query per tab. The canonical fix makes `SessionCapability` managed lists own exact normalized queries, retained pagination windows, reconnect epochs, and direct `sessions.changed` refreshes; the route and page now consume that exact owner, while the `canonicalListRevision` dependency, direct page fetch, and page-local generation fencing are removed.

AI-assisted: yes. The resulting ownership and request behavior were reviewed against the source, focused tests, real Chromium behavior, and a clean Codex autoreview.

## User Impact

Dashboards now place less demand on the Gateway: each tab issues one dashboard list request instead of a duplicate round-trip, while pushed row updates, agent filters, and retained pagination windows continue to refresh correctly.

## Evidence

- Real Chromium + Vite + mock Gateway, two tabs: before the fix, canonical=2, dashboard=4, total=6 while the expected total was 4; after the fix, canonical=2, dashboard=2, total=4. Completing the older canonical requests added zero dashboard requests.
- One `sessions.changed` wave added exactly one canonical refresh and one exact dashboard refresh per tab. Dashboard params were exactly `limit=50`, `boardFace=dashboard`, `archived=all`, with no `agentId` in all-agent scope, and the visible rendered rows updated.
- Focused unit command: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/components/session-data-controller.event-refresh.test.ts ui/src/lib/sessions/index-list.test.ts ui/src/lib/sessions/index.event-refresh.test.ts ui/src/lib/sessions/list-options.test.ts ui/src/pages/dashboards/dashboards-page.test.ts ui/src/pages/dashboards/route.test.ts ui/src/pages/dashboards/view.test.ts` — 7 files, 39 tests passed.
- Focused Chromium E2E command: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/dashboards-list-demand.e2e.test.ts` — 1 test passed.
- Direct AWS Crabbox changed gate passed: provider `aws`, lease `cbx_d359300b4571`, run `run_a9f7f93a8f17`, exit 0: https://crabbox.openclaw.ai/portal/runs/run_a9f7f93a8f17
- Fresh closeout autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- LOC: production +215/-188 (net +27); tests/E2E +479/-115 (net +364).
- UI proof: this is deliberately no-visual-delta network/query ownership work, so before/after screenshots would be pixel-identical. The real Chromium E2E asserts the rendered dashboard row before and after a pushed update while also counting exact Gateway requests.
