### PR TITLE
fix(gateway): prevent large history from blocking chat startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ Mechanics only; policy lives above.
 - Tests asserting resolver/root-containment paths: `fs.realpath` mkdtemp/tmp roots first. macOS `os.tmpdir()` is a `/var` -> `/private/var` symlink; prod resolvers return canonical paths, so raw mkdtemp assertions pass on Linux CI but fail on Mac.
 - Explicit `vi.mock` factories must export every binding prod touches, including error classes used in `instanceof` checks; `vi.importActual` the defining module for those instead of stub classes.
 - Prefer injection and narrow `*.runtime.ts` mocks over broad barrels or `openclaw/plugin-sdk/*`.
-- Do not edit baseline/inventory/ignore/snapshot/expected-failure files to silence checks without explicit approval.
+- Do not edit baseline/inventory/ignore/snapshot/expected-failure files to silence checks without explicit approval. Shrink-only ratchet updates that exactly record removed violations are required maintenance and need no separate approval.
 - Never edit source/test files while a Vitest run is in flight in the same checkout; mid-collection reads produce phantom failures and 120s timeouts. Wait for the run to finish, then edit.
 - Vitest rejects Jest `--runInBand`; use `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test` for serial proof. Test workers max 16.
 - Live: `OPENCLAW_LIVE_TEST=1 pnpm test:live`; verbose `OPENCLAW_LIVE_TEST_QUIET=0`.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2772,7 +2772,7 @@ src/config/sessions/session-accessor.sqlite-delta.ts	3
 src/config/sessions/session-accessor.sqlite-entry-availability.ts	1
 src/config/sessions/session-accessor.sqlite-entry-cache.ts	3
 src/config/sessions/session-accessor.sqlite-entry.ts	1
-src/config/sessions/session-accessor.sqlite-history-events.ts	3
+src/config/sessions/session-accessor.sqlite-history-events.ts	2
 src/config/sessions/session-accessor.sqlite-message-cut.ts	1
 src/config/sessions/session-accessor.sqlite-parent-fork.ts	1
 src/config/sessions/session-accessor.sqlite-read.ts	12
@@ -2920,7 +2920,7 @@ src/gateway/chat-display-projection.sanitize.ts	16
 src/gateway/chat-sanitize.ts	3
 src/gateway/chat-tool-titles.ts	2
 src/gateway/cli-session-history.claude-activity.ts	1
-src/gateway/cli-session-history.claude.ts	16
+src/gateway/cli-session-history.claude.ts	15
 src/gateway/cli-session-history.merge.ts	6
 src/gateway/config-reload-plan.ts	5
 src/gateway/control-ui-plugin-auth-cookie.ts	1

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -37,6 +37,9 @@ const manageMocks = vi.hoisted(() => {
     tabsAction,
   };
 });
+const cookieSyncMocks = vi.hoisted(() => ({
+  registerBrowserCookieSyncCommand: vi.fn(),
+}));
 const inspectMocks = vi.hoisted(() => ({
   registerBrowserInspectCommands: vi.fn(),
 }));
