### PR TITLE
test: replace assertion chains with typed fixture builders — wave 3

### DIFF
--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -3,12 +3,7 @@ import { ChannelType, Routes } from "discord-api-types/v10";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSendAssetsAndRetriesTests } from "./send.assets-and-retries.test-support.js";
-import {
-  makeDiscordRest,
-  requestBody,
-  requestPath,
-  type MockCallSource,
-} from "./send.test-harness.js";
+import { makeDiscordRest, requestBody, requestPath } from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", async () => {
   const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
@@ -248,8 +243,8 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).not.toHaveBeenCalled();
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1", "m1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({ name: "thread" });
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1", "m1"));
+    expect(requestBody(postMock)).toEqual({ name: "thread" });
   });
 
   it("creates forum threads with an initial message", async () => {
@@ -258,8 +253,8 @@ describe("sendMessageDiscord", () => {
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
     expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       message: { content: "thread" },
     });
@@ -273,7 +268,7 @@ describe("sendMessageDiscord", () => {
     });
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       auto_archive_duration: 1440,
       message: { content: "thread" },
@@ -288,7 +283,7 @@ describe("sendMessageDiscord", () => {
     });
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       auto_archive_duration: 10080,
       type: ChannelType.PublicThread,
@@ -307,7 +302,7 @@ describe("sendMessageDiscord", () => {
       { name: "thread", autoArchiveMinutes: 4320 },
       discordClientOpts(rest),
     );
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       auto_archive_duration: 4320,
       message: { content: "thread" },
@@ -323,7 +318,7 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).not.toHaveBeenCalled();
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       auto_archive_duration: 4320,
     });
@@ -338,8 +333,8 @@ describe("sendMessageDiscord", () => {
       { name: "thread", content: "initial forum post" },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock)).toEqual({
       name: "thread",
       message: { content: "initial forum post" },
     });
