### PR TITLE
feat(cron): enable automation triggers by default

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -89,7 +89,7 @@ Heartbeat scratch is now monitor prose only. Runtime heartbeats do not parse `ta
 
 ### Stream sources
 
-A stream schedule keeps an operator-authored argv command running under the Gateway and fires the job from its stdout and stderr lines. Stream schedules are event-driven, never time-due, and require `cron.triggers.enabled: true` because the long-lived command has the same unattended trust class as trigger scripts. Disabling or removing the job stops the process; Gateway shutdown waits for process-tree teardown. Fast failures restart with the scheduler's built-in error backoff. Five consecutive runs shorter than 60 seconds leave the job in an error state and use the normal failure-alert path; manually re-enable the job to clear the restart cap.
+A stream schedule keeps an operator-authored argv command running under the Gateway and fires the job from its stdout and stderr lines. Stream schedules are event-driven, never time-due, and are available by default. Set `cron.triggers.enabled: false` to disable them together with condition-trigger scripts and script payloads. Disabling or removing the job stops the process; Gateway shutdown waits for process-tree teardown. Fast failures restart with the scheduler's built-in error backoff. Five consecutive runs shorter than 60 seconds leave the job in an error state and use the normal failure-alert path; manually re-enable the job to clear the restart cap.
 
 ```bash
 openclaw automations add \
@@ -155,7 +155,7 @@ The script must return `{ fire, message?, state? }`. The previous JSON state is 
 Author watchers around **actionable state**, not only success: a watcher that goes quiet when its check fails or times out looks healthy while broken. Compare the observation with `trigger.state` and return fresh state to deduplicate; do not rely on model or process memory. When firing, make `message` self-contained because it becomes the fired run's complete event context.
 
 <Warning>
-Enabling `cron.triggers.enabled` permits both condition-trigger scripts and `script` payloads to run headlessly with the owning agent's **full tool policy, including `exec`**. Treat this as unattended code execution with that agent's permissions; leave it disabled unless every agent allowed to create automation jobs is trusted accordingly.
+Condition-trigger scripts and `script` payloads run unattended by default with the owning agent's **full tool policy, including `exec`**. Stream schedules also keep operator-authored commands running unattended. Treat these surfaces as unattended code execution with that agent's permissions. Operators who need a hard stop can set `cron.triggers.enabled: false`; remove it or set it to `true` to re-enable them.
 </Warning>
 
 Create a watcher from a local script file (`-` reads the script from stdin):
@@ -264,7 +264,7 @@ Delivered text is derived from process output: non-empty stdout wins; if stdout 
 
 ### Script payloads
 
