### PR TITLE
fix(ui): show Review immediately when opening files

### DIFF
--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -34,6 +34,57 @@ describeControlUiE2e("Control UI chat file links", () => {
     await server?.close();
   });
 
+  it("shows the Review panel before a clicked file finishes loading", async () => {
+    const context = await browser.newContext({
+      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
+    try {
+      const file = {
+        root: "/workspace",
+        sessionKey: "main",
+        file: {
+          content: "export const loaded = true;\n",
+          kind: "read",
+          missing: false,
+          name: "slow.ts",
+          path: "src/slow.ts",
+          workspacePath: "src/slow.ts",
+        },
+      };
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["sessions.files.get"],
+        historyMessages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Review `src/slow.ts`." }],
+            timestamp: 1,
+          },
+        ],
+        methodResponses: { "sessions.files.get": file },
+      });
+      await page.goto(`${server.baseUrl}chat`);
+
+      await page.locator('a.markdown-file-link[data-file-path="src/slow.ts"]').click();
+      await gateway.waitForRequest("sessions.files.get");
+
+      await page.locator(".side-panel").waitFor({ state: "visible" });
+      expect(await page.locator(".sidebar-file-view").count()).toBe(0);
+      await page.screenshot({ path: path.join(artifactDir, "latency-panel-before-file.png") });
+
+      await gateway.resolveDeferred("sessions.files.get");
+      await page.locator(".sidebar-file-view").waitFor({ state: "visible" });
+      await expect
+        .poll(() => page.locator(".cm-content").textContent())
+        .toContain("export const loaded = true;");
+      await page.screenshot({ path: path.join(artifactDir, "latency-file-loaded.png") });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("opens the selected file from chat and the workspace root", async () => {
     const context = await browser.newContext({
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -6,6 +6,15 @@ import {
   renderSessionWorkspaceRail,
   type SessionWorkspaceHost,
 } from "./chat-session-workspace.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
+
+async function loadedSidebarContent(
+  handleOpenSidebar: ReturnType<typeof vi.fn>,
+): Promise<SidebarContent> {
+  await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledTimes(2));
+  expect(handleOpenSidebar.mock.calls[0]?.[0]).toBeNull();
+  return handleOpenSidebar.mock.calls[1]?.[0] as SidebarContent;
+}
 
 function gatewayHello(methods: string[], scopes = ["operator.admin"]) {
   return {
@@ -83,8 +92,7 @@ describe("session workspace artifacts", () => {
 
       createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
 
-      await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-      expect(handleOpenSidebar.mock.calls[0]?.[0]).toEqual({
+      expect(await loadedSidebarContent(handleOpenSidebar)).toEqual({
         kind: "markdown",
         content: `# Unicode artifact\n\n${testCase.fence}\n${testCase.content}\n\`\`\``,
         rawText: testCase.content,
@@ -102,8 +110,7 @@ describe("session workspace artifacts", () => {
 
     createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    expect(handleOpenSidebar.mock.calls[0]?.[0]).toEqual({
+    expect(await loadedSidebarContent(handleOpenSidebar)).toEqual({
       kind: "image",
       mimeType: "image/png",
       rawText: null,
@@ -123,7 +130,8 @@ describe("session workspace artifacts", () => {
     await vi.waitFor(() =>
       expect(createSessionWorkspaceProps(state).error).toMatch(/InvalidCharacterError|invalid/i),
     );
-    expect(handleOpenSidebar).not.toHaveBeenCalled();
+    expect(handleOpenSidebar).toHaveBeenCalledOnce();
+    expect(handleOpenSidebar).toHaveBeenCalledWith(null);
   });
 });
 
@@ -156,8 +164,7 @@ describe("openSessionWorkspaceFile", () => {
 
     openSessionWorkspaceFile(state, { path: "readme.md" });
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    expect(handleOpenSidebar.mock.calls[0]?.[0]).toMatchObject({
+    expect(await loadedSidebarContent(handleOpenSidebar)).toMatchObject({
       kind: "file",
       name: "README.md",
       content: "# Before\n",
@@ -199,9 +206,9 @@ describe("openSessionWorkspaceFile", () => {
 
     openSessionWorkspaceFile(state, { path: "README.md" });
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    expect(handleOpenSidebar.mock.calls[0]?.[0]).toMatchObject({ kind: "file" });
-    expect(handleOpenSidebar.mock.calls[0]?.[0]?.edit).toBeUndefined();
+    const content = await loadedSidebarContent(handleOpenSidebar);
+    expect(content).toMatchObject({ kind: "file" });
+    expect(content.kind === "file" ? content.edit : undefined).toBeUndefined();
   });
 
   it.each([
@@ -289,8 +296,7 @@ describe("openSessionWorkspaceFile", () => {
 
     openSessionWorkspaceFile(state, { path: "screenshots/result.png" });
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    expect(handleOpenSidebar.mock.calls[0]?.[0]).toMatchObject({
+    expect(await loadedSidebarContent(handleOpenSidebar)).toMatchObject({
       kind: "image",
       mimeType: "image/png",
       src: "data:image/png;base64,iVBORw0KGgo=",
@@ -333,7 +339,8 @@ describe("openSessionWorkspaceFile", () => {
         "Failed to load screenshots/result.png",
       ),
     );
-    expect(handleOpenSidebar).not.toHaveBeenCalled();
+    expect(handleOpenSidebar).toHaveBeenCalledOnce();
+    expect(handleOpenSidebar).toHaveBeenCalledWith(null);
   });
 
   it("does not render base64 content as text when the preview discriminator disagrees", async () => {
@@ -365,7 +372,8 @@ describe("openSessionWorkspaceFile", () => {
     await vi.waitFor(() =>
       expect(createSessionWorkspaceProps(state).error).toBe("Failed to load notes.txt"),
     );
-    expect(handleOpenSidebar).not.toHaveBeenCalled();
+    expect(handleOpenSidebar).toHaveBeenCalledOnce();
+    expect(handleOpenSidebar).toHaveBeenCalledWith(null);
   });
 
   it("opens unsupported session files as metadata without treating bytes as text", async () => {
@@ -395,9 +403,9 @@ describe("openSessionWorkspaceFile", () => {
 
     openSessionWorkspaceFile(state, { path: "build/cache.db" });
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    expect(handleOpenSidebar.mock.calls[0]?.[0]).toMatchObject({ kind: "markdown" });
-    const content = handleOpenSidebar.mock.calls[0]?.[0]?.content ?? "";
+    const sidebarContent = await loadedSidebarContent(handleOpenSidebar);
+    expect(sidebarContent).toMatchObject({ kind: "markdown" });
+    const content = sidebarContent.kind === "markdown" ? sidebarContent.content : "";
     expect(content).toContain("This file is not previewable inline.");
     expect(content).toContain("application/x-sqlite3");
     expect(content).toContain("8,192 bytes");
@@ -431,8 +439,8 @@ describe("openSessionWorkspaceFile", () => {
 
     openSessionWorkspaceFile(state, { path: hostilePath });
 
-    await vi.waitFor(() => expect(handleOpenSidebar).toHaveBeenCalledOnce());
-    const content = handleOpenSidebar.mock.calls[0]?.[0]?.content ?? "";
+    const sidebarContent = await loadedSidebarContent(handleOpenSidebar);
+    const content = sidebarContent.kind === "markdown" ? sidebarContent.content : "";
     expect(content).toContain(
       "``  build/`\\n\\n![remote](https://example.com/x) report~~old~~&amp;.db  ``",
     );

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -136,6 +136,36 @@ describe("session workspace artifacts", () => {
 });
 
 describe("openSessionWorkspaceFile", () => {
+  it.each([
+    { client: null, connected: true, label: "no Gateway client exists" },
+    { client: {}, connected: false, label: "the Gateway is disconnected" },
+  ])("preserves existing Review content when $label", ({ client, connected }) => {
+    const existingContent = {
+      kind: "markdown",
+      content: "Existing review",
+      rawText: "Existing review",
+    } satisfies SidebarContent;
+    let sidebarContent: SidebarContent | null = existingContent;
+    const handleOpenSidebar = vi.fn((content: SidebarContent | null) => {
+      sidebarContent = content;
+    });
+    const getFile = vi.fn();
+    const state = {
+      client,
+      connected,
+      handleOpenSidebar,
+      hello: gatewayHello([]),
+      sessionKey: "agent:main:current",
+      sessions: { getFile },
+    } as unknown as SessionWorkspaceHost;
+
+    openSessionWorkspaceFile(state, { path: "README.md" });
+
+    expect(getFile).not.toHaveBeenCalled();
+    expect(handleOpenSidebar).not.toHaveBeenCalled();
+    expect(sidebarContent).toBe(existingContent);
+  });
+
   it("opens Markdown with a canonical Gateway- and pane-scoped draft identity", async () => {
     const handleOpenSidebar = vi.fn();
     const getFile = vi.fn().mockResolvedValue({

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -425,11 +425,11 @@ function openWorkspaceItem<T>(
   missingMessage: string,
 ) {
   const request = beginOpenRequest(state, workspace, itemId);
-  state.handleOpenSidebar(null);
   void (async () => {
     if (!state.client || !state.connected) {
       return;
     }
+    state.handleOpenSidebar(null);
     workspace.error = null;
     try {
       const result = await load(request);

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -105,7 +105,7 @@ export type SessionWorkspaceHost = {
   sessionWorkspaceOpenRequest?: SessionWorkspaceOpenRequest;
   sessionWorkspaceDraftScope?: string;
   requestUpdate?: () => void;
-  handleOpenSidebar: (content: SidebarContent) => void;
+  handleOpenSidebar: (content: SidebarContent | null) => void;
 };
 
 /** Agent owning the pane's current session: explicit key scope first, then the
@@ -425,6 +425,7 @@ function openWorkspaceItem<T>(
   missingMessage: string,
 ) {
   const request = beginOpenRequest(state, workspace, itemId);
+  state.handleOpenSidebar(null);
   void (async () => {
     if (!state.client || !state.connected) {
       return;
@@ -436,7 +437,6 @@ function openWorkspaceItem<T>(
       if (!content) {
         if (isCurrentOpenRequest(state, request)) {
           workspace.error = missingMessage;
-          requestUpdate(state);
         }
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a workspace file from chat could see no visible response while a slow remote file request was still loading. The Review panel stayed closed until the file contents arrived, making the click appear broken.

## Why This Change Was Made

The workspace-opening owner now opens and clears Review synchronously before starting file or artifact loading once a Gateway client is connected, then publishes content only when the matching request is still current. This preserves stale-request protection while making the interaction respond immediately, without clearing existing Review content when no request can start. Production LOC is +2/-2 (net 0); tests are +108/-19.

AI-assisted: yes.

## User Impact

Opening a workspace file from chat now shows Review immediately, even when the remote workspace is slow. The requested file appears in the already-visible panel as soon as it finishes loading, and an older delayed response cannot replace a newer selection.

## Evidence

### Before

With `sessions.files.get` deferred, clicking the file left the UI without a sidebar:

![Before: no Review panel while the file request is deferred](https://github.com/user-attachments/assets/1a66254a-ae63-433c-b9bb-320b78812c6a)

### After click

With the fix, Review is visible before the deferred response is released:

![After click: Review is visible before file contents load](https://github.com/user-attachments/assets/6a44a02a-942d-4584-9ac9-3c1ba3cb60e9)

### Loaded

After the response resolves, the requested file appears in Review:

![Loaded: requested file is visible after the response](https://github.com/user-attachments/assets/7f7977e3-091d-4ad6-91f4-1bdeb3fc1305)

The pre-fix delayed-response E2E reproduction failed waiting for `.side-panel` visibility while `sessions.files.get` remained deferred. On the final diff:

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-session-workspace.test.ts` — 18 passed, including parameterized no-client and disconnected cases that preserve existing Review content and do not start a file request.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-file-links.e2e.test.ts` — 3 passed.
- Formatting, oxlint, `git diff --check`, production build, and UI typecheck passed.
- Codex autoreview found no actionable issues.
- Source-blind behavior validation passed.

The deployed `team.openclaw.ai` surface was not exercised because the signed-in Chrome extension relay was unavailable; the screenshots and E2E results above are local Control UI proof, not deployed-live proof.