@@ -354,8 +349,8 @@ describe("sendMessageDiscord", () => {
       { name: "tagged post", appliedTags: ["tag1", "tag2"] },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock)).toEqual({
       name: "tagged post",
       message: { content: "tagged post" },
       applied_tags: ["tag1", "tag2"],
@@ -371,8 +366,8 @@ describe("sendMessageDiscord", () => {
       { name: "thread", appliedTags: ["tag1"] },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect("applied_tags" in requestBody(postMock as unknown as MockCallSource)).toBe(false);
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect("applied_tags" in requestBody(postMock)).toBe(false);
   });
 
   it("falls back when channel lookup is unavailable", async () => {
@@ -380,9 +375,9 @@ describe("sendMessageDiscord", () => {
     getMock.mockRejectedValue(new Error("lookup failed"));
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource).type).toBe(ChannelType.PublicThread);
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock).name).toBe("thread");
+    expect(requestBody(postMock).type).toBe(ChannelType.PublicThread);
   });
 
   it("respects explicit thread type for standalone threads", async () => {
@@ -395,9 +390,9 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource).type).toBe(ChannelType.PrivateThread);
+    expect(requestPath(postMock)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock).name).toBe("thread");
+    expect(requestBody(postMock).type).toBe(ChannelType.PrivateThread);
   });
 
   it("sends initial message for non-forum threads with content", async () => {
@@ -411,16 +406,12 @@ describe("sendMessageDiscord", () => {
     );
     expect(postMock).toHaveBeenCalledTimes(2);
     // First call: create thread
-    expect(requestPath(postMock as unknown as MockCallSource, 0)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource, 0).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource, 0).type).toBe(
-      ChannelType.PublicThread,
-    );
+    expect(requestPath(postMock, 0)).toBe(Routes.threads("chan1"));
+    expect(requestBody(postMock, 0).name).toBe("thread");
+    expect(requestBody(postMock, 0).type).toBe(ChannelType.PublicThread);
     // Second call: send message to thread
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
-      Routes.channelMessages("t1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(requestPath(postMock, 1)).toBe(Routes.channelMessages("t1"));
+    expect(requestBody(postMock, 1)).toMatchObject({
       content: "Hello thread!",
       enforce_nonce: true,
     });
@@ -464,15 +455,11 @@ describe("sendMessageDiscord", () => {
     expect(getMock).not.toHaveBeenCalled();
     expect(postMock).toHaveBeenCalledTimes(2);
     // First call: create thread from message
-    expect(requestPath(postMock as unknown as MockCallSource, 0)).toBe(
-      Routes.threads("chan1", "m1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 0)).toEqual({ name: "thread" });
+    expect(requestPath(postMock, 0)).toBe(Routes.threads("chan1", "m1"));
+    expect(requestBody(postMock, 0)).toEqual({ name: "thread" });
     // Second call: send message to thread
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
-      Routes.channelMessages("t1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(requestPath(postMock, 1)).toBe(Routes.channelMessages("t1"));
+    expect(requestBody(postMock, 1)).toMatchObject({
       content: "Discussion here",
       enforce_nonce: true,
     });
@@ -492,12 +479,8 @@ describe("sendMessageDiscord", () => {
       { guildId: "g1", userId: "u1", durationMinutes: 10 },
       discordClientOpts(rest),
     );
-    expect(requestPath(patchMock as unknown as MockCallSource)).toBe(
-      Routes.guildMember("g1", "u1"),
-    );
-    expect(
-      requestBody(patchMock as unknown as MockCallSource).communication_disabled_until,
-    ).toBeTypeOf("string");
+    expect(requestPath(patchMock)).toBe(Routes.guildMember("g1", "u1"));
+    expect(requestBody(patchMock).communication_disabled_until).toBeTypeOf("string");
   });
 
   it("rejects timeout durations outside Date range", async () => {
@@ -543,7 +526,7 @@ describe("sendMessageDiscord", () => {
       { guildId: "g1", userId: "u1", deleteMessageDays: 2 },
       discordClientOpts(rest),
     );
-    expect(requestPath(putMock as unknown as MockCallSource)).toBe(Routes.guildBan("g1", "u1"));
-    expect(requestBody(putMock as unknown as MockCallSource)).toEqual({ delete_message_days: 2 });
+    expect(requestPath(putMock)).toBe(Routes.guildBan("g1", "u1"));
+    expect(requestBody(putMock)).toEqual({ delete_message_days: 2 });
   });
 });

--- a/extensions/discord/src/send.test-harness.ts
+++ b/extensions/discord/src/send.test-harness.ts
@@ -26,11 +26,7 @@ type DiscordLoopbackRequest = {
   path: string | undefined;
 };
 
-export type MockCallSource = {
-  mock: {
-    calls: ArrayLike<ReadonlyArray<unknown>>;
-  };
-};
+export type MockCallSource = Pick<MockFn, "mock">;
 
 const requireRecord = createRequireRecord("object", "expected-label");
 

--- a/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
+++ b/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
@@ -1,11 +1,13 @@
 // Imported by register.test.ts to keep its mocked suite in one Vitest module graph.
-import { runDoctorLintChecks, type OpenClawConfig } from "openclaw/plugin-sdk/health";
+import { runDoctorLintChecks } from "openclaw/plugin-sdk/health";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { collectPolicyEvidence } from "../policy-state.js";
 import { registerPolicyDoctorChecks } from "./register.js";
 import {
   cfgWithPolicy,
+  cfgWithPolicyOverrides,
   ctx,
+  rawCfgWithPolicy,
   runPolicyChecks,
   setupPolicyDoctorTest,
   teardownPolicyDoctorTest,
@@ -18,7 +20,7 @@ describe("registerPolicyDoctorChecks", () => {
   afterEach(teardownPolicyDoctorTest);
 
   it("ignores agent-local Docker and browser posture under shared sandbox scope", async () => {
-    const cfg = {
+    const cfg = rawCfgWithPolicy({
       agents: {
         defaults: {
           sandbox: {
@@ -52,9 +54,9 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    };
+    });
 
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
     const runnerEvidence = (evidence.sandboxPosture ?? []).filter(
       (entry) => entry.agentId === "runner",
     );
@@ -96,8 +98,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("treats blank agent browser CDP source range as an explicit clear", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -115,7 +116,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         browser: { requireCdpSourceRange: true },
@@ -135,8 +136,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports enabled container posture rules that the backend cannot observe", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -150,7 +150,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         allowBackends: ["openshell"],
@@ -163,7 +163,7 @@ describe("registerPolicyDoctorChecks", () => {
     });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
@@ -209,8 +209,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("evaluates inherited container mounts for browser containers on non-Docker backends", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -226,7 +225,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         allowBackends: ["openshell"],
@@ -238,7 +237,7 @@ describe("registerPolicyDoctorChecks", () => {
     });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
@@ -265,8 +264,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("normalizes mixed-case Docker backend before collecting container posture", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -280,7 +278,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         allowBackends: ["docker"],
@@ -293,7 +291,7 @@ describe("registerPolicyDoctorChecks", () => {
     });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
@@ -317,8 +315,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("evaluates Podman container posture without reporting it as unobservable", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -332,7 +329,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         allowBackends: ["podman"],
@@ -363,7 +360,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses explicit agent sandbox scope before inherited legacy perSession", async () => {
-    const cfg = {
+    // `perSession` is retired runtime config but remains raw doctor input so policy evidence can
+    // verify that an explicit modern scope wins over the legacy field.
+    const cfg = rawCfgWithPolicy({
       agents: {
         defaults: {
           sandbox: {
@@ -393,9 +392,9 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    };
+    });
 
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
     const runnerEvidence = (evidence.sandboxPosture ?? []).filter(
       (entry) => entry.agentId === "runner",
     );
@@ -422,8 +421,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts configured sandbox posture that matches policy", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -438,7 +436,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         requireMode: ["all", "non-main"],
@@ -460,15 +458,14 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies agent-scoped sandbox claims only to matching agents", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         list: [
           { id: "Sebby", sandbox: { mode: "off", backend: "ssh" } },
           { id: "buddy", sandbox: { mode: "all", backend: "docker" } },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       sandbox: {
         requireMode: ["all"],
@@ -510,12 +507,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not apply sandbox overlays from invalid scoped policy", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         list: [{ id: "sebby", sandbox: { mode: "off" } }],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         sebby: {
@@ -549,8 +545,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports scoped container posture rules that a non-Docker agent group cannot observe", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -569,7 +564,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         release: {
@@ -593,8 +588,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows scoped non-Docker agent groups when container posture rules are off", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -613,7 +607,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         release: {
@@ -631,8 +625,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not fall back to default browser posture for scoped browser-disabled agents", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: {
@@ -648,7 +641,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         release: {
@@ -662,7 +655,7 @@ describe("registerPolicyDoctorChecks", () => {
     });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
@@ -682,8 +675,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies main-scoped sandbox claims to defaults when unrelated agents exist", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: { mode: "off" },
@@ -695,7 +687,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         mainSandbox: {
@@ -719,8 +711,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports tool posture denied by policy", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         profile: "coding",
         deny: ["write"],
@@ -742,7 +733,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         profiles: { allow: ["messaging", "minimal"] },
@@ -759,7 +750,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -834,8 +825,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts configured tool posture that matches policy", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         profile: "messaging",
         deny: ["group:runtime", "group:fs"],
@@ -843,7 +833,7 @@ describe("registerPolicyDoctorChecks", () => {
         fs: { workspaceOnly: true },
         elevated: { enabled: false },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         profiles: { allow: ["messaging", "minimal"] },
@@ -865,8 +855,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports global and agent-scoped tool claims independently", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         exec: { host: "sandbox" },
       },
@@ -876,7 +865,7 @@ describe("registerPolicyDoctorChecks", () => {
           { id: "buddy", tools: { exec: { host: "sandbox" } } },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: { allowHosts: ["sandbox", "gateway"] },
@@ -918,15 +907,14 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not apply agent-scoped tool claims to other agents", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         list: [
           { id: "sebby", tools: { exec: { host: "sandbox" } } },
           { id: "buddy", tools: { exec: { host: "node" } } },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       scopes: {
         sebby: {
@@ -945,8 +933,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports global and agent-scoped alsoAllow drift", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: { alsoAllow: ["read", "cron"] },
       agents: {
         list: [
@@ -954,7 +941,7 @@ describe("registerPolicyDoctorChecks", () => {
           { id: "buddy", tools: { alsoAllow: ["read"] } },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         alsoAllow: { expected: ["read", "message"] },
@@ -1007,10 +994,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports unexpected alsoAllow entries when policy expects none", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: { alsoAllow: ["read"] },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         alsoAllow: { expected: [] },
@@ -1030,12 +1016,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses config-level exec defaults and normalizes required deny aliases", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         deny: ["exec", "apply_patch"],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: {
@@ -1072,12 +1057,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts omitted exec defaults and individual denies for required deny groups", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         deny: ["exec", "process", "code_execution", "read", "write", "edit", "apply_patch"],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: {
@@ -1096,12 +1080,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts wildcard tool denies for required tool posture", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         deny: ["web_*"],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         denyTools: ["web_search"],
@@ -1115,12 +1098,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts canonical tool groups for required tool denies", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         deny: ["group:openclaw"],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         denyTools: ["message"],
@@ -1129,7 +1111,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -1145,8 +1127,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("treats globally disabled elevated mode as disabling per-agent elevated posture", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         elevated: { enabled: false },
       },
@@ -1160,7 +1141,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         elevated: { allow: false },
@@ -1169,7 +1150,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -1205,12 +1186,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses deny as the omitted exec security default for explicit sandbox host", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       tools: {
         exec: { host: "sandbox" },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: {
@@ -1222,7 +1202,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -1238,14 +1218,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses deny as the omitted exec security default for auto host when sandbox can apply", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: { mode: "all" },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: {
@@ -1257,7 +1236,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -1273,14 +1252,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("keeps omitted auto-host exec security full when sandbox is non-main only", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       agents: {
         defaults: {
           sandbox: { mode: "non-main" },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       tools: {
         exec: {
@@ -1292,7 +1270,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     registerPolicyDoctorChecks();
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+    const evidence = collectPolicyEvidence(cfg);
 
     expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
@@ -1314,8 +1292,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports gateway exposure settings denied by policy", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         bind: "lan",
         auth: { mode: "none" },
@@ -1341,7 +1318,7 @@ describe("registerPolicyDoctorChecks", () => {
           commands: { allow: ["mcp.help", "mcp.invoke", "system.run"] },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1427,8 +1404,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report gateway node commands denied by runtime config", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         nodes: {
           commands: {
@@ -1437,7 +1413,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         nodes: {
@@ -1453,12 +1429,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports gateway node commands denied by policy without explicit extra allows", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         nodes: {},
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         nodes: {
@@ -1481,10 +1456,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports omitted gateway bind when non-loopback exposure is denied", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {},
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1507,12 +1481,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report omitted gateway bind when Tailscale forces loopback", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         tailscale: { mode: "serve" },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1528,12 +1501,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports preserved Tailscale Funnel routes when policy denies Funnel exposure", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         tailscale: { mode: "serve", preserveFunnel: true },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1578,13 +1550,12 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report inactive custom bind hosts", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         bind: "loopback",
         customBindHost: "0.0.0.0",
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1600,13 +1571,12 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report loopback custom bind hosts", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         bind: "custom",
         customBindHost: "127.0.0.1",
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1622,13 +1592,12 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports valid non-loopback custom bind hosts", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         bind: "custom",
         customBindHost: "192.168.1.20",
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1651,13 +1620,12 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report blank custom bind config as active non-loopback exposure", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         bind: "custom",
         customBindHost: "   ",
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         exposure: {
@@ -1675,13 +1643,12 @@ describe("registerPolicyDoctorChecks", () => {
   it.each(["localhost", "::1", "192.168.001.20"])(
     "does not report invalid custom bind host %s as active non-loopback exposure",
     async (customBindHost) => {
-      const cfg = {
-        ...cfgWithPolicy(),
+      const cfg = cfgWithPolicyOverrides({
         gateway: {
           bind: "custom",
           customBindHost,
         },
-      } as unknown as OpenClawConfig;
+      });
       const configPath = await writePolicyFixture({
         gateway: {
           exposure: {
@@ -1698,15 +1665,14 @@ describe("registerPolicyDoctorChecks", () => {
   );
 
   it("reports configured gateway remote URLs when remote mode is active", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         mode: "remote",
         remote: {
           url: "wss://remote.example.test:18789",
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         remote: {
@@ -1735,14 +1701,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report inert remote config outside remote mode", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         remote: {
           url: "wss://remote.example.test:18789",
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         remote: {
@@ -1758,8 +1723,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports default Responses URL fetching without allowlists", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         http: {
           endpoints: {
@@ -1769,7 +1733,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         http: {
@@ -1801,8 +1765,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports wildcard Responses URL allowlists as unrestricted", async () => {
-    const cfg = {
-      ...cfgWithPolicy(),
+    const cfg = cfgWithPolicyOverrides({
       gateway: {
         http: {
           endpoints: {
@@ -1814,7 +1777,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const configPath = await writePolicyFixture({
       gateway: {
         http: {

--- a/extensions/policy/src/doctor/register.test-harness.ts
+++ b/extensions/policy/src/doctor/register.test-harness.ts
@@ -32,6 +32,18 @@ export function cfgWithPolicy(settings: Record<string, unknown> = {}): OpenClawC
   };
 }
 
+export type PolicyConfigFixture = OpenClawConfig & Record<string, unknown>;
+
+export function cfgWithPolicyOverrides(
+  overrides: Partial<OpenClawConfig> = {},
+): PolicyConfigFixture {
+  return { ...cfgWithPolicy(), ...overrides };
+}
+
+export function rawCfgWithPolicy(overrides: Record<string, unknown>): Record<string, unknown> {
+  return { ...cfgWithPolicy(), ...overrides };
+}
+
 export async function writePolicyFixture(
   ...json: Parameters<typeof JSON.stringify>
 ): Promise<string> {

--- a/extensions/policy/src/doctor/register.test-harness.ts
+++ b/extensions/policy/src/doctor/register.test-harness.ts
@@ -32,7 +32,7 @@ export function cfgWithPolicy(settings: Record<string, unknown> = {}): OpenClawC
   };
 }
 
-export type PolicyConfigFixture = OpenClawConfig & Record<string, unknown>;
+type PolicyConfigFixture = OpenClawConfig & Record<string, unknown>;
 
 export function cfgWithPolicyOverrides(
   overrides: Partial<OpenClawConfig> = {},

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -21,9 +21,13 @@ vi.mock("../../logger.js", async (importOriginal) => ({
   logWarn: loggerMocks.logWarn,
 }));
 
+function makeConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return overrides;
+}
+
 describe("resolveSessionToolsVisibility", () => {
   it("defaults to tree when unset or invalid", () => {
-    expect(resolveSessionToolsVisibility({} as unknown as OpenClawConfig)).toBe("tree");
+    expect(resolveSessionToolsVisibility(makeConfig())).toBe("tree");
     expect(
       resolveSessionToolsVisibility({
         tools: { sessions: { visibility: "invalid" } },
@@ -42,32 +46,32 @@ describe("resolveSessionToolsVisibility", () => {
 
 describe("resolveEffectiveSessionToolsVisibility", () => {
   it("clamps to tree in sandbox when sandbox visibility is spawned", () => {
-    const cfg = {
+    const cfg = makeConfig({
       tools: { sessions: { visibility: "all" } },
       agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
-    } as unknown as OpenClawConfig;
+    });
     expect(resolveEffectiveSessionToolsVisibility({ cfg, sandboxed: true })).toBe("tree");
   });
 
   it("preserves visibility when sandbox clamp is all", () => {
-    const cfg = {
+    const cfg = makeConfig({
       tools: { sessions: { visibility: "all" } },
       agents: { defaults: { sandbox: { sessionToolsVisibility: "all" } } },
-    } as unknown as OpenClawConfig;
+    });
     expect(resolveEffectiveSessionToolsVisibility({ cfg, sandboxed: true })).toBe("all");
   });
 });
 
 describe("sandbox session-tools context", () => {
   it("defaults sandbox visibility clamp to spawned", () => {
-    expect(resolveSandboxSessionToolsVisibility({} as unknown as OpenClawConfig)).toBe("spawned");
+    expect(resolveSandboxSessionToolsVisibility(makeConfig())).toBe("spawned");
   });
 
   it("restricts non-subagent sandboxed sessions to spawned visibility", () => {
-    const cfg = {
+    const cfg = makeConfig({
       tools: { sessions: { visibility: "all" } },
       agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
-    } as unknown as OpenClawConfig;
+    });
     const context = resolveSandboxedSessionToolContext({
       cfg,
       agentSessionKey: "agent:main:main",
@@ -81,10 +85,10 @@ describe("sandbox session-tools context", () => {
   });
 
   it("does not restrict subagent sessions in sandboxed mode", () => {
-    const cfg = {
+    const cfg = makeConfig({
       tools: { sessions: { visibility: "all" } },
       agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
-    } as unknown as OpenClawConfig;
+    });
     const context = resolveSandboxedSessionToolContext({
       cfg,
       agentSessionKey: "agent:main:subagent:abc",
@@ -124,21 +128,23 @@ describe("sandbox session-tools context", () => {
 
 describe("createAgentToAgentPolicy", () => {
   it("denies cross-agent access when disabled", () => {
-    const policy = createAgentToAgentPolicy({} as unknown as OpenClawConfig);
+    const policy = createAgentToAgentPolicy(makeConfig());
     expect(policy.enabled).toBe(false);
     expect(policy.isAllowed("main", "main")).toBe(true);
     expect(policy.isAllowed("main", "ops")).toBe(false);
   });
 
   it("honors allow patterns when enabled", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["ops-*", "main"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["ops-*", "main"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.isAllowed("ops-a", "ops-b")).toBe(true);
     expect(policy.isAllowed("main", "ops-a")).toBe(true);
@@ -146,14 +152,16 @@ describe("createAgentToAgentPolicy", () => {
   });
 
   it("matches wildcard patterns case-insensitively", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["Ops-*"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["Ops-*"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("ops-worker")).toBe(true);
     expect(policy.matchesAllow("OPS-WORKER")).toBe(true);
@@ -161,42 +169,48 @@ describe("createAgentToAgentPolicy", () => {
   });
 
   it("keeps exact allow patterns case-sensitive", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["Ops"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["Ops"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("Ops")).toBe(true);
     expect(policy.matchesAllow("ops")).toBe(false);
   });
 
   it("keeps blank configured allow patterns fail-closed", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: [" "],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: [" "],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("ops")).toBe(false);
     expect(policy.isAllowed("main", "ops")).toBe(false);
   });
 
   it("handles interior wildcards", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["team-*-prod"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["team-*-prod"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("team-ops-prod")).toBe(true);
     expect(policy.matchesAllow("team-dev-prod")).toBe(true);
@@ -207,14 +221,16 @@ describe("createAgentToAgentPolicy", () => {
   it("handles multiple wildcards without polynomial backtracking", () => {
     // Allow patterns use segment matching rather than a greedy regex so
     // adversarial agent ids cannot cause slow policy checks.
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["*a*b*c*d*e*"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["*a*b*c*d*e*"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     // Positive match
     expect(policy.matchesAllow("xaxbxcxdxe")).toBe(true);
@@ -230,14 +246,16 @@ describe("createAgentToAgentPolicy", () => {
   });
 
   it("rejects when suffix overlaps prefix", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["abc*xyz"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["abc*xyz"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("abcxyz")).toBe(true);
     expect(policy.matchesAllow("abc-middle-xyz")).toBe(true);
@@ -245,14 +263,16 @@ describe("createAgentToAgentPolicy", () => {
   });
 
   it("treats regex syntax as literal text in wildcard patterns", () => {
-    const policy = createAgentToAgentPolicy({
-      tools: {
-        agentToAgent: {
-          enabled: true,
-          allow: ["ops.[prod]*"],
+    const policy = createAgentToAgentPolicy(
+      makeConfig({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["ops.[prod]*"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(policy.matchesAllow("OPS.[PROD]-worker")).toBe(true);
     expect(policy.matchesAllow("opsXprod-worker")).toBe(false);
@@ -265,7 +285,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "list",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
     });
 
     expect(
@@ -281,9 +301,11 @@ describe("createSessionVisibilityGuard", () => {
       action: "list",
       requesterSessionKey: "agent:main:main",
       visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({
-        tools: { agentToAgent: { enabled: false } },
-      } as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(
+        makeConfig({
+          tools: { agentToAgent: { enabled: false } },
+        }),
+      ),
     });
 
     expect(
@@ -299,9 +321,11 @@ describe("createSessionVisibilityGuard", () => {
       action: "list",
       requesterSessionKey: "agent:main:main",
       visibility: "agent",
-      a2aPolicy: createAgentToAgentPolicy({
-        tools: { agentToAgent: { enabled: true, allow: ["main", "codex"] } },
-      } as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(
+        makeConfig({
+          tools: { agentToAgent: { enabled: true, allow: ["main", "codex"] } },
+        }),
+      ),
     });
 
     expect(
@@ -326,7 +350,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "list",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: callGateway as never,
     });
 
@@ -351,7 +375,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: callGateway as never,
     });
 
@@ -363,7 +387,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "self",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
     });
 
     expect(guard.check("agent:codex:acp:child-1")).toEqual({
@@ -391,7 +415,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "send",
       requesterSessionKey: "agent:main:main",
       visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: callGateway as never,
     });
 
@@ -415,7 +439,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "status",
       requesterSessionKey: "agent:main:main",
       visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: callGateway as never,
     });
 
@@ -438,7 +462,7 @@ describe("createSessionVisibilityGuard", () => {
       targetSessionKey: "agent:main:subagent:worker-999",
       requesterOwned: false,
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: gateway as never,
     });
 
@@ -466,7 +490,7 @@ describe("createSessionVisibilityGuard", () => {
       targetSessionKey: "agent:main:subagent:worker",
       requesterOwned: false,
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: gateway as never,
     });
 
@@ -494,7 +518,7 @@ describe("createSessionVisibilityGuard", () => {
       targetSessionKey: "agent:ops:main",
       requesterOwned: false,
       visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: gateway as never,
     });
 
@@ -524,7 +548,7 @@ describe("createSessionVisibilityGuard", () => {
         targetSessionKey: "shared",
         requesterOwned: false,
         visibility: "self",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+        a2aPolicy: createAgentToAgentPolicy(makeConfig()),
         callGateway: gateway as never,
       });
 
@@ -551,7 +575,7 @@ describe("createSessionVisibilityGuard", () => {
         targetSessionKey,
         requesterOwned: true,
         visibility: "all",
-        a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+        a2aPolicy: createAgentToAgentPolicy(makeConfig()),
         callGateway: gateway as never,
       });
 
@@ -583,7 +607,7 @@ describe("createSessionVisibilityGuard", () => {
       targetSessionKey: "agent:codex:acp:child-1",
       requesterOwned: false,
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: gateway as never,
     });
 
@@ -601,7 +625,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "send",
       requesterSessionKey: "agent:main:main",
       visibility: "all",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => ({ sessions: [] })) as never,
     });
 
@@ -619,7 +643,7 @@ describe("createSessionVisibilityGuard", () => {
       requesterSessionKey: "agent:main:main",
       mainSessionKey: "agent:main:main",
       visibility: "self",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
     });
 
     expect(guard.check("agent:main:main")).toEqual({ allowed: true });
@@ -637,7 +661,7 @@ describe("createSessionVisibilityGuard", () => {
       requesterSessionKey: "agent:main:main",
       mainSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => ({ sessions: [] })) as never,
     });
 
@@ -681,7 +705,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility,
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
           code: "UNAVAILABLE",
@@ -704,7 +728,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => {
         throw new GatewayClientRequestError({
           code: "UNAVAILABLE",
@@ -732,7 +756,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => {
         throw new GatewayCredentialsRequiredError({
           method: "sessions.list",
@@ -756,7 +780,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => {
         throw new Error("failed to decode session row");
       }) as never,
@@ -777,7 +801,7 @@ describe("createSessionVisibilityGuard", () => {
       action: "history",
       requesterSessionKey: "agent:main:main",
       visibility: "tree",
-      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+      a2aPolicy: createAgentToAgentPolicy(makeConfig()),
       callGateway: vi.fn(async () => ({})) as never,
     });
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -23,7 +23,6 @@ import {
 } from "../../plugins/memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import type { TemplateContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import {
   runMemoryFlushIfNeeded as runMemoryFlushIfNeededRaw,
@@ -32,6 +31,7 @@ import {
 import { setAgentRunnerMemoryTestDeps } from "./agent-runner-memory.test-support.js";
 import {
   createTestFollowupRun,
+  createTestTemplateContext,
   withTestModelContextTokens,
   writeTestSessionStore,
 } from "./agent-runner.test-fixtures.js";
@@ -472,7 +472,7 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       },
       followupRun,
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -572,7 +572,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ workspaceDir: rootDir, senderIsOwner: false }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -663,7 +663,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
         senderIsOwner: true,
       }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -721,7 +721,7 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       },
       followupRun,
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "openai/gpt-5.6-sol",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -763,7 +763,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun,
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "ollama/qwen3.5:4b",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -816,7 +816,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionId: sessionEntry.sessionId,
         sessionKey: "main",
       }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -871,7 +871,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun,
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -924,7 +924,7 @@ describe("runMemoryFlushIfNeeded", () => {
         authProfileId: "anthropic:auto",
         authProfileIdSource: "auto",
       }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -963,7 +963,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1003,7 +1003,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1042,7 +1042,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1076,7 +1076,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1167,7 +1167,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const params = {
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ workspaceDir: rootDir }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off" as const,
@@ -1243,7 +1243,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ workspaceDir: rootDir }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1278,7 +1278,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1311,7 +1311,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1346,7 +1346,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1413,7 +1413,7 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       },
       followupRun: createTestFollowupRun({ provider: "anthropic", model: "claude" }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1490,7 +1490,7 @@ describe("runMemoryFlushIfNeeded", () => {
         provider: "openai",
         model: "gpt-5.4",
       }),
-      sessionCtx: { Provider: "telegram" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "telegram" }),
       defaultModel: "openai/gpt-5.4",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1544,7 +1544,7 @@ describe("runMemoryFlushIfNeeded", () => {
         provider: "openai",
         model: "gpt-5.4",
       }),
-      sessionCtx: { Provider: "telegram" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "telegram" }),
       defaultModel: "openai/gpt-5.4",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1580,7 +1580,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: {},
       followupRun: createTestFollowupRun({ provider: "codex-cli" }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "codex-cli/gpt-5.5",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1609,7 +1609,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "webchat" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "webchat" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1639,7 +1639,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "webchat" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "webchat" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1672,7 +1672,7 @@ describe("runMemoryFlushIfNeeded", () => {
         provider: "anthropic",
         model: "claude-opus-4-6",
       }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -1716,7 +1716,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "agent:main:main",
         runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
       }),
-      sessionCtx: { Provider: "telegram" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "telegram" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -2608,7 +2608,7 @@ describe("runMemoryFlushIfNeeded", () => {
           sessionFile,
           sessionKey: "main",
         }),
-        sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+        sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
         defaultModel: "anthropic/claude-opus-4-6",
         modelContextTokens: 100_000,
         resolvedVerboseLevel: "off",
@@ -3440,7 +3440,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const flushResult = await runMemoryFlushIfNeeded({
       cfg,
       followupRun,
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -3714,7 +3714,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",
@@ -3876,7 +3876,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ extraSystemPrompt: "extra system" }),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100_000,
       resolvedVerboseLevel: "off",

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -1,11 +1,20 @@
 // Program force tests cover root force flag behavior and command propagation.
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ExecFileSyncMock = (
+  command: string,
+  args: string[],
+  options: ExecFileSyncOptionsWithStringEncoding,
+) => string;
+
+const execFileSyncMock = vi.hoisted(() => vi.fn<ExecFileSyncMock>());
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    execFileSync: vi.fn(),
+    execFileSync: execFileSyncMock,
   };
 });
 
@@ -15,7 +24,6 @@ vi.mock("../infra/ports-probe.js", () => ({
   probePortUsage: (...args: unknown[]) => probePortUsageMock(...args),
 }));
 
-import { execFileSync } from "node:child_process";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { forceFreePort, forceFreePortAndWait } from "./ports.js";
 
@@ -42,12 +50,12 @@ describe("gateway --force helpers", () => {
 
   it("parses lsof output into pid/command pairs", () => {
     const sample = ["p123", "cnode", "p456", "cpython", ""].join("\n");
-    (execFileSync as unknown as Mock).mockReturnValue(sample);
+    execFileSyncMock.mockReturnValue(sample);
     process.kill = vi.fn();
 
     const parsed = forceFreePort(18789);
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFileSyncMock).toHaveBeenCalledWith(
       expect.stringContaining("lsof"),
       ["-nP", "-iTCP:18789", "-sTCP:LISTEN", "-FpFc"],
       { encoding: "utf-8", killSignal: "SIGKILL", timeout: 10_000 },
@@ -60,35 +68,35 @@ describe("gateway --force helpers", () => {
 
   it("rejects malformed lsof 'p' lines with no PID", () => {
     const sample = ["p", "cnode", "p456", "cpython", ""].join("\n");
-    (execFileSync as unknown as Mock).mockReturnValue(sample);
+    execFileSyncMock.mockReturnValue(sample);
     expect(() => forceFreePort(18789)).toThrow(/malformed PID field/);
   });
 
   it("rejects malformed lsof 'p' lines with digit-prefixed garbage", () => {
     const sample = ["p111abc", "cnode", "p456", "cpython", ""].join("\n");
-    (execFileSync as unknown as Mock).mockReturnValue(sample);
+    execFileSyncMock.mockReturnValue(sample);
     expect(() => forceFreePort(18789)).toThrow(/malformed PID field/);
   });
 
   it("does not return partial results when a later lsof PID is malformed", () => {
     const sample = ["p456", "cpython", "pabc", "cnode", ""].join("\n");
-    (execFileSync as unknown as Mock).mockReturnValue(sample);
+    execFileSyncMock.mockReturnValue(sample);
     expect(() => forceFreePort(18789)).toThrow(/malformed PID field/);
   });
 
   it("handles empty lsof output", () => {
-    (execFileSync as unknown as Mock).mockReturnValue("");
+    execFileSyncMock.mockReturnValue("");
     expect(forceFreePort(18789)).toEqual<PortProcess[]>([]);
   });
 
   it("rejects non-positive lsof PIDs", () => {
     const sample = ["p0", "cnode", "p456", "cpython", ""].join("\n");
-    (execFileSync as unknown as Mock).mockReturnValue(sample);
+    execFileSyncMock.mockReturnValue(sample);
     expect(() => forceFreePort(18789)).toThrow(/malformed PID field/);
   });
 
   it("returns empty list when lsof finds nothing", () => {
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       const err = new Error("no matches") as NodeJS.ErrnoException & { status?: number };
       err.status = 1; // lsof uses exit 1 for no matches
       throw err;
@@ -98,7 +106,7 @@ describe("gateway --force helpers", () => {
 
   it("returns without cleanup when lsof and the bind probe find no listener", async () => {
     probePortUsageMock.mockResolvedValue("free");
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       const err = new Error("no matches") as NodeJS.ErrnoException & { status?: number };
       err.status = 1;
       throw err;
@@ -111,15 +119,13 @@ describe("gateway --force helpers", () => {
       waitedMs: 0,
       escalatedToSigkill: false,
     });
-    expect(execFileSync).toHaveBeenCalledOnce();
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
     expect(probePortUsageMock).toHaveBeenCalledWith(18789);
   });
 
   it("kills an interface-specific listener even when the bind probe would report free", async () => {
     probePortUsageMock.mockResolvedValue("free");
-    (execFileSync as unknown as Mock)
-      .mockReturnValueOnce(["p42", "cnode", ""].join("\n"))
-      .mockReturnValue("");
+    execFileSyncMock.mockReturnValueOnce(["p42", "cnode", ""].join("\n")).mockReturnValue("");
     const killMock = vi.fn();
     process.kill = killMock;
 
@@ -136,7 +142,7 @@ describe("gateway --force helpers", () => {
 
   it("returns without fuser when lsof is unavailable and the bind probe reports free", async () => {
     probePortUsageMock.mockResolvedValue("free");
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       const err = new Error("not found") as NodeJS.ErrnoException;
       err.code = "ENOENT";
       throw err;
@@ -149,12 +155,12 @@ describe("gateway --force helpers", () => {
       waitedMs: 0,
       escalatedToSigkill: false,
     });
-    expect(execFileSync).toHaveBeenCalledOnce();
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
     expect(probePortUsageMock).toHaveBeenCalledWith(18789);
   });
 
   it("fails closed when lsof has a malformed PID and fuser cannot identify one", async () => {
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
+    execFileSyncMock.mockImplementation((cmd: string) => {
       if (cmd.includes("lsof")) {
         return ["p111abc", "cnode", ""].join("\n");
       }
@@ -173,7 +179,7 @@ describe("gateway --force helpers", () => {
       /still busy.*no listener PID/i,
     );
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFileSyncMock).toHaveBeenCalledWith(
       "fuser",
       ["-k", "-TERM", "18789/tcp"],
       expect.anything(),
@@ -181,7 +187,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("throws when lsof missing", () => {
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       const err = new Error("not found") as NodeJS.ErrnoException;
       err.code = "ENOENT";
       throw err;
@@ -190,15 +196,13 @@ describe("gateway --force helpers", () => {
   });
 
   it("kills each listener and returns metadata", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(
-      ["p42", "cnode", "p99", "cssh", ""].join("\n"),
-    );
+    execFileSyncMock.mockReturnValue(["p42", "cnode", "p99", "cssh", ""].join("\n"));
     const killMock = vi.fn();
     process.kill = killMock;
 
     const killed = forceFreePort(18789);
 
-    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
     expect(killMock).toHaveBeenCalledTimes(2);
     expect(killMock).toHaveBeenCalledWith(42, "SIGTERM");
     expect(killMock).toHaveBeenCalledWith(99, "SIGTERM");
@@ -209,9 +213,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("continues when a discovered listener exits before it can be signaled", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(
-      ["p42", "cnode", "p99", "cssh", ""].join("\n"),
-    );
+    execFileSyncMock.mockReturnValue(["p42", "cnode", "p99", "cssh", ""].join("\n"));
     const gone = Object.assign(new Error("no such process"), { code: "ESRCH" });
     const killMock = vi.fn().mockImplementationOnce(() => {
       throw gone;
@@ -227,7 +229,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("does not suppress listener ownership-guard errors", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    execFileSyncMock.mockReturnValue(["p42", "cnode", ""].join("\n"));
     const guardError = Object.assign(new Error("ownership verification failed"), {
       code: "ESRCH",
     });
@@ -245,7 +247,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("preserves real signal permission failures", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    execFileSyncMock.mockReturnValue(["p42", "cnode", ""].join("\n"));
     const denied = Object.assign(new Error("permission denied"), { code: "EPERM" });
     process.kill = vi.fn(() => {
       throw denied;
@@ -257,7 +259,7 @@ describe("gateway --force helpers", () => {
   it("retries until the port is free", async () => {
     vi.useFakeTimers();
     let call = 0;
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       call += 1;
       // 1st call: initial listeners to kill.
       // 2nd/3rd calls: still listed.
@@ -294,7 +296,7 @@ describe("gateway --force helpers", () => {
   it("escalates to SIGKILL if SIGTERM doesn't free the port", async () => {
     vi.useFakeTimers();
     let call = 0;
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       call += 1;
       // 1st call: initial kill list; then keep showing until after SIGKILL.
       if (call <= 7) {
@@ -327,7 +329,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("bounds oversized force-free intervals by the remaining timeout", async () => {
-    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    execFileSyncMock.mockReturnValue(["p42", "cnode", ""].join("\n"));
     const killMock = vi.fn();
     process.kill = killMock;
 
@@ -344,7 +346,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("falls back to fuser when lsof is permission denied", async () => {
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
+    execFileSyncMock.mockImplementation((cmd: string) => {
       if (cmd.includes("lsof")) {
         const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
         err.code = "EACCES";
@@ -358,7 +360,7 @@ describe("gateway --force helpers", () => {
 
     expect(result.escalatedToSigkill).toBe(false);
     expect(result.killed).toEqual<PortProcess[]>([{ pid: 4242 }]);
-    const termCall = (execFileSync as unknown as Mock).mock.calls.find(
+    const termCall = execFileSyncMock.mock.calls.find(
       ([cmd, args]) => cmd === "fuser" && Array.isArray(args) && args.includes("-TERM"),
     );
     expect(termCall?.[1]).toEqual(["-k", "-TERM", "18789/tcp"]);
@@ -372,7 +374,7 @@ describe("gateway --force helpers", () => {
 
   it("freezes guarded fuser PIDs before signaling when the port owner changes", async () => {
     let fuserPids = [4242];
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string, args: string[]) => {
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd.includes("lsof")) {
         const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
         err.code = "EACCES";
@@ -401,11 +403,11 @@ describe("gateway --force helpers", () => {
     expect(killMock).toHaveBeenCalledOnce();
     expect(killMock).toHaveBeenCalledWith(4242, "SIGTERM");
     expect(killMock).not.toHaveBeenCalledWith(5252, expect.anything());
-    expect(execFileSync).toHaveBeenCalledWith("fuser", ["18789/tcp"], expect.anything());
+    expect(execFileSyncMock).toHaveBeenCalledWith("fuser", ["18789/tcp"], expect.anything());
   });
 
   it("never derives guarded fuser victims from stderr diagnostics", async () => {
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
+    execFileSyncMock.mockImplementation((cmd: string) => {
       if (cmd.includes("lsof")) {
         const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
         err.code = "EACCES";
@@ -443,7 +445,7 @@ describe("gateway --force helpers", () => {
 
   it("uses fuser SIGKILL escalation when port stays busy", async () => {
     vi.useFakeTimers();
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string, args: string[]) => {
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd.includes("lsof")) {
         const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
         err.code = "EACCES";
@@ -475,7 +477,7 @@ describe("gateway --force helpers", () => {
 
     expect(result.escalatedToSigkill).toBe(true);
     expect(result.waitedMs).toBe(100);
-    const killCall = (execFileSync as unknown as Mock).mock.calls.find(
+    const killCall = execFileSyncMock.mock.calls.find(
       ([cmd, args]) => cmd === "fuser" && Array.isArray(args) && args.includes("-KILL"),
     );
     expect(killCall?.[1]).toEqual(["-k", "-KILL", "18789/tcp"]);
@@ -486,7 +488,7 @@ describe("gateway --force helpers", () => {
   it("throws when lsof is unavailable and fuser is missing", async () => {
     // An inconclusive four-host probe must continue into the cleanup tools.
     probePortUsageMock.mockResolvedValue("unknown");
-    (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
+    execFileSyncMock.mockImplementation((cmd: string) => {
       const err = new Error(`spawnSync ${cmd} ENOENT`) as NodeJS.ErrnoException;
       err.code = "ENOENT";
       throw err;
@@ -538,44 +540,48 @@ describe("gateway --force helpers (Windows netstat path)", () => {
   };
 
   it("returns empty list when netstat finds no listeners on the port", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(9999, 42));
+    execFileSyncMock.mockReturnValue(makeNetstatOutput(9999, 42));
     expect(forceFreeWindowsPort(18789)).toStrictEqual([]);
   });
 
   it("parses PIDs from netstat output correctly", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(18789, 42, 99));
+    execFileSyncMock.mockReturnValue(makeNetstatOutput(18789, 42, 99));
     expect(forceFreeWindowsPort(18789)).toEqual<PortProcess[]>([{ pid: 42 }, { pid: 99 }]);
-    expect(execFileSync).toHaveBeenCalledWith(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
-      encoding: "utf-8",
-      killSignal: "SIGKILL",
-      timeout: 10_000,
-    });
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      getWindowsSystem32ExePath("netstat.exe"),
+      ["-ano"],
+      {
+        encoding: "utf-8",
+        killSignal: "SIGKILL",
+        timeout: 10_000,
+      },
+    );
   });
 
   it("parses localized Windows listener rows without depending on the state text", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeLocalizedNetstatOutput());
+    execFileSyncMock.mockReturnValue(makeLocalizedNetstatOutput());
     expect(forceFreeWindowsPort(18789)).toEqual<PortProcess[]>([{ pid: 42 }, { pid: 99 }]);
   });
 
   it("does not incorrectly match a port that is a substring (e.g. 80 vs 8080)", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(8080, 42));
+    execFileSyncMock.mockReturnValue(makeNetstatOutput(8080, 42));
     expect(forceFreeWindowsPort(80)).toStrictEqual([]);
   });
 
   it("deduplicates PIDs that appear multiple times", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(18789, 42, 42));
+    execFileSyncMock.mockReturnValue(makeNetstatOutput(18789, 42, 42));
     expect(forceFreeWindowsPort(18789)).toEqual<PortProcess[]>([{ pid: 42 }]);
   });
 
   it("throws a descriptive error when netstat fails", () => {
-    (execFileSync as unknown as Mock).mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       throw new Error("access denied");
     });
     expect(() => forceFreeWindowsPort(18789)).toThrow(/netstat failed/);
   });
 
   it("kills Windows listeners and returns metadata", () => {
-    (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(18789, 42, 99));
+    execFileSyncMock.mockReturnValue(makeNetstatOutput(18789, 42, 99));
     const killMock = vi.fn();
     process.kill = killMock;
 

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -347,7 +347,7 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("does not prune bindings from malformed agent entries", () => {
-    const config = {
+    const config = legacyConfig({
       agents: {
         list: [null],
       },
@@ -358,7 +358,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
         },
       ],
-    } as unknown as OpenClawConfig;
+    });
 
     const res = normalizeCompatibilityConfigValues(config);
 
@@ -433,23 +433,25 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy secretref-env markers on SecretRef credential paths", () => {
-    const res = normalizeCompatibilityConfigValues({
-      secrets: {
-        defaults: {
-          env: "gateway-env",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        secrets: {
+          defaults: {
+            env: "gateway-env",
+          },
         },
-      },
-      channels: {
-        discord: {
-          token: "secretref-env:DISCORD_BOT_TOKEN",
-          accounts: {
-            work: {
-              token: "__env__:DISCORD_WORK_TOKEN",
+        channels: {
+          discord: {
+            token: "secretref-env:DISCORD_BOT_TOKEN",
+            accounts: {
+              work: {
+                token: "__env__:DISCORD_WORK_TOKEN",
+              },
             },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.channels?.discord?.token).toBeUndefined();
     expect(res.config.channels?.discord?.accounts?.default?.token).toEqual({
@@ -471,18 +473,20 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("leaves invalid legacy secretref-env markers unchanged", () => {
-    const res = normalizeCompatibilityConfigValues({
-      messages: {
-        groupChat: {
-          visibleReplies: "message_tool",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        messages: {
+          groupChat: {
+            visibleReplies: "message_tool",
+          },
         },
-      },
-      channels: {
-        discord: {
-          token: "secretref-env:not-valid",
+        channels: {
+          discord: {
+            token: "secretref-env:not-valid",
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.channels?.discord?.token).toBe("secretref-env:not-valid");
     expect(res.changes).toStrictEqual([]);
@@ -531,7 +535,7 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("defers the whole promotion for uncovered keys on an undeclared channel", () => {
-    const config = {
+    const config = legacyConfig({
       channels: {
         "uninstalled-demo": {
           dmPolicy: "allowlist",
@@ -540,7 +544,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           accounts: { work: { enabled: true } },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const res = normalizeCompatibilityConfigValues(config);
 
@@ -564,15 +568,17 @@ describe("normalizeCompatibilityConfigValues", () => {
       ]),
     );
 
-    const res = normalizeCompatibilityConfigValues({
-      channels: {
-        "undeclared-demo": {
-          dmPolicy: "allowlist",
-          appToken: "legacy-app-token",
-          accounts: { work: { enabled: true } },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        channels: {
+          "undeclared-demo": {
+            dmPolicy: "allowlist",
+            appToken: "legacy-app-token",
+            accounts: { work: { enabled: true } },
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     const channel = res.config.channels?.["undeclared-demo"] as
       | { dmPolicy?: string; appToken?: string; accounts?: Record<string, unknown> }
@@ -603,15 +609,17 @@ describe("normalizeCompatibilityConfigValues", () => {
       ]),
     );
 
-    const res = normalizeCompatibilityConfigValues({
-      channels: {
-        "late-demo": {
-          dmPolicy: "allowlist",
-          customAuth: "move-with-plugin",
-          accounts: { work: { enabled: true } },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        channels: {
+          "late-demo": {
+            dmPolicy: "allowlist",
+            customAuth: "move-with-plugin",
+            accounts: { work: { enabled: true } },
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     const channel = res.config.channels?.["late-demo"] as
       | { dmPolicy?: string; customAuth?: string; accounts?: Record<string, unknown> }
@@ -628,21 +636,23 @@ describe("normalizeCompatibilityConfigValues", () => {
   it.each(["discord", "slack", "telegram", "signal", "imessage", "irc"])(
     "preserves inherited %s access policy when seeding accounts.default",
     (channelId) => {
-      const res = normalizeCompatibilityConfigValues({
-        channels: {
-          [channelId]: {
-            dmPolicy: "allowlist",
-            allowFrom: ["sender-1"],
-            groupPolicy: "allowlist",
-            groupAllowFrom: ["group-sender-1"],
-            accounts: {
-              work: {
-                enabled: true,
+      const res = normalizeCompatibilityConfigValues(
+        legacyConfig({
+          channels: {
+            [channelId]: {
+              dmPolicy: "allowlist",
+              allowFrom: ["sender-1"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["group-sender-1"],
+              accounts: {
+                work: {
+                  enabled: true,
+                },
               },
             },
           },
-        },
-      } as unknown as OpenClawConfig);
+        }),
+      );
       const channel = (
         res.config.channels as Record<string, { accounts?: Record<string, unknown> }>
       )?.[channelId];
@@ -664,23 +674,25 @@ describe("normalizeCompatibilityConfigValues", () => {
   );
 
   it("keeps named-account access policy overrides when seeding accounts.default", () => {
-    const res = normalizeCompatibilityConfigValues({
-      channels: {
-        discord: {
-          dmPolicy: "allowlist",
-          allowFrom: ["top-dm"],
-          groupPolicy: "allowlist",
-          groupAllowFrom: ["top-group"],
-          accounts: {
-            work: {
-              token: "work-token",
-              allowFrom: ["work-dm"],
-              groupPolicy: "disabled",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        channels: {
+          discord: {
+            dmPolicy: "allowlist",
+            allowFrom: ["top-dm"],
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["top-group"],
+            accounts: {
+              work: {
+                token: "work-token",
+                allowFrom: ["work-dm"],
+                groupPolicy: "disabled",
+              },
             },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.channels?.discord?.accounts?.work).toEqual({
       token: "work-token",
@@ -752,14 +764,16 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates browser ssrfPolicy allowPrivateNetwork to dangerouslyAllowPrivateNetwork", () => {
-    const res = normalizeCompatibilityConfigValues({
-      browser: {
-        ssrfPolicy: {
-          allowPrivateNetwork: true,
-          allowedHostnames: ["localhost"],
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        browser: {
+          ssrfPolicy: {
+            allowPrivateNetwork: true,
+            allowedHostnames: ["localhost"],
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(
       (res.config.browser?.ssrfPolicy as Record<string, unknown> | undefined)?.allowPrivateNetwork,
@@ -772,14 +786,16 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("normalizes conflicting browser SSRF alias keys without changing effective behavior", () => {
-    const res = normalizeCompatibilityConfigValues({
-      browser: {
-        ssrfPolicy: {
-          allowPrivateNetwork: true,
-          dangerouslyAllowPrivateNetwork: false,
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        browser: {
+          ssrfPolicy: {
+            allowPrivateNetwork: true,
+            dangerouslyAllowPrivateNetwork: false,
+          },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(
       (res.config.browser?.ssrfPolicy as Record<string, unknown> | undefined)?.allowPrivateNetwork,
@@ -823,28 +839,30 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy OpenAI provider api values to OpenAI completions", () => {
-    const res = normalizeCompatibilityConfigValues({
-      models: {
-        providers: {
-          openrouter: {
-            baseUrl: "https://openrouter.ai/api/v1",
-            api: "openai",
-            models: [
-              {
-                id: "openai/gpt-4o-mini",
-                name: "OpenRouter GPT-4o Mini",
-                api: "openai",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 128_000,
-                maxTokens: 16_384,
-              },
-            ],
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.ai/api/v1",
+              api: "openai",
+              models: [
+                {
+                  id: "openai/gpt-4o-mini",
+                  name: "OpenRouter GPT-4o Mini",
+                  api: "openai",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 16_384,
+                },
+              ],
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.models?.providers?.openrouter?.api).toBe("openai-completions");
     expect(res.config.models?.providers?.openrouter?.models?.[0]?.api).toBe("openai-completions");
@@ -857,29 +875,31 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("marks legacy untagged /models add OpenAI Codex metadata rows for doctor repair", () => {
-    const res = normalizeCompatibilityConfigValues({
-      models: {
-        providers: {
-          "openai-codex": {
-            baseUrl: "https://chatgpt.com/backend-api",
-            api: "openai-chatgpt-responses",
-            models: [
-              {
-                id: "gpt-5.5",
-                name: "gpt-5.5",
-                api: "openai-chatgpt-responses",
-                reasoning: true,
-                input: ["text", "image"],
-                cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-                contextWindow: 400_000,
-                contextTokens: 272_000,
-                maxTokens: 128_000,
-              },
-            ],
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        models: {
+          providers: {
+            "openai-codex": {
+              baseUrl: "https://chatgpt.com/backend-api",
+              api: "openai-chatgpt-responses",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "gpt-5.5",
+                  api: "openai-chatgpt-responses",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+                  contextWindow: 400_000,
+                  contextTokens: 272_000,
+                  maxTokens: 128_000,
+                },
+              ],
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     const codexModel = res.config.models?.providers?.["openai-codex"]?.models?.[0];
     expect(codexModel?.id).toBe("gpt-5.5");
@@ -1108,13 +1128,13 @@ describe("normalizeCompatibilityConfigValues", () => {
   it("does not throw on malformed best-effort model config", () => {
     expect(() =>
       repairStaleAgentModelRefs(
-        {
+        legacyConfig({
           agents: {
             defaults: {
               model: { primary: "deleted/main", fallbacks: 42 },
             },
           },
-        } as unknown as OpenClawConfig,
+        }),
         { pluginProviderIds: new Set(), persistedProviderIdsByAgentId: new Map() },
       ),
     ).not.toThrow();
@@ -1122,7 +1142,7 @@ describe("normalizeCompatibilityConfigValues", () => {
 
   it("uses only explicit providers when models.mode is replace", () => {
     const result = repairStaleAgentModelRefs(
-      {
+      legacyConfig({
         models: {
           mode: "replace",
           providers: {
@@ -1140,7 +1160,7 @@ describe("normalizeCompatibilityConfigValues", () => {
             },
           },
         },
-      } as unknown as OpenClawConfig,
+      }),
       {
         pluginProviderIds: new Set(["plugin-provider"]),
         persistedProviderIdsByAgentId: new Map(),
@@ -1156,29 +1176,31 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("does not mark untagged manual OpenAI Codex metadata overrides", () => {
-    const res = normalizeCompatibilityConfigValues({
-      models: {
-        providers: {
-          "openai-codex": {
-            baseUrl: "https://chatgpt.com/backend-api",
-            api: "openai-chatgpt-responses",
-            models: [
-              {
-                id: "gpt-5.5",
-                name: "gpt-5.5",
-                api: "openai-chatgpt-responses",
-                reasoning: true,
-                input: ["text", "image"],
-                cost: { input: 9, output: 99, cacheRead: 0.9, cacheWrite: 0 },
-                contextWindow: 555_555,
-                contextTokens: 111_111,
-                maxTokens: 22_222,
-              },
-            ],
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        models: {
+          providers: {
+            "openai-codex": {
+              baseUrl: "https://chatgpt.com/backend-api",
+              api: "openai-chatgpt-responses",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "gpt-5.5",
+                  api: "openai-chatgpt-responses",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 9, output: 99, cacheRead: 0.9, cacheWrite: 0 },
+                  contextWindow: 555_555,
+                  contextTokens: 111_111,
+                  maxTokens: 22_222,
+                },
+              ],
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config).toEqual({
       models: {
@@ -1207,28 +1229,30 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates shipped Codex refs to canonical OpenAI refs with model runtime pins", () => {
-    const normalized = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          agentRuntime: { id: "auto" },
-          model: {
-            primary: "codex/gpt-5.6-sol",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "codex/gpt-5.4-mini"],
+    const normalized = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            agentRuntime: { id: "auto" },
+            model: {
+              primary: "codex/gpt-5.6-sol",
+              fallbacks: ["anthropic/claude-sonnet-4-6", "codex/gpt-5.4-mini"],
+            },
+            models: {
+              "codex/gpt-5.6-sol": { alias: "legacy-codex" },
+              "openai/gpt-5.6-sol": { alias: "gpt", params: { temperature: 0.2 } },
+              "codex/gpt-5.4-mini": {},
+            },
           },
-          models: {
-            "codex/gpt-5.6-sol": { alias: "legacy-codex" },
-            "openai/gpt-5.6-sol": { alias: "gpt", params: { temperature: 0.2 } },
-            "codex/gpt-5.4-mini": {},
-          },
+          list: [
+            {
+              id: "reviewer",
+              model: "codex/gpt-5.6-sol",
+            },
+          ],
         },
-        list: [
-          {
-            id: "reviewer",
-            model: "codex/gpt-5.6-sol",
-          },
-        ],
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
     const repaired = maybeRepairCodexRoutes({
       cfg: normalized.config,
       shouldRepair: true,
@@ -1266,7 +1290,7 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates fallback-only Codex refs through the complete route repair", () => {
-    const input = {
+    const input = legacyConfig({
       agents: {
         defaults: {
           model: {
@@ -1278,7 +1302,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const repaired = maybeRepairCodexRoutes({
       cfg: input,
@@ -1299,7 +1323,7 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("keeps the whole provider-conflicted Codex namespace legacy", () => {
-    const migrated = {
+    const migrated = legacyConfig({
       models: {
         providers: {
           openai: {
@@ -1330,7 +1354,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
     const migrationChanges: string[] = [];
     for (const migration of LEGACY_CONFIG_MIGRATIONS) {
       migration.apply(migrated as unknown as Record<string, unknown>, migrationChanges);
@@ -1429,20 +1453,22 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy Claude CLI primary refs to Anthropic refs plus model runtime", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          model: {
-            primary: "claude-cli/claude-opus-4-7",
-            fallbacks: ["claude-cli/claude-sonnet-4-6"],
-          },
-          models: {
-            "claude-cli/claude-opus-4-7": { alias: "Opus" },
-            "anthropic/claude-opus-4-7": { alias: "Anthropic Opus" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "claude-cli/claude-opus-4-7",
+              fallbacks: ["claude-cli/claude-sonnet-4-6"],
+            },
+            models: {
+              "claude-cli/claude-opus-4-7": { alias: "Opus" },
+              "anthropic/claude-opus-4-7": { alias: "Anthropic Opus" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.model).toEqual({
       primary: "anthropic/claude-opus-4-7",
@@ -1462,23 +1488,25 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("preserves legacy whole-agent Claude CLI intent for canonical Anthropic defaults", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          agentRuntime: { id: "claude-cli" },
-          model: {
-            primary: "anthropic/claude-opus-4-7",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
-          },
-          models: {
-            "anthropic/claude-opus-4-7": {
-              alias: "Opus",
-              agentRuntime: { id: "auto", mode: "strict" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            agentRuntime: { id: "claude-cli" },
+            model: {
+              primary: "anthropic/claude-opus-4-7",
+              fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
+            },
+            models: {
+              "anthropic/claude-opus-4-7": {
+                alias: "Opus",
+                agentRuntime: { id: "auto", mode: "strict" },
+              },
             },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.agentRuntime).toEqual({ id: "claude-cli" });
     expect(res.config.agents?.defaults?.models).toEqual({
@@ -1496,20 +1524,22 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("does not overwrite explicit model runtime while preserving legacy whole-agent CLI intent", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        list: [
-          {
-            id: "paige",
-            agentRuntime: { id: "claude-cli" },
-            model: "anthropic/claude-opus-4-7",
-            models: {
-              "anthropic/claude-opus-4-7": { agentRuntime: { id: "openclaw" } },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          list: [
+            {
+              id: "paige",
+              agentRuntime: { id: "claude-cli" },
+              model: "anthropic/claude-opus-4-7",
+              models: {
+                "anthropic/claude-opus-4-7": { agentRuntime: { id: "openclaw" } },
+              },
             },
-          },
-        ],
-      },
-    } as unknown as OpenClawConfig);
+          ],
+        },
+      }),
+    );
 
     expect(res.config.agents?.list?.[0]?.agentRuntime).toEqual({ id: "claude-cli" });
     expect(res.config.agents?.list?.[0]?.models).toEqual({
@@ -1519,20 +1549,22 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy Codex CLI primary refs to the Codex app-server route", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          model: {
-            primary: "codex-cli/gpt-5.5",
-            fallbacks: ["codex-cli/gpt-5.4-mini"],
-          },
-          models: {
-            "codex-cli/gpt-5.5": { alias: "Codex CLI" },
-            "openai/gpt-5.5": { alias: "OpenAI GPT" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "codex-cli/gpt-5.5",
+              fallbacks: ["codex-cli/gpt-5.4-mini"],
+            },
+            models: {
+              "codex-cli/gpt-5.5": { alias: "Codex CLI" },
+              "openai/gpt-5.5": { alias: "OpenAI GPT" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",
@@ -1547,19 +1579,21 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy Codex CLI fallback refs when the primary is already canonical", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.5",
-            fallbacks: ["codex-cli/gpt-5.4"],
-          },
-          models: {
-            "codex-cli/gpt-5.4": { alias: "Legacy CLI fallback" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.5",
+              fallbacks: ["codex-cli/gpt-5.4"],
+            },
+            models: {
+              "codex-cli/gpt-5.4": { alias: "Legacy CLI fallback" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",
@@ -1575,15 +1609,17 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates standalone legacy Codex CLI allowlist keys", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          models: {
-            "codex-cli/gpt-5.4": { alias: "Legacy CLI fallback" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            models: {
+              "codex-cli/gpt-5.4": { alias: "Legacy CLI fallback" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.models).toEqual({
       "codex-cli/gpt-5.4": { alias: "Legacy CLI fallback" },
@@ -1595,20 +1631,22 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("pins migrated Codex CLI refs to Codex when OpenAI uses a custom base URL", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          model: "codex-cli/gpt-5.5",
-        },
-      },
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://proxy.example/v1",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: "codex-cli/gpt-5.5",
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example/v1",
+            },
+          },
+        },
+      }),
+    );
 
     expect(res.config.agents?.defaults?.model).toBe("openai/gpt-5.5");
     expect(res.config.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
@@ -1617,40 +1655,42 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates existing Codex CLI runtime pins to the Codex app-server runtime", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          models: {
-            "openai/gpt-5.5": {
-              agentRuntime: { id: "codex-cli", mode: "strict" },
-            },
-          },
-        },
-        list: [
-          {
-            id: "reviewer",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
             models: {
-              "openai/gpt-5.4-mini": {
-                agentRuntime: { id: "codex-cli" },
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex-cli", mode: "strict" },
               },
             },
           },
-        ],
-      },
-      models: {
-        providers: {
-          openai: {
-            agentRuntime: { id: "codex-cli" },
-            models: [
-              {
-                id: "gpt-5.5",
-                agentRuntime: { id: "codex-cli" },
+          list: [
+            {
+              id: "reviewer",
+              models: {
+                "openai/gpt-5.4-mini": {
+                  agentRuntime: { id: "codex-cli" },
+                },
               },
-            ],
+            },
+          ],
+        },
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "codex-cli" },
+              models: [
+                {
+                  id: "gpt-5.5",
+                  agentRuntime: { id: "codex-cli" },
+                },
+              ],
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
       id: "codex",
@@ -1678,15 +1718,17 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates provider-scoped Codex CLI runtime pins without agents config", () => {
-    const res = normalizeCompatibilityConfigValues({
-      models: {
-        providers: {
-          openai: {
-            agentRuntime: { id: "codex-cli" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "codex-cli" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.models?.providers?.openai?.agentRuntime).toEqual({ id: "codex" });
     expect(res.changes).toContain(
@@ -1695,20 +1737,22 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("migrates legacy Gemini CLI primary refs to Google refs plus model runtime", () => {
-    const res = normalizeCompatibilityConfigValues({
-      agents: {
-        defaults: {
-          model: {
-            primary: "google-gemini-cli/gemini-3-pro-preview",
-            fallbacks: ["google-gemini-cli/gemini-3-flash-preview"],
-          },
-          models: {
-            "google-gemini-cli/gemini-3-pro-preview": { alias: "Gemini CLI" },
-            "google/gemini-3.1-pro-preview": { alias: "Gemini API" },
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "google-gemini-cli/gemini-3-pro-preview",
+              fallbacks: ["google-gemini-cli/gemini-3-flash-preview"],
+            },
+            models: {
+              "google-gemini-cli/gemini-3-pro-preview": { alias: "Gemini CLI" },
+              "google/gemini-3.1-pro-preview": { alias: "Gemini API" },
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.agents?.defaults?.model).toEqual({
       primary: "google/gemini-3.1-pro-preview",
@@ -1728,7 +1772,7 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("preserves legacy runtime fallback-only refs because runtime is container-scoped", () => {
-    const input = {
+    const input = legacyConfig({
       agents: {
         defaults: {
           model: {
@@ -1740,7 +1784,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const res = normalizeCompatibilityConfigValues(input);
 
@@ -1975,16 +2019,18 @@ describe("normalizeCompatibilityConfigValues", () => {
   });
 
   it("normalizes talk provider ids without overriding explicit provider config", () => {
-    const res = normalizeCompatibilityConfigValues({
-      talk: {
-        provider: " elevenlabs ",
-        providers: {
-          " elevenlabs ": {
-            voiceId: "voice-123",
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        talk: {
+          provider: " elevenlabs ",
+          providers: {
+            " elevenlabs ": {
+              voiceId: "voice-123",
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig);
+      }),
+    );
 
     expect(res.config.talk).toEqual({
       provider: "elevenlabs",

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -127,9 +127,10 @@ const createExecFileError = (
 };
 
 const createWritableStreamMock = (write = vi.fn()) => {
+  const stdout = { write };
   return {
     write,
-    stdout: { write } as NodeJS.WritableStream,
+    stdout: stdout as typeof stdout & NodeJS.WritableStream,
   };
 };
 
@@ -3099,7 +3100,7 @@ describe("systemd service control", () => {
 
     await expect(
       startSystemdService({
-        stdout: { write } as NodeJS.WritableStream,
+        stdout: createWritableStreamMock(write).stdout,
         env: {},
         onMutation,
       }),

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -126,11 +126,10 @@ const createExecFileError = (
   return err;
 };
 
-const createWritableStreamMock = () => {
-  const write = vi.fn();
+const createWritableStreamMock = (write = vi.fn()) => {
   return {
     write,
-    stdout: { write } as unknown as NodeJS.WritableStream,
+    stdout: { write } as NodeJS.WritableStream,
   };
 };
 
@@ -1573,7 +1572,7 @@ describe("stageSystemdService", () => {
       await expect(
         stageSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -1601,7 +1600,7 @@ describe("stageSystemdService", () => {
       await expect(
         stageSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -1625,7 +1624,7 @@ describe("stageSystemdService", () => {
       await expect(
         stageSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: { OPENCLAW_GATEWAY_TOKEN: "new-token" },
@@ -1648,7 +1647,7 @@ describe("stageSystemdService", () => {
       await expect(
         stageSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: {
@@ -1688,7 +1687,7 @@ describe("stageSystemdService", () => {
       await expect(
         stageSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: {
@@ -1722,7 +1721,7 @@ describe("stageSystemdService", () => {
       mockSystemctlStatusOk();
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -1747,7 +1746,7 @@ describe("stageSystemdService", () => {
       await expect(
         installSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "gateway", "run"],
           workingDirectory: "/tmp",
           environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -1772,7 +1771,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -1818,7 +1817,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: [wrapperPath, "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -1886,7 +1885,7 @@ describe("stageSystemdService", () => {
       mockSystemctlStatusOk();
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         ...plan,
       });
 
@@ -1912,7 +1911,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -1966,7 +1965,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2009,7 +2008,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2042,7 +2041,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2083,7 +2082,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2125,7 +2124,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2161,7 +2160,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         // Staging manages OPENCLAW_GATEWAY_TOKEN inline; OPENCLAW_SERVICE_MANAGED_ENV_KEYS
@@ -2208,7 +2207,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -2240,7 +2239,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { LLM_API_KEY: "new-value" },
@@ -2271,7 +2270,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -2303,7 +2302,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -2330,7 +2329,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -2364,7 +2363,7 @@ describe("stageSystemdService", () => {
 
       await stageSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "gateway", "run"],
         workingDirectory: "/tmp",
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -2434,7 +2433,7 @@ describe("systemd service install and uninstall", () => {
 
       await installSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         description: "OpenClaw Node Host",
@@ -2486,7 +2485,7 @@ describe("systemd service install and uninstall", () => {
 
       await installSystemdService({
         env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2531,7 +2530,7 @@ describe("systemd service install and uninstall", () => {
 
       await installSystemdService({
         env: installEnv,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2577,7 +2576,7 @@ describe("systemd service install and uninstall", () => {
 
       await installSystemdService({
         env: installEnv,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
         environment: {
@@ -2617,7 +2616,7 @@ describe("systemd service install and uninstall", () => {
       await expect(
         installSystemdService({
           env,
-          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          stdout: createWritableStreamMock().stdout,
           programArguments: ["/usr/bin/openclaw", "node", "run"],
           workingDirectory: "/tmp",
           environment: {
@@ -3071,7 +3070,7 @@ describe("systemd service control", () => {
 
     await expect(
       startSystemdService({
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         env: { HOME: TEST_MANAGED_HOME },
       }),
     ).rejects.toThrow("same-name system ownership");
@@ -3100,7 +3099,7 @@ describe("systemd service control", () => {
 
     await expect(
       startSystemdService({
-        stdout: { write } as unknown as NodeJS.WritableStream,
+        stdout: { write } as NodeJS.WritableStream,
         env: {},
         onMutation,
       }),
@@ -3153,7 +3152,7 @@ describe("systemd service control", () => {
       });
     const write = vi.fn();
     const onMutation = vi.fn();
-    const stdout = { write } as unknown as NodeJS.WritableStream;
+    const { stdout } = createWritableStreamMock(write);
 
     await stopSystemdService({ stdout, env: {}, onMutation });
 
@@ -3177,11 +3176,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     const onMutation = vi.fn();
-    const stdout = {
-      write: vi.fn(() => {
-        throw new Error("output failed");
-      }),
-    } as unknown as NodeJS.WritableStream;
+    const write = vi.fn(() => {
+      throw new Error("output failed");
+    });
+    const { stdout } = createWritableStreamMock(write);
 
     await expect(stopSystemdService({ stdout, env: {}, onMutation })).rejects.toThrow(
       "output failed",
@@ -3205,7 +3203,7 @@ describe("systemd service control", () => {
       });
 
     await stopSystemdService({
-      stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+      stdout: createWritableStreamMock().stdout,
       env: {},
     });
   });
@@ -3242,7 +3240,7 @@ describe("systemd service control", () => {
 
     await expect(
       stopSystemdService({
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         env: {},
       }),
     ).rejects.toThrow("systemctl stop failed: permission denied");
@@ -3262,7 +3260,7 @@ describe("systemd service control", () => {
 
     await expect(
       stopSystemdService({
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        stdout: createWritableStreamMock().stdout,
         env: { USER: "", LOGNAME: "" },
       }),
     ).rejects.toThrow("systemctl --user unavailable: Failed to connect to bus");

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -62,11 +62,12 @@ import { consumeCronCreatorAuthorityGrant } from "../cron-creator-authority-gran
 import { createChatRunState } from "../server-chat-state.js";
 import { STALE_WORKER_BUILD_REASON } from "../worker-environments/admission.js";
 import { handleChatSend } from "./chat-send-handler.js";
-import type { GatewayRequestContext } from "./types.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 type ProjectedDispatchParams = Parameters<
   typeof import("../../auto-reply/dispatch.js").dispatchInboundMessageWithProjectedDispatcher
 >[0];
+type RespondMock = ReturnType<typeof vi.fn<RespondFn>>;
 
 const TEST_TOOL_AUTHORITY_FINGERPRINT = "test-tool-authority";
 const TEST_TOOL_AUTHORITY_ROUTE = { provider: "openai", model: "gpt-5.6-sol" } as const;
@@ -872,7 +873,7 @@ function mockCallAt(
   return calls[normalizedIndex];
 }
 
-function lastRespondCall(respond: ReturnType<typeof vi.fn>) {
+function lastRespondCall(respond: RespondMock) {
   return mockCallAt(respond, -1) as
     | [boolean, Record<string, any> | undefined, Record<string, any> | undefined]
     | undefined;
@@ -893,13 +894,13 @@ function responseErrorMessage(error: unknown): string {
 }
 
 function lastBroadcastPayload(context: ChatContext): Record<string, any> | undefined {
-  const chatCall = mockCallAt(context.broadcast as unknown as ReturnType<typeof vi.fn>, -1);
+  const chatCall = mockCallAt(context.broadcast, -1);
   expect(chatCall?.[0]).toBe("chat");
   return chatCall?.[1] as Record<string, any> | undefined;
 }
 
 function lastNodeSendCall(context: ChatContext) {
-  return mockCallAt(context.nodeSendToSession as unknown as ReturnType<typeof vi.fn>, -1) as
+  return mockCallAt(context.nodeSendToSession, -1) as
     | [string, string, Record<string, any>]
     | undefined;
 }
@@ -1000,27 +1001,10 @@ function createScopedCliClient(
   };
 }
 
-function createChatContext(): Pick<
-  GatewayRequestContext,
-  | "broadcast"
-  | "nodeSendToSession"
-  | "agentRunSeq"
-  | "chatAbortControllers"
-  | "chatQueuedTurns"
-  | "chatRunState"
-  | "addChatRun"
-  | "removeChatRun"
-  | "dedupe"
-  | "loadGatewayModelCatalog"
-  | "registerToolEventRecipient"
-  | "getRuntimeConfig"
-  | "broadcastToConnIds"
-  | "getSessionEventSubscriberConnIds"
-  | "logGateway"
-> {
+function createChatContext() {
   return {
-    broadcast: vi.fn() as unknown as GatewayRequestContext["broadcast"],
-    nodeSendToSession: vi.fn() as unknown as GatewayRequestContext["nodeSendToSession"],
+    broadcast: vi.fn<GatewayRequestContext["broadcast"]>(),
+    nodeSendToSession: vi.fn<GatewayRequestContext["nodeSendToSession"]>(),
     agentRunSeq: new Map<string, number>(),
     chatAbortControllers: new Map(),
     chatQueuedTurns: new Map(),
@@ -1053,14 +1037,14 @@ function createChatContext(): Pick<
           mainKey: mockState.mainSessionKey,
         },
       }) as never,
-    registerToolEventRecipient: vi.fn(),
-    broadcastToConnIds: vi.fn(),
+    registerToolEventRecipient: vi.fn<GatewayRequestContext["registerToolEventRecipient"]>(),
+    broadcastToConnIds: vi.fn<GatewayRequestContext["broadcastToConnIds"]>(),
     getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
     logGateway: {
-      warn: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-    } as unknown as GatewayRequestContext["logGateway"],
+      warn: vi.fn<GatewayRequestContext["logGateway"]["warn"]>(),
+      debug: vi.fn<GatewayRequestContext["logGateway"]["debug"]>(),
+      error: vi.fn<GatewayRequestContext["logGateway"]["error"]>(),
+    },
   };
 }
 
@@ -1085,7 +1069,7 @@ async function createReadyChatTranscript(prefix: string) {
 
 function createChatRequestFixture() {
   const context = createChatContext();
-  const respond = vi.fn();
+  const respond = vi.fn<RespondFn>();
   return {
     context,
     respond,
@@ -1164,7 +1148,7 @@ function expectManagedAudioBlock(
 
 async function runNonStreamingChatSend(params: {
   context: ChatContext;
-  respond: ReturnType<typeof vi.fn>;
+  respond: RespondFn;
   idempotencyKey: string;
   message?: string;
   sessionKey?: string;
@@ -1199,9 +1183,7 @@ async function runNonStreamingChatSend(params: {
       ...sendParams,
       ...params.requestParams,
     },
-    respond: params.respond as unknown as Parameters<
-      (typeof chatHandlers)["chat.send"]
-    >[0]["respond"],
+    respond: params.respond,
     req: {} as never,
     client: (params.client ?? null) as never,
     isWebchatConnect: () => false,
@@ -1226,12 +1208,10 @@ async function runNonStreamingChatSend(params: {
   }
 
   await waitForAssertion(() => {
-    expect(
-      (params.context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
-    ).toBe(1);
+    expect(params.context.broadcast.mock.calls.length).toBe(1);
   });
 
-  const chatCall = mockCallAt(params.context.broadcast as unknown as ReturnType<typeof vi.fn>, 0);
+  const chatCall = mockCallAt(params.context.broadcast, 0);
   expect(chatCall?.[0]).toBe("chat");
   return chatCall?.[1] as Record<string, any> | undefined;
 }
@@ -2300,7 +2280,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(dispatchCallsBefore + 1);
     expect(mockState.lastMessageInjectionAttempted).toBe(true);
     expect(readPersistedUserMessages()).toHaveLength(1);
-    const broadcasts = (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+    const broadcasts = context.broadcast.mock.calls.map(
       ([, payload]) => payload as Record<string, unknown>,
     );
     expect(broadcasts.filter((payload) => payload.state === "error")).toEqual([]);
@@ -2559,7 +2539,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(successorCancel).not.toHaveBeenCalled();
     expect(readPersistedUserMessages()).toHaveLength(1);
     expect(
-      (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      context.broadcast.mock.calls.filter(
         ([, payload]) => (payload as { state?: unknown }).state === "error",
       ),
     ).toEqual([]);
@@ -2629,7 +2609,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(staleCancel).not.toHaveBeenCalled();
     expect(readPersistedUserMessages()).toHaveLength(1);
     expect(
-      (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      context.broadcast.mock.calls.filter(
         ([, payload]) => (payload as { state?: unknown }).state === "error",
       ),
     ).toEqual([]);
@@ -2658,11 +2638,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     await waitForAssertion(() => {
-      expect(
-        (context.broadcastToConnIds as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
-      ).toBe(1);
+      expect(context.broadcastToConnIds.mock.calls.length).toBe(1);
     });
-    const call = mockCallAt(context.broadcastToConnIds as unknown as ReturnType<typeof vi.fn>, 0);
+    const call = mockCallAt(context.broadcastToConnIds, 0);
     const payload = call?.[1] as { ts?: unknown } | undefined;
     expect(call?.[0]).toBe("sessions.changed");
     expect(call?.[2]).toEqual(new Set(["conn-1"]));
@@ -2697,7 +2675,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => {
       expect(context.dedupe.get("chat:idem-command-session-metadata-error")?.ok).toBe(false);
     });
-    const call = mockCallAt(context.broadcastToConnIds as unknown as ReturnType<typeof vi.fn>, 0);
+    const call = mockCallAt(context.broadcastToConnIds, 0);
     expect(call?.[0]).toBe("sessions.changed");
     expect(call?.[1]).toMatchObject({
       sessionKey: "agent:main:main",
@@ -2964,7 +2942,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
+    const register = context.registerToolEventRecipient;
     expect(register).toHaveBeenCalledWith("run-current", "conn-1");
     expect(register).toHaveBeenCalledWith("run-same-session", "conn-1");
     expect(register).not.toHaveBeenCalledWith("run-other-session", "conn-1");
@@ -3006,7 +2984,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
+    const register = context.registerToolEventRecipient;
     expect(register).toHaveBeenCalledWith("run-current-global", "conn-global");
     expect(register).toHaveBeenCalledWith("run-default-global", "conn-global");
     expect(register).not.toHaveBeenCalledWith("run-work-global", "conn-global");
@@ -3049,7 +3027,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
+    const register = context.registerToolEventRecipient;
     expect(register).toHaveBeenCalledWith("run-current-work-global", "conn-work");
     expect(register).toHaveBeenCalledWith("run-work-global", "conn-work");
     expect(register).not.toHaveBeenCalledWith("run-default-global", "conn-work");
@@ -3243,7 +3221,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
+    const register = context.registerToolEventRecipient;
     expect(register).not.toHaveBeenCalled();
   });
 
@@ -3695,7 +3673,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       state: "final",
     });
     expect(extractFirstTextBlock(broadcast)).toBe("Model set to openai/gpt-5.5 for this session.");
-    expect((context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    expect(context.broadcast.mock.calls).toHaveLength(1);
     expect(findAssistantTranscriptUpdates()).toStrictEqual([]);
     expect(await readActiveAssistantTranscriptMessages()).toStrictEqual([]);
   });
@@ -3725,7 +3703,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       waitFor: "dedupe",
     });
 
-    expect((context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls).toStrictEqual([]);
+    expect(context.broadcast.mock.calls).toStrictEqual([]);
     expect(findAssistantTranscriptUpdates()).toStrictEqual([]);
     expect(await readActiveAssistantTranscriptMessages()).toStrictEqual([]);
   });
@@ -4419,9 +4397,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       state: "final",
     });
     expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply");
-    const errorBroadcasts = (
-      context.broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter(([, payload]) => (payload as { state?: unknown })?.state === "error");
+    const errorBroadcasts = context.broadcast.mock.calls.filter(
+      ([, payload]) => (payload as { state?: unknown })?.state === "error",
+    );
     expect(errorBroadcasts).toStrictEqual([]);
     const dedupe = context.dedupe.get("chat:idem-agent-source-reply-error");
     expect(dedupe?.ok).toBe(true);
@@ -4466,7 +4444,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       waitFor: "dedupe",
     });
 
-    const broadcasts = (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+    const broadcasts = context.broadcast.mock.calls.map(
       ([, payload]) => payload as Record<string, unknown>,
     );
     expect(broadcasts).toHaveLength(1);
@@ -4516,9 +4494,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       errorMessage,
     });
     expect(broadcast).not.toHaveProperty("message");
-    const finalBroadcasts = (
-      context.broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter(([, payload]) => (payload as { state?: unknown })?.state === "final");
+    const finalBroadcasts = context.broadcast.mock.calls.filter(
+      ([, payload]) => (payload as { state?: unknown })?.state === "final",
+    );
     expect(finalBroadcasts).toStrictEqual([]);
   });
 
@@ -5309,7 +5287,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     expect(respond).toHaveBeenCalled();
-    const chatCall = mockCallAt(context.broadcast as unknown as ReturnType<typeof vi.fn>, -1);
+    const chatCall = mockCallAt(context.broadcast, -1);
     expect(chatCall?.[0]).toBe("chat");
     expect(extractFirstTextBlock(chatCall?.[1])).toBe("hello");
   });
@@ -5929,9 +5907,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       timestamp: expect.any(Number),
       idempotencyKey: "idem-user-transcript-agent-run:user",
     });
-    const finalBroadcast = (
-      context.broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.find((call) => call[0] === "chat" && call[1]?.state === "final")?.[1];
+    const finalBroadcast = context.broadcast.mock.calls.find(
+      (call) => call[0] === "chat" && call[1]?.state === "final",
+    )?.[1];
     expect(finalBroadcast).toBeUndefined();
   });
 
@@ -6311,11 +6289,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       waitForCompletion: false,
     });
 
-    expect((context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+    expect(context.broadcast.mock.calls.length).toBe(0);
     releaseSave();
 
     await waitForAssertion(() => {
-      expect((context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+      expect(context.broadcast.mock.calls.length).toBe(1);
       const userUpdate = findUserUpdate();
       if (userUpdate?.message === undefined) {
         throw new Error("Expected streamed user transcript update message");
@@ -6882,10 +6860,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(payload).toBeUndefined();
     expect(error?.code).toBe(ErrorCodes.UNAVAILABLE);
     expect(responseErrorMessage(error)).toMatch(/ENOSPC|non-image attachments/i);
-    const unavailableLogCall = mockCallAt(
-      context.logGateway.error as unknown as ReturnType<typeof vi.fn>,
-      0,
-    ) as [string, Record<string, string>] | undefined;
+    const unavailableLogCall = mockCallAt(context.logGateway.error, 0) as
+      | [string, Record<string, string>]
+      | undefined;
     expect(unavailableLogCall?.[0]).toBe("chat.send attachment parse/stage failed");
     expect(unavailableLogCall?.[1].consoleMessage).toContain(
       "chat.send attachment parse/stage failed: MediaOffloadError",
@@ -6925,8 +6902,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(response?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
     expect(response?.[2]?.message).toContain("attachment broken.png: invalid base64 content");
     expect(getAgentRunContext("idem-chat-send-attachment-parse-stack")).toBeUndefined();
-    const parseLogCall = (context.logGateway.error as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0] as [string, Record<string, string>] | undefined;
+    const parseLogCall = context.logGateway.error.mock.calls[0] as
+      | [string, Record<string, string>]
+      | undefined;
     expect(parseLogCall?.[0]).toBe("chat.send attachment parse/stage failed");
     expect(parseLogCall?.[1].consoleMessage).toContain(
       "chat.send attachment parse/stage failed: Error: attachment broken.png",
@@ -6934,8 +6912,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(parseLogCall?.[1].error).toContain(
       "Error: attachment broken.png: invalid base64 content",
     );
-    const logMeta = (context.logGateway.error as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0]?.[1] as { error?: string } | undefined;
+    const logMeta = context.logGateway.error.mock.calls[0]?.[1] as { error?: string } | undefined;
     expect(logMeta?.error).toContain("\n    at ");
   });
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1002,7 +1002,7 @@ function createScopedCliClient(
 }
 
 function createChatContext() {
-  return {
+  const context = {
     broadcast: vi.fn<GatewayRequestContext["broadcast"]>(),
     nodeSendToSession: vi.fn<GatewayRequestContext["nodeSendToSession"]>(),
     agentRunSeq: new Map<string, number>(),
@@ -1046,6 +1046,7 @@ function createChatContext() {
       error: vi.fn<GatewayRequestContext["logGateway"]["error"]>(),
     },
   };
+  return context as typeof context & GatewayRequestContext;
 }
 
 type ChatContext = ReturnType<typeof createChatContext>;
@@ -1085,7 +1086,7 @@ function createChatRequestFixture() {
         req: {} as never,
         client: null as never,
         isWebchatConnect: () => false,
-        context: context as GatewayRequestContext,
+        context,
       }),
   };
 }
@@ -1187,7 +1188,7 @@ async function runNonStreamingChatSend(params: {
     req: {} as never,
     client: (params.client ?? null) as never,
     isWebchatConnect: () => false,
-    context: params.context as GatewayRequestContext,
+    context: params.context,
   });
 
   const waitFor =
@@ -1880,7 +1881,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             },
           } as never,
           isWebchatConnect: () => false,
-          context: context as GatewayRequestContext,
+          context,
         },
         async () => {
           original.complete();
@@ -3170,7 +3171,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       req: {} as never,
       client: null,
       isWebchatConnect: () => false,
-      context: context as GatewayRequestContext,
+      context,
     });
 
     expect(mockState.loadSessionEntryCalls).toContainEqual({
@@ -3198,7 +3199,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       req: {} as never,
       client: null,
       isWebchatConnect: () => false,
-      context: createChatContext() as GatewayRequestContext,
+      context: createChatContext(),
     });
 
     expect(lastRespondCall(respond)?.[1]).toMatchObject({
@@ -5147,7 +5148,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         req: {} as never,
         client: null as never,
         isWebchatConnect: () => false,
-        context: context as GatewayRequestContext,
+        context,
       });
       await waitForAssertion(() => expect(mockState.loadSessionEntryCalls).toHaveLength(1));
       mockState.sessionEntry = { archivedAt: Date.now() };
@@ -5236,7 +5237,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       req: {} as never,
       client: null as never,
       isWebchatConnect: () => false,
-      context: context as GatewayRequestContext,
+      context,
     });
 
     const response = lastRespondCall(respond);
@@ -5264,7 +5265,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       req: {} as never,
       client: null as never,
       isWebchatConnect: () => false,
-      context: context as GatewayRequestContext,
+      context,
     });
 
     const response = lastRespondCall(respond);
@@ -5908,7 +5909,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-user-transcript-agent-run:user",
     });
     const finalBroadcast = context.broadcast.mock.calls.find(
-      (call) => call[0] === "chat" && call[1]?.state === "final",
+      (call) =>
+        call[0] === "chat" && (call[1] as { state?: unknown } | undefined)?.state === "final",
     )?.[1];
     expect(finalBroadcast).toBeUndefined();
   });

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -12,6 +12,8 @@ import type {
 } from "../../api/types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
+  createGatewayBrowserClientFixture,
+  createSessionCapabilityFixture,
   createSessionContext,
   createTestChatPane,
   type TestChatPane,
@@ -122,10 +124,10 @@ function installReplacementConnection(
   row: GatewaySessionRow,
 ) {
   const request = vi.fn();
-  const sessions = {
+  const sessions = createSessionCapabilityFixture({
     refreshReplacement: vi.fn(),
-  } as unknown as SessionCapability;
-  replaceConnection(pane, state, { request } as unknown as GatewayBrowserClient, sessions);
+  });
+  replaceConnection(pane, state, createGatewayBrowserClientFixture({ request }), sessions);
   const cacheKey = pane.sessionSharingCacheKey(row.key);
   const sharingState: ChatSessionSharingState = {
     loading: false,
@@ -158,11 +160,11 @@ describe("chat pane sharing authorization", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -189,11 +191,11 @@ describe("chat pane sharing authorization", () => {
         }
         return {};
       });
-      const sessions = {
+      const sessions = createSessionCapabilityFixture({
         refreshReplacement: vi.fn(async () => undefined),
-      } as unknown as SessionCapability;
+      });
       const { pane: testPane } = createSharingTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createGatewayBrowserClientFixture({ request }),
         sessions,
       });
       const pane = testPane as SharingPane;
@@ -219,11 +221,11 @@ describe("chat pane sharing authorization", () => {
       { row: sessionRow(), phase: "reconnecting" as const },
     ]) {
       const request = vi.fn();
-      const sessions = {
+      const sessions = createSessionCapabilityFixture({
         refreshReplacement: vi.fn(),
-      } as unknown as SessionCapability;
+      });
       const { pane: testPane } = createSharingTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createGatewayBrowserClientFixture({ request }),
         sessions,
       });
       const pane = testPane as SharingPane;
@@ -244,11 +246,11 @@ describe("chat pane sharing authorization", () => {
   it("refuses explicitly unadvertised sharing methods", async () => {
     const row = sessionRow();
     const request = vi.fn(async () => sharingResult(row));
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -279,11 +281,11 @@ describe("chat pane sharing authorization", () => {
     },
   ])("refuses callbacks retained from $name", async ({ current }) => {
     const request = vi.fn();
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -310,11 +312,11 @@ describe("chat pane sharing authorization", () => {
         ? listed.promise
         : Promise.resolve(sharingResult(replacement));
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -339,8 +341,8 @@ describe("chat pane sharing authorization", () => {
     const listed = createDeferred<SessionMembersListResult>();
     const request = vi.fn(() => listed.promise);
     const { pane: testPane } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const pane = testPane as SharingPane;
     const pending = pane.loadSessionSharing(row);
@@ -365,11 +367,11 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
         }
         return response.promise;
       });
-      const oldSessions = {
+      const oldSessions = createSessionCapabilityFixture({
         refreshReplacement: vi.fn(),
-      } as unknown as SessionCapability;
+      });
       const { pane: testPane, state } = createSharingTestChatPane({
-        client: { request: oldRequest } as unknown as GatewayBrowserClient,
+        client: createGatewayBrowserClientFixture({ request: oldRequest }),
         sessions: oldSessions,
       });
       const pane = testPane as SharingPane;
@@ -407,11 +409,11 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
         }
         return response.promise;
       });
-      const sessions = {
+      const sessions = createSessionCapabilityFixture({
         refreshReplacement: vi.fn(),
-      } as unknown as SessionCapability;
+      });
       const { pane: testPane, state } = createSharingTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createGatewayBrowserClientFixture({ request }),
         sessions,
       });
       const pane = testPane as SharingPane;
@@ -454,11 +456,11 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       }
       return response.promise;
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -496,11 +498,11 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       }
       return response.promise;
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -525,11 +527,11 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -558,11 +560,11 @@ describe("chat pane sharing mutation phase ownership", () => {
         }
         throw new Error(`unexpected old-connection request: ${method}`);
       });
-      const oldSessions = {
+      const oldSessions = createSessionCapabilityFixture({
         refreshReplacement: vi.fn(() => refreshed.promise),
-      } as unknown as SessionCapability;
+      });
       const { pane: testPane, state } = createSharingTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createGatewayBrowserClientFixture({ request }),
         sessions: oldSessions,
       });
       const pane = testPane as SharingPane;
@@ -600,11 +602,11 @@ describe("chat pane sharing mutation phase ownership", () => {
           }
           throw new Error(`unexpected old-connection request: ${requestMethod}`);
         });
-        const oldSessions = {
+        const oldSessions = createSessionCapabilityFixture({
           refreshReplacement: vi.fn(async () => undefined),
-        } as unknown as SessionCapability;
+        });
         const { pane: testPane, state } = createSharingTestChatPane({
-          client: { request } as unknown as GatewayBrowserClient,
+          client: createGatewayBrowserClientFixture({ request }),
           sessions: oldSessions,
         });
         const pane = testPane as SharingPane;
@@ -645,11 +647,11 @@ describe("chat pane sharing mutation phase ownership", () => {
       }
       throw new Error(`unexpected old-connection request: ${method}`);
     });
-    const oldSessions = {
+    const oldSessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(() => refreshed.promise),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane, state } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions: oldSessions,
     });
     const pane = testPane as SharingPane;
@@ -679,13 +681,13 @@ describe("chat pane current sharing mutation refresh order", () => {
       }
       return {};
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(async () => {
         calls.push("sessions.refreshReplacement");
       }),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;
@@ -712,13 +714,13 @@ describe("chat pane current sharing mutation refresh order", () => {
       }
       return {};
     });
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       refreshReplacement: vi.fn(async () => {
         calls.push("sessions.refreshReplacement");
       }),
-    } as unknown as SessionCapability;
+    });
     const { pane: testPane } = createSharingTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createGatewayBrowserClientFixture({ request }),
       sessions,
     });
     const pane = testPane as SharingPane;

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -149,16 +149,25 @@ export type TestChatPane = HTMLElement & {
   ) => TemplateResult;
 };
 
+type GatewayBrowserClientFixtureOverrides = Omit<Partial<GatewayBrowserClient>, "request"> & {
+  request?: (method: string, params?: unknown) => unknown;
+};
+
 export function createGatewayBrowserClientFixture(
-  overrides: Partial<GatewayBrowserClient> = {},
+  overrides: GatewayBrowserClientFixtureOverrides = {},
 ): GatewayBrowserClient {
-  return overrides as GatewayBrowserClient;
+  return overrides as typeof overrides & GatewayBrowserClient;
 }
 
+type SessionCapabilityFixtureOverrides = Omit<Partial<SessionCapability>, "patch" | "state"> & {
+  patch?: (...args: Parameters<NonNullable<SessionCapability["patch"]>>) => unknown;
+  state?: Partial<SessionCapability["state"]>;
+};
+
 export function createSessionCapabilityFixture(
-  overrides: Partial<SessionCapability> = {},
+  overrides: SessionCapabilityFixtureOverrides = {},
 ): SessionCapability {
-  return overrides as SessionCapability;
+  return overrides as typeof overrides & SessionCapability;
 }
 
 export function createSessionContext(

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -149,6 +149,18 @@ export type TestChatPane = HTMLElement & {
   ) => TemplateResult;
 };
 
+export function createGatewayBrowserClientFixture(
+  overrides: Partial<GatewayBrowserClient> = {},
+): GatewayBrowserClient {
+  return overrides as GatewayBrowserClient;
+}
+
+export function createSessionCapabilityFixture(
+  overrides: Partial<SessionCapability> = {},
+): SessionCapability {
+  return overrides as SessionCapability;
+}
+
 export function createSessionContext(
   client: GatewayBrowserClient,
   sessions: SessionCapability,

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -2,19 +2,19 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { t } from "../../i18n/index.ts";
-import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { showToast } from "../../lib/toast.ts";
 import {
   installDialogPolyfill,
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
 import {
+  createGatewayBrowserClientFixture,
+  createSessionCapabilityFixture,
   createSessionContext,
   createTestChatPane,
   type TestChatPane,
@@ -96,11 +96,11 @@ function nativeHistoryMessage(seq: number, text = `message ${seq}`) {
 describe("chat pane header state", () => {
   it("forks through the shared session organizer flow and selects the new session", async () => {
     const create = vi.fn(async () => "agent:main:forked");
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       create,
       state: { error: null },
-    } as unknown as SessionCapability;
-    const { pane } = createTestChatPane({ client: {} as GatewayBrowserClient, sessions });
+    });
+    const { pane } = createTestChatPane({ client: createGatewayBrowserClientFixture(), sessions });
     Object.assign(pane.context.gateway.snapshot.hello?.features ?? {}, {
       methods: ["sessions.patch", "sessions.create"],
     });
@@ -128,11 +128,11 @@ describe("chat pane header state", () => {
     const restoreDialogPolyfill = installDialogPolyfill();
     try {
       const deleteOne = vi.fn(async () => ({ deleted: true }));
-      const sessions = {
+      const sessions = createSessionCapabilityFixture({
         delete: deleteOne,
         refreshReplacement: vi.fn(async () => undefined),
-      } as unknown as SessionCapability;
-      const client = {} as GatewayBrowserClient;
+      });
+      const client = createGatewayBrowserClientFixture();
       const { pane } = createTestChatPane({ client, sessions });
       const session = {
         key: "agent:main:current",
@@ -170,8 +170,8 @@ describe("chat pane header state", () => {
 
   it("commits a trimmed label and clears with null", async () => {
     const patch = vi.fn(async () => ({}));
-    const sessions = { patch } as unknown as SessionCapability;
-    const { pane } = createTestChatPane({ client: {} as GatewayBrowserClient, sessions });
+    const sessions = createSessionCapabilityFixture({ patch });
+    const { pane } = createTestChatPane({ client: createGatewayBrowserClientFixture(), sessions });
     const session = {
       key: "agent:main:current",
       kind: "direct",
@@ -195,8 +195,11 @@ describe("chat pane header state", () => {
 
   it("renames the selected agent's canonical global session", () => {
     const patch = vi.fn(async () => ({}));
-    const sessions = { patch } as unknown as SessionCapability;
-    const { pane, state } = createTestChatPane({ client: {} as GatewayBrowserClient, sessions });
+    const sessions = createSessionCapabilityFixture({ patch });
+    const { pane, state } = createTestChatPane({
+      client: createGatewayBrowserClientFixture(),
+      sessions,
+    });
     state.sessionKey = "global";
     state.assistantAgentId = "research";
     const session = {
@@ -218,8 +221,8 @@ describe("chat pane header state", () => {
 
   it("cancels and skips unchanged labels", () => {
     const patch = vi.fn(async () => ({}));
-    const sessions = { patch } as unknown as SessionCapability;
-    const { pane } = createTestChatPane({ client: {} as GatewayBrowserClient, sessions });
+    const sessions = createSessionCapabilityFixture({ patch });
+    const { pane } = createTestChatPane({ client: createGatewayBrowserClientFixture(), sessions });
     pane.paneTitle = "Derived title";
     const session = {
       key: "agent:main:current",
@@ -235,8 +238,8 @@ describe("chat pane header state", () => {
 
   it("copies the resolved workspace path and branch", async () => {
     const { pane } = createTestChatPane({
-      client: {} as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture(),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:current",
@@ -255,8 +258,8 @@ describe("chat pane header state", () => {
     "surfaces a rejected workspace %s clipboard action",
     async (action) => {
       const { pane, requestUpdate, state } = createTestChatPane({
-        client: {} as GatewayBrowserClient,
-        sessions: {} as SessionCapability,
+        client: createGatewayBrowserClientFixture(),
+        sessions: createSessionCapabilityFixture(),
       });
       const session = {
         key: "agent:main:current",
@@ -276,8 +279,8 @@ describe("chat pane header state", () => {
   it("does not query gateway-local branches for exec-node sessions", async () => {
     const request = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     await pane.loadHeaderMenuData(
       {
@@ -301,8 +304,8 @@ describe("chat pane header state", () => {
         worktrees: [{ id: "wt-1", path: "/src/worktree" }],
       });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:worktree",
@@ -321,8 +324,8 @@ describe("chat pane header state", () => {
       .mockRejectedValueOnce(new Error("temporary failure"))
       .mockResolvedValueOnce({ headBranch: "feature/header" });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:plain",
@@ -337,8 +340,8 @@ describe("chat pane header state", () => {
   it("probes session-specific roots for a branch even when the agent workspace is not Git", async () => {
     const request = vi.fn().mockResolvedValue({ headBranch: "spawned/topic" });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:spawned",
@@ -368,8 +371,8 @@ describe("chat pane header state", () => {
       return { headBranch: "main" };
     });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const worktreeRow = {
       key: "agent:main:reused",
@@ -395,8 +398,8 @@ describe("chat pane header state", () => {
   it("skips branch lookups while the session runs remotely", async () => {
     const request = vi.fn().mockResolvedValue({ headBranch: "main" });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const dispatched = {
       key: "agent:main:moves",
@@ -414,8 +417,8 @@ describe("chat pane header state", () => {
       .mockResolvedValueOnce({ headBranch: "main" })
       .mockResolvedValueOnce({ headBranch: "feature/next" });
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:plain",
@@ -430,8 +433,8 @@ describe("chat pane header state", () => {
   it("surfaces resolved reveal failures in the chat error", async () => {
     const request = vi.fn(async () => ({ ok: false, error: "No desktop available." }));
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:current",
@@ -461,8 +464,8 @@ describe("chat pane header state", () => {
     const revealed = createDeferred<{ ok: false; error: string }>();
     const request = vi.fn(() => revealed.promise);
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
     const session = {
       key: "agent:main:current",
@@ -548,10 +551,10 @@ describe("chat pane initialization", () => {
 
   it("starts the connected client when a route alias is already selected canonically", () => {
     const request = vi.fn(() => new Promise<never>(() => {}));
-    const client = {
+    const client = createGatewayBrowserClientFixture({
       request,
-    } as unknown as GatewayBrowserClient;
-    const sessions = {} as SessionCapability;
+    });
+    const sessions = createSessionCapabilityFixture();
     const { pane, state } = createTestChatPane({ client, sessions });
     const canonicalSessionKey = "agent:main:main";
     const hello = {
@@ -614,10 +617,10 @@ describe("chat pane initialization", () => {
 
   it("keeps active turn state when re-entry canonicalizes the main route alias", () => {
     const canonicalSessionKey = "agent:main:main";
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
     const { pane, state } = createTestChatPane({
       client,
-      sessions: {} as SessionCapability,
+      sessions: createSessionCapabilityFixture(),
     });
     const hello = {
       snapshot: {
@@ -656,8 +659,8 @@ describe("chat pane initialization", () => {
 
 describe("chat pane keyboard shortcuts", () => {
   it("toggles only the active pane's session workspace", () => {
-    const client = {} as GatewayBrowserClient;
-    const sessions = {} as SessionCapability;
+    const client = createGatewayBrowserClientFixture();
+    const sessions = createSessionCapabilityFixture();
     const { pane, state } = createTestChatPane({ client, sessions });
     const canvasContent: SidebarContent = {
       kind: "canvas",
@@ -701,8 +704,8 @@ describe("chat pane keyboard shortcuts", () => {
 
   it("toggles the terminal tab in the active pane", () => {
     const { pane, state } = createTestChatPane({
-      client: {} as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture(),
+      sessions: createSessionCapabilityFixture(),
     });
     pane.active = true;
     state.terminalAvailable = true;
@@ -734,10 +737,10 @@ describe("chat pane session creation lifecycle", () => {
 
   it("drops a created session after a same-client reconnect", async () => {
     const created = createDeferred<string | null>();
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       create: vi.fn(() => created.promise),
-    } as unknown as SessionCapability;
-    const client = {} as GatewayBrowserClient;
+    });
+    const client = createGatewayBrowserClientFixture();
     const { pane, state } = createTestChatPane({ client, sessions });
     const navigate = vi.fn();
     pane.onPaneSessionChange = navigate;
@@ -759,12 +762,12 @@ describe("chat pane session creation lifecycle", () => {
 
   it("does not publish a stale creation error after the context is replaced", async () => {
     const created = createDeferred<string | null>();
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       create: vi.fn(() => created.promise),
-    } as unknown as SessionCapability;
-    const client = {} as GatewayBrowserClient;
+    });
+    const client = createGatewayBrowserClientFixture();
     const { pane, requestUpdate, state } = createTestChatPane({ client, sessions });
-    const replacementSessions = {} as SessionCapability;
+    const replacementSessions = createSessionCapabilityFixture();
     advertiseSessionCreate(pane);
 
     const pending = pane.createSession();
@@ -781,10 +784,10 @@ describe("chat pane session creation lifecycle", () => {
 
   it("does not publish a stale creation error after the pane detaches", async () => {
     const created = createDeferred<string | null>();
-    const sessions = {
+    const sessions = createSessionCapabilityFixture({
       create: vi.fn(() => created.promise),
-    } as unknown as SessionCapability;
-    const client = {} as GatewayBrowserClient;
+    });
+    const client = createGatewayBrowserClientFixture();
     const { pane, requestUpdate, state } = createTestChatPane({ client, sessions });
     advertiseSessionCreate(pane);
 
@@ -806,8 +809,11 @@ describe("chat pane session creation lifecycle", () => {
 
 describe("chat pane history pagination intent", () => {
   it("re-arms a failed older-page load only after another user scroll", () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
+    const { pane, state } = createTestChatPane({
+      client,
+      sessions: createSessionCapabilityFixture(),
+    });
     state.handleChatScroll = vi.fn();
     pane.historyAutoLoadBlocked = true;
     pane.transcriptScrollTop = 100;
@@ -825,8 +831,11 @@ describe("chat pane history pagination intent", () => {
   });
 
   it("does not arm older history on downward or in-flight scroll movement", () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
+    const { pane, state } = createTestChatPane({
+      client,
+      sessions: createSessionCapabilityFixture(),
+    });
     state.handleChatScroll = vi.fn();
     pane.transcriptScrollTop = 100;
     pane.syncHistoryObserver = vi.fn();
@@ -845,8 +854,8 @@ describe("chat pane history pagination intent", () => {
   });
 
   it("loads a blocked unscrollable transcript from renewed upward intent", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
+    const { pane } = createTestChatPane({ client, sessions: createSessionCapabilityFixture() });
     pane.historyAutoLoadBlocked = true;
     pane.hasOlderMessages = vi.fn(() => true);
     pane.loadOlderMessages = vi.fn(async () => undefined);
@@ -865,8 +874,8 @@ describe("chat pane history pagination intent", () => {
   });
 
   it("loads a blocked unscrollable transcript from a downward touch pull", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
+    const { pane } = createTestChatPane({ client, sessions: createSessionCapabilityFixture() });
     pane.historyAutoLoadBlocked = true;
     pane.hasOlderMessages = vi.fn(() => true);
     pane.loadOlderMessages = vi.fn(async () => undefined);


### PR DESCRIPTION
## What Problem This Solves

The next-highest test-fixture clusters still erased useful type information behind repeated chained assertions. That made mocks and scenario inputs easier to drift while hiding the intended runtime contracts from TypeScript.

## Why This Change Was Made

This maintainer-requested wave extends the typed-fixture pattern from #124625 and #124865 across ten coherent clusters. Existing test-support owners now accept narrow typed overrides, existing fixture builders are reused where available, and intentionally malformed or heterogeneous boundary projections remain explicit instead of being hidden behind generic cast helpers.

The test-audit gate found no new or removed coverage, no behavior assertion changes, and no production seam. AI-assisted: yes. The final branch review reported no actionable findings.

## User Impact

No user-visible runtime behavior changes. Maintainers get compiler-checked fixture setup and 327 fewer chained assertions while all existing test declarations and assertions remain in place.

## Evidence

| Cluster | Chains before → after | Test declarations before → after |
| --- | ---: | ---: |
| `extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts` | 41 → 0 | 45 → 45 |
| `src/agents/tools/sessions-access.test.ts` | 39 → 2 intentional invalid visibility inputs | 40 → 40 |
| `src/daemon/systemd.test.ts` | 36 → 0 | 133 → 133 |
| `ui/src/pages/chat/chat-pane-sharing.test.ts` | 35 → 0 | 17 → 17 |
| `extensions/discord/src/send.creates-thread.test.ts` | 33 → 0 | 25 → 25 |
| `src/cli/program.force.test.ts` | 33 → 0 | 31 → 31 |
| `src/commands/doctor-legacy-config.migrations.test.ts` | 32 → 2 intentional malformed/migration boundary projections | 72 → 72 |
| `src/gateway/server-methods/chat.directive-tags.test.ts` | 30 → 0 | 157 → 157 |
| `ui/src/pages/chat/chat-pane.test.ts` | 30 → 7 heterogeneous context/DOM/hello projections | 29 → 29 |
| `src/auto-reply/reply/agent-runner-memory.test.ts` | 29 → 0 | 63 → 63 |
| **Total** | **338 → 11** | **612 → 612** |

Focused Vitest proof passed 675 discovered tests across the nine directly runnable target files: sessions 43, systemd 151, chat-pane sharing 31, Discord 42, CLI force 31, doctor migrations 77, Gateway chat 199, chat pane 31, and agent-runner memory 70. The policy aggregate extension runner stalled twice at its 15-minute local no-output cutoff; the exact-head extension production/test type lanes and all changed-file lint passed remotely.

`node scripts/check-changed.mjs` passed the complete changed matrix on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31993643550

The final exact anti-slop scan reports only the 11 documented intentional boundary/projection cases. `git diff --check` is clean. Production LOC: `+0/-0`; test and test-support LOC: `+962/-922` (net `+40`).

Final autoreview: clean, no accepted/actionable findings (`--mode branch --base origin/main`, 183,019-byte bundle).

Skipped after fresh classification:

- `ui/src/app/app-host.test.ts` (49) and `extensions/voice-call/src/webhook.test.ts` (45): previously documented heterogeneous clusters.
- `src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts` (39): output projections plus malformed media boundary fixtures.
- `ui/src/pages/agents/agents-page.test.ts` (35), `ui/src/pages/chat/components/chat-message.test.ts` (33), and `src/cli/capability-cli.test.ts` (31): multiple unrelated fixture/mock targets.
- `extensions/discord/src/internal/gateway.test.ts` (31): private-state/member projections, not fixture construction.
- `extensions/anthropic/session-catalog.test.ts` (30) and `extensions/browser/src/browser/chrome.internal.test.ts` (30): several distinct runtime/config/response types rather than one builder family.