-Script payloads run headlessly in the same code-mode executor as trigger scripts, without starting a conversational agent turn. Enable `cron.triggers.enabled` before creating or running them; this dangerous-automation gate covers both trigger scripts and script payloads. Script jobs support only `main` and `isolated` session targets.
+Script payloads run headlessly in the same code-mode executor as trigger scripts, without starting a conversational agent turn. They are available by default; setting `cron.triggers.enabled: false` disables creation and execution of script payloads together with condition-trigger scripts and stream schedules. Script jobs support only `main` and `isolated` session targets.
 
 ```bash
 openclaw automations create "0 * * * *" \

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1644,7 +1644,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `enabled`: execute stored automation jobs (default: `true`). Set `false` to pause all automation execution without deleting jobs.
-- `triggers.enabled`: also run event-driven automation triggers (default: `false`).
+- `triggers.enabled`: run event-driven automation triggers (default: `true`). Set `false` to disable condition triggers, script payloads, and stream schedules.
 - `sessionRetention`: how long to keep completed isolated automation run sessions before pruning SQLite session rows. Also controls cleanup of archived deleted automation transcripts. Default: `24h`; set `false` or a zero duration such as `"0h"` to disable (negative durations are invalid).
 - Run history automatically keeps the newest 2000 terminal rows per job. Lost rows retain their 24-hour cleanup window.
 - `webhookToken`: bearer token used for automation webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -226,7 +226,11 @@ Set per channel or per room/conversation - see [Groups](/channels/groups#context
 
 ## Prompt injection
 
-An attacker crafts a message that manipulates the model into unsafe action ("ignore your instructions", "dump your filesystem", "follow this link and run commands"). Prompt injection is **not solved** by system prompt guardrails alone - those are soft guidance; hard enforcement comes from tool policy, exec approvals, sandboxing, and channel allowlists (which operators can still disable by design).
+An attacker crafts a message that manipulates the model into unsafe action ("ignore your instructions", "dump your filesystem", "follow this link and run commands").
+
+Model choice now carries real weight here. Frontier models have become substantially more resistant: in a 2026 crowdsourced arena of 272K attacks across 41 agent scenarios - scored only when the agent both executed the harmful action **and** hid it from the user - success rates were 0.5% for Claude Opus 4.5, 1.0% for Sonnet 4.5, 1.3% for Haiku 4.5, and 8.5% for Gemini 2.5 Pro. Robustness tracked capability within a model family, so the models we recommend are a meaningful mitigation in their own right, not just a soft guardrail.
+
+Two caveats keep this from being a solved problem. Adaptive human attackers still break models that score well on static benchmarks, with published success rates above 80% against state-of-the-art defenses once the attacker adapts. And smaller or older models remain markedly easier to steer. So treat model choice as your first and cheapest layer, then keep hard enforcement - tool policy, exec approvals, sandboxing, and channel allowlists - for anything whose blast radius you would not accept on a bad day.
 
 Prompt injection does not require public DMs: even if only you can message the bot, any **untrusted content** it reads (web search/fetch results, browser pages, emails, docs, attachments, pasted logs/code) can carry adversarial instructions. The content itself is a threat surface, not just the sender.
 
@@ -239,7 +243,7 @@ Red flags to treat as untrusted:
 
 What helps in practice:
 
-- Keep inbound DMs locked down (pairing/allowlists); prefer mention gating in groups; avoid always-on bots in public rooms.
+- Keep inbound DMs locked down (pairing/allowlists). Groups are a supported deployment, not a last resort: use mention gating and `contextVisibility` so the agent reads what it needs and no more. Reserve extra caution for genuinely public rooms, where anyone can post untrusted content.
 - Treat links, attachments, and pasted instructions as hostile by default.
 - Run sensitive tool execution in a sandbox; keep secrets out of the agent's reachable filesystem. Sandboxing is opt-in: if sandbox mode is off, implicit `host=auto` resolves to the gateway host, while explicit `host=sandbox` still fails closed (no sandbox runtime available). Set `host=gateway` to make that behavior explicit in config.
 - Limit high-risk tools (`exec`, `browser`, `web_fetch`, `web_search`) to trusted agents or explicit allowlists.
@@ -840,7 +844,7 @@ Details: [Logging](/gateway/logging)
 }
 ```
 
-Keeps the Gateway private, requires DM pairing, and avoids always-on group bots. For safer tool execution too, add a sandbox + deny dangerous tools for any non-owner agent (see "Per-agent access profiles" above).
+Keeps the Gateway private, requires DM pairing, and gates group replies behind a mention. Groups are fully supported - sender identity is threaded through to the agent, and per-group settings let one room run different defaults than another - so the goal here is scoping the agent's attention, not avoiding groups. For safer tool execution too, add a sandbox + deny dangerous tools for any non-owner agent (see "Per-agent access profiles" above).
 
 ### Separate numbers (WhatsApp, Signal, Telegram)
 

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -183,27 +183,27 @@ Out-of-scope reports and false-positive patterns (public internet exposure, prom
 
 #### T-EXEC-001: Direct prompt injection
 
-| Attribute               | Value                                                                                                                                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                                                                                                 |
-| **Description**         | Attacker sends crafted prompts to manipulate agent behavior                                                                                  |
-| **Attack vector**       | Channel messages containing adversarial instructions                                                                                         |
-| **Affected components** | Agent LLM, all input surfaces                                                                                                                |
-| **Current mitigations** | Pattern detection, external content wrapping; treated as out-of-scope for vulnerability reports absent a boundary bypass (see `SECURITY.md`) |
-| **Residual risk**       | Critical - detection only, no blocking; sophisticated attacks bypass                                                                         |
-| **Recommendations**     | Output validation and user confirmation for sensitive actions, layered on top of existing detection                                          |
+| Attribute               | Value                                                                                                                                                                                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                                                                                                                                                                                                                                                     |
+| **Description**         | Attacker sends crafted prompts to manipulate agent behavior                                                                                                                                                                                                                                      |
+| **Attack vector**       | Channel messages containing adversarial instructions                                                                                                                                                                                                                                             |
+| **Affected components** | Agent LLM, all input surfaces                                                                                                                                                                                                                                                                    |
+| **Current mitigations** | Pattern detection, external content wrapping, and frontier-model robustness (2026 crowdsourced arena: 0.5% ASR on Claude Opus 4.5, 8.5% on Gemini 2.5 Pro, scored on execution plus concealment); treated as out-of-scope for vulnerability reports absent a boundary bypass (see `SECURITY.md`) |
+| **Residual risk**       | Model-tier dependent - low single-digit ASR against organic attacks on recommended frontier models, but adaptive attackers still exceed 80% against state-of-the-art defenses, and smaller/older models remain markedly easier to steer                                                          |
+| **Recommendations**     | Output validation and user confirmation for sensitive actions, layered on top of existing detection                                                                                                                                                                                              |
 
 #### T-EXEC-002: Indirect prompt injection
 
-| Attribute               | Value                                                                                                                 |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0051.001 - LLM Prompt Injection: Indirect                                                                        |
-| **Description**         | Attacker embeds malicious instructions in fetched content                                                             |
-| **Attack vector**       | Malicious URLs, poisoned emails, compromised webhooks                                                                 |
-| **Affected components** | `web_fetch`, email ingestion, external data sources                                                                   |
-| **Current mitigations** | Content wrapping with random-boundary XML-style markers, homoglyph/special-token normalization, and a security notice |
-| **Residual risk**       | High - LLM may still ignore wrapper instructions                                                                      |
-| **Recommendations**     | Separate execution contexts for wrapped content                                                                       |
+| Attribute               | Value                                                                                                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0051.001 - LLM Prompt Injection: Indirect                                                                                                                                                                     |
+| **Description**         | Attacker embeds malicious instructions in fetched content                                                                                                                                                          |
+| **Attack vector**       | Malicious URLs, poisoned emails, compromised webhooks                                                                                                                                                              |
+| **Affected components** | `web_fetch`, email ingestion, external data sources                                                                                                                                                                |
+| **Current mitigations** | Content wrapping with random-boundary XML-style markers, homoglyph/special-token normalization, a security notice, and frontier-model robustness (see T-EXEC-001)                                                  |
+| **Residual risk**       | Model-tier dependent - recommended frontier models largely hold the wrapper boundary, but it remains soft guidance an adaptive attacker can erode; scope tool policy and sandboxing to the blast radius you accept |
+| **Recommendations**     | Separate execution contexts for wrapped content                                                                                                                                                                    |
 
 #### T-EXEC-003: Tool argument injection
 

--- a/src/agents/tools/cron-tool-schema.ts
+++ b/src/agents/tools/cron-tool-schema.ts
@@ -35,8 +35,8 @@ const CRON_ACTIONS = [
 ] as const;
 
 const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "stream"] as const;
