### PR TITLE
chore(ci): prune stale assertion safety allowance

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3217,7 +3217,6 @@ src/infra/delivery-queue-sqlite-namespace.ts	3
 src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-identity-store.ts	1
 src/infra/device-identity.ts	1
 src/infra/device-pairing-store.ts	6
 src/infra/diagnostic-event-listener-presence.ts	3


### PR DESCRIPTION
Related: #124951

## What Problem This Solves

Resolves a problem where pull request CI fails the assertion-safety baseline ratchet after `src/infra/device-identity-store.ts` reached zero grandfathered type assertions. The stale allowance currently blocks #124951 and other PRs tested against the same `main` tree.

## Why This Change Was Made

Remove only the obsolete per-file allowance. The ratchet contract requires baseline entries to shrink when the real count falls; production source and tests are unchanged.

## User Impact

Pull requests no longer fail on this stale CI bookkeeping entry. There is no runtime behavior change.

## Evidence

Before:

```text
$ pnpm check:assertion-safety --base origin/main
Shrink config/assertion-safety-baseline.txt entries (or run with --prune):
  src/infra/device-identity-store.ts: 0 < 1
```

After:

```text
$ node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main
assertion SAFETY ratchet OK: 4325 files, 13769 grandfathered assertions.
```

Diff proof: one baseline deletion; production LOC +0/-0; tests +0/-0.
