### PR TITLE
fix(agents): show creation hierarchy in Control UI

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -93,7 +93,6 @@ import {
   readAgentDeletionJournal,
   type AgentDeletionJournalCleanupPath,
 } from "../../state/agent-deletion-journal.js";
-import { listAgentProvenance } from "../../state/agent-provenance.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -899,27 +898,11 @@ export const agentsHandlers: GatewayRequestHandlers = {
 
     const cfg = context.getRuntimeConfig();
     const modelCatalog = await readPreparedServerMethodModelCatalog(context);
-    const result = listAgentsForGateway(cfg, modelCatalog, {
-      includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
-    });
-    const provenanceById = new Map(
-      listAgentProvenance().map((record) => [record.agentId, record] as const),
-    );
     respond(
       true,
-      {
-        ...result,
-        agents: result.agents.map((agent) => {
-          const provenance = provenanceById.get(agent.id);
-          return provenance
-            ? Object.assign({}, agent, {
-                createdVia: provenance.createdVia,
-                creatorAgentId: provenance.creatorAgentId,
-                createdAt: provenance.createdAtMs,
-              })
-            : agent;
-        }),
-      },
+      listAgentsForGateway(cfg, modelCatalog, {
+        includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
+      }),
       undefined,
     );
   },

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -40,6 +40,7 @@ import {
   runExclusiveSessionLifecycleMutation,
 } from "../sessions/session-lifecycle-admission.js";
 import { buildPersistedUserTurnMessage } from "../sessions/user-turn-transcript.js";
+import { recordAgentProvenance } from "../state/agent-provenance.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -1123,7 +1124,7 @@ describe("gateway server chat", () => {
     });
   });
 
