### PR TITLE
fix(codex): restore restricted-profile side-question coverage

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -2279,7 +2279,7 @@ describe("runCodexAppServerSideQuestion", () => {
             {
               name: "wiki_status",
               description: "Check wiki status",
-              parameters: { type: "object", properties: {} },
+              parameters: { type: "object", properties: {}, additionalProperties: true },
               execute: toolExecuteMock,
             },
           ]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Codex restricted-profile side-question test failed after native tool argument validation became strict, leaving unrelated changes unable to pass CI.

## Why This Change Was Made

The fixture invokes its fake `wiki_status` tool with arbitrary arguments but still declared an empty closed object schema. Marking that fixture schema as permissive matches the test's intended bridge behavior and the neighboring generic tool fixtures; production validation remains strict and unchanged.

## User Impact

No runtime behavior changes. CI again verifies that prepared restricted-profile tools bridge into Codex side threads.

## Evidence

- Before: CI run 31989687735, job 95273026504 failed `bridges prepared restricted-profile tools into side threads` because `toolExecuteMock` was never called.
- Focused regression: 1 passed, 63 skipped.
- Full `extensions/codex/src/app-server/side-question.test.ts`: 64 passed.
- `git diff --check`: clean.
- Production LOC: +0/-0; tests: +1/-1.
