### PR TITLE
refactor(ui): colocate side-panel header actions with their slot

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -102,6 +102,29 @@ async function readColdOpenOutcome(page: Page): Promise<ColdOpenOutcome> {
 }
 
 suite.define(() => {
+  it("preserves the production header-action shapes for Side chat and Discussion", async () => {
+    const context = await suite.newBrowserContext({ serviceWorkers: "block" });
+    const page = await context.newPage();
+    const choices = await openColdSidebar(page);
+
+    await choices.filter({ hasText: "Side chat" }).click();
+    const contentActions = page.locator(".side-panel__action-group--content");
+    const companionMenu = contentActions.locator("wa-dropdown.chat-session-rail__menu");
+    await companionMenu.waitFor();
+    expect(await companionMenu.count()).toBe(1);
+    expect(await contentActions.locator(":scope > button").count()).toBe(0);
+
+    await page.locator(".side-panel-type-menu__trigger").click();
+    await page.locator(".side-panel-type-menu__item").filter({ hasText: "Discussion" }).click();
+    const discussionAction = contentActions.locator(
+      ':scope > a.rail-header__action[target="_blank"]',
+    );
+    await discussionAction.waitFor();
+    expect(await discussionAction.getAttribute("href")).toBe("https://discussion.example/session");
+
+    await suite.closeBrowserContext(context);
+  });
+
   it("accounts for every offered slot when opened cold", async () => {
     const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
     const probePage = await probeContext.newPage();

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -31,7 +31,11 @@ type SidebarPanelDefinitionParams = {
   onCompanionSubmit: (question: string) => void;
   onCompanionDraftChange: (draft: string) => void;
   onCompanionVisibilityChange: (visible: boolean) => void;
+  connected: boolean;
+  pendingQuestion: string | null;
+  onClearCompanion: () => void;
   discussion: SessionDiscussionPanelConfig | null;
+  discussionOpenUrl: string | null;
   discussionSourceGeneration: number;
 };
 
@@ -46,66 +50,13 @@ type SidebarPanelTextKey =
   | "tasks"
   | "terminal";
 
-/**
- * Header actions contributed by the panels that own content actions. Panels
- * have no header of their own in the tabbed model, so anything acting on the
- * active panel — the destructive side-chat clear, the discussion's external
- * link — is only reachable through the shared side-panel header.
- */
-export function sidePanelHeaderActions(params: {
-  connected: boolean;
-  pendingQuestion: string | null;
-  discussionOpenUrl: string | null;
-  onClearCompanion: () => void;
-}): SidebarPanelTemplates {
-  return {
-    ...(params.discussionOpenUrl
-      ? {
-          discussion: html`<a
-            class="rail-header__action"
-            href=${params.discussionOpenUrl}
-            target="_blank"
-            rel="noopener"
-            aria-label=${t("chat.sessionDiscussion.openExternal")}
-            title=${t("chat.sessionDiscussion.openExternal")}
-            >${icons.externalLink}</a
-          >`,
-        }
-      : {}),
-    companion: html`<wa-dropdown
-      class="chat-session-rail__menu"
-      placement="bottom-end"
-      @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-        if (event.detail.item.value === "clear") {
-          params.onClearCompanion();
-        }
-      }}
-    >
-      <button
-        slot="trigger"
-        class="rail-header__action"
-        type="button"
-        aria-label=${t("chat.rail.moreActions")}
-        aria-haspopup="menu"
-        aria-expanded="false"
-      >
-        ${icons.moreHorizontal}
-      </button>
-      <wa-dropdown-item
-        value="clear"
-        ?disabled=${!params.connected || params.pendingQuestion !== null}
-      >
-        ${t("chat.rail.clear")}
-      </wa-dropdown-item>
-    </wa-dropdown>`,
-  };
-}
-
 /** One ordered declaration for every chat side-panel slot. */
 export function sidebarPanelDefinitions(
   params?: SidebarPanelDefinitionParams,
 ): SidebarPanelDefinition[] {
   const state = params?.state;
+  // Metadata-only definitions have no pane context, so they describe types without offering tabs.
+  const hasPaneContext = params !== undefined;
   const terminalAvailable = state?.terminalAvailable === true;
   const browserAvailable = state?.browserPanelAvailable === true;
   const desktopAvailable = params?.desktopAvailable === true;
@@ -114,14 +65,15 @@ export function sidebarPanelDefinitions(
     textKey: SidebarPanelTextKey,
     icon: TemplateResult,
     content: TemplateResult | typeof nothing | null,
-    options?: { available?: boolean; shortcut?: string },
+    options?: { available?: boolean; headerAction?: TemplateResult; shortcut?: string },
   ): SidebarPanelDefinition => ({
     slot,
     label: t(`chat.sidePanel.${textKey}`),
     icon,
-    available: options?.available ?? params !== undefined,
+    available: options?.available ?? hasPaneContext,
     content,
     empty: { description: t(`chat.sidePanel.${textKey}Empty`) },
+    ...(options?.headerAction ? { headerAction: options.headerAction } : {}),
     ...(options?.shortcut ? { shortcut: options.shortcut } : {}),
   });
   const terminal =
@@ -193,11 +145,59 @@ export function sidebarPanelDefinitions(
     definePanel("workspace", "files", icons.fileText, params?.workspace ?? null, {
       shortcut: "⇧⌘B",
     }),
-    definePanel("companion", "companion", icons.bot, companion),
+    definePanel(
+      "companion",
+      "companion",
+      icons.bot,
+      companion,
+      params
+        ? {
+            headerAction: html`<wa-dropdown
+              class="chat-session-rail__menu"
+              placement="bottom-end"
+              @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                if (event.detail.item.value === "clear") {
+                  params.onClearCompanion();
+                }
+              }}
+            >
+              <button
+                slot="trigger"
+                class="rail-header__action"
+                type="button"
+                aria-label=${t("chat.rail.moreActions")}
+                aria-haspopup="menu"
+                aria-expanded="false"
+              >
+                ${icons.moreHorizontal}
+              </button>
+              <wa-dropdown-item
+                value="clear"
+                ?disabled=${!params.connected || params.pendingQuestion !== null}
+              >
+                ${t("chat.rail.clear")}
+              </wa-dropdown-item>
+            </wa-dropdown>`,
+          }
+        : undefined,
+    ),
     definePanel("tasks", "tasks", icons.listChecks, params?.tasks ?? null),
     definePanel("desktop", "desktop", icons.monitor, desktop, { available: desktopAvailable }),
     definePanel("discussion", "discussion", icons.messageSquare, discussion, {
       available: discussion !== null,
+      ...(params?.discussionOpenUrl
+        ? {
+            headerAction: html`<a
+              class="rail-header__action"
+              href=${params.discussionOpenUrl}
+              target="_blank"
+              rel="noopener"
+              aria-label=${t("chat.sessionDiscussion.openExternal")}
+              title=${t("chat.sessionDiscussion.openExternal")}
+              >${icons.externalLink}</a
+            >`,
+          }
+        : {}),
     }),
     definePanel("chat", "boardChat", icons.messageSquare, params?.chat ?? null, {
       available: params?.hasBoard === true,
@@ -221,4 +221,14 @@ export function sidebarPanelTemplates(
     }
   }
   return templates;
+}
+
+export function sidebarPanelActions(definitions: SidebarPanelDefinition[]): SidebarPanelTemplates {
+  const actions: SidebarPanelTemplates = {};
+  for (const definition of definitions) {
+    if (definition.headerAction) {
+      actions[definition.slot] = definition.headerAction;
+    }
+  }
+  return actions;
 }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -28,9 +28,9 @@ import { requiresChatModelSetup } from "./chat-model-setup.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
 import {
   availableSidebarSlots,
+  sidebarPanelActions,
   sidebarPanelDefinitions,
   sidebarPanelTemplates,
-  sidePanelHeaderActions,
 } from "./chat-pane-embedded-panels.ts";
 import {
   createChatPaneSessionActionCallbacks,
@@ -658,11 +658,16 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       onCompanionDraftChange: (draft) =>
         this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
       onCompanionVisibilityChange: this.setSessionObserverVisibility,
+      connected: state.connected,
+      pendingQuestion: companionThread.pendingQuestion,
+      onClearCompanion: () => void this.clearSessionCompanion(),
       discussion,
+      discussionOpenUrl: discussion?.openUrl ?? null,
       discussionSourceGeneration: this.connectionGeneration,
     });
     const availableSlots = availableSidebarSlots(panelDefinitions);
     const panelTemplates = sidebarPanelTemplates(panelDefinitions);
+    const panelActions = sidebarPanelActions(panelDefinitions);
     const content = renderSidebarRegion({
       availableWidth: this.paneWidth,
       availableSlots,
@@ -678,12 +683,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       }),
       layout: sidebarLayout,
       panelDefinitions,
-      panelActions: sidePanelHeaderActions({
-        connected: state.connected,
-        pendingQuestion: companionThread.pendingQuestion,
-        discussionOpenUrl: discussion?.openUrl ?? null,
-        onClearCompanion: () => void this.clearSessionCompanion(),
-      }),
+      panelActions,
       narrow: this.paneWidth < SIDEBAR_NARROW_BREAKPOINT_PX,
       panelTemplates,
       primary,

--- a/ui/src/pages/chat/components/chat-sidebar-region-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region-types.ts
@@ -10,6 +10,7 @@ export type SidebarPanelDefinition = {
   shortcut?: string;
   available: boolean;
   content: TemplateResult | typeof nothing | null;
+  headerAction?: TemplateResult;
   empty: {
     description: string;
     action?: TemplateResult;

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -3,7 +3,6 @@
 import { html } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../../components/resizable-divider.ts";
-import { sidePanelHeaderActions } from "../chat-pane-embedded-panels.ts";
 import {
   openSlot,
   setSidebarDock,
@@ -82,15 +81,24 @@ describe("chat sidebar region", () => {
     expect(root(region).querySelector('[data-panel="detail"]')).not.toBeNull();
   });
 
-  it("keeps the destructive companion clear reachable, behind the active panel's overflow menu", async () => {
+  it("renders the active panel's supplied dropdown without hoisting its destructive action", async () => {
     const onClear = vi.fn();
     const region = await createRegion(openSlot(openSlot({ columns: [] }, "detail"), "companion"));
-    region.panelActions = sidePanelHeaderActions({
-      connected: true,
-      pendingQuestion: null,
-      discussionOpenUrl: null,
-      onClearCompanion: onClear,
-    });
+    // This representative action exercises the region contract; the app E2E
+    // separately verifies the production Side chat action's exact markup.
+    region.panelActions = {
+      companion: html`<wa-dropdown
+        class="chat-session-rail__menu"
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          if (event.detail.item.value === "clear") {
+            onClear();
+          }
+        }}
+      >
+        <button slot="trigger" type="button">More</button>
+        <wa-dropdown-item value="clear">Clear</wa-dropdown-item>
+      </wa-dropdown>`,
+    };
     await region.updateComplete;
 
     const actions = root(region).querySelector(".side-panel__action-group--content");


### PR DESCRIPTION
## What Problem This Solves

`sidePanelHeaderActions()` was the last place a chat side-panel slot's identity lived outside its
declaration. It built a second slot-keyed map — an external-link anchor for Discussion, a clear-thread
dropdown for Side chat — which `chat-pane-render.ts` passed to the sidebar region separately from the
templates. So after #124950 gave every slot one definition for availability, content, label, icon, and empty
state, a slot's header controls still came from a different function with its own parameter list.

## Why This Change Was Made

This is step 2 of the series that makes one declaration per slot the single source of truth. Header actions
move onto `SidebarPanelDefinition.headerAction`, the region's `panelActions` map is derived by
`sidebarPanelActions()` exactly as `sidebarPanelTemplates()` derives content, and `sidePanelHeaderActions()`
plus its call site are deleted. The inputs those actions need (`discussionOpenUrl`, `onClearCompanion`,
`connected`, `pendingQuestion`) now thread through the one builder instead of a parallel signature.

While in the same file, the availability default `options?.available ?? params !== undefined` became a named
`hasPaneContext` with a comment. Whether a tab is offered at all is load-bearing enough that it should not
read as an incidental undefined-check. No behavior change.

## User Impact

None. Same actions on the same panels, same markup, same gating.

## Evidence

The jsdom region test previously built its `panelActions` by calling the production function, so it proved
two separate things: that production's Side chat action is a dropdown, and that the region does not hoist a
destructive control into the always-visible row. Deriving that map from the new definitions inside a jsdom
test is not cheap — the builder constructs every slot's content and needs a full `ChatPageHost` — so rather
than fake production's markup and quietly keep the old assertion text, the two guarantees were split to the
level where each is honest:

- the unit test keeps the **region contract** (renamed accordingly, with a comment): given a panel's action,
  the region renders it and does not lift its destructive item into the always-visible row;
- a new case in `chat-sidebar-panel-contract.e2e.test.ts` covers **production markup** against a real
  Control UI: Side chat's header action is `wa-dropdown.chat-session-rail__menu`, the action row has zero
  direct `button` children, and Discussion's action carries its external href.

That is stronger than what it replaces: the production-markup invariant is now asserted against the running
app instead of a jsdom fixture.

```
pnpm test ui/src/pages/chat/components/chat-sidebar-region.test.ts ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
 Test Files  1 passed (1)      Tests  15 passed (15)
 Test Files  1 passed (1)      Tests   2 passed (2)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `+76 / −65` (net **+11**), tests `+39 / −8`. The small
positive is two inline action templates becoming declarations; it buys the deletion of the last parallel
slot-keyed map in this file. Series running total remains net-negative in production (−17 from #124950).

No `CHANGELOG.md` edit — release-only per repo policy, and this step is behavior-neutral.