@@ -52,13 +55,18 @@ const debugMocks = vi.hoisted(() => ({
 const stateMocks = vi.hoisted(() => ({
   registerBrowserStateCommands: vi.fn(),
 }));
+const extensionMocks = vi.hoisted(() => ({
+  registerBrowserExtensionCommands: vi.fn(),
+}));
 
 vi.mock("./browser-cli-manage.js", () => manageMocks);
+vi.mock("./browser-cli-cookie-sync.js", () => cookieSyncMocks);
 vi.mock("./browser-cli-inspect.js", () => inspectMocks);
 vi.mock("./browser-cli-actions-input.js", () => actionInputMocks);
 vi.mock("./browser-cli-actions-observe.js", () => actionObserveMocks);
 vi.mock("./browser-cli-debug.js", () => debugMocks);
 vi.mock("./browser-cli-state.js", () => stateMocks);
+vi.mock("./browser-cli-extension.js", () => extensionMocks);
 
 const { registerBrowserCli } = await import("./browser-cli.js");
 
@@ -117,11 +125,13 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     manageMocks.statusAction.mockClear();
     manageMocks.tabNewAction.mockClear();
     manageMocks.tabsAction.mockClear();
+    cookieSyncMocks.registerBrowserCookieSyncCommand.mockClear();
     inspectMocks.registerBrowserInspectCommands.mockClear();
     actionInputMocks.registerBrowserActionInputCommands.mockClear();
     actionObserveMocks.registerBrowserActionObserveCommands.mockClear();
     debugMocks.registerBrowserDebugCommands.mockClear();
     stateMocks.registerBrowserStateCommands.mockClear();
+    extensionMocks.registerBrowserExtensionCommands.mockClear();
   });
 
   afterEach(() => {
@@ -287,13 +297,15 @@ describe("registerBrowserCli lazy browser subcommands", () => {
 
     registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
 
-    await vi.waitFor(() =>
-      expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1),
-    );
-    expect(inspectMocks.registerBrowserInspectCommands).toHaveBeenCalledTimes(1);
-    expect(actionInputMocks.registerBrowserActionInputCommands).toHaveBeenCalledTimes(1);
-    expect(actionObserveMocks.registerBrowserActionObserveCommands).toHaveBeenCalledTimes(1);
-    expect(debugMocks.registerBrowserDebugCommands).toHaveBeenCalledTimes(1);
-    expect(stateMocks.registerBrowserStateCommands).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1);
+      expect(cookieSyncMocks.registerBrowserCookieSyncCommand).toHaveBeenCalledTimes(1);
+      expect(inspectMocks.registerBrowserInspectCommands).toHaveBeenCalledTimes(1);
+      expect(actionInputMocks.registerBrowserActionInputCommands).toHaveBeenCalledTimes(1);
+      expect(actionObserveMocks.registerBrowserActionObserveCommands).toHaveBeenCalledTimes(1);
+      expect(debugMocks.registerBrowserDebugCommands).toHaveBeenCalledTimes(1);
+      expect(stateMocks.registerBrowserStateCommands).toHaveBeenCalledTimes(1);
+      expect(extensionMocks.registerBrowserExtensionCommands).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -233,6 +233,72 @@ describe("SQLite transcript history events", () => {
     expect(page.events.map(({ seq }) => seq)).toEqual([3]);
   });
 
+  it("does not read an inactive boundary between active sequence bounds", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    const boundaryEvents = [
+      {
+        seq: 2,
+        id: "active-boundary-2",
+        eventJson: JSON.stringify({
+          type: "compaction",
+          id: "active-boundary-2",
+          parentId: "seed",
+          timestamp: "2026-08-15T00:00:01.000Z",
+          summary: "active",
+        }),
+        activePosition: 1,
+      },
+      { seq: 3, id: "inactive-boundary", eventJson: "{", activePosition: undefined },
+      {
+        seq: 4,
+        id: "active-boundary-4",
+        eventJson: JSON.stringify({
+          type: "compaction",
+          id: "active-boundary-4",
+          parentId: "active-boundary-2",
+          timestamp: "2026-08-15T00:00:02.000Z",
+          summary: "active",
+        }),
+        activePosition: 2,
+      },
+    ];
+    const insertEvent = database.db.prepare(
+      "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, ?, ?, ?)",
+    );
+    const insertIdentity = database.db.prepare(
+      `INSERT INTO transcript_event_identities
+         (session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at)
+       VALUES (?, ?, ?, 'compaction', NULL, NULL, ?)`,
+    );
+    const insertActive = database.db.prepare(
+      `INSERT INTO session_transcript_active_events
+         (session_id, active_position, event_seq, message_position)
+       VALUES (?, ?, ?, NULL)`,
+    );
+    for (const event of boundaryEvents) {
+      insertEvent.run(scope.sessionId, event.seq, event.eventJson, event.seq);
+      insertIdentity.run(scope.sessionId, event.id, event.seq, event.seq);
+      if (event.activePosition !== undefined) {
+        insertActive.run(scope.sessionId, event.activePosition, event.seq);
+      }
+    }
+    database.db
+      .prepare(
+        `UPDATE session_transcript_index_state
+         SET indexed_seq = 4, leaf_event_id = 'active-boundary-4', active_event_count = 3
+         WHERE session_id = ?`,
+      )
+      .run(scope.sessionId);
+
+    const events = readSessionTranscriptHistoryEvents(scope);
+
+    expect(events.map(historyEventId)).toEqual(["seed", "active-boundary-2", "active-boundary-4"]);
+  });
+
   it("bounds metadata bindings when the raw history window exceeds SQLite's limit", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],

--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -1,14 +1,167 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
+  type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { appendTranscriptEvent, persistSessionTranscriptTurn } from "./session-accessor.js";
-import { readRecentSessionTranscriptHistoryEvents } from "./session-accessor.sqlite-history-events.js";
+import {
+  readRecentSessionTranscriptHistoryEvents,
+  readSessionTranscriptHistoryEvents,
+} from "./session-accessor.sqlite-history-events.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const REGRESSION_SQLITE_VARIABLE_LIMIT = 64;
+const REGRESSION_MAX_MESSAGES = 32;
+
+function historyEventId(entry: { event: unknown } | undefined): unknown {
+  const event = entry?.event;
+  return event && typeof event === "object" && "id" in event ? event.id : undefined;
+}
+
+function enforceSqliteVariableLimit(database: OpenClawAgentDatabase): void {
+  const prepare = database.db.prepare.bind(database.db);
+  vi.spyOn(database.db, "prepare").mockImplementation((source) => {
+    const variableCount = source.match(/\?/gu)?.length ?? 0;
+    if (variableCount > REGRESSION_SQLITE_VARIABLE_LIMIT) {
+      throw new Error("too many SQL variables");
+    }
+    return prepare(source);
+  });
+}
+
+function insertSyntheticMessages(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  additionalCount: number,
+): void {
+  const lastSeq = additionalCount + 1;
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(seq) AS (
+         SELECT 2
+         UNION ALL
+         SELECT seq + 1 FROM synthetic WHERE seq < ?
+       )
+       INSERT INTO transcript_events (session_id, seq, event_json, created_at)
+       SELECT ?, seq,
+         printf('{"type":"message","id":"synthetic-message-%d","parentId":null,"timestamp":"2026-08-15T00:00:00.000Z","message":{"role":"user","content":"synthetic"}}', seq),
+         seq
+       FROM synthetic`,
+    )
+    .run(lastSeq, sessionId);
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(seq) AS (
+         SELECT 2
+         UNION ALL
+         SELECT seq + 1 FROM synthetic WHERE seq < ?
+       )
+       INSERT INTO transcript_event_identities
+         (session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at)
+       SELECT ?, printf('synthetic-message-%d', seq), seq, 'message', NULL, NULL, seq
+       FROM synthetic`,
+    )
+    .run(lastSeq, sessionId);
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(seq) AS (
+         SELECT 2
+         UNION ALL
+         SELECT seq + 1 FROM synthetic WHERE seq < ?
+       )
+       INSERT INTO session_transcript_active_events
+         (session_id, active_position, event_seq, message_position)
+       SELECT ?, seq - 1, seq, seq - 1
+       FROM synthetic`,
+    )
+    .run(lastSeq, sessionId);
+  database.db
+    .prepare(
+      `UPDATE session_transcript_index_state
+       SET indexed_seq = ?, leaf_event_id = ?, active_event_count = ?, active_message_count = ?
+       WHERE session_id = ?`,
+    )
+    .run(lastSeq, `synthetic-message-${String(lastSeq)}`, lastSeq, lastSeq, sessionId);
+}
+
+function insertSyntheticBoundaryPairs(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  pairCount: number,
+): void {
+  const lastSeq = pairCount * 2 + 1;
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(pair_index) AS (
+         SELECT 1
+         UNION ALL
+         SELECT pair_index + 1 FROM synthetic WHERE pair_index < ?
+       )
+       INSERT INTO transcript_events (session_id, seq, event_json, created_at)
+       SELECT ?, pair_index * 2,
+         printf('{"type":"compaction","id":"synthetic-boundary-%d","parentId":null,"timestamp":"2026-08-15T00:00:00.000Z","summary":"synthetic"}', pair_index * 2),
+         pair_index * 2
+       FROM synthetic
+       UNION ALL
+       SELECT ?, pair_index * 2 + 1,
+         printf('{"type":"message","id":"synthetic-message-%d","parentId":null,"timestamp":"2026-08-15T00:00:00.000Z","message":{"role":"user","content":"synthetic"}}', pair_index * 2 + 1),
+         pair_index * 2 + 1
+       FROM synthetic`,
+    )
+    .run(pairCount, sessionId, sessionId);
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(pair_index) AS (
+         SELECT 1
+         UNION ALL
+         SELECT pair_index + 1 FROM synthetic WHERE pair_index < ?
+       )
+       INSERT INTO transcript_event_identities
+         (session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at)
+       SELECT ?, printf('synthetic-boundary-%d', pair_index * 2), pair_index * 2,
+         'compaction', NULL, NULL, pair_index * 2
+       FROM synthetic
+       UNION ALL
+       SELECT ?, printf('synthetic-message-%d', pair_index * 2 + 1), pair_index * 2 + 1,
+         'message', NULL, NULL, pair_index * 2 + 1
+       FROM synthetic`,
+    )
+    .run(pairCount, sessionId, sessionId);
+  database.db
+    .prepare(
+      `WITH RECURSIVE synthetic(pair_index) AS (
+         SELECT 1
+         UNION ALL
+         SELECT pair_index + 1 FROM synthetic WHERE pair_index < ?
+       )
+       INSERT INTO session_transcript_active_events
+         (session_id, active_position, event_seq, message_position)
+       SELECT ?, pair_index * 2 - 1, pair_index * 2, NULL
+       FROM synthetic
+       UNION ALL
+       SELECT ?, pair_index * 2, pair_index * 2 + 1, pair_index
+       FROM synthetic`,
+    )
+    .run(pairCount, sessionId, sessionId);
+  const activeEventCount = pairCount * 2 + 1;
+  const activeMessageCount = pairCount + 1;
+  database.db
+    .prepare(
+      `UPDATE session_transcript_index_state
+       SET indexed_seq = ?, leaf_event_id = ?, active_event_count = ?, active_message_count = ?
+       WHERE session_id = ?`,
+    )
+    .run(
+      lastSeq,
+      `synthetic-message-${String(lastSeq)}`,
+      activeEventCount,
+      activeMessageCount,
+      sessionId,
+    );
+}
 
 describe("SQLite transcript history events", () => {
   let scope: {
@@ -28,6 +181,7 @@ describe("SQLite transcript history events", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
   });
@@ -77,5 +231,48 @@ describe("SQLite transcript history events", () => {
       "oversized-newest",
     ]);
     expect(page.events.map(({ seq }) => seq)).toEqual([3]);
+  });
+
+  it("bounds metadata bindings when the raw history window exceeds SQLite's limit", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    const bindingCount = REGRESSION_SQLITE_VARIABLE_LIMIT;
+    insertSyntheticMessages(database, scope.sessionId, bindingCount);
+    enforceSqliteVariableLimit(database);
+
+    const page = readRecentSessionTranscriptHistoryEvents(scope, {
+      maxBytes: 1_000_000,
+      maxLines: bindingCount + 1,
+      maxMessages: REGRESSION_MAX_MESSAGES,
+    });
+
+    expect(page.totalMessages).toBe(bindingCount + 1);
+    expect(page.events).toHaveLength(REGRESSION_MAX_MESSAGES);
+    expect(historyEventId(page.events[0])).toBe(
+      `synthetic-message-${String(bindingCount - REGRESSION_MAX_MESSAGES + 2)}`,
+    );
+    expect(historyEventId(page.events.at(-1))).toBe(
+      `synthetic-message-${String(bindingCount + 1)}`,
+    );
+  });
+
+  it("reads more boundaries than SQLite permits as statement bindings", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    const bindingCount = REGRESSION_SQLITE_VARIABLE_LIMIT;
+    insertSyntheticBoundaryPairs(database, scope.sessionId, bindingCount);
+    enforceSqliteVariableLimit(database);
+
+    const events = readSessionTranscriptHistoryEvents(scope);
+
+    expect(events).toHaveLength(bindingCount * 2 + 1);
+    expect(historyEventId(events[0])).toBe("seed");
+    expect(historyEventId(events.at(-1))).toBe(`synthetic-message-${String(bindingCount * 2 + 1)}`);
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { appendTranscriptEvent, persistSessionTranscriptTurn } from "./session-accessor.js";
+import { readRecentSessionTranscriptHistoryEvents } from "./session-accessor.sqlite-history-events.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("SQLite transcript history events", () => {
+  let scope: {
+    agentId: string;
+    env: NodeJS.ProcessEnv;
+    sessionId: string;
+    sessionKey: string;
+  };
+
+  beforeEach(() => {
+    scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDirs.make("openclaw-history-events-") },
+      sessionId: "history-events-test",
+      sessionKey: "agent:main:history-events-test",
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("retains an oversized newest history row without parsing excluded older payloads", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "older", parentId: null, message: { role: "user", content: "older" } }],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "excluded-boundary",
+      parentId: "older",
+      timestamp: "2026-08-15T00:00:00.000Z",
+      summary: "excluded",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "oversized-newest",
+          parentId: "excluded-boundary",
+          message: { role: "assistant", content: "x".repeat(16_384) },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    database.db
+      .prepare(
+        `UPDATE transcript_events
+         SET event_json = '{'
+         WHERE session_id = ? AND seq IN (
+           SELECT seq FROM transcript_event_identities
+           WHERE session_id = ? AND event_id IN ('older', 'excluded-boundary')
+         )`,
+      )
+      .run(scope.sessionId, scope.sessionId);
+
+    const page = readRecentSessionTranscriptHistoryEvents(scope, {
+      maxBytes: 1024,
+      maxLines: 3,
+      maxMessages: 3,
+    });
+
+    expect(page.totalMessages).toBe(3);
+    expect(page.events.map(({ event }) => (event as { id?: unknown }).id)).toEqual([
+      "oversized-newest",
+    ]);
+    expect(page.events.map(({ seq }) => seq)).toEqual([3]);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -136,14 +136,19 @@ function readBoundaryEvents(
     executeSqliteQuerySync(
       projection.database.db,
       db
-        .selectFrom("transcript_event_identities as identity")
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_event_identities as identity", (join) =>
+          join
+            .onRef("identity.session_id", "=", "active.session_id")
+            .onRef("identity.seq", "=", "active.event_seq"),
+        )
         .innerJoin("transcript_events as event", (join) =>
           join
-            .onRef("event.session_id", "=", "identity.session_id")
-            .onRef("event.seq", "=", "identity.seq"),
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
         )
         .select(["event.seq", "event.event_json"])
-        .where("identity.session_id", "=", projection.resolved.sessionId)
+        .where("active.session_id", "=", projection.resolved.sessionId)
         .where("identity.event_type", "in", ["compaction", "reset"])
         .where("identity.seq", ">=", firstSeq)
         .where("identity.seq", "<=", lastSeq),

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -1,3 +1,4 @@
+import { sql } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -18,14 +19,17 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   readVisibleMessageRange,
+  resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
 import { MAX_VISIBLE_MESSAGE_MAX_MESSAGES } from "./session-accessor.sqlite-visible-cursor.js";
 
 type VisibleHistoryBoundary = {
   displayPosition: number;
-  event: TranscriptEvent;
+  eventId: string;
+  eventSeq: number;
   messagePosition: number;
+  serializedBytes: number;
 };
 
 type VisibleHistoryProjection = {
@@ -52,7 +56,13 @@ function resolveVisibleHistoryProjection(
           .onRef("event.session_id", "=", "active.session_id")
           .onRef("event.seq", "=", "active.event_seq"),
       )
-      .select(["identity.event_type", "event.event_json"])
+      .select([
+        "identity.event_id",
+        "identity.event_type",
+        "identity.seq",
+        /* kysely-allow-raw: history byte caps include each event's JSONL newline. */
+        sql<number>`LENGTH(CAST(event.event_json AS BLOB)) + 1`.as("serialized_bytes"),
+      ])
       .select((eb) =>
         eb
           .selectFrom("session_transcript_active_events as next")
@@ -78,8 +88,10 @@ function resolveVisibleHistoryProjection(
         );
     return {
       displayPosition: messagePosition + priorBoundaries++,
-      event: JSON.parse(row.event_json) as TranscriptEvent,
+      eventId: row.event_id,
+      eventSeq: row.seq,
       messagePosition,
+      serializedBytes: row.serialized_bytes,
     };
   });
   return {
@@ -88,35 +100,70 @@ function resolveVisibleHistoryProjection(
   };
 }
 
+function resolveVisibleHistoryRange(
+  history: VisibleHistoryProjection,
+  start: number,
+  endExclusive: number,
+) {
+  const boundedStart = Math.min(Math.max(0, start), history.total);
+  const boundedEnd = Math.min(Math.max(boundedStart, endExclusive), history.total);
+  const selectedBoundaries = history.boundaries.filter(
+    (boundary) => boundary.displayPosition >= boundedStart && boundary.displayPosition < boundedEnd,
+  );
+  const boundaries = new Map(
+    selectedBoundaries.map((boundary) => [boundary.displayPosition, boundary] as const),
+  );
+  const boundariesBefore = history.boundaries.filter(
+    (boundary) => boundary.displayPosition < boundedStart,
+  ).length;
+  const messageStart = boundedStart - boundariesBefore;
+  const messageEnd = messageStart + boundedEnd - boundedStart - selectedBoundaries.length;
+  return { boundedEnd, boundedStart, boundaries, messageEnd, messageStart };
+}
+
+function readBoundaryEvents(
+  projection: CurrentTranscriptProjection,
+  boundaries: Iterable<VisibleHistoryBoundary>,
+): Map<number, TranscriptEvent> {
+  const eventSeqs = Array.from(boundaries, (boundary) => boundary.eventSeq);
+  if (eventSeqs.length === 0) {
+    return new Map();
+  }
+  const db = getActiveTranscriptKysely(projection.database);
+  return new Map(
+    executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("transcript_events")
+        .select(["seq", "event_json"])
+        .where("session_id", "=", projection.resolved.sessionId)
+        .where("seq", "in", eventSeqs),
+    ).rows.map((row) => [row.seq, JSON.parse(row.event_json) as TranscriptEvent]),
+  );
+}
+
 function readVisibleHistoryRange(
   projection: CurrentTranscriptProjection,
   start: number,
   endExclusive: number,
   history = resolveVisibleHistoryProjection(projection),
 ): SessionTranscriptMessageEvent[] {
-  const boundedStart = Math.min(Math.max(0, start), history.total);
-  const boundedEnd = Math.min(Math.max(boundedStart, endExclusive), history.total);
+  const { boundedEnd, boundedStart, boundaries, messageEnd, messageStart } =
+    resolveVisibleHistoryRange(history, start, endExclusive);
   if (boundedEnd <= boundedStart) {
     return [];
   }
-  const boundaries = new Map(
-    history.boundaries.map((boundary) => [boundary.displayPosition, boundary] as const),
-  );
-  const boundariesBefore = history.boundaries.filter(
-    (boundary) => boundary.displayPosition < boundedStart,
-  ).length;
-  const selectedBoundaryCount = history.boundaries.filter(
-    (boundary) => boundary.displayPosition >= boundedStart && boundary.displayPosition < boundedEnd,
-  ).length;
-  const messageStart = boundedStart - boundariesBefore;
-  const messageEnd = messageStart + boundedEnd - boundedStart - selectedBoundaryCount;
   const messages = readVisibleMessageRange(projection, messageStart, messageEnd);
+  const boundaryEvents = readBoundaryEvents(projection, boundaries.values());
   let messageIndex = 0;
   const events: SessionTranscriptMessageEvent[] = [];
   for (let displayPosition = boundedStart; displayPosition < boundedEnd; displayPosition += 1) {
     const boundary = boundaries.get(displayPosition);
     if (boundary) {
-      events.push({ event: boundary.event, seq: displayPosition + 1 });
+      const event = boundaryEvents.get(boundary.eventSeq);
+      if (event) {
+        events.push({ event, seq: displayPosition + 1 });
+      }
       continue;
     }
     const message = messages[messageIndex++];
@@ -125,6 +172,70 @@ function readVisibleHistoryRange(
     }
   }
   return events;
+}
+
+function resolveRecentHistoryStart(
+  projection: CurrentTranscriptProjection,
+  start: number,
+  endExclusive: number,
+  history: VisibleHistoryProjection,
+  maxBytes: number,
+  maxMessages: number,
+): number {
+  const { boundedEnd, boundedStart, boundaries, messageEnd, messageStart } =
+    resolveVisibleHistoryRange(history, start, endExclusive);
+  const positions = resolveVisibleMessagePositionRange(projection, messageStart, messageEnd);
+  const db = getActiveTranscriptKysely(projection.database);
+  const messageBytes = new Map(
+    positions.length === 0
+      ? []
+      : executeSqliteQuerySync(
+          projection.database.db,
+          db
+            .selectFrom("session_transcript_active_events as active")
+            .innerJoin("transcript_events as event", (join) =>
+              join
+                .onRef("event.session_id", "=", "active.session_id")
+                .onRef("event.seq", "=", "active.event_seq"),
+            )
+            .select([
+              "active.message_position",
+              /* kysely-allow-raw: excluded history payloads must not be fetched or parsed. */
+              sql<number>`LENGTH(CAST(event.event_json AS BLOB)) + 1`.as("serialized_bytes"),
+            ])
+            .where("active.session_id", "=", projection.resolved.sessionId)
+            .where("active.message_position", "in", positions),
+        ).rows.flatMap((row) =>
+          row.message_position === null
+            ? []
+            : [[row.message_position, row.serialized_bytes] as const],
+        ),
+  );
+  let messageIndex = positions.length - 1;
+  let selectedStart = boundedEnd;
+  let selectedCount = 0;
+  let bytes = 0;
+  for (
+    let displayPosition = boundedEnd - 1;
+    displayPosition >= boundedStart;
+    displayPosition -= 1
+  ) {
+    const boundary = boundaries.get(displayPosition);
+    const messagePosition = boundary ? undefined : positions[messageIndex--];
+    const serializedBytes =
+      boundary?.serializedBytes ??
+      (messagePosition === undefined ? undefined : messageBytes.get(messagePosition));
+    if (serializedBytes === undefined) {
+      continue;
+    }
+    if (selectedCount >= maxMessages || (selectedCount > 0 && bytes + serializedBytes > maxBytes)) {
+      break;
+    }
+    selectedStart = displayPosition;
+    selectedCount += 1;
+    bytes += serializedBytes;
+  }
+  return selectedStart;
 }
 
 function readVisibleMessageById(
@@ -169,11 +280,10 @@ function resolveHistoryEventById(
   eventId: string,
   history = resolveVisibleHistoryProjection(projection),
 ): SessionTranscriptMessageEvent | undefined {
-  const boundary = history.boundaries.find(
-    (candidate) => (candidate.event as { id?: unknown }).id === eventId,
-  );
+  const boundary = history.boundaries.find((candidate) => candidate.eventId === eventId);
   if (boundary) {
-    return { event: boundary.event, seq: boundary.displayPosition + 1 };
+    const event = readBoundaryEvents(projection, [boundary]).get(boundary.eventSeq);
+    return event ? { event, seq: boundary.displayPosition + 1 } : undefined;
   }
   const message = readVisibleMessageById(projection, eventId);
   if (!message) {
@@ -223,28 +333,17 @@ export function readRecentSessionTranscriptHistoryEvents(
       1024,
       Math.floor(Number.isFinite(options.maxBytes) ? options.maxBytes : 8 * 1024 * 1024),
     );
-    const candidates = readVisibleHistoryRange(
+    const selectedStart = resolveRecentHistoryStart(
       projection,
       Math.max(0, history.total - maxLines),
       history.total,
       history,
+      maxBytes,
+      maxMessages,
     );
-    const selected: SessionTranscriptMessageEvent[] = [];
-    let bytes = 0;
-    for (const event of candidates.toReversed()) {
-      const eventBytes = Buffer.byteLength(JSON.stringify(event.event)) + 1;
-      if (
-        selected.length >= maxMessages ||
-        (selected.length > 0 && bytes + eventBytes > maxBytes)
-      ) {
-        break;
-      }
-      selected.push(event);
-      bytes += eventBytes;
-    }
     return {
       activeLeafEntryId: projection.state.leafEventId,
-      events: selected.toReversed(),
+      events: readVisibleHistoryRange(projection, selectedStart, history.total, history),
       totalMessages: history.total,
     };
   });

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -126,7 +126,9 @@ function readBoundaryEvents(
   boundaries: Iterable<VisibleHistoryBoundary>,
 ): Map<number, TranscriptEvent> {
   const eventSeqs = Array.from(boundaries, (boundary) => boundary.eventSeq);
-  if (eventSeqs.length === 0) {
+  const [firstSeq] = eventSeqs;
+  const lastSeq = eventSeqs.at(-1);
+  if (firstSeq === undefined || lastSeq === undefined) {
     return new Map();
   }
   const db = getActiveTranscriptKysely(projection.database);
@@ -134,10 +136,17 @@ function readBoundaryEvents(
     executeSqliteQuerySync(
       projection.database.db,
       db
-        .selectFrom("transcript_events")
-        .select(["seq", "event_json"])
-        .where("session_id", "=", projection.resolved.sessionId)
-        .where("seq", "in", eventSeqs),
+        .selectFrom("transcript_event_identities as identity")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "identity.session_id")
+            .onRef("event.seq", "=", "identity.seq"),
+        )
+        .select(["event.seq", "event.event_json"])
+        .where("identity.session_id", "=", projection.resolved.sessionId)
+        .where("identity.event_type", "in", ["compaction", "reset"])
+        .where("identity.seq", ">=", firstSeq)
+        .where("identity.seq", "<=", lastSeq),
     ).rows.map((row) => [row.seq, JSON.parse(row.event_json) as TranscriptEvent]),
   );
 }
@@ -184,7 +193,10 @@ function resolveRecentHistoryStart(
 ): number {
   const { boundedEnd, boundedStart, boundaries, messageEnd, messageStart } =
     resolveVisibleHistoryRange(history, start, endExclusive);
-  const positions = resolveVisibleMessagePositionRange(projection, messageStart, messageEnd);
+  // No result can include more than maxMessages events, so older metadata would
+  // only add SQLite bindings and synchronous work before the backward scan stops.
+  const metadataStart = Math.max(messageStart, messageEnd - maxMessages);
+  const positions = resolveVisibleMessagePositionRange(projection, metadataStart, messageEnd);
   const db = getActiveTranscriptKysely(projection.database);
   const messageBytes = new Map(
     positions.length === 0
@@ -220,6 +232,9 @@ function resolveRecentHistoryStart(
     displayPosition >= boundedStart;
     displayPosition -= 1
   ) {
+    if (selectedCount >= maxMessages) {
+      break;
+    }
     const boundary = boundaries.get(displayPosition);
     const messagePosition = boundary ? undefined : positions[messageIndex--];
     const serializedBytes =
@@ -228,7 +243,7 @@ function resolveRecentHistoryStart(
     if (serializedBytes === undefined) {
       continue;
     }
-    if (selectedCount >= maxMessages || (selectedCount > 0 && bytes + serializedBytes > maxBytes)) {
+    if (selectedCount > 0 && bytes + serializedBytes > maxBytes) {
       break;
     }
     selectedStart = displayPosition;

--- a/src/gateway/cli-session-history.claude-snapshot.ts
+++ b/src/gateway/cli-session-history.claude-snapshot.ts
@@ -85,7 +85,14 @@ async function parseSnapshot(filePath: string, params: HistoryParams): Promise<r
       // Ignore malformed external history entries.
     }
   }
-  return Object.freeze(messages);
+  const redacted: Message[] = [];
+  for (const [index, message] of messages.entries()) {
+    if (index % 32 === 0) {
+      await yieldToEventLoop();
+    }
+    redacted.push(redactClaudeCliHistoryMessage(message));
+  }
+  return Object.freeze(redacted);
 }
 
 export async function readClaudeCliSessionMessagesAsync(params: HistoryParams): Promise<Message[]> {
@@ -107,13 +114,13 @@ export async function readClaudeCliSessionMessagesAsync(params: HistoryParams): 
     }
     return [];
   }
-  const redacted: Message[] = [];
+  const messages: Message[] = [];
   for (const [index, message] of snapshot.entries()) {
     if (index % 32 === 0) {
       await yieldToEventLoop();
     }
-    // Redaction and downstream merge/projection are pure; only the frozen array is shared.
-    redacted.push(redactClaudeCliHistoryMessage(message));
+    // The process cache owns redacted objects; callers receive isolated mutable copies.
+    messages.push(structuredClone(message));
   }
-  return redacted;
+  return messages;
 }

--- a/src/gateway/cli-session-history.claude-snapshot.ts
+++ b/src/gateway/cli-session-history.claude-snapshot.ts
@@ -1,18 +1,62 @@
 import fs from "node:fs";
 import readline from "node:readline";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { Worker } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { CliSessionReseedReceipt } from "../config/sessions.js";
 import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
 import {
   appendCoalescedClaudeCliToolMessage,
   createClaudeReseedImportState,
   decodeClaudeCliProjectEntry,
+  type ClaudeCliProjectEntry,
   parseClaudeCliHistoryEntry,
   redactClaudeCliHistoryMessage,
   resolveClaudeCliSessionFilePath,
 } from "./cli-session-history.claude.js";
 
 const YIELD_BYTES = 256 * 1024;
+const OFFTHREAD_JSONL_LINE_CHARS = 1024 * 1024;
+const OVERSIZED_HISTORY_PLACEHOLDER =
+  "[Claude CLI history record omitted from context because it exceeded 1 MiB.]";
+const OVERSIZED_ENTRY_WORKER_SOURCE = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  const boundedString = (value, max) =>
+    typeof value === "string" && value.length <= max ? value : undefined;
+  try {
+    const entry = JSON.parse(workerData);
+    const type = entry?.type;
+    const message = entry?.message;
+    if ((type !== "user" && type !== "assistant") || !message || message.role !== type) {
+      parentPort.postMessage(null);
+    } else {
+      const rawUsage = message.usage;
+      const usage = rawUsage && typeof rawUsage === "object"
+        ? Object.fromEntries(
+            ["input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"]
+              .flatMap((key) => Number.isFinite(rawUsage[key]) ? [[key, rawUsage[key]]] : []),
+          )
+        : undefined;
+      parentPort.postMessage({
+        type,
+        timestamp: boundedString(entry.timestamp, 128),
+        uuid: boundedString(entry.uuid, 1_024),
+        isSidechain: entry.isSidechain === true,
+        isMeta: entry.isMeta === true,
+        isCompactSummary: entry.isCompactSummary === true,
+        message: {
+          role: type,
+          content: ${JSON.stringify(OVERSIZED_HISTORY_PLACEHOLDER)},
+          model: boundedString(message.model, 256),
+          stop_reason: boundedString(message.stop_reason, 128),
+          usage,
+        },
+      });
+    }
+  } catch {
+    parentPort.postMessage(null);
+  }
+`;
 type Message = Record<string, unknown>;
 type HistoryParams = {
   cliSessionId: string;
@@ -21,6 +65,63 @@ type HistoryParams = {
   reseedReceipt?: CliSessionReseedReceipt;
 };
 let snapshotCache: { key: string; pending: Promise<readonly Message[]> } | undefined;
+
+function normalizeOversizedEntry(value: unknown): ClaudeCliProjectEntry | null {
+  if (!isRecord(value) || (value.type !== "user" && value.type !== "assistant")) {
+    return null;
+  }
+  const message = value.message;
+  if (!isRecord(message) || message.role !== value.type) {
+    return null;
+  }
+  const usage = isRecord(message.usage) ? message.usage : undefined;
+  return {
+    type: value.type,
+    ...(typeof value.timestamp === "string" ? { timestamp: value.timestamp } : {}),
+    ...(typeof value.uuid === "string" ? { uuid: value.uuid } : {}),
+    ...(value.isSidechain === true ? { isSidechain: true } : {}),
+    ...(value.isMeta === true ? { isMeta: true } : {}),
+    ...(value.isCompactSummary === true ? { isCompactSummary: true } : {}),
+    message: {
+      role: value.type,
+      content: OVERSIZED_HISTORY_PLACEHOLDER,
+      ...(typeof message.model === "string" ? { model: message.model } : {}),
+      ...(typeof message.stop_reason === "string" ? { stop_reason: message.stop_reason } : {}),
+      ...(usage
+        ? {
+            usage: {
+              input_tokens: usage.input_tokens,
+              output_tokens: usage.output_tokens,
+              cache_read_input_tokens: usage.cache_read_input_tokens,
+              cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+async function decodeOversizedClaudeEntry(line: string): Promise<ClaudeCliProjectEntry | null> {
+  let worker: Worker;
+  try {
+    worker = new Worker(OVERSIZED_ENTRY_WORKER_SOURCE, { eval: true, workerData: line });
+  } catch {
+    return null;
+  }
+  return await new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(normalizeOversizedEntry(value));
+    };
+    worker.once("message", finish);
+    worker.once("error", () => finish(null));
+    worker.once("exit", () => finish(null));
+  });
+}
 
 function fingerprint(stats: fs.Stats): string {
   return [stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs].join(":");
@@ -62,17 +163,30 @@ async function parseSnapshot(filePath: string, params: HistoryParams): Promise<r
   let lineNumber = 0;
   for await (const line of lines) {
     lineNumber += 1;
-    bytesSinceYield += Buffer.byteLength(line, "utf8") + 1;
-    if (bytesSinceYield >= YIELD_BYTES) {
+    const oversized = line.length > OFFTHREAD_JSONL_LINE_CHARS;
+    if (oversized) {
       bytesSinceYield = 0;
-      await yieldToEventLoop();
-    }
-    if (!line.trim()) {
-      continue;
+    } else {
+      bytesSinceYield += Buffer.byteLength(line, "utf8") + 1;
+      if (bytesSinceYield >= YIELD_BYTES) {
+        bytesSinceYield = 0;
+        await yieldToEventLoop();
+      }
+      if (!line.trim()) {
+        continue;
+      }
     }
     try {
+      // Keep large valid user/assistant records visible through a bounded projection;
+      // unsupported external records are still ignored, but JSON.parse runs off-loop.
+      const entry = oversized
+        ? await decodeOversizedClaudeEntry(line)
+        : decodeClaudeCliProjectEntry(line);
+      if (!entry) {
+        continue;
+      }
       const message = parseClaudeCliHistoryEntry(
-        decodeClaudeCliProjectEntry(line),
+        entry,
         params.cliSessionId,
         lineNumber,
         toolNames,

--- a/src/gateway/cli-session-history.claude-snapshot.ts
+++ b/src/gateway/cli-session-history.claude-snapshot.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import readline from "node:readline";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import type { CliSessionReseedReceipt } from "../config/sessions.js";
+import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
+import {
+  appendCoalescedClaudeCliToolMessage,
+  createClaudeReseedImportState,
+  decodeClaudeCliProjectEntry,
+  parseClaudeCliHistoryEntry,
+  redactClaudeCliHistoryMessage,
+  resolveClaudeCliSessionFilePath,
+} from "./cli-session-history.claude.js";
+
+const YIELD_BYTES = 256 * 1024;
+type Message = Record<string, unknown>;
+type HistoryParams = {
+  cliSessionId: string;
+  homeDir?: string;
+  localSessionId?: string;
+  reseedReceipt?: CliSessionReseedReceipt;
+};
+let snapshotCache: { key: string; pending: Promise<readonly Message[]> } | undefined;
+
+function fingerprint(stats: fs.Stats): string {
+  return [stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs].join(":");
+}
+
+async function resolveSource(
+  params: HistoryParams,
+): Promise<readonly [filePath: string, cacheKey: string] | undefined> {
+  const candidate = resolveClaudeCliSessionFilePath(params);
+  if (!candidate) {
+    return undefined;
+  }
+  try {
+    const filePath = await fs.promises.realpath(candidate);
+    const stats = await fs.promises.stat(filePath);
+    const sourceFingerprint = fingerprint(stats);
+    const cacheKey = JSON.stringify([
+      filePath,
+      sourceFingerprint,
+      params.cliSessionId,
+      params.localSessionId?.trim() || null,
+      normalizeCliSessionReseedReceipt(params.reseedReceipt),
+    ]);
+    return [filePath, cacheKey];
+  } catch {
+    return undefined;
+  }
+}
+
+async function parseSnapshot(filePath: string, params: HistoryParams): Promise<readonly Message[]> {
+  const messages: Message[] = [];
+  const toolNames = new Map<string, string>();
+  const lines = readline.createInterface({
+    input: fs.createReadStream(filePath, { encoding: "utf8" }),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+  const reseedState = createClaudeReseedImportState(params);
+  let bytesSinceYield = 0;
+  let lineNumber = 0;
+  for await (const line of lines) {
+    lineNumber += 1;
+    bytesSinceYield += Buffer.byteLength(line, "utf8") + 1;
+    if (bytesSinceYield >= YIELD_BYTES) {
+      bytesSinceYield = 0;
+      await yieldToEventLoop();
+    }
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const message = parseClaudeCliHistoryEntry(
+        decodeClaudeCliProjectEntry(line),
+        params.cliSessionId,
+        lineNumber,
+        toolNames,
+        { reseedMode: "recover", reseedState },
+      );
+      if (message) {
+        appendCoalescedClaudeCliToolMessage(messages, message);
+      }
+    } catch {
+      // Ignore malformed external history entries.
+    }
+  }
+  return Object.freeze(messages);
+}
+
+export async function readClaudeCliSessionMessagesAsync(params: HistoryParams): Promise<Message[]> {
+  const source = await resolveSource(params);
+  if (!source) {
+    return [];
+  }
+  const [filePath, cacheKey] = source;
+  if (snapshotCache?.key !== cacheKey) {
+    snapshotCache = { key: cacheKey, pending: parseSnapshot(filePath, params) };
+  }
+  const pending = snapshotCache.pending;
+  let snapshot: readonly Message[];
+  try {
+    snapshot = await pending;
+  } catch {
+    if (snapshotCache?.pending === pending) {
+      snapshotCache = undefined;
+    }
+    return [];
+  }
+  const redacted: Message[] = [];
+  for (const [index, message] of snapshot.entries()) {
+    if (index % 32 === 0) {
+      await yieldToEventLoop();
+    }
+    // Redaction and downstream merge/projection are pure; only the frozen array is shared.
+    redacted.push(redactClaudeCliHistoryMessage(message));
+  }
+  return redacted;
+}

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -57,12 +57,56 @@ type ReseedImportState = {
   inspectedFirstUser: boolean;
 };
 
+export function decodeClaudeCliProjectEntry(line: string): ClaudeCliProjectEntry {
+  return JSON.parse(line) as ClaudeCliProjectEntry;
+}
+
+export function redactClaudeCliHistoryMessage(
+  message: TranscriptLikeMessage,
+): TranscriptLikeMessage {
+  return redactTranscriptMessage(
+    message as unknown as AgentMessage,
+  ) as unknown as TranscriptLikeMessage;
+}
+
 function resolveHistoryHomeDir(homeDir?: string): string {
   return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
 }
 
 function resolveClaudeProjectsDir(homeDir?: string): string {
   return path.join(resolveHistoryHomeDir(homeDir), CLAUDE_PROJECTS_RELATIVE_DIR);
+}
+
+function normalizeClaudeCliSessionId(value: string): string | undefined {
+  const sessionId = value.trim();
+  return !sessionId ||
+    sessionId === "." ||
+    sessionId === ".." ||
+    path.isAbsolute(sessionId) ||
+    sessionId.includes("/") ||
+    sessionId.includes("\\")
+    ? undefined
+    : sessionId;
+}
+
+function resolveClaudeSessionCandidate(projectDir: string, sessionId: string): string | undefined {
+  const candidate = path.resolve(projectDir, `${sessionId}.jsonl`);
+  return candidate.startsWith(`${path.resolve(projectDir)}${path.sep}`) ? candidate : undefined;
+}
+
+export function createClaudeReseedImportState(params: {
+  localSessionId?: string;
+  reseedReceipt?: CliSessionReseedReceipt;
+}): ReseedImportState {
+  const localSessionId = normalizeOptionalString(params.localSessionId);
+  const normalizedReceipt = normalizeCliSessionReseedReceipt(params.reseedReceipt);
+  return {
+    receipt:
+      normalizedReceipt && normalizedReceipt.localSessionId === localSessionId
+        ? normalizedReceipt
+        : undefined,
+    inspectedFirstUser: false,
+  };
 }
 
 export function resolveClaudeCliBindingSessionId(
@@ -191,19 +235,20 @@ function isUserToolResultMessage(message: unknown): boolean {
 
 function coalesceClaudeCliToolMessages(messages: TranscriptLikeMessage[]): TranscriptLikeMessage[] {
   const coalesced: TranscriptLikeMessage[] = [];
-  for (let index = 0; index < messages.length; index += 1) {
-    const current = messages.at(index);
-    if (current === undefined) {
-      break;
-    }
-    const next = messages[index + 1];
-    if (!isAssistantToolCallMessage(current) || !isUserToolResultMessage(next)) {
-      coalesced.push(current);
-      continue;
-    }
+  for (const message of messages) {
+    appendCoalescedClaudeCliToolMessage(coalesced, message);
+  }
+  return coalesced;
+}
 
-    const callBlocks = getMessageBlocks(current) ?? [];
-    const resultBlocks = getMessageBlocks(next) ?? [];
+export function appendCoalescedClaudeCliToolMessage(
+  messages: TranscriptLikeMessage[],
+  message: TranscriptLikeMessage,
+): void {
+  const prior = messages.at(-1);
+  if (prior && isAssistantToolCallMessage(prior) && isUserToolResultMessage(message)) {
+    const callBlocks = getMessageBlocks(prior) ?? [];
+    const resultBlocks = getMessageBlocks(message) ?? [];
     const callIds = new Set(
       callBlocks.map(resolveToolUseId).filter((id): id is string => Boolean(id)),
     );
@@ -213,18 +258,15 @@ function coalesceClaudeCliToolMessages(messages: TranscriptLikeMessage[]): Trans
         const toolUseId = resolveToolUseId(block);
         return Boolean(toolUseId && callIds.has(toolUseId));
       });
-    if (!allResultsMatch) {
-      coalesced.push(current);
-      continue;
+    if (allResultsMatch) {
+      messages[messages.length - 1] = {
+        ...prior,
+        content: [...callBlocks.map(cloneJsonValue), ...resultBlocks.map(cloneJsonValue)],
+      };
+      return;
     }
-
-    coalesced.push({
-      ...current,
-      content: [...callBlocks.map(cloneJsonValue), ...resultBlocks.map(cloneJsonValue)],
-    });
-    index += 1;
   }
-  return coalesced;
+  messages.push(message);
 }
 
 type ClaudeCliPromptTextCandidate = {
@@ -383,19 +425,12 @@ export function parseClaudeCliHistoryEntry(
   ) as TranscriptLikeMessage;
 }
 
-function resolveClaudeCliSessionFilePath(params: {
+export function resolveClaudeCliSessionFilePath(params: {
   cliSessionId: string;
   homeDir?: string;
 }): string | undefined {
-  const sessionId = params.cliSessionId.trim();
-  if (
-    !sessionId ||
-    sessionId === "." ||
-    sessionId === ".." ||
-    path.isAbsolute(sessionId) ||
-    sessionId.includes("/") ||
-    sessionId.includes("\\")
-  ) {
+  const sessionId = normalizeClaudeCliSessionId(params.cliSessionId);
+  if (!sessionId) {
     return undefined;
   }
   const projectsDir = resolveClaudeProjectsDir(params.homeDir);
@@ -411,12 +446,8 @@ function resolveClaudeCliSessionFilePath(params: {
       continue;
     }
     const projectDir = path.join(projectsDir, entry.name);
-    const candidate = path.resolve(projectDir, `${sessionId}.jsonl`);
-    const resolvedProjectDir = path.resolve(projectDir);
-    if (!candidate.startsWith(`${resolvedProjectDir}${path.sep}`)) {
-      continue;
-    }
-    if (fs.existsSync(candidate)) {
+    const candidate = resolveClaudeSessionCandidate(projectDir, sessionId);
+    if (candidate && fs.existsSync(candidate)) {
       return candidate;
     }
   }
@@ -444,15 +475,7 @@ export function readClaudeCliSessionMessages(params: {
 
   const messages: TranscriptLikeMessage[] = [];
   const toolNameRegistry: ToolNameRegistry = new Map();
-  const localSessionId = normalizeOptionalString(params.localSessionId);
-  const normalizedReceipt = normalizeCliSessionReseedReceipt(params.reseedReceipt);
-  const reseedState: ReseedImportState = {
-    receipt:
-      normalizedReceipt && normalizedReceipt.localSessionId === localSessionId
-        ? normalizedReceipt
-        : undefined,
-    inspectedFirstUser: false,
-  };
+  const reseedState = createClaudeReseedImportState(params);
   const lines = content.split(/\r?\n/);
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex] ?? "";
@@ -460,7 +483,7 @@ export function readClaudeCliSessionMessages(params: {
       continue;
     }
     try {
-      const parsed = JSON.parse(line) as ClaudeCliProjectEntry;
+      const parsed = decodeClaudeCliProjectEntry(line);
       const message = parseClaudeCliHistoryEntry(
         parsed,
         params.cliSessionId,
@@ -481,12 +504,7 @@ export function readClaudeCliSessionMessages(params: {
   const visibleMessages = coalesceClaudeCliToolMessages(messages);
   // Match local transcript persistence before dedupe so imported secrets cannot
   // bypass exact-text matching or reach chat history through the external copy.
-  return visibleMessages.map(
-    (message) =>
-      redactTranscriptMessage(
-        message as unknown as AgentMessage,
-      ) as unknown as TranscriptLikeMessage,
-  );
+  return visibleMessages.map(redactClaudeCliHistoryMessage);
 }
 
 type ClaudeCliCompactBoundaryEntry = {
@@ -563,7 +581,7 @@ export function readClaudeCliFallbackSeed(params: {
     }
     let parsed: ClaudeCliProjectEntry;
     try {
-      parsed = JSON.parse(line) as ClaudeCliProjectEntry;
+      parsed = decodeClaudeCliProjectEntry(line);
     } catch {
       continue;
     }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -320,6 +320,53 @@ describe("cli session history", () => {
     });
   });
 
+  it("projects oversized Claude messages after off-thread parsing", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const oversizedRecord = JSON.stringify({
+        type: "user",
+        uuid: "oversized-user",
+        timestamp: "2026-03-26T16:29:54.700Z",
+        message: { role: "user", content: "q".repeat(2 * 1024 * 1024) },
+      });
+      await fs.writeFile(
+        filePath,
+        `${oversizedRecord}\n${createClaudeTextHistoryLines([
+          { role: "user", uuid: "visible-after-oversized", content: "visible" },
+        ])}`,
+        "utf8",
+      );
+      const parseSpy = vi.spyOn(JSON, "parse");
+      try {
+        const messages = await readChatHistoryCliSessionImportSnapshot({
+          entry: {
+            sessionId: "openclaw-session",
+            updatedAt: Date.now(),
+            cliSessionBindings: { "claude-cli": { sessionId } },
+          },
+          provider: "claude-cli",
+          localMessages: [],
+          homeDir,
+        });
+
+        expect(messages).toHaveLength(2);
+        expectFields(readRecord(messages[0])["__openclaw"], {
+          externalId: "oversized-user",
+        });
+        expect(readRecord(messages[0]).content).toContain("exceeded 1 MiB");
+        expectFields(readRecord(messages[1])["__openclaw"], {
+          externalId: "visible-after-oversized",
+        });
+        expect(
+          parseSpy.mock.calls.some(
+            ([source]) => typeof source === "string" && source.length === oversizedRecord.length,
+          ),
+        ).toBe(false);
+      } finally {
+        parseSpy.mockRestore();
+      }
+    });
+  });
+
   it("preserves Date.parse semantics for numeric-looking Claude timestamps", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       await fs.writeFile(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -1,9 +1,10 @@
 // CLI session history tests protect imported Claude CLI transcript lookup,
 // fallback seeding, reseed receipts, and merge ordering with local chat history.
+import rawFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
@@ -12,6 +13,7 @@ import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
   augmentChatHistoryWithCliSessionImports,
   readClaudeCliFallbackSeed,
+  readChatHistoryCliSessionImportSnapshot,
   resolveChatHistoryWithCliSessionImports,
 } from "./cli-session-history.js";
 import { mergeImportedChatHistoryMessages } from "./cli-session-history.merge.js";
@@ -243,6 +245,74 @@ describe("cli session history", () => {
           tool_use_id: "toolu_123",
         },
       ]);
+    });
+  });
+
+  it("refreshes changed Claude snapshots and singleflights concurrent reads", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const params = {
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: { "claude-cli": { sessionId } },
+        },
+        provider: "claude-cli",
+        localMessages: [],
+        homeDir,
+      };
+      const read = async () =>
+        resolveChatHistoryWithCliSessionImports({
+          ...params,
+          preparedImportedMessages: await readChatHistoryCliSessionImportSnapshot(params),
+        });
+      const streamSpy = vi.spyOn(rawFs, "createReadStream");
+      const initial = await (async () => {
+        try {
+          const [first, second] = await Promise.all([
+            readChatHistoryCliSessionImportSnapshot(params),
+            readChatHistoryCliSessionImportSnapshot(params),
+          ]);
+          expect(second).toEqual(first);
+          expect(streamSpy).toHaveBeenCalledTimes(1);
+          return resolveChatHistoryWithCliSessionImports({
+            ...params,
+            preparedImportedMessages: first,
+          });
+        } finally {
+          streamSpy.mockRestore();
+        }
+      })();
+      expect(initial.messages).toHaveLength(3);
+
+      await fs.appendFile(
+        filePath,
+        `\n${createClaudeTextHistoryLines([
+          { role: "user", uuid: "appended-user", content: "appended" },
+        ])}`,
+        "utf8",
+      );
+      const appended = await read();
+      expect(appended.messages).toHaveLength(4);
+      expect(appended.messages.map((message) => readRecord(message)["__openclaw"])).toContainEqual(
+        expect.objectContaining({ externalId: "appended-user" }),
+      );
+
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines([
+          { role: "assistant", uuid: "replacement-assistant", content: "replacement" },
+        ]),
+        "utf8",
+      );
+      const replaced = await read();
+      expect(replaced.messages).toHaveLength(1);
+      expectFields(readRecord(replaced.messages[0])["__openclaw"], {
+        externalId: "replacement-assistant",
+      });
+
+      await fs.rm(filePath);
+      const deleted = await read();
+      expect(deleted).toEqual({ messages: [], imported: false });
     });
   });
 
@@ -888,6 +958,24 @@ describe("cli session history", () => {
       });
 
       expect(messages).toBe(localMessages);
+      const streamSpy = vi.spyOn(rawFs, "createReadStream");
+      try {
+        await expect(
+          readChatHistoryCliSessionImportSnapshot({
+            entry: {
+              sessionId: "openclaw-session",
+              updatedAt: Date.now(),
+              cliSessionBindings: { "claude-cli": { sessionId } },
+            },
+            provider: "openai",
+            localMessages,
+            homeDir,
+          }),
+        ).resolves.toEqual([]);
+        expect(streamSpy).not.toHaveBeenCalled();
+      } finally {
+        streamSpy.mockRestore();
+      }
     });
   });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -266,6 +266,8 @@ describe("cli session history", () => {
           preparedImportedMessages: await readChatHistoryCliSessionImportSnapshot(params),
         });
       const streamSpy = vi.spyOn(rawFs, "createReadStream");
+      const transcriptRedact = await import("../agents/transcript-redact.js");
+      const redactSpy = vi.spyOn(transcriptRedact, "redactTranscriptMessage");
       const initial = await (async () => {
         try {
           const [first, second] = await Promise.all([
@@ -274,12 +276,14 @@ describe("cli session history", () => {
           ]);
           expect(second).toEqual(first);
           expect(streamSpy).toHaveBeenCalledTimes(1);
+          expect(redactSpy).toHaveBeenCalledTimes(first.length);
           return resolveChatHistoryWithCliSessionImports({
             ...params,
             preparedImportedMessages: first,
           });
         } finally {
           streamSpy.mockRestore();
+          redactSpy.mockRestore();
         }
       })();
       expect(initial.messages).toHaveLength(3);

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -3,6 +3,7 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { getCliSessionBinding } from "../config/sessions/cli-session-binding.js";
+import { readClaudeCliSessionMessagesAsync } from "./cli-session-history.claude-snapshot.js";
 import {
   type ClaudeCliFallbackSeed,
   CLAUDE_CLI_PROVIDER,
@@ -17,40 +18,42 @@ const ANTHROPIC_PROVIDER = "anthropic";
 export { readClaudeCliFallbackSeed, resolveClaudeCliBindingSessionId };
 export type { ClaudeCliFallbackSeed };
 
-type CliSessionHistoryAugmentation = {
-  messages: unknown[];
-  imported: boolean;
-};
-
-/** Resolves chat history plus whether a bound external transcript was actually incorporated. */
-export function resolveChatHistoryWithCliSessionImports(params: {
+type CliSessionHistoryParams = {
   entry: SessionEntry | undefined;
   provider?: string;
   localMessages: unknown[];
   homeDir?: string;
-}): CliSessionHistoryAugmentation {
-  const cliSessionBinding = getCliSessionBinding(params.entry, CLAUDE_CLI_PROVIDER);
-  const cliSessionId = cliSessionBinding?.sessionId;
-  if (!cliSessionId) {
+  preparedImportedMessages?: unknown[];
+};
+
+function resolveEligibleCliSessionBinding(params: CliSessionHistoryParams) {
+  const binding = getCliSessionBinding(params.entry, CLAUDE_CLI_PROVIDER);
+  const provider = normalizeProviderId(params.provider ?? "");
+  const eligible =
+    !provider ||
+    params.localMessages.length === 0 ||
+    provider === CLAUDE_CLI_PROVIDER ||
+    provider === ANTHROPIC_PROVIDER;
+  return binding?.sessionId && eligible ? binding : undefined;
+}
+
+/** Resolves chat history plus whether a bound external transcript was actually incorporated. */
+export function resolveChatHistoryWithCliSessionImports(params: CliSessionHistoryParams): {
+  messages: unknown[];
+  imported: boolean;
+} {
+  const binding = resolveEligibleCliSessionBinding(params);
+  if (!binding) {
     return { messages: params.localMessages, imported: false };
   }
-
-  const normalizedProvider = normalizeProviderId(params.provider ?? "");
-  if (
-    normalizedProvider &&
-    normalizedProvider !== CLAUDE_CLI_PROVIDER &&
-    normalizedProvider !== ANTHROPIC_PROVIDER &&
-    params.localMessages.length > 0
-  ) {
-    return { messages: params.localMessages, imported: false };
-  }
-
-  const importedMessages = readClaudeCliSessionMessages({
-    cliSessionId,
-    homeDir: params.homeDir,
-    localSessionId: params.entry?.sessionId,
-    reseedReceipt: cliSessionBinding.reseedReceipt,
-  });
+  const importedMessages =
+    params.preparedImportedMessages ??
+    readClaudeCliSessionMessages({
+      cliSessionId: binding.sessionId,
+      homeDir: params.homeDir,
+      localSessionId: params.entry?.sessionId,
+      reseedReceipt: binding.reseedReceipt,
+    });
   if (importedMessages.length === 0) {
     return { messages: params.localMessages, imported: false };
   }
@@ -61,6 +64,21 @@ export function resolveChatHistoryWithCliSessionImports(params: {
   return messages.length > params.localMessages.length
     ? { messages, imported: true }
     : { messages: params.localMessages, imported: false };
+}
+
+/** Acquires one request-local redacted view of the process-owned external snapshot. */
+export async function readChatHistoryCliSessionImportSnapshot(
+  params: CliSessionHistoryParams,
+): Promise<unknown[]> {
+  const binding = resolveEligibleCliSessionBinding(params);
+  return binding?.sessionId
+    ? await readClaudeCliSessionMessagesAsync({
+        cliSessionId: binding.sessionId,
+        homeDir: params.homeDir,
+        localSessionId: params.entry?.sessionId,
+        reseedReceipt: binding.reseedReceipt,
+      })
+    : [];
 }
 
 /** Augments local chat history with bound Claude CLI session messages when applicable. */

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -9,6 +9,7 @@ import {
   augmentChatHistoryWithCanvasBlocks,
 } from "../chat-display-projection.js";
 import {
+  readChatHistoryCliSessionImportSnapshot,
   resolveChatHistoryWithCliSessionImports,
   resolveClaudeCliBindingSessionId,
 } from "../cli-session-history.js";
@@ -488,19 +489,27 @@ export async function readChatHistoryPage(params: {
   // The ignore flag must gate this resolver too: the tail-window merge can report
   // imported=true while the full merge below dedupes everything to imported=false,
   // and an ungated re-resolve here would recurse through this branch forever.
+  const importedMessages = params.ignoreCliSessionImports
+    ? []
+    : await readChatHistoryCliSessionImportSnapshot({
+        entry,
+        provider,
+        localMessages: localMessagesWithBoundaryFilter,
+      });
   const cliHistory = params.ignoreCliSessionImports
-    ? { messages: localMessagesWithBoundaryFilter, imported: false as const }
+    ? { messages: localMessagesWithBoundaryFilter, imported: false }
     : resolveChatHistoryWithCliSessionImports({
         entry,
         provider,
         localMessages: localMessagesWithBoundaryFilter,
+        preparedImportedMessages: importedMessages,
       });
   if ((offset !== undefined || messageId) && !cliHistory.imported) {
     return readChatHistoryPage({ ...params, ignoreCliSessionImports: true });
   }
   if (cliHistory.imported) {
-    // The import reader already scans the complete external JSONL. Only after it
-    // succeeds do the matching full local read needed to build a pageable merge.
+    // Reuse this request's redacted external snapshot after the full local read;
+    // re-reading here would duplicate a large import and defeat cross-client singleflight.
     const completeLocalMessages = dropPreSessionStartAnnouncePairs(
       await readSessionMessagesAsync(readScope, {
         mode: "full",
@@ -513,6 +522,7 @@ export async function readChatHistoryPage(params: {
       entry,
       provider,
       localMessages: completeLocalMessages,
+      preparedImportedMessages: importedMessages,
     });
     if (!completeCliHistory.imported) {
       return readChatHistoryPage({ ...params, ignoreCliSessionImports: true });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4846,16 +4846,13 @@ describe("gateway server chat", () => {
         const homeDir = path.join(sessionDir, "home");
         const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
         const secret = "sk-abcdef1234567890-large-snapshot";
-        const ignoredLine = JSON.stringify({
+        const oversizedIgnoredLine = JSON.stringify({
           type: "queue-operation",
           operation: "enqueue",
           sessionId: cliSessionId,
-          content: "q".repeat(2_048),
+          content: "q".repeat(34 * 1024 * 1024),
         });
-        const ignoredBlock = `${ignoredLine}\n`.repeat(
-          Math.ceil((34 * 1024 * 1024) / (Buffer.byteLength(ignoredLine, "utf8") + 1)),
-        );
-        const jsonl = `${ignoredBlock}${[
+        const jsonl = `${oversizedIgnoredLine}\n${[
           JSON.stringify({
             type: "user",
             uuid: "large-snapshot-user",

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4833,6 +4833,115 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat startup and history share a non-blocking large Claude snapshot", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const secondWs = await harness.openWs();
+      const homeEnvSnapshot = captureEnv(["HOME"]);
+      try {
+        await connectOk(secondWs);
+        const sessionDir = await createSessionDir();
+        const sessionId = "sess-claude-cli-large-snapshot";
+        const cliSessionId = "7b8b202c-f6bb-4046-9475-d2f15fd07533";
+        const homeDir = path.join(sessionDir, "home");
+        const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
+        const secret = "sk-abcdef1234567890-large-snapshot";
+        const ignoredLine = JSON.stringify({
+          type: "queue-operation",
+          operation: "enqueue",
+          sessionId: cliSessionId,
+          content: "q".repeat(2_048),
+        });
+        const ignoredBlock = `${ignoredLine}\n`.repeat(
+          Math.ceil((34 * 1024 * 1024) / (Buffer.byteLength(ignoredLine, "utf8") + 1)),
+        );
+        const jsonl = `${ignoredBlock}${[
+          JSON.stringify({
+            type: "user",
+            uuid: "large-snapshot-user",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: { role: "user", content: "large snapshot question" },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            uuid: "large-snapshot-assistant",
+            timestamp: "2026-03-26T16:29:55.500Z",
+            message: {
+              role: "assistant",
+              model: "claude-sonnet-4-6",
+              content: [{ type: "text", text: `large snapshot answer ${secret}` }],
+            },
+          }),
+        ].join("\n")}`;
+        expect(Buffer.byteLength(jsonl, "utf8")).toBeGreaterThan(32 * 1024 * 1024);
+        expect(Buffer.byteLength(jsonl, "utf8")).toBeLessThan(36 * 1024 * 1024);
+        await fs.mkdir(claudeProjectsDir, { recursive: true });
+        await fs.writeFile(path.join(claudeProjectsDir, `${cliSessionId}.jsonl`), jsonl, "utf8");
+        setTestEnvValue("HOME", homeDir);
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, cliSessionId),
+        );
+        await writeMainSessionTranscript(
+          [
+            createTextTranscriptEvent("user", "local sqlite row", {
+              timestamp: Date.parse("2026-03-26T16:29:53.000Z"),
+            }),
+          ],
+          sessionId,
+        );
+
+        let heartbeatTicks = 0;
+        const heartbeat = setInterval(() => {
+          heartbeatTicks += 1;
+        }, 5);
+        const [startup, history] = await Promise.all([
+          rpcReq<{
+            messages?: Array<{ __openclaw?: Record<string, unknown> }>;
+            completeSnapshot?: boolean;
+            hasMore?: boolean;
+            nextOffset?: number;
+            totalMessages?: number;
+          }>(ws, "chat.startup", makeMainSessionParams()),
+          rpcReq<{
+            messages?: Array<{ __openclaw?: Record<string, unknown> }>;
+            completeSnapshot?: boolean;
+            hasMore?: boolean;
+            nextOffset?: number;
+            totalMessages?: number;
+          }>(secondWs, "chat.history", makeMainSessionParams()),
+        ]).finally(() => clearInterval(heartbeat));
+
+        expect(startup.ok).toBe(true);
+        expect(history.ok).toBe(true);
+        expect(heartbeatTicks).toBeGreaterThan(5);
+        expect(startup.payload?.messages).toEqual(history.payload?.messages);
+        const messages = startup.payload?.messages ?? [];
+        expect(messages).toHaveLength(3);
+        expect(JSON.stringify(messages)).not.toContain(secret);
+        for (const externalId of ["large-snapshot-user", "large-snapshot-assistant"]) {
+          expect(messages).toContainEqual(
+            expect.objectContaining({
+              __openclaw: expect.objectContaining({
+                cliSessionId,
+                externalId,
+                importedFrom: "claude-cli",
+              }),
+            }),
+          );
+        }
+        for (const response of [startup, history]) {
+          expect(response.payload?.completeSnapshot).toBe(true);
+          expect(response.payload?.hasMore).toBe(false);
+          expect(response.payload?.nextOffset).toBeUndefined();
+          expect(response.payload?.totalMessages).toBe(3);
+        }
+      } finally {
+        secondWs.close();
+        homeEnvSnapshot.restore();
+      }
+    });
+  });
+
   test("chat.history makes the full local prefix reachable in a claude-cli merge", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening chat with a large SQLite transcript or a bound Claude CLI history could block Gateway startup/history responses. Multiple clients connecting together multiplied the Claude JSONL read and parse work, while SQLite could parse large `event_json` payloads before applying the response byte limit.

## Why This Change Was Made

SQLite history now selects a contiguous suffix from metadata and serialized byte lengths before materializing message or reset/compaction payloads. The recent-tail metadata query reads only the newest `maxMessages` candidates, whose public cap remains below SQLite's bind-variable limit. Reset/compaction payloads are fetched through one event-sequence range joined back to the active-event projection, avoiding both unbounded bindings and abandoned-branch payloads.

Claude CLI history is streamed through a process-owned, strong-fingerprint single-slot snapshot with event-loop yields and cross-client singleflight. Oversized records are parsed in a worker: supported user/assistant records retain their role, external ID, timestamp, and bounded metadata through a visible placeholder, while unsupported external record types remain ignored. Messages are coalesced and redacted before the shared snapshot is frozen; each caller receives isolated clones. A request reuses the same snapshot for both the recent-tail and full-local merge.

The synchronous import API is intentionally retained for `embedded-gateway-stub`, whose injected runtime contract is synchronous. The server Gateway path never performs the external read through that API: it supplies the prepared async snapshot. Both paths share the same parser, tool-call coalescing, reseed, and redaction helpers so their semantics cannot drift independently.

The existing external IDs, reseed handling, redaction, marker ordering, cursor behavior, and terminal imported-snapshot contract remain unchanged. The assertion-safety ratchet is lowered for two removed assertions, and the contributor guidance now records that exact shrink-only ratchet maintenance needs no separate approval.

The PR also repairs a current-main browser test failure exposed by the broad exact-head matrix: eager lazy-registration coverage left two newer command groups real and tore down while their OAuth imports were loading. The test now mocks and awaits every declared group.

## User Impact

Chat startup remains responsive with large histories and concurrent clients instead of serially blocking the Gateway event loop. History content and pagination behavior are unchanged.

Release note: Prevent large local or Claude CLI histories from blocking chat startup.

## Evidence

- Pre-fix payload regression failed by parsing an excluded malformed SQLite payload before the byte cutoff (`SyntaxError` through `readVisibleHistoryRange`).
- Pre-fix binding regressions both failed with `too many SQL variables`: the widened recent-tail metadata query and the boundary payload query.
- Pre-fix inactive-branch regression failed by parsing a malformed abandoned compaction payload between two active sequence bounds; the fixed read joins the active projection.
- Pre-fix oversized-record regression proved the multi-megabyte line reached main-thread `JSON.parse`; the fixed path parses it in a worker and preserves supported record identity through a bounded placeholder.
- Pre-fix cache regression observed six redaction calls for three imported messages across two concurrent readers; the fixed snapshot redacts three times during construction and serves isolated clones.
- SQLite history and marker coverage: 4 dedicated metadata/binding/active-path tests plus 16 active-event tests passed.
- Claude import, redaction, freshness, singleflight, and oversized-record coverage: 47 passed.
- Concurrent 34 MiB single-record Claude history Gateway coverage: 151 tests passed across the owning Gateway files, including the real 5 ms event-loop heartbeat across separate clients.
- Production caller audit: the synchronous API is used by `src/agents/tools/embedded-gateway-stub.ts`; server history passes `preparedImportedMessages` from the async snapshot owner.
- Browser teardown repair: focused coverage passed 28/28 and the full browser plugin suite passed 188 files / 2,577 tests with no teardown errors.
- Full `check:changed`: green across formatting, production/test types, lint, dead exports, import cycles, database guards, extension tests, and ratchets. Remote delegation was unavailable (Blacksmith readiness failure and Daytona memory quota), so trusted-source fallback ran on the prepared local checkout.
- Exact committed branch autoreview through P1: clean, no accepted/actionable findings.
- ClawSweeper rank-up moves addressed: bounded metadata bindings, active-only boundary fetch, redaction before shared caching, off-thread oversized-record projection, and rerun owner/concurrent-history proof.
- Production LOC: +525/-120 (net +405). Tests: +610/-9 (net +601). Docs/tooling: net 0.

AI-assisted; implementation and proof reviewed by the maintainer.
