### PR TITLE
fix(ui): show menus for child sessions in the sidebar

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -205,14 +205,12 @@ export function renderRecentSession(params: {
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
-  const openMenuFromEvent = session.isChild
-    ? undefined
-    : (event: MouseEvent | KeyboardEvent) =>
-        handleContextMenuEvent(
-          event,
-          (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
-          (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
-        );
+  const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
+    handleContextMenuEvent(
+      event,
+      (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
+      (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
+    );
   const title = [
     display?.title ?? [label, narration, rowMeta].filter(Boolean).join(" · "),
     trailingDescription,
@@ -274,8 +272,8 @@ export function renderRecentSession(params: {
         : () => {
             host.finishSessionDrag();
           }}
-      @contextmenu=${openMenuFromEvent ?? nothing}
-      @keydown=${openMenuFromEvent ?? nothing}
+      @contextmenu=${openMenuFromEvent}
+      @keydown=${openMenuFromEvent}
       @mouseenter=${(event: MouseEvent) => startHoverMarquee(event.currentTarget as HTMLElement)}
       @mouseleave=${(event: MouseEvent) => stopHoverMarquee(event.currentTarget as HTMLElement)}
     >
@@ -394,11 +392,11 @@ export function renderRecentSession(params: {
                 >`}
           </button>`
         : nothing}
-      ${session.isChild
-        ? nothing
-        : html`<span class="sidebar-recent-session__aside session-row-aside">
-            <span class="session-row-actions">
-              <button
+      <span class="sidebar-recent-session__aside session-row-aside">
+        <span class="session-row-actions">
+          ${session.isChild
+            ? nothing
+            : html`<button
                 class="session-action session-action--pin"
                 data-sidebar-session-pin="true"
                 type="button"
@@ -408,25 +406,25 @@ export function renderRecentSession(params: {
                 @click=${() => host.toggleSessionPin(session)}
               >
                 ${icons.pin}
-              </button>
-              <button
-                class="session-action"
-                data-session-menu="true"
-                type="button"
-                title=${menuLabel}
-                aria-label=${menuLabel}
-                aria-haspopup="menu"
-                aria-expanded=${String(host.sidebarMenus.sessionMenu?.session.key === session.key)}
-                @click=${(event: MouseEvent) => {
-                  event.stopPropagation();
-                  const trigger = event.currentTarget as HTMLElement;
-                  host.toggleSessionMenu(session, trigger);
-                }}
-              >
-                ${icons.moreHorizontal}
-              </button>
-            </span>
-          </span>`}
+              </button>`}
+          <button
+            class="session-action"
+            data-session-menu="true"
+            type="button"
+            title=${menuLabel}
+            aria-label=${menuLabel}
+            aria-haspopup="menu"
+            aria-expanded=${String(host.sidebarMenus.sessionMenu?.session.key === session.key)}
+            @click=${(event: MouseEvent) => {
+              event.stopPropagation();
+              const trigger = event.currentTarget as HTMLElement;
+              host.toggleSessionMenu(session, trigger);
+            }}
+          >
+            ${icons.moreHorizontal}
+          </button>
+        </span>
+      </span>
     </div>
   `;
   // Marquee state mutates the row DOM; keying prevents cross-session reuse.

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -7,6 +7,7 @@ import type { SessionMenuAction, SessionMenuActionKind, SessionMenuWork } from "
 
 type SessionMenuData = {
   label: string;
+  isChild: boolean;
   pinned: boolean;
   unread: boolean;
   archived: boolean;
@@ -53,6 +54,7 @@ async function mountMenu(
   document.body.append(container);
   const session: SessionMenuData = {
     label: "Test session",
+    isChild: false,
     pinned: false,
     unread: false,
     archived: false,
@@ -163,6 +165,22 @@ describe("session menu", () => {
       "Fork",
       "Add to Workboard",
       "Move to group",
+      "Archive session",
+      "Delete…",
+    ]);
+  });
+
+  it("omits root placement actions for child sessions", async () => {
+    const menu = await mountMenu({
+      session: { isChild: true },
+      workboard: null,
+    });
+
+    expect(menuItemLabels(menu)).toEqual([
+      "Mark as unread",
+      "Rename…",
+      "Set icon",
+      "Fork",
       "Archive session",
       "Delete…",
     ]);

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -15,6 +15,7 @@ import { syncDropdownItemRadio } from "./web-awesome.ts";
 
 type SessionMenuData = {
   label: string;
+  isChild?: boolean;
   pinned: boolean;
   unread: boolean;
   archived: boolean;
@@ -53,6 +54,7 @@ export type SessionMenuActionKind = SessionMenuAction["kind"];
 
 const EMPTY_SESSION: SessionMenuData = {
   label: "",
+  isChild: false,
   pinned: false,
   unread: false,
   archived: false,
@@ -422,6 +424,8 @@ class SessionMenu extends OpenClawLightDomElement {
     const clampedY = Math.max(8, Math.min(this.anchor.y, window.innerHeight - menuMaxHeight - 8));
     const session = this.session;
     const batch = this.selectionCount > 1;
+    // Pinning and grouping place root rows; child placement is owned by lineage.
+    const rootPlacementActions = session.isChild !== true;
     const count = String(this.selectionCount);
     const menuLabel = batch
       ? t("chat.sidebar.sessionMenuMany", { count })
@@ -451,7 +455,7 @@ class SessionMenu extends OpenClawLightDomElement {
             </div>`
           : nothing}
         ${batch ? nothing : this.renderWorkItems()}
-        ${batch
+        ${batch || !rootPlacementActions
           ? nothing
           : html`
               <wa-dropdown-item
@@ -562,19 +566,21 @@ class SessionMenu extends OpenClawLightDomElement {
               </wa-dropdown-item>
             `
           : nothing}
-        <wa-dropdown-item
-          class="session-menu__item"
-          ?disabled=${this.actionDisabled("move-to-group")}
-          title=${this.actionTitle("move-to-group")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
-          <span class="session-menu__text"
-            >${batch
-              ? t("sessionsView.moveToGroupMenuCount", { count })
-              : t("sessionsView.moveToGroupMenu")}</span
-          >
-          ${this.renderGroupSubmenu()}
-        </wa-dropdown-item>
+        ${rootPlacementActions
+          ? html`<wa-dropdown-item
+              class="session-menu__item"
+              ?disabled=${this.actionDisabled("move-to-group")}
+              title=${this.actionTitle("move-to-group")}
+            >
+              <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
+              <span class="session-menu__text"
+                >${batch
+                  ? t("sessionsView.moveToGroupMenuCount", { count })
+                  : t("sessionsView.moveToGroupMenu")}</span
+              >
+              ${this.renderGroupSubmenu()}
+            </wa-dropdown-item>`
+          : nothing}
         <div class="session-menu__separator" role="separator"></div>
         ${!batch && this.cloudWorkerStopAllowed
           ? html`

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -177,6 +177,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
       <openclaw-session-menu
         .session=${{
           label: session.label,
+          isChild: session.isChild,
           pinned: session.pinned,
           unread: batchRows ? allUnread : session.unread,
           archived: allArchived,

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -76,7 +76,7 @@ suite.define(() => {
     }
   });
 
-  it("expands child sessions inline and opens a child chat", async () => {
+  it("expands and manages child sessions inline before opening a child chat", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const parentKey = "agent:main:release-plan";
     const childOneKey = "agent:main:research-sources";
@@ -168,7 +168,7 @@ suite.define(() => {
 
       const childRows = page.locator(".sidebar-recent-session--child");
       await expect.poll(() => childRows.count()).toBe(4);
-      expect(await childRows.getByRole("button", { name: "Open session menu" }).count()).toBe(0);
+      expect(await childRows.getByRole("button", { name: "Open session menu" }).count()).toBe(4);
       await childRows.nth(0).getByRole("img", { name: "Active run" }).waitFor();
       await childRows.nth(1).getByRole("img", { name: "Done" }).waitFor();
 
@@ -189,6 +189,23 @@ suite.define(() => {
       }
       await captureUiProof(page, "child-sessions-expanded.png");
       await captureUiProof(page, "child-sessions-run-state-precedence.png");
+
+      const completedChild = childRows.nth(1);
+      const childMenuButton = completedChild.getByRole("button", {
+        name: "Open session menu: Verify tests",
+        exact: true,
+      });
+      await completedChild.hover();
+      await expect.poll(() => actionOpacity(childMenuButton)).toBe("1");
+      await expect.poll(() => actionPointerEvents(childMenuButton)).toBe("auto");
+      await childMenuButton.click();
+      const childMenu = page.getByRole("menu", { name: "Actions for Verify tests" });
+      await childMenu.waitFor({ state: "visible" });
+      await page.getByRole("menuitem", { name: "Archive session" }).waitFor();
+      await page.getByRole("menuitem", { name: "Delete…" }).waitFor();
+      await captureUiProof(page, "child-session-menu.png");
+      await page.keyboard.press("Escape");
+      await childMenu.waitFor({ state: "detached" });
 
       await childRows.nth(1).getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(childTwoKey));

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -201,8 +201,14 @@ suite.define(() => {
       await childMenuButton.click();
       const childMenu = page.getByRole("menu", { name: "Actions for Verify tests" });
       await childMenu.waitFor({ state: "visible" });
+      await page.getByRole("menuitem", { name: "Mark as unread" }).waitFor();
+      await page.getByRole("menuitem", { name: "Rename…" }).waitFor();
+      await page.getByRole("menuitem", { name: "Set icon" }).waitFor();
+      await page.getByRole("menuitem", { name: "Fork" }).waitFor();
       await page.getByRole("menuitem", { name: "Archive session" }).waitFor();
       await page.getByRole("menuitem", { name: "Delete…" }).waitFor();
+      expect(await page.getByRole("menuitem", { name: "Pin session" }).count()).toBe(0);
+      expect(await page.getByRole("menuitem", { name: "Move to group" }).count()).toBe(0);
       await captureUiProof(page, "child-session-menu.png");
       await page.keyboard.press("Escape");
       await childMenu.waitFor({ state: "detached" });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2333,6 +2333,15 @@ body.update-dialog-open .sidebar-update-card__status {
   pointer-events: none;
 }
 
+.sidebar-recent-session--child > .sidebar-recent-session__aside {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  flex: 0 0 24px;
+  padding-right: 0;
+  pointer-events: none;
+}
+
 /* Rows with a child toggle keep it as the rightmost in-flow control; the
    overlaid actions land just left of it, at the link's right edge — the
    same link-relative geometry as toggle-less rows, so one mask fits both. */

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -12,7 +12,7 @@ import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar agent chip", () => {
-  it("loads and expands child sessions inline without root session controls", async () => {
+  it("loads and expands child sessions with menus but without root placement controls", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:parent"]);
     harness.list.mockResolvedValue({
@@ -98,7 +98,10 @@ describe("AppSidebar agent chip", () => {
       expect.stringContaining("Check tests"),
     ]);
     expect(childRows.every((row) => row.getAttribute("draggable") === "false")).toBe(true);
-    expect(childRows.every((row) => row.querySelector(".session-row-actions") === null)).toBe(true);
+    expect(childRows.every((row) => row.querySelector("[data-session-menu]") !== null)).toBe(true);
+    expect(childRows.every((row) => row.querySelector("[data-sidebar-session-pin]") === null)).toBe(
+      true,
+    );
     expect(childRows.every((row) => row.querySelector(".session-row-state") === null)).toBe(true);
     expect(childRows.every((row) => row.querySelector(".sidebar-session-indicator") !== null)).toBe(
       true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users managing spawned/child sessions from the Control UI sidebar had no row menu or context-menu access. Operators had to open the child chat first and then use its header menu to rename, archive, delete, or otherwise manage the session.

Reported by @vyctorbrzezowski.

## Why This Change Was Made

Child rows now use the existing session-menu owner and access checks for mouse, keyboard context-menu, and right-click entry points. The menu also respects the child-session contract: Pin and Move to group are omitted because root sidebar placement is controlled by lineage for child sessions, while session-level actions remain available.

## User Impact

Operators can manage subagent and other child sessions directly where they appear in the sidebar. The coherent child menu offers Mark as unread, Rename, Set icon, Fork, Archive, and Delete, plus applicable worktree or cloud-worker actions. It does not offer root-only Pin or grouping controls.

## Evidence

### Before

Expanded child rows had status/runtime information but no menu affordance.

![Before: child session rows without a sidebar menu](https://github.com/user-attachments/assets/0f71a783-ef19-44b1-bc85-02e20f524f44)

### After

The completed `Verify tests` child exposes the child-specific session menu directly from the sidebar. Pin and Move to group are absent because lineage owns child placement.

![After: coherent child session sidebar menu](https://github.com/user-attachments/assets/df68fcaf-734d-46f0-aa41-fe989d73f94c)

### Validation

- `session-management.sidebar.e2e.test.ts`: 11/11 passed with a fresh dark-theme screenshot capture.
- `session-menu.test.ts`: 39/39 passed, including an exact child action-set regression.
- `app-sidebar.test.ts` + `session-menu.test.ts`: 302/302 passed at the final head.
- Dead-export scans and core test typecheck passed on the prepared host after 4 GB remote gate workers were resource-terminated without source diagnostics.
- Exact-head GitHub CI run 32062453469 passed.
- Final whole-branch autoreview: clean; no accepted/actionable findings.

Production LOC: +62/-48 (net +14) | Tests and test support: +48/-4.
