### PR TITLE
chore(ci): prune assertion safety baseline

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3217,7 +3217,6 @@ src/infra/delivery-queue-sqlite-namespace.ts	3
 src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-identity-store.ts	1
 src/infra/device-identity.ts	1
 src/infra/device-pairing-store.ts	6
 src/infra/diagnostic-event-listener-presence.ts	3


### PR DESCRIPTION
## What Problem This Solves

Current main removed the last uncommented type assertion from `src/infra/device-identity-store.ts` but retained its count in `config/assertion-safety-baseline.txt`. The baseline-ratchet job now fails every synthetic PR merge with `0 < 1`, including #124269.

## Change

Remove the single stale baseline entry. No production or test behavior changes.

## Evidence

- `node scripts/check-assertion-safety-ratchet.mts --staged --base refs/remotes/source/main` — passed: 4,325 files and 13,769 grandfathered assertions.
- Reproduced in #124269 exact-head CI job `checks-fast-baseline-ratchets`: `src/infra/device-identity-store.ts: 0 < 1`.

This is the named CI-blocker follow-up discovered while landing #124269.
