### PR TITLE
fix(slack): honor bot policy for Enterprise Grid messages

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -432,16 +432,59 @@ describe("registerSlackMessageEvents", () => {
     expect(inboundLogLines()).toEqual([]);
   });
 
-  it("drops unsupported enterprise message subtypes before system events or dispatch", async () => {
-    const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
-    await handler({
+  it.each([
+    {
+      name: "message_changed",
       event: makeChangedEvent({ channel: "C123", user: "U123" }),
+      expectedText: "Slack message edited in direct.",
+      expectedContextKey: "slack:message:changed:C123:123.456:Ev-enterprise-subtype",
+    },
+    {
+      name: "message_deleted",
+      event: makeDeletedEvent({ channel: "C123", user: "U123" }),
+      expectedText: "Slack message deleted in direct.",
+      expectedContextKey: "slack:message:deleted:C123:123.456:Ev-enterprise-subtype",
+    },
+  ])(
+    "routes enterprise $name through the authorized system-event path",
+    async ({ event, expectedText, expectedContextKey }) => {
+      const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+      await handler({
+        event,
+        body: { api_app_id: "A_TEST", event_id: "Ev-enterprise-subtype" },
+        context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
+        client: {},
+      });
+
+      expect(handleSlackMessage).not.toHaveBeenCalled();
+      expect(messageQueueMock).toHaveBeenCalledOnce();
+      expect(messageQueueMock).toHaveBeenCalledWith(expectedText, {
+        contextKey: expectedContextKey,
+        sessionKey: "agent:main:main",
+      });
+    },
+  );
+
+  it("passes enterprise thread_broadcast through listener-scoped dispatch", async () => {
+    const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+    const event = makeThreadBroadcastEvent({ channel: "C123", user: "U123" });
+    const client = {};
+    await handler({
+      event,
       body: { api_app_id: "A_TEST" },
       context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
-      client: {},
+      client,
     });
 
-    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    expect(handleSlackMessage).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        source: "message",
+        awaitDispatch: true,
+        eventScope: expect.objectContaining({ teamId: "T111", client }),
+      }),
+    );
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -362,6 +362,18 @@ describe("registerSlackMessageEvents", () => {
 
   it.each([
     {
+      name: "message with bot identity",
+      event: {
+        type: "message",
+        bot_id: "B_OTHER",
+        channel: "C123",
+        channel_type: "channel",
+        user: "U_OTHER",
+        text: "<@U_BOT> hello",
+        ts: "123.456",
+      },
+    },
+    {
       name: "file_share with bot_id",
       event: {
         type: "message",
@@ -385,20 +397,29 @@ describe("registerSlackMessageEvents", () => {
         ts: "123.456",
       },
     },
-  ])("drops enterprise bot-authored $name events before dispatch", async ({ event }) => {
+  ])("passes enterprise bot-authored $name to policy-aware dispatch", async ({ event }) => {
     const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+    const client = {};
     await handler({
       event,
       body: { api_app_id: "A_TEST" },
       context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
-      client: {},
+      client,
     });
 
-    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    expect(handleSlackMessage).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        source: "message",
+        awaitDispatch: true,
+        eventScope: expect.objectContaining({ teamId: "T111", client }),
+      }),
+    );
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("drops bot-authored enterprise app_mention events before dispatch", async () => {
+  it("drops bot-authored enterprise app_mention events in favor of the message event", async () => {
     const { handler, handleSlackMessage } = createEnterpriseHandlers("app_mention");
     await handler({
       event: { ...makeAppMentionEvent(), bot_id: "B_OTHER" },

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -436,13 +436,13 @@ describe("registerSlackMessageEvents", () => {
     {
       name: "message_changed",
       event: makeChangedEvent({ channel: "C123", user: "U123" }),
-      expectedText: "Slack message edited in direct.",
+      expectedText: "Slack message edited in #direct.",
       expectedContextKey: "slack:message:changed:C123:123.456:Ev-enterprise-subtype",
     },
     {
       name: "message_deleted",
       event: makeDeletedEvent({ channel: "C123", user: "U123" }),
-      expectedText: "Slack message deleted in direct.",
+      expectedText: "Slack message deleted in #direct.",
       expectedContextKey: "slack:message:deleted:C123:123.456:Ev-enterprise-subtype",
     },
   ])(

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -250,15 +250,6 @@ export function registerSlackMessageEvents(params: {
       // Subtype handlers do not enter the regular message pipeline. Observe any explicit
       // type here so edits and deletes share the same authoritative conversation cache.
       ctx.rememberSlackChannelType(message.channel, message.channel_type, eventScope);
-      if (
-        eventScope &&
-        message.subtype &&
-        message.subtype !== "file_share" &&
-        message.subtype !== "bot_message"
-      ) {
-        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
-        return;
-      }
       const assistantChangedInbound = resolveAssistantMessageChangedInbound({
         event: message,
         ctx,

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -250,11 +250,12 @@ export function registerSlackMessageEvents(params: {
       // Subtype handlers do not enter the regular message pipeline. Observe any explicit
       // type here so edits and deletes share the same authoritative conversation cache.
       ctx.rememberSlackChannelType(message.channel, message.channel_type, eventScope);
-      if (eventScope && isBotAuthoredEnterpriseEvent(message)) {
-        logVerbose("slack: drop enterprise bot-authored message");
-        return;
-      }
-      if (eventScope && message.subtype && message.subtype !== "file_share") {
+      if (
+        eventScope &&
+        message.subtype &&
+        message.subtype !== "file_share" &&
+        message.subtype !== "bot_message"
+      ) {
         logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
         return;
       }


### PR DESCRIPTION
Closes #125008

## What Problem This Solves

Fixes an issue where Slack Enterprise Grid operators who enabled bot messages and explicitly allowlisted a sender bot would receive no OpenClaw reply when that bot mentioned the app. The listener discarded the canonical bot-authored message before the configured admission policy ran.

The same Enterprise-only prefilter also discarded supported Slack message subtypes before their existing handlers could run.

## Why This Change Was Made

Enterprise listener-scoped `message` events now reach the existing policy-aware dispatch path:

- `bot_message` and bot-identified messages use the normal `allowBots`, channel admission, sender allowlist, mention, and self-message policies.
- `thread_broadcast` uses listener-scoped message dispatch.
- `message_changed` and `message_deleted` use the authorized system-event path.
- `file_share` keeps its existing media-aware handling.
- Other unsupported message subtypes remain rejected by the downstream message handler.

Bot-authored `app_mention` twins remain suppressed in favor of the canonical `message` event, preventing duplicate delivery.

## User Impact

Explicitly enabled and authorized bot-to-bot Slack workflows now work for Enterprise Grid org installations. Enterprise thread broadcasts, edits, and deletions also follow the same established handlers used by workspace installations. This change adds no configuration or public API.

## Evidence

- Before the source change, the focused bot-message regression produced 4 failures because three Enterprise bot-authored `message` shapes and their paired `app_mention` did not reach the intended handlers.
- After the change, `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` passes 186 tests.
- `git diff --check` passes.
- `./node_modules/.bin/oxfmt extensions/slack/src/monitor/events/messages.ts extensions/slack/src/monitor/events/messages.test.ts` passes without changes.
- Branch autoreview reports `autoreview clean: no accepted/actionable findings reported` with overall correctness 0.99.

AI-assisted: Codex traced the event shape to the Enterprise pre-policy guards, prepared the regressions, and validated the patch. I reviewed and understand the change.
