### PR TITLE
fix(codex): preserve resumed session usage

### DIFF
--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -90,8 +90,13 @@ export function buildCodexAttemptResult(
   // A terminal timeout must not publish exact usage, but the timeout watcher
   // can still recover a completed assistant. Keep the snapshot masked until
   // recovery clears the abort instead of destroying it in markTimedOut().
-  const completedUsage = input.responseCompletions.usage ?? input.tokenUsage;
-  const projectedUsage = input.aborted ? input.tokenUsage : completedUsage;
+  const unavailableThreadUsage = input.tokenUsage
+    ? { ...input.tokenUsage, contextUsage: { state: "unavailable" } as const }
+    : undefined;
+  const completedUsage =
+    input.responseCompletions.usage ??
+    (input.responseCompletions.modelIterations > 0 ? unavailableThreadUsage : input.tokenUsage);
+  const projectedUsage = input.aborted ? unavailableThreadUsage : completedUsage;
   const hasAssistantItemText = input.assistantProjection.hasAssistantItemTextForSynthesis();
   const legacyFailClosed =
     !input.completedTurn || input.completedTurn.status !== "completed" || hasAssistantItemText;

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -1,6 +1,5 @@
 import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
-  asFiniteNumber,
   asSafeIntegerInRange,
   readStringField as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -66,55 +65,40 @@ export function projectCodexThreadUsageUpdate(
 export function normalizeCodexThreadTokenUsage(
   record: JsonObject,
 ): ReturnType<typeof normalizeUsage> {
-  // Thread usage preserves per-response accounting on older app servers, but
-  // its `last` snapshot is not guaranteed to describe the final response.
-  return normalizeCodexTokenUsageBreakdown(record, "thread");
+  return normalizeCodexTokenUsageBreakdown(record);
 }
 
 export function normalizeCodexResponseTokenUsage(
   record: JsonObject,
 ): ReturnType<typeof normalizeUsage> {
-  return normalizeCodexTokenUsageBreakdown(record, "response");
+  return normalizeCodexTokenUsageBreakdown(record);
 }
 
-function normalizeCodexTokenUsageBreakdown(
-  record: JsonObject,
-  source: "thread" | "response",
-): ReturnType<typeof normalizeUsage> {
+function normalizeCodexTokenUsageBreakdown(record: JsonObject): ReturnType<typeof normalizeUsage> {
   // v2 TokenUsageBreakdown. inputTokens includes cached input; OpenClaw usage
   // tracks uncached input, cache reads, and cache writes separately.
-  const readCount =
-    source === "response"
-      ? readTokenCount
-      : (value: JsonObject, key: string) => asFiniteNumber(value[key]);
-  const totalTokens = readCount(record, "totalTokens");
-  const inputTokens = readCount(record, "inputTokens");
-  const cacheRead = readCount(record, "cachedInputTokens");
-  const output = readCount(record, "outputTokens");
-  const reasoningTokens = readCount(record, "reasoningOutputTokens");
+  const totalTokens = readTokenCount(record, "totalTokens");
+  const inputTokens = readTokenCount(record, "inputTokens");
+  const cacheRead = readTokenCount(record, "cachedInputTokens");
+  const output = readTokenCount(record, "outputTokens");
+  const reasoningTokens = readTokenCount(record, "reasoningOutputTokens");
   const cacheWrite =
-    record.cacheWriteInputTokens === undefined && source === "response"
+    record.cacheWriteInputTokens === undefined
       ? 0
-      : readCount(record, "cacheWriteInputTokens");
-  if (
-    source === "response" &&
-    (totalTokens === undefined ||
-      inputTokens === undefined ||
-      cacheRead === undefined ||
-      cacheWrite === undefined ||
-      output === undefined ||
-      reasoningTokens === undefined ||
-      cacheRead + cacheWrite > inputTokens ||
-      totalTokens !== inputTokens + output)
-  ) {
-    return undefined;
-  }
+      : readTokenCount(record, "cacheWriteInputTokens");
+  const hasCoherentInput =
+    inputTokens !== undefined &&
+    cacheRead !== undefined &&
+    cacheWrite !== undefined &&
+    cacheRead + cacheWrite <= inputTokens;
+  const hasCoherentContext =
+    hasCoherentInput &&
+    totalTokens !== undefined &&
+    output !== undefined &&
+    totalTokens === inputTokens + output;
 
   const usage = normalizeUsage({
-    input:
-      inputTokens === undefined
-        ? undefined
-        : Math.max(0, inputTokens - (cacheRead ?? 0) - (cacheWrite ?? 0)),
+    input: hasCoherentInput ? inputTokens - cacheRead - cacheWrite : undefined,
     output,
     cacheRead,
     cacheWrite,
@@ -125,13 +109,11 @@ function normalizeCodexTokenUsageBreakdown(
     return undefined;
   }
 
-  // Only exact provider completions own fresh context; thread snapshots may be stale.
   return {
     ...usage,
-    contextUsage:
-      source === "response" && inputTokens !== undefined && totalTokens !== undefined
-        ? { state: "available", promptTokens: inputTokens, totalTokens }
-        : { state: "unavailable" },
+    contextUsage: hasCoherentContext
+      ? { state: "available", promptTokens: inputTokens, totalTokens }
+      : { state: "unavailable" },
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -124,7 +124,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
     expect(projector.buildResult(buildEmptyToolTelemetry()).modelIterations).toBe(2);
   });
 
-  it("keeps cumulative-only thread usage unknown", async () => {
+  it("uses current-turn thread usage when exact response events are unavailable", async () => {
     const projector = await createProjector();
 
     await projector.handleNotification(agentMessageDelta("done"));
@@ -160,7 +160,11 @@ describe("CodexAppServerEventProjector usage projection", () => {
       total: 12,
     });
     expect(result.attemptUsage?.reasoningTokens).toBe(3);
-    expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+    expect(result.attemptUsage?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 5,
+      totalTokens: 12,
+    });
     expectUsageFields(result.lastAssistant?.usage, {
       input: 2,
       output: 7,
@@ -168,12 +172,16 @@ describe("CodexAppServerEventProjector usage projection", () => {
       cacheWrite: 1,
       total: 12,
     });
-    expect(result.lastAssistant?.usage.contextUsage).toEqual({ state: "unavailable" });
+    expect(result.lastAssistant?.usage.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 5,
+      totalTokens: 12,
+    });
     expect(normalizeUsage(result.lastAssistant?.usage)?.reasoningTokens).toBe(3);
   });
 
   it.each([
-    ["incomplete", { totalTokens: 12 }],
+    ["incomplete", { totalTokens: 12 }, { total: 12 }],
     [
       "incoherent total",
       {
@@ -183,6 +191,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
         outputTokens: 7,
         reasoningOutputTokens: 0,
       },
+      { input: 3, output: 7, cacheRead: 2, cacheWrite: 0, total: 6 },
     ],
     [
       "impossible cache counts",
@@ -194,8 +203,9 @@ describe("CodexAppServerEventProjector usage projection", () => {
         outputTokens: 7,
         reasoningOutputTokens: 0,
       },
+      { output: 7, cacheRead: 4, cacheWrite: 2, total: 12 },
     ],
-  ])("keeps %s response usage unknown", async (_label, usage) => {
+  ])("keeps valid fields from %s response usage", async (_label, usage, expectedUsage) => {
     const projector = await createProjector();
 
     await projector.handleNotification(agentMessageDelta("done"));
@@ -206,8 +216,9 @@ describe("CodexAppServerEventProjector usage projection", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(result.assistantTexts).toEqual(["done"]);
-    expect(result.attemptUsage).toBeUndefined();
-    expect(result.lastAssistant?.usage.contextUsage).toBeUndefined();
+    expect(result.attemptUsage).toMatchObject(expectedUsage);
+    expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+    expect(result.lastAssistant?.usage.contextUsage).toEqual({ state: "unavailable" });
   });
 
   it("clears prior response usage when the final response omits usage", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5337,6 +5337,101 @@ describe("runCodexAppServerAttempt", () => {
       },
     ]);
   });
+  it("keeps context usage fresh across two turns of one Codex thread", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const turnIds = ["turn-1", "turn-2"] as const;
+    let nextTurnIndex = 0;
+    const harness = createAppServerHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        const turnId = turnIds[nextTurnIndex++];
+        if (!turnId) {
+          throw new Error("unexpected extra turn/start");
+        }
+        return turnStartResult(turnId);
+      }
+      return {};
+    });
+
+    const runTurn = async (index: number) => {
+      const turnId = turnIds[index]!;
+      const expectedTurnStarts = index + 1;
+      const run = runCodexAppServerAttempt(
+        createParams(sessionFile, workspaceDir, {
+          prompt: `turn ${index + 1}`,
+          runId: `run-${index + 1}`,
+        }),
+      );
+      await vi.waitFor(
+        () =>
+          expect(
+            harness.requests.filter((request) => request.method === "turn/start"),
+          ).toHaveLength(expectedTurnStarts),
+        fastWait,
+      );
+      const inputTokens = 15_000 + index * 1_000;
+      const outputTokens = 100;
+      if (index === 0) {
+        await harness.notify({
+          method: "rawResponse/completed",
+          params: {
+            threadId: "thread-1",
+            turnId,
+            responseId: "response-1",
+            usage: {
+              totalTokens: inputTokens + outputTokens,
+              inputTokens,
+              cachedInputTokens: 0,
+              outputTokens,
+              reasoningOutputTokens: 0,
+            },
+          },
+        });
+      }
+      await harness.notify({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId,
+          tokenUsage: {
+            last: {
+              totalTokens: inputTokens + outputTokens,
+              inputTokens,
+              cachedInputTokens: 0,
+              cacheWriteInputTokens: 0,
+              outputTokens,
+              reasoningOutputTokens: 0,
+            },
+          },
+        },
+      });
+      await harness.completeTurn({ threadId: "thread-1", turnId });
+      return run;
+    };
+
+    const first = await runTurn(0);
+    const second = await runTurn(1);
+
+    expect(first.attemptUsage?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 15_000,
+      totalTokens: 15_100,
+    });
+    expect(second.attemptUsage?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 16_000,
+      totalTokens: 16_100,
+    });
+    expect(
+      harness.requests
+        .filter((request) =>
+          ["thread/start", "thread/resume", "turn/start"].includes(request.method),
+        )
+        .map((request) => request.method),
+    ).toEqual(["thread/start", "turn/start", "turn/start"]);
+  });
   it("starts a fresh Codex thread before resume when the native rollout reaches the fallback fuse", async () => {
     const { sessionFile, workspaceDir, agentDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -235,7 +235,6 @@ export async function persistSessionUsageUpdate(params: {
             (params.preserveFreshTotalTokensOnStaleUsage !== true ||
               entry.totalTokensFresh !== true)
           ) {
-            patch.totalTokens = undefined;
             patch.totalTokensFresh = false;
             patch.totalTokensVersion = undefined;
           }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4851,13 +4851,14 @@ describe("persistSessionUsageUpdate", () => {
       expected: {
         totalTokens: 12_000,
         totalTokensFresh: true,
+        totalTokensVersion: 1,
         inputTokens: 180_000,
         outputTokens: 10_000,
       },
     },
     {
-      name: "clears the prior total when last-call context is unavailable",
-      seed: { totalTokens: 148_874, totalTokensFresh: true },
+      name: "marks the prior total stale when last-call context is unavailable",
+      seed: { totalTokens: 148_874, totalTokensFresh: true, totalTokensVersion: 1 },
       update: {
         usage: { input: 12, output: 15_104, cacheRead: 819_661, cacheWrite: 93_130 },
         lastCallUsage: {
@@ -4870,8 +4871,9 @@ describe("persistSessionUsageUpdate", () => {
         },
       },
       expected: {
-        totalTokens: undefined,
+        totalTokens: 148_874,
         totalTokensFresh: false,
+        totalTokensVersion: undefined,
         inputTokens: 12,
         cacheRead: 819_661,
       },
@@ -4919,10 +4921,14 @@ describe("persistSessionUsageUpdate", () => {
       expected: { totalTokens: 42_000, totalTokensFresh: true },
     },
     {
-      name: "clears older totalTokens when no compaction preservation is requested",
-      seed: { totalTokens: 42_000, totalTokensFresh: true },
+      name: "marks older totalTokens stale when no context snapshot is available",
+      seed: { totalTokens: 42_000, totalTokensFresh: true, totalTokensVersion: 1 },
       update: { usage: { input: 50_000, output: 5_000, total: 55_000 } },
-      expected: { totalTokens: undefined, totalTokensFresh: false },
+      expected: {
+        totalTokens: 42_000,
+        totalTokensFresh: false,
+        totalTokensVersion: undefined,
+      },
     },
     {
       name: "uses promptTokens when available without lastCallUsage",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where resumed Codex app-server sessions lost their context-usage total after a successful turn. In the verified live Codex harness reproduction, two plain no-tool turns reported t1 `15289, fresh`, then t2 `null, stale`, and the value never recovered, while embedded sibling runtimes stayed fresh. Nothing was logged.

That silent loss degraded context displays to `unknown/258k (?%)`, removed the input used by memory-flush thresholds and token preflight, and explains the long-standing papercut where `openclaw sessions` showed `unknown/258k (?%)` immediately after successful turns.

## Why This Change Was Made

There were two root causes, both fixed at their owning boundaries:

1. Codex enables exact raw-response usage only on thread start (`extensions/codex/src/app-server/thread-requests.ts:211`), so resumed threads rely on `thread/tokenUsage/updated`. The projector nevertheless marked every thread-usage notification unavailable. It now accepts a complete breakdown only when its non-negative integer fields are coherent (`totalTokens === inputTokens + cachedInputTokens + outputTokens + reasoningOutputTokens`), retains individually valid partial fields from malformed input, and preserves unavailable status only when a final raw response genuinely omitted usage.
2. Session persistence conflated "not fresh" with "delete the value." `src/auto-reply/reply/session-usage.ts:233` now retains `totalTokens`, sets `totalTokensFresh=false`, and clears the provenance version, reusing the stale-value semantics already defined in `src/config/sessions/types.ts:545`.

The stale marker is honored by each decision-making consumer: `resolveFreshSessionTotalTokens` rejects the value unless freshness is true and the provenance version matches; memory flush and preflight then estimate from the transcript or skip a freshness-dependent gate; Codex startup binding does not use the stale value for its token fuse; context/status/session displays retain the recorded total but withhold the percentage; manual compaction reports unknown context rather than treating stale usage as current. Retaining the last observation therefore improves diagnostics without admitting it as authoritative context state.

The upstream Codex contract supports the resumed-thread path: `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1600` defines `last` as a required complete breakdown, and `../codex/codex-rs/core/src/session/mod.rs:3830` updates token state before emission.

Production LOC: +31/-45 (net -14). Tests: +125/-13.

Deliberate non-goal: `reasoningTokens` survives attempt/assistant projection, but session storage has no field for it. Persisting it needs a SQLite schema decision, so this change does not advance a schema version and leaves that work as a follow-up.

## User Impact

Resumed Codex sessions keep useful context accounting after successful turns. Fresh coherent usage drives context percentages, memory flush, and preflight again; when a later update is unavailable, operators still see the last recorded total clearly marked stale instead of losing it silently.

## Evidence

- Live Codex harness reproduction before the fix: two plain no-tool turns produced t1 `15289, fresh`, then t2 `null, stale` forever; embedded sibling runtimes remained fresh; no log entry explained the loss.
- Fresh final-head autoreview on `42789ac77d568b62c3aafca5823b4378e31289d7`: clean, no accepted/actionable findings.
- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts extensions/codex/src/app-server/run-attempt.test.ts`: 315 tests passed across two shards.
- `node scripts/check-changed.mjs`: passed all affected core, core-test, plugin, and plugin-test lanes. Remote workload routing had no ready provider, so the trusted-source wrapper used its documented local fallback with a worktree-scoped heavy-check lock on the 14-core/64 GB host.
- Upstream contract inspected directly at Codex commit `9ded177ce7c1c0bd2047f902936c177612ab3434` in the files cited above.

