### PR TITLE
fix(deps): override js-yaml to 4.3.1 (CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
   yauzl: 3.4.0
   protobufjs: 8.7.1
   uuid: 14.0.1
+  js-yaml: 4.3.1
 
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
@@ -6908,8 +6909,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscpd-darwin-arm64@5.0.12:
@@ -12876,7 +12877,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13831,7 +13832,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -160,6 +160,7 @@ overrides:
   yauzl: 3.4.0
   protobufjs: 8.7.1
   uuid: 14.0.1
+  js-yaml: 4.3.1
 
 allowBuilds:
   "@openclaw/fs-safe": true


### PR DESCRIPTION
## What Problem This Solves

`js-yaml` < `4.3.1` is vulnerable to **CVE-2026-59870** ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)): quadratic CPU consumption during `!!omap` resolution (CWE-407), enabling denial of service when parsing a crafted YAML document.

`pnpm audit` on `main` flags this as the single high-severity advisory across all 1529 dependencies:

```
js-yaml 4.3.0  >=4.0.0 <4.3.1  high  CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj
```

### Blast radius

`js-yaml` reaches the repo only through the dev path `stylelint -> cosmiconfig@9.0.2 -> js-yaml@4.3.0`. A repo-wide import audit (`rg "from ['\"]cosmiconfig"` and `"js-yaml"` across `src`, `packages`, `extensions`) finds **zero** production imports, so the shipped runtime is unaffected. The exposure is the lint/CI pipeline that loads stylelint config from YAML, where a malicious `.stylelintrc.yaml` using `!!omap` could peg a CPU.

## Evidence

### Before this PR (baseline = `upstream/main`)

```
$ pnpm audit --json
{
  "advisories": { "1138115": { "module_name": "js-yaml", "version": "4.3.0",
      "vulnerable_versions": ">=4.0.0 <4.3.1", "patched_versions": ">=4.3.1",
      "severity": "high", "github_advisory_id": "GHSA-5p4m-2wfm-xmqj" } },
  "metadata": { "vulnerabilities": { "info":0,"low":0,"moderate":0,"high":1,"critical":0 },
    "totalDependencies": 1529 }
}
```

### After this PR (head `fix/js-yaml-cve-2026-59870`)

Added `js-yaml: 4.3.1` to the existing `overrides:` block in `pnpm-workspace.yaml` (pnpm 11 ignores `package.json` `pnpm.overrides`; settings live in the workspace file) and regenerated `pnpm-lock.yaml` against the official npm registry.

```
$ pnpm audit --json
{
  "advisories": {},
  "metadata": { "vulnerabilities": { "info":0,"low":0,"moderate":0,"high":0,"critical":0 },
    "totalDependencies": 1529 }
}
```

Lockfile diff is minimal and scoped to the override — no unrelated integrity/hash churn:

```diff
 overrides:
   ...
   uuid: 14.0.1
+  js-yaml: 4.3.1

-  js-yaml@4.3.0:
-    resolution: { integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q== }
+  js-yaml@4.3.1:
+    resolution: { integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ== }
```

### Scope check

- `rg "js-yaml|cosmiconfig" src packages extensions` — no production imports; dev-only.
- CI on this PR: `check-dependencies`, `check-npm-lock`, `check-lint`, `build-artifacts`, and the full `checks-fast-*` / `checks-node-changed-extensions-*` suites all pass.

## Notes

- No runtime code changes; dev-dependency bump only.
- The `dependency-guard` check is expected to fail for external dependency-graph changes and requires a secops/admin override (`OPENCLAW_SECURITY_APPROVERS`: vincentkoc, steipete, joshavant). Happy to restructure (e.g. drop the override and document the advisory) if a maintainer prefers a different remediation shape.