-  test("chat.startup returns chat history with the initial agents list", async () => {
+  test("chat.startup returns chat history with the initial agents list and provenance", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await writeGatewayConfig({
         agents: {
@@ -1135,7 +1136,7 @@ describe("gateway server chat", () => {
               "openai/gpt-main": {},
             },
           },
-          entries: { main: { default: true } },
+          entries: { main: { default: true }, research: {} },
         },
         models: {
           providers: {
@@ -1146,6 +1147,11 @@ describe("gateway server chat", () => {
           },
         },
       });
+      recordAgentProvenance(
+        "research",
+        { createdVia: "agent", creatorAgentId: "main" },
+        { nowMs: 42 },
+      );
       await connectOk(ws);
       await createSessionDir();
       const updatedAt = Date.now();
@@ -1160,7 +1166,12 @@ describe("gateway server chat", () => {
 
       const startup = await rpcReq<{
         agentsList?: {
-          agents?: Array<{ id?: string }>;
+          agents?: Array<{
+            id?: string;
+            createdVia?: string;
+            creatorAgentId?: string | null;
+            createdAt?: number;
+          }>;
           defaultId?: string | null;
           mainKey?: string | null;
         };
@@ -1176,6 +1187,13 @@ describe("gateway server chat", () => {
       expect(startup.payload?.agentsList?.defaultId).toBe("main");
       expect(startup.payload?.agentsList?.mainKey).toBe("main");
       expect(startup.payload?.agentsList?.agents?.map((agent) => agent.id)).toContain("main");
+      expect(
+        startup.payload?.agentsList?.agents?.find((agent) => agent.id === "research"),
+      ).toMatchObject({
+        createdVia: "agent",
+        creatorAgentId: "main",
+        createdAt: 42,
+      });
       expect(startup.payload?.sessionInfo).toMatchObject({
         key: "agent:main:main",
         sessionId: "sess-main",

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -30,6 +30,7 @@ import { canonicalSessionKeyMigrationRequiredError } from "../config/sessions/se
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { isAcpSessionKey } from "../sessions/session-key-utils.js";
+import { listAgentProvenance } from "../state/agent-provenance.js";
 import { listGatewayAgentsBasic } from "./agent-list.js";
 import type { GatewayAgentOwnership } from "./agent-list.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
@@ -337,6 +338,9 @@ export function listAgentsForGateway(
   const roster = options?.includeSystem
     ? basic.agents
     : basic.agents.filter((entry) => entry.kind !== "system");
+  const provenanceById = new Map(
+    listAgentProvenance().map((record) => [record.agentId, record] as const),
+  );
   const agents = roster.map((entry) => {
     const { id } = entry;
     const meta = configuredById.get(id);
@@ -366,7 +370,7 @@ export function listAgentsForGateway(
     // Must mirror the sessions.create worktree preflight: subdirectory workspaces inside a
     // repo are worktree-capable, so the UI toggle and the create path cannot diverge.
     const workspaceGit = insideGitCheckout(workspace);
-    return Object.assign(
+    const agent = Object.assign(
       {
         id,
         ...(options?.includeSystem ? { kind: entry.kind } : {}),
@@ -382,6 +386,14 @@ export function listAgentsForGateway(
       },
       { model },
     );
+    const provenance = provenanceById.get(id);
+    return provenance
+      ? Object.assign(agent, {
+          createdVia: provenance.createdVia,
+          creatorAgentId: provenance.creatorAgentId,
+          createdAt: provenance.createdAtMs,
+        })
+      : agent;
   });
   return {
     defaultId: basic.defaultId,


### PR DESCRIPTION
Related: #124967
Related: #124828

## What Problem This Solves

Fixes an issue where users opening the Control UI agent switcher would never see agent creation hierarchy, even when durable creation provenance existed. The feature shipped in #124967 joined provenance only in the `agents.list` reader, while the Control UI adopts its roster from the chat startup projection. The startup WebSocket roster therefore omitted the fields entirely, and every agent option rendered with `description: null`.

This was a doctrine-class silent failure: the creation action recorded the fact, but the primary user-visible path produced no visible outcome because two producers of one roster fact family drifted.

## Why This Change Was Made

The provenance join now lives in the shared roster owner, `listAgentsForGateway`, and the duplicate join in `agents.list` is deleted. All four consumers—`agents.list`, chat startup metadata, the chat history/startup fallback, and the embedded TUI—now share one canonical projection. Production LOC is net -5.

Named follow-up: provenance-only mutations currently emit no metadata invalidation event and are absent from generation facts. Normal create/delete flows do refresh because their config mutation republishes prepared model runtime state and invalidates the chat-metadata generation. If an independent provenance mutation path is added later, it should publish an explicit mutation signal instead of polling the hot path.

## User Impact

The Control UI agent switcher now shows “Created by main” beneath an agent created by `main`; the root agent remains unannotated. Creation hierarchy is consistent across every roster consumer instead of appearing only through the direct `agents.list` RPC.

## Evidence

Live before proof against a running gateway with real SQLite rows:

- The `agent_provenance` row `research | agent | main` was present.
- `openclaw gateway call agents.list` returned the provenance fields correctly.
- The WebSocket frame populating the Control UI roster contained no provenance fields.
- The live `<openclaw-agent-select>` component reported `description: null` for every option, so the hierarchy subline was absent entirely.

Live after proof against the same gateway and same state directory:

- The component reports `description: "Created by main"` for `research` and `null` for the root agent `main`.
- The rendered switcher shows the “Created by main” subline.

![Control UI switcher showing Created by main](https://github.com/user-attachments/assets/fae7205d-e1b5-46b2-b655-7dbef80e498a)

Regression proof:

- Extended the existing real-WebSocket `chat.startup` test in `src/gateway/server.chat.gateway-server-chat-b.test.ts`.
- Proven red before the production change: expected `createdVia: 'agent'`, `creatorAgentId: 'main'`, and `createdAt: 42`; received a roster row without those fields.
- Green after the fix.

Implementing-run gates:

- Focused tests: 117 passed across two files.
- Sibling proof: `session-utils.test.ts` 161 passed; `embedded-backend.test.ts` 94 passed.
- `pnpm tsgo`, `pnpm check:test-types`, oxlint on changed files, `pnpm format:check`, and `pnpm build` passed.
- Autoreview clean: “patch is correct” (0.99).

Exact rebased-head gates:

- `pnpm install` completed after dependency metadata changed on `main`.
- `pnpm build` passed, including the Gateway distribution and Control UI production build.
- Fresh branch autoreview clean: “patch is correct” (0.96), with no accepted/actionable findings.
