### PR TITLE
fix(ui): refresh managed sessions on terminal events

### DIFF
--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -187,6 +187,88 @@ describe("event-driven session list refresh", () => {
     }
   });
 
+  it("refreshes a Sessions-style managed query after a terminal session message", async () => {
+    vi.useFakeTimers();
+    const key = "agent:main:main";
+    const calls = { canonical: 0, main: 0, research: 0 };
+    const request = vi.fn(
+      async (method: string, params?: { agentId?: string; includeUnknown?: boolean }) => {
+        if (method !== "sessions.list") {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        const lane =
+          params?.includeUnknown === true
+            ? "canonical"
+            : params?.agentId === "main"
+              ? "main"
+              : "research";
+        calls[lane] += 1;
+        const done = lane !== "research" && calls[lane] > 1;
+        const rowKey = lane === "research" ? "agent:research:other" : key;
+        return sessionsResult(calls[lane], [
+          {
+            key: rowKey,
+            kind: "direct",
+            updatedAt: calls[lane],
+            hasActiveRun: !done,
+            status: done ? "done" : "running",
+          },
+        ]);
+      },
+    );
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+    const mainQuery = {
+      agentId: "main",
+      limit: 50,
+      includeGlobal: true,
+      includeUnknown: false,
+      includeDerivedTitles: false,
+      includeLastMessage: false,
+      archivedFilter: "active" as const,
+    };
+    const researchQuery = { ...mainQuery, agentId: "research" };
+    const stopMain = sessions.subscribeList(mainQuery, () => undefined);
+    const stopResearch = sessions.subscribeList(researchQuery, () => undefined);
+
+    try {
+      await sessions.refresh({ agentId: "main", force: true });
+      await sessions.refreshList({ ...mainQuery, force: true });
+      await sessions.refreshList({ ...researchQuery, force: true });
+      expect(sessions.listSnapshot(mainQuery).result?.sessions[0]).toMatchObject({
+        hasActiveRun: true,
+        status: "running",
+      });
+      request.mockClear();
+
+      emitEvent({
+        type: "event",
+        event: "session.message",
+        payload: { sessionKey: key, updatedAt: 1, status: "done" },
+      });
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(calls).toEqual({ canonical: 2, main: 2, research: 1 });
+      expect(sessions.state.result?.sessions[0]).toMatchObject({
+        key,
+        hasActiveRun: false,
+        status: "done",
+      });
+      expect(sessions.listSnapshot(mainQuery).result?.sessions[0]).toMatchObject({
+        key,
+        hasActiveRun: false,
+        status: "done",
+      });
+    } finally {
+      stopMain();
+      stopResearch();
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("retains every loaded page when a session event replaces the canonical list", async () => {
     vi.useFakeTimers();
     const rows = Array.from({ length: 120 }, (_, index) => ({

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -463,13 +463,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         publish({ ...state, deletedSessions: remainingDeletedSessions });
       }
     }
-    // Gateway lists own filtering/order; events coalesce into one canonical refresh.
+    // Gateway lists own filtering/order; authoritative events invalidate every matching roster.
     roster.scheduleEvent({
       agentId:
         eventInfo?.agentId ??
         parseAgentSessionKey(eventInfo?.key)?.agentId ??
         (typeof payloadAgentId === "string" ? payloadAgentId : undefined),
-      filtered: event.event === "sessions.changed",
     });
   });
 

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -538,11 +538,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refresh({ ...options, force: true });
     },
     lastOptions: () => lastListOptions,
-    scheduleEvent(options: { agentId?: string | null; filtered?: boolean } = {}) {
+    scheduleEvent(options: { agentId?: string | null } = {}) {
       eventRefreshCoordinator.schedule();
-      if (options.filtered === false) {
-        return;
-      }
       const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;
       for (const entry of managedLists.values()) {
         const queryAgentId = managedSessionListAgentId(entry);


### PR DESCRIPTION
Fixes follow-up from #125018

## What Problem This Solves

Fixes an issue where users viewing Sessions could continue to see a run as active after it had finished when the Gateway delivered a terminal `session.message` without a later `sessions.changed` event.

## Why This Change Was Made

Terminal session messages already pass the authoritative event gate and refresh the canonical roster. This change removes the obsolete event-type switch that stopped there, so the same event also invalidates matching managed session-list queries while preserving agent scoping and the early return for non-terminal messages. It does not restore page-local loading or canonical-revision reloads.

## User Impact

The Sessions page now adopts terminal status and server ordering promptly after a run finishes. There is no visual styling delta; this is a terminal-state freshness correction.

AI-assisted: yes.

## Evidence

- Pre-fix regression: the focused owner test failed because the canonical row changed to `done` while the Sessions-style managed snapshot remained `running`.
- Post-fix owner/sibling proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts ui/src/lib/sessions/index-list.test.ts ui/src/lib/sessions/index.event-refresh.test.ts ui/src/pages/sessions/sessions-page.roster.test.ts` — 62/62 passed.
- Mocked browser proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-list-filter.e2e.test.ts` — 4/4 passed.
- The new regression proves one canonical refresh, exactly one matching managed-list refresh, active-to-done snapshot replacement, and no refresh for another known agent's scoped query.
- Targeted oxfmt, targeted oxlint, and `git diff --check` passed.
- Remote changed gate: direct AWS Crabbox run `run_88bf32570a1a` on lease `cbx_782424ed3adb` passed with exit 0 after Blacksmith was unavailable: https://crabbox.openclaw.ai/portal/runs/run_88bf32570a1a
- Fresh uncommitted Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +2/-6 (net -4). Tests: +82/-0.
