### PR TITLE
fix(ci): restore provider provisioning max-lines gate

### DIFF
--- a/src/gateway/worker-environments/provider-provisioning.admission-claims.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.admission-claims.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { admitWorkerConnection } from "./admission.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import * as support from "./service.test-support.js";
+
+describe("worker environment node admission claims", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("commits an installed Gateway bundle receipt and credential for a node lease", async () => {
+    const workerBuild = structuredClone(support.BOOTSTRAP_RECEIPT);
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const placementGate = createWorkerSessionPlacementGate(placements);
+    const workerService = support.createService(
+      support.createProvider({
+        provisionBeforeInstallation: true,
+        provision: async () => ({
+          leaseId: "device-lease-1",
+          node: { deviceId: "device-1" },
+          sharedHost: true,
+        }),
+      }),
+      { ensureNodeWorkerBundle: async () => workerBuild, placementStore: placementGate },
+    );
+
+    const result = await workerService.create("development", "request-device");
+
+    expect(result).toMatchObject({
+      state: "ready",
+      leaseId: "device-lease-1",
+      sshEndpoint: null,
+      bootstrapReceipt: { ...workerBuild, installKind: "bundle" },
+      sharedHost: true,
+      ownerEpoch: 1,
+    });
+    expect(support.testState.prepareInstallation).not.toHaveBeenCalled();
+    expect(support.testState.bootstrapWorker).not.toHaveBeenCalled();
+    const credential = workerService.takeMintedCredential({
+      environmentId: result.environmentId,
+      ownerEpoch: result.ownerEpoch,
+      sessionId: null,
+    });
+    expect(credential).toMatchObject({
+      credential: support.CREDENTIAL,
+      bundleHash: support.BUNDLE_HASH,
+    });
+    await workerService.attachSession({
+      environmentId: result.environmentId,
+      ownerEpoch: result.ownerEpoch,
+      sessionId: REQUEST.sessionId,
+    });
+    const attached = support.testState.store.get(result.environmentId)!;
+    seedActivePlacement(placements, {
+      environmentId: result.environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    const turnClaim = placements.claimTurn({
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+      claimId: "claim-device",
+      runId: "run-device",
+      owner: {
+        kind: "worker",
+        environmentId: result.environmentId,
+        ownerEpoch: attached.ownerEpoch,
+      },
+    });
+    const turnCredential = await workerService.acquireTurnCredential(turnClaim);
+    const admission = {
+      environmentId: result.environmentId,
+      credential: turnCredential.credential,
+      ownerEpoch: attached.ownerEpoch,
+      rpcSetVersion: 1,
+      sessionId: REQUEST.sessionId,
+      runId: turnClaim.runId,
+      handshake: workerBuild,
+    } as const;
+    expect(
+      admitWorkerConnection({
+        store: support.testState.store,
+        admission,
+        expectedBuild: workerBuild,
+        nowMs: support.testState.nowMs,
+        turnClaim,
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      admitWorkerConnection({
+        store: support.testState.store,
+        admission: {
+          ...admission,
+          handshake: { ...workerBuild, bundleHash: "d".repeat(64) },
+        },
+        expectedBuild: workerBuild,
+        nowMs: support.testState.nowMs,
+        turnClaim,
+      }),
+    ).toEqual({ ok: false, reason: "bundle-mismatch" });
+  });
+});

--- a/src/gateway/worker-environments/provider-provisioning.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.test.ts
@@ -10,12 +10,9 @@ import {
 import type { GatewaySessionRow } from "../session-utils.types.js";
 import { writeSessionStore } from "../test-helpers.js";
 import { directSessionReq } from "../test/server-sessions.test-helpers.js";
-import { admitWorkerConnection } from "./admission.js";
 import { hashWorkerCredential } from "./credential.js";
-import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
-import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
 import { createWorkerEnvironmentStore } from "./store.js";
 import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -121,101 +118,6 @@ describe("worker environment service", () => {
     const workerService = support.createService(provider);
 
     await expect(workerService.listMachineOptions("development")).resolves.toBeUndefined();
-  });
-
-  it("commits an installed Gateway bundle receipt and credential for a node lease", async () => {
-    const workerBuild = structuredClone(support.BOOTSTRAP_RECEIPT);
-    const placements = createWorkerSessionPlacementStore({
-      database: support.testState.stateDb,
-      now: () => support.testState.nowMs,
-    });
-    const placementGate = createWorkerSessionPlacementGate(placements);
-    const workerService = support.createService(
-      support.createProvider({
-        provisionBeforeInstallation: true,
-        provision: async () => ({
-          leaseId: "device-lease-1",
-          node: { deviceId: "device-1" },
-          sharedHost: true,
-        }),
-      }),
-      { ensureNodeWorkerBundle: async () => workerBuild, placementStore: placementGate },
-    );
-
-    const result = await workerService.create("development", "request-device");
-
-    expect(result).toMatchObject({
-      state: "ready",
-      leaseId: "device-lease-1",
-      sshEndpoint: null,
-      bootstrapReceipt: { ...workerBuild, installKind: "bundle" },
-      sharedHost: true,
-      ownerEpoch: 1,
-    });
-    expect(support.testState.prepareInstallation).not.toHaveBeenCalled();
-    expect(support.testState.bootstrapWorker).not.toHaveBeenCalled();
-    const credential = workerService.takeMintedCredential({
-      environmentId: result.environmentId,
-      ownerEpoch: result.ownerEpoch,
-      sessionId: null,
-    });
-    expect(credential).toMatchObject({
-      credential: support.CREDENTIAL,
-      bundleHash: support.BUNDLE_HASH,
-    });
-    await workerService.attachSession({
-      environmentId: result.environmentId,
-      ownerEpoch: result.ownerEpoch,
-      sessionId: REQUEST.sessionId,
-    });
-    const attached = support.testState.store.get(result.environmentId)!;
-    seedActivePlacement(placements, {
-      environmentId: result.environmentId,
-      ownerEpoch: attached.ownerEpoch,
-    });
-    const turnClaim = placements.claimTurn({
-      sessionId: REQUEST.sessionId,
-      sessionKey: REQUEST.sessionKey,
-      agentId: REQUEST.agentId,
-      claimId: "claim-device",
-      runId: "run-device",
-      owner: {
-        kind: "worker",
-        environmentId: result.environmentId,
-        ownerEpoch: attached.ownerEpoch,
-      },
-    });
-    const turnCredential = await workerService.acquireTurnCredential(turnClaim);
-    const admission = {
-      environmentId: result.environmentId,
-      credential: turnCredential.credential,
-      ownerEpoch: attached.ownerEpoch,
-      rpcSetVersion: 1,
-      sessionId: REQUEST.sessionId,
-      runId: turnClaim.runId,
-      handshake: workerBuild,
-    } as const;
-    expect(
-      admitWorkerConnection({
-        store: support.testState.store,
-        admission,
-        expectedBuild: workerBuild,
-        nowMs: support.testState.nowMs,
-        turnClaim,
-      }),
-    ).toMatchObject({ ok: true });
-    expect(
-      admitWorkerConnection({
-        store: support.testState.store,
-        admission: {
-          ...admission,
-          handshake: { ...workerBuild, bundleHash: "d".repeat(64) },
-        },
-        expectedBuild: workerBuild,
-        nowMs: support.testState.nowMs,
-        turnClaim,
-      }),
-    ).toEqual({ ok: false, reason: "bundle-mismatch" });
   });
 
   it("fails node provisioning visibly when Gateway bundle installation fails", async () => {


### PR DESCRIPTION
## What Problem This Solves

Main CI has been red since direct commit `4d648892909` grew `provider-provisioning.test.ts` beyond the oxlint max-lines budget. The failure also blocks every open pull request's merge-ref checks.

## Why This Change Was Made

Moves the node-admission/worker-claim provisioning test into a concept-named sibling test file in the same Gateway lane. This is a mechanical suite split: no assertions, test behavior, production code, lint baseline, or suppression changed.

## User Impact

No product behavior changes. This heals the max-lines gate on `main` and restores merge-ref validation for open pull requests.

## Evidence

Before the split:

```text
provider-provisioning.test.ts:1091:4: error eslint(max-lines): File has too many lines (1017). Maximum allowed is 1000.
[oxlint] FAILED (exit 1)
```

After the split on `90685c87b4b8bef09be523041aa0a7ebe36d3958`:

```text
$ node scripts/run-oxlint.mjs src/gateway/worker-environments/
exit 0

$ pnpm test src/gateway/worker-environments/provider-provisioning
Test Files  2 passed (2)
Tests       45 passed (45)
[test] passed 1 Vitest shard
```

Structured autoreview: clean, no accepted/actionable findings.
