### PR TITLE
refactor(channels): finish progress work counter cleanup

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -389,7 +389,7 @@ the final answer, except for the label if one is configured.
 
 | Channel         | Progress transport                     | Notes                                                                                                                                                     |
 | --------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Discord         | Send one message, then edit it.        | `progress` is explicit opt-in; the final answer carries a `-#` activity receipt and the status draft is deleted after the answer lands.                   |
+| Discord         | Send one message, then edit it.        | `progress` is explicit opt-in; the status draft is deleted after the final answer lands.                                                                  |
 | Matrix          | Send one event, then edit it.          | Account-level streaming config controls account-level drafts.                                                                                             |
 | Microsoft Teams | Native Teams stream in personal chats. | `streaming.mode: "block"` maps to Teams block delivery instead.                                                                                           |
 | Slack           | Native stream or editable draft post.  | Needs a reply thread target; top-level DMs without one still get draft preview posts and edits.                                                           |
@@ -405,11 +405,9 @@ full runtime-behavior breakdown per channel.
 When the final answer is ready, OpenClaw tries to keep the chat clean:
 
 - In `progress` mode on Discord, the final answer is sent as a fresh message
-  with a small `-#` activity receipt appended (for example
-  `-# 🧠 2 thoughts · 🛠️ 5 tool calls · ⏱️ 12s`), and the status draft is
-  deleted once that answer is delivered. Busy channels keep no orphaned tool
-  log above the reply; error finals keep the draft as the visible record of
-  the failed turn.
+  and the status draft is deleted once that answer is delivered. Busy channels
+  keep no orphaned tool log above the reply; error finals keep the draft as the
+  visible record of the failed turn.
 - If the draft can safely become the final answer (`partial`/`block` modes),
   OpenClaw edits it in place.
 - If the channel uses native progress streaming, OpenClaw finalizes that

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -257,11 +257,9 @@ Slack-only:
 - `block` mode uses draft chunking (`draftChunk`).
 - Preview streaming is skipped when Discord block streaming is explicitly
   enabled.
