### PR TITLE
refactor: consolidate record guards

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -304,7 +304,7 @@ extensions/cua-computer/src/driver-artifact-verification.ts	2
 extensions/cua-computer/src/driver-artifacts.ts	1
 extensions/cua-computer/src/driver-client.ts	15
 extensions/cua-computer/src/driver-result.ts	10
-extensions/cua-computer/src/mcp-driver-client.ts	6
+extensions/cua-computer/src/mcp-driver-client.ts	5
 extensions/cua-computer/src/window-actions.ts	3
 extensions/deepinfra/embedding-adapter.ts	1
 extensions/deepinfra/provider-models.ts	3
@@ -1593,8 +1593,6 @@ packages/gateway-client/src/gateway-origin-scope.ts	1
 packages/gateway-client/src/pending-request.ts	2
 packages/gateway-client/src/protocol-client.ts	1
 packages/gateway-client/src/scope-upgrade.ts	4
-packages/gateway-client/src/session-projection-run-event.ts	1
-packages/gateway-client/src/session-projection.ts	1
 packages/gateway-client/src/websocket-transport.ts	3
 packages/gateway-protocol/src/clawhub-trust-error-details.ts	1
 packages/gateway-protocol/src/client-info.ts	4
@@ -2390,7 +2388,7 @@ src/claws/doctor.ts	2
 src/claws/export.ts	8
 src/claws/lifecycle-delete-support.ts	7
 src/claws/mcp.ts	4
-src/claws/openclaw-profile.ts	3
+src/claws/openclaw-profile.ts	2
 src/claws/package-update.ts	1
 src/claws/packages.ts	1
 src/claws/project-build.ts	4

--- a/extensions/cua-computer/src/mcp-driver-client.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import type { ActionResult } from "@trycua/cua-driver";
+import { asOptionalRecord as record } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   ClickButton,
   EscalationReason,
