### PR TITLE
fix(copilot): Claude models stop replying after auto-compaction

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -345,12 +345,19 @@ describe("github-copilot plugin", () => {
       },
     ];
 
-    expect(provider.buildReplayPolicy?.({ modelId: "claude-haiku-4.5" } as never)).toEqual({
+    expect(
+      provider.buildReplayPolicy?.({
+        modelId: "claude-haiku-4.5",
+        modelApi: "anthropic-messages",
+      } as never),
+    ).toMatchObject({
       dropThinkingBlocks: true,
+      validateAnthropicTurns: true,
     });
     expect(
       provider.sanitizeReplayHistory?.({
         modelId: "claude-haiku-4.5",
+        modelApi: "anthropic-messages",
         messages,
       } as never),
     ).toEqual([
@@ -362,6 +369,7 @@ describe("github-copilot plugin", () => {
     expect(
       provider.sanitizeReplayHistory?.({
         modelId: "gpt-5.4",
+        modelApi: "openai-responses",
         messages,
       } as never),
     ).toBe(messages);

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -702,7 +702,7 @@ export default definePluginEntry({
       refreshOAuth: async (credential) => refreshGithubCopilotOAuth(credential),
       buildAuthDoctorHint: buildGithubCopilotAuthDoctorHint,
       wrapStreamFn: wrapCopilotProviderStream,
-      buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
+      buildReplayPolicy: buildGithubCopilotReplayPolicy,
       sanitizeReplayHistory: sanitizeGithubCopilotReplayHistory,
       resolveThinkingProfile: ({ modelId, compat }) => {
         const extendedLevels = resolveCopilotExtendedThinkingLevels(modelId, compat);

--- a/extensions/github-copilot/replay-policy.test.ts
+++ b/extensions/github-copilot/replay-policy.test.ts
@@ -1,0 +1,100 @@
+// Github Copilot tests cover replay policy transport dispatch.
+import type { ProviderReplayPolicyContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import {
+  buildGithubCopilotReplayPolicy,
+  sanitizeGithubCopilotReplayHistory,
+} from "./replay-policy.js";
+
+function buildPolicy(modelApi: ProviderReplayPolicyContext["modelApi"], modelId: string) {
+  return buildGithubCopilotReplayPolicy({ provider: "github-copilot", modelApi, modelId });
+}
+
+describe("buildGithubCopilotReplayPolicy", () => {
+  it("applies Anthropic turn validation to Claude models", () => {
+    // Copilot Claude hits a real Anthropic Messages endpoint, which rejects a
+    // transcript ending on an assistant turn. Core only strips that trailing
+    // prefill turn when validateAnthropicTurns is set.
+    expect(buildPolicy("anthropic-messages", "claude-opus-5")).toMatchObject({
+      validateAnthropicTurns: true,
+      sanitizeMode: "full",
+      repairToolUseResultPairing: true,
+      preserveSignatures: true,
+      allowSyntheticToolResults: true,
+    });
+  });
+
+  it("drops replayed thinking for thinking-preserving Claude ids", () => {
+    for (const modelId of [
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-fable-5",
+      "claude-opus-4.8",
+      "claude-sonnet-4.6",
+      "claude-haiku-4.5",
+    ]) {
+      expect(buildPolicy("anthropic-messages", modelId)).toMatchObject({
+        dropThinkingBlocks: true,
+      });
+    }
+  });
+
+  it("leaves transcript tool ids to the Copilot stream wrapper", () => {
+    const policy = buildPolicy("anthropic-messages", "claude-opus-5");
+    expect(policy).not.toHaveProperty("sanitizeToolCallIds");
+    expect(policy).not.toHaveProperty("toolCallIdMode");
+  });
+
+  it("claims no policy for OpenAI-compatible transports", () => {
+    expect(buildPolicy("openai-responses", "gpt-5.4")).toBeUndefined();
+    expect(buildPolicy("openai-completions", "gemini-3.1-pro-preview")).toBeUndefined();
+  });
+});
+
+describe("sanitizeGithubCopilotReplayHistory", () => {
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "private", thinkingSignature: "sig" },
+        { type: "redacted_thinking", data: "opaque" },
+        { type: "text", text: "visible" },
+      ],
+    },
+  ];
+
+  it("strips replayed thinking on the Anthropic transport", () => {
+    expect(
+      sanitizeGithubCopilotReplayHistory({
+        provider: "github-copilot",
+        modelApi: "anthropic-messages",
+        modelId: "claude-opus-5",
+        messages,
+      } as never),
+    ).toEqual([{ role: "assistant", content: [{ type: "text", text: "visible" }] }]);
+  });
+
+  it("replaces a thinking-only assistant turn with a placeholder", () => {
+    expect(
+      sanitizeGithubCopilotReplayHistory({
+        provider: "github-copilot",
+        modelApi: "anthropic-messages",
+        modelId: "claude-opus-5",
+        messages: [{ role: "assistant", content: [{ type: "thinking", thinking: "private" }] }],
+      } as never),
+    ).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "[assistant reasoning omitted]" }] },
+    ]);
+  });
+
+  it("passes history through on OpenAI-compatible transports", () => {
+    expect(
+      sanitizeGithubCopilotReplayHistory({
+        provider: "github-copilot",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.4",
+        messages,
+      } as never),
+    ).toBe(messages);
+  });
+});

--- a/extensions/github-copilot/replay-policy.ts
+++ b/extensions/github-copilot/replay-policy.ts
@@ -1,11 +1,18 @@
 // Github Copilot plugin module implements replay policy behavior.
-import type { ProviderSanitizeReplayHistoryContext } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type {
+  ProviderReplayPolicy,
+  ProviderReplayPolicyContext,
+  ProviderSanitizeReplayHistoryContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { buildStrictAnthropicReplayPolicy } from "openclaw/plugin-sdk/provider-model-shared";
 
 const OMITTED_COPILOT_REASONING_TEXT = "[assistant reasoning omitted]";
 
-function isCopilotClaudeModel(modelId?: string | null): boolean {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("claude");
+// Copilot routes Claude over the real Anthropic Messages transport, so transport
+// identity - not the model id - owns replay behavior. The wire patch in
+// stream.ts gates on the same signal; keep the two in sync.
+function isCopilotAnthropicTransport(modelApi?: string | null): boolean {
+  return modelApi === "anthropic-messages";
 }
 
 function isThinkingBlock(value: unknown): boolean {
@@ -40,16 +47,26 @@ export function stripCopilotAssistantThinkingMessages<T>(messages: T[]): T[] {
   return touched ? sanitized : messages;
 }
 
-export function buildGithubCopilotReplayPolicy(modelId?: string) {
-  return isCopilotClaudeModel(modelId)
-    ? {
-        dropThinkingBlocks: true,
-      }
-    : {};
+export function buildGithubCopilotReplayPolicy(
+  ctx: ProviderReplayPolicyContext,
+): ProviderReplayPolicy | undefined {
+  if (!isCopilotAnthropicTransport(ctx.modelApi)) {
+    return undefined;
+  }
+  return buildStrictAnthropicReplayPolicy({
+    // Unconditional: Copilot strips replayed thinking for every Claude model, so
+    // it never owns signed-thinking replay. The shared by-model helper would
+    // re-enable it for thinking-preserving Claude ids.
+    dropThinkingBlocks: true,
+    // wrapCopilotAnthropicStream rewrites tool ids on the wire and deliberately
+    // leaves the persisted transcript untouched. Core-side rewriting would
+    // mutate that transcript instead.
+    sanitizeToolCallIds: false,
+  });
 }
 
 export function sanitizeGithubCopilotReplayHistory(ctx: ProviderSanitizeReplayHistoryContext) {
-  return isCopilotClaudeModel(ctx.modelId)
+  return isCopilotAnthropicTransport(ctx.modelApi)
     ? stripCopilotAssistantThinkingMessages(ctx.messages)
     : ctx.messages;
 }

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -123,11 +123,16 @@ vi.mock("../plugins/provider-hook-runtime.js", async () => {
                 allowSyntheticToolResults: true,
               };
             case "github-copilot":
-              return modelId.includes("claude")
+              return context?.modelApi === "anthropic-messages"
                 ? {
+                    sanitizeMode: "full",
+                    preserveSignatures: true,
+                    repairToolUseResultPairing: true,
+                    validateAnthropicTurns: true,
+                    allowSyntheticToolResults: true,
                     dropThinkingBlocks: true,
                   }
-                : {};
+                : undefined;
             case "mistral":
               return {
                 sanitizeToolCallIds: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users on the GitHub Copilot provider with any Claude model would see the bot silently stop replying, most reliably right after an auto-compaction, because the next request was rejected by the provider:

```
FailoverError: LLM request rejected: This model does not support assistant message prefill.
The conversation must end with a user message.
```

Raw provider response:

```json
{"type":"error","error":{"type":"invalid_request_error",
"message":"This model does not support assistant message prefill. The conversation must end with a user message."}}
```

Nothing reached the channel. The turn only surfaced as `lane task error` plus `visible channel turn dispatched with no queued reply payloads` in the Gateway log, so from the user's side the agent just went quiet.

Copilot routes Claude to `api.*.githubcopilot.com/v1/messages` — a real Anthropic Messages endpoint with real Anthropic semantics — but it was not getting the Anthropic replay guardrails that the native Anthropic path gets. That is why the earlier prefill fixes on the native Anthropic and Bedrock paths did not cover this one.

## Why This Change Was Made

`resolveTranscriptPolicy` (`src/agents/transcript-policy.ts`) intentionally hands full ownership to a provider once it registers `buildReplayPolicy`:

```ts
// Once a provider adopts the replay-policy hook, replay policy should come
// from the plugin, not from transport-family defaults in core.
const policy = buildReplayPolicy
  ? mergeTranscriptPolicy(buildReplayPolicy(context) ?? undefined)
  : mergeTranscriptPolicy(buildUnownedProviderTransportReplayFallback({ ... }));
```

Copilot registered that hook but returned only `{ dropThinkingBlocks: true }` for Claude, keyed off the model id. That skipped the entire transport-family fallback, so the merge fell back to `DEFAULT_TRANSCRIPT_POLICY` where `validateAnthropicTurns` is `false`. The trailing-assistant guardrail in `attempt-tool-call-replay-sanitization.ts` is gated on exactly that flag:

```ts
if (transcriptPolicy?.validateAnthropicTurns || transcriptPolicy?.validateGeminiTurns) {
  nextMessages = stripTrailingAssistantPrefillTurns(nextMessages);
}
```

so it never ran for Copilot Claude, and a transcript ending on an assistant turn went straight to the Anthropic endpoint. Copilot's own wire patch (`patchCopilotAnthropicPayload`) only strips thinking blocks and normalizes tool ids, so there was no second line of defense.

The fix makes the hook dispatch on `ctx.modelApi` (already present on `ProviderReplayPolicyContext`) instead of a model-id substring, and reuses the shared `buildStrictAnthropicReplayPolicy` for the Anthropic transport. Two Copilot-specific behaviors are deliberately preserved:

- **`dropThinkingBlocks` stays unconditional.** The shared `hybrid-anthropic-openai` family computes it via `shouldDropClaudeThinkingBlocks()`, which returns `false` for `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4.8` and `claude-sonnet-4.6`. Adopting that family as-is would have reverted #81520 and, combined with `preserveSignatures: true`, would have flipped `shouldAllowProviderOwnedThinkingReplay` to `true` for a provider that does not own signed thinking replay.
- **Tool-call ids stay owned by `wrapCopilotAnthropicStream`.** It rewrites ids on the wire and deliberately leaves the persisted transcript untouched, so `sanitizeToolCallIds` is left off rather than letting core rewrite the stored transcript.

`sanitizeGithubCopilotReplayHistory` moves to the same `modelApi` signal so the policy hook, the history hook, and the existing wire patch all gate on one canonical fact instead of two competing predicates.

**Non-goal:** the OpenAI-compatible Copilot transports still claim no provider policy and keep today's behavior. Aligning `openai-responses` / `openai-completions` with the OpenAI-compatible family would also change tool-id sanitization and `dropReasoningFromHistory` for Copilot GPT and Gemini models, which is a separate, unproven change and is left as a follow-up.

## User Impact

Copilot users on Claude models — including the Copilot default `claude-sonnet-5` — no longer hit a hard 400 and a silent non-reply when a turn ends on an assistant message. In practice this removes the "bot stopped responding after a long session" failure that followed auto-compaction.

No configuration change is required, and behavior for Copilot GPT and Gemini models is unchanged.

## Evidence

Root cause was traced through the full chain on `main`:

| Step | Location |
| --- | --- |
| Copilot Claude resolves to the Anthropic transport | `extensions/github-copilot/model-metadata.ts:105-114`, `openclaw.plugin.json` |
| Plugin registers the replay hook | `extensions/github-copilot/index.ts:705` |
| Registering the hook skips the transport-family fallback | `src/agents/transcript-policy.ts:350-360` |
| Fallback would have set `validateAnthropicTurns: true` | `src/agents/transcript-policy.ts:176-178` |
| Default policy leaves it `false` | `src/agents/transcript-policy.ts:68-83` |
| Guardrail is gated on that flag | `src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts:491-495` |
| Wire patch has no trailing-assistant guard | `extensions/github-copilot/stream.ts:179-183` |

Tests added in `extensions/github-copilot/replay-policy.test.ts`. Two of them fail on pre-fix code for the intended reason:

- `applies Anthropic turn validation to Claude models` — pre-fix the policy is `{ dropThinkingBlocks: true }`, so `validateAnthropicTurns` is absent.
- `claims no policy for OpenAI-compatible transports` — pre-fix the hook returns `{}` rather than yielding ownership.

The remaining cases lock in the behavior that must not regress: unconditional `dropThinkingBlocks` across thinking-preserving Claude ids (guarding #81520), transcript tool ids left to the stream wrapper, and the existing thinking-strip and placeholder behavior of `sanitizeGithubCopilotReplayHistory`.

`extensions/github-copilot/index.test.ts` previously asserted `toEqual({ dropThinkingBlocks: true })`, which pinned the incomplete policy; it now asserts the transport-correct shape. The `github-copilot` fixture in `src/agents/transcript-policy.test.ts` carried a stale copy of the old plugin logic and was updated to match production.

**Validation gap — please rely on CI.** I could not run `pnpm test` / `pnpm check` locally: this checkout has no `node_modules` and the npm registry is unreachable from my environment (`registry.npmjs.org` fails the TLS handshake for both npm and curl, while github.com is reachable). Every assertion above was derived by reading current `main` rather than from a local run, so CI on this PR is the first execution of these tests. Happy to iterate on anything CI turns up.

**Follow-ups noticed while here, not changed in this PR:**

- The `sanitizeGithubCopilotHistory` helper in `src/agents/embedded-agent-runner.sanitize-session-history.test.ts:148-162` defaults Copilot Claude to `modelApi: "openai-completions"`, which does not match production routing. Those tests mock the plugin hook out, so they are unaffected by this change, but the fixture is misleading.
- The silent-failure behavior itself is worth its own issue: a turn that dies with a provider 400 currently produces only a `WARN` in `src/channels/turn/execution.ts:105-110` and no channel-visible output.



---

### External validation run (independent reviewer)

Executed on a clean checkout of `8be939af5cb890a0952c6b3b6af39f027a951887`, `pnpm install && pnpm build` both `rc=0`, dev gateway started on isolated state so it did not touch the reviewer's production gateway.

**1. Correct commit is running**

```
$ node dist/index.js --version
OpenClaw 2026.8.1 (8be939a) — All your chats, one OpenClaw.
```

**2. Unit + evidence tests pass**

`pnpm vitest run extensions/github-copilot/replay-policy.test.ts src/agents/transcript-policy.test.ts` → **107 passed / 0 failed**.

A dedicated evidence test (not committed) was run against the built code:

```
[EVIDENCE] pre-fix policy : {"dropThinkingBlocks":true}
[EVIDENCE] post-fix policy: {"sanitizeMode":"full","preserveSignatures":true,"repairToolUseResultPairing":true,"validateAnthropicTurns":true,"allowSyntheticToolResults":true,"dropThinkingBlocks":true}
[EVIDENCE] resolved.validateAnthropicTurns = true
[EVIDENCE] gpt-5 policy = undefined
```

This is the exact hop the PR fixes: the resolved transcript policy on `github-copilot / anthropic-messages / claude-opus-5` now has `validateAnthropicTurns: true`, so `attempt-tool-call-replay-sanitization` will strip a trailing `assistant` prefill turn before replay. OpenAI-compatible Copilot transports (`gpt-5`) remain untouched — the hook yields ownership.

**3. Live end-to-end against Copilot Anthropic Messages transport**

Ran the built agent 7 turns in isolated mode with a lowered `contextWindow` override to build context pressure, targeting `api=anthropic-messages` (the real Anthropic Messages endpoint served by Copilot Enterprise). Every request succeeded — no `400 assistant message prefill`:

```
[provider-transport-fetch] [model-fetch] start    provider=*** api=anthropic-messages model=claude-opus-5 method=POST url=https://api.enterprise.githubcopilot.com/v1/messages policy=custom
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1256
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1137
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1994
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1777
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1513
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1794
[provider-transport-fetch] [model-fetch] response provider=*** api=anthropic-messages model=claude-opus-5 status=200 elapsedMs=1725
```

Model replies were the requested acknowledgements (`ACK 1` … `ACK 7`).

**Caveat.** In this local environment I could not force an explicit auto-compaction event within budget (the `contextWindow: 12000` override was applied to config, but the `context-pressure-diagnostic` line kept `promptBudgetBeforeReserve=6000` and admitted requests up to `estimatedPromptTokens=33753` without invoking `compaction_start`, so the "next request no longer 400s *after* auto-compaction" post-condition was not observed directly). The strip that fixes it (`validateAnthropicTurns → true` on the resolved policy) is verified. If ClawSweeper wants the raw compaction-then-replay path exercised, it needs the harness in `run.overflow-compaction.test.ts` — that suite passes (10/10) on this build.

Tokens, channel IDs, and workspace paths redacted (`provider=***`, no state directory shown).



---

### Follow-up: A/B proof of the actual failure condition (independent reviewer)

ClawSweeper was right about the previous section: it showed healthy requests succeeding, but never exercised the assistant-tail condition this PR changes. Here is that condition, isolated and reproduced against the live endpoint.

**The failing shape.** After auto-compaction the transcript can end with an assistant turn (summary + the assistant tail that was never followed by a user message). Both requests below were sent to the real `https://api.enterprise.githubcopilot.com/v1/messages` with `model: claude-opus-5`. The *only* difference is whether the trailing assistant turn was stripped:

```
=== A: PRE-FIX shape (transcript ends with assistant) ===
[PRE-FIX] HTTP 400
[PRE-FIX] last role sent = assistant
[PRE-FIX] body = {"type":"error","error":{"type":"invalid_request_error",
  "message":"This model does not support assistant message prefill.
   The conversation must end with a user message."},"request_id":"req_011Ce9***"}

=== B: POST-FIX shape (trailing assistant stripped) ===
[POST-FIX] HTTP 200
[POST-FIX] last role sent = user
[POST-FIX] body = {"content":[{"signature":"CAISxQMKnAEIEBgC***

=== RESULT: pre-fix=400 post-fix=200 ===
```

That reproduces the exact error from the issue report, on the exact transport, and shows the strip is what clears it.

**Wiring that strip to this PR.** The strip is `stripTrailingAssistantPrefillTurns` in `src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts:493`, and it runs only behind the `transcriptPolicy?.validateAnthropicTurns` gate at line 491. That gate is precisely what this PR flips for Copilot Claude. Driving the real `buildGithubCopilotReplayPolicy` and `resolveTranscriptPolicy` on the built code:

```
[GATE] pre-fix  validateAnthropicTurns = undefined
[GATE] post-fix validateAnthropicTurns = true
[GATE] pre-fix  last role sent = assistant -> Copilot returns 400
[GATE] post-fix last role sent = user      -> Copilot returns 200
```

So the chain is complete and each link is observed rather than asserted:

1. Post-compaction transcripts can end with an assistant turn.
2. Sending that shape to Copilot Claude returns `400 assistant message prefill` — **observed live above**.
3. `stripTrailingAssistantPrefillTurns` fixes the shape, but only runs when `validateAnthropicTurns` is set.
4. Pre-fix, Copilot Claude's policy is `{ dropThinkingBlocks: true }` — the flag is absent, so the strip never runs.
5. Post-fix, the resolved policy has `validateAnthropicTurns: true` — **observed above** — so the strip runs and the request returns `200`.

**Correction to my previous section.** I earlier implied `validateAnthropicTurns` (in `embedded-agent-helpers/turns.ts`) performs the strip. It does not — it merges consecutive same-role turns and repairs dangling tool uses, and leaves a `user,assistant` pair unchanged. The trailing-assistant strip is the separate `stripTrailingAssistantPrefillTurns` call gated on the same flag. The conclusion is unchanged, but the mechanism above is the accurate one.

Token, request id, and response signature redacted.


Maintainer verification: The Copilot-owned Anthropic replay policy enables trailing-assistant sanitization while preserving the GPT/Gemini transport split; the existing live Copilot A/B evidence demonstrates HTTP 400 before the fix and HTTP 200 after the fix.