### PR TITLE
docs: cover groupScope in faq and security guide

### DIFF
--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -30,7 +30,7 @@ If Gateway password auth is supplied only at startup, pass the same value with `
 
 **DM/trust model**
 
-- Warns when multiple DM senders share the main session and recommends secure DM mode: `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes. This is cooperative/shared-inbox hardening, not isolation for mutually untrusted operators; split trust boundaries with separate gateways (or separate OS users/hosts) for that.
+- Warns when multiple DM senders share the main session and recommends secure DM mode: `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes. This is cooperative/shared-inbox hardening, not isolation for mutually untrusted operators; split trust boundaries with separate gateways (or separate OS users/hosts) for that. The same caveat applies to `session.groupScope: "main"` bindings, which merge every member of the matched room into the main session — reserve them for trusted rooms (see [Groups](/channels/groups#session-keys)).
 - Emits `security.trust_model.multi_user_heuristic` when config suggests likely shared-user ingress (for example open DM/group policy, configured group targets, or wildcard sender rules) — OpenClaw's default trust model is personal-assistant (one operator), not hostile multi-tenant isolation. For intentional shared-user setups: sandbox all sessions, keep filesystem access workspace-scoped, and keep personal/private identities or credentials off that runtime.
 - Warns when small models (`<=300B` parameters) are used without sandboxing and with web/browser tools enabled.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1090,7 +1090,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
   </Accordion>
 
   <Accordion title="Do groups/threads share context with DMs?">
-    Direct chats collapse to the main session by default. Groups/channels have their own session keys, and Telegram topics / Discord threads are separate sessions. See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
+    Direct chats collapse to the main session by default. Groups/channels get their own session keys unless a route binding sets `session.groupScope: "main"` to merge that room into the main session; Telegram topics / Discord threads are separate sessions. See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
   </Accordion>
 
   <Accordion title="How many workspaces and agents can I create?">


### PR DESCRIPTION
Related: #124965

## What Problem This Solves

A docs audit after #124965 found two stale or missing `session.groupScope` mentions: the FAQ implied groups always use separate sessions, and the CLI security guide omitted the trust caveat for `"main"` bindings.

## Why This Change Was Made

This updates exactly those two passages to describe route-bound main-session sharing and its trusted-room boundary. It does not claim the security audit currently warns about `groupScope`.

## User Impact

Operators can now see when a group shares the main session and why that setting should be reserved for trusted rooms.

## Evidence

- Updated the FAQ group/thread context hunk and the CLI security trust-model hunk.
- `node scripts/check-changed.mjs` (`docs-only` plan)
- `pnpm docs:check-mdx` (774 files passed)
- `pnpm docs:check-links` (6,500 internal links, 0 broken)
- `pnpm docs:check-i18n-glossary`
- `git diff --check`
- Confirmed `docs/channels/groups.md` contains the `## Session keys` heading used by `/channels/groups#session-keys`.

AI-assisted documentation follow-up; autoreview reported no accepted/actionable findings.