@@ -67,12 +68,6 @@ function driverUnavailable(message: string, cause?: unknown): Error {
 
 function driverProtocolError(message: string, cause?: unknown): Error {
   return new Error(`COMPUTER_DRIVER_ERROR: ${message}`, { cause });
-}
-
-function record(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function mappedEnum(value: unknown, values: readonly string[], label: string): number {

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -69,6 +69,9 @@
     "ipaddr.js": "2.4.0",
     "ws": "8.21.1"
   },
+  "devDependencies": {
+    "@openclaw/normalization-core": "workspace:*"
+  },
   "engines": {
     "node": ">=22.19.0"
   },

--- a/packages/gateway-client/src/session-projection-run-event.ts
+++ b/packages/gateway-client/src/session-projection-run-event.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   reduceSessionProjection,
   type SessionProjectionEvent,
@@ -25,10 +26,7 @@ export function reduceSessionProjectionRunEventImpl(
     return null;
   }
   const message = event.message;
-  const messageStopReason =
-    message !== null && typeof message === "object" && !Array.isArray(message)
-      ? readNonemptyString((message as Record<string, unknown>).stopReason)
-      : null;
+  const messageStopReason = isRecord(message) ? readNonemptyString(message.stopReason) : null;
   const stopReason = readNonemptyString(event.stopReason) ?? messageStopReason;
   const errorKind = readNonemptyString(event.errorKind);
   const base = { runId, ...(message === undefined ? {} : { message }), scope };

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -1,5 +1,6 @@
 /** Browser-safe identity and replay rules shared by Gateway conversation clients. */
 
+import { asNullableRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { reduceSessionProjectionRunEventImpl } from "./session-projection-run-event.js";
 
 export type SessionMessageEnvelope = {
@@ -119,12 +120,6 @@ export type SessionProjectionEvent = ScopedSessionProjectionEvent &
     | { type: "transportGap" }
     | { type: "reconnected" }
   );
-
-function readRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function readNonemptyString(value: unknown): string | null {
   return typeof value === "string" ? value.trim() || null : null;

--- a/packages/gateway-protocol/package.json
+++ b/packages/gateway-protocol/package.json
@@ -80,6 +80,9 @@
   "dependencies": {
     "typebox": "1.3.6"
   },
+  "devDependencies": {
+    "@openclaw/normalization-core": "workspace:*"
+  },
   "engines": {
     "node": ">=22.19.0"
   },

--- a/packages/gateway-protocol/src/clawhub-trust-error-details.ts
+++ b/packages/gateway-protocol/src/clawhub-trust-error-details.ts
@@ -1,3 +1,5 @@
+import { isProtocolRecord } from "./protocol-value-normalization.js";
+
 /** Structured ClawHub trust details carried in gateway error payloads. */
 export const ClawHubTrustErrorCodes = {
   SECURITY_UNAVAILABLE: "clawhub_security_unavailable",
@@ -43,7 +45,7 @@ export function buildClawHubTrustErrorDetails(params: {
 export function readClawHubTrustErrorDetails(
   details: unknown,
 ): ClawHubTrustErrorDetails | undefined {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return undefined;
   }
   const raw = details as {

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -4,7 +4,10 @@
  * These details cross client/server boundaries, so readers normalize untrusted
  * payloads before using them in reconnect decisions or user-facing messages.
  */
-import { normalizeOptionalProtocolString } from "./protocol-value-normalization.js";
+import {
+  isProtocolRecord,
+  normalizeOptionalProtocolString,
+} from "./protocol-value-normalization.js";
 
 function normalizeOptionalConnectDetailStringList(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
@@ -223,7 +226,7 @@ export function resolveDeviceAuthConnectErrorDetailCode(
 
 /** Reads a non-empty detail code from an untrusted error details payload. */
 export function readConnectErrorDetailCode(details: unknown): string | null {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return null;
   }
   const code = (details as { code?: unknown }).code;
@@ -249,7 +252,7 @@ export function readControlUiBuildMismatchId(details: unknown): string | null {
 
 /** Extracts normalized retry advice from untrusted connect-error details. */
 export function readConnectErrorRecoveryAdvice(details: unknown): ConnectErrorRecoveryAdvice {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return {};
   }
   const raw = details as {
@@ -406,7 +409,7 @@ export function readPairingConnectErrorDetails(
   if (readConnectErrorDetailCode(details) !== ConnectErrorDetailCodes.PAIRING_REQUIRED) {
     return null;
   }
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return null;
   }
   const raw = details as {

--- a/packages/gateway-protocol/src/protocol-value-normalization.ts
+++ b/packages/gateway-protocol/src/protocol-value-normalization.ts
@@ -1,12 +1,7 @@
-/** Narrows untrusted protocol values to non-array records. */
-export function isProtocolRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-/** Converts untrusted protocol values to records without accepting arrays. */
-export function asProtocolRecord(value: unknown): Record<string, unknown> | null {
-  return isProtocolRecord(value) ? value : null;
-}
+export {
+  asNullableRecord as asProtocolRecord,
+  isRecord as isProtocolRecord,
+} from "@openclaw/normalization-core/record-coerce";
 
 /** Checks string presence without changing wire-significant whitespace. */
 export function isNonEmptyProtocolString(value: unknown): value is string {

--- a/packages/gateway-protocol/src/system-agent-error-details.ts
+++ b/packages/gateway-protocol/src/system-agent-error-details.ts
@@ -1,3 +1,5 @@
+import { isProtocolRecord } from "./protocol-value-normalization.js";
+
 /** Structured system-agent details carried in gateway error payloads. */
 export const SystemAgentErrorDetailCodes = {
   INFERENCE_UNAVAILABLE: "system_agent_inference_unavailable",
@@ -23,7 +25,7 @@ export function buildSystemAgentSessionInvalidatedErrorDetails(): SystemAgentSes
 export function readSystemAgentInferenceUnavailableErrorDetails(
   details: unknown,
 ): SystemAgentInferenceUnavailableErrorDetails | undefined {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return undefined;
   }
   const code = (details as { code?: unknown }).code;
@@ -33,7 +35,7 @@ export function readSystemAgentInferenceUnavailableErrorDetails(
 export function readSystemAgentSessionInvalidatedErrorDetails(
   details: unknown,
 ): SystemAgentSessionInvalidatedErrorDetails | undefined {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
+  if (!isProtocolRecord(details)) {
     return undefined;
   }
   const code = (details as { code?: unknown }).code;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2193,12 +2193,20 @@ importers:
       ws:
         specifier: 8.21.1
         version: 8.21.1
+    devDependencies:
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
 
   packages/gateway-protocol:
     dependencies:
       typebox:
         specifier: 1.3.6
         version: 1.3.6
+    devDependencies:
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
 
   packages/llm-core:
     dependencies:

--- a/scripts/check-coercion-helper-declarations.mts
+++ b/scripts/check-coercion-helper-declarations.mts
@@ -221,6 +221,18 @@ const EXCEPTIONAL_COERCION_HELPER_CARVE_OUTS = [
     reason: "Serialized mock Gateway closure cannot capture module imports.",
   },
   {
+    file: "src/gateway/mcp-app-standalone.ts",
+    name: "asStandaloneRecord",
+    kind: "variable",
+    reason: "Serialized standalone app closure cannot capture module imports.",
+  },
+  {
+    file: "extensions/diffs/src/viewer-payload.ts",
+    name: "isViewerRecord",
+    kind: "function",
+    reason: "Standalone browser asset build cannot resolve workspace package imports.",
+  },
+  {
     file: "scripts/lib/kova-report-gate.mts",
     name: "isRecord",
     kind: "function",

--- a/src/claws/openclaw-profile.ts
+++ b/src/claws/openclaw-profile.ts
@@ -1,4 +1,5 @@
 // Safe loader for the conventional package-local OpenClaw profile.
+import { asOptionalRecord as record } from "@openclaw/normalization-core/record-coerce";
 import { isScalar, parseDocument, visit } from "yaml";
 import type { ToolProfileId } from "../agents/tool-policy-shared.js";
 import { FsSafeError, root as fsSafeRoot } from "../infra/fs-safe.js";
@@ -82,12 +83,6 @@ function parseProfileYaml(
       ],
     };
   }
-}
-
-function record(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function isToolProfileId(value: string): value is ToolProfileId {


### PR DESCRIPTION
## What Problem This Solves

Equivalent non-array record guards remained scattered across gateway packages, core, and the CUA plugin even though `@openclaw/normalization-core/record-coerce` is the canonical owner. That duplication lets guard semantics and assertion baselines drift.

## Why This Change Was Made

- Reuses the canonical record guard/coercers in core and gateway-client code.
- Keeps `packages/gateway-protocol/src/protocol-value-normalization.ts` as one thin protocol-local alias over the canonical helpers, then routes protocol readers through it.
- Uses `openclaw/plugin-sdk/string-coerce-runtime` at the CUA plugin boundary.
- Records the two real local exceptions in the coercion checker: the serialized MCP app closure and the standalone diffs browser asset cannot capture/resolve workspace imports.
- Tightens the assertion-safety baseline after four casts disappeared.

The published gateway packages add `@openclaw/normalization-core` only as a workspace dev dependency. Their tsdown builds bundle that private implementation, so published package manifests gain no external runtime dependency.

## User Impact

No behavior change is intended. Untrusted record-shaped payloads continue to reject `null`, primitives, and arrays, but the behavior now has one canonical implementation wherever packaging permits.

## Evidence

- Focused Vitest: 235 assertions passed across gateway protocol/client, CUA, OpenClaw profile loading, MCP standalone serialization, diffs payload/build, and the coercion checker.
- `node --import tsx scripts/check-coercion-helper-declarations.mts`: passed with 106 explicitly allowlisted declarations.
- Autoreview: no accepted/actionable findings.
- `check:changed` Testbox run 31986337093 passed on the exact rebased head in 21m35.7s, including coercion declarations, package locks, full typechecks, lint, and import-cycle checks.
