### PR TITLE
fix: warn when final legacy transcript record is malformed

### DIFF
--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -504,9 +504,7 @@ function parseSqliteSessionEntry(entryJson: string): SessionEntry | undefined {
   }
 }
 
-function* iterateJsonlLinesSync(
-  filePath: string,
-): Generator<{ final: boolean; lineNumber: number; text: string }> {
+function* iterateJsonlLinesSync(filePath: string): Generator<{ lineNumber: number; text: string }> {
   const fd = fs.openSync(filePath, "r");
   const decoder = new TextDecoder("utf-8", { fatal: true });
   const buffer = Buffer.allocUnsafe(JSONL_READ_CHUNK_BYTES);
@@ -525,14 +523,14 @@ function* iterateJsonlLinesSync(
         lineNumber += 1;
         const text = part.trim();
         if (text) {
-          yield { final: false, lineNumber, text };
+          yield { lineNumber, text };
         }
       }
     }
     carry += decoder.decode();
     const text = carry.trim();
     if (text) {
-      yield { final: true, lineNumber: lineNumber + 1, text };
+      yield { lineNumber: lineNumber + 1, text };
     }
   } catch (err) {
     throw new Error(`${filePath}:${lineNumber + 1}: ${String(err)}`, { cause: err });
@@ -551,15 +549,8 @@ function sqliteNumber(value: unknown): number {
   return 0;
 }
 
-function parseJsonlLine(line: { final: boolean; lineNumber: number; text: string }): unknown {
-  try {
-    return JSON.parse(line.text);
-  } catch (error) {
-    if (line.final) {
-      return undefined;
-    }
-    throw error;
-  }
+function parseJsonlLine(line: { text: string }): unknown {
+  return JSON.parse(line.text);
 }
 
 // Schema-tolerant session enumeration for transcript-label migration (avoids post-ship columns).

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -3157,7 +3157,7 @@ describe("runDoctorSessionSqlite", () => {
     ).toHaveLength(2);
   });
 
-  it("imports valid transcript rows when only the final JSONL line is crash-truncated", async () => {
+  it("reports a malformed non-newline-terminated final JSONL record", async () => {
     const store = createLegacyStore();
     fs.writeFileSync(
       store.transcriptPath,
@@ -3174,9 +3174,10 @@ describe("runDoctorSessionSqlite", () => {
     expect(report.totals).toMatchObject({
       importedEntries: 1,
       importedTranscriptEvents: 1,
-      issues: 0,
+      issues: 1,
       sqliteEntries: 1,
     });
+    expect(report.targets[0]?.issues[0]?.code).toBe("transcript_malformed");
     expect(
       loadTranscriptEventsSync({
         agentId: "main",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading legacy JSONL sessions to SQLite could lose a malformed final transcript record without any warning when that record was not newline-terminated. The valid prefix imported and the original transcript was archived, but the migration incorrectly reported zero issues.

## Why This Change Was Made

The JSONL reader treated parse failure at physical EOF as a special success case, so the doctor never entered its existing malformed-prefix import and `transcript_malformed` reporting path. This removes that EOF-only suppression: all malformed records now use the same migration contract while valid prefix rows still import and the original transcript still archives. No schema or runtime storage contract changes.

Provenance: the EOF suppression was introduced in #98236 (`0a8e3604ba24`) by @jalehman and merged by @steipete on 2026-07-11.

## User Impact

Upgrades preserve the readable transcript prefix and archive the source as before, but now durably report `transcript_malformed` for a malformed unterminated final record instead of silently presenting the migration as clean. Reruns retain the existing idempotent import behavior.

## Evidence

AI-assisted; implementation and migration contract were independently traced before editing.

Pre-fix regression proof:
- `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -t "reports a malformed non-newline-terminated final JSONL record"`
- Failed as intended: expected `issues: 1`, received `issues: 0`; valid prefix count was 1.

Post-fix focused proof (exact PR head):
- `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -t "reports a malformed non-newline-terminated final JSONL record|reports malformed transcripts while importing the session entry|reports malformed selected legacy transcripts during validation"`
- 3 passed, 81 skipped.

Broader owner proof:
- `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts`
- 82 passed, 2 skipped.
- `AGENT_HOST_ROLE=worker node scripts/check-changed.mjs -- src/commands/doctor-session-sqlite-readers.ts src/commands/doctor-session-sqlite.test.ts`
- Passed all selected core/coreTests gates, including format, oxlint, core + core-test typechecks, dead exports, database-first guard, and import cycles.
- `git diff --check origin/main...HEAD`
- Passed.

Autoreview:
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main ...`
- Clean: no accepted/actionable findings; patch correct (0.98 confidence). TruffleHog scan clean.

Hosted exact-head CI and ClawSweeper review completed with no failed checks or actionable findings.

Production LOC: +5/-14 (net -9) | Tests: +3/-2.
