### PR TITLE
fix(test): labeler coverage fails with stale extension directories

### DIFF
--- a/test/scripts/labeler-extension-coverage.test.ts
+++ b/test/scripts/labeler-extension-coverage.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -11,13 +12,18 @@ type LabelerRule = Array<{
 }>;
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
-const extensionsRoot = path.join(repoRoot, "extensions");
 const labelerPath = path.join(repoRoot, ".github/labeler.yml");
 
-const extensionDirectories = readdirSync(extensionsRoot, { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .map((entry) => entry.name)
-  .toSorted();
+const extensionDirectories = [
+  ...new Set(
+    execFileSync("git", ["ls-files", "--", "extensions"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+      .split("\n")
+      .flatMap((file) => file.match(/^extensions\/([^/]+)\//)?.[1] ?? []),
+  ),
+].toSorted();
 const extensionDirectorySet = new Set(extensionDirectories);
 const labeler = parse(readFileSync(labelerPath, "utf8")) as Record<string, LabelerRule>;
 const extensionGlobDirectories = Object.values(labeler)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running the labeler extension coverage test in a long-lived checkout would get a false failure after an extension was renamed or removed. Git can remove the tracked files while build output keeps the old directory alive, so the test reported stale directories such as `fish-audio`, `qqbot`, and `video-generation-core` as missing labeler entries even though current tracked extensions were fully covered.

## Why This Change Was Made

The test now derives extension directories from Git's tracked file set instead of every directory currently present on disk. This keeps the guard aligned with the repository topology it is meant to validate while ignoring untracked leftovers; no `.github/labeler.yml` change is needed, and the existing `extensions: fish-audio`, `channel: qqbot`, and `channel: zaloclawbot` labels already exist.

## User Impact

Maintainer-facing only: labeler coverage remains strict for tracked plugins, but local validation no longer fails because of stale extension build directories.

AI-assisted: yes. The change was independently reviewed with Codex autoreview.

## Evidence

- Before the fix, creating stale `extensions/fish-audio`, `extensions/qqbot`, and `extensions/video-generation-core` directories reproduced the failure with exactly those three names.
- After the fix, the same stale-directory reproduction passes: `node scripts/run-vitest.mjs test/scripts/labeler-extension-coverage.test.ts` — 2 passed.
- Focused post-rebase proof: labeler coverage plus worker admission/provisioning tests — 59 passed.
- Changed-file gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31995219584
- Exact-head CI passed, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31995390808
- `git diff --check` passed.
- Codex autoreview: clean, no accepted/actionable findings.
