### PR TITLE
fix(codex): report dynamic tool audit starts once

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -442,11 +442,9 @@ export function isDynamicToolTerminalDiagnosticEvent(
   );
 }
 
-/** Matches execution diagnostics to a specific dynamic tool call id/name. */
-export function isMatchingDynamicToolDiagnostic(params: {
-  event:
-    | TerminalToolExecutionDiagnostic
-    | Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>;
+/** Matches terminal diagnostics to a specific dynamic tool call id/name. */
+export function isMatchingDynamicToolTerminalDiagnostic(params: {
+  event: TerminalToolExecutionDiagnostic;
   call: CodexDynamicToolCallParams;
   runId?: string;
   sessionId?: string;
@@ -485,7 +483,7 @@ export function hasPendingDynamicToolTerminalDiagnostic(params: {
     if (!isDynamicToolTerminalDiagnosticEvent(event)) {
       return false;
     }
-    return isMatchingDynamicToolDiagnostic({
+    return isMatchingDynamicToolTerminalDiagnostic({
       event,
       call: params.call,
       runId: params.runId,

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -442,9 +442,11 @@ export function isDynamicToolTerminalDiagnosticEvent(
   );
 }
 
-/** Matches terminal diagnostics to a specific dynamic tool call id/name. */
-export function isMatchingDynamicToolTerminalDiagnostic(params: {
-  event: TerminalToolExecutionDiagnostic;
+/** Matches execution diagnostics to a specific dynamic tool call id/name. */
+export function isMatchingDynamicToolDiagnostic(params: {
+  event:
+    | TerminalToolExecutionDiagnostic
+    | Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>;
   call: CodexDynamicToolCallParams;
   runId?: string;
   sessionId?: string;
@@ -483,7 +485,7 @@ export function hasPendingDynamicToolTerminalDiagnostic(params: {
     if (!isDynamicToolTerminalDiagnosticEvent(event)) {
       return false;
     }
-    return isMatchingDynamicToolTerminalDiagnostic({
+    return isMatchingDynamicToolDiagnostic({
       event,
       call: params.call,
       runId: params.runId,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -1,4 +1,7 @@
-import { onInternalDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
+  hasPendingInternalDiagnosticEvent,
+  onInternalDiagnosticEvent,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { isCodexAppServerApprovalRequest } from "./client.js";
 import { shouldAutoApproveCodexAppServerApprovals } from "./config.js";
@@ -11,7 +14,7 @@ import {
   handleDynamicToolCallWithTimeout,
   hasPendingDynamicToolTerminalDiagnostic,
   isDynamicToolTerminalDiagnosticEvent,
-  isMatchingDynamicToolTerminalDiagnostic,
+  isMatchingDynamicToolDiagnostic,
   resolveDynamicToolCallTimeoutMs,
   shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   toCodexDynamicToolProgressResponse,
@@ -172,13 +175,6 @@ export function createCodexAttemptServerRequestController(
         tool: call.tool,
         toolCallId: call.callId,
       });
-      emitDynamicToolStartedDiagnostic({
-        call,
-        agentId: sessionAgentId,
-        runId: params.runId,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-      });
       const toolMeta = inferCodexDynamicToolMeta(
         call,
         resolveCodexToolProgressDetailMode(params.toolProgressDetail),
@@ -201,21 +197,48 @@ export function createCodexAttemptServerRequestController(
       }
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({ call, config: params.config });
       const toolStartedAt = Date.now();
+      let startedDiagnosticObserved = false;
       let terminalDiagnosticObserved = false;
+      const diagnosticMatch = {
+        call,
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      };
       const unsubscribeToolDiagnosticObserver = onInternalDiagnosticEvent((event) => {
         if (
+          event.type === "tool.execution.started" &&
+          isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch })
+        ) {
+          startedDiagnosticObserved = true;
+        }
+        if (
           isDynamicToolTerminalDiagnosticEvent(event) &&
-          isMatchingDynamicToolTerminalDiagnostic({
-            event,
-            call,
-            runId: params.runId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-          })
+          isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch })
         ) {
           terminalDiagnosticObserved = true;
         }
       });
+      const emitBridgeStartedDiagnosticIfNeeded = () => {
+        if (
+          startedDiagnosticObserved ||
+          hasPendingInternalDiagnosticEvent(
+            (event) =>
+              event.type === "tool.execution.started" &&
+              isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch }),
+          )
+        ) {
+          return;
+        }
+        emitDynamicToolStartedDiagnostic({
+          ...diagnosticMatch,
+          agentId: sessionAgentId,
+        });
+        startedDiagnosticObserved = true;
+      };
+      if (!toolBridge.availableTools.some((tool) => tool.name === call.tool)) {
+        emitBridgeStartedDiagnosticIfNeeded();
+      }
       try {
         const { execution } = openClawDynamicToolExecutions.claim(call, () =>
           handleDynamicToolCallWithTimeout({
@@ -244,6 +267,7 @@ export function createCodexAttemptServerRequestController(
           }),
         );
         const response = await execution;
+        emitBridgeStartedDiagnosticIfNeeded();
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
         if (!protocolResponse.success && toolCallOrdinal !== undefined) {
           suppressedDynamicToolOutcomeOrdinals.add(toolCallOrdinal);
@@ -319,6 +343,7 @@ export function createCodexAttemptServerRequestController(
         return protocolResponse as JsonValue;
       } catch (error) {
         pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
+        emitBridgeStartedDiagnosticIfNeeded();
         if (
           !terminalDiagnosticObserved &&
           !hasPendingDynamicToolTerminalDiagnostic({

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -1,7 +1,4 @@
-import {
-  hasPendingInternalDiagnosticEvent,
-  onInternalDiagnosticEvent,
-} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { onInternalDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { isCodexAppServerApprovalRequest } from "./client.js";
 import { shouldAutoApproveCodexAppServerApprovals } from "./config.js";
@@ -14,7 +11,7 @@ import {
   handleDynamicToolCallWithTimeout,
   hasPendingDynamicToolTerminalDiagnostic,
   isDynamicToolTerminalDiagnosticEvent,
-  isMatchingDynamicToolDiagnostic,
+  isMatchingDynamicToolTerminalDiagnostic,
   resolveDynamicToolCallTimeoutMs,
   shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   toCodexDynamicToolProgressResponse,
@@ -197,51 +194,31 @@ export function createCodexAttemptServerRequestController(
       }
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({ call, config: params.config });
       const toolStartedAt = Date.now();
-      let startedDiagnosticObserved = false;
       let terminalDiagnosticObserved = false;
-      const diagnosticMatch = {
-        call,
-        runId: params.runId,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-      };
       const unsubscribeToolDiagnosticObserver = onInternalDiagnosticEvent((event) => {
         if (
-          event.type === "tool.execution.started" &&
-          isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch })
-        ) {
-          startedDiagnosticObserved = true;
-        }
-        if (
           isDynamicToolTerminalDiagnosticEvent(event) &&
-          isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch })
+          isMatchingDynamicToolTerminalDiagnostic({
+            event,
+            call,
+            runId: params.runId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          })
         ) {
           terminalDiagnosticObserved = true;
         }
       });
-      const emitBridgeStartedDiagnosticIfNeeded = () => {
-        if (
-          startedDiagnosticObserved ||
-          hasPendingInternalDiagnosticEvent(
-            (event) =>
-              event.type === "tool.execution.started" &&
-              isMatchingDynamicToolDiagnostic({ event, ...diagnosticMatch }),
-          )
-        ) {
-          return;
-        }
-        emitDynamicToolStartedDiagnostic({
-          ...diagnosticMatch,
-          agentId: sessionAgentId,
-        });
-        startedDiagnosticObserved = true;
-      };
-      if (!toolBridge.availableTools.some((tool) => tool.name === call.tool)) {
-        emitBridgeStartedDiagnosticIfNeeded();
-      }
       try {
-        const { execution } = openClawDynamicToolExecutions.claim(call, () =>
-          handleDynamicToolCallWithTimeout({
+        const { execution } = openClawDynamicToolExecutions.claim(call, () => {
+          emitDynamicToolStartedDiagnostic({
+            call,
+            agentId: sessionAgentId,
+            runId: params.runId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          });
+          return handleDynamicToolCallWithTimeout({
             call,
             toolBridge,
             signal,
@@ -264,10 +241,9 @@ export function createCodexAttemptServerRequestController(
                 timeoutMs: dynamicToolTimeoutMs,
               });
             },
-          }),
-        );
+          });
+        });
         const response = await execution;
-        emitBridgeStartedDiagnosticIfNeeded();
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
         if (!protocolResponse.success && toolCallOrdinal !== undefined) {
           suppressedDynamicToolOutcomeOrdinals.add(toolCallOrdinal);
@@ -343,7 +319,6 @@ export function createCodexAttemptServerRequestController(
         return protocolResponse as JsonValue;
       } catch (error) {
         pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
-        emitBridgeStartedDiagnosticIfNeeded();
         if (
           !terminalDiagnosticObserved &&
           !hasPendingDynamicToolTerminalDiagnostic({

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -1,16 +1,13 @@
 // Codex tests cover run attemptynamic tools plugin behavior.
 import path from "node:path";
-import {
-  onAgentEvent,
-  wrapToolWithBeforeToolCallHook,
-  type AgentEventPayload,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   emitTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   waitForDiagnosticEventsDrained,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -24,6 +21,7 @@ import { hasPendingDynamicToolTerminalDiagnostic } from "./dynamic-tool-executio
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import type { CodexDynamicToolCallParams } from "./protocol.js";
 import {
+  bindProductionHarnessHostCapabilitiesForTest,
   createParams,
   createCodexRuntimePlanFixture,
   createRuntimeDynamicTool,
@@ -65,17 +63,12 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
-  it("emits one audit lifecycle for a wrapped dynamic tool call", async () => {
-    const tool = wrapToolWithBeforeToolCallHook(createRuntimeDynamicTool("echo"), {
-      agentId: "main",
-      runId: "run-1",
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      loopDetection: { enabled: false },
-    });
+  it("emits one audit lifecycle when runtime normalization clones a wrapped tool", async () => {
+    const tool = createRuntimeDynamicTool("echo");
     dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
     const harness = createStartedThreadHarness();
     const diagnosticEvents: DiagnosticEventPayload[] = [];
+    let closeHostCapabilities: (() => void) | undefined;
     const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
       if ("toolCallId" in event && event.toolCallId === "call-echo-audit") {
         diagnosticEvents.push(event);
@@ -87,6 +80,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
         path.join(tempDir, "workspace"),
       );
       setCodexTestModelSupportsTools(params, true);
+      closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
       const runtimePlan = createCodexRuntimePlanFixture();
       params.runtimePlan = {
         ...runtimePlan,
@@ -115,9 +109,78 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
       await run;
       await flushDiagnosticEvents();
     } finally {
+      closeHostCapabilities?.();
       unsubscribeDiagnostics();
     }
 
+    expect(diagnosticEvents.map((event) => event.type)).toEqual([
+      "tool.execution.started",
+      "tool.execution.completed",
+    ]);
+  });
+
+  it("emits the bridge audit start before dynamic tool execution settles", async () => {
+    const completion = createDeferred<{
+      content: Array<{ type: "text"; text: string }>;
+      details: Record<string, never>;
+    }>();
+    const tool = createRuntimeDynamicTool("echo");
+    const execute = vi.fn(async () => await completion.promise);
+    tool.execute = execute;
+    dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
+    const harness = createStartedThreadHarness();
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    let inFlightEventTypes: DiagnosticEventPayload["type"][] | undefined;
+    let closeHostCapabilities: (() => void) | undefined;
+    const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
+      if ("toolCallId" in event && event.toolCallId === "call-echo-in-flight") {
+        diagnosticEvents.push(event);
+      }
+    });
+    try {
+      const params = createParams(
+        path.join(tempDir, "session.jsonl"),
+        path.join(tempDir, "workspace"),
+      );
+      setCodexTestModelSupportsTools(params, true);
+      closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
+
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      const toolResult = harness.handleServerRequest({
+        id: "request-echo-in-flight",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-echo-in-flight",
+          namespace: null,
+          tool: "echo",
+          arguments: {},
+        },
+      });
+      await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+      await flushDiagnosticEvents();
+      inFlightEventTypes = diagnosticEvents.map((event) => event.type);
+
+      completion.resolve({
+        content: [{ type: "text", text: "echo done" }],
+        details: {},
+      });
+      await expect(toolResult).resolves.toMatchObject({ success: true });
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+      await flushDiagnosticEvents();
+    } finally {
+      completion.resolve({
+        content: [{ type: "text", text: "echo done" }],
+        details: {},
+      });
+      closeHostCapabilities?.();
+      unsubscribeDiagnostics();
+    }
+
+    expect(inFlightEventTypes).toEqual(["tool.execution.started"]);
     expect(diagnosticEvents.map((event) => event.type)).toEqual([
       "tool.execution.started",
       "tool.execution.completed",

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -3,11 +3,11 @@ import path from "node:path";
 import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   emitTrustedDiagnosticEvent,
+  hasPendingInternalDiagnosticEvent,
   onInternalDiagnosticEvent,
   waitForDiagnosticEventsDrained,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -119,18 +119,28 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     ]);
   });
 
-  it("emits the bridge audit start before dynamic tool execution settles", async () => {
-    const completion = createDeferred<{
-      content: Array<{ type: "text"; text: string }>;
-      details: Record<string, never>;
-    }>();
+  it("emits the bridge audit start before dynamic tool implementation begins", async () => {
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    let startPresentAtImplementation = false;
     const tool = createRuntimeDynamicTool("echo");
-    const execute = vi.fn(async () => await completion.promise);
+    const execute = vi.fn(async () => {
+      startPresentAtImplementation =
+        diagnosticEvents.some(
+          (event) =>
+            event.type === "tool.execution.started" && event.toolCallId === "call-echo-in-flight",
+        ) ||
+        hasPendingInternalDiagnosticEvent(
+          (event) =>
+            event.type === "tool.execution.started" && event.toolCallId === "call-echo-in-flight",
+        );
+      return {
+        content: [{ type: "text" as const, text: "echo done" }],
+        details: {},
+      };
+    });
     tool.execute = execute;
     dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
     const harness = createStartedThreadHarness();
-    const diagnosticEvents: DiagnosticEventPayload[] = [];
-    let inFlightEventTypes: DiagnosticEventPayload["type"][] | undefined;
     let closeHostCapabilities: (() => void) | undefined;
     const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
       if ("toolCallId" in event && event.toolCallId === "call-echo-in-flight") {
@@ -147,7 +157,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
 
       const run = runCodexAppServerAttempt(params);
       await harness.waitForMethod("turn/start");
-      const toolResult = harness.handleServerRequest({
+      const toolResult = await harness.handleServerRequest({
         id: "request-echo-in-flight",
         method: "item/tool/call",
         params: {
@@ -159,28 +169,17 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
           arguments: {},
         },
       });
-      await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
-      await flushDiagnosticEvents();
-      inFlightEventTypes = diagnosticEvents.map((event) => event.type);
-
-      completion.resolve({
-        content: [{ type: "text", text: "echo done" }],
-        details: {},
-      });
-      await expect(toolResult).resolves.toMatchObject({ success: true });
+      expect(toolResult).toMatchObject({ success: true });
       await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       await run;
       await flushDiagnosticEvents();
     } finally {
-      completion.resolve({
-        content: [{ type: "text", text: "echo done" }],
-        details: {},
-      });
       closeHostCapabilities?.();
       unsubscribeDiagnostics();
     }
 
-    expect(inFlightEventTypes).toEqual(["tool.execution.started"]);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(startPresentAtImplementation).toBe(true);
     expect(diagnosticEvents.map((event) => event.type)).toEqual([
       "tool.execution.started",
       "tool.execution.completed",

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -63,11 +63,28 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
-  it("emits one audit lifecycle when runtime normalization clones a wrapped tool", async () => {
+  it("emits one eager audit lifecycle when runtime normalization clones a wrapped tool", async () => {
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    let startPresentAtImplementation = false;
     const tool = createRuntimeDynamicTool("echo");
+    const execute = vi.fn(async () => {
+      startPresentAtImplementation =
+        diagnosticEvents.some(
+          (event) =>
+            event.type === "tool.execution.started" && event.toolCallId === "call-echo-audit",
+        ) ||
+        hasPendingInternalDiagnosticEvent(
+          (event) =>
+            event.type === "tool.execution.started" && event.toolCallId === "call-echo-audit",
+        );
+      return {
+        content: [{ type: "text" as const, text: "echo done" }],
+        details: {},
+      };
+    });
+    tool.execute = execute;
     dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
     const harness = createStartedThreadHarness();
-    const diagnosticEvents: DiagnosticEventPayload[] = [];
     let closeHostCapabilities: (() => void) | undefined;
     const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
       if ("toolCallId" in event && event.toolCallId === "call-echo-audit") {
@@ -105,71 +122,6 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
         },
       })) as { success?: boolean };
       expect(toolResult.success).toBe(true);
-      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-      await run;
-      await flushDiagnosticEvents();
-    } finally {
-      closeHostCapabilities?.();
-      unsubscribeDiagnostics();
-    }
-
-    expect(diagnosticEvents.map((event) => event.type)).toEqual([
-      "tool.execution.started",
-      "tool.execution.completed",
-    ]);
-  });
-
-  it("emits the bridge audit start before dynamic tool implementation begins", async () => {
-    const diagnosticEvents: DiagnosticEventPayload[] = [];
-    let startPresentAtImplementation = false;
-    const tool = createRuntimeDynamicTool("echo");
-    const execute = vi.fn(async () => {
-      startPresentAtImplementation =
-        diagnosticEvents.some(
-          (event) =>
-            event.type === "tool.execution.started" && event.toolCallId === "call-echo-in-flight",
-        ) ||
-        hasPendingInternalDiagnosticEvent(
-          (event) =>
-            event.type === "tool.execution.started" && event.toolCallId === "call-echo-in-flight",
-        );
-      return {
-        content: [{ type: "text" as const, text: "echo done" }],
-        details: {},
-      };
-    });
-    tool.execute = execute;
-    dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
-    const harness = createStartedThreadHarness();
-    let closeHostCapabilities: (() => void) | undefined;
-    const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
-      if ("toolCallId" in event && event.toolCallId === "call-echo-in-flight") {
-        diagnosticEvents.push(event);
-      }
-    });
-    try {
-      const params = createParams(
-        path.join(tempDir, "session.jsonl"),
-        path.join(tempDir, "workspace"),
-      );
-      setCodexTestModelSupportsTools(params, true);
-      closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
-
-      const run = runCodexAppServerAttempt(params);
-      await harness.waitForMethod("turn/start");
-      const toolResult = await harness.handleServerRequest({
-        id: "request-echo-in-flight",
-        method: "item/tool/call",
-        params: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-echo-in-flight",
-          namespace: null,
-          tool: "echo",
-          arguments: {},
-        },
-      });
-      expect(toolResult).toMatchObject({ success: true });
       await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       await run;
       await flushDiagnosticEvents();

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -1,6 +1,10 @@
 // Codex tests cover run attemptynamic tools plugin behavior.
 import path from "node:path";
-import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  onAgentEvent,
+  wrapToolWithBeforeToolCallHook,
+  type AgentEventPayload,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   emitTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
@@ -10,6 +14,7 @@ import {
 import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import { resolveCodexAppServerHookChannelId } from "./dynamic-tool-build.js";
 import {
   emitDynamicToolStartedDiagnostic,
@@ -20,9 +25,11 @@ import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import type { CodexDynamicToolCallParams } from "./protocol.js";
 import {
   createParams,
+  createCodexRuntimePlanFixture,
   createRuntimeDynamicTool,
   createStartedThreadHarness,
   runCodexAppServerAttempt,
+  setCodexTestModelSupportsTools,
   setupRunAttemptTestHooks,
   tempDir,
 } from "./run-attempt-test-harness.js";
@@ -58,6 +65,65 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
+  it("emits one audit lifecycle for a wrapped dynamic tool call", async () => {
+    const tool = wrapToolWithBeforeToolCallHook(createRuntimeDynamicTool("echo"), {
+      agentId: "main",
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      loopDetection: { enabled: false },
+    });
+    dynamicToolBuildState.openClawCodingToolsFactory = () => [tool];
+    const harness = createStartedThreadHarness();
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) => {
+      if ("toolCallId" in event && event.toolCallId === "call-echo-audit") {
+        diagnosticEvents.push(event);
+      }
+    });
+    try {
+      const params = createParams(
+        path.join(tempDir, "session.jsonl"),
+        path.join(tempDir, "workspace"),
+      );
+      setCodexTestModelSupportsTools(params, true);
+      const runtimePlan = createCodexRuntimePlanFixture();
+      params.runtimePlan = {
+        ...runtimePlan,
+        tools: {
+          ...runtimePlan.tools,
+          normalize: (tools) => tools.map((entry) => ({ ...entry })),
+        },
+      };
+
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      const toolResult = (await harness.handleServerRequest({
+        id: "request-echo-audit",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-echo-audit",
+          namespace: null,
+          tool: "echo",
+          arguments: {},
+        },
+      })) as { success?: boolean };
+      expect(toolResult.success).toBe(true);
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+      await flushDiagnosticEvents();
+    } finally {
+      unsubscribeDiagnostics();
+    }
+
+    expect(diagnosticEvents.map((event) => event.type)).toEqual([
+      "tool.execution.started",
+      "tool.execution.completed",
+    ]);
+  });
+
   it.each(["cancelled", "timed_out"] as const)(
     "preserves the %s terminal reason in trusted tool diagnostics",
     async (terminalReason) => {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -2279,7 +2279,12 @@ describe("runCodexAppServerSideQuestion", () => {
             {
               name: "wiki_status",
               description: "Check wiki status",
-              parameters: { type: "object", properties: {} },
+              parameters: {
+                type: "object",
+                properties: { topic: { type: "string" } },
+                required: ["topic"],
+                additionalProperties: false,
+              },
               execute: toolExecuteMock,
             },
           ]

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -55,6 +55,13 @@ export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAg
     value: true,
     enumerable: true,
   });
+  const diagnosticOptions = withBeforeToolCallMetadata(source)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
+  if (diagnosticOptions) {
+    Object.defineProperty(target, BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS, {
+      value: diagnosticOptions,
+      enumerable: false,
+    });
+  }
   const sourceTool = getBeforeToolCallSourceTool(source);
   if (sourceTool) {
     Object.defineProperty(target, BEFORE_TOOL_CALL_SOURCE_TOOL, {


### PR DESCRIPTION
## What Problem This Solves

Codex dynamic tools could write two durable `tool.action.started` rows but only one terminal row for the same `tool_call_id`. This inflated execution counts and made genuine orphaned starts harder to distinguish from instrumentation duplication.

The durable invariant is now explicit: one start per claimed dynamic-tool execution, recorded before the implementation begins, followed by one terminal event when execution settles.

## Root Cause

The Codex bridge eagerly emitted the canonical start. Separately, host binding rewrapped tools with shared before-tool-call diagnostics enabled. Later wrappers and runtime normalization copied the “already wrapped” marker but dropped its non-enumerable diagnostics-control object. The Codex projection therefore attempted to disable diagnostics through missing metadata while the executing wrapper closure still emitted its own start.

The exact second producer is `src/agents/agent-tools.before-tool-call.wrapper.ts`; the failed suppression path crosses `src/agents/harness/host-capability.ts`, `src/agents/before-tool-call-metadata.ts`, and `extensions/codex/src/app-server/dynamic-tools.ts`.

## Fix

This takes the eager-bridge option:

- the claimed Codex execution owns the bridge start synchronously before execution;
- copied before-tool metadata retains the live diagnostics-control object, so the Codex projection reliably disables wrapper diagnostics after host/runtime clones;
- the delayed post-execution observer fallback is removed;
- audit dedupe/schema, admission, and SQLite behavior are unchanged.

There is no schema-version bump and no synchronous SQLite work on admission or tool execution.

## Evidence

The regression uses an unwrapped dynamic tool, production host-capability binding, and runtime normalization. Applied to the rebased PR base `2c4651538cec70529950e39634231e83cad8a5a7`, it fails with:

```text
Expected: started, completed
Received: started, started, completed
Test Files  1 failed (1)
Tests  1 failed | 10 skipped (11)
```

On the repaired branch:

- Codex dynamic-tool lifecycle: 10/10 passed, including start presence at the implementation boundary.
- Native Codex audit lifecycle: 40/40 passed.
- Embedded before-tool lifecycle: 99/99 passed.
- Audit projection: 48/48 passed.
- Exact CI shard reproduction completes the dynamic-tool regression without its former deferred-test timeout.
- A current-main side-question fixture that blocked exact-head CI now declares the `topic` argument it sends; its focused case and full 64-test file pass.
- `node scripts/check-changed.mjs` passed through its documented trusted-source local fallback because configured remote backends were unavailable.
- Fresh autoreview is clean with no accepted/actionable findings.

The remote live-proof backend was unavailable, so no new after-fix provider trace is claimed. For this deterministic maintainer-authored owner-boundary repair, the maintainer accepts the base-failing/fixed executable-harness proof plus exact-head CI; this is not described as live evidence.

Direct sibling Codex source inspection was completed:

- `../codex/codex-rs/core/src/tools/handlers/dynamic.rs:196-245`
- `../codex/codex-rs/app-server/src/bespoke_event_handling.rs:991-1017`
- `../codex/codex-rs/app-server/src/dynamic_tools.rs:18-56`
- `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs:1546-1561`

Those files confirm one upstream dynamic request/response lifecycle per call ID.

## Surface

Production: +18/-11 (net +7). Tests: +86/-1.

AI-assisted: yes. The final diff, upstream contract, base failure, and fixed behavior were reviewed directly.