-- `progress` mode appends a small `-#` activity receipt (thought/tool-call
-  counts and elapsed time) to the final answer and deletes the status draft
-  once that answer is delivered, so busy channels keep no orphaned tool log
-  above the reply. Error finals keep the draft as the record of the failed
-  turn.
+- `progress` mode deletes the status draft once the final answer is delivered,
+  so busy channels keep no orphaned tool log above the reply. Error finals keep
+  the draft as the record of the failed turn.
 - Final media, error, and explicit-reply payloads cancel pending previews
   without flushing a new draft, then use normal delivery.
 

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
@@ -1,5 +1,5 @@
 import {
-  createChannelProgressReceiptTracker,
+  createChannelProgressWorkCounter,
   formatChannelProgressDraftText,
   type ChannelProgressDraftCompositorSnapshot,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -23,7 +23,7 @@ export function createSlackDraftProgressCardRuntime(params: {
   setup: Pick<SlackDispatchSetup, "account" | "cfg" | "ctx" | "prepared" | "slackClient">;
   draftStream: ReturnType<typeof createSlackDraftStream> | undefined;
   enabled: boolean;
-  progressReceipt: ReturnType<typeof createChannelProgressReceiptTracker>;
+  progressWorkCounter: ReturnType<typeof createChannelProgressWorkCounter>;
   progressSeed: string;
   explicitTitle: string | undefined;
   maxLineChars: number;
@@ -91,8 +91,8 @@ export function createSlackDraftProgressCardRuntime(params: {
       diffStat: snapshot.diffStat,
       ...(state === "working"
         ? {
-            toolCalls: params.progressReceipt.toolCalls,
-            elapsedSeconds: params.progressReceipt.elapsedSeconds,
+            toolCalls: params.progressWorkCounter.toolCalls,
+            elapsedSeconds: params.progressWorkCounter.elapsedSeconds,
           }
         : { sessionUrl: resolveSessionUrl() }),
     });

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -3,7 +3,7 @@ import {
   buildChannelProgressDraftLine,
   buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftCompositor,
-  createChannelProgressReceiptTracker,
+  createChannelProgressWorkCounter,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
   resolveChannelProgressDraftMaxLineChars,
@@ -124,7 +124,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     nativeStreamOrder = run.catch(() => undefined);
     return run;
   };
-  const progressReceipt = createChannelProgressReceiptTracker();
+  const progressWorkCounter = createChannelProgressWorkCounter();
   const progressSeed = `${account.accountId}:${message.channel}`;
   const useDraftProgressCard = Boolean(draftStream) && isProgressMode;
   const explicitProgressTitle = resolveExplicitSlackProgressTitle(account.config);
@@ -133,7 +133,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     setup: { account, cfg, ctx, prepared, slackClient },
     draftStream,
     enabled: useDraftProgressCard,
-    progressReceipt,
+    progressWorkCounter,
     progressSeed,
     explicitTitle: explicitProgressTitle,
     maxLineChars: progressDraftMaxLineChars,
@@ -318,7 +318,7 @@ export function createSlackProgressRuntime(runtimeParams: {
   };
 
   const resetProgressTurnState = () => {
-    progressReceipt.reset();
+    progressWorkCounter.reset();
     nativeNarrationRenderedText = "";
     nativeNarrationSourceText = "";
   };
@@ -661,7 +661,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     suppressDefaultToolProgressMessages,
     progressDraft,
     commentaryProgressEnabled,
-    progressReceipt,
+    progressWorkCounter,
     get nativeProgressCompletionSent() {
       return nativeProgressCompletionSent;
     },

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -543,7 +543,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             await statusReactions.setTool(payload.name);
           }
           if (payload.phase === "start") {
-            progress.progressReceipt.noteToolCall(payload.name);
+            progress.progressWorkCounter.noteToolCall(payload.name);
           }
           return await progress.progressDraft.pushToolEvent(payload);
         },

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createChannelProgressDraftCompositor,
-  createChannelProgressReceiptTracker,
+  createChannelProgressWorkCounter,
   PROGRESS_STATUS_PREAMBLE_FRESH_MS,
 } from "./progress-draft-compositor.js";
 
@@ -25,19 +25,19 @@ const DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS = 1_500;
 describe("createChannelProgressDraftCompositor", () => {
   it("counts only work tool calls and resets per turn", () => {
     let now = 1_000;
-    const receipt = createChannelProgressReceiptTracker({ now: () => now });
+    const work = createChannelProgressWorkCounter({ now: () => now });
 
-    receipt.noteToolCall("exec");
-    receipt.noteToolCall("update_plan");
+    work.noteToolCall("exec");
+    work.noteToolCall("update_plan");
     now = 43_000;
 
-    expect(receipt.toolCalls).toBe(1);
-    expect(receipt.elapsedSeconds).toBe(42);
+    expect(work.toolCalls).toBe(1);
+    expect(work.elapsedSeconds).toBe(42);
 
-    receipt.reset();
+    work.reset();
     now = 43_500;
-    expect(receipt.toolCalls).toBe(0);
-    expect(receipt.elapsedSeconds).toBe(1);
+    expect(work.toolCalls).toBe(0);
+    expect(work.elapsedSeconds).toBe(1);
   });
 
   it("starts immediately for plans, replaces snapshots, and clears them on reset", async () => {

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -34,7 +34,7 @@ import {
   type StreamingMode,
 } from "./streaming.js";
 
-export { createChannelProgressReceiptTracker } from "./progress-receipt-tracker.js";
+export { createChannelProgressWorkCounter } from "./progress-work-counter.js";
 
 // A recent model preamble remains the primary status; utility narration fills
 // the slot only after the model has been quiet for this interval. Exported for

--- a/src/channels/progress-work-counter.ts
+++ b/src/channels/progress-work-counter.ts
@@ -4,7 +4,7 @@ import { isChannelProgressDraftWorkToolName } from "./streaming.js";
  * Per-turn work counters for live channel progress surfaces. These describe the
  * turn while it runs; nothing here survives into the finished transcript.
  */
-export function createChannelProgressReceiptTracker(params?: { now?: () => number }) {
+export function createChannelProgressWorkCounter(params?: { now?: () => number }) {
   const now = params?.now ?? Date.now;
   let startedAt = now();
   let toolCalls = 0;

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -133,7 +133,7 @@ export type {
 } from "../channels/streaming.js";
 export {
   createChannelProgressDraftCompositor,
-  createChannelProgressReceiptTracker,
+  createChannelProgressWorkCounter,
 } from "../channels/progress-draft-compositor.js";
 
 /** @deprecated The streaming.progress.render key was retired (#122927). */


### PR DESCRIPTION
## What Problem This Solves

#124972 landed the Discord and Telegram progress-receipt deletion, completing the behavior precedent from #122976 and #123851. Two frozen-spec cleanup items remained on current `main`:

- the surviving Slack-only live counter was still exported as `createChannelProgressReceiptTracker` from `progress-receipt-tracker.ts`;
- the progress-draft and streaming docs still told operators that Discord appends the deleted `-#` activity receipt.

## Why This Change Was Made

A receipt name is now actively misleading: the surviving object tracks only live tool-call count and elapsed time for Slack's in-flight working footer. The old symbol exists only in beta tags, not stable tags, so the repository compatibility policy says to remove it rather than add an alias or deprecation shim.

This follow-up renames the factory/file to `createChannelProgressWorkCounter` / `progress-work-counter.ts`, migrates the bundled Slack callers, and corrects the two stale docs pages. It does not change the already-landed Discord or Telegram runtime behavior.

## User Impact

No runtime behavior change beyond #124972. Plugin authors on beta-only builds see the accurate work-counter name; operator docs now match shipped progress finalization. There is no config or migration work.

## Evidence

Production code is a pure rename: +41/-41 (net 0). Tests are +9/-9. Docs are +7/-11.

- Slack focused coverage: 173 tests passed.
- Core channel coverage: 43 tests passed.
- `pnpm plugin-sdk:check-exports`: passed.
- `pnpm plugin-sdk:surface:check`: passed.
- `pnpm format:docs:check`: 758 files clean.
- Autoreview: clean, no accepted/actionable findings.
- #124972 exact-head CI: `openclaw/ci-gate` passed on run 31986881214.

The broader receipt-deletion proof was rerun while preparing this follow-up:

```json
{
  "discord": {
    "verdict": "PASS",
    "proofClass": "mocked-process-harness",
    "changedSurfaceTests": 83,
    "adoptedThreadVisibleReply": true,
    "standaloneReceiptFallback": false,
    "mockGatewayAdapterAvailable": false
  },
  "telegram": {
    "verdict": "PASS",
    "proofClass": "mock-provider-ephemeral-gateway-crabline",
    "scenario": "channel-message-flows",
    "channel": "telegram",
    "sequence": "sent -> edited",
    "finalMarker": "QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890",
    "counts": { "passed": 1, "failed": 0, "skipped": 0 }
  }
}
```

The repository currently has no Discord Crabline/mock-gateway adapter: the QA lane matrix rejects `channelDriver=crabline, channel=discord`; Discord QA scenarios require the live private guild. This PR does not build a new QA platform for a rename-only follow-up. Discord behavior is covered by the process-level mocked channel harness and #124972's green exact-head CI.

### Frozen-spec guard verification

1. Discord adopted-thread deletion is safe: `extensions/discord/src/monitor/message-handler.process.ts` reaches finalization only under `activeThreadRoute.threadReplyDelivered && !userFacingFinalDelivered`. The model-owned thread reply is already visible, so dropping the standalone receipt fallback cannot create a silent no-outcome turn.
2. Telegram lifecycle remains complete without a receipt: `teardownProgressWindow` rotates/repositions tool-only drafts (which consumes/reset their lane identity) and otherwise clears the active stream before `resetLaneState`. `deliverProgressCollapseSummary` had no non-receipt lifecycle work and was deleted by #124972.

No golden trace files changed. No changelog entry is required for this rename/docs correction.
