### PR TITLE
fix(ui): inset limited access badge from chat edge

### DIFF
--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -241,6 +241,21 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     const statusChip = page.getByRole("button", { name: "Show limited access details" });
     await statusChip.waitFor();
     expect(await statusChip.getAttribute("aria-expanded")).toBe("false");
+    await waitForLayoutSettled(page, ".content, .scope-upgrade-chip-row");
+    const chipInset = await statusChip.evaluate((chip) => {
+      const content = document.querySelector<HTMLElement>(".content");
+      if (!content) {
+        throw new Error("Missing content around limited-access status chip");
+      }
+      const contentBox = content.getBoundingClientRect();
+      const chipBox = chip.getBoundingClientRect();
+      return {
+        right: contentBox.right - chipBox.right,
+        top: chipBox.top - contentBox.top,
+      };
+    });
+    await captureProof(page, "collapsed.png");
+    expect(chipInset).toEqual({ right: 20, top: 8 });
     expect(await page.getByText("This browser has limited access.", { exact: true }).count()).toBe(
       0,
     );

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -28,6 +28,10 @@
     padding-right: 0;
   }
 
+  .content--chat:has(.chat-workbench) .scope-upgrade-chip-row {
+    padding: 8px 20px 0;
+  }
+
   .content--chat:has(.chat-workbench) .chat {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a limited-access browser saw the collapsed **Limited access** badge sit flush against the top-right window edge in the wide desktop chat workspace.

## Why This Change Was Made

The wide chat workbench intentionally removes the content gutter so its workspace rail can dock to the window edge. This change restores an 8 px top and 20 px right inset only for the limited-access status row, preserving the flush rail layout, and adds a browser-level geometry regression assertion.

## User Impact

The persistent limited-access badge now has deliberate breathing room from the window edges instead of appearing cramped or clipped.

## Evidence

### Before

![Limited access badge flush against the window edge](https://github.com/user-attachments/assets/c4de775a-8e7a-4537-9218-0c707b57d745)

### After

![Limited access badge with top and right inset](https://github.com/user-attachments/assets/81726634-8a6a-4ebc-83a5-8d9f8febce1c)

- Regression proof before the fix: measured `{ right: 0, top: 0 }`; the new assertion expected `{ right: 20, top: 8 }` and failed.
- Focused Chromium E2E after the fix: `ui/src/e2e/device-scope-upgrade.e2e.test.ts` — 11/11 passed.
- `pnpm check:changed` — passed (format, UI/core typechecks, style lint, i18n, dependency and dead-code guards).
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.

AI-assisted by Codex. The implementation and browser evidence were reviewed before submission.