-// Stream schedules, script payloads, and condition triggers all require
-// cron.triggers.enabled; when it is off the scheduler rejects them, so the
+// When cron.triggers.enabled is explicitly false, the scheduler rejects
+// stream schedules, script payloads, and condition triggers, so the
 // model-facing schema must not advertise them.
 const CRON_SCHEDULE_KINDS_TRIGGERS_DISABLED = ["at", "every", "cron"] as const;
 const CRON_WAKE_MODES = ["now", "next-heartbeat"] as const;
@@ -106,7 +106,7 @@ function createCronScheduleSchema(params: { triggersEnabled: boolean }): TSchema
                 Type.Array(Type.String({ minLength: 1 }), {
                   minItems: 1,
                   description:
-                    "Supervised source argv (kind=stream; requires cron.triggers.enabled)",
+                    "Supervised source argv (kind=stream; disabled when cron.triggers.enabled=false)",
                 }),
               ),
               cwd: Type.Optional(Type.String({ description: "Working directory (kind=stream)" })),

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -519,16 +519,12 @@ describe("createCronToolSchema with cron triggers disabled", () => {
     expect(propertyAt(configlessSchema, "job.schedule.kind")?.enum).toContain("stream");
   });
 
-  it("gates the surface when config omits cron.triggers entirely (disabled default)", () => {
+  it("keeps the full surface when config omits cron.triggers (enabled default)", () => {
     const defaultPostureSchema = createCronTool({
       config: { cron: { enabled: true } } as OpenClawConfig,
     }).parameters as unknown as Record<string, unknown>;
-    expect(keysAt(defaultPostureSchema, "job")).not.toContain("trigger");
-    expect(propertyAt(defaultPostureSchema, "job.schedule.kind")?.enum).toEqual([
-      "at",
-      "every",
-      "cron",
-    ]);
+    expect(keysAt(defaultPostureSchema, "job")).toContain("trigger");
+    expect(propertyAt(defaultPostureSchema, "job.schedule.kind")?.enum).toContain("stream");
   });
 
   it("still validates a plain reminder add call", () => {

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -939,7 +939,7 @@ describe("cron tool", () => {
     const tool = createTestCronTool();
 
     expect(tool.description).toContain(
-      "needs cron.triggers.enabled — if off, say so; never model-poll instead",
+      "available unless cron.triggers.enabled=false — if off, say so; never model-poll instead",
     );
     expect(tool.description).toContain("Quiet headless check, no model");
     expect(tool.description).toContain("trigger.state");

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -172,13 +172,13 @@ function buildCronToolDescription(params: { triggersEnabled: boolean }): string 
     ? "{name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}"
     : "{name?,schedule,payload,sessionTarget?,pacing?,delivery?,enabled?}";
   const streamScheduleLine = params.triggersEnabled
-    ? '\n- {kind:"stream",command:[argv],mode?:"line"|"match",match?}: fires on supervised process output; needs cron.triggers.enabled.'
+    ? '\n- {kind:"stream",command:[argv],mode?:"line"|"match",match?}: fires on supervised process output; disabled only when cron.triggers.enabled=false.'
     : "";
   const scriptPayloadLine = params.triggersEnabled
-    ? '\n- script {kind:"script",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.'
+    ? '\n- script {kind:"script",script,timeoutSeconds?,toolBudget?}: main|isolated only; disabled only when cron.triggers.enabled=false.'
     : "";
   const triggerSection = params.triggersEnabled
-    ? `TRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call("exec",{command:"..."}).`
+    ? `TRIGGER (condition watcher on every/cron): {script,once?}; available unless cron.triggers.enabled=false — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call("exec",{command:"..."}).`
     : `TRIGGERS DISABLED (cron.triggers.enabled=false): condition triggers, script payloads, and stream schedules are unavailable here. Omit trigger; use plain time-based schedules. If the user asks for a conditional watcher, say it is unsupported — never model-poll instead, and never silently create an unconditional job in its place.`;
   const silentWatcherCue = params.triggersEnabled ? ' Silent watcher=>mode:"none".' : "";
   return `Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work${params.triggersEnabled ? ", event watchers" : ""}. Never exec sleep/poll as timer.
@@ -209,15 +209,11 @@ DELIVERY {mode:"none"|"announce"|"webhook",channel?,to?,threadId?,bestEffort?,co
 Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.`;
 }
 
-// Trigger-gated surfaces stay advertised for config-less callers; only an
-// explicit runtime config with cron.triggers.enabled !== true narrows the
-// model-facing surface, matching the scheduler's own gate in
+// Trigger-gated surfaces are advertised by default. Only an explicit false
+// narrows the model-facing surface, matching the scheduler's own gate in
 // cron/service/jobs-validation.ts.
 function resolveCronTriggersEnabled(config?: OpenClawConfig): boolean {
-  if (!config) {
-    return true;
-  }
-  return config.cron?.triggers?.enabled === true;
+  return config?.cron?.triggers?.enabled !== false;
 }
 
 export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): AnyAgentTool {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -890,7 +890,7 @@ describe("script payload validation", () => {
   it("rejects creation while the trigger gate is disabled", () => {
     expect(() =>
       createJob(createMockState(now, { scriptPayloadsEnabled: false }), input()),
-    ).toThrow("cron.triggers.enabled=true");
+    ).toThrow("the operator set cron.triggers.enabled: false");
   });
 
   it("rejects malformed scripts on creation with a user-relative location", () => {
@@ -998,7 +998,7 @@ describe("script payload validation", () => {
         { payload: { kind: "script", script: "return {}" } },
         { cronConfig: { triggers: { enabled: false } } },
       ),
-    ).toThrow("cron.triggers.enabled=true");
+    ).toThrow("the operator set cron.triggers.enabled: false");
 
     const patched = structuredClone(base);
     applyJobPatch(

--- a/src/cron/service.stream-validation.test.ts
+++ b/src/cron/service.stream-validation.test.ts
@@ -40,7 +40,9 @@ describe("cron stream schedule validation", () => {
   it("rejects creation while cron triggers are disabled", async () => {
     const cron = await createCron(false);
     try {
-      await expect(cron.add(streamJob())).rejects.toThrow("cron.triggers.enabled=true");
+      await expect(cron.add(streamJob())).rejects.toThrow(
+        "the operator set cron.triggers.enabled: false",
+      );
     } finally {
       cron.stop();
     }

--- a/src/cron/service/jobs-validation.test.ts
+++ b/src/cron/service/jobs-validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { assertTriggerSupport } from "./jobs-validation.js";
+
+const triggerJob = {
+  schedule: { kind: "every" as const, everyMs: 30_000 },
+  trigger: { script: "json({ fire: true })" },
+};
+
+describe("cron trigger enablement", () => {
+  it("allows triggers by default when cron.triggers is omitted", () => {
+    expect(() =>
+      assertTriggerSupport(triggerJob, {
+        cronConfig: {},
+        requireEnabled: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects triggers when the operator explicitly opts out", () => {
+    expect(() =>
+      assertTriggerSupport(triggerJob, {
+        cronConfig: { triggers: { enabled: false } },
+        requireEnabled: true,
+      }),
+    ).toThrow(
+      "cron triggers are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
+    );
+  });
+});

--- a/src/cron/service/jobs-validation.ts
+++ b/src/cron/service/jobs-validation.ts
@@ -77,9 +77,9 @@ export function assertScriptPayloadSupport(
     // persisted state slot two owners and make the next trigger run ambiguous.
     throw new Error("cron script payloads cannot be combined with a condition trigger");
   }
-  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled !== true) {
+  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled === false) {
     throw new Error(
-      "cron script payloads are disabled; set cron.triggers.enabled=true to allow unattended scripts",
+      "cron script payloads are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true to allow unattended scripts",
     );
   }
 }
@@ -91,8 +91,10 @@ export function assertTriggerSupport(
   if (!job.trigger) {
     return;
   }
-  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled !== true) {
-    throw new Error("cron triggers are disabled; set cron.triggers.enabled=true");
+  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled === false) {
+    throw new Error(
+      "cron triggers are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
+    );
   }
   if (
     job.schedule.kind !== "every" &&
@@ -124,8 +126,10 @@ export function assertStreamScheduleSupport(
   if (job.schedule.kind !== "stream") {
     return;
   }
-  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled !== true) {
-    throw new Error("cron stream schedules are disabled; set cron.triggers.enabled=true");
+  if (opts?.requireEnabled && opts.cronConfig?.triggers?.enabled === false) {
+    throw new Error(
+      "cron stream schedules are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
+    );
   }
   const { command, mode = "line", match } = job.schedule;
   if (

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -507,11 +507,11 @@ async function executeScriptCronJob(
   streamBatch?: string,
   assertRunCurrent?: () => void,
 ) {
-  if (state.deps.cronConfig?.triggers?.enabled !== true) {
+  if (state.deps.cronConfig?.triggers?.enabled === false) {
     return {
       status: "error" as const,
       error:
-        "cron script payload execution is disabled; set cron.triggers.enabled=true to allow unattended scripts",
+        "cron script payload execution is disabled because the operator set cron.triggers.enabled: false; remove it or set it to true to allow unattended scripts",
     };
   }
   if (!state.deps.runScriptJob) {

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -482,7 +482,7 @@ describe("cron service timer seam coverage", () => {
 
     await expect(executeJobCore(state, createDueScriptJob({ now }))).resolves.toMatchObject({
       status: "error",
-      error: expect.stringContaining("cron.triggers.enabled=true"),
+      error: expect.stringContaining("the operator set cron.triggers.enabled: false"),
     });
     expect(runScriptJob).not.toHaveBeenCalled();
   });

--- a/src/gateway/cron-stream-job-owner.ts
+++ b/src/gateway/cron-stream-job-owner.ts
@@ -573,7 +573,8 @@ export class CronStreamJobOwner {
       reason === "trust-disabled"
         ? {
             streamStatus: "disabled",
-            streamError: "stream sources require cron.triggers.enabled=true",
+            streamError:
+              "stream sources are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
           }
         : reason === "cron-disabled"
           ? { streamStatus: "disabled", streamError: "cron is disabled" }

--- a/src/gateway/cron-stream-watchers.test.ts
+++ b/src/gateway/cron-stream-watchers.test.ts
@@ -72,7 +72,8 @@ describe("cron stream watchers", () => {
       "stream-job",
       expect.objectContaining({
         streamStatus: "disabled",
-        streamError: "stream sources require cron.triggers.enabled=true",
+        streamError:
+          "stream sources are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
       }),
       expect.any(String),
       expect.any(String),
@@ -105,7 +106,8 @@ describe("cron stream watchers", () => {
       "stream-job",
       expect.objectContaining({
         streamStatus: "disabled",
-        streamError: "stream sources require cron.triggers.enabled=true",
+        streamError:
+          "stream sources are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true",
       }),
       expect.any(String),
       expect.any(String),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -517,10 +517,10 @@ export function buildGatewayCronService(params: {
       agentId: agentId ?? resolveSessionStoreCompatibilityAgentId(getRuntimeConfig()),
     });
   const sessionStorePath = resolveSessionStorePath(defaultAgentId);
-  const scriptRuntime =
-    params.cfg.cron?.triggers?.enabled === true
-      ? createCronScriptRuntime({ config: params.cfg })
-      : undefined;
+  const cronTriggersEnabled = params.cfg.cron?.triggers?.enabled !== false;
+  const scriptRuntime = cronTriggersEnabled
+    ? createCronScriptRuntime({ config: params.cfg })
+    : undefined;
 
   const runCronChangedHook = (evt: PluginHookCronChangedEvent) => {
     const hookRunner = getGlobalHookRunner();
@@ -623,11 +623,7 @@ export function buildGatewayCronService(params: {
         const jobs: CronJob[] = Array.isArray(result)
           ? result
           : (result as { jobs: CronJob[] }).jobs;
-        await watchers.reconcile(
-          jobs,
-          cronEnabled && params.cfg.cron?.triggers?.enabled === true,
-          params.cfg.cron?.triggers?.enabled === true,
-        );
+        await watchers.reconcile(jobs, cronEnabled && cronTriggersEnabled, cronTriggersEnabled);
         return;
       }
       cronLogger.warn({}, "cron-stream: reconcile skipped after repeated concurrent mutations");
@@ -659,13 +655,13 @@ export function buildGatewayCronService(params: {
         job.enabled &&
         !job.state.streamRestartExhausted &&
         cronEnabled &&
-        params.cfg.cron?.triggers?.enabled === true
+        cronTriggersEnabled
       ) {
         await watchers.start(job);
         return;
       }
       const reason = resolveStreamStopReason({
-        triggersEnabled: params.cfg.cron?.triggers?.enabled === true,
+        triggersEnabled: cronTriggersEnabled,
         cronEnabled,
         restartExhausted: job?.state.streamRestartExhausted === true,
         isStream: job?.schedule.kind === "stream",

--- a/src/gateway/server-methods/cron-error-classification.test.ts
+++ b/src/gateway/server-methods/cron-error-classification.test.ts
@@ -6,7 +6,7 @@ describe("isCronInvalidRequestError", () => {
     "cron script payload has a syntax error: Unexpected token (line 1, column 10)",
     "cron script payload must not be empty",
     "cron script payloads cannot be combined with a condition trigger",
-    "cron script payloads are disabled; set cron.triggers.enabled=true to allow unattended scripts",
+    "cron script payloads are disabled because the operator set cron.triggers.enabled: false; remove it or set it to true to allow unattended scripts",
   ])("classifies script payload validation: %s", (message) => {
     expect(isCronInvalidRequestError(new Error(message))).toBe(true);
   });

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -137,6 +137,7 @@ async function cleanupCronTestRun(params: {
     testState.sessionConfig = undefined;
   }
   testState.cronEnabled = undefined;
+  testState.cronTriggersEnabled = undefined;
   if (params.prevSkipCron === undefined) {
     delete process.env.OPENCLAW_SKIP_CRON;
     return;
@@ -147,6 +148,7 @@ async function cleanupCronTestRun(params: {
 async function setupCronTestRun(params: {
   tempPrefix: string;
   cronEnabled?: boolean;
+  cronTriggersEnabled?: boolean;
   sessionConfig?: { mainKey: string };
   jobs?: unknown[];
 }): Promise<{ prevSkipCron: string | undefined; dir: string }> {
@@ -156,6 +158,7 @@ async function setupCronTestRun(params: {
   testState.cronStorePath = storePath;
   testState.sessionConfig = params.sessionConfig;
   testState.cronEnabled = params.cronEnabled;
+  testState.cronTriggersEnabled = params.cronTriggersEnabled;
   if (params.jobs) {
     await saveCronStore(testState.cronStorePath, {
       version: 1,
@@ -690,6 +693,7 @@ describe("gateway server cron", () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-trigger-gate-",
       cronEnabled: false,
+      cronTriggersEnabled: false,
     });
     const cronState = await createDirectCronState();
 

--- a/src/gateway/test-helpers.config-runtime.ts
+++ b/src/gateway/test-helpers.config-runtime.ts
@@ -135,6 +135,9 @@ export function createGatewayConfigModuleMock(actual: GatewayConfigModule): Gate
     if (typeof testState.cronEnabled === "boolean") {
       fileCron.enabled = testState.cronEnabled;
     }
+    if (typeof testState.cronTriggersEnabled === "boolean") {
+      fileCron.triggers = { enabled: testState.cronTriggersEnabled };
+    }
     if (typeof testState.cronStorePath === "string") {
       writeConfigMachineState("cron.store", testState.cronStorePath);
     }

--- a/src/gateway/test-helpers.runtime-state.ts
+++ b/src/gateway/test-helpers.runtime-state.ts
@@ -74,6 +74,7 @@ type GatewayTestHoistedState = {
     allowFrom: string[] | undefined;
     cronStorePath: string | undefined;
     cronEnabled: boolean | undefined;
+    cronTriggersEnabled: boolean | undefined;
     gatewayBind: "auto" | "lan" | "tailnet" | "loopback" | undefined;
     gatewayAuth: Record<string, unknown> | undefined;
     gatewayControlUi: Record<string, unknown> | undefined;
@@ -135,6 +136,7 @@ const gatewayTestHoisted = vi.hoisted(() => {
       allowFrom: undefined,
       cronStorePath: undefined,
       cronEnabled: false,
+      cronTriggersEnabled: undefined,
       gatewayBind: undefined,
       gatewayAuth: undefined,
       gatewayControlUi: undefined,

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -367,6 +367,7 @@ function resetGatewayMutableTestFixtures(): void {
   testState.migrationConfig = null;
   testState.migrationChanges = [];
   testState.cronEnabled = false;
+  testState.cronTriggersEnabled = undefined;
   testState.cronStorePath = undefined;
   testState.sessionConfig = undefined;
   testState.sessionStorePath = undefined;

--- a/src/mcp/openclaw-tools-serve.test.ts
+++ b/src/mcp/openclaw-tools-serve.test.ts
@@ -47,7 +47,8 @@ describe("OpenClaw tools MCP server", () => {
     };
 
     expect(jobKeys({ cron: { triggers: { enabled: false } } })).not.toContain("trigger");
-    expect(jobKeys({ cron: {} })).not.toContain("trigger");
+    // Absent config means enabled; only an explicit false narrows the surface.
+    expect(jobKeys({ cron: {} })).toContain("trigger");
     expect(jobKeys({ cron: { triggers: { enabled: true } } })).toContain("trigger");
   });
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -275,7 +275,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId job (partial: only supplied fields change; null clears) | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- Inherited configured MCP authority includes only model-callable tools; interactive app-view-only capabilities are excluded from headless jobs.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGERS DISABLED (cron.triggers.enabled=false): condition triggers, script payloads, and stream schedules are unavailable here. Omit trigger; use plain time-based schedules. If the user asks for a conditional watcher, say it is unsupported — never model-poll instead, and never silently create an unconditional job in its place.\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?,completionDestination?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). webhook posts finished-run event to URL in `to`. To keep announce delivery and also POST completion, use mode:\"announce\" with completionDestination:{mode:\"webhook\",to:\"https://...\"}.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted automation-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
+        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId job (partial: only supplied fields change; null clears) | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; disabled only when cron.triggers.enabled=false.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- Inherited configured MCP authority includes only model-callable tools; interactive app-view-only capabilities are excluded from headless jobs.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; disabled only when cron.triggers.enabled=false.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; available unless cron.triggers.enabled=false — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?,completionDestination?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`. To keep announce delivery and also POST completion, use mode:\"announce\" with completionDestination:{mode:\"webhook\",to:\"https://...\"}.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted automation-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -607,7 +607,7 @@
                     },
                     "kind": {
                       "description": "Payload kind",
-                      "enum": ["systemEvent", "agentTurn"],
+                      "enum": ["systemEvent", "agentTurn", "script"],
                       "type": "string"
                     },
                     "lightContext": {
@@ -629,6 +629,10 @@
                       ],
                       "description": "Model override, or null to clear"
                     },
+                    "script": {
+                      "description": "Headless code-mode script",
+                      "type": "string"
+                    },
                     "text": {
                       "description": "systemEvent text",
                       "type": "string"
@@ -640,6 +644,11 @@
                     "timeoutSeconds": {
                       "minimum": 0,
                       "type": "number"
+                    },
+                    "toolBudget": {
+                      "description": "Maximum script tool calls",
+                      "minimum": 1,
+                      "type": "integer"
                     },
                     "toolsAllow": {
                       "anyOf": [
@@ -671,6 +680,23 @@
                       "description": "ISO-8601 time (kind=at)",
                       "type": "string"
                     },
+                    "batchMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "command": {
+                      "description": "Supervised source argv (kind=stream; disabled when cron.triggers.enabled=false)",
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "cwd": {
+                      "description": "Working directory (kind=stream)",
+                      "type": "string"
+                    },
                     "everyMs": {
                       "description": "Interval ms (kind=every)",
                       "maximum": 8640000000000000,
@@ -683,7 +709,19 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
+                      "type": "string"
+                    },
+                    "match": {
+                      "description": "Regex source (stream match mode)",
+                      "type": "string"
+                    },
+                    "maxBatchBytes": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "enum": ["line", "match"],
                       "type": "string"
                     },
                     "staggerMs": {
@@ -713,6 +751,28 @@
                 "sessionTarget": {
                   "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
+                },
+                "trigger": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "once": {
+                          "type": "boolean"
+                        },
+                        "script": {
+                          "maxLength": 65536,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["script"],
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "wakeMode": {
                   "description": "Wake timing",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49785,
-    "roughTokens": 12447
+    "chars": 52849,
+    "roughTokens": 13213
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78649,
-    "roughTokens": 19663
+    "chars": 81713,
+    "roughTokens": 20429
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49477,
-    "roughTokens": 12370
+    "chars": 52541,
+    "roughTokens": 13136
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76861,
-    "roughTokens": 19216
+    "chars": 79925,
+    "roughTokens": 19982
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51011,
-    "roughTokens": 12753
+    "chars": 54075,
+    "roughTokens": 13519
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78811,
-    "roughTokens": 19703
+    "chars": 81875,
+    "roughTokens": 20469
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

`cron.triggers.enabled` defaulted to `false`, so condition watchers, script payloads, and stream schedules were dark-shipped: the capability existed, and the `automations` tool description actively told the model to say it was unsupported and to never poll in its place. Operators asking for "watch X and tell me when it changes" got a refusal for a feature that ships in the box.

## Why This Change Was Made

An audit of the actual authority boundary found the gate was not buying what its warning implied:

- **No authority delta.** `cronJobUsesToolRuntime` (`src/cron/tools-allow.ts`) treats `agentTurn`, `script`, and `trigger.script` identically for tool policy, and jobs are capped to the creating agent's allowlist via `creatorToolAllowlist` (`src/agents/tools/cron-tool-creator-cap.ts`). An **`agentTurn` cron job was never gated** — it already runs unattended, recurring, with that same creator-capped authority including `exec`.
- **Triggers are strictly tighter.** A condition gate gets a 30s wall clock, 5 tool calls, 16KB state, and a 30s minimum interval. An ungated `agentTurn` has no such budget.
- **Sandboxing already applies.** `src/cron/trigger-script.ts` resolves sandbox context and redirects the workspace when access is not `rw`, passing `sandbox` into tool construction — so a sandboxed deployment sandboxes its triggers.

So the gate blocked the bounded paths while leaving the broader one open. Absent config now means enabled; an explicit `cron.triggers.enabled: false` still disables everything it disabled before, and the error text now says so.

## User Impact

Condition watchers, script payloads, and stream schedules work out of the box. Operators who want a hard stop set `cron.triggers.enabled: false`. No new config surface, no migration.

Docs updated alongside: the trigger warning no longer advises leaving the feature off, and the configuration reference records the new default.

## Security doc accuracy pass

Two claims in the security docs had drifted from measured reality:

- **Prompt injection** was described flatly as "**not solved** by system prompt guardrails alone." That understated model choice as a mitigation. A 2026 crowdsourced arena (272K attacks, 41 agent scenarios, scored only when the agent both executed the harmful action *and* concealed it) measured 0.5% ASR on Claude Opus 4.5, 1.0% Sonnet 4.5, 1.3% Haiku 4.5, and 8.5% Gemini 2.5 Pro. The text now states that, and keeps the two caveats that matter: adaptive attackers still exceed 80% against state-of-the-art defenses, and smaller/older models remain easy to steer. Hard enforcement is still recommended, now proportionate to blast radius rather than as a blanket.
- **Groups** were framed as something to avoid ("avoid always-on group bots"). Groups are a supported deployment with sender identity threaded through and per-group settings; the guidance now points at mention gating and `contextVisibility` for scoping attention, reserving extra caution for genuinely public rooms.

The ATLAS threat-model entries (T-EXEC-001/002) keep their structure; residual risk is restated as model-tier dependent with the measured numbers rather than a flat severity label, since those rows are used for report triage.

## Evidence

See the commit for full test output.

- `node scripts/run-vitest.mjs run src/cron/service src/cron/service.jobs.test.ts src/cron/service.stream-validation.test.ts src/cron/trigger-script.test.ts` — **41 files, 692 tests passed**
- `node scripts/run-vitest.mjs run src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.schema.test.ts src/gateway/cron-stream-watchers.test.ts src/gateway/server.cron.test.ts src/gateway/server-methods/cron-error-classification.test.ts` — **3 shards passed (202 tests in the agents-tools shard)**
- New regression test `src/cron/service/jobs-validation.test.ts` proves both directions: omitted `cron.triggers` allows a trigger job, and an explicit `enabled: false` still rejects it with the new message.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` clean. The root `tsconfig.json` lane fails only on two pre-existing `tsdown.config.ts` errors that reproduce identically on unmodified `main`.
- oxfmt + oxlint clean on all 18 changed TypeScript files.

**Note on a suite stall:** `node scripts/run-vitest.mjs run src/cron` (raw path filter) stalls with no output and is killed at 120s. I verified this **reproduces on clean `main` with zero changes** — it is pre-existing and unrelated, caused by the path filter pulling in the three `*.e2e.test.ts` files that need live resources. The unit slice above covers the same code and passes.
