### PR TITLE
fix: prevent duplicate Claude CLI replies after reload

### DIFF
--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,6 +6,7 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
 
@@ -40,7 +41,9 @@ function extractComparableText(message: unknown): string | undefined {
   if (!joined) {
     return undefined;
   }
-  const visible = role === "user" ? stripInboundMetadata(joined) : joined;
+  const visible = stripInlineDirectiveTagsForDisplay(
+    role === "user" ? stripInboundMetadata(joined) : joined,
+  ).text;
   const normalized = visible.replace(/\s+/g, " ").trim();
   return normalized || undefined;
 }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4736,6 +4736,85 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history deduplicates a directive-tagged local Claude delivery with managed audio", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const sessionId = "sess-claude-cli-delivery-dedupe";
+      const cliSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07531";
+      const deliveryTimestamp = Date.parse("2026-03-26T16:29:55.500Z");
+      const homeEnvSnapshot = captureEnv(["HOME"]);
+      const homeDir = path.join(sessionDir, "home");
+      const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
+      const managedAudioUrl = "/api/chat/media/outgoing/main/claude-delivery/full";
+      await fs.mkdir(claudeProjectsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(claudeProjectsDir, `${cliSessionId}.jsonl`),
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-delivery-ready",
+          timestamp: new Date(deliveryTimestamp).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "CLAUDE DELIVERY READY" }],
+          },
+        }),
+        "utf-8",
+      );
+      setTestEnvValue("HOME", homeDir);
+      try {
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, cliSessionId),
+        );
+        await writeMainSessionTranscript(
+          [
+            createTextTranscriptEvent(
+              "assistant",
+              "[[reply_to:delivery-run-1]]CLAUDE DELIVERY READY",
+              {
+                timestamp: deliveryTimestamp,
+                message: {
+                  content: [
+                    {
+                      type: "text",
+                      text: "[[reply_to:delivery-run-1]]CLAUDE DELIVERY READY",
+                    },
+                    { type: "audio", url: managedAudioUrl, openUrl: managedAudioUrl },
+                  ],
+                },
+              },
+            ),
+          ],
+          sessionId,
+        );
+
+        const history = await rpcReq<{
+          messages?: Array<{ role?: unknown; content?: unknown }>;
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 100 }));
+        expect(history.ok).toBe(true);
+        const assistantMessages = (history.payload?.messages ?? []).filter(
+          (message) => message.role === "assistant",
+        );
+        expect(assistantMessages).toHaveLength(1);
+        const survivingContent = expectDefined(
+          assistantMessages[0]?.content,
+          "surviving assistant content",
+        );
+        expect(Array.isArray(survivingContent)).toBe(true);
+        const contentBlocks = survivingContent as Array<{ type?: unknown; text?: unknown }>;
+        expect(
+          contentBlocks.filter(
+            (block) => block.type === "text" && block.text === "CLAUDE DELIVERY READY",
+          ),
+        ).toHaveLength(1);
+        expect(contentBlocks.filter((block) => block.type === "audio")).toHaveLength(1);
+        expect(JSON.stringify(assistantMessages)).not.toContain("[[reply_to:");
+      } finally {
+        homeEnvSnapshot.restore();
+      }
+    });
+  });
+
   test("chat.history makes the full local prefix reachable in a claude-cli merge", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);


### PR DESCRIPTION
Related: #124910 (separate history-merge follow-up; the media-delivery repair remains unchanged)

## What Problem This Solves

Fixes an issue where users could see the same Claude CLI assistant text in two separate Control UI bubbles after a full reload when the turn also produced managed TTS audio. The audio attachment appeared once, but local and imported transcript text failed to deduplicate because only the local row retained an inline reply directive before display projection.

## Why This Change Was Made

The CLI history merge now compares the same display-normalized text that the UI ultimately renders. Local transcript rows remain authoritative, so the managed audio block survives; external Claude message identity still takes precedence when both rows provide it, preventing distinct imported messages from being collapsed.

This is AI-assisted work. I reviewed the owner boundary, regression, live runtime behavior, and final diff.

## User Impact

A Claude CLI response with managed audio now remains one assistant text bubble plus one audio attachment after reopening or reloading the chat.

## Evidence

### Regression and focused proof

- Pre-fix boundary regression: failed with `expected length 1, received 2`.
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.history deduplicates a directive-tagged local Claude delivery with managed audio"` — 1 passed, 102 skipped.
- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts` — 45 passed.
- `pnpm build` — passed.
- `pnpm ui:build` — passed.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Codex autoreview (`--mode uncommitted`, Sol/high) — clean, no actionable findings.

Production LOC: +4/-1 (net +3) | Tests: +79/-0

### Real Gateway + Control UI proof

An isolated loopback Gateway used the real `claude-cli` runtime with Claude Opus 5 and the bundled `tts` tool. The latest turn produced:

- exactly 1 `chat.send`
- exactly 1 `mcp__openclaw__tts` call
- exactly 1 plain Claude project-history final
- exactly 1 local directive-bearing final with 1 managed audio block
- after a genuine document reload: exactly 1 `CLAUDE DELIVERY READY` bubble and 1 audio card
- 0 visible reply directive tags

Before hard reload (single live bubble + audio card):

![Claude CLI TTS response before reload](https://github.com/user-attachments/assets/e0e2cadc-be93-451f-bfcb-5f823cc475fc)

After hard reload (same single bubble + audio card):

![Claude CLI TTS response after reload](https://github.com/user-attachments/assets/b4f2caea-817c-4453-8c3f-5cce3f307ce7)

Reload recording:

https://github.com/user-attachments/assets/5ed1853f-eb6b-4c66-80b0-4a884f420bda
