### PR TITLE
docs(cron): recommend lighter models for routine automation jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -221,6 +221,12 @@ until their tool policy is explicitly edited or the job is recreated.
 
 `--model` sets the job's primary model; it does not replace a session `/model` override, so configured fallback chains still apply on top of it. An unresolved or disallowed model fails the run with an explicit validation error rather than silently falling back to the default. If a job has `--model` but no explicit or configured fallback list, OpenClaw passes an empty fallback override instead of silently appending the agent primary as a hidden retry target.
 
+Pick the model for the job's difficulty, not the agent's default. Routine
+automation - summaries, triage, classification, status checks - runs well on a
+lighter model, which is cheaper and faster per run and adds up across a
+schedule. Keep your default model for jobs that need deep reasoning, and use
+`--fallbacks` when a light primary should escalate on failure.
+
 Model-selection precedence for isolated jobs, highest first:
 
 1. Per-job payload `model` (explicit config; a disallowed model fails the run)

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6120,7 +6120,8 @@ export const en: TranslationMap = {
       model: "Model",
       customModel: "Custom model…",
       modelPlaceholder: "openai/gpt-5.2",
-      modelHelp: "Start typing to pick a known model, or enter a custom one.",
+      modelHelp:
+        "Start typing to pick a known model, or enter a custom one. Routine jobs (summaries, triage, classification) run well on a lighter model — cheaper and faster than your default.",
       thinking: "Reasoning",
       thinkingPlaceholder: "low",
       thinkingHelp: "Use a suggested level or enter a provider-specific value.",


### PR DESCRIPTION
## What Problem This Solves

Operators often let routine automation jobs inherit their expensive main model even when summaries, triage, classification, and status checks do not need its full capability.

## Why This Change Was Made

The cron model-picker help and automation documentation now recommend choosing a lighter model for routine jobs, while pointing operators to `--fallbacks` when a lighter primary should escalate on failure.

## User Impact

Operators get clearer guidance to reduce scheduled-job cost and latency without giving up escalation for harder runs.

## Evidence

- Copy-only change in the cron model picker and automation docs.
- `pnpm ui:i18n:verify` — green.
- `git diff --check` — clean.
