### PR TITLE
fix(plugins): failed plugins retain diagnostics without activating capabilities

### DIFF
--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -489,17 +489,6 @@ export function loadRuntimePluginCandidate(params: {
       record.memorySlotSelected = true;
     }
   }
-  if (registrationPlan.runFullActivationOnlyRegistrations) {
-    if (definition?.reload) {
-      params.registryBuilder.registerReload(record, definition.reload);
-    }
-    for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
-      params.registryBuilder.registerNodeHostCommand(record, nodeHostCommand);
-    }
-    for (const collector of definition?.securityAuditCollectors ?? []) {
-      params.registryBuilder.registerSecurityAuditCollector(record, collector);
-    }
-  }
   if (params.validateOnly) {
     registry.plugins.push(record);
     state.seenIds.set(pluginId, candidate.origin);
@@ -517,6 +506,17 @@ export function loadRuntimePluginCandidate(params: {
       pushPluginLoadError(formatMissingPluginRegisterError(mod, context.env));
     }
     return;
+  }
+  if (registrationPlan.runFullActivationOnlyRegistrations) {
+    if (definition?.reload) {
+      params.registryBuilder.registerReload(record, definition.reload);
+    }
+    for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
+      params.registryBuilder.registerNodeHostCommand(record, nodeHostCommand);
+    }
+    for (const collector of definition?.securityAuditCollectors ?? []) {
+      params.registryBuilder.registerSecurityAuditCollector(record, collector);
+    }
   }
   const api = params.registryBuilder.createApi(record, {
     config: context.cfg,

--- a/src/plugins/loader.activation.test-utils.ts
+++ b/src/plugins/loader.activation.test-utils.ts
@@ -420,12 +420,24 @@ describe("loadOpenClawPlugins", () => {
     });
   });
 
-  it("can include plugin export shape when register is missing", () => {
+  it("reports plugin export shape without registering activation metadata when register is missing", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "missing-register-shape",
       filename: "missing-register-shape.cjs",
-      body: `module.exports = { default: { default: { id: "missing-register-shape" } } };`,
+      body: `module.exports = {
+        default: {
+          default: {
+            id: "missing-register-shape",
+            reload: { restartPrefixes: ["plugins.entries.missing-register-shape"] },
+            nodeHostCommands: [{
+              command: "missing-register-shape.command",
+              handle: async () => "ok",
+            }],
+            securityAuditCollectors: [async () => []],
+          },
+        },
+      };`,
     });
 
     const registry = withEnv({ OPENCLAW_PLUGIN_LOAD_DEBUG: "1" }, () =>
@@ -443,6 +455,15 @@ describe("loadOpenClawPlugins", () => {
     expect(loaded?.error).toContain("module shape:");
     expect(loaded?.error).toContain("export:object keys=default");
     expect(loaded?.error).toContain("export.default:object keys=default");
+    expect({
+      reloads: registry.reloads.map((entry) => entry.pluginId),
+      nodeHostCommands: registry.nodeHostCommands.map((entry) => entry.pluginId),
+      securityAuditCollectors: registry.securityAuditCollectors.map((entry) => entry.pluginId),
+    }).toStrictEqual({
+      reloads: [],
+      nodeHostCommands: [],
+      securityAuditCollectors: [],
+    });
   });
 
   it.each([

--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -290,7 +290,7 @@ describe("loadOpenClawPlugins", () => {
     clearInternalHooks();
   });
 
-  it("rolls back global side effects when registration fails", async () => {
+  it("preserves load diagnostics while rolling back global side effects when registration fails", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "failing-side-effects",
@@ -365,6 +365,14 @@ describe("loadOpenClawPlugins", () => {
     const failedRecord = registry.plugins.find((entry) => entry.id === "failing-side-effects");
     expect(failedRecord?.status).toBe("error");
     expect(failedRecord?.providerIds).toStrictEqual([]);
+    expect(
+      registry.diagnostics
+        .filter((diagnostic) => diagnostic.pluginId === "failing-side-effects")
+        .map(({ level, message }) => ({ level, message })),
+    ).toEqual([
+      { level: "warn", message: "reload registration missing prefixes" },
+      { level: "error", message: "plugin failed during register: Error: boom" },
+    ]);
     expect(getRegisteredEventKeys()).toStrictEqual([]);
     expect(getPluginCommandSpecs()).toStrictEqual([]);
     expect(registry.reloads).toStrictEqual([]);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -57,7 +57,11 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     const gatewayMethods = state.registry.gatewayMethodDescriptors
       .filter((entry) => entry.owner.kind === "plugin" && entry.owner.pluginId === pluginId)
       .map((entry) => entry.name);
-    for (const value of Object.values(state.registry)) {
+    for (const [key, value] of Object.entries(state.registry)) {
+      // Plugin records and diagnostics are operator-visible load outcomes, not registrations.
+      if (key === "plugins" || key === "diagnostics") {
+        continue;
+      }
       if (Array.isArray(value)) {
         for (let index = value.length - 1; index >= 0; index -= 1) {
           const entry = value[index] as

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -57,9 +57,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     const gatewayMethods = state.registry.gatewayMethodDescriptors
       .filter((entry) => entry.owner.kind === "plugin" && entry.owner.pluginId === pluginId)
       .map((entry) => entry.name);
-    for (const [key, value] of Object.entries(state.registry)) {
+    for (const [registryKey, value] of Object.entries(state.registry)) {
       // Plugin records and diagnostics are operator-visible load outcomes, not registrations.
-      if (key === "plugins" || key === "diagnostics") {
+      if (registryKey === "plugins" || registryKey === "diagnostics") {
         continue;
       }
       if (Array.isArray(value)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a plugin registration failure could erase diagnostics recorded earlier in the same load, leaving operators with only the terminal error. It also fixes invalid plugin modules without a callable `register`/`activate` export publishing reload rules, node-host commands, and security-audit collectors despite being recorded as failed.

## Why This Change Was Made

Plugin records and diagnostics are load outcomes, not runtime contributions, so rollback now preserves them while continuing to remove plugin-owned registry state. Full-activation metadata is registered only after the loader validates a callable registration entrypoint, keeping invalid modules failure-atomic at the owner boundary rather than filtering stale state in every consumer.

The lightweight manifest metadata scanner's malformed-manifest warning policy is intentionally left to a separate follow-up because it needs distinct semantics for missing, unreadable, malformed, non-object, and cached files.

Provenance: the broad registry rollback sweep came from #117372 (2026-08-01), while the activation ordering was carried forward by #108513 (2026-07-16).

## User Impact

Operators now retain the complete diagnostic chain for failed plugins. Plugins that cannot activate no longer leave node capabilities, reload behavior, or security-audit hooks live in the registry.

## Evidence

- Regression-first proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/plugins/loader.test.ts` failed before the production fix with exactly 2 failures / 180 passes: the earlier reload warning was missing, and all three activation-only registries contained the invalid plugin.
- Focused post-fix proof: the same loader suite passes 182/182 tests.
- Final changed gate: Blacksmith Testbox `tbx_01m06zjanb5417h9v4jjcz6qws`, [Actions run 31994521896](https://github.com/openclaw/openclaw/actions/runs/31994521896), `pnpm check:changed`, passed.
- The first changed-gate attempt caught a `no-shadow` lint error in the rollback loop; the key was renamed and the final gate is green.
- Final branch autoreview: clean, no accepted/actionable findings.
- Production LOC: +16/-12, including an 11-line block move (net +4). Tests: +32/-3 (net +29).
- No external API, channel, protocol, config, or persistence contract changed; the real loader fixture tests exercise the owning boundary directly.

AI-assisted: yes.
