### PR TITLE
fix(ui): recover stale Control UI after gateway updates

### DIFF
--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -88,6 +88,26 @@ describe("isStaleChunkImportError", () => {
 });
 
 describe("scheduleStaleChunkReload", () => {
+  it("waits through a gateway handoff before reloading", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const storage = memoryStorage();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("gateway handoff reset the connection"))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const recovery = scheduleStaleChunkReload({ storage, reload });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(recovery).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("HEAD");
+    expect(fetchMock.mock.calls[1]?.[1]?.method).toBe("HEAD");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
   it("reloads once the document probe succeeds and records the build guard", async () => {
     const reload = vi.fn();
     const storage = memoryStorage();
@@ -129,24 +149,46 @@ describe("scheduleStaleChunkReload", () => {
     expect(storage.getItem(GUARD_KEY)).toBe("build-b");
   });
 
-  it("does not reload or set the guard while the gateway is unreachable", async () => {
+  it("reloads only once when same-build recovery attempts overlap", async () => {
+    vi.useFakeTimers();
     const reload = vi.fn();
     const storage = memoryStorage();
-    stubDocumentFetch(new Response(null, { status: 503 }));
-    await expect(
-      scheduleStaleChunkReload({
-        now: () => 1000,
-        storage,
-        reload,
-      }),
-    ).resolves.toBe(false);
+    let gatewayReachable = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: gatewayReachable ? 200 : 503 })),
+    );
+
+    const firstAttempt = scheduleStaleChunkReload({ buildId: "build-a", storage, reload });
+    await vi.advanceTimersByTimeAsync(5_100);
+    const secondAttempt = scheduleStaleChunkReload({ buildId: "build-a", storage, reload });
+    gatewayReachable = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(Promise.all([firstAttempt, secondAttempt])).resolves.toEqual([true, false]);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(GUARD_KEY)).toBe("build-a");
+  });
+
+  it("does not reload or set the guard while the gateway is unreachable", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const storage = memoryStorage();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })),
+    );
+    const recovery = scheduleStaleChunkReload({ now: () => 1000, storage, reload });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(recovery).resolves.toBe(false);
     expect(reload).not.toHaveBeenCalled();
     expect(storage.getItem(GUARD_KEY)).toBeNull();
   });
 
   it("does not auto-reload when the guard cannot be persisted", async () => {
     const reload = vi.fn();
-    stubDocumentFetch(new Response(null, { status: 200 }));
+    stubDocumentFetch(new Response(null, { status: 200 }), new Response(null, { status: 200 }));
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
@@ -170,23 +212,23 @@ describe("scheduleStaleChunkReload", () => {
   });
 
   it("applies an in-memory cooldown between attempts", async () => {
+    vi.useFakeTimers();
     const reload = vi.fn();
     const storage = memoryStorage();
-    const fetchMock = stubDocumentFetch(
-      new Response(null, { status: 503 }),
-      new Response(null, { status: 200 }),
+    let gatewayReachable = false;
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(null, { status: gatewayReachable ? 200 : 503 }),
     );
-    await expect(
-      scheduleStaleChunkReload({
-        now: () => 1000,
-        storage,
-        reload,
-      }),
-    ).resolves.toBe(false);
+    vi.stubGlobal("fetch", fetchMock);
+    const firstAttempt = scheduleStaleChunkReload({ now: () => 1000, storage, reload });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(firstAttempt).resolves.toBe(false);
+    const callsAfterFirstAttempt = fetchMock.mock.calls.length;
     await expect(scheduleStaleChunkReload({ now: () => 2000, storage, reload })).resolves.toBe(
       false,
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirstAttempt);
+    gatewayReachable = true;
     await expect(scheduleStaleChunkReload({ now: () => 7000, storage, reload })).resolves.toBe(
       true,
     );
@@ -212,9 +254,10 @@ describe("scheduleStaleChunkReload", () => {
   });
 
   it("coalesces automatic and manual probes and clears the busy state", async () => {
+    vi.useFakeTimers();
     const firstProbe = deferred<Response>();
     const fetchMock = vi.fn<typeof fetch>().mockImplementationOnce(async () => firstProbe.promise);
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
     const reload = vi.fn();
     const storage = memoryStorage();
@@ -225,10 +268,12 @@ describe("scheduleStaleChunkReload", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     firstProbe.resolve(new Response(null, { status: 503 }));
-    await expect(Promise.all([automatic, manual])).resolves.toEqual([false, false]);
+    await expect(manual).resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(automatic).resolves.toBe(true);
     await expect(retryStaleChunkReloadWhenReachable({ reload, timeoutMs: 0 })).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(reload).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -386,6 +431,22 @@ describe("installMissingStylesheetRecovery", () => {
       reloadButton?.click();
       expect(retry).toHaveBeenCalledTimes(1);
       expect(banner?.isConnected).toBe(true);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it("shows the reload banner while automatic recovery is still pending", async () => {
+    setReadyState("complete");
+    const pending = deferred<boolean>();
+    const uninstall = installMissingStylesheetRecovery({
+      isCssApplied: () => false,
+      schedule: vi.fn(() => pending.promise),
+    });
+    try {
+      expect(document.querySelector('[role="alert"]')).not.toBeNull();
+      pending.resolve(false);
+      await pending.promise;
     } finally {
       uninstall();
     }

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -145,7 +145,10 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   if (readGuardBuildId(storage) === buildId) {
     return false;
   }
-  if (!(await probeControlUiDocument())) {
+  if (!(await retryStaleChunkReloadWhenReachable({ reload: () => undefined }))) {
+    return false;
+  }
+  if (readGuardBuildId(storage) === buildId) {
     return false;
   }
   // A reload resets the in-memory state, so without a persisted guard a broken
@@ -257,8 +260,8 @@ export function installMissingStylesheetRecovery(
       getComputedStyle(document.documentElement).getPropertyValue("--openclaw-css-ok").trim() ===
       "1");
   const schedule = deps.schedule ?? scheduleStaleChunkReload;
-  // Single-shot (timeoutMs: 0) keeps the stylesheet banner's existing
-  // behavior; only the lazy-route button waits out a restart.
+  // Keep the banner's manual action single-shot; automatic recovery continues
+  // in the background while the banner provides immediate guidance.
   const retry = deps.retry ?? (() => retryStaleChunkReloadWhenReachable({ timeoutMs: 0 }));
   let detected = false;
   let uninstalled = false;
@@ -317,9 +320,11 @@ export function installMissingStylesheetRecovery(
     }
     detected = true;
     removeListeners();
+    showBanner();
     const reloaded = await schedule();
-    if (!reloaded) {
-      showBanner();
+    if (reloaded) {
+      banner?.remove();
+      banner = null;
     }
   };
 

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -2,6 +2,13 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+
+const { retryStaleChunkReloadWhenReachable } = vi.hoisted(() => ({
+  retryStaleChunkReloadWhenReachable: vi.fn(),
+}));
+
+vi.mock("../app/stale-chunk-reload.ts", () => ({ retryStaleChunkReloadWhenReachable }));
+
 import "./login-gate.ts";
 
 type LoginGateElement = HTMLElement & {
@@ -37,20 +44,23 @@ async function mountFailure(lastError: string, lastErrorCode: string | null) {
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.clearAllMocks();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   Reflect.deleteProperty(document, "execCommand");
 });
 
 describe("login gate failure recovery", () => {
-  it("offers page refresh for a protocol mismatch and reloads when selected", async () => {
+  it("offers page refresh for a protocol mismatch and retries when selected", async () => {
+    let finishRefresh: (reloaded: boolean) => void = () => undefined;
+    const refreshResult = new Promise<boolean>((resolve) => {
+      finishRefresh = resolve;
+    });
+    retryStaleChunkReloadWhenReachable.mockReturnValueOnce(refreshResult);
     const element = await mountFailure(
       "protocol mismatch",
       ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
     );
-    const reload = vi.fn();
-    vi.stubGlobal("window", { location: { reload } });
-
     const failure = element.querySelector<HTMLElement>(
       '.login-gate__failure[data-kind="protocol-mismatch"]',
     );
@@ -61,7 +71,25 @@ describe("login gate failure recovery", () => {
     expect(failure?.querySelector(".login-gate__failure-docs")).not.toBeNull();
 
     refresh?.click();
-    expect(reload).toHaveBeenCalledOnce();
+    refresh?.click();
+    await element.updateComplete;
+    expect(retryStaleChunkReloadWhenReachable).toHaveBeenCalledOnce();
+    expect(element.querySelector<HTMLButtonElement>(".login-gate__failure-refresh")?.disabled).toBe(
+      true,
+    );
+    expect(
+      element.querySelector<HTMLButtonElement>(".login-gate__failure-refresh")?.textContent?.trim(),
+    ).toBe("Refreshing…");
+
+    finishRefresh(false);
+    await refreshResult;
+    await element.updateComplete;
+    expect(element.querySelector<HTMLButtonElement>(".login-gate__failure-refresh")?.disabled).toBe(
+      false,
+    );
+    expect(
+      element.querySelector<HTMLButtonElement>(".login-gate__failure-refresh")?.textContent?.trim(),
+    ).toBe("Retry");
   });
 
   it.each([

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -1,10 +1,11 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 // Control UI component renders the login gate.
 import { html, nothing } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { normalizeBasePath } from "../app-route-paths.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
+import { retryStaleChunkReloadWhenReachable } from "../app/stale-chunk-reload.ts";
 import { t } from "../i18n/index.ts";
 import {
   resolveAuthHintKind,
@@ -280,12 +281,10 @@ function resolveLoginFailureFeedback(
   });
 }
 
-function refreshLoginGatePage() {
-  // The login gate blocks before the composer mounts, so there is no draft to preserve.
-  window.location.reload();
-}
-
-function renderLoginFailure(feedback: LoginFailureFeedback) {
+function renderLoginFailure(
+  feedback: LoginFailureFeedback,
+  refresh: { pending: boolean; failed: boolean; run: () => void },
+) {
   return html`
     <div
       class="callout danger login-gate__failure"
@@ -300,9 +299,14 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
             <button
               type="button"
               class="btn primary login-gate__failure-refresh"
-              @click=${refreshLoginGatePage}
+              ?disabled=${refresh.pending}
+              @click=${refresh.run}
             >
-              ${feedback.refreshAction.label}
+              ${refresh.pending
+                ? t("common.refreshing")
+                : refresh.failed
+                  ? t("common.retry")
+                  : feedback.refreshAction.label}
             </button>
           `
         : nothing}
@@ -324,7 +328,10 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
   `;
 }
 
-function renderLoginGate(props: LoginGateProps) {
+function renderLoginGate(
+  props: LoginGateProps,
+  refresh: { pending: boolean; failed: boolean; run: () => void },
+) {
   const basePath = normalizeBasePath(props.basePath);
   const faviconSrc = controlUiPublicAssetPath("favicon.svg", basePath);
   const failure = resolveLoginFailureFeedback({
@@ -439,7 +446,7 @@ function renderLoginGate(props: LoginGateProps) {
             ${t("common.connect")}
           </button>
         </div>
-        ${failure ? renderLoginFailure(failure) : ""}
+        ${failure ? renderLoginFailure(failure, refresh) : ""}
         <details class="login-gate__help">
           <summary class="login-gate__help-title">${t("connection.help.title")}</summary>
           <ol class="login-gate__steps">
@@ -464,9 +471,29 @@ function renderLoginGate(props: LoginGateProps) {
 
 class LoginGate extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: LoginGateProps;
+  @state() private refreshPending = false;
+  @state() private refreshFailed = false;
+
+  private readonly refreshPage = () => {
+    if (this.refreshPending) {
+      return;
+    }
+    this.refreshPending = true;
+    this.refreshFailed = false;
+    void retryStaleChunkReloadWhenReachable().then((reloaded) => {
+      this.refreshPending = false;
+      this.refreshFailed = !reloaded;
+    });
+  };
 
   override render() {
-    return this.props ? renderLoginGate(this.props) : nothing;
+    return this.props
+      ? renderLoginGate(this.props, {
+          pending: this.refreshPending,
+          failed: this.refreshFailed,
+          run: this.refreshPage,
+        })
+      : nothing;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the protocol-mismatch **Refresh page** action navigating into an error page while the Gateway is restarting.

## User Impact

Refresh waits for the served Gateway to answer, shows **Refreshing…**, and offers **Retry** if the bounded wait fails. Connecting, changing the target or credential, dismissing the failure, or replacing the login gate cancels the old attempt. Unsaved-input guards remain binding.

## Why This Change Was Made

This retains sallyom’s manual-refresh proposal on the shipped recovery owner. The obsolete automatic-recovery changes are removed: build-keyed winner election, persisted guards, authentication/privacy behavior, and automatic/manual one-navigation coordination are preserved. No new recovery service or dependency is added.

Existing JavaScript in an already-open pre-fix page cannot gain this behavior retroactively.

## Evidence

- The new handoff regression fails on unchanged current main; the repaired candidate passes **92 focused/sibling tests**.
- All required changed-source checks passed: type checks, formatting, dependency/source guards, export scans, lint, and UI style lane.
- Independent P0–P2 review: scoped-clean; no actionable findings.
- Real Chromium, production bundles, an isolated real Gateway, the same loopback origin, and a controlling production service worker: a HEAD probe fails during shutdown without navigating; changing the secret cancels the attempt and preserves the typed value; a later retry makes exactly **one** cache-busting navigation and moves the worker from the old to the new build.
- The browser fixture injects only an old client protocol range into the initial connect request. Gateway rejection, HTTP probes, service-worker handling, Gateway stop/start, rendered interaction, and navigation are real. This is not evidence from an unmodified historical release.
- All three hosted UI test shards and all 13 hosted UI end-to-end shards passed on `e8881ddbcdd8ada1f106e645c0db672f9bffe11d`.
- Historical [CI34926367717](https://github.com/openclaw/openclaw/actions/runs/34926367717) finished with the existing model-policy authenticated `/model default` timeout; its other hosted jobs have settled. The canonical completion-order correction [PR #141008](https://github.com/openclaw/openclaw/pull/141008) merged as `d8e50a38` and is now included through a signed, contributor-preserving main integration at `be3a8ac7f41bfa1f6cc81cf27f0abee92e6f1dad`. The UI patch, recovery owners and pinned dependencies are unchanged. On fresh exact-head [CI34927605266](https://github.com/openclaw/openclaw/actions/runs/34927605266), the model-policy shard passed. A separate known Code Mode deadline classification failed in [job104249052866](https://github.com/openclaw/openclaw/actions/runs/34927605266/job/104249052866): expected `timeout`, received `internal_error` at `code-mode-headless.test.ts:883`. Existing contributor repair [#143234](https://github.com/openclaw/openclaw/pull/143234) has now merged as `4c7cabb58b4a` after a current-source before/after proof, 100 passing affected tests, fresh independent review and 151 successful hosted CI jobs. This UI PR incorporates it and #141008 at signed `d9641d9a454c95d410f10a88b865ebacf74a3f9b`; fresh [CI34930924196](https://github.com/openclaw/openclaw/actions/runs/34930924196) passed with 126 successful jobs, 13 skips and no failures. Native preparation completed without changing that head. The three-file UI patch, recovery owners and pinned dependencies are unchanged, and sallyom's ancestry remains intact. No duplicate implementation, relaxed assertion or CI waiver is included.
- No provider invocation or operator Gateway/state was used.

### Before clicking Refresh

![Protocol-mismatch refresh action](https://github.com/user-attachments/assets/047a6a5c-8df9-4327-9a35-d1bd8e037444)

### While the Gateway is restarting

![Refresh remains on the recoverable login page while waiting](https://github.com/user-attachments/assets/0ab8260b-590f-4e6a-9ae0-26e23ed5e320)

### Editing the credential cancels recovery

![Typed synthetic credential retained after canceling refresh](https://github.com/user-attachments/assets/a37a5d50-8200-48ec-830a-33a277fe5f19)

Screenshots are from the corrected candidate with synthetic, masked input. Exact-head hosted CI and native preparation are complete on `d9641d9a`. All three original sanitized screenshots have now been visibly delivered and verified rendered in the originating chat as well as GitHub. The existing embeds and original test/browser evidence are unchanged; no proof was replayed. Merged as `6c6b03462404b36e68e269fcbceb678294a236a7` after exact-head native merge verification. Native local cleanup completed; the contributor fork branch is retained because GitHub denied its deletion.

Original contribution: [sallyom](https://github.com/sallyom); original commit ancestry is preserved.
