### PR TITLE
fix(doctor): report unusable cloud worker profiles

### DIFF
--- a/extensions/crabbox/doctor-health-api.ts
+++ b/extensions/crabbox/doctor-health-api.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { resolveOpenClawRoot } from "./src/crabbox-worker-profile.js";
+import {
+  CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+  registerCrabboxWorkerProviderDoctorChecks as registerChecks,
+} from "./src/doctor.js";
+
+const CRABBOX_PLUGIN_ROOT = path.dirname(fileURLToPath(import.meta.url));
+
+export { CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID };
+
+export function registerWorkerProviderDoctorChecks(host: {
+  registerHealthCheck(check: HealthCheck): void;
+}): void {
+  registerChecks({
+    ...host,
+    openclawRoot: resolveOpenClawRoot(CRABBOX_PLUGIN_ROOT),
+  });
+}

--- a/extensions/crabbox/src/crabbox-worker-doctor-runtime.ts
+++ b/extensions/crabbox/src/crabbox-worker-doctor-runtime.ts
@@ -1,0 +1,45 @@
+import { runCommandWithTimeout, type SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+
+const CRABBOX_VERSION_TIMEOUT_MS = 2_000;
+const CRABBOX_VERSION_MAX_OUTPUT_BYTES = 64 * 1024;
+
+type CrabboxVersionProbe =
+  | { status: "supported"; version: string }
+  | { status: "outdated"; version: string }
+  | { status: "indeterminate"; reason: string };
+
+export async function probeCrabboxVersion(binary: string): Promise<CrabboxVersionProbe> {
+  let result: SpawnResult;
+  try {
+    result = await runCommandWithTimeout([binary, "--version"], {
+      killProcessTree: true,
+      maxOutputBytes: CRABBOX_VERSION_MAX_OUTPUT_BYTES,
+      timeoutMs: CRABBOX_VERSION_TIMEOUT_MS,
+    });
+  } catch {
+    return { status: "indeterminate", reason: "version command could not start" };
+  }
+  if (result.termination !== "exit" || result.code !== 0 || result.outputLimitExceeded) {
+    const reason =
+      result.termination === "timeout"
+        ? `version command timed out after ${CRABBOX_VERSION_TIMEOUT_MS} ms`
+        : result.outputLimitExceeded
+          ? "version output exceeded 64 KiB"
+          : result.termination !== "exit"
+            ? `version command did not exit normally (${result.termination})`
+            : `version command exited with code ${result.code ?? "unknown"}`;
+    return { status: "indeterminate", reason };
+  }
+  const match = /(?:^|\s)v?(\d+)\.(\d+)\.(\d+)(?:\s|$)/u.exec(
+    `${result.stdout}\n${result.stderr}`.trim(),
+  );
+  if (!match) {
+    return { status: "indeterminate", reason: "version output was not recognized" };
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  const version = `${major}.${minor}.${patch}`;
+  const supported = major > 0 || (major === 0 && (minor > 41 || (minor === 41 && patch >= 1)));
+  return supported ? { status: "supported", version } : { status: "outdated", version };
+}

--- a/extensions/crabbox/src/crabbox-worker-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-profile.ts
@@ -50,6 +50,8 @@ const CRABBOX_MACHINE_OPTIONS = [
 
 type IsExecutable = (candidate: string) => boolean;
 
+export const CRABBOX_WORKER_PROVIDER_ID = "crabbox";
+
 function requirePositiveDuration(value: unknown, key: string): string {
   const duration = nonEmptyString(value);
   if (!duration || parsePositiveGoDurationNanoseconds(duration) === undefined) {
@@ -230,9 +232,22 @@ export function resolveCrabboxBinary(params: {
   if (params.explicit) {
     return params.explicit;
   }
+  return findCrabboxBinary(params) ?? "crabbox";
+}
+
+export function findCrabboxBinary(params: {
+  explicit?: string;
+  isExecutable?: IsExecutable;
+  openclawRoot: string;
+  pathEnv?: string;
+  platform?: NodeJS.Platform;
+}): string | undefined {
   const platform = params.platform ?? process.platform;
   const isExecutable =
     params.isExecutable ?? ((candidate) => defaultIsExecutable(candidate, platform));
+  if (params.explicit) {
+    return isExecutable(params.explicit) ? params.explicit : undefined;
+  }
   const siblingBase = path.resolve(params.openclawRoot, "../crabbox/bin/crabbox");
   for (const candidate of binaryCandidates(siblingBase, platform)) {
     if (isExecutable(candidate)) {
@@ -252,7 +267,7 @@ export function resolveCrabboxBinary(params: {
       }
     }
   }
-  return "crabbox";
+  return undefined;
 }
 
 export function resolveOpenClawRoot(pluginRoot: string | undefined): string {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1,9 +1,20 @@
 import path from "node:path";
+import type { HealthCheck } from "openclaw/plugin-sdk/health";
 import type { WorkerProfile, WorkerProvider } from "openclaw/plugin-sdk/plugin-entry";
+import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { operationLeaseId, resolveCrabboxBinary } from "./crabbox-worker-profile.js";
+import * as doctorRuntime from "./crabbox-worker-doctor-runtime.js";
+import {
+  findCrabboxBinary,
+  operationLeaseId,
+  resolveCrabboxBinary,
+} from "./crabbox-worker-profile.js";
 import { createCrabboxWorkerProvider, resolveOpenClawRoot } from "./crabbox-worker-provider.js";
+import {
+  CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+  registerCrabboxWorkerProviderDoctorChecks,
+} from "./doctor.js";
 
 const OPERATION_ID = `provision:v2:${"0".repeat(64)}`;
 const LEASE_ID = "cbx_6071fc2062a6";
@@ -1675,6 +1686,25 @@ describe("Crabbox binary resolution", () => {
     ).toBe("crabbox");
   });
 
+  it("distinguishes executable discovery from the dispatch fallback", () => {
+    const explicitBinary = path.resolve(path.sep, "custom", "crabbox");
+
+    expect(
+      findCrabboxBinary({
+        explicit: explicitBinary,
+        openclawRoot: OPENCLAW_ROOT,
+        isExecutable: () => false,
+      }),
+    ).toBeUndefined();
+    expect(
+      findCrabboxBinary({
+        openclawRoot: OPENCLAW_ROOT,
+        pathEnv: path.resolve(path.sep, "not-executable"),
+        isExecutable: () => false,
+      }),
+    ).toBeUndefined();
+  });
+
   it("derives the package root from source and bundled plugin roots", () => {
     expect(resolveOpenClawRoot(path.join(OPENCLAW_ROOT, "extensions", "crabbox"))).toBe(
       OPENCLAW_ROOT,
@@ -1682,5 +1712,147 @@ describe("Crabbox binary resolution", () => {
     expect(resolveOpenClawRoot(path.join(OPENCLAW_ROOT, "dist", "extensions", "crabbox"))).toBe(
       OPENCLAW_ROOT,
     );
+  });
+});
+
+function captureCrabboxDoctorCheck(): HealthCheck {
+  let check: HealthCheck | undefined;
+  registerCrabboxWorkerProviderDoctorChecks({
+    openclawRoot: OPENCLAW_ROOT,
+    registerHealthCheck(value) {
+      check = value;
+    },
+  });
+  if (!check) {
+    throw new Error("Crabbox doctor check was not registered");
+  }
+  return check;
+}
+
+describe("Crabbox worker doctor", () => {
+  it("reports a configured non-executable binary with a profile-specific repair", async () => {
+    const probe = vi.spyOn(doctorRuntime, "probeCrabboxVersion");
+    const binary = path.resolve(path.sep, "nonexistent", "crabbox");
+    try {
+      await expect(
+        captureCrabboxDoctorCheck().detect({
+          cfg: {
+            cloudWorkers: {
+              profiles: {
+                aws: { provider: "crabbox", settings: { binary } },
+              },
+            },
+          },
+          env: { PATH: "" },
+        } as never),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          checkId: CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+          severity: "warning",
+          message: expect.stringContaining('profile "aws"'),
+          path: binary,
+          target: "aws",
+          fixHint: expect.stringContaining("cloudWorkers.profiles.aws.settings.binary"),
+        }),
+      ]);
+      expect(probe).not.toHaveBeenCalled();
+    } finally {
+      probe.mockRestore();
+    }
+  });
+
+  it("emits no finding for a supported configured binary", async () => {
+    const probe = vi
+      .spyOn(doctorRuntime, "probeCrabboxVersion")
+      .mockResolvedValue({ status: "supported", version: "0.41.6" });
+    try {
+      await expect(
+        captureCrabboxDoctorCheck().detect({
+          cfg: {
+            cloudWorkers: {
+              profiles: {
+                aws: { provider: "crabbox", settings: { binary: process.execPath } },
+              },
+            },
+          },
+        } as never),
+      ).resolves.toEqual([]);
+      expect(probe).toHaveBeenCalledOnce();
+    } finally {
+      probe.mockRestore();
+    }
+  });
+
+  it("reports an indeterminate version probe without asserting failure", async () => {
+    const probe = vi.spyOn(doctorRuntime, "probeCrabboxVersion").mockResolvedValue({
+      status: "indeterminate",
+      reason: "version command timed out after 2000 ms",
+    });
+    try {
+      await expect(
+        captureCrabboxDoctorCheck().detect({
+          cfg: {
+            cloudWorkers: {
+              profiles: {
+                aws: { provider: "crabbox", settings: { binary: process.execPath } },
+              },
+            },
+          },
+        } as never),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          severity: "info",
+          message: expect.stringContaining("could not determine its version"),
+          fixHint: expect.stringContaining(`${process.execPath} --version`),
+        }),
+      ]);
+    } finally {
+      probe.mockRestore();
+    }
+  });
+
+  it("does not probe when no Crabbox cloud worker profile is configured", async () => {
+    const probe = vi.spyOn(doctorRuntime, "probeCrabboxVersion");
+    try {
+      await expect(captureCrabboxDoctorCheck().detect({ cfg: {} } as never)).resolves.toEqual([]);
+      expect(probe).not.toHaveBeenCalled();
+    } finally {
+      probe.mockRestore();
+    }
+  });
+});
+
+describe("Crabbox version probe", () => {
+  it.each([
+    { output: "0.41.1\n", expected: { status: "supported", version: "0.41.1" } },
+    { output: "crabbox 0.41.6\n", expected: { status: "supported", version: "0.41.6" } },
+    { output: "0.40.9\n", expected: { status: "outdated", version: "0.40.9" } },
+  ])("classifies $output", async ({ output, expected }) => {
+    const run = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockResolvedValue(commandResult({ stdout: output }));
+    try {
+      await expect(doctorRuntime.probeCrabboxVersion("/opt/crabbox")).resolves.toEqual(expected);
+      expect(run).toHaveBeenCalledWith(
+        ["/opt/crabbox", "--version"],
+        expect.objectContaining({ timeoutMs: 2_000, killProcessTree: true }),
+      );
+    } finally {
+      run.mockRestore();
+    }
+  });
+
+  it("turns timeout into an indeterminate result", async () => {
+    const run = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockResolvedValue(commandResult({ code: 124, termination: "timeout" }));
+    try {
+      await expect(doctorRuntime.probeCrabboxVersion("/opt/crabbox")).resolves.toEqual({
+        status: "indeterminate",
+        reason: "version command timed out after 2000 ms",
+      });
+    } finally {
+      run.mockRestore();
+    }
   });
 });

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -23,6 +23,7 @@ import { createCrabboxHeartbeatManager } from "./crabbox-worker-heartbeat.js";
 import { parseInspectJson, type ParsedInspect } from "./crabbox-worker-inspect.js";
 import {
   buildCrabboxWarmupArgs,
+  CRABBOX_WORKER_PROVIDER_ID,
   listCrabboxMachineOptions,
   nonEmptyString,
   operationLeaseId,
@@ -41,8 +42,6 @@ import {
 } from "./crabbox-worker-timeouts.js";
 
 export { resolveOpenClawRoot } from "./crabbox-worker-profile.js";
-
-const CRABBOX_WORKER_PROVIDER_ID = "crabbox";
 
 const READY_POLL_INTERVAL_MS = 2_000;
 const MAX_ERROR_DETAIL_CHARS = 512;

--- a/extensions/crabbox/src/doctor.ts
+++ b/extensions/crabbox/src/doctor.ts
@@ -1,0 +1,117 @@
+import { getHealthCheck, type HealthCheck, type HealthFinding } from "openclaw/plugin-sdk/health";
+import {
+  asOptionalRecord as readRecord,
+  normalizeOptionalString as nonEmptyString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import * as doctorRuntime from "./crabbox-worker-doctor-runtime.js";
+import { CRABBOX_WORKER_PROVIDER_ID, findCrabboxBinary } from "./crabbox-worker-profile.js";
+
+export const CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID = "crabbox/cloud-worker-profiles";
+
+type CrabboxDoctorRegistrationHost = {
+  readonly openclawRoot: string;
+  readonly registerHealthCheck: (check: HealthCheck) => void;
+};
+
+function finding(params: {
+  profileId: string;
+  message: string;
+  fixHint: string;
+  binary?: string;
+  severity?: "info" | "warning";
+}): HealthFinding {
+  return {
+    checkId: CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+    severity: params.severity ?? "warning",
+    source: "crabbox",
+    message: `Cloud worker profile "${params.profileId}" ${params.message}`,
+    ...(params.binary ? { path: params.binary } : {}),
+    ocPath: `cloudWorkers.profiles.${params.profileId}.settings.binary`,
+    target: params.profileId,
+    requirement: "an executable Crabbox 0.41.1 or newer binary",
+    fixHint: params.fixHint,
+  };
+}
+
+function repairHint(profileId: string, explicitBinary?: string): string {
+  const configPath = `cloudWorkers.profiles.${profileId}.settings.binary`;
+  return explicitBinary
+    ? `Install Crabbox 0.41.1 or newer at ${explicitBinary}, or set ${configPath} to an executable absolute path, then rerun \`openclaw doctor --json\`.`
+    : `Install Crabbox 0.41.1 or newer on the Gateway user's PATH, or set ${configPath} to an executable absolute path, then rerun \`openclaw doctor --json\`.`;
+}
+
+function createCrabboxCloudWorkerProfileCheck(openclawRoot: string): HealthCheck {
+  return {
+    id: CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+    kind: "plugin",
+    description: "Verify configured Crabbox cloud worker binaries before dispatch.",
+    source: "crabbox",
+    async detect(ctx) {
+      const profiles = Object.entries(ctx.cfg.cloudWorkers?.profiles ?? {}).filter(
+        ([, profile]) => profile.provider.trim().toLowerCase() === CRABBOX_WORKER_PROVIDER_ID,
+      );
+      if (profiles.length === 0) {
+        return [];
+      }
+      const probes = new Map<string, ReturnType<typeof doctorRuntime.probeCrabboxVersion>>();
+      const findings: HealthFinding[] = [];
+      for (const [profileId, profile] of profiles) {
+        const explicitBinary = nonEmptyString(readRecord(profile.settings)?.binary);
+        const binary = findCrabboxBinary({
+          ...(explicitBinary ? { explicit: explicitBinary } : {}),
+          openclawRoot,
+          pathEnv: ctx.env?.PATH ?? process.env.PATH,
+        });
+        if (!binary) {
+          findings.push(
+            finding({
+              profileId,
+              ...(explicitBinary ? { binary: explicitBinary } : {}),
+              message: explicitBinary
+                ? `cannot use Crabbox because ${explicitBinary} is not an executable file.`
+                : "cannot resolve an executable Crabbox binary from the Gateway user's PATH.",
+              fixHint: repairHint(profileId, explicitBinary),
+            }),
+          );
+          continue;
+        }
+        let probe = probes.get(binary);
+        if (!probe) {
+          probe = doctorRuntime.probeCrabboxVersion(binary);
+          probes.set(binary, probe);
+        }
+        const result = await probe;
+        if (result.status === "outdated") {
+          findings.push(
+            finding({
+              profileId,
+              binary,
+              message: `uses Crabbox ${result.version}, but cloud workers require 0.41.1 or newer.`,
+              fixHint: repairHint(profileId, explicitBinary),
+            }),
+          );
+        } else if (result.status === "indeterminate") {
+          findings.push(
+            finding({
+              profileId,
+              binary,
+              severity: "info",
+              message: `has an executable Crabbox binary, but Doctor could not determine its version: ${result.reason}.`,
+              fixHint: `Run \`${binary} --version\` and confirm it reports Crabbox 0.41.1 or newer, then rerun \`openclaw doctor --json --severity-min info\`.`,
+            }),
+          );
+        }
+      }
+      return findings;
+    },
+  };
+}
+
+export function registerCrabboxWorkerProviderDoctorChecks(
+  host: CrabboxDoctorRegistrationHost,
+): void {
+  if (getHealthCheck(CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID)) {
+    return;
+  }
+  host.registerHealthCheck(createCrabboxCloudWorkerProfileCheck(host.openclawRoot));
+}

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -73,6 +73,8 @@ const runtime = {
   exit: vi.fn(),
 };
 
+const CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID = "crabbox/cloud-worker-profiles";
+
 describe("runDoctorLintCli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -322,6 +324,53 @@ describe("runDoctorLintCli", () => {
       expect(payload.ok).toBe(true);
       expect(payload.checksRun).toBe(2);
       expect(payload.findings).toEqual([]);
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it("reports an actionable Crabbox profile finding before dispatch", async () => {
+    const binary = "/nonexistent/path/to/crabbox";
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        gateway: { mode: "local", port: 19_001 },
+        cloudWorkers: {
+          profiles: {
+            aws: {
+              provider: "crabbox",
+              install: "bundle",
+              settings: { provider: "aws", class: "standard", binary },
+            },
+          },
+        },
+      },
+      path: "/tmp/openclaw.json",
+    });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: [CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 1,
+        findings: [
+          {
+            checkId: CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID,
+            severity: "warning",
+            path: binary,
+            target: "aws",
+          },
+        ],
+      });
+      expect(payload.findings[0].message).toContain('profile "aws"');
+      expect(payload.findings[0].fixHint).toContain("cloudWorkers.profiles.aws.settings.binary");
     } finally {
       stdout.mockRestore();
     }

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { ProviderPolicySurface } from "../plugins/provider-policy-surface.js";
 import {
   registerBundledHealthChecks,
@@ -14,6 +15,12 @@ const STATE_DEFERRED_CHECK_ID = "memory-core/managed-local-embedding-setup";
 const mocks = vi.hoisted(() => ({
   registerCodexManagedAppServerDoctorChecks: vi.fn(),
   inspectEmbeddingProviderSetup: vi.fn(),
+  loadBundledPluginManifestRegistry: vi.fn(
+    (): PluginManifestRegistry => ({
+      plugins: [],
+      diagnostics: [],
+    }),
+  ),
   loadPluginManifestRegistryForPluginRegistry: vi.fn(() => ({
     plugins: [],
     diagnostics: [],
@@ -21,6 +28,13 @@ const mocks = vi.hoisted(() => ({
   registerCuaDriverDoctorChecks: vi.fn(),
   registerMemoryCoreDoctorChecks: vi.fn(),
   registerPolicyDoctorChecks: vi.fn(),
+  registerWorkerProviderDoctorChecks: vi.fn(),
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync: vi.fn(
+    ({ dirName }: { dirName: string }) =>
+      dirName === "crabbox"
+        ? { registerWorkerProviderDoctorChecks: mocks.registerWorkerProviderDoctorChecks }
+        : null,
+  ),
   loadBundledPluginPublicArtifactModuleSync: vi.fn(({ dirName }: { dirName: string }) =>
     dirName === "memory-core"
       ? {
@@ -44,10 +58,16 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../plugins/plugin-registry.js", () => ({
   loadPluginManifestRegistryForPluginRegistry: mocks.loadPluginManifestRegistryForPluginRegistry,
 }));
+vi.mock("../plugins/manifest-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/manifest-registry.js")>()),
+  loadBundledPluginManifestRegistry: mocks.loadBundledPluginManifestRegistry,
+}));
 vi.mock("../plugins/provider-public-artifacts.js", () => ({
   resolveProviderPolicySurface: mocks.resolveProviderPolicySurface,
 }));
 vi.mock("../plugins/public-surface-loader.js", () => ({
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync:
+    mocks.loadBundledPluginPublicArtifactModuleFromCandidatesSync,
   loadBundledPluginPublicArtifactModuleSync: mocks.loadBundledPluginPublicArtifactModuleSync,
 }));
 
@@ -156,6 +176,7 @@ describe("registerBundledHealthChecks", () => {
     });
     expect(mocks.registerPolicyDoctorChecks).not.toHaveBeenCalled();
     expect(mocks.registerCuaDriverDoctorChecks).not.toHaveBeenCalled();
+    expect(mocks.loadBundledPluginPublicArtifactModuleFromCandidatesSync).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -286,6 +307,50 @@ describe("registerBundledHealthChecks", () => {
     expect(mocks.registerCuaDriverDoctorChecks).toHaveBeenCalledWith({
       registerHealthCheck: expect.any(Function),
     });
+  });
+
+  it("loads configured worker-provider health through its bundled manifest owner", () => {
+    mocks.loadBundledPluginManifestRegistry.mockReturnValueOnce({
+      plugins: [
+        {
+          id: "crabbox",
+          origin: "bundled",
+          contracts: { workerProviders: ["crabbox"] },
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          rootDir: "/bundled/crabbox",
+          source: "/bundled/crabbox/index.js",
+          manifestPath: "/bundled/crabbox/openclaw.plugin.json",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    registerBundledHealthChecks({
+      cfg: { cloudWorkers: { profiles: { aws: { provider: "crabbox" } } } },
+      cwd: workspaceDir,
+    });
+
+    expect(mocks.loadBundledPluginPublicArtifactModuleFromCandidatesSync).toHaveBeenCalledWith({
+      dirName: "crabbox",
+      artifactCandidates: ["doctor-health-api.js"],
+    });
+    expect(mocks.registerWorkerProviderDoctorChecks).toHaveBeenCalledWith({
+      registerHealthCheck: expect.any(Function),
+    });
+  });
+
+  it("does not load health artifacts for a configured provider without a bundled owner", () => {
+    registerBundledHealthChecks({
+      cfg: { cloudWorkers: { profiles: { development: { provider: "static-ssh" } } } },
+      cwd: workspaceDir,
+    });
+
+    expect(mocks.loadBundledPluginPublicArtifactModuleFromCandidatesSync).not.toHaveBeenCalled();
+    expect(mocks.registerWorkerProviderDoctorChecks).not.toHaveBeenCalled();
   });
 
   it("loads managed Codex health when an effective model route selects Codex", () => {

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -4,11 +4,19 @@ import { collectConfiguredAgentHarnessRuntimes } from "../agents/harness-runtime
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginId, normalizePluginsConfig } from "../plugins/config-state.js";
 import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
-import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import {
+  loadBundledPluginManifestRegistry,
+  type PluginManifestRegistry,
+} from "../plugins/manifest-registry.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../plugins/plugin-registry.js";
 import type { InspectEmbeddingProviderSetup } from "../plugins/provider-policy-surface.js";
 import { resolveProviderPolicySurface } from "../plugins/provider-public-artifacts.js";
-import { loadBundledPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
+import {
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync,
+  loadBundledPluginPublicArtifactModuleSync,
+} from "../plugins/public-surface-loader.js";
+import { collectConfiguredWorkerProviderIds } from "../plugins/worker-provider-config.js";
+import { listBundledWorkerProviderOwners } from "../plugins/worker-provider-manifest.js";
 import { getHealthCheck, registerHealthCheck } from "./health-check-registry.js";
 
 type EmbeddingProviderSetupInspectionResult =
@@ -33,6 +41,12 @@ type BundledHealthApi = {
     memoryCoreActive: boolean;
   }) => void;
   registerPolicyDoctorChecks?: (host: { registerHealthCheck: typeof registerHealthCheck }) => void;
+};
+
+type WorkerProviderHealthApi = {
+  registerWorkerProviderDoctorChecks?: (host: {
+    registerHealthCheck: typeof registerHealthCheck;
+  }) => void;
 };
 
 type BundledHealthCheckSelection = {
@@ -126,6 +140,27 @@ export function registerBundledHealthChecks(params: {
       dirName: "cua-computer",
       artifactBasename: "api.js",
     }).registerCuaDriverDoctorChecks?.({ registerHealthCheck });
+  }
+  registerBundledWorkerProviderHealthChecks(params, env);
+}
+
+function registerBundledWorkerProviderHealthChecks(
+  params: { cfg: OpenClawConfig; cwd?: string },
+  env: NodeJS.ProcessEnv,
+): void {
+  const providerIds = collectConfiguredWorkerProviderIds(params.cfg);
+  if (providerIds.length === 0) {
+    return;
+  }
+  const manifestRegistry = loadBundledPluginManifestRegistry({ env });
+  const pluginIds = new Set(
+    listBundledWorkerProviderOwners(manifestRegistry, providerIds).map((owner) => owner.pluginId),
+  );
+  for (const pluginId of pluginIds) {
+    loadBundledPluginPublicArtifactModuleFromCandidatesSync<WorkerProviderHealthApi>({
+      dirName: pluginId,
+      artifactCandidates: ["doctor-health-api.js"],
+    })?.registerWorkerProviderDoctorChecks?.({ registerHealthCheck });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could configure a Crabbox cloud worker profile with a missing binary, pass `openclaw config validate`, and receive no relevant `openclaw doctor` finding until a later session dispatch failed.

Before this change, an isolated profile with `settings.binary: "/nonexistent/path/to/crabbox"` produced:

```text
Config valid: .../openclaw.json
doctor --json: 28 checks run; crabbox/cloud-worker-profiles findings: 0
```

Gateway startup also reached `ready` without a profile-readiness warning. `environments.list` advertised the `aws` profile, while `environments.status` rejected `aws` as an unknown environment ID because that method reports concrete environments, not profile health. The Cloud Worker Desktop path uses the same advertised profile inventory and had the same gap.

Follow-up observed but intentionally not folded into this repair: the minimal reproduction omits Crabbox `ttl` and `idleTimeout`, so the machine-options subcall logs a provider-shape error while `environments.list` still advertises the profile. A separate semantic-profile doctor check can surface that broader provider-settings class without widening this binary-readiness fix.

## Why This Change Was Made

Crabbox owns the readiness policy. A narrow `doctor-health-api` artifact contributes a plugin health check, while core only discovers configured bundled worker-provider owners from manifest metadata and invokes their optional health registrar. No Crabbox identifier or rule is hardcoded into core doctor.

The default check is conservative and local:

- verifies that each configured Crabbox binary resolves to an executable file;
- runs one cached, process-tree-bounded `--version` probe per binary with a 2-second timeout and 64 KiB output cap;
- warns when the version is definitively older than the documented 0.41.1 floor;
- reports timeout, launch failure, nonzero exit, oversized output, or unrecognized output only as informational “could not determine” findings with a manual command.

Deliberately excluded:

- `config validate` remains a shape check, so a binary that will appear later is still valid and the two surfaces do not duplicate one another;
- heartbeat capability is not probed: missing heartbeat is degraded operation rather than an unusable profile, has no released version floor beyond “after 0.43.0,” and the placement path already warns;
- AWS `inspect` is not called because it performs fresh EC2 control-plane reads; doctor makes no cloud-provider API calls;
- dispatch, provider allocation, config schema, and Gateway startup failure behavior are unchanged.

Codex remote-exec status was also checked directly in `openai/codex` at `be6e8eac029b183056b7e4402879f15d2c85f61b` (`codex-rs/exec-server/src/environment.rs:100`): it observes an already-configured exec-server connection without starting or reconnecting one, so it is not a reusable pre-dispatch Crabbox profile probe.

## User Impact

Operators who run `openclaw doctor --lint` or `openclaw doctor --json` now get a profile-specific warning and exact repair command before dispatch when the Crabbox binary is missing, non-executable, or definitively too old. Healthy profiles and installations without cloud workers remain silent for this check.

## Evidence

Built CLI, isolated state directories, free non-default ports, `OPENCLAW_SKIP_CHANNELS=1`, and Discord/Twilio credential variables unset for every run:

```text
no-profile:
  config validate: valid
  text: crabbox/cloud-worker-profiles findings: 0
  json: crabbox/cloud-worker-profiles findings: 0

healthy-profile (/Users/steipete/.local/bin/crabbox 0.41.6):
  config validate: valid
  text: crabbox/cloud-worker-profiles findings: 0
  json: crabbox/cloud-worker-profiles findings: 0

broken-profile (/nonexistent/path/to/crabbox):
  config validate: valid
  text: [warning] crabbox/cloud-worker-profiles /nonexistent/path/to/crabbox - Cloud worker profile "aws" cannot use Crabbox because /nonexistent/path/to/crabbox is not an executable file.
        fix: Install Crabbox 0.41.1 or newer at /nonexistent/path/to/crabbox, or set cloudWorkers.profiles.aws.settings.binary to an executable absolute path, then rerun `openclaw doctor --json`.
  json: one matching warning with target="aws", path="/nonexistent/path/to/crabbox", and ocPath="cloudWorkers.profiles.aws.settings.binary"
```

The post-rebase stdout/stderr captures were inspected separately. Config validation and human-text stderr were empty. Each JSON run also emitted one unrelated current-main `memory-core` owner-authorization diagnostic on stderr; JSON integrity and the Crabbox finding state were unaffected.

Validation:

```text
node scripts/run-vitest.mjs extensions/crabbox/src/crabbox-worker-provider.test.ts src/flows/bundled-health-checks.test.ts src/commands/doctor-lint.test.ts
  3 files, 144 tests passed

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs
  passed all selected core, core-test, extension, and extension-test gates

pnpm build
  passed; doctor-health-api.js present in the built Crabbox plugin surface

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
  clean; no accepted/actionable findings
```

Production LOC: +237/-5 (net +232) | Tests: +287/-1. The production growth is the new generic manifest-owner discovery boundary plus the plugin-owned readiness detector and bounded subprocess contract; no parallel runtime, config, or dispatch path was added.

---

### Rebased over worker node-transport convergence

Rebased onto `0e7f3209f2d` and force-pushed exact head `d581993bfab`. The conflict preserved current main's node-enrollment provider and tests while keeping the shared provider ID needed by doctor.

`identityRefId`, `CRABBOX_KEY_REF_PROVIDER`, and Crabbox's `resolveSshIdentity` remain deleted. They are dead rather than renamed: Crabbox now advertises `worker-turn`, returns `{ node: { deviceId } }`, and core launches turns through `node-worker-tunnel.ts`. The generic SSH tunnel is workspace-only after #125465; no key-reference replacement exists for Crabbox.

The rebuilt three-state proof again shows no Crabbox finding for no-profile and real-binary configs, and exactly one actionable warning for `/nonexistent/path/to/crabbox` in both human text and JSON. `pnpm build` emits `dist/extensions/crabbox/doctor-health-api.js` on the rebased head. Focused tests, the complete local changed gate, and autoreview are clean. The prior unrelated Codex fixture and ratchet notes were removed because their fixes are now upstream and absent from this branch diff.
