### PR TITLE
feat(ui): make session references first-class links with titled chips and hovercards

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -513,6 +513,7 @@ enum class GatewayMethod(
   PluginsUninstall("plugins.uninstall"),
   PluginsRefresh("plugins.refresh"),
   ControlUiSessionPullRequestsSubscribe("controlUi.sessionPullRequests.subscribe"),
+  ControlUiSessionPreview("controlUi.sessionPreview"),
   GatewaySuspendPrepare("gateway.suspend.prepare"),
   GatewaySuspendStatus("gateway.suspend.status"),
   GatewaySuspendResume("gateway.suspend.resume"),

--- a/packages/session-url-contract/src/index.ts
+++ b/packages/session-url-contract/src/index.ts
@@ -7,6 +7,8 @@ import {
   parseShortSessionRef,
 } from "./grammar.js";
 
+export { normalizeControlUiBasePath };
+
 // Control UI session URL grammar shared by browser and plugin consumers.
 export type ControlUiSessionNamespace = "chat" | "dashboard";
 

--- a/packages/session-url-contract/src/index.ts
+++ b/packages/session-url-contract/src/index.ts
@@ -18,6 +18,7 @@ type BuildControlUiSessionPathParams = {
   fallbackAgentId?: string;
   basePath?: string;
   displayName?: string;
+  exactKey?: boolean;
   mainKey?: string;
   shortIdLength?: number;
 };
@@ -96,6 +97,17 @@ export function buildControlUiSessionPath(params: BuildControlUiSessionPathParam
   ) {
     return `${namespace}/${encodedAgentId}`;
   }
+  const segments = rest.split(":");
+  if (segments.some((segment) => !segment)) {
+    return null;
+  }
+  if (params.exactKey) {
+    const segment = segments[0] ?? "";
+    return segments.length === 1 &&
+      (isReservedSessionRest(segment, params.mainKey) || parseShortSessionRef(segment))
+      ? `${namespace}/${encodedAgentId}/~key/${encodePathSegment(segment)}`
+      : `${namespace}/${encodedAgentId}/${segments.map(encodePathSegment).join("/")}`;
+  }
   const matchedUuid = parsed?.rest.match(SESSION_UUID_SUFFIX_RE)?.[1];
   const uuid = matchedUuid?.toLowerCase().replaceAll("-", "") ?? null;
   if (uuid) {
@@ -110,10 +122,6 @@ export function buildControlUiSessionPath(params: BuildControlUiSessionPathParam
     return isReservedSessionRest(sessionRef, params.mainKey)
       ? null
       : `${namespace}/${encodedAgentId}/${sessionRef}`;
-  }
-  const segments = rest.split(":");
-  if (segments.some((segment) => !segment)) {
-    return null;
   }
   if (segments.length === 1) {
     const segment = segments[0] ?? "";

--- a/packages/session-url-contract/src/parse.test.ts
+++ b/packages/session-url-contract/src/parse.test.ts
@@ -29,7 +29,13 @@ describe("parseControlUiSessionPath", () => {
     {
       name: "short ref",
       pathname: "/dashboard/main/12345678",
-      expected: { namespace: "dashboard", kind: "short", agentId: "main", shortId: "12345678" },
+      expected: {
+        namespace: "dashboard",
+        kind: "short",
+        agentId: "main",
+        shortId: "12345678",
+        literalSessionKey: "agent:main:12345678",
+      },
     },
     {
       name: "slugged short ref",
@@ -39,6 +45,7 @@ describe("parseControlUiSessionPath", () => {
         kind: "short",
         agentId: "wrong",
         shortId: "1234567890ab",
+        literalSessionKey: "agent:wrong:wrong-slug-1234567890AB",
         slugHint: "wrong-slug",
       },
     },
@@ -164,6 +171,7 @@ describe("parseControlUiSessionPath", () => {
           kind: "short",
           agentId: "main",
           shortId: "12345678",
+          literalSessionKey: "agent:main:deploy-monitor-12345678",
           slugHint: "deploy-monitor",
         },
       ],
@@ -175,5 +183,71 @@ describe("parseControlUiSessionPath", () => {
         expected,
       );
     }
+  });
+
+  it.each([
+    {
+      sessionKey: "agent:main:main",
+      expected: { namespace: "chat", kind: "main", agentId: "main" },
+    },
+    {
+      sessionKey: "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6",
+      expected: {
+        namespace: "chat",
+        kind: "literal",
+        agentId: "roboclaw",
+        sessionKey: "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6",
+      },
+    },
+    {
+      sessionKey: "agent:x:telegram:group:12345",
+      expected: {
+        namespace: "chat",
+        kind: "literal",
+        agentId: "x",
+        sessionKey: "agent:x:telegram:group:12345",
+      },
+    },
+    {
+      sessionKey: "agent:x:discord:direct:9",
+      expected: {
+        namespace: "chat",
+        kind: "literal",
+        agentId: "x",
+        sessionKey: "agent:x:discord:direct:9",
+      },
+    },
+    {
+      sessionKey: "agent:x:standup",
+      expected: {
+        namespace: "chat",
+        kind: "literal",
+        agentId: "x",
+        sessionKey: "agent:x:standup",
+        slugCandidate: "standup",
+      },
+    },
+    {
+      sessionKey: "agent:main:2139bddb-3211-4641-b993-10f619f124e6",
+      expected: {
+        namespace: "chat",
+        kind: "short",
+        agentId: "main",
+        shortId: "10f619f124e6",
+        slugHint: "2139bddb-3211-4641-b993",
+        literalSessionKey: "agent:main:2139bddb-3211-4641-b993-10f619f124e6",
+      },
+    },
+  ] satisfies ReadonlyArray<{
+    sessionKey: string;
+    expected: ControlUiSessionPathTarget;
+  }>)("parses the mechanically composed URL for $sessionKey", ({ sessionKey, expected }) => {
+    const base = "https://gateway.example/control";
+    const url =
+      sessionKey === "agent:main:main"
+        ? `${base}/chat/main`
+        : `${base}/chat/${sessionKey.slice("agent:".length).replaceAll(":", "/")}`;
+
+    expect(parseControlUiSessionPath(new URL(url).pathname, "/control")).toEqual(expected);
   });
 });

--- a/packages/session-url-contract/src/parse.test.ts
+++ b/packages/session-url-contract/src/parse.test.ts
@@ -186,6 +186,32 @@ describe("parseControlUiSessionPath", () => {
   });
 
   it.each([
+    ["agent:main:main", "/chat/main", "main"],
+    ["agent:main:standup", "/chat/main/standup", "literal"],
+    ["agent:main:sessions", "/chat/main/~key/sessions", "literal"],
+    ["agent:main:12345678", "/chat/main/~key/12345678", "literal"],
+    [
+      "agent:main:12345678-90ab-cdef-1234-567890abcdef",
+      "/chat/main/~key/12345678-90ab-cdef-1234-567890abcdef",
+      "literal",
+    ],
+    [
+      "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef",
+      "/chat/main/dashboard/12345678-90ab-cdef-1234-567890abcdef",
+      "literal",
+    ],
+  ] as const)("round-trips exact key %s", (sessionKey, expectedPath, expectedKind) => {
+    const path = buildControlUiSessionPath({ namespace: "chat", sessionKey, exactKey: true });
+
+    expect(path).toBe(expectedPath);
+    const parsed = parseControlUiSessionPath(path ?? "");
+    expect(parsed?.kind).toBe(expectedKind);
+    if (parsed?.kind === "literal") {
+      expect(parsed.sessionKey).toBe(sessionKey);
+    }
+  });
+
+  it.each([
     {
       sessionKey: "agent:main:main",
       agentId: "main",

--- a/packages/session-url-contract/src/parse.test.ts
+++ b/packages/session-url-contract/src/parse.test.ts
@@ -188,10 +188,12 @@ describe("parseControlUiSessionPath", () => {
   it.each([
     {
       sessionKey: "agent:main:main",
+      agentId: "main",
       expected: { namespace: "chat", kind: "main", agentId: "main" },
     },
     {
       sessionKey: "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6",
+      agentId: "roboclaw",
       expected: {
         namespace: "chat",
         kind: "literal",
@@ -201,6 +203,7 @@ describe("parseControlUiSessionPath", () => {
     },
     {
       sessionKey: "agent:x:telegram:group:12345",
+      agentId: "x",
       expected: {
         namespace: "chat",
         kind: "literal",
@@ -210,6 +213,7 @@ describe("parseControlUiSessionPath", () => {
     },
     {
       sessionKey: "agent:x:discord:direct:9",
+      agentId: "x",
       expected: {
         namespace: "chat",
         kind: "literal",
@@ -219,34 +223,36 @@ describe("parseControlUiSessionPath", () => {
     },
     {
       sessionKey: "agent:x:standup",
+      agentId: "x",
       expected: {
         namespace: "chat",
         kind: "literal",
         agentId: "x",
         sessionKey: "agent:x:standup",
-        slugCandidate: "standup",
       },
     },
     {
       sessionKey: "agent:main:2139bddb-3211-4641-b993-10f619f124e6",
+      agentId: "main",
       expected: {
         namespace: "chat",
-        kind: "short",
+        kind: "literal",
         agentId: "main",
-        shortId: "10f619f124e6",
-        slugHint: "2139bddb-3211-4641-b993",
-        literalSessionKey: "agent:main:2139bddb-3211-4641-b993-10f619f124e6",
+        sessionKey: "agent:main:2139bddb-3211-4641-b993-10f619f124e6",
       },
     },
   ] satisfies ReadonlyArray<{
     sessionKey: string;
+    agentId: string;
     expected: ControlUiSessionPathTarget;
-  }>)("parses the mechanically composed URL for $sessionKey", ({ sessionKey, expected }) => {
+  }>)("parses the tool-composed URL for $sessionKey", ({ sessionKey, agentId, expected }) => {
     const base = "https://gateway.example/control";
     const url =
       sessionKey === "agent:main:main"
         ? `${base}/chat/main`
-        : `${base}/chat/${sessionKey.slice("agent:".length).replaceAll(":", "/")}`;
+        : `${base}/chat/${agentId}/~key/${sessionKey
+            .slice(`agent:${agentId}:`.length)
+            .replaceAll(":", "/")}`;
 
     expect(parseControlUiSessionPath(new URL(url).pathname, "/control")).toEqual(expected);
   });

--- a/packages/session-url-contract/src/parse.ts
+++ b/packages/session-url-contract/src/parse.ts
@@ -13,6 +13,8 @@ export type ControlUiSessionPathTarget =
       kind: "short";
       agentId: string;
       shortId: string;
+      /** Exact decoded key candidate for route resolution after a short lookup misses. */
+      literalSessionKey: string;
       /**
        * Display-name slug that preceded the id, when the reference carried one. The id
        * stays authoritative; this only breaks a tie between sessions whose ids share the
@@ -103,7 +105,7 @@ export function parseControlUiSessionPath(
     if (!shortRef) {
       return { namespace, kind: "literal", agentId, sessionKey, slugCandidate: segment };
     }
-    return { namespace, kind: "short", agentId, ...shortRef };
+    return { namespace, kind: "short", agentId, literalSessionKey: sessionKey, ...shortRef };
   }
   return null;
 }

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -169,6 +169,25 @@ describe("openclaw-tools update_plan gating", () => {
     ).toBe(false);
   });
 
+  it("injects reachable Control UI session links into all session lookup tools", () => {
+    const tools = createTestOpenClawTools({
+      config: {
+        gateway: {
+          publicOrigin: "http://127.0.0.1:18789",
+          controlUi: { basePath: " /control/// " },
+        },
+      } as OpenClawConfig,
+      disablePluginTools: true,
+      wrapBeforeToolCallHook: false,
+    });
+    const guidance =
+      "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/` + key without leading `agent:`, with `:` replaced by `/`.";
+
+    for (const name of ["sessions_list", "sessions_history", "sessions_search"]) {
+      expect(expectToolNamed(tools, name).description).toContain(guidance);
+    }
+  });
+
   it("keeps message tool in embedded message-tool-only completions", () => {
     setEmbeddedMode(true);
     const tools = createTestOpenClawTools({

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -181,7 +181,7 @@ describe("openclaw-tools update_plan gating", () => {
       wrapBeforeToolCallHook: false,
     });
     const guidance =
-      "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/` + key without leading `agent:`, with `:` replaced by `/`.";
+      "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/<agentId>/~key/` + key minus `agent:<agentId>:`, with `:` replaced by `/`.";
 
     for (const name of ["sessions_list", "sessions_history", "sessions_search"]) {
       expect(expectToolNamed(tools, name).description).toContain(guidance);

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -9,6 +9,7 @@ import type { ChatType } from "../channels/chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
 import { selectApplicableRuntimeConfig } from "../config/config.js";
+import { resolveControlUiSessionLinkBase } from "../config/control-ui-link-base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
@@ -231,6 +232,7 @@ export function createOpenClawTools(
     ModelAwareToolContext,
 ): AnyAgentTool[] {
   const resolvedConfig = options?.config;
+  const sessionLinkBase = resolveControlUiSessionLinkBase(resolvedConfig);
   const activeProjectKeys = options?.preparedModelRuntime?.activeProjectKeys ?? [];
   const runtimeSnapshot = getActiveSecretsRuntimeConfigSnapshot();
   const availabilityConfig = selectApplicableRuntimeConfig({
@@ -450,6 +452,13 @@ export function createOpenClawTools(
       denylist: explicitFactoryDenylist,
     });
   const effectiveCallGateway = embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest;
+  const sessionLookupToolOptions = {
+    agentSessionKey: options?.agentSessionKey,
+    sandboxed: options?.sandboxed,
+    config: resolvedConfig,
+    callGateway: effectiveCallGateway,
+    sessionLinkBase,
+  };
   const includeUpdatePlanTool = shouldIncludeUpdatePlanToolForOpenClawTools({
     config: resolvedConfig,
     pluginToolDenylist: options?.pluginToolDenylist,
@@ -603,26 +612,14 @@ export function createOpenClawTools(
         ]
       : []),
     createSessionsListTool({
-      agentSessionKey: options?.agentSessionKey,
+      ...sessionLookupToolOptions,
       requesterAgentIdOverride: sessionAgentId,
-      sandboxed: options?.sandboxed,
-      config: resolvedConfig,
-      callGateway: effectiveCallGateway,
     }),
     createSessionsHistoryTool({
-      agentSessionKey: options?.agentSessionKey,
+      ...sessionLookupToolOptions,
       requesterAgentIdOverride: sessionAgentId,
-      sandboxed: options?.sandboxed,
-      config: resolvedConfig,
-      callGateway: effectiveCallGateway,
     }),
-    createSessionsSearchTool({
-      agentId: sessionAgentId,
-      agentSessionKey: options?.agentSessionKey,
-      sandboxed: options?.sandboxed,
-      config: resolvedConfig,
-      callGateway: effectiveCallGateway,
-    }),
+    createSessionsSearchTool({ ...sessionLookupToolOptions, agentId: sessionAgentId }),
     ...(embedded
       ? []
       : [

--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -1,8 +1,47 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeSessionsHistoryTool,
+  describeSessionsListTool,
+  describeSessionsSearchTool,
   describeSessionsSendTool,
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
 } from "./tool-description-presets.js";
+
+const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
+const SESSION_LINK_LINE =
+  "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/` + key without leading `agent:`, with `:` replaced by `/`.";
+const SESSION_DESCRIPTIONS = [
+  {
+    tool: "sessions_list",
+    describe: describeSessionsListTool,
+    original:
+      "List visible sessions; filter kind/label/agentId/search/activity/archive. Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles. Use before history/send target selection.",
+  },
+  {
+    tool: "sessions_history",
+    describe: describeSessionsHistoryTool,
+    original:
+      "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+  },
+  {
+    tool: "sessions_search",
+    describe: describeSessionsSearchTool,
+    original:
+      "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
+  },
+] as const;
+
+describe("session tool link guidance", () => {
+  it.each(SESSION_DESCRIPTIONS)("keeps $tool bytes unchanged without a link base", (entry) => {
+    expect(entry.describe()).toBe(entry.original);
+  });
+
+  it.each(SESSION_DESCRIPTIONS)("appends the shared link rule to $tool", (entry) => {
+    expect(entry.describe({ sessionLinkBase: SESSION_LINK_BASE })).toBe(
+      `${entry.original} ${SESSION_LINK_LINE}`,
+    );
+  });
+});
 
 describe("sessions_send tool description", () => {
   it("distinguishes local context selection from exact external addressing", () => {

--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -9,7 +9,7 @@ import {
 
 const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
 const SESSION_LINK_LINE =
-  "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/` + key without leading `agent:`, with `:` replaced by `/`.";
+  "When pointing the user at a session, cite its Control UI URL: main session -> `http://127.0.0.1:18789/control/chat/<agentId>`; any other display session key -> `http://127.0.0.1:18789/control/chat/<agentId>/~key/` + key minus `agent:<agentId>:`, with `:` replaced by `/`.";
 const SESSION_DESCRIPTIONS = [
   {
     tool: "sessions_list",

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -57,7 +57,7 @@ export function describeSessionVisibilityScope(
 
 type SessionLinkDescriptionOptions = { sessionLinkBase?: string };
 
-function describeSessionLinkLine(base: string): string {
+export function describeSessionLinkRule(base: string): string {
   return `When pointing the user at a session, cite its Control UI URL: main session -> \`${base}/chat/<agentId>\`; any other display session key -> \`${base}/chat/\` + key without leading \`agent:\`, with \`:\` replaced by \`/\`.`;
 }
 
@@ -67,7 +67,7 @@ export function describeSessionsListTool(options?: SessionLinkDescriptionOptions
     "List visible sessions; filter kind/label/agentId/search/activity/archive.",
     "Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles.",
     "Use before history/send target selection.",
-    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
+    ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 
@@ -76,7 +76,7 @@ export function describeSessionsHistoryTool(options?: SessionLinkDescriptionOpti
   return [
     "Read sanitized visible-session history.",
     "Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
-    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
+    ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 
@@ -85,7 +85,7 @@ export function describeSessionsSearchTool(options?: SessionLinkDescriptionOptio
   return [
     "Search your own past sessions for matching user and assistant text.",
     "Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
-    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
+    ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -55,28 +55,37 @@ export function describeSessionVisibilityScope(
   return SESSION_VISIBILITY_SCOPE_COPY[visibility];
 }
 
+type SessionLinkDescriptionOptions = { sessionLinkBase?: string };
+
+function describeSessionLinkLine(base: string): string {
+  return `When pointing the user at a session, cite its Control UI URL: main session -> \`${base}/chat/<agentId>\`; any other display session key -> \`${base}/chat/\` + key without leading \`agent:\`, with \`:\` replaced by \`/\`.`;
+}
+
 /** Describes the sessions_list tool for model-facing instructions. */
-export function describeSessionsListTool(): string {
+export function describeSessionsListTool(options?: SessionLinkDescriptionOptions): string {
   return [
     "List visible sessions; filter kind/label/agentId/search/activity/archive.",
     "Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles.",
     "Use before history/send target selection.",
+    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 
 /** Describes the sessions_history tool for model-facing instructions. */
-export function describeSessionsHistoryTool(): string {
+export function describeSessionsHistoryTool(options?: SessionLinkDescriptionOptions): string {
   return [
     "Read sanitized visible-session history.",
     "Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 
 /** Describes the sessions_search tool for model-facing instructions. */
-export function describeSessionsSearchTool(): string {
+export function describeSessionsSearchTool(options?: SessionLinkDescriptionOptions): string {
   return [
     "Search your own past sessions for matching user and assistant text.",
     "Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
+    ...(options?.sessionLinkBase ? [describeSessionLinkLine(options.sessionLinkBase)] : []),
   ].join(" ");
 }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -58,7 +58,7 @@ export function describeSessionVisibilityScope(
 type SessionLinkDescriptionOptions = { sessionLinkBase?: string };
 
 export function describeSessionLinkRule(base: string): string {
-  return `When pointing the user at a session, cite its Control UI URL: main session -> \`${base}/chat/<agentId>\`; any other display session key -> \`${base}/chat/\` + key without leading \`agent:\`, with \`:\` replaced by \`/\`.`;
+  return `When pointing the user at a session, cite its Control UI URL: main session -> \`${base}/chat/<agentId>\`; any other display session key -> \`${base}/chat/<agentId>/~key/\` + key minus \`agent:<agentId>:\`, with \`:\` replaced by \`/\`.`;
 }
 
 /** Describes the sessions_list tool for model-facing instructions. */

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { callGateway as gatewayCall } from "../../gateway/call.js";
 import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
+import { describeSessionLinkRule } from "../tool-description-presets.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 
 type CallGatewayRequest = Parameters<typeof gatewayCall>[0];
@@ -26,6 +27,8 @@ type HistoryMessage = {
 let createSessionsHistoryTool: typeof import("./sessions-history-tool.js").createSessionsHistoryTool;
 let previousConfigPath: string | undefined;
 let tempDir: string | undefined;
+const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
+const SESSION_LINK_RULE = describeSessionLinkRule(SESSION_LINK_BASE);
 
 function useLoggingConfig(name: string, logging: Record<string, unknown>): void {
   if (!tempDir) {
@@ -58,9 +61,10 @@ async function writeSessionStore(
   return storePath;
 }
 
-function createHistoryToolWithMessage(content: unknown) {
+function createHistoryToolWithMessage(content: unknown, sessionLinkBase?: string) {
   return createSessionsHistoryTool({
     config: {},
+    sessionLinkBase,
     callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
       if (request.method === "chat.history") {
         return {
@@ -134,15 +138,21 @@ describe("sessions_history redaction", () => {
   it("declares complete success and closed error contracts", async () => {
     const tool = createHistoryToolWithMessage("hello");
     const result = await tool.execute("contract", { sessionKey: "main" });
+    const linkedResult = await createHistoryToolWithMessage("hello", SESSION_LINK_BASE).execute(
+      "linked-contract",
+      { sessionKey: "main" },
+    );
 
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
+    expect(result.details).not.toHaveProperty("sessionLinkRule");
+    expect(linkedResult.details).toHaveProperty("sessionLinkRule", SESSION_LINK_RULE);
     expect(Value.Check(tool.outputSchema!, { status: "error", error: "missing" })).toBe(true);
     expect(
       Value.Check(tool.outputSchema!, { status: "forbidden", error: "hidden", extra: true }),
     ).toBe(false);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ bytes: number; contentRedacted: boolean; contentTruncated: boolean; droppedMessages: boolean; messages: Array<unknown>; sessionKey: string; truncated: boolean; hasMore?: boolean; nextOffset?: number; offset?: number; totalMessages?: number } | { error: string; status: "error" | "forbidden" }',
+      '{ bytes: number; contentRedacted: boolean; contentTruncated: boolean; droppedMessages: boolean; messages: Array<unknown>; sessionKey: string; truncated: boolean; hasMore?: boolean; nextOffset?: number; offset?: number; sessionLinkRule?: string; totalMessages?: number } | { error: string; status: "error" | "forbidden" }',
     );
   });
 

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -16,6 +16,7 @@ import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSessionAgentId, resolveSessionAgentIds } from "../agent-scope.js";
 import { optionalPositiveIntegerSchema } from "../schema/typebox.js";
 import {
+  describeSessionLinkRule,
   describeSessionsHistoryTool,
   SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
@@ -66,6 +67,11 @@ const SessionsHistoryOutputSchema = Type.Union([
       contentTruncated: Type.Boolean(),
       contentRedacted: Type.Boolean(),
       bytes: Type.Number(),
+      sessionLinkRule: Type.Optional(
+        Type.String({
+          description: "How to build Control UI URLs for sessionKey values in this result.",
+        }),
+      ),
       offset: Type.Optional(Type.Number()),
       nextOffset: Type.Optional(Type.Number()),
       hasMore: Type.Optional(Type.Boolean()),
@@ -550,6 +556,9 @@ export function createSessionsHistoryTool(opts?: {
         contentTruncated,
         contentRedacted,
         bytes: hardened.bytes,
+        ...(opts?.sessionLinkBase
+          ? { sessionLinkRule: describeSessionLinkRule(opts.sessionLinkBase) }
+          : {}),
         ...pagination,
       });
     },

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -363,12 +363,13 @@ export function createSessionsHistoryTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  sessionLinkBase?: string;
 }): AnyAgentTool {
   return {
     label: "Session History",
     name: "sessions_history",
     displaySummary: SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
-    description: describeSessionsHistoryTool(),
+    description: describeSessionsHistoryTool({ sessionLinkBase: opts?.sessionLinkBase }),
     parameters: SessionsHistoryToolSchema,
     outputSchema: SessionsHistoryOutputSchema,
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -5,8 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildGatewaySessionRow } from "../../gateway/session-utils-row.js";
+import { describeSessionLinkRule } from "../tool-description-presets.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { createSessionsListTool } from "./sessions-list-tool.js";
+
+const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
+const SESSION_LINK_RULE = describeSessionLinkRule(SESSION_LINK_BASE);
 
 const VALID_CONFIG: OpenClawConfig = {
   agents: { entries: { main: { default: true } } },
@@ -380,11 +384,22 @@ describe("sessions-list-tool", () => {
     });
     const tool = createSessionsListTool({ config: VALID_CONFIG });
     const result = await tool.execute("contract", {});
+    const linkedTool = createSessionsListTool({
+      config: VALID_CONFIG,
+      sessionLinkBase: SESSION_LINK_BASE,
+    });
+    const linkedResult = await linkedTool.execute("linked-contract", {});
+    const linkedDetails = linkedResult.details as Record<string, unknown>;
 
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
+    expect(result.details).not.toHaveProperty("sessionLinkRule");
+    expect(linkedDetails.sessionLinkRule).toBe(SESSION_LINK_RULE);
+    expect(linkedTool.description.slice(-SESSION_LINK_RULE.length)).toBe(
+      linkedDetails.sessionLinkRule,
+    );
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
+      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; sessionLinkRule?: string; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
     );
     expect(result.details).toEqual({
       count: 1,

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -148,12 +148,13 @@ export function createSessionsListTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  sessionLinkBase?: string;
 }): AnyAgentTool {
   return {
     label: "Sessions",
     name: "sessions_list",
     displaySummary: SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
-    description: describeSessionsListTool(),
+    description: describeSessionsListTool({ sessionLinkBase: opts?.sessionLinkBase }),
     parameters: SessionsListToolSchema,
     outputSchema: SessionsListOutputSchema,
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -23,6 +23,7 @@ import {
   optionalPositiveIntegerSchema,
 } from "../schema/typebox.js";
 import {
+  describeSessionLinkRule,
   describeSessionsListTool,
   describeSessionVisibilityScope,
   SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
@@ -113,6 +114,11 @@ const SessionsListOutputSchema = Type.Object(
   {
     count: Type.Number(),
     sessions: Type.Array(SessionListRowOutputSchema),
+    sessionLinkRule: Type.Optional(
+      Type.String({
+        description: "How to build Control UI URLs for sessionKey values in this result.",
+      }),
+    ),
     visibility: Type.Optional(
       Type.Object(
         {
@@ -529,6 +535,9 @@ export function createSessionsListTool(opts?: {
       return jsonResult({
         count: rows.length,
         sessions: rows,
+        ...(opts?.sessionLinkBase
+          ? { sessionLinkRule: describeSessionLinkRule(opts.sessionLinkBase) }
+          : {}),
         ...(visibilityMetadata ? { visibility: visibilityMetadata } : {}),
       });
     },

--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -10,10 +10,13 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { callGateway as gatewayCall } from "../../gateway/call.js";
 import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
+import { describeSessionLinkRule } from "../tool-description-presets.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { createSessionsSearchTool } from "./sessions-search-tool.js";
 
 type CallGatewayRequest = Parameters<typeof gatewayCall>[0];
+const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
+const SESSION_LINK_RULE = describeSessionLinkRule(SESSION_LINK_BASE);
 
 function hit(overrides: Record<string, unknown> = {}) {
   return {
@@ -35,6 +38,7 @@ function createTool(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   requests?: CallGatewayRequest[];
+  sessionLinkBase?: string;
   truncated?: boolean;
 }) {
   const config = params.config ?? { tools: { sessions: { visibility: "self" } } };
@@ -49,6 +53,7 @@ function createTool(params: {
     agentId: params.agentId,
     agentSessionKey: params.agentSessionKey,
     sandboxed: params.sandboxed,
+    sessionLinkBase: params.sessionLinkBase,
     callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
       params.requests?.push(request);
       const results = params.results ?? [];
@@ -126,6 +131,10 @@ describe("sessions_search tool", () => {
   it("declares exact success and error result contracts", async () => {
     const tool = createTool({ results: [hit()] });
     const success = await tool.execute("success-contract", { query: "text" });
+    const linkedSuccess = await createTool({
+      results: [hit()],
+      sessionLinkBase: SESSION_LINK_BASE,
+    }).execute("linked-success-contract", { query: "text" });
     const error = await tool.execute("error-contract", {
       query: "text",
       sessionKey: "01234567-89ab-4def-8123-456789abcdef",
@@ -133,10 +142,12 @@ describe("sessions_search tool", () => {
 
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, success.details)).toBe(true);
+    expect(success.details).not.toHaveProperty("sessionLinkRule");
+    expect(linkedSuccess.details).toHaveProperty("sessionLinkRule", SESSION_LINK_RULE);
     expect(error.details).toMatchObject({ status: "error", error: expect.any(String) });
     expect(Value.Check(tool.outputSchema!, error.details)).toBe(true);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ results: Array<{ role: "assistant" | "user"; score: number; sessionKey: string; snippet: string; timestamp: number; messageId?: string; sessionId?: string }>; indexing?: true; truncated?: true } | { error: string; status: "error" | "forbidden" }',
+      '{ results: Array<{ role: "assistant" | "user"; score: number; sessionKey: string; snippet: string; timestamp: number; messageId?: string; sessionId?: string }>; indexing?: true; sessionLinkRule?: string; truncated?: true } | { error: string; status: "error" | "forbidden" }',
     );
   });
 

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -336,13 +336,14 @@ export function createSessionsSearchTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  sessionLinkBase?: string;
 }): AnyAgentTool {
   const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
   return {
     label: "Sessions Search",
     name: "sessions_search",
     displaySummary: SESSIONS_SEARCH_TOOL_DISPLAY_SUMMARY,
-    description: describeSessionsSearchTool(),
+    description: describeSessionsSearchTool({ sessionLinkBase: opts?.sessionLinkBase }),
     parameters: SessionsSearchToolSchema,
     outputSchema: SessionsSearchOutputSchema,
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -13,6 +13,7 @@ import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { optionalPositiveIntegerSchema } from "../schema/typebox.js";
 import {
+  describeSessionLinkRule,
   describeSessionsSearchTool,
   SESSIONS_SEARCH_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
@@ -73,6 +74,11 @@ const SessionsSearchOutputSchema = Type.Union([
   Type.Object(
     {
       results: Type.Array(SessionsSearchHitSchema),
+      sessionLinkRule: Type.Optional(
+        Type.String({
+          description: "How to build Control UI URLs for sessionKey values in this result.",
+        }),
+      ),
       indexing: Type.Optional(Type.Literal(true)),
       truncated: Type.Optional(Type.Literal(true)),
     },
@@ -591,6 +597,9 @@ export function createSessionsSearchTool(opts?: {
       const capped = capSearchHits(limited);
       return jsonResult({
         results: capped.items,
+        ...(opts?.sessionLinkBase
+          ? { sessionLinkRule: describeSessionLinkRule(opts.sessionLinkBase) }
+          : {}),
         ...(indexing ? { indexing: true } : {}),
         ...(backendTruncated || visibleHits.length > limit || capped.truncated
           ? { truncated: true }

--- a/src/config/control-ui-link-base.test.ts
+++ b/src/config/control-ui-link-base.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveControlUiSessionLinkBase } from "./control-ui-link-base.js";
+
+describe("resolveControlUiSessionLinkBase", () => {
+  it("omits session links without a public Gateway origin", () => {
+    expect(resolveControlUiSessionLinkBase({ gateway: {} })).toBeUndefined();
+  });
+
+  it("omits session links when the Control UI is disabled", () => {
+    expect(
+      resolveControlUiSessionLinkBase({
+        gateway: {
+          publicOrigin: "http://127.0.0.1:18789",
+          controlUi: { enabled: false },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("joins a valid public origin with the normalized Control UI base path", () => {
+    expect(
+      resolveControlUiSessionLinkBase({
+        gateway: {
+          publicOrigin: "http://127.0.0.1:18789",
+          controlUi: { basePath: " /control/// " },
+        },
+      }),
+    ).toBe("http://127.0.0.1:18789/control");
+  });
+});

--- a/src/config/control-ui-link-base.test.ts
+++ b/src/config/control-ui-link-base.test.ts
@@ -27,4 +27,33 @@ describe("resolveControlUiSessionLinkBase", () => {
       }),
     ).toBe("http://127.0.0.1:18789/control");
   });
+
+  it("preserves a session link base just under the hard cap", () => {
+    const origin = "http://127.0.0.1:18789";
+    const basePath = `/${"a".repeat(176)}`;
+    const expected = `${origin}${basePath}`;
+    expect(expected).toHaveLength(199);
+    expect(
+      resolveControlUiSessionLinkBase({
+        gateway: { publicOrigin: origin, controlUi: { basePath } },
+      }),
+    ).toBe(expected);
+  });
+
+  it("omits a session link base with an oversized Control UI base path", () => {
+    expect(
+      resolveControlUiSessionLinkBase({
+        gateway: {
+          publicOrigin: "http://127.0.0.1:18789",
+          controlUi: { basePath: `/${"a".repeat(178)}` },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("omits a session link base with an oversized public origin", () => {
+    const publicOrigin = `https://${"a.".repeat(91)}example.com`;
+    expect(publicOrigin).toHaveLength(201);
+    expect(resolveControlUiSessionLinkBase({ gateway: { publicOrigin } })).toBeUndefined();
+  });
 });

--- a/src/config/control-ui-link-base.ts
+++ b/src/config/control-ui-link-base.ts
@@ -1,0 +1,18 @@
+import { normalizeControlUiBasePath } from "@openclaw/session-url-contract";
+import { resolveGatewayPublicOrigin } from "./gateway-public-origin.js";
+import type { OpenClawConfig } from "./types.js";
+
+export function resolveControlUiSessionLinkBase(
+  cfg: Pick<OpenClawConfig, "gateway"> | null | undefined,
+): string | undefined {
+  // Session tool descriptions advertise links only when the operator exposes
+  // a public Gateway origin and the Control UI can serve those session routes.
+  if (cfg?.gateway?.controlUi?.enabled === false) {
+    return undefined;
+  }
+  const origin = resolveGatewayPublicOrigin(cfg);
+  if (!origin) {
+    return undefined;
+  }
+  return `${origin}${normalizeControlUiBasePath(cfg?.gateway?.controlUi?.basePath)}`;
+}

--- a/src/config/control-ui-link-base.ts
+++ b/src/config/control-ui-link-base.ts
@@ -14,5 +14,8 @@ export function resolveControlUiSessionLinkBase(
   if (!origin) {
     return undefined;
   }
-  return `${origin}${normalizeControlUiBasePath(cfg?.gateway?.controlUi?.basePath)}`;
+  const sessionLinkBase = `${origin}${normalizeControlUiBasePath(cfg?.gateway?.controlUi?.basePath)}`;
+  // Model-context budget: bound every model-visible injection at its producer.
+  // Omit oversized bases because truncation would produce incorrect URLs.
+  return sessionLinkBase.length <= 200 ? sessionLinkBase : undefined;
 }

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -85,6 +85,22 @@ export type ControlUiGitHubPreview = {
   updatedAt: string;
 };
 
+/** Bounded session metadata rendered by Control UI session-link hover cards. */
+export type ControlUiSessionPreview =
+  | {
+      status: "ok";
+      sessionKey: string;
+      title?: string;
+      derivedTitle?: string;
+      agentId: string;
+      kind?: string;
+      channel?: string;
+      updatedAt?: number;
+      lastMessagePreview?: string;
+      archived?: boolean;
+    }
+  | { status: "unavailable" };
+
 // Control UI ships inside the gateway dist, so these payloads move in
 // lockstep with the server; shapes here are not independently versioned.
 /** Check-run rollup for a PR head commit, chip pill + CI monitoring popover. */

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -110,6 +110,7 @@ const CURRENT_TRAIN_METHODS = [
   "portal.close",
   "sessions.move",
   "sessions.assignOwner",
+  "controlUi.sessionPreview",
 ] as const;
 
 describe("core gateway method release trains", () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -392,6 +392,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   // Session PR chips read the session's own checkout metadata, matching the
   // sessions.files.* trusted-operator read domain.
   ["controlUi.sessionPullRequests.subscribe", "control-ui", "operator.read", "2026.7"],
+  ["controlUi.sessionPreview", "control-ui", "operator.read", "2026.8"],
   [
     "gateway.suspend.prepare",
     "suspend",

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -1,7 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
-import type { ControlUiGitHubPreview } from "../control-ui-contract.js";
+import type { ControlUiGitHubPreview, ControlUiSessionPreview } from "../control-ui-contract.js";
 import { ControlUiGitHubError } from "../control-ui-github-api.js";
 import { createControlUiHandlers } from "./control-ui.js";
 import type { RespondFn } from "./types.js";
@@ -124,6 +124,79 @@ describe("controlUi.githubPreview", () => {
       message:
         "The configured Control UI GitHub credential is unavailable. Resolve gateway.controlUi.github.token and retry.",
       retryable: false,
+    });
+  });
+});
+
+describe("controlUi.sessionPreview", () => {
+  it("returns bounded, redacted metadata for one session", async () => {
+    const secret = "sk-test-session-preview-secret-1234567890";
+    const loadSessionPreview = vi.fn().mockResolvedValue({
+      sessionKey: "agent:main:research",
+      title: `  ${"T".repeat(240)}  `,
+      derivedTitle: "  Research notes  ",
+      agentId: "main",
+      kind: "direct",
+      channel: "webchat",
+      updatedAt: 1_786_000_000_000,
+      lastMessagePreview: `  OPENAI_API_KEY=${secret} ${"x".repeat(240)}  `,
+      archived: false,
+    });
+    const handlers = createControlUiHandlers(vi.fn(), loadSessionPreview);
+    const respond = vi.fn<RespondFn>();
+
+    await expectDefined(
+      handlers["controlUi.sessionPreview"],
+      'handlers["controlUi.sessionPreview"] test invariant',
+    )(requestOptions({ sessionKey: " agent:main:research " }, respond));
+
+    expect(loadSessionPreview).toHaveBeenCalledWith("agent:main:research", expect.any(Object));
+    const payload = respond.mock.calls[0]?.[1] as ControlUiSessionPreview | undefined;
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(payload).toMatchObject({
+      status: "ok",
+      sessionKey: "agent:main:research",
+      derivedTitle: "Research notes",
+      agentId: "main",
+      kind: "direct",
+      channel: "webchat",
+      updatedAt: 1_786_000_000_000,
+      archived: false,
+    });
+    if (payload?.status !== "ok") {
+      throw new Error("expected an available session preview");
+    }
+    expect(payload.title).toHaveLength(200);
+    expect(payload.lastMessagePreview?.length).toBeLessThanOrEqual(200);
+    expect(payload.lastMessagePreview).not.toContain(secret);
+  });
+
+  it("returns unavailable for an unknown session", async () => {
+    const handlers = createControlUiHandlers(vi.fn(), vi.fn().mockResolvedValue(null));
+    const respond = vi.fn<RespondFn>();
+
+    await expectDefined(
+      handlers["controlUi.sessionPreview"],
+      'handlers["controlUi.sessionPreview"] test invariant',
+    )(requestOptions({ sessionKey: "agent:main:missing" }, respond));
+
+    expect(respond).toHaveBeenCalledWith(true, { status: "unavailable" }, undefined);
+  });
+
+  it("rejects malformed preview params", async () => {
+    const loadSessionPreview = vi.fn();
+    const handlers = createControlUiHandlers(vi.fn(), loadSessionPreview);
+    const respond = vi.fn<RespondFn>();
+
+    await expectDefined(
+      handlers["controlUi.sessionPreview"],
+      'handlers["controlUi.sessionPreview"] test invariant',
+    )(requestOptions({ sessionKey: "agent:main:research", extra: true }, respond));
+
+    expect(loadSessionPreview).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "INVALID_REQUEST",
+      message: "invalid controlUi.sessionPreview params",
     });
   });
 });

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -150,7 +150,11 @@ describe("controlUi.sessionPreview", () => {
       'handlers["controlUi.sessionPreview"] test invariant',
     )(requestOptions({ sessionKey: " agent:main:research " }, respond));
 
-    expect(loadSessionPreview).toHaveBeenCalledWith("agent:main:research", expect.any(Object));
+    expect(loadSessionPreview).toHaveBeenCalledWith(
+      "agent:main:research",
+      expect.any(Object),
+      null,
+    );
     const payload = respond.mock.calls[0]?.[1] as ControlUiSessionPreview | undefined;
     expect(respond.mock.calls[0]?.[0]).toBe(true);
     expect(payload).toMatchObject({

--- a/src/gateway/server-methods/control-ui.ts
+++ b/src/gateway/server-methods/control-ui.ts
@@ -15,9 +15,10 @@ import {
 } from "../control-ui-github-preview.js";
 import { parseControlUiSessionPullRequestsSubscribeParams } from "../control-ui-session-pr-subscriptions.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { createSessionListEntryFilter } from "../session-sharing.js";
 import { buildGatewaySessionRow } from "../session-utils.js";
 import { loadSessionEntriesForTarget } from "./sessions-shared.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 type LoadGitHubPreview = (
   target: ControlUiGitHubPreviewTarget,
@@ -38,6 +39,7 @@ type SessionPreviewSource = {
 type LoadSessionPreview = (
   sessionKey: string,
   context: GatewayRequestContext,
+  client: GatewayClient | null,
 ) => SessionPreviewSource | null | Promise<SessionPreviewSource | null>;
 
 const SESSION_PREVIEW_TEXT_MAX_CHARS = 200;
@@ -85,6 +87,7 @@ function projectSessionPreview(source: SessionPreviewSource | null): ControlUiSe
 function loadControlUiSessionPreview(
   sessionKey: string,
   context: GatewayRequestContext,
+  client: GatewayClient | null,
 ): SessionPreviewSource | null {
   const cfg = context.getRuntimeConfig();
   const requestedAgent = resolveRequestedGlobalAgentId(cfg, sessionKey);
@@ -97,6 +100,13 @@ function loadControlUiSessionPreview(
     ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
   });
   if (!entry) {
+    return null;
+  }
+  // Hover previews must not reveal more than sessions.list: apply the same
+  // incognito/draft sharing predicate so a member cannot preview-by-key a
+  // session the sidebar hides from them.
+  const entryFilter = createSessionListEntryFilter({ client });
+  if (entryFilter && !entryFilter(target.canonicalKey, entry)) {
     return null;
   }
   const row = buildGatewaySessionRow({
@@ -154,7 +164,7 @@ export function createControlUiHandlers(
         );
       }
     },
-    "controlUi.sessionPreview": async ({ params, context, respond }) => {
+    "controlUi.sessionPreview": async ({ params, client, context, respond }) => {
       const sessionKey = parseSessionPreviewKey(params);
       if (!sessionKey) {
         respond(
@@ -167,7 +177,7 @@ export function createControlUiHandlers(
       try {
         respond(
           true,
-          projectSessionPreview(await loadSessionPreview(sessionKey, context)),
+          projectSessionPreview(await loadSessionPreview(sessionKey, context, client)),
           undefined,
         );
       } catch {

--- a/src/gateway/server-methods/control-ui.ts
+++ b/src/gateway/server-methods/control-ui.ts
@@ -1,5 +1,9 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { redactToolPayloadText } from "../../logging/redact.js";
 import { isTrustedSecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
+import { truncateUtf16Safe } from "../../utils.js";
+import type { ControlUiSessionPreview } from "../control-ui-contract.js";
 import {
   CONTROL_UI_GITHUB_CREDENTIAL_UNAVAILABLE_MESSAGE,
   ControlUiGitHubError,
@@ -10,14 +14,117 @@ import {
   type ControlUiGitHubPreviewTarget,
 } from "../control-ui-github-preview.js";
 import { parseControlUiSessionPullRequestsSubscribeParams } from "../control-ui-session-pr-subscriptions.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { buildGatewaySessionRow } from "../session-utils.js";
+import { loadSessionEntriesForTarget } from "./sessions-shared.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 type LoadGitHubPreview = (
   target: ControlUiGitHubPreviewTarget,
 ) => ReturnType<typeof loadControlUiGitHubPreview>;
 
+type SessionPreviewSource = {
+  sessionKey: string;
+  title?: string;
+  derivedTitle?: string;
+  agentId: string;
+  kind?: string;
+  channel?: string;
+  updatedAt?: number | null;
+  lastMessagePreview?: string;
+  archived?: boolean;
+};
+
+type LoadSessionPreview = (
+  sessionKey: string,
+  context: GatewayRequestContext,
+) => SessionPreviewSource | null | Promise<SessionPreviewSource | null>;
+
+const SESSION_PREVIEW_TEXT_MAX_CHARS = 200;
+
+function boundedPreviewText(value: string | undefined, maxChars = SESSION_PREVIEW_TEXT_MAX_CHARS) {
+  const trimmed = value?.trim();
+  return trimmed ? truncateUtf16Safe(trimmed, maxChars) : undefined;
+}
+
+function parseSessionPreviewKey(params: unknown): string | null {
+  if (!isRecord(params) || Object.keys(params).some((key) => key !== "sessionKey")) {
+    return null;
+  }
+  const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
+  return sessionKey && sessionKey.length <= 512 ? sessionKey : null;
+}
+
+function projectSessionPreview(source: SessionPreviewSource | null): ControlUiSessionPreview {
+  if (!source) {
+    return { status: "unavailable" };
+  }
+  const lastMessagePreview = boundedPreviewText(
+    source.lastMessagePreview ? redactToolPayloadText(source.lastMessagePreview) : undefined,
+  );
+  const title = boundedPreviewText(source.title);
+  const derivedTitle = boundedPreviewText(source.derivedTitle);
+  const kind = boundedPreviewText(source.kind, 64);
+  const channel = boundedPreviewText(source.channel, 80);
+  return {
+    status: "ok",
+    sessionKey: source.sessionKey,
+    agentId: source.agentId,
+    ...(title ? { title } : {}),
+    ...(derivedTitle ? { derivedTitle } : {}),
+    ...(kind ? { kind } : {}),
+    ...(channel ? { channel } : {}),
+    ...(typeof source.updatedAt === "number" && Number.isFinite(source.updatedAt)
+      ? { updatedAt: source.updatedAt }
+      : {}),
+    ...(lastMessagePreview ? { lastMessagePreview } : {}),
+    ...(typeof source.archived === "boolean" ? { archived: source.archived } : {}),
+  };
+}
+
+function loadControlUiSessionPreview(
+  sessionKey: string,
+  context: GatewayRequestContext,
+): SessionPreviewSource | null {
+  const cfg = context.getRuntimeConfig();
+  const requestedAgent = resolveRequestedGlobalAgentId(cfg, sessionKey);
+  if (!requestedAgent.ok) {
+    return null;
+  }
+  const { target, storePath, store, entry } = loadSessionEntriesForTarget({
+    key: sessionKey,
+    cfg,
+    ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+  });
+  if (!entry) {
+    return null;
+  }
+  const row = buildGatewaySessionRow({
+    cfg,
+    storePath,
+    store,
+    key: target.canonicalKey,
+    entry,
+    includeDerivedTitles: true,
+    includeLastMessage: true,
+    transcriptUsageMaxBytes: 64 * 1024,
+  });
+  return {
+    sessionKey: row.key,
+    agentId: row.agentId ?? target.agentId,
+    title: row.displayName,
+    derivedTitle: row.derivedTitle,
+    kind: row.kind,
+    channel: row.channel,
+    updatedAt: row.updatedAt,
+    lastMessagePreview: row.lastMessagePreview,
+    archived: row.archived,
+  };
+}
+
 export function createControlUiHandlers(
   loadGitHubPreview: LoadGitHubPreview = loadControlUiGitHubPreview,
+  loadSessionPreview: LoadSessionPreview = loadControlUiSessionPreview,
 ): GatewayRequestHandlers {
   return {
     "controlUi.githubPreview": async ({ params, respond }) => {
@@ -44,6 +151,30 @@ export function createControlUiHandlers(
           errorShape(ErrorCodes.UNAVAILABLE, message, {
             retryable: !credentialUnavailable && (statusCode === 429 || statusCode === 502),
           }),
+        );
+      }
+    },
+    "controlUi.sessionPreview": async ({ params, context, respond }) => {
+      const sessionKey = parseSessionPreviewKey(params);
+      if (!sessionKey) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid controlUi.sessionPreview params"),
+        );
+        return;
+      }
+      try {
+        respond(
+          true,
+          projectSessionPreview(await loadSessionPreview(sessionKey, context)),
+          undefined,
+        );
+      } catch {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "Session preview unavailable"),
         );
       }
     },

--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -25,6 +25,7 @@ import {
   createSessionListEntryFilter,
   invalidateSessionSharingSnapshot,
 } from "../session-sharing.js";
+import { createControlUiHandlers } from "./control-ui.js";
 import { sessionReadHandlers } from "./sessions-read.js";
 import { sessionSharingHandlers } from "./sessions-sharing.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
@@ -208,6 +209,47 @@ describe("session sharing handlers", () => {
       const visible = await listFor(admin);
       expect(visible?.sessions?.some((session) => session.key === incognitoKey)).toBe(true);
       expect(visible?.path).not.toBe(before?.path);
+    });
+  });
+
+  it("never previews sessions hidden from sessions.list", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const sessionKey = "agent:main:dashboard:incognito-preview";
+      await upsertSessionEntryCore(
+        {
+          agentId: "main",
+          sessionKey,
+          storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env: state.env }),
+        },
+        {
+          sessionId: "session-incognito-preview",
+          updatedAt: 2,
+          incognito: true,
+          visibility: "shared",
+          createdActor: { type: "human", id: "owner@example.com" },
+        },
+      );
+      const previewFor = async (client: GatewayClient) => {
+        const responses: Parameters<RespondFn>[] = [];
+        await createControlUiHandlers()["controlUi.sessionPreview"]?.({
+          params: { sessionKey },
+          client,
+          context: context(vi.fn()),
+          respond: (...response: Parameters<RespondFn>) => responses.push(response),
+        } as never);
+        return responses[0]?.[1];
+      };
+
+      expect(await previewFor(identifiedClient("viewer@example.com"))).toEqual({
+        status: "unavailable",
+      });
+      const admin = soloClient();
+      admin.connect.scopes = ["operator.admin"];
+      expect(await previewFor(admin)).toMatchObject({
+        status: "ok",
+        sessionKey,
+        agentId: "main",
+      });
     });
   });
 

--- a/ui/src/app-session-path-builder.ts
+++ b/ui/src/app-session-path-builder.ts
@@ -2,6 +2,7 @@ import type { ControlUiSessionNamespace } from "@openclaw/session-url-contract";
 
 type SessionPathDetails = {
   displayName?: string | null;
+  exactKey?: boolean;
   mainKey?: string | null;
   shortIdLength?: number;
 };
@@ -28,6 +29,7 @@ export function pathForSession(
       fallbackAgentId: agentId,
       basePath,
       displayName: details.displayName ?? undefined,
+      exactKey: details.exactKey,
       mainKey: details.mainKey ?? undefined,
       shortIdLength: details.shortIdLength,
     }) ?? null

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -7,7 +7,6 @@ import "../components/gateway-url-confirmation.ts";
 import "../components/github-link-hovercard-registration.ts";
 import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
-import "../components/session-link-hovercard-registration.ts";
 import "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -7,6 +7,7 @@ import "../components/gateway-url-confirmation.ts";
 import "../components/github-link-hovercard-registration.ts";
 import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
+import "../components/session-link-hovercard-registration.ts";
 import "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
@@ -362,11 +363,16 @@ export class OpenClawApp extends OpenClawLightDomElement {
     return html`
       <openclaw-tooltip-provider>
         <openclaw-github-link-hovercard-provider .client=${gatewaySnapshot.client}>
-          ${gatewayUrlConfirmation}
-          <openclaw-app-shell
-            .runtime=${runtime}
-            .onboarding=${this.onboarding}
-          ></openclaw-app-shell>
+          <openclaw-session-link-hovercard-provider
+            .client=${gatewaySnapshot.client}
+            .context=${context}
+          >
+            ${gatewayUrlConfirmation}
+            <openclaw-app-shell
+              .runtime=${runtime}
+              .onboarding=${this.onboarding}
+            ></openclaw-app-shell>
+          </openclaw-session-link-hovercard-provider>
         </openclaw-github-link-hovercard-provider>
       </openclaw-tooltip-provider>
     `;

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover markdown link rendering: autolinking, file links, and link marks.
 import { describe, expect, it, vi } from "vitest";
 import { shortestFileLabels } from "./file-kind.ts";
-import { toSanitizedMarkdownHtml } from "./markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
   const container = document.createElement("div");
@@ -511,6 +511,66 @@ describe("toSanitizedMarkdownHtml links", () => {
         expect(link.dataset.filePath).not.toMatch(/[\s()?]/);
       }
       expect(fragment.textContent).toContain(input);
+    });
+  });
+
+  describe("session links", () => {
+    const sessionKey = "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
+
+    it("links structural keys only when enabled", () => {
+      const disabled = htmlFragment(toSanitizedMarkdownHtml(`Open ${sessionKey}`));
+      expect(disabled.querySelector("a[data-session-key]")).toBeNull();
+
+      const enabled = htmlFragment(
+        toSanitizedMarkdownHtml(`Open ${sessionKey}`, { sessionLinks: true }),
+      );
+      const link = enabled.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      expect(link?.dataset.sessionKey).toBe(sessionKey);
+      expect(link?.textContent).toBe(sessionKey);
+      expect(link?.getAttribute("role")).toBe("link");
+      expect(link?.getAttribute("tabindex")).toBe("0");
+      expect(link?.hasAttribute("href")).toBe(false);
+    });
+
+    it.each([
+      ["plain text", `Open ${sessionKey}`],
+      ["inline code", `Open \`${sessionKey}\``],
+    ])("linkifies keys in %s", (_kind, input) => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(input, { sessionLinks: true }));
+      const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      expect(link?.dataset.sessionKey).toBe(sessionKey);
+      expect(link?.textContent).toBe(sessionKey);
+    });
+
+    it.each([
+      ["an empty prefix", "agent:"],
+      ["a missing rest segment", "agent:x"],
+      ["an empty middle segment", "agent:x::y"],
+      ["a URL query value", `https://example.test/?session=${sessionKey}`],
+      ["a fenced code block", `\`\`\`text\n${sessionKey}\n\`\`\``],
+    ])("does not link %s", (_kind, input) => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(input, { sessionLinks: true }));
+      expect(fragment.querySelector("a[data-session-key]")).toBeNull();
+    });
+
+    it("keeps punctuation outside the link and rejects embedded word matches", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(`(${sessionKey}), x${sessionKey}`, { sessionLinks: true }),
+      );
+      const links = fragment.querySelectorAll<HTMLAnchorElement>("a.markdown-session-link");
+      expect(links).toHaveLength(1);
+      expect(links[0]?.textContent).toBe(sessionKey);
+      expect(fragment.textContent).toBe(`(${sessionKey}), x${sessionKey}\n`);
+    });
+
+    it("stays deterministic across streaming tail renders", () => {
+      const options = { sessionLinks: true } as const;
+      const first = htmlFragment(toStreamingMarkdownHtml(`Open ${sessionKey}`, options));
+      const extended = htmlFragment(
+        toStreamingMarkdownHtml(`Open ${sessionKey} and continue`, options),
+      );
+      expect(first.querySelector<HTMLAnchorElement>("a")?.dataset.sessionKey).toBe(sessionKey);
+      expect(extended.querySelector<HTMLAnchorElement>("a")?.dataset.sessionKey).toBe(sessionKey);
     });
   });
 

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -21,6 +21,7 @@ import {
   splitMarkdownFileLineSuffix,
 } from "./markdown-file-links.ts";
 import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
+import { installMarkdownSessionLinks, SESSION_LINK_SCAN_RE } from "./markdown-session-links.ts";
 import { escapeMarkdownHtml } from "./markdown-text.ts";
 
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
@@ -473,6 +474,8 @@ export function createMarkdownParser(): MarkdownIt {
     }
   });
 
+  installMarkdownSessionLinks(markdownParser, SESSION_LINK_SCAN_RE);
+
   // Classify web anchors for presentation; runs after linkify so bare URLs are
   // already anchors. The GitHub mark skips links whose only content is an image
   // (badges/shields), where a mark beside a mark reads as noise. Code spans and
@@ -565,14 +568,17 @@ export function createMarkdownParser(): MarkdownIt {
   markdownParser.renderer.rules.code_inline = (tokens, index, options, env, self) => {
     const rendered = defaultCodeInlineRenderer(tokens, index, options, env, self);
     const target = tokens[index]?.meta?.fileLink as MarkdownFileLinkMeta | undefined;
-    if (!target) {
-      return rendered;
+    if (target) {
+      const lineAttribute =
+        target.line === null ? "" : ` data-file-line="${escapeMarkdownHtml(String(target.line))}"`;
+      const titleAttribute =
+        target.title === null ? "" : ` title="${escapeMarkdownHtml(target.title)}"`;
+      return `<a class="markdown-file-link" role="button" tabindex="0" data-file-path="${escapeMarkdownHtml(target.path)}" data-file-kind="${fileKindForPath(target.path)}"${lineAttribute}${titleAttribute}>${rendered}</a>`;
     }
-    const lineAttribute =
-      target.line === null ? "" : ` data-file-line="${escapeMarkdownHtml(String(target.line))}"`;
-    const titleAttribute =
-      target.title === null ? "" : ` title="${escapeMarkdownHtml(target.title)}"`;
-    return `<a class="markdown-file-link" role="button" tabindex="0" data-file-path="${escapeMarkdownHtml(target.path)}" data-file-kind="${fileKindForPath(target.path)}"${lineAttribute}${titleAttribute}>${rendered}</a>`;
+    const sessionKey: unknown = tokens[index]?.meta?.sessionLink?.sessionKey;
+    return typeof sessionKey === "string"
+      ? `<a class="markdown-session-link" role="link" tabindex="0" data-session-key="${escapeMarkdownHtml(sessionKey)}">${rendered}</a>`
+      : rendered;
   };
 
   // Message rendering allows inline data images and explicit open-only placeholders

--- a/ui/src/components/markdown-render-options.ts
+++ b/ui/src/components/markdown-render-options.ts
@@ -7,6 +7,7 @@ export type MarkdownRenderOptions = {
   fileLinks?: boolean;
   interactiveImages?: boolean;
   mode?: MarkdownRenderMode;
+  sessionLinks?: boolean;
 };
 
 export type MarkdownRenderEnv = Required<MarkdownRenderOptions>;
@@ -20,5 +21,6 @@ export function normalizeMarkdownRenderOptions(
     fileLinks: options.fileLinks ?? false,
     interactiveImages: options.interactiveImages ?? false,
     mode: options.mode ?? "message",
+    sessionLinks: options.sessionLinks ?? false,
   };
 }

--- a/ui/src/components/markdown-session-links.test.ts
+++ b/ui/src/components/markdown-session-links.test.ts
@@ -1,0 +1,31 @@
+import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
+import { describe, expect, it, vi } from "vitest";
+import { setSessionPathBuilder } from "../app-session-path-builder.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { navigateMarkdownSession, type SessionLinkTarget } from "./markdown-session-links.ts";
+
+describe("markdown session links", () => {
+  it("navigates through the canonical chat session route", () => {
+    setSessionPathBuilder(buildControlUiSessionPath);
+    const navigate = vi.fn();
+    const context = {
+      basePath: "",
+      sessions: { state: {} },
+      agents: { state: {} },
+      agentSelection: { state: {} },
+      gateway: { snapshot: {} },
+      navigate,
+    } as unknown as ApplicationContext;
+    const target: SessionLinkTarget = {
+      sessionKey: "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6",
+      agentId: "roboclaw",
+    };
+
+    navigateMarkdownSession(context, target);
+
+    expect(navigate).toHaveBeenCalledWith("chat", {
+      pathname: "/chat/roboclaw/2139bddb",
+      search: "?__openclawSessionFacePreference=1",
+    });
+  });
+});

--- a/ui/src/components/markdown-session-links.test.ts
+++ b/ui/src/components/markdown-session-links.test.ts
@@ -24,7 +24,7 @@ describe("markdown session links", () => {
     navigateMarkdownSession(context, target);
 
     expect(navigate).toHaveBeenCalledWith("chat", {
-      pathname: "/chat/roboclaw/2139bddb",
+      pathname: "/chat/roboclaw/dashboard/2139bddb-3211-4641-b993-10f619f124e6",
       search: "?__openclawSessionFacePreference=1",
     });
   });

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -1,14 +1,25 @@
+import type { ControlUiSessionNamespace } from "@openclaw/session-url-contract";
 import type MarkdownIt from "markdown-it";
+import { sessionRefFromPath } from "../app-session-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 
 export const SESSION_LINK_SCAN_RE = /agent:[^\s<>"'`]*[^\s<>"'`.,;:!?)}\]]/g;
 
-export type SessionLinkTarget = {
+type SessionKeyTarget = {
   sessionKey: string;
   agentId: string;
 };
+
+type SessionPathTarget = {
+  namespace: ControlUiSessionNamespace;
+  pathname: string;
+  search?: string;
+  hash?: string;
+};
+
+export type SessionLinkTarget = SessionKeyTarget | SessionPathTarget;
 
 type SessionLinkMeta = {
   sessionKey: string;
@@ -24,7 +35,7 @@ function isSessionLinkBoundaryAfter(value: string, index: number): boolean {
   return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
 }
 
-function parseSessionLinkKey(raw: string): SessionLinkTarget | null {
+function parseSessionLinkKey(raw: string): SessionKeyTarget | null {
   const sessionKey = raw.trim();
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed || `agent:${parsed.agentId}:${parsed.rest}` !== sessionKey.toLowerCase()) {
@@ -131,6 +142,37 @@ export function markdownSessionLinkFromEvent(event: Event): SessionLinkTarget | 
   return sessionKey ? parseSessionLinkKey(sessionKey) : null;
 }
 
+export function markdownSessionHref(event: Event, basePath = ""): SessionPathTarget | null {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  const href = target.closest<HTMLAnchorElement>("a[href]")?.getAttribute("href")?.trim();
+  const location = globalThis.location;
+  if (!href || !location) {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(href, location.href);
+  } catch {
+    return null;
+  }
+  if (url.origin !== location.origin) {
+    return null;
+  }
+  const parsed = sessionRefFromPath(url.pathname, basePath);
+  if (!parsed) {
+    return null;
+  }
+  return {
+    namespace: parsed.namespace,
+    pathname: url.pathname,
+    ...(url.search ? { search: url.search } : {}),
+    ...(url.hash ? { hash: url.hash } : {}),
+  };
+}
+
 export function markdownSessionLinkFromKeyboardEvent(
   event: KeyboardEvent,
 ): SessionLinkTarget | null {
@@ -148,11 +190,17 @@ export function navigateMarkdownSession(
   context: ApplicationContext,
   target: SessionLinkTarget,
 ): void {
+  if ("pathname" in target) {
+    const { namespace, ...options } = target;
+    context.navigate(namespace, options);
+    return;
+  }
   const navigation = sessionNavigationTarget({
     context,
     face: "chat",
     sessionKey: target.sessionKey,
     agentId: target.agentId,
+    exactKey: true,
     preferenceDerivedFace: true,
   });
   context.navigate("chat", navigation.options);

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -1,0 +1,159 @@
+import type MarkdownIt from "markdown-it";
+import type { ApplicationContext } from "../app/context.ts";
+import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
+import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+
+export const SESSION_LINK_SCAN_RE = /agent:[^\s<>"'`]*[^\s<>"'`.,;:!?)}\]]/g;
+
+export type SessionLinkTarget = {
+  sessionKey: string;
+  agentId: string;
+};
+
+type SessionLinkMeta = {
+  sessionKey: string;
+};
+
+function isSessionLinkBoundaryBefore(value: string, index: number): boolean {
+  const char = value[index - 1];
+  return char === undefined || /\s/.test(char) || "([{<\"'`".includes(char);
+}
+
+function isSessionLinkBoundaryAfter(value: string, index: number): boolean {
+  const char = value[index];
+  return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
+}
+
+function parseSessionLinkKey(raw: string): SessionLinkTarget | null {
+  const sessionKey = raw.trim();
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed || `agent:${parsed.agentId}:${parsed.rest}` !== sessionKey.toLowerCase()) {
+    return null;
+  }
+  return { sessionKey, agentId: parsed.agentId };
+}
+
+export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPattern: RegExp): void {
+  markdownParser.core.ruler.after("linkify", "session-links", (state) => {
+    const sessionLinks: unknown = state.env?.sessionLinks;
+    if (sessionLinks !== true) {
+      return;
+    }
+    for (const blockToken of state.tokens) {
+      if (blockToken.type !== "inline" || !blockToken.children) {
+        continue;
+      }
+      const children = blockToken.children;
+      let linkDepth = 0;
+      for (let index = 0; index < children.length; index++) {
+        const token = children[index];
+        if (!token) {
+          continue;
+        }
+        if (token.type === "link_open") {
+          linkDepth += 1;
+          continue;
+        }
+        if (token.type === "link_close") {
+          linkDepth = Math.max(0, linkDepth - 1);
+          continue;
+        }
+        if (linkDepth > 0) {
+          continue;
+        }
+        if (token.type === "code_inline") {
+          const target = parseSessionLinkKey(token.content);
+          if (target) {
+            token.meta = {
+              ...token.meta,
+              sessionLink: { sessionKey: target.sessionKey } satisfies SessionLinkMeta,
+            };
+          }
+          continue;
+        }
+        if (token.type !== "text") {
+          continue;
+        }
+
+        const replacements: typeof children = [];
+        let cursor = 0;
+        scanPattern.lastIndex = 0;
+        for (const match of token.content.matchAll(scanPattern)) {
+          const matchIndex = match.index;
+          const matched = match[0];
+          const matchEnd = matchIndex + matched.length;
+          if (
+            !isSessionLinkBoundaryBefore(token.content, matchIndex) ||
+            !isSessionLinkBoundaryAfter(token.content, matchEnd) ||
+            !parseSessionLinkKey(matched)
+          ) {
+            continue;
+          }
+          if (matchIndex > cursor) {
+            const leading = new state.Token("text", "", 0);
+            leading.content = token.content.slice(cursor, matchIndex);
+            replacements.push(leading);
+          }
+          const open = new state.Token("link_open", "a", 1);
+          open.markup = "session-link";
+          open.attrSet("class", "markdown-session-link");
+          open.attrSet("role", "link");
+          open.attrSet("tabindex", "0");
+          open.attrSet("data-session-key", matched);
+          const label = new state.Token("text", "", 0);
+          label.content = matched;
+          const close = new state.Token("link_close", "a", -1);
+          close.markup = "session-link";
+          replacements.push(open, label, close);
+          cursor = matchEnd;
+        }
+        if (replacements.length === 0) {
+          continue;
+        }
+        if (cursor < token.content.length) {
+          const trailing = new state.Token("text", "", 0);
+          trailing.content = token.content.slice(cursor);
+          replacements.push(trailing);
+        }
+        children.splice(index, 1, ...replacements);
+        index += replacements.length - 1;
+      }
+    }
+  });
+}
+
+export function markdownSessionLinkFromEvent(event: Event): SessionLinkTarget | null {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  const sessionKey = target.closest<HTMLAnchorElement>("a[data-session-key]")?.dataset.sessionKey;
+  return sessionKey ? parseSessionLinkKey(sessionKey) : null;
+}
+
+export function markdownSessionLinkFromKeyboardEvent(
+  event: KeyboardEvent,
+): SessionLinkTarget | null {
+  if (event.key !== "Enter" && event.key !== " ") {
+    return null;
+  }
+  const target = markdownSessionLinkFromEvent(event);
+  if (target) {
+    event.preventDefault();
+  }
+  return target;
+}
+
+export function navigateMarkdownSession(
+  context: ApplicationContext,
+  target: SessionLinkTarget,
+): void {
+  const navigation = sessionNavigationTarget({
+    context,
+    face: "chat",
+    sessionKey: target.sessionKey,
+    agentId: target.agentId,
+    preferenceDerivedFace: true,
+  });
+  context.navigate("chat", navigation.options);
+}

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -1,6 +1,5 @@
 import type { ControlUiSessionNamespace } from "@openclaw/session-url-contract";
 import type MarkdownIt from "markdown-it";
-import { sessionRefFromPath } from "../app-session-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
@@ -18,6 +17,8 @@ type SessionPathTarget = {
   search?: string;
   hash?: string;
 };
+
+type SessionPathParser = typeof import("../app-session-route-paths.ts").sessionRefFromPath;
 
 export type SessionLinkTarget = SessionKeyTarget | SessionPathTarget;
 
@@ -142,7 +143,11 @@ export function markdownSessionLinkFromEvent(event: Event): SessionLinkTarget | 
   return sessionKey ? parseSessionLinkKey(sessionKey) : null;
 }
 
-export function markdownSessionHref(event: Event, basePath = ""): SessionPathTarget | null {
+export function markdownSessionHref(
+  event: Event,
+  parseSessionPath: SessionPathParser,
+  basePath = "",
+): SessionPathTarget | null {
   const target = event.target;
   if (!(target instanceof Element)) {
     return null;
@@ -161,7 +166,7 @@ export function markdownSessionHref(event: Event, basePath = ""): SessionPathTar
   if (url.origin !== location.origin) {
     return null;
   }
-  const parsed = sessionRefFromPath(url.pathname, basePath);
+  const parsed = parseSessionPath(url.pathname, basePath);
   if (!parsed) {
     return null;
   }

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -635,9 +635,7 @@ PY
 
     it("keeps app-relative links navigable", () => {
       const html = toSanitizedMarkdownHtml("[usage](/usage)");
-      expect(html).toBe(
-        '<p><a href="/usage" rel="noreferrer noopener" target="_blank">usage</a></p>\n',
-      );
+      expect(html).toBe('<p><a href="/usage">usage</a></p>\n');
     });
 
     it("rewrites docs-root links to the public docs host", () => {
@@ -656,7 +654,7 @@ PY
         ),
       );
       expect(html).toBe(
-        '<p><a href="/channels" rel="noreferrer noopener" target="_blank">channels</a> <a href="/automation" rel="noreferrer noopener" target="_blank">automation</a> <a href="/skills/workshop" rel="noreferrer noopener" target="_blank">workshop</a> <a href="/chat" rel="noreferrer noopener" target="_blank">chat</a> <a href="/control/chat/main" rel="noreferrer noopener" target="_blank">baseChat</a> <a href="/control/sessions" rel="noreferrer noopener" target="_blank">baseSessions</a> <a href="/healthz" rel="noreferrer noopener" target="_blank">health</a> <a href="/googlechat" rel="noreferrer noopener" target="_blank">pluginDynamic</a> <a href="/api/files/1" rel="noreferrer noopener" target="_blank">asset</a> <a href="/control/api/files/1" rel="noreferrer noopener" target="_blank">baseApi</a> <a href="/control/avatar/main" rel="noreferrer noopener" target="_blank">baseAvatar</a> <a href="/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">plugin</a> <a href="/control/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">basePlugin</a> <a href="/__openclaw__/canvas/documents/x/index.html" rel="noreferrer noopener" target="_blank">artifact</a> <a href="/control/__openclaw__/canvas/x" rel="noreferrer noopener" target="_blank">baseArtifact</a></p>\n',
+        '<p><a href="/channels">channels</a> <a href="/automation">automation</a> <a href="/skills/workshop">workshop</a> <a href="/chat">chat</a> <a href="/control/chat/main">baseChat</a> <a href="/control/sessions">baseSessions</a> <a href="/healthz" rel="noreferrer noopener" target="_blank">health</a> <a href="/googlechat" rel="noreferrer noopener" target="_blank">pluginDynamic</a> <a href="/api/files/1" rel="noreferrer noopener" target="_blank">asset</a> <a href="/control/api/files/1" rel="noreferrer noopener" target="_blank">baseApi</a> <a href="/control/avatar/main" rel="noreferrer noopener" target="_blank">baseAvatar</a> <a href="/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">plugin</a> <a href="/control/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">basePlugin</a> <a href="/__openclaw__/canvas/documents/x/index.html" rel="noreferrer noopener" target="_blank">artifact</a> <a href="/control/__openclaw__/canvas/x" rel="noreferrer noopener" target="_blank">baseArtifact</a></p>\n',
       );
     });
   });

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -75,6 +75,7 @@ const allowedAttrs = [
   "data-file-kind",
   "data-file-line",
   "data-file-path",
+  "data-session-key",
   "type",
   "aria-label",
   "role",
@@ -459,6 +460,11 @@ function installHooks() {
         node.removeAttribute("href");
         return;
       }
+      if (url.origin === window.location.origin && isControlUiRoutePath(url.pathname)) {
+        node.removeAttribute("rel");
+        node.removeAttribute("target");
+        return;
+      }
     } catch {
       // Relative URLs are fine; malformed absolute URLs with dangerous schemes
       // will fail to parse and keep their href — but DOMPurify already strips
@@ -538,7 +544,7 @@ export function toSanitizedMarkdownHtml(
   }
   const renderInput = isMarkdownBlockArtText(rawInput) ? rawInput : input;
   const cacheable = input.length <= MARKDOWN_CACHE_MAX_CHARS;
-  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.mode}\0${renderInput}`;
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.mode}\0${renderOptions.sessionLinks}\0${renderInput}`;
   if (cacheable) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {

--- a/ui/src/components/session-link-hovercard-registration.ts
+++ b/ui/src/components/session-link-hovercard-registration.ts
@@ -9,6 +9,9 @@ import {
 import type { SessionLinkHovercardProvider } from "./session-link-hovercard.runtime.ts";
 
 const HOVERCARD_TAG = "openclaw-session-link-hovercard-provider";
+const SESSION_LINK_SELECTOR = "a.markdown-session-link";
+
+let bootstrapObserver: MutationObserver | null = null;
 
 type HovercardProviderElement = HTMLElement & {
   client: GatewayBrowserClient | null;
@@ -19,9 +22,11 @@ function providerForAnchor(anchor: HTMLAnchorElement): SessionLinkHovercardProvi
   return anchor.closest<SessionLinkHovercardProvider>(HOVERCARD_TAG);
 }
 
-function removeBootstrapListeners(): void {
+function removeBootstrapActivation(): void {
   document.removeEventListener("pointerover", handleBootstrapPointerOver, true);
   document.removeEventListener("focusin", handleBootstrapFocusIn, true);
+  bootstrapObserver?.disconnect();
+  bootstrapObserver = null;
 }
 
 async function defineProvider(): Promise<void> {
@@ -41,7 +46,21 @@ async function defineProvider(): Promise<void> {
       provider.context = properties.context;
     }
   });
-  removeBootstrapListeners();
+  removeBootstrapActivation();
+}
+
+function handleBootstrapMutations(records: MutationRecord[]): void {
+  for (const record of records) {
+    for (const node of record.addedNodes) {
+      if (!(node instanceof Element)) {
+        continue;
+      }
+      if (node.matches(SESSION_LINK_SELECTOR) || node.querySelector(SESSION_LINK_SELECTOR)) {
+        void defineProvider();
+        return;
+      }
+    }
+  }
 }
 
 async function activateHovercard(event: Event, trigger: "focus" | "pointer"): Promise<void> {
@@ -77,8 +96,13 @@ function handleBootstrapFocusIn(event: Event): void {
 }
 
 if (customElements.get(HOVERCARD_TAG)) {
-  removeBootstrapListeners();
+  removeBootstrapActivation();
 } else {
   document.addEventListener("pointerover", handleBootstrapPointerOver, true);
   document.addEventListener("focusin", handleBootstrapFocusIn, true);
+  bootstrapObserver = new MutationObserver(handleBootstrapMutations);
+  bootstrapObserver.observe(document, { childList: true, subtree: true });
+  if (document.querySelector(SESSION_LINK_SELECTOR)) {
+    void defineProvider();
+  }
 }

--- a/ui/src/components/session-link-hovercard-registration.ts
+++ b/ui/src/components/session-link-hovercard-registration.ts
@@ -1,0 +1,84 @@
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
+import {
+  isPotentialSessionLink,
+  SESSION_HOVERCARD_OPEN_DELAY_MS,
+  sessionLinkAnchorFromEvent,
+} from "./session-link-hovercard-target.ts";
+import type { SessionLinkHovercardProvider } from "./session-link-hovercard.runtime.ts";
+
+const HOVERCARD_TAG = "openclaw-session-link-hovercard-provider";
+
+type HovercardProviderElement = HTMLElement & {
+  client: GatewayBrowserClient | null;
+  context: ApplicationContext | null;
+};
+
+function providerForAnchor(anchor: HTMLAnchorElement): SessionLinkHovercardProvider | null {
+  return anchor.closest<SessionLinkHovercardProvider>(HOVERCARD_TAG);
+}
+
+function removeBootstrapListeners(): void {
+  document.removeEventListener("pointerover", handleBootstrapPointerOver, true);
+  document.removeEventListener("focusin", handleBootstrapFocusIn, true);
+}
+
+async function defineProvider(): Promise<void> {
+  const pendingProviders = new Map(
+    [...document.querySelectorAll<HovercardProviderElement>(HOVERCARD_TAG)].map((provider) => [
+      provider,
+      { client: provider.client, context: provider.context },
+    ]),
+  );
+  await ensureCustomElementDefined(HOVERCARD_TAG, async () => {
+    const runtime = await import("./session-link-hovercard.runtime.ts");
+    if (!customElements.get(HOVERCARD_TAG)) {
+      customElements.define(HOVERCARD_TAG, runtime.SessionLinkHovercardProvider);
+    }
+    for (const [provider, properties] of pendingProviders) {
+      provider.client = properties.client;
+      provider.context = properties.context;
+    }
+  });
+  removeBootstrapListeners();
+}
+
+async function activateHovercard(event: Event, trigger: "focus" | "pointer"): Promise<void> {
+  if (trigger === "pointer" && "pointerType" in event && event.pointerType === "touch") {
+    return;
+  }
+  const anchor = sessionLinkAnchorFromEvent(event);
+  const provider = anchor ? providerForAnchor(anchor) : null;
+  if (!anchor || !provider || !isPotentialSessionLink(anchor, provider.context?.basePath)) {
+    return;
+  }
+  const startedAt = performance.now();
+  await defineProvider();
+  const upgraded = providerForAnchor(anchor);
+  const stillActive =
+    trigger === "pointer" ? anchor.matches(":hover") : document.activeElement === anchor;
+  if (!upgraded || !anchor.isConnected || !stillActive) {
+    return;
+  }
+  const delay =
+    trigger === "pointer"
+      ? Math.max(0, SESSION_HOVERCARD_OPEN_DELAY_MS - (performance.now() - startedAt))
+      : 0;
+  upgraded.activateFromBootstrap(anchor, trigger, delay);
+}
+
+function handleBootstrapPointerOver(event: Event): void {
+  void activateHovercard(event, "pointer");
+}
+
+function handleBootstrapFocusIn(event: Event): void {
+  void activateHovercard(event, "focus");
+}
+
+if (customElements.get(HOVERCARD_TAG)) {
+  removeBootstrapListeners();
+} else {
+  document.addEventListener("pointerover", handleBootstrapPointerOver, true);
+  document.addEventListener("focusin", handleBootstrapFocusIn, true);
+}

--- a/ui/src/components/session-link-hovercard-target.ts
+++ b/ui/src/components/session-link-hovercard-target.ts
@@ -3,7 +3,8 @@ export const SESSION_HOVERCARD_OPEN_DELAY_MS = 250;
 export function sessionLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   for (const candidate of event.composedPath()) {
     if (candidate instanceof HTMLAnchorElement) {
-      return candidate;
+      // Sidebar rows already expose session identity and must stay unobstructed navigation targets.
+      return candidate.matches(".sidebar-recent-session__link") ? null : candidate;
     }
     if (candidate === event.currentTarget) {
       break;

--- a/ui/src/components/session-link-hovercard-target.ts
+++ b/ui/src/components/session-link-hovercard-target.ts
@@ -1,0 +1,31 @@
+export const SESSION_HOVERCARD_OPEN_DELAY_MS = 250;
+
+export function sessionLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
+  for (const candidate of event.composedPath()) {
+    if (candidate instanceof HTMLAnchorElement) {
+      return candidate;
+    }
+    if (candidate === event.currentTarget) {
+      break;
+    }
+  }
+  return null;
+}
+
+export function isPotentialSessionLink(anchor: HTMLAnchorElement, basePath = ""): boolean {
+  if (anchor.matches("a.markdown-session-link[data-session-key]")) {
+    return true;
+  }
+  try {
+    const url = new URL(anchor.href, globalThis.location?.href ?? "http://localhost/");
+    const normalizedBasePath = basePath.replace(/\/+$/u, "");
+    return (
+      url.origin === globalThis.location?.origin &&
+      ["chat", "dashboard"].some((namespace) =>
+        url.pathname.startsWith(`${normalizedBasePath}/${namespace}/`),
+      )
+    );
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -428,6 +428,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
       this.context?.basePath,
       {
         displayName: title,
+        exactKey: true,
         mainKey: this.mainKey(),
       },
     );

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -365,13 +365,13 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     }
   }
 
-  private loadPreview(target: SessionPreviewTarget): Promise<SessionPreview> {
+  private cachedOrSeededEntry(target: SessionPreviewTarget): CacheEntry | undefined {
     const key = target.sessionKey;
     const now = Date.now();
     const cached = this.cache.get(key);
     if (cached && cached.expiresAt > now) {
       this.setCacheEntry(key, cached);
-      return cached.promise;
+      return cached;
     }
     if (cached) {
       this.cache.delete(key);
@@ -381,7 +381,15 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
       const value = previewFromRow(seeded, target);
       const entry = { expiresAt: now + SUCCESS_CACHE_MS, promise: Promise.resolve(value), value };
       this.setCacheEntry(key, entry);
-      return entry.promise;
+      return entry;
+    }
+    return undefined;
+  }
+
+  private loadPreview(target: SessionPreviewTarget): Promise<SessionPreview> {
+    const cached = this.cachedOrSeededEntry(target);
+    if (cached) {
+      return cached.promise;
     }
 
     const load = async () => {
@@ -395,7 +403,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
       );
     };
     const entry: CacheEntry = {
-      expiresAt: now + SUCCESS_CACHE_MS,
+      expiresAt: Date.now() + SUCCESS_CACHE_MS,
       promise: Promise.resolve().then(load),
     };
     entry.promise = entry.promise.then(
@@ -408,7 +416,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
         throw error;
       },
     );
-    this.setCacheEntry(key, entry);
+    this.setCacheEntry(target.sessionKey, entry);
     return entry.promise;
   }
 
@@ -448,16 +456,8 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     if (!target) {
       return;
     }
-    const promise = this.loadPreview(target);
-    this.stampAnchor(anchor, target, this.cache.get(target.sessionKey)?.value);
-    void promise.then(
-      (preview) => {
-        if (anchor.isConnected && anchor.dataset.sessionKey === target.sessionKey) {
-          this.stampAnchor(anchor, target, preview);
-        }
-      },
-      () => undefined,
-    );
+    // Discovery must stay network-free: only an opened hovercard may populate an unseeded entry.
+    this.stampAnchor(anchor, target, this.cachedOrSeededEntry(target)?.value);
   }
 
   private readonly handlePointerOver = (event: Event) => {

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -1,0 +1,666 @@
+import { initialState, Task } from "@lit/task";
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
+import { controlUiSessionSlug } from "@openclaw/session-url-contract";
+import { ReactiveElement } from "lit";
+import type { ControlUiSessionPreview } from "../../../src/gateway/control-ui-contract.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
+import { pathForSession } from "../app-session-path-builder.ts";
+import { sessionRefFromPath, type SessionPathTarget } from "../app-session-route-paths.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { i18n, t } from "../i18n/index.ts";
+import { formatRelativeTimestamp } from "../lib/format.ts";
+import {
+  areUiSessionKeysEquivalent,
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+} from "../lib/sessions/session-key.ts";
+import { sessionKeyUuid } from "../pages/chat/route-loader-short-cache.ts";
+import {
+  SESSION_HOVERCARD_OPEN_DELAY_MS,
+  sessionLinkAnchorFromEvent,
+} from "./session-link-hovercard-target.ts";
+
+const SESSION_LINK_SELECTOR = "a.markdown-session-link[data-session-key]";
+const SUCCESS_CACHE_MS = 5 * 60_000;
+const FAILURE_CACHE_MS = 30_000;
+const CACHE_LIMIT = 100;
+const VIEWPORT_PADDING = 12;
+const CARD_GAP = 10;
+const CLOSE_DELAY_MS = 120;
+
+type SessionPreview = Extract<ControlUiSessionPreview, { status: "ok" }>;
+
+type SessionPreviewTarget = {
+  sessionKey: string;
+  agentId: string;
+  namespace: "chat" | "dashboard";
+};
+
+type CacheEntry = {
+  expiresAt: number;
+  promise: Promise<SessionPreview>;
+  value?: SessionPreview;
+};
+
+let nextHovercardId = 0;
+
+function parsePreviewResponse(value: unknown): SessionPreview {
+  if (!isRecord(value) || value.status !== "ok") {
+    throw new Error("Session preview unavailable");
+  }
+  const sessionKey = readNonBlankString(value.sessionKey);
+  const agentId = readNonBlankString(value.agentId);
+  if (!sessionKey || !agentId) {
+    throw new Error("Session preview response was incomplete");
+  }
+  return {
+    status: "ok",
+    sessionKey,
+    agentId,
+    title: readNonBlankString(value.title),
+    derivedTitle: readNonBlankString(value.derivedTitle),
+    kind: readNonBlankString(value.kind),
+    channel: readNonBlankString(value.channel),
+    updatedAt: asFiniteNumber(value.updatedAt),
+    lastMessagePreview: readNonBlankString(value.lastMessagePreview),
+    archived: typeof value.archived === "boolean" ? value.archived : undefined,
+  };
+}
+
+function displayTitle(preview: SessionPreview): string | undefined {
+  return preview.title ?? preview.derivedTitle;
+}
+
+function previewFromRow(row: GatewaySessionRow, target: SessionPreviewTarget): SessionPreview {
+  return {
+    status: "ok",
+    sessionKey: row.key,
+    agentId: row.agentId ?? parseAgentSessionKey(row.key)?.agentId ?? target.agentId,
+    title: row.displayName ?? undefined,
+    derivedTitle: row.derivedTitle,
+    kind: row.kind,
+    channel: row.channel,
+    updatedAt: row.updatedAt ?? undefined,
+    lastMessagePreview: row.lastMessagePreview,
+    archived: row.archived,
+  };
+}
+
+function appendTextElement(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  className: string,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  parent.append(element);
+  return element;
+}
+
+function renderLoading(card: HTMLDivElement): void {
+  card.replaceChildren();
+  card.dataset.loading = "true";
+  const label = t("sessionPreview.loading");
+  card.setAttribute("aria-label", label);
+  appendTextElement(card, "div", "session-link-hovercard__loading", label);
+}
+
+function renderUnavailable(card: HTMLDivElement): void {
+  card.replaceChildren();
+  card.dataset.loading = "false";
+  const label = t("sessionPreview.unavailable");
+  card.setAttribute("aria-label", label);
+  appendTextElement(card, "div", "session-link-hovercard__unavailable", label);
+}
+
+function renderPreview(card: HTMLDivElement, preview: SessionPreview): void {
+  card.replaceChildren();
+  card.dataset.loading = "false";
+  const title = displayTitle(preview) ?? preview.sessionKey;
+  appendTextElement(card, "div", "session-link-hovercard__title", title);
+
+  const meta = [preview.agentId, preview.kind, preview.channel].filter(Boolean).join(" · ");
+  if (meta) {
+    appendTextElement(card, "div", "session-link-hovercard__meta", meta);
+  }
+  if (preview.lastMessagePreview) {
+    appendTextElement(card, "div", "session-link-hovercard__message", preview.lastMessagePreview);
+  }
+  const footer = document.createElement("div");
+  footer.className = "session-link-hovercard__footer";
+  if (preview.archived) {
+    appendTextElement(
+      footer,
+      "span",
+      "session-link-hovercard__archived",
+      t("sessionPreview.archived"),
+    );
+  }
+  if (preview.updatedAt !== undefined) {
+    appendTextElement(
+      footer,
+      "time",
+      "session-link-hovercard__time",
+      formatRelativeTimestamp(preview.updatedAt),
+    );
+  }
+  if (footer.childElementCount > 0) {
+    card.append(footer);
+  }
+  card.setAttribute("aria-label", t("sessionPreview.ariaLabel", { title }));
+}
+
+export class SessionLinkHovercardProvider extends ReactiveElement {
+  client: GatewayBrowserClient | null = null;
+  context: ApplicationContext | null = null;
+
+  private readonly cache = new Map<string, CacheEntry>();
+  private activeAnchor: HTMLAnchorElement | null = null;
+  private activeTarget: SessionPreviewTarget | null = null;
+  private card: HTMLDivElement | null = null;
+  private closeTimer: number | null = null;
+  private focusInside = false;
+  private openTimer: number | null = null;
+  private pointerInside = false;
+  private pointerOverCard = false;
+  private renderedPreview: SessionPreview | null = null;
+  private renderedUnavailable = false;
+  private scanAnimationFrame: number | null = null;
+  private readonly pendingAnchors = new Set<HTMLAnchorElement>();
+  private stopI18n: (() => void) | null = null;
+  private readonly previewTask = new Task(this, {
+    autoRun: false,
+    args: () => [this.activeTarget] as const,
+    task: ([target]) => (target ? this.loadPreview(target) : initialState),
+    onComplete: (preview) => {
+      const card = this.card;
+      if (!card) {
+        return;
+      }
+      this.renderedPreview = preview;
+      if (this.activeAnchor?.matches(SESSION_LINK_SELECTOR)) {
+        this.stampAnchor(this.activeAnchor, this.activeTarget, preview);
+      }
+      renderPreview(card, preview);
+      this.positionCard();
+    },
+    onError: () => {
+      const card = this.card;
+      if (!card) {
+        return;
+      }
+      this.renderedUnavailable = true;
+      renderUnavailable(card);
+      this.positionCard();
+    },
+  });
+  private readonly subtreeObserver = new MutationObserver((records) => {
+    if (this.activeAnchor && !this.contains(this.activeAnchor)) {
+      this.close();
+    }
+    let found = false;
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (!(node instanceof Element)) {
+          continue;
+        }
+        if (node instanceof HTMLAnchorElement && node.matches(SESSION_LINK_SELECTOR)) {
+          this.pendingAnchors.add(node);
+          found = true;
+        }
+        for (const anchor of node.querySelectorAll<HTMLAnchorElement>(SESSION_LINK_SELECTOR)) {
+          this.pendingAnchors.add(anchor);
+          found = true;
+        }
+      }
+    }
+    if (!found || this.scanAnimationFrame !== null) {
+      return;
+    }
+    this.scanAnimationFrame = requestAnimationFrame(() => {
+      this.scanAnimationFrame = null;
+      const anchors = [...this.pendingAnchors];
+      this.pendingAnchors.clear();
+      for (const anchor of anchors) {
+        if (anchor.isConnected && this.contains(anchor)) {
+          this.prepareAnchor(anchor);
+        }
+      }
+    });
+  });
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    return this;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.style.display = "contents";
+    this.addEventListener("pointerover", this.handlePointerOver);
+    this.addEventListener("pointerout", this.handlePointerOut);
+    this.addEventListener("focusin", this.handleFocusIn);
+    this.addEventListener("focusout", this.handleFocusOut);
+    this.addEventListener("keydown", this.handleKeyDown);
+    this.addEventListener("click", this.handleClick);
+    this.stopI18n ??= i18n.subscribe(this.handleLocaleChange);
+    this.subtreeObserver.observe(this, { childList: true, subtree: true });
+    for (const anchor of this.querySelectorAll<HTMLAnchorElement>(SESSION_LINK_SELECTOR)) {
+      this.prepareAnchor(anchor);
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.removeEventListener("pointerover", this.handlePointerOver);
+    this.removeEventListener("pointerout", this.handlePointerOut);
+    this.removeEventListener("focusin", this.handleFocusIn);
+    this.removeEventListener("focusout", this.handleFocusOut);
+    this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("click", this.handleClick);
+    this.subtreeObserver.disconnect();
+    if (this.scanAnimationFrame !== null) {
+      cancelAnimationFrame(this.scanAnimationFrame);
+      this.scanAnimationFrame = null;
+    }
+    this.pendingAnchors.clear();
+    this.stopI18n?.();
+    this.stopI18n = null;
+    this.close();
+    super.disconnectedCallback();
+  }
+
+  private readonly handleLocaleChange = () => {
+    const card = this.card;
+    if (!card) {
+      return;
+    }
+    if (this.renderedPreview) {
+      renderPreview(card, this.renderedPreview);
+    } else if (this.renderedUnavailable) {
+      renderUnavailable(card);
+    } else {
+      renderLoading(card);
+    }
+    this.positionCard();
+  };
+
+  private mainKey(): string {
+    const context = this.context;
+    return context
+      ? resolveUiConfiguredMainKey({
+          agentsList: context.agents.state.agentsList,
+          hello: context.gateway.snapshot.hello,
+        })
+      : "main";
+  }
+
+  private resolveShortTarget(target: Extract<SessionPathTarget, { kind: "short" }>): string | null {
+    const rows = this.context?.sessions.state.result?.sessions ?? [];
+    for (const row of rows) {
+      const parsed = parseAgentSessionKey(row.key);
+      const uuid = sessionKeyUuid(row.key);
+      if (
+        parsed &&
+        normalizeAgentId(parsed.agentId) === normalizeAgentId(target.agentId) &&
+        uuid?.startsWith(target.shortId.toLowerCase().replaceAll("-", "")) &&
+        (!target.slugHint || controlUiSessionSlug(row.displayName) === target.slugHint)
+      ) {
+        return row.key;
+      }
+    }
+    // A short ref is not a canonical key. V1 deliberately avoids a resolve RPC
+    // on hover; only the already-loaded session roster may make it previewable.
+    return null;
+  }
+
+  private targetForAnchor(anchor: HTMLAnchorElement): SessionPreviewTarget | null {
+    const rawKey = anchor.dataset.sessionKey?.trim();
+    if (rawKey) {
+      const parsed = parseAgentSessionKey(rawKey);
+      return parsed ? { sessionKey: rawKey, agentId: parsed.agentId, namespace: "chat" } : null;
+    }
+    let url: URL;
+    try {
+      url = new URL(anchor.href, globalThis.location?.href ?? "http://localhost/");
+    } catch {
+      return null;
+    }
+    if (url.origin !== globalThis.location?.origin) {
+      return null;
+    }
+    const target = sessionRefFromPath(url.pathname, this.context?.basePath ?? "", this.mainKey());
+    if (!target) {
+      return null;
+    }
+    const sessionKey =
+      target.kind === "main"
+        ? buildAgentMainSessionKey({ agentId: target.agentId, mainKey: this.mainKey() })
+        : target.kind === "literal"
+          ? target.sessionKey
+          : this.resolveShortTarget(target);
+    return sessionKey ? { sessionKey, agentId: target.agentId, namespace: target.namespace } : null;
+  }
+
+  private findSeedRow(target: SessionPreviewTarget): GatewaySessionRow | undefined {
+    return this.context?.sessions.state.result?.sessions.find((row) =>
+      areUiSessionKeysEquivalent(row.key, target.sessionKey),
+    );
+  }
+
+  private setCacheEntry(key: string, entry: CacheEntry): void {
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    while (this.cache.size > CACHE_LIMIT) {
+      const oldest = this.cache.keys().next().value;
+      if (!oldest) {
+        break;
+      }
+      this.cache.delete(oldest);
+    }
+  }
+
+  private loadPreview(target: SessionPreviewTarget): Promise<SessionPreview> {
+    const key = target.sessionKey;
+    const now = Date.now();
+    const cached = this.cache.get(key);
+    if (cached && cached.expiresAt > now) {
+      this.setCacheEntry(key, cached);
+      return cached.promise;
+    }
+    if (cached) {
+      this.cache.delete(key);
+    }
+    const seeded = this.findSeedRow(target);
+    if (seeded) {
+      const value = previewFromRow(seeded, target);
+      const entry = { expiresAt: now + SUCCESS_CACHE_MS, promise: Promise.resolve(value), value };
+      this.setCacheEntry(key, entry);
+      return entry.promise;
+    }
+
+    const load = async () => {
+      if (!this.client) {
+        throw new Error("Session preview requires a connected Gateway");
+      }
+      return parsePreviewResponse(
+        await this.client.request<ControlUiSessionPreview>("controlUi.sessionPreview", {
+          sessionKey: target.sessionKey,
+        }),
+      );
+    };
+    const entry: CacheEntry = {
+      expiresAt: now + SUCCESS_CACHE_MS,
+      promise: Promise.resolve().then(load),
+    };
+    entry.promise = entry.promise.then(
+      (value) => {
+        entry.value = value;
+        return value;
+      },
+      (error: unknown) => {
+        entry.expiresAt = Date.now() + FAILURE_CACHE_MS;
+        throw error;
+      },
+    );
+    this.setCacheEntry(key, entry);
+    return entry.promise;
+  }
+
+  private stampAnchor(
+    anchor: HTMLAnchorElement,
+    target: SessionPreviewTarget | null,
+    preview?: SessionPreview,
+  ): void {
+    if (!target) {
+      return;
+    }
+    const title = preview ? displayTitle(preview) : undefined;
+    const href = pathForSession(
+      target.namespace,
+      target.agentId,
+      target.sessionKey,
+      this.context?.basePath,
+      {
+        displayName: title,
+        mainKey: this.mainKey(),
+      },
+    );
+    if (href && anchor.getAttribute("href") !== href) {
+      anchor.setAttribute("href", href);
+    }
+    if (!title || anchor.classList.contains("markdown-session-link--titled")) {
+      return;
+    }
+    anchor.classList.add("markdown-session-link--titled");
+    anchor.textContent = title;
+    anchor.title = target.sessionKey;
+  }
+
+  private prepareAnchor(anchor: HTMLAnchorElement): void {
+    const target = this.targetForAnchor(anchor);
+    if (!target) {
+      return;
+    }
+    const promise = this.loadPreview(target);
+    this.stampAnchor(anchor, target, this.cache.get(target.sessionKey)?.value);
+    void promise.then(
+      (preview) => {
+        if (anchor.isConnected && anchor.dataset.sessionKey === target.sessionKey) {
+          this.stampAnchor(anchor, target, preview);
+        }
+      },
+      () => undefined,
+    );
+  }
+
+  private readonly handlePointerOver = (event: Event) => {
+    if ("pointerType" in event && event.pointerType === "touch") {
+      return;
+    }
+    const anchor = sessionLinkAnchorFromEvent(event);
+    const target = anchor ? this.targetForAnchor(anchor) : null;
+    if (anchor && target) {
+      this.activateFromBootstrap(anchor, "pointer", SESSION_HOVERCARD_OPEN_DELAY_MS);
+    }
+  };
+
+  private readonly handlePointerOut = (event: PointerEvent) => {
+    const anchor = sessionLinkAnchorFromEvent(event);
+    if (!anchor || anchor !== this.activeAnchor) {
+      return;
+    }
+    if (event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) {
+      return;
+    }
+    this.pointerInside = false;
+    this.scheduleClose();
+  };
+
+  private readonly handleFocusIn = (event: Event) => {
+    const anchor = sessionLinkAnchorFromEvent(event);
+    const target = anchor ? this.targetForAnchor(anchor) : null;
+    if (anchor && target) {
+      this.activateFromBootstrap(anchor, "focus", 0);
+    }
+  };
+
+  private readonly handleFocusOut = (event: FocusEvent) => {
+    if (
+      this.activeAnchor &&
+      !(event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget))
+    ) {
+      this.focusInside = false;
+      this.scheduleClose();
+    }
+  };
+
+  private readonly handleCardPointerEnter = () => {
+    this.pointerOverCard = true;
+    this.clearCloseTimer();
+  };
+
+  private readonly handleCardPointerLeave = () => {
+    this.pointerOverCard = false;
+    this.scheduleClose();
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      this.close();
+    }
+  };
+
+  private readonly handleClick = () => {
+    this.close();
+  };
+
+  activateFromBootstrap(
+    anchor: HTMLAnchorElement,
+    trigger: "focus" | "pointer",
+    delay: number,
+  ): void {
+    const target = this.targetForAnchor(anchor);
+    if (!target) {
+      return;
+    }
+    if (anchor === this.activeAnchor && this.activeTarget?.sessionKey === target.sessionKey) {
+      return;
+    }
+    this.close();
+    this.activeAnchor = anchor;
+    this.activeTarget = target;
+    anchor.setAttribute("aria-haspopup", "dialog");
+    anchor.setAttribute("aria-expanded", "false");
+    if (trigger === "pointer") {
+      this.pointerInside = true;
+    } else {
+      this.focusInside = true;
+    }
+    this.openTimer = window.setTimeout(() => {
+      this.openTimer = null;
+      this.show(anchor, target);
+    }, delay);
+  }
+
+  private show(anchor: HTMLAnchorElement, target: SessionPreviewTarget): void {
+    if (this.activeAnchor !== anchor || this.activeTarget?.sessionKey !== target.sessionKey) {
+      return;
+    }
+    const card = document.createElement("div");
+    nextHovercardId += 1;
+    card.id = `openclaw-session-hovercard-${nextHovercardId}`;
+    card.className = "session-link-hovercard";
+    card.dataset.open = "true";
+    card.setAttribute("role", "dialog");
+    this.renderedPreview = null;
+    this.renderedUnavailable = false;
+    renderLoading(card);
+    card.addEventListener("pointerenter", this.handleCardPointerEnter);
+    card.addEventListener("pointerleave", this.handleCardPointerLeave);
+    document.body.append(card);
+    this.card = card;
+    anchor.setAttribute("aria-controls", card.id);
+    anchor.setAttribute("aria-expanded", "true");
+    this.listenForViewportChanges();
+    this.positionCard();
+    void this.previewTask.run([target]);
+  }
+
+  private get hoverIntentHeld(): boolean {
+    return this.pointerInside || this.pointerOverCard || this.focusInside;
+  }
+
+  private clearCloseTimer(): void {
+    if (this.closeTimer !== null) {
+      window.clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
+  }
+
+  private scheduleClose(): void {
+    this.clearCloseTimer();
+    if (this.hoverIntentHeld) {
+      return;
+    }
+    if (!this.card) {
+      this.close();
+      return;
+    }
+    this.closeTimer = window.setTimeout(() => {
+      this.closeTimer = null;
+      if (!this.hoverIntentHeld) {
+        this.close();
+      }
+    }, CLOSE_DELAY_MS);
+  }
+
+  private close(): void {
+    if (this.openTimer !== null) {
+      window.clearTimeout(this.openTimer);
+      this.openTimer = null;
+    }
+    this.clearCloseTimer();
+    void this.previewTask.run([null]);
+    if (this.activeAnchor) {
+      this.activeAnchor.removeAttribute("aria-controls");
+      this.activeAnchor.removeAttribute("aria-expanded");
+      this.activeAnchor.removeAttribute("aria-haspopup");
+    }
+    this.card?.remove();
+    this.card = null;
+    this.renderedPreview = null;
+    this.renderedUnavailable = false;
+    this.activeAnchor = null;
+    this.activeTarget = null;
+    this.focusInside = false;
+    this.pointerInside = false;
+    this.pointerOverCard = false;
+    this.stopListeningForViewportChanges();
+  }
+
+  private readonly handleViewportChange = () => {
+    this.positionCard();
+  };
+
+  private listenForViewportChanges(): void {
+    window.addEventListener("resize", this.handleViewportChange);
+    window.addEventListener("scroll", this.handleViewportChange, true);
+    window.visualViewport?.addEventListener("resize", this.handleViewportChange);
+    window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
+  }
+
+  private stopListeningForViewportChanges(): void {
+    window.removeEventListener("resize", this.handleViewportChange);
+    window.removeEventListener("scroll", this.handleViewportChange, true);
+    window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
+    window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
+  }
+
+  private positionCard(): void {
+    const anchor = this.activeAnchor;
+    const card = this.card;
+    if (!anchor || !card) {
+      return;
+    }
+    const anchorRect = anchor.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const fitsBelow =
+      anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
+    const side = fitsBelow ? "bottom" : "top";
+    const top =
+      side === "bottom"
+        ? anchorRect.bottom + CARD_GAP
+        : anchorRect.top - cardRect.height - CARD_GAP;
+    const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
+    const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
+    card.dataset.side = side;
+    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
+    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;
+  }
+}

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -10,7 +10,6 @@ import { i18n } from "../i18n/index.ts";
 import { SessionLinkHovercardProvider } from "./session-link-hovercard.runtime.ts";
 
 const ELEMENT_NAME = `test-openclaw-session-link-hovercard-provider-${crypto.randomUUID()}`;
-const REGISTERED_ELEMENT_NAME = "openclaw-session-link-hovercard-provider";
 const SESSION_KEY = "agent:main:research";
 
 customElements.define(ELEMENT_NAME, class extends SessionLinkHovercardProvider {});
@@ -141,15 +140,18 @@ describe("openclaw-session-link-hovercard-provider", () => {
     document.body.append(provider);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(anchor.textContent).toBe("Research plan");
-    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", { sessionKey: SESSION_KEY });
+    expect(anchor.textContent).toBe(SESSION_KEY);
+    expect(anchor.getAttribute("href")).toBe("/chat/main/research");
+    expect(request).not.toHaveBeenCalled();
 
     await hover(anchor);
     const card = document.querySelector<HTMLElement>(".session-link-hovercard");
+    expect(anchor.textContent).toBe("Research plan");
     expect(card?.textContent).toContain("Research plan");
     expect(card?.textContent).toContain("main · direct · webchat");
     expect(card?.textContent).toContain("The rollout notes are ready.");
     expect(card?.textContent).toContain("5m ago");
+    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", { sessionKey: SESSION_KEY });
     expect(request).toHaveBeenCalledTimes(1);
 
     anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
@@ -176,10 +178,13 @@ describe("openclaw-session-link-hovercard-provider", () => {
     provider.append(anchor);
     document.body.append(provider);
     await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).not.toHaveBeenCalled();
     expect(anchor.textContent).toBe(SESSION_KEY);
     expect(anchor.getAttribute("href")).toBe("/chat/main/research");
 
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(1);
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
     await vi.advanceTimersByTimeAsync(5 * 60_000);
     await hover(anchor);
     expect(request).toHaveBeenCalledTimes(2);
@@ -281,24 +286,45 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(document.activeElement).toBe(anchor);
   });
 
-  it("upgrades session chips without user interaction when they appear", async () => {
-    const request = vi.fn().mockResolvedValue(previewResponse());
-    const provider = document.createElement(REGISTERED_ELEMENT_NAME) as ProviderElement;
-    provider.client = { request } as unknown as GatewayBrowserClient;
-    provider.context = sessionContext();
+  it("defers unseeded preview requests until intent across many attached anchors", async () => {
+    const seededKey = "agent:main:seeded";
+    const seededRow = {
+      key: seededKey,
+      agentId: "main",
+      kind: "direct",
+      displayName: "Seeded session",
+      updatedAt: Date.now(),
+    } as GatewaySessionRow;
+    const unseededAnchors = Array.from({ length: 50 }, (_, index) =>
+      sessionAnchor(`agent:main:unseeded-${index}`),
+    );
+    const request = vi.fn().mockResolvedValue(
+      previewResponse({
+        sessionKey: unseededAnchors[0]?.dataset.sessionKey,
+        title: "Hovered session",
+      }),
+    );
+    const { provider } = createProvider({ rows: [seededRow], request });
+    const seededAnchor = sessionAnchor(seededKey);
     document.body.append(provider);
-    await import("./session-link-hovercard-registration.ts");
-
-    const anchor = sessionAnchor();
-    provider.append(anchor);
+    provider.append(seededAnchor, ...unseededAnchors);
 
     await flushMutationBatch();
-    await vi.waitFor(() => {
-      expect(anchor.classList.contains("markdown-session-link--titled")).toBe(true);
+    expect(request).not.toHaveBeenCalled();
+    expect(unseededAnchors.every((anchor) => anchor.hasAttribute("href"))).toBe(true);
+    expect(seededAnchor.textContent).toBe("Seeded session");
+    expect(seededAnchor.classList.contains("markdown-session-link--titled")).toBe(true);
+
+    const hoveredAnchor = unseededAnchors[0];
+    if (!hoveredAnchor) {
+      throw new Error("Expected an unseeded session anchor");
+    }
+    await hover(hoveredAnchor);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", {
+      sessionKey: hoveredAnchor.dataset.sessionKey,
     });
-    expect(anchor.textContent).toBe("Research plan");
-    expect(anchor.title).toBe(SESSION_KEY);
-    expect(anchor.getAttribute("href")).toBe("/chat/main/research");
-    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", { sessionKey: SESSION_KEY });
+    expect(hoveredAnchor.textContent).toBe("Hovered session");
   });
 });

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -10,6 +10,7 @@ import { i18n } from "../i18n/index.ts";
 import { SessionLinkHovercardProvider } from "./session-link-hovercard.runtime.ts";
 
 const ELEMENT_NAME = `test-openclaw-session-link-hovercard-provider-${crypto.randomUUID()}`;
+const REGISTERED_ELEMENT_NAME = "openclaw-session-link-hovercard-provider";
 const SESSION_KEY = "agent:main:research";
 
 customElements.define(ELEMENT_NAME, class extends SessionLinkHovercardProvider {});
@@ -244,5 +245,26 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(document.querySelector(".session-link-hovercard")).toBeNull();
     expect(anchor.hasAttribute("aria-expanded")).toBe(false);
     expect(document.activeElement).toBe(anchor);
+  });
+
+  it("upgrades session chips without user interaction when they appear", async () => {
+    const request = vi.fn().mockResolvedValue(previewResponse());
+    const provider = document.createElement(REGISTERED_ELEMENT_NAME) as ProviderElement;
+    provider.client = { request } as unknown as GatewayBrowserClient;
+    provider.context = sessionContext();
+    document.body.append(provider);
+    await import("./session-link-hovercard-registration.ts");
+
+    const anchor = sessionAnchor();
+    provider.append(anchor);
+
+    await flushMutationBatch();
+    await vi.waitFor(() => {
+      expect(anchor.classList.contains("markdown-session-link--titled")).toBe(true);
+    });
+    expect(anchor.textContent).toBe("Research plan");
+    expect(anchor.title).toBe(SESSION_KEY);
+    expect(anchor.getAttribute("href")).toBe("/chat/main/research");
+    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", { sessionKey: SESSION_KEY });
   });
 });

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -1,0 +1,248 @@
+/* @vitest-environment jsdom */
+
+import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
+import { setSessionPathBuilder } from "../app-session-path-builder.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { i18n } from "../i18n/index.ts";
+import { SessionLinkHovercardProvider } from "./session-link-hovercard.runtime.ts";
+
+const ELEMENT_NAME = `test-openclaw-session-link-hovercard-provider-${crypto.randomUUID()}`;
+const SESSION_KEY = "agent:main:research";
+
+customElements.define(ELEMENT_NAME, class extends SessionLinkHovercardProvider {});
+
+type ProviderElement = HTMLElement & {
+  client: GatewayBrowserClient | null;
+  context: ApplicationContext | null;
+};
+
+function sessionContext(rows: GatewaySessionRow[] = []): ApplicationContext {
+  return {
+    basePath: "",
+    sessions: {
+      state: {
+        result: { count: rows.length, sessions: rows },
+      },
+    },
+    agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
+    gateway: { snapshot: { hello: null } },
+  } as unknown as ApplicationContext;
+}
+
+function createProvider(options: {
+  rows?: GatewaySessionRow[];
+  response?: unknown;
+  request?: ReturnType<typeof vi.fn>;
+}) {
+  const provider = document.createElement(ELEMENT_NAME) as ProviderElement;
+  const request = options.request ?? vi.fn().mockResolvedValue(options.response);
+  provider.client = { request } as unknown as GatewayBrowserClient;
+  provider.context = sessionContext(options.rows);
+  return { provider, request };
+}
+
+function sessionAnchor(sessionKey = SESSION_KEY): HTMLAnchorElement {
+  const anchor = document.createElement("a");
+  anchor.className = "markdown-session-link";
+  anchor.dataset.sessionKey = sessionKey;
+  anchor.textContent = sessionKey;
+  return anchor;
+}
+
+function previewResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "ok",
+    sessionKey: SESSION_KEY,
+    title: "Research plan",
+    agentId: "main",
+    kind: "direct",
+    channel: "webchat",
+    updatedAt: Date.parse("2026-08-16T11:55:00Z"),
+    lastMessagePreview: "The rollout notes are ready.",
+    archived: false,
+    ...overrides,
+  };
+}
+
+async function flushMutationBatch(): Promise<void> {
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(16);
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(16);
+}
+
+async function hover(anchor: HTMLAnchorElement): Promise<void> {
+  anchor.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+  await vi.advanceTimersByTimeAsync(250);
+}
+
+describe("openclaw-session-link-hovercard-provider", () => {
+  beforeEach(() => {
+    setSessionPathBuilder(buildControlUiSessionPath);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-16T12:00:00Z"));
+  });
+
+  afterEach(async () => {
+    await i18n.setLocale("en");
+    document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("seeds from the loaded session roster and stamps a titled chip synchronously", () => {
+    const row = {
+      key: SESSION_KEY,
+      agentId: "main",
+      kind: "direct",
+      displayName: "Cached research",
+      updatedAt: Date.now(),
+    } as GatewaySessionRow;
+    const { provider, request } = createProvider({ rows: [row] });
+    const anchor = sessionAnchor();
+
+    provider.append(anchor);
+    document.body.append(provider);
+
+    expect(anchor.textContent).toBe("Cached research");
+    expect(anchor.classList.contains("markdown-session-link--titled")).toBe(true);
+    expect(anchor.title).toBe(SESSION_KEY);
+    expect(anchor.getAttribute("href")).toBe("/chat/main/research");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("upgrades from the RPC, renders the card, and reuses one cache entry", async () => {
+    const { provider, request } = createProvider({ response: previewResponse() });
+    const anchor = sessionAnchor();
+    provider.append(anchor);
+    document.body.append(provider);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(anchor.textContent).toBe("Research plan");
+    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", { sessionKey: SESSION_KEY });
+
+    await hover(anchor);
+    const card = document.querySelector<HTMLElement>(".session-link-hovercard");
+    expect(card?.textContent).toContain("Research plan");
+    expect(card?.textContent).toContain("main · direct · webchat");
+    expect(card?.textContent).toContain("The rollout notes are ready.");
+    expect(card?.textContent).toContain("5m ago");
+    expect(request).toHaveBeenCalledTimes(1);
+
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+    const stamped = anchor.outerHTML;
+    const replacement = sessionAnchor();
+    anchor.replaceWith(replacement);
+    await flushMutationBatch();
+    expect(replacement.outerHTML).toBe(stamped);
+    replacement.remove();
+    provider.append(replacement);
+    await flushMutationBatch();
+    expect(replacement.outerHTML).toBe(stamped);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("expires successful and failed cache entries at their separate TTLs", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(previewResponse({ title: undefined, derivedTitle: undefined }))
+      .mockResolvedValueOnce({ status: "unavailable" })
+      .mockResolvedValueOnce(previewResponse());
+    const { provider } = createProvider({ request });
+    const anchor = sessionAnchor();
+    provider.append(anchor);
+    document.body.append(provider);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(anchor.textContent).toBe(SESSION_KEY);
+    expect(anchor.getAttribute("href")).toBe("/chat/main/research");
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(document.querySelector(".session-link-hovercard")?.textContent).toContain(
+      "Session preview unavailable",
+    );
+
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(2);
+
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not resolve an uncached short session path through the preview RPC", async () => {
+    const { provider, request } = createProvider({ response: previewResponse() });
+    const anchor = document.createElement("a");
+    anchor.href = "/chat/main/research-1234abcd";
+    anchor.textContent = "Research";
+    provider.append(anchor);
+    document.body.append(provider);
+
+    await hover(anchor);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(document.querySelector(".session-link-hovercard")).toBeNull();
+  });
+
+  it("resolves a short session path only from the loaded roster", async () => {
+    const sessionKey = "agent:main:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
+    const row = {
+      key: sessionKey,
+      agentId: "main",
+      kind: "direct",
+      displayName: "Research plan",
+      updatedAt: Date.now(),
+    } as GatewaySessionRow;
+    const { provider, request } = createProvider({ rows: [row] });
+    const anchor = document.createElement("a");
+    anchor.href = "/chat/main/research-plan-2139bddb";
+    anchor.textContent = "Research";
+    provider.append(anchor);
+    document.body.append(provider);
+
+    await hover(anchor);
+
+    expect(document.querySelector(".session-link-hovercard")?.textContent).toContain(
+      "Research plan",
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("shows loading while the RPC is pending and supports focus plus Escape", async () => {
+    let resolvePreview: ((value: unknown) => void) | undefined;
+    const request = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+    const { provider } = createProvider({ request });
+    const anchor = sessionAnchor();
+    provider.append(anchor);
+    document.body.append(provider);
+
+    anchor.focus();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.querySelector(".session-link-hovercard")?.textContent).toContain(
+      "Loading session details…",
+    );
+
+    resolvePreview?.(previewResponse());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.querySelector(".session-link-hovercard")?.textContent).toContain(
+      "Research plan",
+    );
+    expect(anchor.getAttribute("aria-expanded")).toBe("true");
+
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+    expect(document.querySelector(".session-link-hovercard")).toBeNull();
+    expect(anchor.hasAttribute("aria-expanded")).toBe(false);
+    expect(document.activeElement).toBe(anchor);
+  });
+});

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -115,6 +115,25 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("stamps single-segment UUID keys with a forced-literal href", () => {
+    const uuid = "12345678-90ab-cdef-1234-567890abcdef";
+    const sessionKey = `agent:main:${uuid}`;
+    const row = {
+      key: sessionKey,
+      agentId: "main",
+      kind: "direct",
+      updatedAt: Date.now(),
+    } as GatewaySessionRow;
+    const { provider, request } = createProvider({ rows: [row] });
+    const anchor = sessionAnchor(sessionKey);
+
+    provider.append(anchor);
+    document.body.append(provider);
+
+    expect(anchor.getAttribute("href")).toBe(`/chat/main/~key/${uuid}`);
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("upgrades from the RPC, renders the card, and reuses one cache entry", async () => {
     const { provider, request } = createProvider({ response: previewResponse() });
     const anchor = sessionAnchor();

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -192,6 +192,21 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(document.querySelector(".session-link-hovercard")).toBeNull();
   });
 
+  it("does not overlay sidebar session navigation", async () => {
+    const { provider, request } = createProvider({ response: previewResponse() });
+    const anchor = document.createElement("a");
+    anchor.className = "sidebar-recent-session__link";
+    anchor.href = "/chat/main/research";
+    anchor.textContent = "Research";
+    provider.append(anchor);
+    document.body.append(provider);
+
+    await hover(anchor);
+
+    expect(document.querySelector(".session-link-hovercard")).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("resolves a short session path only from the loaded roster", async () => {
     const sessionKey = "agent:main:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
     const row = {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -160,6 +160,12 @@ export const en: TranslationMap = {
     issue: "issue",
     ariaLabel: "{state} {kind} {repo} #{number}: {title}, by {author}",
   },
+  sessionPreview: {
+    loading: "Loading session details…",
+    unavailable: "Session preview unavailable",
+    archived: "Archived",
+    ariaLabel: "Session: {title}",
+  },
   channels: {
     lastError: "Last error",
     refreshingStaleSnapshot:

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -35,6 +35,7 @@ type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   row?: never;
   mainKey?: never;
   shortIdLength?: number;
+  exactKey?: boolean;
   preferenceDerivedFace?: boolean;
   focusComposer?: boolean;
   navigationKey?: string;
@@ -49,6 +50,7 @@ type ExplicitSessionNavigationTargetParams = {
   row?: Pick<GatewaySessionRow, "displayName" | "key">;
   mainKey?: string | null;
   shortIdLength?: number;
+  exactKey?: boolean;
   agentId?: never;
   preferenceDerivedFace?: boolean;
   focusComposer?: boolean;
@@ -117,6 +119,7 @@ function pathForNonCatalogSessionKey(params: {
   row?: Pick<GatewaySessionRow, "displayName" | "key">;
   mainKey?: string | null;
   shortIdLength?: number;
+  exactKey?: boolean;
 }): string {
   const key = params.row?.key ?? params.sessionKey;
   const agentId =
@@ -127,6 +130,7 @@ function pathForNonCatalogSessionKey(params: {
   return (
     pathForSession(params.face, normalizeAgentId(agentId), key, params.basePath, {
       displayName: params.row?.displayName,
+      exactKey: params.exactKey,
       mainKey: params.mainKey,
       shortIdLength: params.shortIdLength,
     }) ?? pathForRoute(params.face, params.basePath)
@@ -168,6 +172,7 @@ export function sessionNavigationTarget<TRouteId extends string>(
     fallbackAgentId,
     basePath,
     shortIdLength: params.shortIdLength,
+    exactKey: params.exactKey,
     ...(catalogKey ? { mainKey } : { row, mainKey }),
   });
   const search = catalogKey ? catalogSessionSearch(catalogKey) : undefined;

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -5,6 +5,7 @@ import { repeat } from "lit/directives/repeat.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { mergeChatPageChrome, mobileNavLayoutMediaQuery } from "../../app/mobile-nav-layout.ts";
 import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
+import "../../components/session-link-hovercard-registration.ts";
 import "../../components/resizable-divider.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { McpAppUnmountGate } from "../../components/mcp-app-unmount.ts";

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -5,6 +5,7 @@ import { findInlineApproval } from "../../app/approval-presentation.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-prompt.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../../app/user-profile.ts";
+import { navigateMarkdownSession } from "../../components/markdown-session-links.ts";
 import { hasSessionPresenceViewers } from "../../components/viewer-facepile.ts";
 import { t } from "../../i18n/index.ts";
 import {
@@ -489,6 +490,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
         void this.acceptTaskSuggestion(suggestion, mode, cloudProfileId),
       onDismissTaskSuggestion: (suggestion) => void this.dismissTaskSuggestion(suggestion),
       onOpenWorkspaceFile: (target) => openSessionWorkspaceFile(state, target),
+      onOpenSessionLink: (target) => navigateMarkdownSession(this.context, target),
       onRevealWorkspaceFile: (path) => revealSessionWorkspaceFile(state, path),
       onRefresh: () => {
         if (catalogKey) {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -19,6 +19,7 @@ import type { ChatSendShortcut } from "../../app/settings.ts";
 import { renderExecApprovalCard } from "../../components/exec-approval-card.ts";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
+import type { SessionLinkTarget } from "../../components/markdown-session-links.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardProvider } from "../../lib/board/provider.ts";
 import type {
@@ -233,6 +234,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     onSessionSelect?: (sessionKey: string) => void;
     onOpenSidebar?: (content: SidebarContent) => void;
     onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
+    onOpenSessionLink?: (target: SessionLinkTarget) => void;
     onRevealWorkspaceFile?: (path: string) => void;
     onChatScroll?: (event: Event) => void;
     basePath?: string;
@@ -330,6 +332,7 @@ export function renderChat(props: ChatProps) {
       realtimeTalkConversation: props.realtimeTalkConversation,
       onOpenSidebar: props.onOpenSidebar,
       onOpenWorkspaceFile: props.onOpenWorkspaceFile,
+      onOpenSessionLink: props.onOpenSessionLink,
       onOpenSessionCheckpoints: props.onOpenSessionCheckpoints,
       onAssistantAttachmentLoaded: props.onAssistantAttachmentLoaded,
       onRequestOpenImage: props.onRequestOpenImage,

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -50,6 +50,7 @@ export function renderChatDetailSlot(params: {
     .allowExternalEmbedUrls=${host.allowExternalEmbedUrls}
     .onOpenWorkspaceFile=${(target: { path: string; line?: number | null }) =>
       openSessionWorkspaceFile(host, target)}
+    .onOpenSessionLink=${params.chat.onOpenSessionLink}
     .onRevealInWorkspace=${(path: string) => {
       revealSessionWorkspaceFile(host, path);
       host.updateSidebarLayout(openSlot(host.sidebarLayout, "workspace"));

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -44,6 +44,7 @@ export function renderChatDetailSlot(params: {
   return html`<openclaw-chat-detail-panel
     class="chat-sidebar"
     .content=${content}
+    .basePath=${params.chat.basePath ?? ""}
     .loadFullMessage=${params.fullMessageLoader}
     .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}
     .embedSandboxMode=${host.embedSandboxMode}

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -295,6 +295,7 @@ export function renderGroupedMessage(
     codeBlockChrome: role === "user" ? "none" : "copy",
     fileLinks: true,
     interactiveImages: opts.onOpenImage !== undefined,
+    sessionLinks: true,
   };
 
   // Detect pure-JSON messages and render as collapsible block

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -898,6 +898,7 @@ describe("grouped chat rendering", () => {
       codeBlockChrome: "none",
       fileLinks: true,
       interactiveImages: false,
+      sessionLinks: true,
     });
   });
 
@@ -1016,6 +1017,7 @@ describe("grouped chat rendering", () => {
       codeBlockChrome: "copy",
       fileLinks: true,
       interactiveImages: false,
+      sessionLinks: true,
     });
   });
 
@@ -1558,6 +1560,7 @@ describe("grouped chat rendering", () => {
       codeBlockChrome: "copy",
       fileLinks: true,
       interactiveImages: false,
+      sessionLinks: true,
     });
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -158,6 +158,40 @@ describe("markdown sidebar", () => {
     },
   );
 
+  it.each(["click", "Enter"])(
+    "SPA-routes markdown preview session hrefs with %s",
+    async (action) => {
+      const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+        basePath?: string;
+        content: unknown;
+        onOpenSessionLink?: (target: unknown) => void;
+        updateComplete?: Promise<unknown>;
+      };
+      const onOpenSessionLink = vi.fn();
+      const literalUuid = "12345678-90ab-cdef-1234-567890abcdef";
+      const href = `${window.location.origin}/control/dashboard/main/~key/${literalUuid}`;
+      panel.basePath = "/control";
+      panel.content = { kind: "markdown", content: `[Open session](${href})` };
+      panel.onOpenSessionLink = onOpenSessionLink;
+      document.body.append(panel);
+      await panel.updateComplete;
+
+      const link = panel.querySelector<HTMLAnchorElement>(`a[href^="${window.location.origin}"]`);
+      const event =
+        action === "click"
+          ? new MouseEvent("click", { bubbles: true, button: 0, cancelable: true })
+          : new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+      link?.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onOpenSessionLink).toHaveBeenCalledWith({
+        namespace: "dashboard",
+        pathname: `/control/dashboard/main/~key/${literalUuid}`,
+      });
+      panel.remove();
+    },
+  );
+
   it("activates Markdown images only when a chat owner opts in", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -110,8 +110,8 @@ describe("markdown sidebar", () => {
     panel.remove();
   });
 
-  it.each(["click", "Enter", " "])(
-    "opens markdown preview session links with %j",
+  it.each(["click", "Ctrl+click", "Enter", " "])(
+    "handles markdown preview session links with %j",
     async (action) => {
       const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
         content: unknown;
@@ -126,8 +126,22 @@ describe("markdown sidebar", () => {
       await panel.updateComplete;
 
       const link = panel.querySelector<HTMLAnchorElement>("a.markdown-session-link");
-      if (action === "click") {
-        link?.click();
+      if (action === "click" || action === "Ctrl+click") {
+        link?.setAttribute("href", "/chat/roboclaw/2139bddb");
+        const modified = action === "Ctrl+click";
+        const event = new MouseEvent("click", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+          ctrlKey: modified,
+        });
+        link?.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(!modified);
+        if (modified) {
+          expect(onOpenSessionLink).not.toHaveBeenCalled();
+          panel.remove();
+          return;
+        }
       } else {
         link?.focus();
         const event = new KeyboardEvent("keydown", {

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -110,6 +110,40 @@ describe("markdown sidebar", () => {
     panel.remove();
   });
 
+  it.each(["click", "Enter", " "])(
+    "opens markdown preview session links with %j",
+    async (action) => {
+      const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+        content: unknown;
+        onOpenSessionLink?: (target: { sessionKey: string; agentId: string }) => void;
+        updateComplete?: Promise<unknown>;
+      };
+      const onOpenSessionLink = vi.fn();
+      const sessionKey = "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
+      panel.content = { kind: "markdown", content: `Open \`${sessionKey}\`` };
+      panel.onOpenSessionLink = onOpenSessionLink;
+      document.body.append(panel);
+      await panel.updateComplete;
+
+      const link = panel.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      if (action === "click") {
+        link?.click();
+      } else {
+        link?.focus();
+        const event = new KeyboardEvent("keydown", {
+          key: action,
+          bubbles: true,
+          cancelable: true,
+        });
+        link?.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+      }
+
+      expect(onOpenSessionLink).toHaveBeenCalledWith({ sessionKey, agentId: "roboclaw" });
+      panel.remove();
+    },
+  );
+
   it("activates Markdown images only when a chat owner opts in", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -10,6 +10,7 @@ import {
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
 import {
+  markdownSessionHref,
   markdownSessionLinkFromEvent,
   markdownSessionLinkFromKeyboardEvent,
   type SessionLinkTarget,
@@ -699,6 +700,7 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
 class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) content: ChatDetailContent | null = null;
   @property({ attribute: false }) loadFullMessage?: SidebarFullMessageLoader | null = null;
+  @property() basePath = "";
   @property() canvasPluginSurfaceUrl: string | null = null;
   @property() embedSandboxMode: EmbedSandboxMode = "scripts";
   @property({ type: Boolean }) allowExternalEmbedUrls = false;
@@ -1316,7 +1318,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       this.onOpenWorkspaceFile?.(target);
       return;
     }
-    const sessionTarget = markdownSessionLinkFromEvent(event);
+    const sessionTarget =
+      markdownSessionLinkFromEvent(event) ?? markdownSessionHref(event, this.basePath);
     if (sessionTarget && shouldHandleNavigationClick(event)) {
       event.preventDefault();
       this.onOpenSessionLink?.(sessionTarget);
@@ -1329,8 +1332,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       this.onOpenWorkspaceFile?.(target);
       return;
     }
-    const sessionTarget = markdownSessionLinkFromKeyboardEvent(event);
+    const sessionTarget =
+      markdownSessionLinkFromKeyboardEvent(event) ??
+      (event.key === "Enter" ? markdownSessionHref(event, this.basePath) : null);
     if (sessionTarget) {
+      event.preventDefault();
       this.onOpenSessionLink?.(sessionTarget);
     }
   };

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -27,6 +27,7 @@ import {
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
+import { shouldHandleNavigationClick } from "../../../lib/navigation-click.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { openInlineChatImage } from "./chat-image-lightbox.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
@@ -1305,7 +1306,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     this.error = null;
   };
 
-  private readonly handlePanelClick = (event: Event) => {
+  private readonly handlePanelClick = (event: MouseEvent) => {
     if (openInlineChatImage(event, this.onOpenImage ?? undefined)) {
       return;
     }
@@ -1316,7 +1317,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       return;
     }
     const sessionTarget = markdownSessionLinkFromEvent(event);
-    if (sessionTarget) {
+    if (sessionTarget && shouldHandleNavigationClick(event)) {
+      event.preventDefault();
       this.onOpenSessionLink?.(sessionTarget);
     }
   };

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
@@ -1319,7 +1320,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       return;
     }
     const sessionTarget =
-      markdownSessionLinkFromEvent(event) ?? markdownSessionHref(event, this.basePath);
+      markdownSessionLinkFromEvent(event) ??
+      markdownSessionHref(event, sessionRefFromPath, this.basePath);
     if (sessionTarget && shouldHandleNavigationClick(event)) {
       event.preventDefault();
       this.onOpenSessionLink?.(sessionTarget);
@@ -1334,7 +1336,9 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     }
     const sessionTarget =
       markdownSessionLinkFromKeyboardEvent(event) ??
-      (event.key === "Enter" ? markdownSessionHref(event, this.basePath) : null);
+      (event.key === "Enter"
+        ? markdownSessionHref(event, sessionRefFromPath, this.basePath)
+        : null);
     if (sessionTarget) {
       event.preventDefault();
       this.onOpenSessionLink?.(sessionTarget);

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -9,6 +9,11 @@ import {
   markdownFileLinkFromEvent,
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
+import {
+  markdownSessionLinkFromEvent,
+  markdownSessionLinkFromKeyboardEvent,
+  type SessionLinkTarget,
+} from "../../../components/markdown-session-links.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
@@ -521,6 +526,7 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
       ? toSanitizedMarkdownHtml(content.content, {
           fileLinks: true,
           interactiveImages: props.onOpenImage !== undefined,
+          sessionLinks: true,
         })
       : "";
   const canvasSandbox =
@@ -699,6 +705,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) onOpenWorkspaceFile?:
     | ((target: { path: string; line?: number | null }) => void)
     | null = null;
+  @property({ attribute: false }) onOpenSessionLink?: ((target: SessionLinkTarget) => void) | null =
+    null;
   @property({ attribute: false }) onRevealInWorkspace?: ((path: string) => void) | null = null;
   @property({ attribute: false }) onOpenImage?: ((item: ImageLightboxItem) => void) | null = null;
 
@@ -1305,6 +1313,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const target = markdownFileLinkFromEvent(event);
     if (target) {
       this.onOpenWorkspaceFile?.(target);
+      return;
+    }
+    const sessionTarget = markdownSessionLinkFromEvent(event);
+    if (sessionTarget) {
+      this.onOpenSessionLink?.(sessionTarget);
     }
   };
 
@@ -1312,6 +1325,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const target = markdownFileLinkFromKeyboardEvent(event);
     if (target) {
       this.onOpenWorkspaceFile?.(target);
+      return;
+    }
+    const sessionTarget = markdownSessionLinkFromKeyboardEvent(event);
+    if (sessionTarget) {
+      this.onOpenSessionLink?.(sessionTarget);
     }
   };
 

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -7,6 +7,7 @@ import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { copyMarkdownLabel } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import type { SessionLinkTarget } from "../../../components/markdown-session-links.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";
@@ -99,6 +100,7 @@ export type ChatThreadProps = {
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   onOpenSidebar?: (content: SidebarContent) => void;
   onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
+  onOpenSessionLink?: (target: SessionLinkTarget) => void;
   onOpenSessionCheckpoints?: () => void | Promise<void>;
   onAssistantAttachmentLoaded?: () => void;
   onRequestOpenImage?: () => number;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -6,6 +6,7 @@ import {
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
 import {
+  markdownSessionHref,
   markdownSessionLinkFromEvent,
   markdownSessionLinkFromKeyboardEvent,
 } from "../../../components/markdown-session-links.ts";
@@ -123,8 +124,11 @@ function renderTranscriptShell(
           props.onOpenWorkspaceFile?.(target);
           return;
         }
-        const sessionTarget = markdownSessionLinkFromKeyboardEvent(event);
+        const sessionTarget =
+          markdownSessionLinkFromKeyboardEvent(event) ??
+          (event.key === "Enter" ? markdownSessionHref(event, props.basePath) : null);
         if (sessionTarget) {
+          event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);
           return;
         }
@@ -145,7 +149,8 @@ function renderTranscriptShell(
           props.onOpenWorkspaceFile?.(target);
           return;
         }
-        const sessionTarget = markdownSessionLinkFromEvent(event);
+        const sessionTarget =
+          markdownSessionLinkFromEvent(event) ?? markdownSessionHref(event, props.basePath);
         if (sessionTarget && shouldHandleNavigationClick(event)) {
           event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,5 +1,6 @@
 // Public chat transcript renderer and DOM shell.
 import { html, nothing, type TemplateResult } from "lit";
+import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
 import {
   markdownFileLinkFromEvent,
@@ -126,7 +127,9 @@ function renderTranscriptShell(
         }
         const sessionTarget =
           markdownSessionLinkFromKeyboardEvent(event) ??
-          (event.key === "Enter" ? markdownSessionHref(event, props.basePath) : null);
+          (event.key === "Enter"
+            ? markdownSessionHref(event, sessionRefFromPath, props.basePath)
+            : null);
         if (sessionTarget) {
           event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);
@@ -150,7 +153,8 @@ function renderTranscriptShell(
           return;
         }
         const sessionTarget =
-          markdownSessionLinkFromEvent(event) ?? markdownSessionHref(event, props.basePath);
+          markdownSessionLinkFromEvent(event) ??
+          markdownSessionHref(event, sessionRefFromPath, props.basePath);
         if (sessionTarget && shouldHandleNavigationClick(event)) {
           event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -5,6 +5,10 @@ import {
   markdownFileLinkFromEvent,
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
+import {
+  markdownSessionLinkFromEvent,
+  markdownSessionLinkFromKeyboardEvent,
+} from "../../../components/markdown-session-links.ts";
 import { t } from "../../../i18n/index.ts";
 import {
   handleTranscriptContextMenu,
@@ -118,6 +122,11 @@ function renderTranscriptShell(
           props.onOpenWorkspaceFile?.(target);
           return;
         }
+        const sessionTarget = markdownSessionLinkFromKeyboardEvent(event);
+        if (sessionTarget) {
+          props.onOpenSessionLink?.(sessionTarget);
+          return;
+        }
         props.onHistoryIntent?.(event);
       }}
       @touchstart=${props.onHistoryIntent
@@ -133,6 +142,11 @@ function renderTranscriptShell(
         const target = markdownFileLinkFromEvent(event);
         if (target) {
           props.onOpenWorkspaceFile?.(target);
+          return;
+        }
+        const sessionTarget = markdownSessionLinkFromEvent(event);
+        if (sessionTarget) {
+          props.onOpenSessionLink?.(sessionTarget);
         }
       }}
       @contextmenu=${(event: MouseEvent) => handleTranscriptContextMenu(event, props)}

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -10,6 +10,7 @@ import {
   markdownSessionLinkFromKeyboardEvent,
 } from "../../../components/markdown-session-links.ts";
 import { t } from "../../../i18n/index.ts";
+import { shouldHandleNavigationClick } from "../../../lib/navigation-click.ts";
 import {
   handleTranscriptContextMenu,
   handleTranscriptPointerUp,
@@ -137,7 +138,7 @@ function renderTranscriptShell(
         : null}
       @touchend=${props.onHistoryIntent}
       @touchcancel=${props.onHistoryIntent}
-      @click=${(event: Event) => {
+      @click=${(event: MouseEvent) => {
         handleMarkdownCodeBlockCopy(event);
         const target = markdownFileLinkFromEvent(event);
         if (target) {
@@ -145,7 +146,8 @@ function renderTranscriptShell(
           return;
         }
         const sessionTarget = markdownSessionLinkFromEvent(event);
-        if (sessionTarget) {
+        if (sessionTarget && shouldHandleNavigationClick(event)) {
+          event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);
         }
       }}

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -343,40 +343,57 @@ describe("chat transcript rendering", () => {
     transcript.hostDisconnected();
   });
 
-  it.each(["click", "Enter", " "])("opens transcript session links with %j", async (action) => {
-    const transcript = createTestTranscript();
-    const onOpenSessionLink = vi.fn();
-    const onHistoryIntent = vi.fn();
-    const sessionKey = "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
-    const container = document.body.appendChild(document.createElement("div"));
-    const props = {
-      ...threadProps("pane-session-link", "agent:main:main", [
-        { role: "assistant", content: `Open \`${sessionKey}\``, timestamp: 1_000 },
-      ]),
-      onOpenSessionLink,
-      onHistoryIntent,
-    };
-    render(renderChatThread(props, transcript), container);
-    transcript.hostConnected();
-    transcript.hostUpdated();
-    await flushDeferredRowPrune();
+  it.each(["click", "Ctrl+click", "Enter", " "])(
+    "handles transcript session links with %j",
+    async (action) => {
+      const transcript = createTestTranscript();
+      const onOpenSessionLink = vi.fn();
+      const onHistoryIntent = vi.fn();
+      const sessionKey = "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
+      const container = document.body.appendChild(document.createElement("div"));
+      const props = {
+        ...threadProps("pane-session-link", "agent:main:main", [
+          { role: "assistant", content: `Open \`${sessionKey}\``, timestamp: 1_000 },
+        ]),
+        onOpenSessionLink,
+        onHistoryIntent,
+      };
+      render(renderChatThread(props, transcript), container);
+      transcript.hostConnected();
+      transcript.hostUpdated();
+      await flushDeferredRowPrune();
 
-    const link = container.querySelector<HTMLAnchorElement>("a.markdown-session-link");
-    if (action === "click") {
-      link?.click();
-    } else {
-      link?.focus();
-      const event = new KeyboardEvent("keydown", {
-        key: action,
-        bubbles: true,
-        cancelable: true,
-      });
-      link?.dispatchEvent(event);
-      expect(event.defaultPrevented).toBe(true);
-      expect(onHistoryIntent).not.toHaveBeenCalled();
-    }
+      const link = container.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      if (action === "click" || action === "Ctrl+click") {
+        link?.setAttribute("href", "/chat/roboclaw/2139bddb");
+        const modified = action === "Ctrl+click";
+        const event = new MouseEvent("click", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+          ctrlKey: modified,
+        });
+        link?.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(!modified);
+        if (modified) {
+          expect(onOpenSessionLink).not.toHaveBeenCalled();
+          transcript.hostDisconnected();
+          return;
+        }
+      } else {
+        link?.focus();
+        const event = new KeyboardEvent("keydown", {
+          key: action,
+          bubbles: true,
+          cancelable: true,
+        });
+        link?.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+        expect(onHistoryIntent).not.toHaveBeenCalled();
+      }
 
-    expect(onOpenSessionLink).toHaveBeenCalledWith({ sessionKey, agentId: "roboclaw" });
-    transcript.hostDisconnected();
-  });
+      expect(onOpenSessionLink).toHaveBeenCalledWith({ sessionKey, agentId: "roboclaw" });
+      transcript.hostDisconnected();
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -342,4 +342,41 @@ describe("chat transcript rendering", () => {
     expect(onHistoryIntent).not.toHaveBeenCalled();
     transcript.hostDisconnected();
   });
+
+  it.each(["click", "Enter", " "])("opens transcript session links with %j", async (action) => {
+    const transcript = createTestTranscript();
+    const onOpenSessionLink = vi.fn();
+    const onHistoryIntent = vi.fn();
+    const sessionKey = "agent:roboclaw:dashboard:2139bddb-3211-4641-b993-10f619f124e6";
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = {
+      ...threadProps("pane-session-link", "agent:main:main", [
+        { role: "assistant", content: `Open \`${sessionKey}\``, timestamp: 1_000 },
+      ]),
+      onOpenSessionLink,
+      onHistoryIntent,
+    };
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const link = container.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+    if (action === "click") {
+      link?.click();
+    } else {
+      link?.focus();
+      const event = new KeyboardEvent("keydown", {
+        key: action,
+        bubbles: true,
+        cancelable: true,
+      });
+      link?.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(onHistoryIntent).not.toHaveBeenCalled();
+    }
+
+    expect(onOpenSessionLink).toHaveBeenCalledWith({ sessionKey, agentId: "roboclaw" });
+    transcript.hostDisconnected();
+  });
 });

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -396,4 +396,70 @@ describe("chat transcript rendering", () => {
       transcript.hostDisconnected();
     },
   );
+
+  it.each(["click", "Enter"])("SPA-routes transcript session hrefs with %s", async (action) => {
+    const transcript = createTestTranscript();
+    const onOpenSessionLink = vi.fn();
+    const onHistoryIntent = vi.fn();
+    const literalUuid = "12345678-90ab-cdef-1234-567890abcdef";
+    const href = `/control/chat/main/~key/${literalUuid}?view=full#latest`;
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = {
+      ...threadProps("pane-session-href", "agent:main:main", [
+        { role: "assistant", content: `[Open session](${href})`, timestamp: 1_000 },
+      ]),
+      basePath: "/control",
+      onOpenSessionLink,
+      onHistoryIntent,
+    };
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const link = container.querySelector<HTMLAnchorElement>(`a[href^="/control/chat/"]`);
+    const event =
+      action === "click"
+        ? new MouseEvent("click", { bubbles: true, button: 0, cancelable: true })
+        : new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    link?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenSessionLink).toHaveBeenCalledWith({
+      namespace: "chat",
+      pathname: `/control/chat/main/~key/${literalUuid}`,
+      search: "?view=full",
+      hash: "#latest",
+    });
+    expect(onHistoryIntent).not.toHaveBeenCalled();
+    transcript.hostDisconnected();
+  });
+
+  it("leaves external transcript hrefs to the browser", async () => {
+    const transcript = createTestTranscript();
+    const onOpenSessionLink = vi.fn();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = {
+      ...threadProps("pane-external-href", "agent:main:main", [
+        {
+          role: "assistant",
+          content: "[External session](https://example.com/chat/main/~key/12345678)",
+          timestamp: 1_000,
+        },
+      ]),
+      onOpenSessionLink,
+    };
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const link = container.querySelector<HTMLAnchorElement>('a[href^="https://example.com/"]');
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    link?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onOpenSessionLink).not.toHaveBeenCalled();
+    transcript.hostDisconnected();
+  });
 });

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -705,6 +705,23 @@ export async function loadChatRoute(
     ? ({ kind: "unique", session: cached.row } as const)
     : await resolveShortSessionReference(context, target, signal);
   if (resolution.kind === "not-found") {
+    // A mechanically composed literal, notably a full UUID, can match the short grammar.
+    // Only after the authoritative short lookup misses may its exact decoded key win.
+    const literalResolution = await querySessionReference(
+      context,
+      { kind: "exact", value: target.literalSessionKey, agentId: target.agentId },
+      signal,
+    );
+    if (literalResolution?.kind === "unique") {
+      const literal = resolvedSessionRouteData({
+        context,
+        location: routeLocation,
+        face,
+        row: literalResolution.session,
+        preferenceDerived,
+      });
+      return literal ?? notFound({ routeId: face });
+    }
     return notFound({ routeId: face });
   }
   if (resolution.kind === "ambiguous") {

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -786,8 +786,36 @@ describe("gateway-backed session route resolution", () => {
     );
 
     expect(loaded).not.toHaveProperty("kind", "session");
-    expect(list).not.toHaveBeenCalled();
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "roboclaw", search: "agent:roboclaw:deadbeef" }),
+    );
     expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("opens a mechanically composed single-segment UUID as its exact session key", async () => {
+    const literalKey = `agent:main:${uuid}`;
+    const literalRow = row({ key: literalKey, displayName: undefined });
+    const { context, list } = contextFor(({ agentId, search }) =>
+      agentId === "main" && search === literalKey ? result([literalRow]) : result([]),
+    );
+    const request = installShortResolver(context, [], { ok: false });
+
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: `/chat/main/${uuid}`, search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({
+      kind: "session",
+      sessionKey: literalKey,
+      canonicalLocation: { pathname: "/chat/main/12345678" },
+    });
+    expect(request).toHaveBeenCalledOnce();
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", search: literalKey }),
+    );
   });
 
   it("prefers an exact literal key over slug matches", async () => {

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -838,14 +838,19 @@ describe("gateway-backed session route resolution", () => {
       ok: true,
       key: shortMatch.key,
     });
+    const chipTarget = sessionNavigationTarget({
+      context,
+      face: "chat",
+      sessionKey: literal.key,
+      agentId: "main",
+      preferenceDerivedFace: true,
+      exactKey: true,
+    });
+
+    expect(chipTarget.options.pathname).toBe(`/chat/main/~key/${literalUuid}`);
 
     await expect(
-      loadChatRoute(
-        context,
-        { pathname: `/chat/main/~key/${literalUuid}`, search: "", hash: "" },
-        "chat",
-        new AbortController().signal,
-      ),
+      loadChatRoute(context, targetLocation(chipTarget), "chat", new AbortController().signal),
     ).resolves.toMatchObject({ kind: "session", sessionKey: literal.key });
 
     // Plain literal paths remain short-first, so this collision opens the short match.

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -818,6 +818,52 @@ describe("gateway-backed session route resolution", () => {
     );
   });
 
+  it("uses forced-literal URLs to avoid a colliding short session reference", async () => {
+    const literalUuid = "12345678-90ab-cdef-1234-567890abcdef";
+    const collidingUuid = "567890ab-cdef-4321-8765-43210fedcba9";
+    const literal = row({
+      key: `agent:main:${literalUuid}`,
+      sessionId: literalUuid,
+      displayName: undefined,
+    });
+    const shortMatch = row({
+      key: `agent:main:thread:${collidingUuid}`,
+      sessionId: collidingUuid,
+      displayName: undefined,
+    });
+    const { context } = contextFor(({ agentId, search }) =>
+      agentId === "main" && search === literal.key ? result([literal]) : result([]),
+    );
+    const request = installShortResolver(context, [literal, shortMatch], {
+      ok: true,
+      key: shortMatch.key,
+    });
+
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname: `/chat/main/~key/${literalUuid}`, search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({ kind: "session", sessionKey: literal.key });
+
+    // Plain literal paths remain short-first, so this collision opens the short match.
+    // Tool-generated links advertise `~key` to bypass that intentional ambiguity.
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname: `/chat/main/${literalUuid}`, search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({ kind: "session", sessionKey: shortMatch.key });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.resolve",
+      expect.objectContaining({ shortId: "567890abcdef" }),
+    );
+  });
+
   it("prefers an exact literal key over slug matches", async () => {
     const literal = row({
       key: "agent:roboclaw:default-mode-with-rare-surprises",

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -348,6 +348,21 @@
   text-decoration: underline;
 }
 
+:is(.chat-text, .sidebar-markdown) a.markdown-session-link--titled {
+  display: inline-block;
+  max-width: min(28em, 100%);
+  padding: 0.08em 0.45em;
+  background: color-mix(in srgb, var(--accent-subtle) 72%, var(--bg-muted));
+  color: var(--text-strong);
+  font-family: var(--font-body);
+  font-weight: 600;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: -0.12em;
+  white-space: nowrap;
+}
+
 :is(.chat-text, .sidebar-markdown) a.markdown-session-link > code {
   padding: 0;
   border: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -328,6 +328,35 @@
   line-break: anywhere;
 }
 
+:is(.chat-text, .sidebar-markdown) a.markdown-session-link {
+  display: inline;
+  padding: 0.1em 0.2em;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-muted);
+  color: var(--link);
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 0.9em;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+:is(.chat-text, .sidebar-markdown) a.markdown-session-link:hover,
+:is(.chat-text, .sidebar-markdown) a.markdown-session-link:focus-visible {
+  text-decoration: underline;
+}
+
+:is(.chat-text, .sidebar-markdown) a.markdown-session-link > code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+}
+
 /* Both chat Markdown renderers enable file links — message bubbles (.chat-text)
    and the Chat Detail Panel (.sidebar-markdown) — and the parser shortens labels
    for both, so presentation has to follow or the panel shows bare basenames with

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -802,6 +802,10 @@ openclaw-github-link-hovercard-provider {
   display: contents;
 }
 
+openclaw-session-link-hovercard-provider {
+  display: contents;
+}
+
 .github-link-hovercard {
   position: fixed;
   z-index: 1990;
@@ -1045,6 +1049,129 @@ openclaw-github-link-hovercard-provider {
   }
 
   .github-link-hovercard__loading::before {
+    animation: none;
+  }
+}
+
+.session-link-hovercard {
+  position: fixed;
+  z-index: 1990;
+  width: min(400px, calc(100vw - 24px));
+  min-height: 96px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--card) 96%, var(--bg) 4%);
+  box-shadow: var(--shadow-lg);
+  color: var(--text);
+  font-family: var(--font-body);
+  pointer-events: auto;
+  opacity: 0;
+  transform: translateY(-5px) scale(0.99);
+  transform-origin: bottom left;
+  transition:
+    opacity var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.session-link-hovercard[data-side="bottom"] {
+  transform: translateY(5px) scale(0.99);
+  transform-origin: top left;
+}
+
+.session-link-hovercard[data-open="true"] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.session-link-hovercard__title {
+  color: var(--text-strong);
+  font-size: var(--control-ui-text-lg);
+  font-weight: 650;
+  letter-spacing: -0.012em;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.session-link-hovercard__meta {
+  margin-top: 6px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: var(--control-ui-text-sm);
+  overflow-wrap: anywhere;
+}
+
+.session-link-hovercard__message {
+  display: -webkit-box;
+  margin-top: 14px;
+  color: var(--text);
+  font-size: var(--control-ui-text-md);
+  line-height: 1.45;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.session-link-hovercard__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.session-link-hovercard__archived {
+  padding: 3px 7px;
+  border-radius: var(--radius-full);
+  background: var(--bg-muted);
+}
+
+.session-link-hovercard__time {
+  margin-left: auto;
+}
+
+.session-link-hovercard__loading,
+.session-link-hovercard__unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 64px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.session-link-hovercard__loading::before {
+  width: 18px;
+  height: 18px;
+  margin-right: 9px;
+  border: 2px solid color-mix(in srgb, var(--muted) 25%, transparent);
+  border-top-color: var(--muted);
+  border-radius: 50%;
+  content: "";
+  animation: session-hovercard-spin 0.8s linear infinite;
+}
+
+@keyframes session-hovercard-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 560px) {
+  .session-link-hovercard {
+    padding: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-link-hovercard {
+    transition: none;
+  }
+
+  .session-link-hovercard__loading::before {
     animation: none;
   }
 }


### PR DESCRIPTION
# What Problem This Solves

When an agent answers "which session was that?" it names the session and prints its key (`agent:roboclaw:dashboard:2139bddb-…`), but nothing is clickable — the operator has to hunt the sidebar manually. Session references in chat were dead text: no link, no preview, no navigation.

# Why This Change Was Made

Session references become first-class links across three layers, all install-dynamic (nothing hardcodes an agent id, domain, or channel):

1. **Model-side link rule (config-gated).** `resolveControlUiSessionLinkBase(cfg)` resolves `gateway.publicOrigin` + Control UI base path, using the same guard as the Slack "Open in OpenClaw" card. When it resolves, one shared sentence teaching a mechanical URL rule (`<base>/chat/` + key without `agent:`, `:`→`/`) is injected into the `sessions_list`/`sessions_history`/`sessions_search` descriptions at definition-build time **and** carried as `sessionLinkRule` in their result envelopes. The envelope copy exists because live testing showed deferred-descriptions tool mode hides prose descriptions — result text is the only surface every mode sees. Headless installs (no `publicOrigin`, or Control UI disabled) get byte-identical tools with no URL mention.
2. **Renderer linkification (Control UI only, no config needed).** A markdown-it core rule (same family as file links and GitHub refs) structurally matches session keys in text and inline code and emits `a.markdown-session-link[data-session-key]` anchors — no hrefs in the parser, so rendering stays pure and cacheable. The URL grammar's literal path form resolves mechanically composed links, with a route-loader fallback for single-segment keys that misparse as short refs.
3. **Titled chips + hovercard.** A provider element (cloned from the GitHub link hovercard) stamps canonical hrefs, asynchronously upgrades raw keys into titled chips once the title is known (MutationObserver + rAF, idempotent across streaming re-renders), and shows a hover preview card (title, agent/kind meta, last-message preview, relative time) backed by a new `controlUi.sessionPreview` RPC (`operator.read`). The RPC applies `createSessionListEntryFilter` so previews can never reveal more than `sessions.list` (incognito rows, non-owner drafts); the regression test fails pre-fix.

Also fixed in passing: markdown anchors pointing at internal Control UI routes no longer get forced `target="_blank"` — they SPA-navigate like the rest of the app.

# User Impact

- Agent mentions of sessions render as clickable titled chips with hover previews; clicking navigates in-app.
- Models cite working session URLs on any channel (Slack, Telegram, …) when the install has a public origin — links compose from keys the tools already return, costing ~40 tokens once per result instead of a URL per row.
- Side effect worth noting: sidebar session anchors also get hover preview cards (the provider triggers on any internal session anchor). Judged useful — matches GitHub/Slack hover-preview conventions.
- No new config. Headless installs see zero change.

# Evidence

Live dev gateway (isolated `OPENCLAW_STATE_DIR`, port 19850, loopback `publicOrigin`, real Anthropic model):

- Model found a session via `sessions_search` and cited a working markdown link composed per the envelope rule.
- Raw key in inline code rendered as a titled chip; hovercard showed title/meta/preview/time; click SPA-navigated to the session.
- Visibility parity: regression test proves an identity-bearing viewer gets `unavailable` for incognito sessions while an admin gets metadata (pre-fix run leaked `ok`).
Agent reply with model-composed link (built per the envelope `sessionLinkRule` — the model credits the rule in its own reply text) and the raw key auto-upgraded to a titled chip on a fresh page with no pointer events:

![reply with link and chip](https://github.com/user-attachments/assets/304c47ad-3ade-456a-ad5e-be2b34477d30)

Chip hovercard (title, agent/kind meta, last-message preview, relative time):

![chip hovercard](https://github.com/user-attachments/assets/24c42eb8-5aa7-4d28-a6da-5cff1cda0e9c)

URL-form link hovercard (same provider, href-based trigger):

![url link hovercard](https://github.com/user-attachments/assets/fce0ebea-a1c0-4f3f-adfb-5e98f124149a)

Chip click SPA-navigated to the target session; the address canonicalized from the literal key path to the slug URL (`/chat/main/acknowledged-3a257c22`):

![after click navigation](https://github.com/user-attachments/assets/cf7a7fb8-77d0-4acb-b798-5902184a23d2)

Full recorded flow (Playwright, live gateway + real model turn):

https://github.com/user-attachments/assets/87b1940f-8756-46d6-a5c0-fd833a8daa91

Recorder console proof: `MODEL_LINK_HREF: http://127.0.0.1:19850/chat/main/dashboard/3a257c22-f4cd-444b-82a1-46d95671c403` · `NAVIGATED_TO: /chat/main/acknowledged-3a257c22` · `PROOF_OK`.

Focused suites: session-url-contract round-trips, markdown parser/sanitizer, hovercard provider, gateway handler + sharing tests, tool description/envelope gating. `check:changed` green per commit; `pnpm build` clean (no `[INEFFECTIVE_DYNAMIC_IMPORT]`).

Production LOC: dominated by the new hovercard provider (new capability); tool/gateway surface is small and additive.
