### PR TITLE
fix(plugins): honor per-agent runtime config

### DIFF
--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -671,12 +671,11 @@ describe("normalizeClaudeBackendConfig", () => {
         config: {
           tools: { exec: { mode: "full" } },
           agents: {
-            list: [
-              {
-                id: "safe-agent",
+            entries: {
+              "safe-agent": {
                 tools: { exec: { mode: "ask" } },
               },
-            ],
+            },
           },
         },
       }),
@@ -688,12 +687,11 @@ describe("normalizeClaudeBackendConfig", () => {
         config: {
           tools: { exec: { mode: "ask" } },
           agents: {
-            list: [
-              {
-                id: "yolo-agent",
+            entries: {
+              "yolo-agent": {
                 tools: { exec: { mode: "full" } },
               },
-            ],
+            },
           },
         },
       }),

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 /**
  * Shared Claude CLI backend normalization for args, thinking, and isolated runs.
  */
@@ -163,7 +164,7 @@ export function supportsClaudeDynamicSystemPromptSections(
 
 function isOpenClawRequestedYolo(context?: CliBackendNormalizeConfigContext): boolean {
   const agentExec = context?.agentId
-    ? context.config?.agents?.list?.find((agent) => agent.id === context.agentId)?.tools?.exec
+    ? resolveAgentConfig(context.config ?? {}, context.agentId)?.tools?.exec
     : undefined;
   const exec = agentExec ?? context?.config?.tools?.exec;
   return (

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -1,4 +1,4 @@
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 /**
  * Shared Claude CLI backend normalization for args, thinking, and isolated runs.
  */

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -1,4 +1,4 @@
-import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 /**
  * Anthropic config defaulting helpers. They seed default Anthropic/Claude CLI
  * model refs and cache-retention params based on configured auth mode.

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -1,3 +1,4 @@
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 /**
  * Anthropic config defaulting helpers. They seed default Anthropic/Claude CLI
  * model refs and cache-retention params based on configured auth mode.
@@ -218,10 +219,13 @@ function collectClaudeCliRuntimeRefsFromConfig(config: OpenClawConfig): string[]
       model: config.agents?.defaults?.model as ClaudeCliModelSelection,
       models: config.agents?.defaults?.models,
     },
-    ...(config.agents?.list ?? []).map((agent) => ({
-      model: agent.model as ClaudeCliModelSelection,
-      models: agent.models,
-    })),
+    ...listAgentIds(config).map((agentId) => {
+      const agent = resolveAgentConfig(config, agentId);
+      return {
+        model: agent?.model as ClaudeCliModelSelection,
+        models: agent?.models,
+      };
+    }),
   ];
   const refs = new Set<string>();
   for (const { model, models } of selections) {

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -446,15 +446,14 @@ describe("anthropic provider replay hooks", () => {
           defaults: {
             models: {},
           },
-          list: [
-            {
+          entries: {
+            main: {
               default: true,
-              id: "main",
               model: { primary: "anthropic/opus-4.7" },
               name: "Main",
               workspace: "/tmp/openclaw-agent",
             },
-          ],
+          },
         },
       },
     } as never);
@@ -484,16 +483,15 @@ describe("anthropic provider replay hooks", () => {
               "anthropic/opus-4.7": { params: { maxTokens: 1200 } },
             },
           },
-          list: [
-            {
-              id: "main",
+          entries: {
+            main: {
               models: {
                 "anthropic/sonnet-4.6": { alias: "Sonnet shorthand" },
               },
               name: "Main",
               workspace: "/tmp/openclaw-agent",
             },
-          ],
+          },
         },
       },
     } as never);

--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -467,6 +467,12 @@ describe("browser plugin", () => {
       "browser tool referenced",
     );
     expect(
+      probe({
+        config: { agents: { entries: { reviewer: { tools: { allow: ["browser"] } } } } },
+        env: {},
+      }),
+    ).toBe("browser tool referenced");
+    expect(
       probe({ config: { browser: { defaultProfile: "openclaw", enabled: false } }, env: {} }),
     ).toBeNull();
   });

--- a/extensions/browser/setup-api.ts
+++ b/extensions/browser/setup-api.ts
@@ -1,4 +1,4 @@
-import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 /**
  * Browser setup entry. It auto-enables the Browser plugin when config or tool
  * policies reference browser control.

--- a/extensions/browser/setup-api.ts
+++ b/extensions/browser/setup-api.ts
@@ -1,3 +1,4 @@
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 /**
  * Browser setup entry. It auto-enables the Browser plugin when config or tool
  * policies reference browser control.
@@ -26,10 +27,9 @@ function hasBrowserToolReference(config: OpenClawConfig): boolean {
   if (toolPolicyReferencesBrowser(config.tools)) {
     return true;
   }
-  const agentList = config.agents?.list;
-  return Array.isArray(agentList)
-    ? agentList.some((entry) => isRecord(entry) && toolPolicyReferencesBrowser(entry.tools))
-    : false;
+  return listAgentIds(config).some((agentId) =>
+    toolPolicyReferencesBrowser(resolveAgentConfig(config, agentId)?.tools),
+  );
 }
 
 /** Setup entry that detects existing Browser configuration references. */

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -2036,165 +2036,7 @@ describe("maybeCompactCodexAppServerSession", () => {
     warn.mockRestore();
   });
 
-  it("bounds ignored compaction override warnings through the compact entry point", async () => {
-    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
-
-    async function runWithIgnoredOverrides(index: number): Promise<void> {
-      const agentId = `cap-${index}`;
-      await maybeCompactCodexAppServerSessionImpl(
-        {
-          sessionId: `session-${index}`,
-          sessionKey: `agent:${agentId}:session-${index}`,
-          sessionFile: path.join(tempDir, `${agentId}.jsonl`),
-          workspaceDir: tempDir,
-          trigger: "budget",
-          config: {
-            agents: {
-              entries: {
-                [agentId]: {
-                  compaction: {
-                    model: "openai/gpt-5.4-mini",
-                    provider: "custom-summary",
-                  },
-                },
-              },
-            },
-          },
-        },
-        { bindingStore: testCodexAppServerBindingStore },
-      );
-    }
-
-    // Fill exactly the advertised 4,096-entry cap: every distinct key warns once.
-    for (let index = 0; index < 4_096; index += 1) {
-      await runWithIgnoredOverrides(index);
-      if ((index + 1) % 256 === 0) {
-        // Thousands of resolved promises otherwise starve Vitest timeout and
-        // progress callbacks without increasing real LRU-cap coverage.
-        await flushAsyncTasks(1);
-      }
-    }
-    expect(warn).toHaveBeenCalledTimes(4_096);
-
-    // At exactly 4,096 entries the oldest key is still retained, so a duplicate stays suppressed.
-    await runWithIgnoredOverrides(0);
-    expect(warn).toHaveBeenCalledTimes(4_096);
-
-    // The 4,097th distinct key pushes past the cap and evicts the LRU entry. The duplicate
-    // check on key 0 refreshed its recency, so the evicted key is 1.
-    await runWithIgnoredOverrides(4_096);
-    expect(warn).toHaveBeenCalledTimes(4_097);
-
-    // The evicted key warns again on reappearance.
-    await runWithIgnoredOverrides(1);
-    expect(warn).toHaveBeenCalledTimes(4_098);
-
-    // A recent duplicate stays suppressed.
-    await runWithIgnoredOverrides(4_096);
-    expect(warn).toHaveBeenCalledTimes(4_098);
-    expect(warn.mock.calls.at(-1)).toEqual([
-      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
-      {
-        sessionId: "session-1",
-        sessionKey: "agent:cap-1:session-1",
-        ignoredConfig: [
-          "agents.entries.cap-1.compaction.model",
-          "agents.entries.cap-1.compaction.provider",
-        ],
-      },
-    ]);
-    info.mockRestore();
-    warn.mockRestore();
-  });
-
-  it("warns when active agent compaction overrides are ignored", async () => {
-    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const fake = createFakeCodexClient();
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding({}, "agent:sara:session-1");
-
-    await maybeCompactCodexAppServerSession({
-      sessionId: "session-1",
-      sessionKey: "agent:sara:session-1",
-      sessionFile,
-      workspaceDir: tempDir,
-      trigger: "manual",
-      config: {
-        agents: {
-          entries: {
-            sara: {
-              compaction: {
-                model: "openai/gpt-5.4-mini",
-                provider: "openai",
-              },
-            },
-          },
-        },
-      },
-    });
-
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    expect(warn).toHaveBeenCalledWith(
-      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
-      {
-        sessionId: "session-1",
-        sessionKey: "agent:sara:session-1",
-        ignoredConfig: [
-          "agents.entries.sara.compaction.model",
-          "agents.entries.sara.compaction.provider",
-        ],
-      },
-    );
-    warn.mockRestore();
-  });
-
-  it("reports inherited compaction providers at the source path", async () => {
-    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const fake = createFakeCodexClient();
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding({}, "agent:nik:session-1");
-
-    await maybeCompactCodexAppServerSession({
-      sessionId: "session-1",
-      sessionKey: "agent:nik:session-1",
-      sessionFile,
-      workspaceDir: tempDir,
-      trigger: "manual",
-      config: {
-        agents: {
-          defaults: {
-            compaction: {
-              provider: "custom-summary",
-            },
-          },
-          entries: {
-            nik: {
-              compaction: {
-                model: "openai/gpt-5.4-mini",
-              },
-            },
-          },
-        },
-      },
-    });
-
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    expect(warn).toHaveBeenCalledWith(
-      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
-      {
-        sessionId: "session-1",
-        sessionKey: "agent:nik:session-1",
-        ignoredConfig: [
-          "agents.defaults.compaction.provider",
-          "agents.entries.nik.compaction.model",
-        ],
-      },
-    );
-    warn.mockRestore();
-  });
-
-  it("warns for legacy Lossless config even when the Lossless context engine slot is active", async () => {
+  it("warns for a legacy Lossless default when the Lossless slot is active", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);
@@ -2220,12 +2062,9 @@ describe("maybeCompactCodexAppServerSession", () => {
           },
         },
         agents: {
-          entries: {
-            lossless: {
-              compaction: {
-                model: "openai/gpt-5.4",
-                provider: "lossless-claw",
-              },
+          defaults: {
+            compaction: {
+              provider: "lossless-claw",
             },
           },
         },
@@ -2238,67 +2077,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       {
         sessionId: "session-1",
         sessionKey: "agent:lossless:session-1",
-        ignoredConfig: [
-          "agents.entries.lossless.compaction.model",
-          "agents.entries.lossless.compaction.provider",
-        ],
-      },
-    );
-    warn.mockRestore();
-  });
-
-  it("warns for inherited legacy Lossless provider when the Lossless slot is active", async () => {
-    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const fake = createFakeCodexClient();
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding({}, "agent:lossless-child:session-1");
-    const contextEngine: ContextEngine = {
-      info: { id: "lcm", name: "Lossless Context Manager", ownsCompaction: true },
-      assemble: vi.fn() as never,
-      ingest: vi.fn() as never,
-      compact: vi.fn(async () => ({ ok: true, compacted: false, reason: "below threshold" })),
-    };
-
-    await maybeCompactCodexAppServerSession({
-      sessionId: "session-1",
-      sessionKey: "agent:lossless-child:session-1",
-      sessionFile,
-      workspaceDir: tempDir,
-      trigger: "manual",
-      contextEngine,
-      config: {
-        plugins: {
-          slots: {
-            contextEngine: "lossless-claw",
-          },
-        },
-        agents: {
-          defaults: {
-            compaction: {
-              provider: "lossless-claw",
-            },
-          },
-          entries: {
-            "lossless-child": {
-              compaction: {
-                model: "openai/gpt-5.4-mini",
-              },
-            },
-          },
-        },
-      },
-    });
-
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    expect(warn).toHaveBeenCalledWith(
-      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
-      {
-        sessionId: "session-1",
-        sessionKey: "agent:lossless-child:session-1",
-        ignoredConfig: [
-          "agents.defaults.compaction.provider",
-          "agents.entries.lossless-child.compaction.model",
-        ],
+        ignoredConfig: ["agents.defaults.compaction.provider"],
       },
     );
     warn.mockRestore();

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1170,6 +1170,39 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(fake.request).not.toHaveBeenCalled();
   });
 
+  it("uses the retained agent for unscoped explicit-roster compaction", async () => {
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const result = requireCompactResult(
+      await maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "node-session",
+        sessionFile,
+        workspaceDir: tempDir,
+        trigger: "manual",
+        agentId: "alpha",
+        config: {
+          tools: { exec: { host: "gateway" } },
+          agents: {
+            entries: {
+              alpha: { tools: { exec: { host: "node", node: "worker-1" } } },
+              beta: {},
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain(
+      "Codex-native native compaction is unavailable because OpenClaw exec host=node is active for this session.",
+    );
+    expect(fake.request).not.toHaveBeenCalled();
+  });
+
   it("does not finish until the matching native compaction turn completes", async () => {
     const fake = createFakeCodexClient({ autoCompleteCompaction: false });
     setCodexAppServerClientFactoryForTest(async () => fake.client);

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -2051,15 +2051,14 @@ describe("maybeCompactCodexAppServerSession", () => {
           trigger: "budget",
           config: {
             agents: {
-              list: [
-                {
-                  id: agentId,
+              entries: {
+                [agentId]: {
                   compaction: {
                     model: "openai/gpt-5.4-mini",
                     provider: "custom-summary",
                   },
                 },
-              ],
+              },
             },
           },
         },
@@ -2100,8 +2099,8 @@ describe("maybeCompactCodexAppServerSession", () => {
         sessionId: "session-1",
         sessionKey: "agent:cap-1:session-1",
         ignoredConfig: [
-          "agents.list.cap-1.compaction.model",
-          "agents.list.cap-1.compaction.provider",
+          "agents.entries.cap-1.compaction.model",
+          "agents.entries.cap-1.compaction.provider",
         ],
       },
     ]);
@@ -2123,15 +2122,14 @@ describe("maybeCompactCodexAppServerSession", () => {
       trigger: "manual",
       config: {
         agents: {
-          list: [
-            {
-              id: "sara",
+          entries: {
+            sara: {
               compaction: {
                 model: "openai/gpt-5.4-mini",
                 provider: "openai",
               },
             },
-          ],
+          },
         },
       },
     });
@@ -2143,8 +2141,8 @@ describe("maybeCompactCodexAppServerSession", () => {
         sessionId: "session-1",
         sessionKey: "agent:sara:session-1",
         ignoredConfig: [
-          "agents.list.sara.compaction.model",
-          "agents.list.sara.compaction.provider",
+          "agents.entries.sara.compaction.model",
+          "agents.entries.sara.compaction.provider",
         ],
       },
     );
@@ -2170,14 +2168,13 @@ describe("maybeCompactCodexAppServerSession", () => {
               provider: "custom-summary",
             },
           },
-          list: [
-            {
-              id: "nik",
+          entries: {
+            nik: {
               compaction: {
                 model: "openai/gpt-5.4-mini",
               },
             },
-          ],
+          },
         },
       },
     });
@@ -2188,7 +2185,10 @@ describe("maybeCompactCodexAppServerSession", () => {
       {
         sessionId: "session-1",
         sessionKey: "agent:nik:session-1",
-        ignoredConfig: ["agents.defaults.compaction.provider", "agents.list.nik.compaction.model"],
+        ignoredConfig: [
+          "agents.defaults.compaction.provider",
+          "agents.entries.nik.compaction.model",
+        ],
       },
     );
     warn.mockRestore();
@@ -2220,15 +2220,14 @@ describe("maybeCompactCodexAppServerSession", () => {
           },
         },
         agents: {
-          list: [
-            {
-              id: "lossless",
+          entries: {
+            lossless: {
               compaction: {
                 model: "openai/gpt-5.4",
                 provider: "lossless-claw",
               },
             },
-          ],
+          },
         },
       },
     });
@@ -2240,8 +2239,8 @@ describe("maybeCompactCodexAppServerSession", () => {
         sessionId: "session-1",
         sessionKey: "agent:lossless:session-1",
         ignoredConfig: [
-          "agents.list.lossless.compaction.model",
-          "agents.list.lossless.compaction.provider",
+          "agents.entries.lossless.compaction.model",
+          "agents.entries.lossless.compaction.provider",
         ],
       },
     );
@@ -2279,14 +2278,13 @@ describe("maybeCompactCodexAppServerSession", () => {
               provider: "lossless-claw",
             },
           },
-          list: [
-            {
-              id: "lossless-child",
+          entries: {
+            "lossless-child": {
               compaction: {
                 model: "openai/gpt-5.4-mini",
               },
             },
-          ],
+          },
         },
       },
     });
@@ -2299,7 +2297,7 @@ describe("maybeCompactCodexAppServerSession", () => {
         sessionKey: "agent:lossless-child:session-1",
         ignoredConfig: [
           "agents.defaults.compaction.provider",
-          "agents.list.lossless-child.compaction.model",
+          "agents.entries.lossless-child.compaction.model",
         ],
       },
     );

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -439,6 +439,7 @@ async function compactCodexNativeThread(
     config: params.config,
     sessionKey: params.sandboxSessionKey ?? params.sessionKey,
     sessionId: params.sessionId,
+    agentId: params.agentId,
     sandbox,
     surface: "native compaction",
   });

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -8,7 +8,11 @@ import {
   type CompactEmbeddedAgentSessionParams,
   type EmbeddedAgentCompactResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  resolveAgentConfig,
+  resolveAgentDir,
+  resolveDefaultAgentId,
+} from "openclaw/plugin-sdk/agent-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
@@ -418,15 +422,12 @@ function readCompactionOverrideEntries(params: CompactEmbeddedAgentSessionParams
   if (!agentId) {
     return entries;
   }
-  const agents = Array.isArray(params.config?.agents?.list) ? params.config.agents.list : [];
-  const activeAgent = agents.find((agent) => {
-    const id = typeof agent?.id === "string" ? agent.id.trim().toLowerCase() : "";
-    return id === agentId;
-  });
-  const agentRecord = asOptionalRecord(activeAgent?.compaction);
+  const agentRecord = asOptionalRecord(
+    resolveAgentConfig(params.config ?? {}, agentId)?.compaction,
+  );
   if (agentRecord) {
     entries.push({
-      path: `agents.list.${agentId}`,
+      path: `agents.entries.${agentId}`,
       record: agentRecord,
       inheritedRecord: defaultRecord,
       inheritedPath: "agents.defaults",

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -8,11 +8,8 @@ import {
   type CompactEmbeddedAgentSessionParams,
   type EmbeddedAgentCompactResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import {
-  resolveAgentConfig,
-  resolveAgentDir,
-  resolveDefaultAgentId,
-} from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
@@ -380,23 +377,14 @@ function readIgnoredCompactionOverridePaths(params: CompactEmbeddedAgentSessionP
   for (const entry of readCompactionOverrideEntries(params)) {
     const localProvider =
       typeof entry.record.provider === "string" ? entry.record.provider.trim() : "";
-    const inheritedProvider =
-      !localProvider && typeof entry.inheritedRecord?.provider === "string"
-        ? entry.inheritedRecord.provider.trim()
-        : "";
-    const providerPath = localProvider
-      ? `${entry.path}.compaction.provider`
-      : inheritedProvider && entry.inheritedPath
-        ? `${entry.inheritedPath}.compaction.provider`
-        : undefined;
     if (typeof entry.record.model === "string" && entry.record.model.trim()) {
       ignored.add(`${entry.path}.compaction.model`);
     }
     if (typeof entry.record.thinkingLevel === "string" && entry.record.thinkingLevel.trim()) {
       ignored.add(`${entry.path}.compaction.thinkingLevel`);
     }
-    if (providerPath) {
-      ignored.add(providerPath);
+    if (localProvider) {
+      ignored.add(`${entry.path}.compaction.provider`);
     }
   }
   return [...ignored];
@@ -405,33 +393,14 @@ function readIgnoredCompactionOverridePaths(params: CompactEmbeddedAgentSessionP
 function readCompactionOverrideEntries(params: CompactEmbeddedAgentSessionParams): Array<{
   path: string;
   record: Record<string, unknown>;
-  inheritedRecord?: Record<string, unknown>;
-  inheritedPath?: string;
 }> {
   const entries: Array<{
     path: string;
     record: Record<string, unknown>;
-    inheritedRecord?: Record<string, unknown>;
-    inheritedPath?: string;
   }> = [];
   const defaultRecord = asOptionalRecord(params.config?.agents?.defaults?.compaction);
   if (defaultRecord) {
     entries.push({ path: "agents.defaults", record: defaultRecord });
-  }
-  const agentId = readAgentIdFromSessionKey(params.sessionKey ?? params.sandboxSessionKey);
-  if (!agentId) {
-    return entries;
-  }
-  const agentRecord = asOptionalRecord(
-    resolveAgentConfig(params.config ?? {}, agentId)?.compaction,
-  );
-  if (agentRecord) {
-    entries.push({
-      path: `agents.entries.${agentId}`,
-      record: agentRecord,
-      inheritedRecord: defaultRecord,
-      inheritedPath: "agents.defaults",
-    });
   }
   return entries;
 }

--- a/extensions/codex/src/app-server/config-exec-policy.ts
+++ b/extensions/codex/src/app-server/config-exec-policy.ts
@@ -1,5 +1,5 @@
 import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveExecApprovalsFromFile,

--- a/extensions/codex/src/app-server/config-exec-policy.ts
+++ b/extensions/codex/src/app-server/config-exec-policy.ts
@@ -1,9 +1,10 @@
 import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveExecApprovalsFromFile,
   type ExecApprovalsFile,
 } from "openclaw/plugin-sdk/exec-approvals-runtime";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type {
   CodexAppServerApprovalPolicy,
   CodexAppServerApprovalsReviewer,
@@ -85,24 +86,15 @@ export function resolveApprovalsReviewer(
 }
 
 function resolveOpenClawExecPolicyFromConfig(params: {
-  config?: unknown;
+  config?: OpenClawConfig;
   agentId?: string;
 }): OpenClawExecPolicy {
-  const root = readRecord(params.config);
-  const globalExec = readRecord(readRecord(root?.tools)?.exec);
+  const globalExec = readRecord(params.config?.tools?.exec);
   const globalPolicy = applyOpenClawExecPolicyLayer(createDefaultOpenClawExecPolicy(), globalExec);
   const agentId = params.agentId?.trim();
-  if (!agentId) {
-    return globalPolicy;
-  }
-  const agents = readRecord(root?.agents);
-  const agentList = Array.isArray(agents?.list) ? agents.list : [];
-  const normalizedAgentId = normalizeAgentId(agentId);
-  const agentEntry = agentList.find((entry) => {
-    const id = readRecord(entry)?.id;
-    return typeof id === "string" && normalizeAgentId(id) === normalizedAgentId;
-  });
-  const agentExec = readRecord(readRecord(readRecord(agentEntry)?.tools)?.exec);
+  const agentExec = agentId
+    ? readRecord(resolveAgentConfig(params.config ?? {}, agentId)?.tools?.exec)
+    : undefined;
   return applyOpenClawExecPolicyLayer(globalPolicy, agentExec);
 }
 
@@ -112,7 +104,7 @@ export function resolveOpenClawExecPolicyForCodexAppServer(params: {
     ask?: unknown;
   };
   approvals?: ExecApprovalsFile;
-  config?: unknown;
+  config?: OpenClawConfig;
   agentId?: string;
 }): OpenClawExecPolicyForCodexAppServer {
   const basePolicy = resolveOpenClawExecPolicyFromConfig({

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 // Codex tests cover config plugin behavior.
@@ -2478,6 +2479,21 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
   });
 
+  it("enforces canonical per-agent exec deny before starting Codex app-server", () => {
+    const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({
+      config: {
+        tools: { exec: { mode: "full" } },
+        agents: { entries: { reviewer: { tools: { exec: { mode: "deny" } } } } },
+      },
+      agentId: "reviewer",
+    });
+
+    expect(execPolicy.mode).toBe("deny");
+    expect(() => resolveRuntimeForTest({ execPolicy })).toThrow(
+      "Codex app-server local execution is unavailable because effective tools.exec.mode=deny",
+    );
+  });
+
   it("keeps auto mode prompting when requirements use the on-failure alias", () => {
     const runtime = resolveRuntimeForTest({
       pluginConfig: {},
@@ -2612,7 +2628,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
             ask,
           },
         },
-      };
+      } satisfies OpenClawConfig;
       const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({ config });
 
       expectRuntimePolicy(
@@ -2644,7 +2660,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
           ask: "on-miss",
         },
       },
-    };
+    } satisfies OpenClawConfig;
     const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({ config });
 
     expectRuntimePolicy(resolveRuntimeForTest({ execPolicy }), {
@@ -2662,7 +2678,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
           ask: "always",
         },
       },
-    };
+    } satisfies OpenClawConfig;
 
     expect(() =>
       resolveRuntimeForTest({
@@ -2680,7 +2696,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
           ask: "always",
         },
       },
-    };
+    } satisfies OpenClawConfig;
 
     expectRuntimePolicy(
       resolveRuntimeForTest({

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1180,10 +1180,10 @@ describe("Codex app-server dynamic tool build", () => {
     runtimePolicyParams.sandboxSessionKey = "agent:policy:session-1";
     runtimePolicyParams.config = {
       agents: {
-        list: [
-          { id: "main", tools: { exec: { host: "gateway" } } },
-          { id: "policy", tools: { exec: { host: "node", node: "worker-1" } } },
-        ],
+        entries: {
+          main: { tools: { exec: { host: "gateway" } } },
+          policy: { tools: { exec: { host: "node", node: "worker-1" } } },
+        },
       },
     } as never;
     const runtimePolicyNativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
@@ -2039,7 +2039,7 @@ describe("Codex app-server dynamic tool build", () => {
     agentParams.disableTools = false;
     agentParams.config = {
       agents: {
-        list: [{ id: "main", tools: { exec: { host: "node" } } }],
+        entries: { main: { tools: { exec: { host: "node" } } } },
       },
     } as never;
 
@@ -2058,10 +2058,10 @@ describe("Codex app-server dynamic tool build", () => {
     runtimePolicyParams.sandboxSessionKey = "agent:policy:session-1";
     runtimePolicyParams.config = {
       agents: {
-        list: [
-          { id: "main", tools: { exec: { host: "gateway" } } },
-          { id: "policy", tools: { exec: { host: "node", node: "worker-1" } } },
-        ],
+        entries: {
+          main: { tools: { exec: { host: "gateway" } } },
+          policy: { tools: { exec: { host: "node", node: "worker-1" } } },
+        },
       },
     } as never;
 

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -192,6 +192,31 @@ describe("resolveCodexNativeExecutionPolicy", () => {
     expect(sessionStoreMocks.getSessionEntry).not.toHaveBeenCalled();
   });
 
+  it("uses global policy when an explicit multi-agent roster has no selected agent", () => {
+    sessionStoreMocks.getSessionEntry.mockReturnValue({
+      sessionId: "session-1",
+      updatedAt: 1,
+      execHost: "node",
+      execNode: "worker-6",
+    });
+
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          tools: { exec: { host: "gateway" } },
+          agents: { entries: { alpha: {}, beta: {} } },
+        },
+        sessionKey: "node-session",
+        readRuntimeSessionEntry: true,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: true,
+      requestedExecHost: "gateway",
+      effectiveExecHost: "gateway",
+    });
+    expect(sessionStoreMocks.getSessionEntry).not.toHaveBeenCalled();
+  });
+
   it("honors agent exec config before global exec config", () => {
     expect(
       resolveCodexNativeExecutionPolicy({

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -147,7 +147,7 @@ describe("resolveCodexNativeExecutionPolicy", () => {
       resolveCodexNativeExecutionPolicy({
         config: {
           tools: { exec: { host: "gateway" } },
-          agents: { entries: { "bot-a": { default: true } } },
+          agents: { list: [{ id: "bot-a", default: true }] },
         },
         sessionKey: "node-session",
         agentId: "bot-a",
@@ -164,6 +164,32 @@ describe("resolveCodexNativeExecutionPolicy", () => {
       agentId: "bot-a",
       hydrateSkillPromptRefs: false,
     });
+  });
+
+  it("does not read an unscoped session entry for an explicit multi-agent roster", () => {
+    sessionStoreMocks.getSessionEntry.mockReturnValue({
+      sessionId: "session-1",
+      updatedAt: 1,
+      execHost: "node",
+      execNode: "worker-6",
+    });
+
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          tools: { exec: { host: "gateway" } },
+          agents: { entries: { alpha: {}, beta: {} } },
+        },
+        sessionKey: "node-session",
+        agentId: "alpha",
+        readRuntimeSessionEntry: true,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: true,
+      requestedExecHost: "gateway",
+      effectiveExecHost: "gateway",
+    });
+    expect(sessionStoreMocks.getSessionEntry).not.toHaveBeenCalled();
   });
 
   it("honors agent exec config before global exec config", () => {

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -147,7 +147,7 @@ describe("resolveCodexNativeExecutionPolicy", () => {
       resolveCodexNativeExecutionPolicy({
         config: {
           tools: { exec: { host: "gateway" } },
-          agents: { list: [{ id: "bot-a", default: true }] },
+          agents: { entries: { "bot-a": { default: true } } },
         },
         sessionKey: "node-session",
         agentId: "bot-a",
@@ -171,7 +171,9 @@ describe("resolveCodexNativeExecutionPolicy", () => {
       resolveCodexNativeExecutionPolicy({
         config: {
           tools: { exec: { host: "gateway" } },
-          agents: { list: [{ id: "main", tools: { exec: { host: "node", node: "worker-4" } } }] },
+          agents: {
+            entries: { main: { tools: { exec: { host: "node", node: "worker-4" } } } },
+          },
         },
         sessionKey: "agent:main:session-1",
       }),

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -1,4 +1,8 @@
-import { resolveAgentConfig, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  resolveAgentConfig,
+  resolveDefaultAgentId,
+  tryResolveDefaultAgentId,
+} from "openclaw/plugin-sdk/agent-scope-runtime";
 /**
  * Resolves whether Codex app-server native execution can own shell/file work,
  * or whether OpenClaw must keep exec/process on a configured node host.
@@ -64,6 +68,8 @@ export function resolveCodexNativeExecutionPolicy(params: {
       ? resolveSandboxRuntimeStatus({
           cfg: config,
           sessionKey,
+          agentId,
+          classificationAgentId: agentId,
         }).sandboxed
       : false);
   const agentExec = resolvePolicyAgentExec({ config, agentId });
@@ -169,7 +175,7 @@ function isDefaultAgentSessionKeyForAgent(params: {
   config: OpenClawConfig;
   agentId: string;
 }): boolean {
-  return normalizeAgentId(params.agentId) === resolveDefaultAgentId(params.config);
+  return normalizeAgentId(params.agentId) === tryResolveDefaultAgentId(params.config);
 }
 
 function normalizeAgentIdOrDefault(value?: string | null): string | undefined {

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -1,6 +1,5 @@
 import {
   resolveAgentConfig,
-  resolveDefaultAgentId,
   tryResolveDefaultAgentId,
 } from "openclaw/plugin-sdk/agent-scope-runtime";
 /**
@@ -55,17 +54,18 @@ export function resolveCodexNativeExecutionPolicy(params: {
   const sessionKey = params.sessionKey?.trim() || params.sessionId?.trim() || undefined;
   const agentId = resolvePolicyAgentId({ config, sessionKey, agentId: params.agentId });
   const canReadSessionEntry =
+    Boolean(agentId) &&
     params.readRuntimeSessionEntry &&
-    shouldReadRuntimeSessionEntry({ config, sessionKey, agentId: params.agentId });
+    shouldReadRuntimeSessionEntry({ config, sessionKey, agentId });
   const sessionEntry =
     params.sessionEntry ??
-    (canReadSessionEntry && sessionKey
+    (canReadSessionEntry && sessionKey && agentId
       ? readRuntimeSessionEntryBestEffort({ sessionKey, agentId })
       : undefined);
   const sandboxAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? agentId;
   const sandboxAvailable =
     params.sandboxAvailable ??
-    (sessionKey
+    (sessionKey && sandboxAgentId
       ? resolveSandboxRuntimeStatus({
           cfg: config,
           sessionKey,
@@ -73,7 +73,7 @@ export function resolveCodexNativeExecutionPolicy(params: {
           classificationAgentId: sandboxAgentId,
         }).sandboxed
       : false);
-  const agentExec = resolvePolicyAgentExec({ config, agentId });
+  const agentExec = agentId ? resolvePolicyAgentExec({ config, agentId }) : undefined;
   const globalExec = config.tools?.exec;
   const requestedExecHost =
     normalizeExecTarget(params.execOverrides?.host) ??
@@ -122,7 +122,7 @@ function resolvePolicyAgentId(params: {
   config: OpenClawConfig;
   sessionKey?: string;
   agentId?: string;
-}): string {
+}): string | undefined {
   const explicitAgentId = normalizeAgentIdOrDefault(params.agentId);
   if (explicitAgentId) {
     return explicitAgentId;
@@ -131,7 +131,7 @@ function resolvePolicyAgentId(params: {
   if (sessionAgentId) {
     return sessionAgentId;
   }
-  return resolveDefaultAgentId(params.config);
+  return tryResolveDefaultAgentId(params.config);
 }
 
 function resolvePolicyAgentExec(params: {

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -8,7 +8,7 @@ import {
  * or whether OpenClaw must keep exec/process on a configured node host.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { normalizeAgentId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveSandboxRuntimeStatus } from "openclaw/plugin-sdk/sandbox";
 import { getSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 
@@ -62,14 +62,15 @@ export function resolveCodexNativeExecutionPolicy(params: {
     (canReadSessionEntry && sessionKey
       ? readRuntimeSessionEntryBestEffort({ sessionKey, agentId })
       : undefined);
+  const sandboxAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? agentId;
   const sandboxAvailable =
     params.sandboxAvailable ??
     (sessionKey
       ? resolveSandboxRuntimeStatus({
           cfg: config,
           sessionKey,
-          agentId,
-          classificationAgentId: agentId,
+          agentId: sandboxAgentId,
+          classificationAgentId: sandboxAgentId,
         }).sandboxed
       : false);
   const agentExec = resolvePolicyAgentExec({ config, agentId });

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 /**
  * Resolves whether Codex app-server native execution can own shell/file work,
  * or whether OpenClaw must keep exec/process on a configured node host.
@@ -14,8 +15,6 @@ type ExecHostOverride = {
   host?: string;
   node?: string;
 };
-
-type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 
 /** Effective execution-host policy for the Codex app-server native tool surface. */
 export type CodexNativeExecutionPolicy = {
@@ -125,23 +124,14 @@ function resolvePolicyAgentId(params: {
   if (sessionAgentId) {
     return sessionAgentId;
   }
-  const agents = listAgentEntries(params.config);
-  return resolveDefaultPolicyAgentId(agents);
+  return resolveDefaultAgentId(params.config);
 }
 
 function resolvePolicyAgentExec(params: {
   config: OpenClawConfig;
   agentId: string;
 }): ExecHostOverride | undefined {
-  return listAgentEntries(params.config).find(
-    (entry) => normalizeAgentId(entry?.id) === params.agentId,
-  )?.tools?.exec;
-}
-
-function listAgentEntries(config: OpenClawConfig): AgentEntry[] {
-  return (config.agents?.list ?? []).filter(
-    (entry): entry is AgentEntry => entry !== null && typeof entry === "object",
-  );
+  return resolveAgentConfig(params.config, params.agentId)?.tools?.exec;
 }
 
 function parseAgentIdFromSessionKey(sessionKey?: string): string | undefined {
@@ -179,15 +169,7 @@ function isDefaultAgentSessionKeyForAgent(params: {
   config: OpenClawConfig;
   agentId: string;
 }): boolean {
-  return (
-    normalizeAgentId(params.agentId) ===
-    resolveDefaultPolicyAgentId(listAgentEntries(params.config))
-  );
-}
-
-function resolveDefaultPolicyAgentId(agents: AgentEntry[]): string {
-  const defaultEntry = agents.find((entry) => entry?.default) ?? agents[0];
-  return normalizeAgentId(defaultEntry?.id);
+  return normalizeAgentId(params.agentId) === resolveDefaultAgentId(params.config);
 }
 
 function normalizeAgentIdOrDefault(value?: string | null): string | undefined {

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -149,6 +149,7 @@ export function resolveCodexNativeSandboxBlock(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   sessionId?: string;
+  agentId?: string;
   sandbox?: Pick<SandboxContext, "enabled"> | null;
   sandboxEnvironmentSelected?: boolean;
   surface: string;
@@ -166,6 +167,8 @@ export function resolveCodexNativeSandboxBlock(params: {
   const runtime = resolveSandboxRuntimeStatus({
     cfg: params.config,
     sessionKey,
+    agentId: params.agentId,
+    classificationAgentId: params.agentId,
   });
   if (!runtime.sandboxed) {
     return undefined;

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -3,6 +3,7 @@
  * node-exec routing guarantees.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveSandboxRuntimeStatus, type SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { isCodexRemoteExecPlacementSandbox } from "./config-parsing.js";
 import {
@@ -164,11 +165,12 @@ export function resolveCodexNativeSandboxBlock(params: {
   if (isCodexRemoteExecPlacementSandbox(params.sandbox) || params.sandbox?.enabled === true) {
     return formatCodexNativeSandboxBlock({ surface: params.surface });
   }
+  const sandboxAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? params.agentId;
   const runtime = resolveSandboxRuntimeStatus({
     cfg: params.config,
     sessionKey,
-    agentId: params.agentId,
-    classificationAgentId: params.agentId,
+    agentId: sandboxAgentId,
+    classificationAgentId: sandboxAgentId,
   });
   if (!runtime.sandboxed) {
     return undefined;

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -2,6 +2,7 @@
  * Blocks direct Codex app-server requests that would bypass OpenClaw sandbox or
  * node-exec routing guarantees.
  */
+import { tryResolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveSandboxRuntimeStatus, type SandboxContext } from "openclaw/plugin-sdk/sandbox";
@@ -165,7 +166,13 @@ export function resolveCodexNativeSandboxBlock(params: {
   if (isCodexRemoteExecPlacementSandbox(params.sandbox) || params.sandbox?.enabled === true) {
     return formatCodexNativeSandboxBlock({ surface: params.surface });
   }
-  const sandboxAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? params.agentId;
+  const sandboxAgentId =
+    parseAgentSessionKey(sessionKey)?.agentId ??
+    params.agentId ??
+    tryResolveDefaultAgentId(params.config ?? {});
+  if (!sandboxAgentId) {
+    return undefined;
+  }
   const runtime = resolveSandboxRuntimeStatus({
     cfg: params.config,
     sessionKey,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1417,6 +1417,30 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
   });
 
+  it("uses the retained agent for an unscoped explicit-roster side question", async () => {
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          agentId: "alpha",
+          cfg: {
+            tools: { exec: { host: "gateway" } },
+            agents: {
+              entries: {
+                alpha: { tools: { exec: { host: "node", node: "worker-1" } } },
+                beta: {},
+              },
+            },
+          } as never,
+          sessionKey: "node-session",
+        }),
+      ),
+    ).rejects.toThrow(
+      "Codex-native /btw side-question mode is unavailable because OpenClaw exec host=node is active for this session.",
+    );
+
+    expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
+  });
+
   it("installs native hook relay config for opted-in side threads", async () => {
     const client = createFakeClient();
     let relayIdDuringFork: string | undefined;

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -299,7 +299,7 @@ export async function runCodexAppServerSideQuestion(
   const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
     sideRunParams,
     params.sandbox ?? undefined,
-    { sandboxExecServerEnabled },
+    { agentId: sideRunParams.agentId, sandboxExecServerEnabled },
   );
   const sandboxEnvironmentRequired = shouldRequireCodexSandboxExecServerEnvironment({
     sandbox: params.sandbox ?? undefined,
@@ -310,6 +310,7 @@ export async function runCodexAppServerSideQuestion(
     config: sideRunParams.config,
     sessionKey: sideRunParams.sandboxSessionKey?.trim() || sideRunParams.sessionKey,
     sessionId: sideRunParams.sessionId,
+    agentId: sideRunParams.agentId,
     sandbox: params.sandbox,
     sandboxEnvironmentSelected: sandboxEnvironmentRequired,
     surface: "/btw side-question mode",

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -121,9 +121,10 @@ vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => 
     loadExecApprovals: execApprovalsRuntimeMocks.loadExecApprovals,
   };
 });
-vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-runtime")>()),
-  ...agentRuntimeMocks,
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/agent-scope-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-scope-runtime")>()),
+  resolveSessionAgentIds: agentRuntimeMocks.resolveSessionAgentIds,
 }));
 
 import {
@@ -1940,6 +1941,56 @@ describe("codex conversation binding", () => {
           agents: {
             entries: {
               "bot-a": { tools: { exec: { host: "node", node: "worker-1" } } },
+            },
+          },
+        } as never,
+      },
+    );
+
+    expect(result?.handled).toBe(true);
+    expect(result?.reply?.text).toContain("OpenClaw exec host=node is active");
+    expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
+  });
+
+  it("does not infer an unscoped session owner from an explicit multi-agent roster", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeTestConversationBinding(sessionFile, { threadId: "thread-1", cwd: tempDir });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue the task",
+        channel: "discord",
+        isGroup: true,
+        commandAuthorized: true,
+        sessionKey: "node-session",
+      },
+      {
+        channelId: "discord",
+        sessionKey: "node-session",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel-1",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+            agentId: "alpha",
+          },
+        },
+      },
+      {
+        config: {
+          tools: { exec: { host: "gateway" } },
+          agents: {
+            entries: {
+              alpha: { tools: { exec: { host: "node", node: "worker-1" } } },
+              beta: {},
             },
           },
         } as never,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -121,7 +121,10 @@ vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => 
     loadExecApprovals: execApprovalsRuntimeMocks.loadExecApprovals,
   };
 });
-vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-runtime")>()),
+  ...agentRuntimeMocks,
+}));
 
 import {
   consumeCodexAppServerLiveThread,
@@ -1935,12 +1938,9 @@ describe("codex conversation binding", () => {
         config: {
           tools: { exec: { host: "gateway" } },
           agents: {
-            list: [
-              {
-                id: "bot-a",
-                tools: { exec: { host: "node", node: "worker-1" } },
-              },
-            ],
+            entries: {
+              "bot-a": { tools: { exec: { host: "node", node: "worker-1" } } },
+            },
           },
         } as never,
       },

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -5,7 +5,10 @@ import {
   resolveActiveEmbeddedRunSessionId,
   resolveSandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { resolveDefaultAgentId, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  resolveSessionAgentIds,
+  tryResolveDefaultAgentId,
+} from "openclaw/plugin-sdk/agent-scope-runtime";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-binding-runtime";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
@@ -1463,7 +1466,7 @@ function isDefaultAgentSessionKeyForAgent(params: {
   config: ResolvedCodexConversationConfig;
   agentId: string;
 }): boolean {
-  return normalizeAgentId(params.agentId) === resolveDefaultAgentId(params.config);
+  return normalizeAgentId(params.agentId) === tryResolveDefaultAgentId(params.config);
 }
 
 function normalizeAgentIdOrDefault(value?: string | null): string | undefined {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -5,7 +5,7 @@ import {
   resolveActiveEmbeddedRunSessionId,
   resolveSandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveDefaultAgentId, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-binding-runtime";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
@@ -1463,19 +1463,7 @@ function isDefaultAgentSessionKeyForAgent(params: {
   config: ResolvedCodexConversationConfig;
   agentId: string;
 }): boolean {
-  return normalizeAgentId(params.agentId) === resolveDefaultPolicyAgentId(params.config);
-}
-
-function resolveDefaultPolicyAgentId(config: ResolvedCodexConversationConfig): string {
-  const agents = (config.agents?.list ?? []).filter(
-    (
-      entry,
-    ): entry is NonNullable<
-      NonNullable<ResolvedCodexConversationConfig["agents"]>["list"]
-    >[number] => entry !== null && typeof entry === "object",
-  );
-  const defaultEntry = agents.find((entry) => entry?.default) ?? agents[0];
-  return normalizeAgentId(defaultEntry?.id);
+  return normalizeAgentId(params.agentId) === resolveDefaultAgentId(params.config);
 }
 
 function normalizeAgentIdOrDefault(value?: string | null): string | undefined {

--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 // Discord plugin module owns progress-window state and agent-event rendering.
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
@@ -44,10 +45,7 @@ export function createDiscordMessageProgressRuntime(params: {
   const { cfg, route, abortSignal } = ctx;
   // Reasoning delivery follows the session /reasoning level, not streaming config.
   const reasoningLevel = ((): "on" | "stream" | "off" => {
-    const normalizedAgentId = (route.agentId ?? "").trim().toLowerCase() || "main";
-    const agentEntryDefault = cfg.agents?.list?.find(
-      (entry) => ((entry?.id ?? "").trim().toLowerCase() || "main") === normalizedAgentId,
-    )?.reasoningDefault;
+    const agentEntryDefault = resolveAgentConfig(cfg, route.agentId ?? "main")?.reasoningDefault;
     const cfgDefault = agentEntryDefault ?? cfg.agents?.defaults?.reasoningDefault;
     const configDefault: "on" | "stream" | "off" =
       cfgDefault === "on" || cfgDefault === "stream" ? cfgDefault : "off";

--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -1,4 +1,4 @@
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 // Discord plugin module owns progress-window state and agent-event rendering.
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";

--- a/extensions/discord/src/subagent-progress.ts
+++ b/extensions/discord/src/subagent-progress.ts
@@ -1,4 +1,4 @@
-import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 // Discord plugin module cleans up reactions left by the retired subagent progress feature.
 import { DEFAULT_EMOJIS } from "openclaw/plugin-sdk/channel-feedback";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";

--- a/extensions/discord/src/subagent-progress.ts
+++ b/extensions/discord/src/subagent-progress.ts
@@ -1,3 +1,4 @@
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 // Discord plugin module cleans up reactions left by the retired subagent progress feature.
 import { DEFAULT_EMOJIS } from "openclaw/plugin-sdk/channel-feedback";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -66,8 +67,8 @@ function reservedReactionEmojis(api: ProgressCleanupApi, accountAckReaction?: st
       reserved.add(emoji.trim());
     }
   }
-  for (const agent of api.config.agents?.list ?? []) {
-    const emoji = agent.identity?.emoji?.trim();
+  for (const agentId of listAgentIds(api.config)) {
+    const emoji = resolveAgentConfig(api.config, agentId)?.identity?.emoji?.trim();
     if (emoji) {
       reserved.add(emoji);
     }

--- a/extensions/feishu/src/agent-config.ts
+++ b/extensions/feishu/src/agent-config.ts
@@ -1,5 +1,5 @@
 // Feishu helper module supports agent config behavior.
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { ClawdbotConfig } from "./bot-runtime-api.js";
 
 type ReasoningDefault = "on" | "stream" | "off";

--- a/extensions/feishu/src/agent-config.ts
+++ b/extensions/feishu/src/agent-config.ts
@@ -1,5 +1,5 @@
 // Feishu helper module supports agent config behavior.
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { ClawdbotConfig } from "./bot-runtime-api.js";
 
 type ReasoningDefault = "on" | "stream" | "off";
@@ -8,9 +8,6 @@ export function resolveFeishuConfigReasoningDefault(
   cfg: ClawdbotConfig,
   agentId: string,
 ): ReasoningDefault {
-  const id = normalizeAgentId(agentId);
-  const agentDefault = cfg.agents?.list?.find(
-    (entry) => normalizeAgentId(entry?.id) === id,
-  )?.reasoningDefault;
+  const agentDefault = resolveAgentConfig(cfg, agentId)?.reasoningDefault;
   return agentDefault ?? cfg.agents?.defaults?.reasoningDefault ?? "off";
 }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,6 +1,6 @@
 // Feishu plugin module implements channel behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { ToolAuthorizationError } from "openclaw/plugin-sdk/channel-actions";
 import {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,5 +1,6 @@
 // Feishu plugin module implements channel behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { ToolAuthorizationError } from "openclaw/plugin-sdk/channel-actions";
 import {
@@ -669,10 +670,7 @@ function resolveFeishuMessageActionResponsePrefix(ctx: ChannelMessageActionConte
   if (!configured) {
     return undefined;
   }
-  const agentId = (ctx.agentId?.trim() || "main").toLowerCase();
-  const identityName = ctx.cfg.agents?.list
-    ?.find((agent) => agent.id.trim().toLowerCase() === agentId)
-    ?.identity?.name?.trim();
+  const identityName = resolveAgentConfig(ctx.cfg, ctx.agentId ?? "main")?.identity?.name?.trim();
   const resolved =
     configured === "auto"
       ? identityName

--- a/extensions/feishu/src/reasoning-preview.test.ts
+++ b/extensions/feishu/src/reasoning-preview.test.ts
@@ -94,7 +94,7 @@ describe("resolveFeishuReasoningPreviewEnabled", () => {
     const cfg: ClawdbotConfig = {
       agents: {
         defaults: { reasoningDefault: "stream" },
-        list: [{ id: "Ops", reasoningDefault: "off" }],
+        entries: { Ops: { reasoningDefault: "off" } },
       },
     };
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 // Googlechat plugin module implements monitor behavior.
 import {
   formatInboundMediaUnavailableText,
@@ -170,7 +171,7 @@ function resolveBotDisplayName(params: {
   if (accountName?.trim()) {
     return accountName.trim();
   }
-  const agent = config.agents?.list?.find((a) => a.id === agentId);
+  const agent = resolveAgentConfig(config, agentId);
   if (agent?.name?.trim()) {
     return agent.name.trim();
   }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,4 +1,4 @@
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 // Googlechat plugin module implements monitor behavior.
 import {
   formatInboundMediaUnavailableText,

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -582,6 +582,31 @@ describe("openrouter provider hooks", () => {
     expect(contribution?.dynamicSuffix).not.toContain("deepseek/deepseek-v4-pro");
   });
 
+  it("reads per-agent Fusion config from the canonical agent roster", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      agentId: "reviewer",
+      config: {
+        agents: {
+          entries: {
+            reviewer: {
+              params: {
+                extraBody: {
+                  plugins: [{ id: "fusion", analysis_models: ["deepseek/deepseek-v4-pro"] }],
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution?.dynamicSuffix).toContain("Analysis models: deepseek/deepseek-v4-pro.");
+  });
+
   it("keeps arbitrary OpenRouter extraBody fields out of the system prompt", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const contribution = provider.resolveSystemPromptContribution?.({

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -1,5 +1,5 @@
 // Openrouter plugin entrypoint registers its OpenClaw integration.
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   ProviderReplayPolicy,

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -1,4 +1,6 @@
 // Openrouter plugin entrypoint registers its OpenClaw integration.
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   ProviderReplayPolicy,
   ProviderReplayPolicyContext,
@@ -51,15 +53,7 @@ const OPENROUTER_CACHE_TTL_MODEL_FAMILY = /^(?:anthropic|deepseek|moonshot(?:ai)
 const MAX_PROMPT_MODEL_ID_DISPLAY_CHARS = 256;
 
 type OpenRouterFusionPromptContext = {
-  config?: {
-    agents?: {
-      defaults?: {
-        params?: Record<string, unknown>;
-        models?: Record<string, { params?: Record<string, unknown> }>;
-      };
-      list?: Array<{ id?: string; params?: Record<string, unknown> }>;
-    };
-  };
+  config?: OpenClawConfig;
   agentId?: string;
   modelId: string;
 };
@@ -163,7 +157,7 @@ function findConfiguredOpenRouterAgentParams(
   if (!ctx.agentId) {
     return undefined;
   }
-  return readRecord(ctx.config?.agents?.list?.find((agent) => agent.id === ctx.agentId)?.params);
+  return readRecord(resolveAgentConfig(ctx.config ?? {}, ctx.agentId)?.params);
 }
 
 function resolveMergedOpenRouterPromptParams(

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -9,15 +9,10 @@ import {
   normalizeAccountId,
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-
-function resolveDefaultAgentId(cfg: OpenClawConfig): string {
-  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
-  const chosen = (agents.find((agent) => agent?.default) ?? agents[0])?.id;
-  return normalizeAgentId(chosen);
-}
 
 function resolveBindingAccount(params: {
   binding: unknown;

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -9,7 +9,7 @@ import {
   normalizeAccountId,
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -50,6 +50,9 @@ function listBoundAccountIds(cfg: OpenClawConfig, channelId: string): string[] {
 }
 
 function resolveDefaultAgentBoundAccountId(cfg: OpenClawConfig, channelId: string): string | null {
+  if (cfg.agents?.ownership === "explicit" && listAgentIds(cfg).length !== 1) {
+    return null;
+  }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   for (const binding of cfg.bindings ?? []) {
     const resolved = resolveBindingAccount({ binding, channelId });

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -151,7 +151,7 @@ describe("resolveTelegramAccount", () => {
 
   it("preserves normalized agent-bound accounts and default-agent selection", () => {
     const cfg = {
-      agents: { list: [{ id: "primary", default: true }] },
+      agents: { entries: { primary: { default: true } } },
       channels: {
         telegram: {
           botToken: "tok-default",

--- a/extensions/telegram/src/agent-config.ts
+++ b/extensions/telegram/src/agent-config.ts
@@ -1,5 +1,5 @@
 // Telegram helper module supports agent config behavior.
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
 type ReasoningDefault = "on" | "stream" | "off";

--- a/extensions/telegram/src/agent-config.ts
+++ b/extensions/telegram/src/agent-config.ts
@@ -1,6 +1,6 @@
 // Telegram helper module supports agent config behavior.
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 
 type ReasoningDefault = "on" | "stream" | "off";
 
@@ -8,9 +8,6 @@ export function resolveTelegramConfigReasoningDefault(
   cfg: OpenClawConfig,
   agentId: string,
 ): ReasoningDefault {
-  const id = normalizeAgentId(agentId);
-  const agentDefault = cfg.agents?.list?.find(
-    (entry) => normalizeAgentId(entry?.id) === id,
-  )?.reasoningDefault;
+  const agentDefault = resolveAgentConfig(cfg, agentId)?.reasoningDefault;
   return agentDefault ?? cfg.agents?.defaults?.reasoningDefault ?? "off";
 }

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -681,7 +681,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
       cfg: {
         agents: {
           defaults: { reasoningDefault: "off" },
-          list: [{ id: "Ops", reasoningDefault: "stream" }],
+          entries: { Ops: { reasoningDefault: "stream" } },
         },
       },
     });

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -888,12 +888,11 @@ describe("generateVoiceResponse", () => {
     ]);
     const coreConfig = {
       agents: {
-        list: [
-          {
-            id: "voice",
+        entries: {
+          voice: {
             tools: { allow: [] },
           },
-        ],
+        },
       },
     } as OpenClawConfig;
 

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -4,7 +4,7 @@
  */
 
 import crypto from "node:crypto";
-import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   applyModelOverrideWithAuthProfileCompatibility,
@@ -75,14 +75,7 @@ function resolveVoiceAgentToolsAllow(
   config: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  const agents = isRecord(config.agents) ? config.agents : undefined;
-  const list = Array.isArray(agents?.list) ? agents.list : [];
-  const agent = list.find((entry) => isRecord(entry) && entry.id === agentId);
-  if (!isRecord(agent)) {
-    return undefined;
-  }
-
-  return readExplicitToolsAllow(isRecord(agent.tools) ? agent.tools : undefined);
+  return readExplicitToolsAllow(resolveAgentConfig(config, agentId)?.tools);
 }
 
 const VOICE_SPOKEN_OUTPUT_CONTRACT = [

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -4,7 +4,8 @@
  */
 
 import crypto from "node:crypto";
-import { resolveAgentConfig, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   applyModelOverrideWithAuthProfileCompatibility,

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -1,5 +1,5 @@
 // Voice Call plugin module implements runtime behavior.
-import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -1,5 +1,5 @@
 // Voice Call plugin module implements runtime behavior.
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
@@ -244,8 +244,8 @@ async function resolveRealtimeProvider(params: {
 
 function listRealtimeAgentIds(config: VoiceCallConfig, coreConfig: OpenClawConfig): string[] {
   const agentIds = new Set<string>([normalizeAgentId(config.agentId)]);
-  for (const agent of coreConfig.agents?.list ?? []) {
-    agentIds.add(normalizeAgentId(agent.id));
+  for (const agentId of listAgentIds(coreConfig)) {
+    agentIds.add(normalizeAgentId(agentId));
   }
   for (const route of Object.values(config.numbers)) {
     if (route.agentId) {

--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveMessagePrefix } from "./message-line.runtime.js";
+
+describe("WhatsApp message prefix", () => {
+  it("reads the agent identity from the canonical roster", () => {
+    expect(
+      resolveMessagePrefix(
+        {
+          agents: {
+            entries: { main: { identity: { name: "Mainbot" } } },
+          },
+        },
+        "main",
+      ),
+    ).toBe("[Mainbot]");
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.ts
@@ -1,5 +1,5 @@
 // Whatsapp plugin module implements message line behavior.
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
 export {

--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.runtime.ts
@@ -1,6 +1,6 @@
 // Whatsapp plugin module implements message line behavior.
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 
 export {
   formatInboundEnvelope,
@@ -13,10 +13,7 @@ function resolveIdentityNamePrefix(
   cfg: WhatsAppMessagePrefixConfig,
   agentId: string,
 ): string | undefined {
-  const normalizedAgentId = normalizeAgentId(agentId);
-  const identityName = cfg.agents?.list
-    ?.find((agent) => normalizeAgentId(agent.id ?? "") === normalizedAgentId)
-    ?.identity?.name?.trim();
+  const identityName = resolveAgentConfig(cfg, agentId)?.identity?.name?.trim();
   return identityName ? `[${identityName}]` : undefined;
 }
 

--- a/node-version.d.mts
+++ b/node-version.d.mts
@@ -10,4 +10,4 @@ export function isNodeVersionAtLeast(
   minimum: NodeReleaseVersion,
 ): boolean;
 export function isSupportedOpenClawNodeVersion(value: unknown): boolean;
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK: string;
+export const PROCESS_NODE_VERSION_CHECK: string;

--- a/node-version.mjs
+++ b/node-version.mjs
@@ -73,4 +73,4 @@ function renderProcessNodeVersionCheck() {
 
 // Worker bootstrap runs before OpenClaw is transferred. Carry the canonical
 // release policy as a self-contained expression instead of a second parser.
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();
+export const PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -119,10 +119,10 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   core: 3,
   "plugin-entry": 1,
   routing: 1,
-  // +1 each: the shipped default-agent resolver remains available through
+  // +2: the shipped default-agent resolvers remain available through
   // compatibility barrels while callers migrate to explicit/sole selection.
   health: 1,
-  "agent-scope-runtime": 1,
+  "agent-scope-runtime": 2,
   // +1: shipped channel setup state-migration declaration during its migration window.
   "channel-entry-contract": 1,
   "approval-gateway-runtime": 1,
@@ -293,7 +293,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +5: session-catalog paging capability, family/node-host composers, and option contracts.
       // +3: two focused primitives and the closed read-only SecretRef result contract.
       // -2: remove obsolete transcript display helper exports.
-      4325,
+      // +2: lightweight agent config resolution and nonthrowing default-agent lookup.
+      4327,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -372,7 +373,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: session-catalog family and node-host binding composers.
       // +2: bounded provider stream and read-only SecretRef resolver.
       // -1: remove the obsolete transcript tool-call predicate.
-      2569,
+      // +2: lightweight agent config resolution and nonthrowing default-agent lookup.
+      2571,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
@@ -386,12 +388,12 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +4: session-write lease no-op compatibility stubs through the 2026.10 train.
       // +7: restore still-existing deprecated inbound-dispatch compatibility re-exports.
       // +6: source-compatible harness contracts retained during the V2 migration window.
-      // +4: shipped default-agent resolver projections retained during explicit-owner migration.
+      // +5: shipped default-agent resolver projections retained during explicit-owner migration.
       // +5: load-only bridges for published pre-split plugin artifacts
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1133,
+      1134,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -75,7 +75,6 @@ export type ResolvedAgentConfig = {
   typingMode?: AgentEntry["typingMode"];
   tts?: AgentEntry["tts"];
   contextLimits?: AgentContextLimitsConfig;
-  compaction?: AgentEntry["compaction"];
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
@@ -333,7 +332,6 @@ export function resolveAgentConfig(
       typeof entry.contextLimits === "object" && entry.contextLimits
         ? { ...agentDefaults?.contextLimits, ...entry.contextLimits }
         : agentDefaults?.contextLimits,
-    compaction: entry.compaction,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -75,6 +75,7 @@ export type ResolvedAgentConfig = {
   typingMode?: AgentEntry["typingMode"];
   tts?: AgentEntry["tts"];
   contextLimits?: AgentContextLimitsConfig;
+  compaction?: AgentEntry["compaction"];
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
@@ -332,6 +333,7 @@ export function resolveAgentConfig(
       typeof entry.contextLimits === "object" && entry.contextLimits
         ? { ...agentDefaults?.contextLimits, ...entry.contextLimits }
         : agentDefaults?.contextLimits,
+    compaction: entry.compaction,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/gateway/worker-environments/bootstrap.test.ts
+++ b/src/gateway/worker-environments/bootstrap.test.ts
@@ -5,7 +5,7 @@ import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import {
   isSupportedOpenClawNodeVersion,
-  OPENCLAW_PROCESS_NODE_VERSION_CHECK,
+  PROCESS_NODE_VERSION_CHECK,
 } from "../../../node-version.mjs";
 import { NODE_RELEASE_VERSION_CASES } from "../../../test/helpers/node-version-cases.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
@@ -392,15 +392,15 @@ describe("bootstrapWorker", () => {
     ).rejects.toThrow("Node 22.22.3+, 24.15.0+, or 25.9.0+ with WAL-reset-safe SQLite");
     expect(runner.calls).toHaveLength(2);
     expect(runner.calls[0]?.options.input).toContain(
-      `const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};`,
+      `const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};`,
     );
     expect(runner.calls[0]?.options.input).toContain("SELECT sqlite_version() AS version");
   });
 
   it("embeds a shell-safe Node release check matching the canonical contract", () => {
-    expect(OPENCLAW_PROCESS_NODE_VERSION_CHECK).not.toContain("'");
+    expect(PROCESS_NODE_VERSION_CHECK).not.toContain("'");
     for (const version of NODE_RELEASE_VERSION_CASES) {
-      const actual = runInNewContext(OPENCLAW_PROCESS_NODE_VERSION_CHECK, {
+      const actual = runInNewContext(PROCESS_NODE_VERSION_CHECK, {
         process: { versions: { node: version } },
       });
       expect(actual, version).toBe(isSupportedOpenClawNodeVersion(version));

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { OPENCLAW_PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
+import { PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
 import {
   type WorkerAdmissionHandshake,
   WORKER_PROTOCOL_MAX_FEATURE_LENGTH,
@@ -78,7 +78,7 @@ export function workerBootstrapOperationTimeoutMs(artifact: WorkerInstallationAr
 }
 
 const NODE_RUNTIME_CHECK_JS = String.raw`const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1).map(Number); const atLeast = (version, floor) => version[0] > floor[0] || (version[0] === floor[0] && (version[1] > floor[1] || (version[1] === floor[1] && version[2] >= floor[2])));
-const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};
+const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};
 if (!nodeSafe) process.exit(1);
 try { const { DatabaseSync } = require("node:sqlite"); const db = new DatabaseSync(":memory:");
   const sqlite = parse(String(db.prepare("SELECT sqlite_version() AS version").get()?.version ?? ""));

--- a/src/plugin-sdk/agent-scope-runtime.ts
+++ b/src/plugin-sdk/agent-scope-runtime.ts
@@ -2,8 +2,10 @@
 
 export {
   listAgentIds,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveDefaultAgentId,
   resolveSessionAgentId,
   resolveSessionAgentIds,
+  tryResolveDefaultAgentId,
 } from "../agents/agent-scope.js";


### PR DESCRIPTION
Blast radius: across nine sibling plugins plus Codex, 19 per-agent resolution paths were reading the internal `agents.list` projection. That projection is deliberately defined with `enumerable: false` in `src/config/agent-list-projection.ts:10`, then dropped when the agent harness snapshots plugin config with `structuredClone` in `src/agents/harness/host-capability.ts:88,186`. Per-agent config therefore silently degraded to global-only after crossing the host-capability boundary.

Direct mechanism proof:

```text
sourceKeys=["entries"] cloneHasList=false cloneKeys=["entries"]
```

Two live-verified P0 symptoms exposed the shared defect:

1. Under Codex, per-agent `tools.exec` policy was silently ignored: `mode: "deny"` still ran `./job.sh`, printed `SAFE`, and raised no approval. The identical config on an embedded agent returned `exec denied: host=gateway security=deny`. This reproduced COLD, so it was not a warm-cache artifact.
2. After `/exec host=node`, the Codex native shell stayed registered and `exec_command` ran on the GATEWAY box while the correctly routed `openclaw__node_exec` failed closed. This reproduced in a fresh session with `host: "node"` in config, so it extends beyond the warm-thread window closed by #124777.

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where operators using canonical per-agent configuration could have tool policy, execution ownership, model parameters, compaction settings, identity, reasoning, and channel presentation silently fall back to global defaults in plugin-backed runs.

The affected paths were:

- Codex: compaction overrides; OpenClaw exec policy; native execution agent config; native default-agent ownership; conversation-binding default-agent ownership.
- Anthropic: CLI exec/yolo policy and configured runtime model references.
- Browser: browser-tool policy detection during setup.
- Discord: per-agent reasoning defaults and reserved identity reactions.
- Feishu: per-agent reasoning defaults and message-action identity prefixes.
- Google Chat: per-agent bot display names.
- OpenRouter: per-agent Fusion prompt parameters.
- Telegram: default-agent binding selection and per-agent reasoning defaults.
- Voice Call: per-agent tool allowlists and realtime-agent roster enumeration.
- WhatsApp: per-agent identity prefixes.

Remaining `agents.list` references are intentional: legacy migrations, doctor/config-mutation paths, roster-presence checks, fixtures/test harnesses, and user-facing legacy path strings. Core config's public shape was deliberately not changed. History for #113146 confirms that the list projection is intentionally non-serialized compatibility for legacy runtime consumers.

## Why This Change Was Made

Every affected runtime reader now uses the canonical Plugin SDK agent-resolution helpers (`resolveAgentConfig`, `resolveDefaultAgentId`, or `listAgentIds`). This repairs the defect at the plugin/config ownership boundary without making the compatibility projection serializable or adding another config path.

Canonical `agents.entries` fixtures now exercise each repaired policy path, so a direct projection read fails instead of silently inheriting global config. I deliberately did not add a syntactic lint rule: legitimate migration, doctor, config-mutation, roster-presence, fixture, and user-facing path readers remain, so a repository allowlist would be brittle and would test spelling rather than the runtime invariant.

Final LOC after investigating the previously idle conversation-binding suite and the exact-head Telegram failure:

- Production: +67/-123 (net **-56**)
- Tests: +132/-73 (net **+59**)
- Total: +199/-196 (net +3)

The prepared stack was production +64/-123 and tests +124/-65 (total net zero). The final difference is the required partial-mock/canonical-fixture repair that makes `conversation-binding.test.ts` execute the new SDK import, plus a three-line ownership guard found by exact-head CI. That guard prevents optional Telegram account probing from inventing a default in an explicit multi-agent roster; explicit sole-agent installs still resolve their sole agent unchanged.

## User Impact

Per-agent configuration is now honored consistently across Codex and the nine sibling plugins after config crosses the harness snapshot boundary. In particular, deny policies remain denied, node-owned execution no longer leaves Codex's native gateway shell available, and per-agent identity/reasoning/model/compaction settings no longer disappear silently.

The Codex contract requires the node-ownership behavior:

- `../codex/codex-rs/features/src/lib.rs:863` — the shell tool feature is enabled by default.
- `../codex/codex-rs/core/src/tools/spec_plan.rs:953` — shell registration requires an execution environment.
- `../codex/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs:133` — `exec_command` resolves and runs against the selected turn environment.
- `extensions/codex/src/app-server/thread-requests.ts:698` — OpenClaw therefore sends `environments: []` when node ownership disables the native surface.

## Evidence

- Direct projection/clone proof: `sourceKeys=["entries"] cloneHasList=false cloneKeys=["entries"]`.
- Live P0 policy proof: Codex incorrectly ran `./job.sh` and printed `SAFE` under per-agent deny before the fix; the embedded path denied it. Reproduced cold.
- Live P0 ownership proof: fresh node-host sessions exposed gateway `exec_command` while `openclaw__node_exec` correctly failed closed before the fix.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs <26 focused files>`: 13 Vitest shards passed, including 10 expanded Codex files, compaction/config/native execution, provider/channel siblings, WhatsApp, and core embedded-agent controls.
- `conversation-binding.test.ts`: 76/76 passed and exited normally in 6.28s. Before the test-boundary repair, its explicit SDK mock omitted `resolveDefaultAgentId`; setup rejected, later queue tests waited for calls that could never happen, and one hit the 120s timeout. This was branch-caused, not a pre-existing flake.
- Exact-head CI run `31987810477` found that Telegram's optional bound-default-account probe threw for an explicit three-agent roster. The repaired path treats that roster as having no implicit default, keeps explicit account routing authoritative, and preserves sole-agent resolution. Focused proof: 55/55 tests across the Telegram account/session boundary and core agent-selection owner.
- `node scripts/check-changed.mjs`: passed. No remote backend was ready, so the repository wrapper explicitly fell back to local execution; all selected typecheck, lint, format, boundary, dependency, dead-code, and guard lanes passed.
- Fresh final-diff autoreview: clean, no accepted/actionable findings.
