### PR TITLE
fix(config): record why best-effort reads fell back

### DIFF
--- a/src/config/io.best-effort.test.ts
+++ b/src/config/io.best-effort.test.ts
@@ -154,6 +154,29 @@ describe("readBestEffortConfig", () => {
     });
   });
 
+  it("records why an unparseable config was ignored by best-effort reads", async () => {
+    await withTempHome(async (home) => {
+      const configPath = `${home}/.openclaw/openclaw.json`;
+      await fs.mkdir(`${home}/.openclaw`, { recursive: true });
+      await fs.writeFile(configPath, "{ definitely not json", "utf-8");
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const config = await readSourceConfigBestEffort();
+
+        // The fallback value stays {} — but the degradation is recorded.
+        expect(config).toEqual({});
+        expect(
+          warn.mock.calls.some(([line]) =>
+            String(line).includes("best-effort read ignored unparseable config"),
+          ),
+        ).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
   it("preserves Windows case-insensitive env lookup in isolated reads", async () => {
     await withTempHome(async (home) => {
       const mixedCaseKey = "OpenClaw_Config_Path";

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -1,3 +1,4 @@
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   includeContributionOwnsAgentRoster,
   includeContributionOwnsBindings,
@@ -454,21 +455,31 @@ export async function readSourceConfigBestEffortFromContext(
   if (!deps.fs.existsSync(configPath)) {
     return {};
   }
+  // Best-effort legitimizes the fallback value, not the silence: consumers
+  // (update-channel selection, doctor lint) act on the result, so each
+  // degradation records why the real config was not used.
   try {
     const raw = deps.fs.readFileSync(configPath, "utf-8");
     const parsed = parseConfigJson5(raw, deps.json5);
     if (!parsed.ok) {
+      deps.logger.warn(
+        `Config (${configPath}): best-effort read ignored unparseable config: ${parsed.error}`,
+      );
       return {};
     }
     let resolved: unknown;
     try {
       resolved = resolveConfigIncludesForRead(parsed.parsed, configPath, deps);
-    } catch {
+    } catch (err) {
+      deps.logger.warn(
+        `Config (${configPath}): best-effort read skipped $include resolution: ${formatErrorMessage(err)}`,
+      );
       return coerceConfig(parsed.parsed);
     }
     const resolution = resolveConfigForRead(resolved, deps.env, deps.lowerPrecedenceEnv);
     return coerceConfig(resolution.resolvedConfigRaw);
-  } catch {
+  } catch (err) {
+    deps.logger.warn(`Config (${configPath}): best-effort read failed: ${formatErrorMessage(err)}`);
     return {};
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`readSourceConfigBestEffortFromContext` collapsed three distinct failures — JSON5 parse error, `$include` resolution failure, and any other read error — into `{}` (or a root-only config) with zero recorded fact. Its consumers act on the result: `openclaw update status` reads `config.update?.channel` from it, and doctor `--lint` dispatch feeds from the same path. A corrupt config, or an `update.channel` living in an unresolvable `$include`, silently flipped those decisions to defaults — indistinguishable from a missing file. The main snapshot path logs an actionable message (with a `chown` hint for EACCES) for the very same conditions.

## Why This Change Was Made

Root cause: "best effort" legitimized the fallback *value* and the *silence* together. Per the record-facts-at-the-producer doctrine, each degradation branch now warns once with the config path and cause (`ignored unparseable config: …`, `skipped $include resolution: …`, `read failed: …`). The fallback values are unchanged — callers keep their tolerant behavior, operators get the reason.

## User Impact

A corrupt or permission-broken config no longer silently changes update-channel selection or doctor-lint input; the log names the file and the failure.

## Evidence

- New regression in `src/config/io.best-effort.test.ts`: an unparseable config yields `{}` **plus** the recorded warning — fails pre-fix (silent). Suite 12/12.
- tsgo core + core-test shards, oxfmt, oxlint clean.
- Codex autoreview: clean, 0.99 ("patch is correct").
- LOC: prod +13 −2 (three warn lines + invariant comment), test +23.
