### PR TITLE
fix(ci): prevent node-worker process test flake

### DIFF
--- a/src/node-host/node-worker-supervisor.recovery.test.ts
+++ b/src/node-host/node-worker-supervisor.recovery.test.ts
@@ -266,7 +266,7 @@ describe("node worker supervisor recovery", () => {
       spawned.add(workerProcess);
       const worker = requireNodeWorkerProcessIdentity(workerProcess.pid!);
       ownedProcessGroups.push(worker);
-      await vi.waitFor(() => expect(fs.existsSync(marker)).toBe(true));
+      await vi.waitFor(() => expect(fs.readFileSync(marker, "utf8")).toMatch(/^[1-9]\d*$/u));
       const grandchild = requireNodeWorkerProcessIdentity(Number(fs.readFileSync(marker, "utf8")));
       const input = testWorkerLaunchInput(workspaceDir, "stale-running-launch", "wait");
       const supervisor = createNodeWorkerSupervisor({ bundleRoot, env });
@@ -348,7 +348,9 @@ describe("node worker supervisor recovery", () => {
       const owned = JSON.parse(await waitForChildLine(owner)) as NodeWorkerLaunchReceipt;
       ownedProcessGroups.push(owned.worker!);
       const grandchildPath = path.join(workspaceDir, "grandchild.pid");
-      await vi.waitFor(() => expect(fs.existsSync(grandchildPath)).toBe(true));
+      await vi.waitFor(() =>
+        expect(fs.readFileSync(grandchildPath, "utf8")).toMatch(/^[1-9]\d*$/u),
+      );
       const grandchild = requireNodeWorkerProcessIdentity(
         Number(fs.readFileSync(grandchildPath, "utf8")),
       );

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -665,7 +665,7 @@ describe("node worker supervisor", () => {
     const running = await supervisor.launch(input, TEST_WORKER_ENDPOINT);
     expect(running.state).toBe("running");
     const grandchildPath = path.join(workspaceDir, "grandchild.pid");
-    await vi.waitFor(() => expect(fs.existsSync(grandchildPath)).toBe(true));
+    await vi.waitFor(() => expect(fs.readFileSync(grandchildPath, "utf8")).toMatch(/^[1-9]\d*$/u));
     const grandchildPid = Number(fs.readFileSync(grandchildPath, "utf8"));
     const grandchild = requireNodeWorkerProcessIdentity(grandchildPid);
     expect(inspectNodeWorkerProcessIdentity(grandchild)).toBe("live");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node-worker process-tree tests could fail in CI when they observed a child-written PID marker after creation but before the writer had populated the PID. The empty read became PID 0, producing `cannot establish PID-reuse-safe identity for process 0` even though the process lifecycle behavior was correct.

## Why This Change Was Made

The supervisor and recovery tests now treat PID markers as ready only after they contain a positive decimal PID. This preserves the real process-tree assertions while waiting for the complete cross-process file contract instead of file existence alone.

## User Impact

No runtime behavior changes. Contributors and maintainers should no longer see these false-negative node-worker CI failures.

## Evidence

- Failure: [`checks-node-compact-large-4`](https://github.com/openclaw/openclaw/actions/runs/31989842668/job/95271387006) read the marker as PID 0 on #124934.
- Focused: `node scripts/run-vitest.mjs src/node-host/node-worker-supervisor.test.ts src/node-host/node-worker-supervisor.recovery.test.ts` — 36/36 passed.
- Changed-file gate: `node scripts/check-changed.mjs -- src/node-host/node-worker-supervisor.test.ts src/node-host/node-worker-supervisor.recovery.test.ts` — passed, including core test typecheck and oxlint.
- `git diff --check` — passed.
- TruffleHog pre-review scan — clean. The isolated Codex autoreview itself was unavailable because the configured credential returned HTTP 401; no clean autoreview claim is made.

Production LOC: +0/-0 | Tests: +5/-3
