### PR TITLE
fix(ai): accept retained messages from Responses compact

### DIFF
--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -72,18 +72,6 @@ beforeEach(() => {
 
 describe("xAI server compaction request preparation", () => {
   it("compacts and replays through the legacy fast-mode wrapper", async () => {
-    sdkState.post.mockResolvedValueOnce({
-      object: "response.compaction",
-      output: [
-        {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "Remember NORTH-COPPER-17." }],
-        },
-        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
-      ],
-      usage: { input_tokens: 1_000, output_tokens: 200 },
-    });
     const streamFn = wrapResponses({ fastMode: true });
     const owner: AssistantMessage = {
       role: "assistant",
@@ -109,10 +97,11 @@ describe("xAI server compaction request preparation", () => {
       "/responses/compact",
       expect.objectContaining({ body: expect.objectContaining({ model: "grok-4-fast" }) }),
     );
+    expect(compacted.historyMode).toBe("compacted-prefix");
     captureOpenAIResponsesCompaction(
       owner,
       compacted.item,
-      "retained-users",
+      owner.content.length,
       compacted.model,
       compacted.replayMetadata,
     );
@@ -143,11 +132,10 @@ describe("xAI server compaction request preparation", () => {
     expect(replayPayload?.model).toBe("grok-4-fast");
     expect(replayPayload?.input).toEqual([
       expect.objectContaining({ role: "system", type: "message" }),
-      expect.objectContaining({ role: "user", type: "message" }),
       expect.objectContaining({ type: "compaction", encrypted_content: "opaque" }),
       expect.objectContaining({ role: "user", type: "message" }),
     ]);
-    expect(JSON.stringify(replayPayload)).toContain("NORTH-COPPER-17");
+    expect(JSON.stringify(replayPayload)).not.toContain("NORTH-COPPER-17");
   });
 
   it("uses the same OAuth proxy headers as a normal turn", async () => {

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -72,6 +72,18 @@ beforeEach(() => {
 
 describe("xAI server compaction request preparation", () => {
   it("compacts and replays through the legacy fast-mode wrapper", async () => {
+    sdkState.post.mockResolvedValueOnce({
+      object: "response.compaction",
+      output: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Remember NORTH-COPPER-17." }],
+        },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
+      usage: { input_tokens: 1_000, output_tokens: 200 },
+    });
     const streamFn = wrapResponses({ fastMode: true });
     const owner: AssistantMessage = {
       role: "assistant",
@@ -100,7 +112,7 @@ describe("xAI server compaction request preparation", () => {
     captureOpenAIResponsesCompaction(
       owner,
       compacted.item,
-      owner.content.length,
+      "retained-users",
       compacted.model,
       compacted.replayMetadata,
     );
@@ -131,10 +143,11 @@ describe("xAI server compaction request preparation", () => {
     expect(replayPayload?.model).toBe("grok-4-fast");
     expect(replayPayload?.input).toEqual([
       expect.objectContaining({ role: "system", type: "message" }),
+      expect.objectContaining({ role: "user", type: "message" }),
       expect.objectContaining({ type: "compaction", encrypted_content: "opaque" }),
       expect.objectContaining({ role: "user", type: "message" }),
     ]);
-    expect(JSON.stringify(replayPayload)).not.toContain("NORTH-COPPER-17");
+    expect(JSON.stringify(replayPayload)).toContain("NORTH-COPPER-17");
   });
 
   it("uses the same OAuth proxy headers as a normal turn", async () => {

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -50,7 +50,14 @@ describe("responses compact endpoint", () => {
   it("posts the normal Responses input and returns the validated checkpoint with usage", async () => {
     sdkState.post.mockResolvedValue({
       object: "response.compaction",
-      output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+      output: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Remember NORTH-COPPER-17." }],
+        },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
     });
 
@@ -89,8 +96,28 @@ describe("responses compact endpoint", () => {
     });
   });
 
-  it("rejects responses without exactly one encrypted compaction item", async () => {
-    sdkState.post.mockResolvedValue({ object: "response.compaction", output: [], usage: {} });
+  it.each([
+    ["missing", [{ type: "message", role: "user", content: [] }]],
+    [
+      "duplicated",
+      [
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque-1" },
+        { type: "compaction", id: "cmp_2", encrypted_content: "opaque-2" },
+      ],
+    ],
+    [
+      "non-trailing",
+      [
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+        { type: "message", role: "user", content: [] },
+      ],
+    ],
+  ])("rejects a %s compaction item", async (_case, output) => {
+    sdkState.post.mockResolvedValue({
+      object: "response.compaction",
+      output,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
 
     await expect(
       requestPreparedOpenAIResponsesCompaction(
@@ -99,7 +126,7 @@ describe("responses compact endpoint", () => {
         context,
         { apiKey: "test-key" },
       ),
-    ).rejects.toThrow("exactly one compaction item");
+    ).rejects.toThrow("one trailing compaction item");
   });
 
   it.each([

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -36,6 +36,14 @@ const model = {
   maxTokens: 8_192,
 } satisfies Model<"openai-responses">;
 
+const officialOpenAIModel = {
+  ...model,
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+} satisfies Model<"openai-responses">;
+
 const context = {
   systemPrompt: "Retain the conversation.",
   messages: [{ role: "user", content: "Remember NORTH-COPPER-17.", timestamp: 1 }],
@@ -47,7 +55,7 @@ describe("responses compact endpoint", () => {
     sdkState.post.mockReset();
   });
 
-  it("posts the normal Responses input and returns the validated checkpoint with usage", async () => {
+  it("accepts retained-message prefixes from the official OpenAI endpoint", async () => {
     sdkState.post.mockResolvedValue({
       object: "response.compaction",
       output: [
@@ -68,22 +76,22 @@ describe("responses compact endpoint", () => {
 
     const result = await requestPreparedOpenAIResponsesCompaction(
       createOpenAIResponsesTransportStreamFn(),
-      model,
+      officialOpenAIModel,
       context,
       { apiKey: "test-key", sessionId: "session-1" },
     );
 
     expect(sdkState.clients[0]).toMatchObject({
       apiKey: "test-key",
-      baseURL: "https://api.x.ai/v1",
+      baseURL: "https://api.openai.com/v1",
     });
     expect(sdkState.post).toHaveBeenCalledWith(
       "/responses/compact",
       expect.objectContaining({
         body: {
-          model: "grok-4.5",
+          model: "gpt-5.6-luna",
           input: [
-            expect.objectContaining({ role: "system", type: "message" }),
+            expect.objectContaining({ role: "developer", type: "message" }),
             expect.objectContaining({ role: "user", type: "message" }),
           ],
         },
@@ -93,13 +101,37 @@ describe("responses compact endpoint", () => {
       item: { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
       historyMode: "retained-users",
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
-      model,
+      model: officialOpenAIModel,
       replayMetadata: {
         source: "openai-responses",
-        provider: "xai",
-        model: "grok-4.5",
+        provider: "openai",
+        model: "gpt-5.6-luna",
       },
     });
+  });
+
+  it("rejects retained-message prefixes from native xAI", async () => {
+    sdkState.post.mockResolvedValue({
+      object: "response.compaction",
+      output: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Remember NORTH-COPPER-17." }],
+        },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    await expect(
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        model,
+        context,
+        { apiKey: "test-key" },
+      ),
+    ).rejects.toThrow("one trailing compaction item");
   });
 
   it.each([

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -53,6 +53,11 @@ describe("responses compact endpoint", () => {
       output: [
         {
           type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "Retain the conversation." }],
+        },
+        {
+          type: "message",
           role: "user",
           content: [{ type: "input_text", text: "Remember NORTH-COPPER-17." }],
         },
@@ -86,6 +91,7 @@ describe("responses compact endpoint", () => {
     );
     expect(result).toMatchObject({
       item: { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      historyMode: "retained-users",
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
       model,
       replayMetadata: {
@@ -98,6 +104,20 @@ describe("responses compact endpoint", () => {
 
   it.each([
     ["missing", [{ type: "message", role: "user", content: [] }]],
+    [
+      "malformed retained-message",
+      [
+        { type: "message", role: "assistant", content: [] },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
+    ],
+    [
+      "retained tool-output",
+      [
+        { type: "function_call_output", call_id: "call_1", output: "result" },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
+    ],
     [
       "duplicated",
       [
@@ -127,6 +147,23 @@ describe("responses compact endpoint", () => {
         { apiKey: "test-key" },
       ),
     ).rejects.toThrow("one trailing compaction item");
+  });
+
+  it("keeps the checkpoint-only response shape distinct from retained user history", async () => {
+    sdkState.post.mockResolvedValue({
+      object: "response.compaction",
+      output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    await expect(
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        model,
+        context,
+        { apiKey: "test-key" },
+      ),
+    ).resolves.toMatchObject({ historyMode: "compacted-prefix" });
   });
 
   it.each([

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -201,17 +201,18 @@ async function postOpenAIResponsesCompaction(params: {
           isRecord(candidate) && candidate.type === "message" && candidate.role === "user",
       ).length
     : 0;
-  const compactionItems = output.filter(
-    (candidate) => isRecord(candidate) && candidate.type === "compaction",
-  );
+  const retainedMessagePrefixSupported = supportsNativeOpenAIResponsesEndpoint({
+    provider: params.model.provider,
+    api: params.model.api,
+    baseUrl: params.model.baseUrl,
+  });
   const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
   if (
     !isRecord(response) ||
     response.object !== "response.compaction" ||
-    compactionItems.length !== 1 ||
-    compactionItems[0] !== item ||
     !retainedMessagesAreValid ||
-    (retainedItems.length > 0 && retainedUserMessageCount !== inputUserMessageCount) ||
+    (retainedItems.length > 0 &&
+      (!retainedMessagePrefixSupported || retainedUserMessageCount !== inputUserMessageCount)) ||
     !isRecord(item) ||
     item.type !== "compaction" ||
     typeof item.encrypted_content !== "string" ||

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -177,12 +177,16 @@ async function postOpenAIResponsesCompaction(params: {
     body: { model: params.request.model, input: params.request.input },
   });
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
-  const item = output[0];
+  const item = output.at(-1);
+  const compactionItems = output.filter(
+    (candidate) => isRecord(candidate) && candidate.type === "compaction",
+  );
   const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
   if (
     !isRecord(response) ||
     response.object !== "response.compaction" ||
-    output.length !== 1 ||
+    compactionItems.length !== 1 ||
+    compactionItems[0] !== item ||
     !isRecord(item) ||
     item.type !== "compaction" ||
     typeof item.encrypted_content !== "string" ||
@@ -191,7 +195,7 @@ async function postOpenAIResponsesCompaction(params: {
     typeof usage.input_tokens !== "number" ||
     typeof usage.output_tokens !== "number"
   ) {
-    throw new Error("Responses compact endpoint did not return exactly one compaction item");
+    throw new Error("Responses compact endpoint did not return one trailing compaction item");
   }
   return {
     item,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -201,11 +201,7 @@ async function postOpenAIResponsesCompaction(params: {
           isRecord(candidate) && candidate.type === "message" && candidate.role === "user",
       ).length
     : 0;
-  const retainedMessagePrefixSupported = supportsNativeOpenAIResponsesEndpoint({
-    provider: params.model.provider,
-    api: params.model.api,
-    baseUrl: params.model.baseUrl,
-  });
+  const retainedMessagePrefixSupported = supportsNativeOpenAIResponsesEndpoint(params.model);
   const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
   if (
     !isRecord(response) ||

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -178,6 +178,29 @@ async function postOpenAIResponsesCompaction(params: {
   });
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
   const item = output.at(-1);
+  const retainedItems = output.slice(0, -1);
+  const retainedMessagesAreValid = retainedItems.every(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.type === "message" &&
+      (candidate.role === "user" ||
+        candidate.role === "developer" ||
+        candidate.role === "system") &&
+      Array.isArray(candidate.content),
+  );
+  const retainedUserMessageCount = retainedItems.filter(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.type === "message" &&
+      candidate.role === "user" &&
+      Array.isArray(candidate.content),
+  ).length;
+  const inputUserMessageCount = Array.isArray(params.request.input)
+    ? params.request.input.filter(
+        (candidate) =>
+          isRecord(candidate) && candidate.type === "message" && candidate.role === "user",
+      ).length
+    : 0;
   const compactionItems = output.filter(
     (candidate) => isRecord(candidate) && candidate.type === "compaction",
   );
@@ -187,6 +210,8 @@ async function postOpenAIResponsesCompaction(params: {
     response.object !== "response.compaction" ||
     compactionItems.length !== 1 ||
     compactionItems[0] !== item ||
+    !retainedMessagesAreValid ||
+    (retainedItems.length > 0 && retainedUserMessageCount !== inputUserMessageCount) ||
     !isRecord(item) ||
     item.type !== "compaction" ||
     typeof item.encrypted_content !== "string" ||
@@ -199,6 +224,7 @@ async function postOpenAIResponsesCompaction(params: {
   }
   return {
     item,
+    historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
     usage,
     model: params.model,
     replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(params.model, {

--- a/packages/ai/src/transports/openai-responses-compact-request.ts
+++ b/packages/ai/src/transports/openai-responses-compact-request.ts
@@ -6,6 +6,7 @@ import type {
 
 export type OpenAIResponsesCompactEndpointResult = {
   item: { type: "compaction"; id?: string; encrypted_content: string };
+  historyMode: "compacted-prefix" | "retained-users";
   usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };
   model: Model;
   replayMetadata: OpenAIResponsesReasoningReplayMetadata;

--- a/packages/ai/src/transports/openai-responses-compaction-replay.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.ts
@@ -11,6 +11,7 @@ import type {
 import { shortHash } from "../utils/hash.js";
 import {
   OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
+  OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE,
   OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH,
   type OpenAIResponsesCompactionReplayState,
   type OpenAIResponsesReasoningReplayMetadata,
@@ -72,6 +73,14 @@ function isOpenAIResponsesCompactionState(
   if (state.type === OPENAI_RESPONSES_COMPACTION_SUPPRESSION_TYPE) {
     return state.data === OPENAI_RESPONSES_COMPACTION_SUPPRESSION_DATA;
   }
+  if (state.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE) {
+    return (
+      typeof state.data === "string" &&
+      state.data.length > 0 &&
+      (state.id === undefined || typeof state.id === "string") &&
+      state.replayIndex === undefined
+    );
+  }
   return (
     state.type === OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE &&
     typeof state.data === "string" &&
@@ -112,7 +121,7 @@ export function openAIResponsesReplayContextMatches(
 export function captureOpenAIResponsesCompaction(
   output: Pick<AssistantMessage, "providerReplay">,
   item: ReplayableResponseCompactionItem,
-  replayIndex: number | undefined,
+  boundary: number | "retained-users",
   model: Model,
   captureMetadata?: OpenAIResponsesReasoningReplayMetadata,
 ): void {
@@ -126,17 +135,21 @@ export function captureOpenAIResponsesCompaction(
   }
   const currentReplay = readOpenAIResponsesCompactionReplayState(output.providerReplay);
   if (
+    typeof boundary === "number" &&
     currentReplay?.type === OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE &&
-    (currentReplay.replayIndex ?? -1) > (replayIndex ?? Number.MAX_SAFE_INTEGER)
+    (currentReplay.replayIndex ?? -1) > boundary
   ) {
     return;
   }
   output.providerReplay = {
     v: 1,
-    type: OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
+    type:
+      boundary === "retained-users"
+        ? OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+        : OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
     ...(item.id ? { id: item.id } : {}),
     data: item.encrypted_content,
-    ...(replayIndex === undefined ? {} : { replayIndex }),
+    ...(typeof boundary === "number" ? { replayIndex: boundary } : {}),
     provider: metadata.provider,
     api: metadata.api,
     model: metadata.model,
@@ -220,7 +233,19 @@ function resolveNewestOpenAIResponsesCompactionReplay(
   messages: Context["messages"],
   model: Model,
   options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
-): { owner: AssistantMessage; item: ResponseCompactionItemParam; replayIndex: number } | undefined {
+):
+  | {
+      owner: AssistantMessage;
+      item: ResponseCompactionItemParam;
+      mode: "compacted-prefix";
+      replayIndex: number;
+    }
+  | {
+      owner: AssistantMessage;
+      item: ResponseCompactionItemParam;
+      mode: "retained-users";
+    }
+  | undefined {
   const context = buildOpenAIResponsesReplayContext(model, options);
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
@@ -236,8 +261,14 @@ function resolveNewestOpenAIResponsesCompactionReplay(
       }
       continue;
     }
-    if (replay?.type !== OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE) {
-      if (message.providerReplay?.type === OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE) {
+    if (
+      replay?.type !== OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE &&
+      replay?.type !== OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+    ) {
+      if (
+        message.providerReplay?.type === OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE ||
+        message.providerReplay?.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+      ) {
         return undefined;
       }
       continue;
@@ -252,7 +283,9 @@ function resolveNewestOpenAIResponsesCompactionReplay(
         ...(isSafeResponsesReplayItemId(replay.id) ? { id: replay.id } : {}),
         encrypted_content: replay.data,
       },
-      replayIndex: replay.replayIndex ?? 0,
+      ...(replay.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+        ? { mode: "retained-users" as const }
+        : { mode: "compacted-prefix" as const, replayIndex: replay.replayIndex ?? 0 }),
     };
   }
   return undefined;
@@ -262,6 +295,7 @@ export type OpenAIResponsesReplayMode = "checkpoint" | "full-history";
 
 type OpenAIResponsesCompactionReplayPlan = {
   messages: Context["messages"];
+  retainedMessages?: Context["messages"];
   compaction?: ResponseCompactionItemParam;
   preserveUnframedToolResults: boolean;
 };
@@ -283,14 +317,36 @@ export function buildOpenAIResponsesCompactionReplayPlan(
     return { messages, preserveUnframedToolResults: false };
   }
   const ownerIndex = messages.indexOf(compaction.owner);
+  const collectRetainedUserMessages = (prefix: Context["messages"]): Context["messages"] => {
+    const previous = resolveNewestOpenAIResponsesCompactionReplay(prefix, model, options);
+    if (!previous) {
+      return prefix.filter((message) => message.role === "user");
+    }
+    const previousOwnerIndex = prefix.indexOf(previous.owner);
+    const laterUsers = prefix
+      .slice(previousOwnerIndex + 1)
+      .filter((message) => message.role === "user");
+    // A checkpoint-only window replaces its prefix; a retained-user window extends it.
+    return previous.mode === "retained-users"
+      ? [...collectRetainedUserMessages(prefix.slice(0, previousOwnerIndex)), ...laterUsers]
+      : laterUsers;
+  };
+  const retainedMessages =
+    compaction.mode === "retained-users"
+      ? collectRetainedUserMessages(messages.slice(0, ownerIndex))
+      : undefined;
   const owner = {
     ...compaction.owner,
-    content: compaction.owner.content.slice(compaction.replayIndex),
+    content:
+      compaction.mode === "retained-users"
+        ? []
+        : compaction.owner.content.slice(compaction.replayIndex),
   };
   // Slice before transcript repair so compacted calls cannot synthesize outputs,
   // while real results emitted after the checkpoint remain in chronological order.
   return {
     messages: [owner, ...messages.slice(ownerIndex + 1)],
+    ...(retainedMessages?.length ? { retainedMessages } : {}),
     compaction: compaction.item,
     preserveUnframedToolResults: true,
   };

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -27,6 +27,8 @@ export const OPENAI_RESPONSES_REASONING_REPLAY_META_KEY = "__openclaw_replay";
 export const OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY = "openclawReasoningReplay";
 export const OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH = 64;
 export const OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE = "openai-responses-compaction";
+export const OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE =
+  "openai-responses-retained-compaction";
 export const OPENAI_RESPONSES_APIS: ReadonlySet<Api> = new Set([
   "openai-responses",
   "azure-openai-responses",
@@ -125,10 +127,15 @@ export type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> 
   id?: string;
   [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]?: OpenAIResponsesReasoningReplayMetadata;
 };
-export type OpenAIResponsesCompactionReplayState = ProviderReplayState & {
-  type: typeof OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE;
-  baseUrlHash: string;
-};
+export type OpenAIResponsesCompactionReplayState = ProviderReplayState &
+  (
+    | { type: typeof OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE; baseUrlHash: string }
+    | {
+        type: typeof OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE;
+        baseUrlHash: string;
+        replayIndex?: never;
+      }
+  );
 
 export type OpenAIResponsesOptions = BaseOpenAIStreamOptions & {
   reasoning?: OpenAIReasoningEffort;

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -289,12 +289,17 @@ function convertResponsesMessagesWithStyle(
     authProfileId: options?.authProfileId,
     mode: options?.replayMode,
   });
-  const transformedMessages = providerStyle
-    ? transformProviderMessages(replayPlan.messages, model, normalizeToolCallId)
-    : transformTransportMessages(replayPlan.messages, model, normalizeToolCallId, {
-        normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
-        preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
-      });
+  const transformMessages = (source: Context["messages"]) =>
+    providerStyle
+      ? transformProviderMessages(source, model, normalizeToolCallId)
+      : transformTransportMessages(source, model, normalizeToolCallId, {
+          normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
+          preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
+        });
+  const transformedMessages = transformMessages(replayPlan.messages);
+  const transformedRetainedMessages = replayPlan.retainedMessages
+    ? transformMessages(replayPlan.retainedMessages)
+    : [];
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push(
@@ -317,11 +322,15 @@ function convertResponsesMessagesWithStyle(
       ),
     );
   }
-  if (replayPlan.compaction) {
-    messages.push(replayPlan.compaction);
-  }
+  const replayMessages = replayPlan.compaction
+    ? [...transformedRetainedMessages, replayPlan.compaction, ...transformedMessages]
+    : transformedMessages;
   let msgIndex = 0;
-  for (const msg of transformedMessages) {
+  for (const msg of replayMessages) {
+    if (!("role" in msg)) {
+      messages.push(msg);
+      continue;
+    }
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push(

--- a/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
@@ -1,0 +1,107 @@
+import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
+
+const model = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+const replayIdentity = { sessionId: "session-a", authProfileId: "profile-a" };
+
+function createAssistant(text: string, providerReplay?: ProviderReplayState): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+    ...(providerReplay ? { providerReplay } : {}),
+  };
+}
+
+function compactionState(
+  type: "openai-responses-compaction" | "openai-responses-retained-compaction",
+): ProviderReplayState {
+  const metadata = buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity);
+  if (!metadata.baseUrlHash) {
+    throw new Error("test model must have a replayable base URL");
+  }
+  return {
+    v: 1,
+    type,
+    id: type === "openai-responses-compaction" ? "cmp_previous" : "cmp_retained",
+    data: type === "openai-responses-compaction" ? "opaque-previous" : "opaque-retained",
+    ...(type === "openai-responses-compaction" ? { replayIndex: 1 } : {}),
+    provider: metadata.provider,
+    api: metadata.api,
+    model: metadata.model,
+    baseUrlHash: metadata.baseUrlHash,
+    sessionHash: metadata.sessionHash,
+    authProfileHash: metadata.authProfileHash,
+  };
+}
+
+const converters = [
+  {
+    name: "transport-owned",
+    convert: (context: Context) =>
+      convertResponsesMessages(model, context, new Set(["openai"]), replayIdentity),
+  },
+  {
+    name: "provider-owned",
+    convert: (context: Context) =>
+      convertProviderResponsesMessages(model, context, new Set(["openai"]), replayIdentity),
+  },
+] as const;
+
+describe("Responses retained-user compaction replay", () => {
+  it.each(converters)("$name retains user messages before the checkpoint", ({ convert }) => {
+    const input = convert({
+      systemPrompt: "current system instructions",
+      messages: [
+        { role: "user", content: "user absorbed by older checkpoint", timestamp: 0 },
+        createAssistant("older checkpoint owner", compactionState("openai-responses-compaction")),
+        { role: "user", content: "first retained user", timestamp: 1 },
+        createAssistant("discarded assistant"),
+        { role: "user", content: "second retained user", timestamp: 2 },
+        createAssistant(
+          "assistant content absorbed by compaction",
+          compactionState("openai-responses-retained-compaction"),
+        ),
+        { role: "user", content: "new user after compaction", timestamp: 3 },
+      ],
+    });
+
+    expect(input.slice(0, 4)).toMatchObject([
+      { role: "developer" },
+      { role: "user", content: [{ text: "first retained user" }] },
+      { role: "user", content: [{ text: "second retained user" }] },
+      { type: "compaction", encrypted_content: "opaque-retained" },
+    ]);
+    const encoded = JSON.stringify(input);
+    expect(encoded).toContain("new user after compaction");
+    expect(encoded).not.toContain("user absorbed by older checkpoint");
+    expect(encoded).not.toContain("discarded assistant");
+    expect(encoded).not.toContain("assistant content absorbed by compaction");
+  });
+});

--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -109,4 +109,25 @@ describe("compaction replay owner rewrites", () => {
     expect(input.some((item) => item.type === "compaction")).toBe(false);
     expect(JSON.stringify(input)).toContain("full history prefix");
   });
+
+  it("keeps retained-user checkpoints independent of owner content indexes", () => {
+    const retained = createAssistant([{ type: "text", text: "removed owner output" }], 0);
+    const providerReplay = retained.providerReplay;
+    if (!providerReplay) {
+      throw new Error("expected replay state");
+    }
+    retained.providerReplay = {
+      ...providerReplay,
+      type: "openai-responses-retained-compaction",
+    };
+    delete retained.providerReplay.replayIndex;
+
+    const rewritten = replaceCompactionReplayOwnerContent(retained, []);
+
+    expect(rewritten.providerReplay).toMatchObject({
+      type: "openai-responses-retained-compaction",
+      data: "opaque-replay-compaction",
+    });
+    expect(rewritten.providerReplay).not.toHaveProperty("replayIndex");
+  });
 });

--- a/packages/ai/src/transports/provider-compaction-replay.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.ts
@@ -4,7 +4,11 @@ import type { AssistantMessage, ProviderReplayState } from "@openclaw/llm-core";
 export function isCompactionReplayCheckpoint(replay: unknown): replay is ProviderReplayState {
   const type =
     replay && typeof replay === "object" ? (replay as { type?: unknown }).type : undefined;
-  return type === "anthropic-compaction" || type === "openai-responses-compaction";
+  return (
+    type === "anthropic-compaction" ||
+    type === "openai-responses-compaction" ||
+    type === "openai-responses-retained-compaction"
+  );
 }
 
 /** Strip prefix-bound checkpoints after local history rewrites. */
@@ -34,6 +38,10 @@ export function replaceCompactionReplayOwnerContent(
   const next = { ...message, content };
   const replay = message.providerReplay;
   if (!isCompactionReplayCheckpoint(replay)) {
+    return next;
+  }
+  if (replay.type === "openai-responses-retained-compaction") {
+    // This checkpoint is anchored to retained user turns, not assistant content indexes.
     return next;
   }
   const replayIndex = replay.replayIndex ?? 0;

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
   requestPreparedCompactionMock.mockReset();
   requestPreparedCompactionMock.mockResolvedValue({
     item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+    historyMode: "retained-users",
     usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
     model,
     replayMetadata: {
@@ -104,11 +105,38 @@ describe("attemptServerEndpointCompaction", () => {
     }
     expect(owner.message.content).toEqual([{ type: "text", text: "remembered" }]);
     expect(owner.message.providerReplay).toMatchObject({
-      type: "openai-responses-compaction",
+      type: "openai-responses-retained-compaction",
       id: "cmp_test",
       data: "opaque",
-      replayIndex: 1,
     });
+    expect(owner.message.providerReplay).not.toHaveProperty("replayIndex");
+  });
+
+  it("marks a checkpoint-only response at the assistant content boundary", async () => {
+    requestPreparedCompactionMock.mockResolvedValueOnce({
+      item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+      historyMode: "compacted-prefix",
+      usage: { input_tokens: 1_000, output_tokens: 200 },
+      model,
+      replayMetadata: {
+        v: 1,
+        source: "openai-responses",
+        provider: "xai",
+        api: "openai-responses",
+        model: "grok-4.5",
+        baseUrlHash: "test-base-url",
+      },
+    });
+    const { session, result } = attempt();
+
+    await expect(result).resolves.toBeDefined();
+    const owner = session.sessionManager
+      .getBranch()
+      .findLast((entry) => entry.type === "message" && entry.message.role === "assistant");
+    if (!owner || owner.type !== "message" || owner.message.role !== "assistant") {
+      throw new Error("expected persisted assistant checkpoint owner");
+    }
+    expect(owner.message.providerReplay?.replayIndex).toBe(1);
   });
 
   it("aborts a pending endpoint request at the compaction timeout", async () => {

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -65,7 +65,7 @@ export async function attemptServerEndpointCompaction(params: {
     captureOpenAIResponsesCompaction(
       replacement,
       compacted.item,
-      replacement.content.length,
+      compacted.historyMode === "retained-users" ? "retained-users" : replacement.content.length,
       compacted.model,
       compacted.replayMetadata,
     );
@@ -74,7 +74,10 @@ export async function attemptServerEndpointCompaction(params: {
       replacements: [{ entryId: owner.id, message: replacement }],
       preserveReplacementCompactionReplay: true,
     });
-    if (replacement.providerReplay?.type !== "openai-responses-compaction" || !rewritten.changed) {
+    if (
+      replacement.providerReplay?.data !== compacted.item.encrypted_content ||
+      !rewritten.changed
+    ) {
       throw new Error(
         `Responses compact endpoint checkpoint was not persisted: ${rewritten.reason}`,
       );

--- a/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
+++ b/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
@@ -155,7 +155,10 @@ describe("repairRejectedCompactionReplayInSessionManager", () => {
           content: [{ type: "text", text: id }],
           providerReplay: {
             v: 1,
-            type: "openai-responses-compaction",
+            type:
+              id === "cmp_rejected"
+                ? "openai-responses-retained-compaction"
+                : "openai-responses-compaction",
             data,
             id,
             replayIndex: 0,

--- a/src/agents/embedded-agent-runner/thinking-replay-repair.ts
+++ b/src/agents/embedded-agent-runner/thinking-replay-repair.ts
@@ -90,7 +90,8 @@ export function repairRejectedCompactionReplayInSessionManager(
       (entry) =>
         entry.type === "message" &&
         entry.message.role === "assistant" &&
-        entry.message.providerReplay?.type === "openai-responses-compaction" &&
+        (entry.message.providerReplay?.type === "openai-responses-compaction" ||
+          entry.message.providerReplay?.type === "openai-responses-retained-compaction") &&
         entry.message.providerReplay.data === params.checkpoint.data &&
         (params.checkpoint.id === undefined ||
           entry.message.providerReplay.id === params.checkpoint.id),

--- a/src/agents/transcript-redact-replay.ts
+++ b/src/agents/transcript-redact-replay.ts
@@ -18,7 +18,7 @@ type TranscriptReplaySanitizerHelpers = {
 };
 
 type TranscriptReplayDescriptor = {
-  replayType: string;
+  replayTypes: readonly string[];
   suppressionType: string;
   matchesRoute: (
     route: TranscriptReplayRoute | undefined,
@@ -42,7 +42,7 @@ type TranscriptReplayDescriptor = {
 };
 
 const OPENAI_REPLAY_DESCRIPTOR: TranscriptReplayDescriptor = {
-  replayType: "openai-responses-compaction",
+  replayTypes: ["openai-responses-compaction", "openai-responses-retained-compaction"],
   suppressionType: "openai-responses-compaction-suppression",
   matchesRoute: (route, helpers) => helpers.isOpenAIResponsesRoute(route),
   matchesApi: (api, _route, helpers) =>
@@ -56,7 +56,7 @@ const OPENAI_REPLAY_DESCRIPTOR: TranscriptReplayDescriptor = {
 };
 
 const ANTHROPIC_REPLAY_DESCRIPTOR: TranscriptReplayDescriptor = {
-  replayType: "anthropic-compaction",
+  replayTypes: ["anthropic-compaction"],
   suppressionType: "anthropic-compaction-suppression",
   matchesRoute: (route, helpers) => helpers.isAnthropicReasoningRoute(route),
   matchesApi: (api, route) => api === route?.api,
@@ -75,9 +75,10 @@ export function sanitizeCompactionReplayState(
   if (!value || typeof value !== "object" || !helpers.isPlainTranscriptObject(value)) {
     return undefined;
   }
+  const replayType = typeof value.type === "string" ? value.type : "";
   const descriptor = REPLAY_DESCRIPTORS.find(
-    ({ replayType, suppressionType }) =>
-      value.type === replayType || value.type === suppressionType,
+    ({ replayTypes, suppressionType }) =>
+      replayTypes.includes(replayType) || replayType === suppressionType,
   );
   const isSuppression = value.type === descriptor?.suppressionType;
   if (
@@ -85,6 +86,7 @@ export function sanitizeCompactionReplayState(
     !descriptor.matchesRoute(route, helpers) ||
     value.v !== 1 ||
     typeof value.data !== "string" ||
+    (value.type === "openai-responses-retained-compaction" && value.replayIndex !== undefined) ||
     (value.replayIndex !== undefined &&
       (isSuppression ||
         !Number.isSafeInteger(value.replayIndex) ||

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -232,48 +232,54 @@ describe("redactTranscriptMessage", () => {
     expect(JSON.stringify(msgContent(result))).not.toContain("sk-abcdef1234567890xyz");
   });
 
-  it("preserves only validated OpenAI compaction replay state", () => {
-    const msg = castAgentMessage({
-      role: "assistant",
-      api: "openclaw-openai-responses-transport",
-      model: "gpt-5.6-luna",
-      provider: "openai",
-      content: [{ type: "text", text: "visible" }],
-      providerReplay: {
+  it.each([
+    ["streamed", "openai-responses-compaction", 0],
+    ["retained-user", "openai-responses-retained-compaction", undefined],
+  ] as const)(
+    "preserves only validated %s OpenAI compaction replay state",
+    (_name, type, replayIndex) => {
+      const msg = castAgentMessage({
+        role: "assistant",
+        api: "openclaw-openai-responses-transport",
+        model: "gpt-5.6-luna",
+        provider: "openai",
+        content: [{ type: "text", text: "visible" }],
+        providerReplay: {
+          v: 1,
+          type,
+          id: "cmp_1",
+          data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          ...(replayIndex === undefined ? {} : { replayIndex }),
+          provider: "openai",
+          api: "openai-responses",
+          model: "gpt-5.6-luna",
+          baseUrlHash: "ozhevd1smnk8s",
+          sessionHash: "171dzdv17gum5g",
+          authProfileHash: "oe8bkr3r8947",
+          secret: "sk-abcdef1234567890xyz",
+        },
+      });
+
+      const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
+        providerReplay: Record<string, unknown>;
+      };
+
+      expect(result.providerReplay).toEqual({
         v: 1,
-        type: "openai-responses-compaction",
+        type,
         id: "cmp_1",
         data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
-        replayIndex: 0,
+        ...(replayIndex === undefined ? {} : { replayIndex }),
         provider: "openai",
         api: "openai-responses",
         model: "gpt-5.6-luna",
         baseUrlHash: "ozhevd1smnk8s",
         sessionHash: "171dzdv17gum5g",
         authProfileHash: "oe8bkr3r8947",
-        secret: "sk-abcdef1234567890xyz",
-      },
-    });
-
-    const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
-      providerReplay: Record<string, unknown>;
-    };
-
-    expect(result.providerReplay).toEqual({
-      v: 1,
-      type: "openai-responses-compaction",
-      id: "cmp_1",
-      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
-      replayIndex: 0,
-      provider: "openai",
-      api: "openai-responses",
-      model: "gpt-5.6-luna",
-      baseUrlHash: "ozhevd1smnk8s",
-      sessionHash: "171dzdv17gum5g",
-      authProfileHash: "oe8bkr3r8947",
-    });
-    expect(JSON.stringify(result)).not.toContain("sk-abcdef1234567890xyz");
-  });
+      });
+      expect(JSON.stringify(result)).not.toContain("sk-abcdef1234567890xyz");
+    },
+  );
 
   it("preserves validated OpenAI compaction suppression state", () => {
     const msg = castAgentMessage({
@@ -455,6 +461,7 @@ describe("redactTranscriptMessage", () => {
   it.each([
     ["malformed content", { data: "" }],
     ["invalid replay index", { replayIndex: -1 }],
+    ["retained compaction index", { type: "openai-responses-retained-compaction", replayIndex: 0 }],
     ["invalid context hash", { baseUrlHash: "not-a-context-hash" }],
     ["foreign route", { provider: "azure" }],
   ])("omits invalid OpenAI compaction replay state for %s", (_name, override) => {


### PR DESCRIPTION
## What Problem This Solves

Responses compaction has two verified provider contracts. The official OpenAI endpoint can return retained user messages followed by one encrypted compaction item. Native xAI returns only the encrypted compaction checkpoint. Treating both shapes as one contract either drops valid OpenAI user history or speculatively replays an xAI prefix with unverified meaning.

## Why This Change Was Made

The compact transport now records two explicit replay modes while accepting retained-message prefixes only for the exact official OpenAI Responses route identified by the existing `supportsNativeOpenAIResponsesEndpoint` contract. Native xAI and custom/compatible routes remain checkpoint-only and reject any retained prefix.

The compact transport owns wire validation, persisted replay state carries the observed mode, and both Responses converters consume that mode. Retained-user replay reconstructs canonical user turns before the checkpoint; checkpoint-only replay keeps the existing assistant-content boundary. Transcript redaction, history rewrites, and rejection repair preserve or remove both modes consistently. No config flag, fallback, alias, or parallel path was added.

## User Impact

Agents using the official OpenAI Responses endpoint can continue after retained-user compaction without losing user turns. Native xAI continues with its observed checkpoint-only replay and cannot accidentally persist a fabricated retained prefix. Invalid assistant/tool prefixes, missing or duplicate checkpoints, non-trailing checkpoints, malformed encrypted content, and usage-free replies continue to fall back to client compaction.

Release-note context: official OpenAI Responses compaction now preserves retained user history across the next turn. No changelog file is included because normal PR release notes are derived from the PR body.

## Evidence

### Live provider traces

- Official OpenAI `/responses/compact` returned `historyMode=retained-users`. The next request was exactly developer, retained user, retained user, one compaction item, new user. The provider accepted that replay, and no assistant content crossed the compaction boundary.
- Native xAI `/responses/compact` returned `historyMode=compacted-prefix`. Applying the production boundary produced exactly developer, one compaction item, new user; replaced prefix content was absent.

The traces were inspected in redacted form. No credentials, opaque checkpoint data, or model-internal identifiers are included here.

### Dependency and Codex contracts

- OpenClaw pins OpenAI Node 6.49.0. Its `CompactedResponse.output` contract is all user messages followed by one compaction item: [responses.ts:279-286](https://github.com/openai/openai-node/blob/v6.49.0/src/resources/responses/responses.ts#L279-L286).
- Current Codex parses `/responses/compact` into the full `Vec<ResponseItem>`, not a singleton: [compact.rs:35-68](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/codex-api/src/endpoint/compact.rs#L35-L68), [compact.rs:85-88](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/codex-api/src/endpoint/compact.rs#L85-L88).
- Codex models message and compaction items independently: [models.rs:938-964](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/protocol/src/models.rs#L938-L964), [models.rs:1147-1155](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/protocol/src/models.rs#L1147-L1155).
- Codex installs filtered returned history and preserves user/assistant/compaction items while dropping stale developer/tool material: [compact_remote.rs:311-350](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/core/src/compact_remote.rs#L311-L350), [compact_remote.rs:354-382](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/core/src/compact_remote.rs#L354-L382).
- Codex's current Responses test responder mirrors the retained prefix followed by one newest compaction item: [responses.rs:1166-1192](https://github.com/openai/codex/blob/319b2f72b1d442c3fe2fd4b4d07d0eb9ffde879a/codex-rs/core/tests/common/responses.rs#L1166-L1192).

### Tests and build

- `pnpm test:unit:fast:audit` completed: 4,536 candidates, 1,369 correctly routed to unit-fast, 3,167 rejected by the audit rules.
- Focused transport/replay/xAI/server-endpoint tests: 9 files, 172 tests passed.
- `pnpm test src/agents/transcript-redact.test.ts -t compaction`: 11 passed.
- Final parser/xAI regression rerun: 2 files, 17 tests passed.
- `CI=1 pnpm build` passed on Blacksmith Testbox `tbx_01m094zt89pgq93ky1hdy5e1fz`: [run 32085403984](https://github.com/openclaw/openclaw/actions/runs/32085403984).
- Exact-head CI passed all changed-file, type, lint, test, boundary, and security lanes: [run 32085428290](https://github.com/openclaw/openclaw/actions/runs/32085428290).
- Final branch-wide Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- `git diff --check`: passed.

### Diff hygiene

- Production: +149/-35 (net +114). The growth is the explicit replay-mode state, strict route-aware validation, canonical replay reconstruction, and persistence/redaction support. Reusing the existing endpoint contract and deleting the redundant compaction-count scan reduced production growth by three lines from the reviewed head.
- Tests: +311/-48 (net +263). Coverage includes official retained-prefix acceptance, native xAI retained-prefix rejection and checkpoint-only replay, both converters, repeated windows, transcript persistence/redaction, rewrite behavior, and rejection cleanup.
- No dependencies, config, protocol versions, schemas, docs, changelog, labels, or release artifacts changed.
