### PR TITLE
fix(test): intersect scoped CLI filters with each lane's own scope

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -4,6 +4,8 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
 import { cliProcessTestFiles } from "./vitest/vitest.cli-process-paths.mjs";
 import { createCommandsLightVitestConfig } from "./vitest/vitest.commands-light.config.ts";
+import { createContractsPluginVitestConfig } from "./vitest/vitest.contracts-plugin.config.ts";
+import { pluginContractPatterns } from "./vitest/vitest.contracts-shared.ts";
 import { createPluginSdkLightVitestConfig } from "./vitest/vitest.plugin-sdk-light.config.ts";
 import { createUnitFastFakeTimersVitestConfig } from "./vitest/vitest.unit-fast-fake-timers.config.ts";
 import { createUnitFastIsolatedVitestConfig } from "./vitest/vitest.unit-fast-isolated.config.ts";
@@ -194,6 +196,44 @@ describe("unit-fast vitest lane", () => {
     const testConfig = requireTestConfig(config);
     expect(testConfig.include).toContain("src/plugin-sdk/provider-entry.test.ts");
     expect(testConfig.include).toContain("src/commands/status-overview-values.test.ts");
+  });
+
+  it("keeps excluded stateful files out of directory-scoped CLI runs", () => {
+    // A directory argument must narrow the curated inventory, never replace it with the
+    // directory glob. The lane is non-isolated, so re-admitting an excluded stateful file
+    // pollutes whichever unrelated files share its worker.
+    const otherLaneFiles = new Set([
+      ...getUnitFastTimerTestFiles(),
+      ...getUnitFastIsolatedTestFiles(),
+    ]);
+    for (const dir of ["src/plugins", "src/agents", "src/commands"]) {
+      const testConfig = requireTestConfig(
+        createUnitFastVitestConfig({}, { argv: ["node", "vitest", "run", dir] }),
+      );
+      const include = testConfig.include as string[];
+      const expected = unitFastTestFiles.filter(
+        (file) => file.startsWith(`${dir}/`) && !otherLaneFiles.has(file),
+      );
+
+      expect(include, dir).toEqual(expected);
+      expect(
+        include.filter((entry) => !isUnitFastTestFile(entry)),
+        `${dir} admitted non-unit-fast entries`,
+      ).toEqual([]);
+    }
+
+    const pluginsInclude = requireTestConfig(
+      createUnitFastVitestConfig({}, { argv: ["node", "vitest", "run", "src/plugins"] }),
+    ).include as string[];
+    expect(isUnitFastTestFile("src/plugins/install-persistence.test.ts")).toBe(false);
+    expect(pluginsInclude).not.toContain("src/plugins/install-persistence.test.ts");
+
+    // Glob-scoped lanes keep their own scope too: a parent-directory argument must not widen
+    // contracts-plugin from `contracts/` to every sibling test under `src/plugins`.
+    const contractsInclude = requireTestConfig(
+      createContractsPluginVitestConfig({}, ["node", "vitest", "run", "src/plugins"]),
+    ).include as string[];
+    expect(contractsInclude).toEqual(pluginContractPatterns);
   });
 
   it("keeps obvious stateful files out of the unit-fast lane", () => {

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -132,13 +132,23 @@ function narrowIncludePatterns(
     return null;
   }
 
-  return [
-    ...new Set(
-      candidatePatterns.filter((value) =>
-        includePatterns.some((pattern) => patternsCouldOverlap(value, pattern)),
-      ),
-    ),
-  ];
+  // Narrowing must intersect the CLI selection with the lane's own scope. When the lane is
+  // rooted deeper than the CLI selection, keep the lane: returning the caller's broader
+  // directory pattern re-admits files the lane never owns — `unit-fast` picks up the stateful
+  // files it excludes, and `contracts-*` picks up every sibling test outside `contracts/`.
+  // Both run `isolate: false`, so those extra files share a worker and pollute unrelated ones.
+  const narrowed = new Set<string>();
+  for (const candidate of candidatePatterns) {
+    const candidatePrefix = literalPrefixForGlobPattern(candidate);
+    for (const laneScope of includePatterns) {
+      if (!patternsCouldOverlap(candidate, laneScope)) {
+        continue;
+      }
+      const laneScopePrefix = literalPrefixForGlobPattern(laneScope);
+      narrowed.add(laneScopePrefix.length > candidatePrefix.length ? laneScope : candidate);
+    }
+  }
+  return [...narrowed];
 }
 
 function isPlainRepoRelativePath(value: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers and agents running a directory-scoped test
command (`pnpm test src/plugins`) would hit flaky failures that reproduce in
neither isolation nor CI. Failures moved between files and lanes on every run,
which makes local validation of an unrelated change untrustworthy — I hit this
while verifying a gateway fix earlier today and spent a long time deciding
whether my own change had caused it.

## Why This Change Was Made

`narrowIncludePatterns` returned the caller's CLI pattern whenever it *overlapped*
a lane's include list, rather than intersecting the two. A directory argument
therefore replaced each lane's curated scope with a broad glob:

| lane | intended scope (scoped run) | actual scope before this change |
| --- | --- | --- |
| `unit-fast` | its 60 curated files under `src/plugins` | `src/plugins/**/*.test.*` (all 346) |
| `contracts-plugin` | `src/plugins/contracts/**/*.test.ts` | `src/plugins/**/*.test.*` (all 346) |

Both lanes run `isolate: false`, so every re-admitted file shared a worker with
unrelated files. `unit-fast` re-admitted precisely the files it excludes for being
stateful (module mocking, dynamic import, filesystem state) — e.g.
`src/plugins/install-persistence.test.ts` — and `contracts-plugin` pulled in every
sibling test outside `contracts/`. That is the pollution engine.

The fix keeps the lane's own pattern when it is rooted deeper than the CLI
selection, and the CLI pattern otherwise. Equal-depth selections are unchanged,
so existing `vitest-scoped-config` expectations still hold without edits.

Non-goal: this does not change CI. Unscoped lane runs pass no CLI patterns, so
narrowing returns `null` and the curated lists are used exactly as before.

## User Impact

Directory-scoped test runs are now deterministic and roughly 3x cheaper.
`pnpm test src/plugins` drops from 1171 file-executions to 344 with identical
coverage — the previous number was duplicate execution of the same 346 files
across up to four lanes at once.

## Evidence

Flake rate on `node scripts/run-vitest.mjs src/plugins`, quiet machine:

- **Before:** 2 of 3 runs red. Failures moved around — one run failed 3 tests in
  `install-persistence.test.ts` (`|unit-fast|`), another failed 8 across
  `providers.runtime.consult-current-snapshot.test.ts`, `setup-registry.runtime.test.ts`,
  `plugin-command-runtime.test.ts` and `status-effective-plugin-discovery.test.ts`
  (`|contracts-plugin|`, `|plugins|`).
- **After:** 4 of 4 runs green, `344 passed (344)` / `5363 passed | 1 skipped` every time.

Coverage is unchanged: 346 `*.test.ts` files exist under `src/plugins`; 344 run.
The two not run are `install.npm-spec.e2e.test.ts` and
`wired-hooks-after-tool-call.e2e.test.ts`, excluded by the shared config's
`**/*.e2e.test.ts` rule in every unit lane by design.

CI path unaffected — unscoped `unit-fast` lane: `1257 passed | 2 skipped (1259)`,
`14081 passed`.

Regression test (`test/vitest-unit-fast-config.test.ts`) fails without the fix with
the exact defect:

```
AssertionError: src/plugins: expected [ 'src/plugins/**/*.test.*' ] to deeply equal [ …(60) ]
```

Other scoped lanes verified green: `src/skills` (74 files), `src/config` (239 files).
Owning lane green: `vitest-scoped-config.test.ts` + `vitest-unit-fast-config.test.ts`,
111 tests.

Codex autoreview: clean, no accepted/actionable findings.

Pre-existing unrelated failures in the local `tooling` lane, unchanged by this PR:
`labeler-extension-coverage` (missing `fish-audio`/`qqbot` entries in
`.github/labeler.yml`), plus `package-acceptance-workflow` and
`gateway-ssh-tunnels`, which fail from my local shell/SSH environment rather than
repo state.
