### PR TITLE
test(codex): allow side-question fixture arguments

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -2279,7 +2279,7 @@ describe("runCodexAppServerSideQuestion", () => {
             {
               name: "wiki_status",
               description: "Check wiki status",
-              parameters: { type: "object", properties: {} },
+              parameters: { type: "object", properties: {}, additionalProperties: true },
               execute: toolExecuteMock,
             },
           ]


### PR DESCRIPTION
## What Problem This Solves

The current-main Codex side-question test `bridges prepared restricted-profile tools into side threads` fails deterministically because its mocked `wiki_status` tool declares a closed empty object schema but the simulated Codex call sends `{ topic: "AGENTS.md" }`. Strict native-tool argument validation rejects the arguments before `tool.execute`, so `toolExecuteMock` receives no call. This also blocks unrelated PR #124951.

## Why This Change Was Made

The test covers prepared restricted-profile tool bridging, not a concrete `wiki_status` argument contract. Marking the generic fixture schema with `additionalProperties: true` matches sibling fixtures and preserves the test's intended scope without changing production behavior.

## User Impact

No production behavior changes. The deterministic current-main test failure is repaired so unrelated PRs can pass the Codex extension test lane.

## Evidence

Before the repair on current-main ancestry:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts \
  -t 'bridges prepared restricted-profile tools into side threads'

FAIL: expected toolExecuteMock to be called; received 0 calls
```

After the repair with Node 24.15.0:

```text
focused test: 1 passed, 63 skipped
full file: 64 passed
node scripts/check-changed.mjs -- extensions/codex/src/app-server/side-question.test.ts: passed
oxfmt --check: passed
git diff --check: passed
```

Production LOC: 0. No live provider or channel requests were made; this is a test-only fixture correction.