### PR TITLE
fix(plugins): guard malformed node payloadJSON in session catalog unwrap

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -237,6 +237,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/process-runtime` | Private-local after July 2026; bounded process execution with per-stream and aggregate output caps, opt-in stream-error termination, and configurable TERM-to-KILL grace |
     | `plugin-sdk/node-host` | Private-local after July 2026; Node-host executable resolution and PTY resume helpers |
     | `plugin-sdk/node-selection-runtime` | Private-local bundled runtime facade for shared capability-gated node selection policy |
+    | `plugin-sdk/node-payload-runtime` | Paired-node invoke envelope unwrap (`unwrapNodePayloadJSON`): parses `payloadJSON` with a stable semantic error on malformed JSON and falls back to the structured `payload` field; shared by session-catalog family and bundled provider catalogs |
     | `plugin-sdk/cli-argv` | Dependency-light root-option parsing for CLI metadata, including `getRootOptionAwareCommandPath` and `consumeRootOptionToken` |
     | `plugin-sdk/cli-runtime` | Private-local after July 2026; Deprecated broad barrel for CLI formatting, wait, version, argument-invocation, and lazy command-group helpers; prefer focused CLI/runtime subpaths |
     | `plugin-sdk/qa-runner-runtime` | Private-local after July 2026; Supported facade exposing plugin QA scenarios through the CLI command surface |

--- a/extensions/anthropic/session-catalog-parsing.ts
+++ b/extensions/anthropic/session-catalog-parsing.ts
@@ -1,3 +1,4 @@
+import { unwrapNodePayloadJSON } from "openclaw/plugin-sdk/node-payload-runtime";
 import {
   isRecord,
   normalizeBoundedOptionalString as readBoundedString,
@@ -215,17 +216,7 @@ export function parseCatalogPage(value: unknown): ClaudeSessionCatalogPage {
 }
 
 export function unwrapNodePayload(value: unknown): unknown {
-  if (!isRecord(value)) {
-    return value;
-  }
-  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
-    try {
-      return JSON.parse(value.payloadJSON) as unknown;
-    } catch (error) {
-      throw new Error("node returned malformed session catalog JSON", { cause: error });
-    }
-  }
-  return "payload" in value ? value.payload : value;
+  return unwrapNodePayloadJSON(value);
 }
 
 export function parseGatewayQuery(value: unknown): {

--- a/extensions/anthropic/session-catalog-parsing.ts
+++ b/extensions/anthropic/session-catalog-parsing.ts
@@ -215,10 +215,17 @@ export function parseCatalogPage(value: unknown): ClaudeSessionCatalogPage {
 }
 
 export function unwrapNodePayload(value: unknown): unknown {
-  if (isRecord(value) && typeof value.payloadJSON === "string") {
-    return JSON.parse(value.payloadJSON) as unknown;
+  if (!isRecord(value)) {
+    return value;
   }
-  return value;
+  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
+    try {
+      return JSON.parse(value.payloadJSON) as unknown;
+    } catch (error) {
+      throw new Error("node returned malformed session catalog JSON", { cause: error });
+    }
+  }
+  return "payload" in value ? value.payload : value;
 }
 
 export function parseGatewayQuery(value: unknown): {

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -11,6 +11,7 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import type { SessionCatalogProvider as RegisteredSessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { adoptedSourceKey } from "./session-catalog-adoption.js";
+import { unwrapNodePayload } from "./session-catalog-parsing.js";
 import {
   createClaudeSessionNodeInvokePolicies,
   registerClaudeSessionDiscovery,
@@ -2980,6 +2981,52 @@ describe("Claude session catalog", () => {
     expect(hosts).toEqual([
       expect.objectContaining({ hostId: "node:malformed", error: expect.any(Object) }),
     ]);
+  });
+
+  it("rewraps malformed payloadJSON into a stable catalog error", () => {
+    // The Anthropic owner-local unwrapNodePayload must not leak a bare
+    // SyntaxError; it rewraps the parse failure into a semantic error whose
+    // message is the stable "node returned malformed session catalog JSON"
+    // string, with the original SyntaxError preserved as cause.
+    expect(() => unwrapNodePayload({ payloadJSON: "{bad json" })).toThrow(
+      "node returned malformed session catalog JSON",
+    );
+    let caught: unknown;
+    try {
+      unwrapNodePayload({ payloadJSON: "{bad json" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as { cause?: unknown }).cause).toBeInstanceOf(SyntaxError);
+  });
+
+  it("falls back to payload when a paired node returns empty payloadJSON", async () => {
+    const runtime = {
+      nodes: {
+        list: vi.fn().mockResolvedValue({
+          nodes: [
+            {
+              nodeId: "empty-json",
+              displayName: "Empty JSON",
+              connected: true,
+              commands: [CLAUDE_SESSIONS_LIST_COMMAND],
+            },
+          ],
+        }),
+        // An empty payloadJSON must fall back to the structured payload field
+        // instead of throwing "Unexpected end of JSON input".
+        invoke: vi.fn().mockResolvedValue({
+          payloadJSON: "   ",
+          payload: { sessions: [] },
+        }),
+      },
+    } as unknown as PluginRuntime;
+
+    const provider = captureCatalogProvider(runtime);
+    const hosts = await provider.list({ hostIds: ["node:empty-json"] });
+    expect(hosts).toEqual([expect.objectContaining({ hostId: "node:empty-json", sessions: [] })]);
+    expect((hosts[0] as { error?: unknown }).error).toBeUndefined();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/package.json
+++ b/package.json
@@ -1080,6 +1080,9 @@
     "./plugin-sdk/node-host": {
       "default": "./dist/plugin-sdk/node-host.js"
     },
+    "./plugin-sdk/node-payload-runtime": {
+      "default": "./dist/plugin-sdk/node-payload-runtime.js"
+    },
     "./plugin-sdk/computer-use": {
       "types": "./dist/plugin-sdk/computer-use.d.ts",
       "default": "./dist/plugin-sdk/computer-use.js"

--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/markdown-plain-text.mjs",
       "default": "./dist/markdown-plain-text.mjs"
     },
+    "./node-payload": {
+      "types": "./dist/node-payload.d.mts",
+      "import": "./dist/node-payload.mjs",
+      "default": "./dist/node-payload.mjs"
+    },
     "./number-coercion": {
       "types": "./dist/number-coercion.d.mts",
       "import": "./dist/number-coercion.mjs",
@@ -106,7 +111,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-coercion.ts src/json-schema.ts src/markdown-plain-text.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-coercion.ts src/json-schema.ts src/markdown-plain-text.ts src/node-payload.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
     "libphonenumber-js": "1.13.9",

--- a/packages/normalization-core/src/node-payload.ts
+++ b/packages/normalization-core/src/node-payload.ts
@@ -1,0 +1,34 @@
+import { isRecord } from "./record-coerce.js";
+
+/**
+ * Unwraps a paired-node invoke envelope (`{ payloadJSON, payload }`) into the
+ * payload value, with a stable semantic error when the JSON is malformed.
+ *
+ * Mirrors the codex extension's `unwrapNodeInvokePayload`: a non-record input is
+ * returned as-is; a present non-blank `payloadJSON` is parsed with the parse
+ * failure rewrapped into an `Error` whose `cause` keeps the original
+ * `SyntaxError` (so low-level parser internals never leak to the client); an
+ * empty/blank or missing `payloadJSON` falls back to the structured `payload`
+ * field, then to the raw envelope.
+ *
+ * @param value The raw envelope returned by a paired-node invoke.
+ * @param errorMessage Message for the rewrapped error; defaults to the shared
+ *   catalog wording. Callers with a distinct owner (e.g. Codex CLI) may override
+ *   it to name their boundary.
+ */
+export function unwrapNodePayloadJSON(
+  value: unknown,
+  errorMessage = "node returned malformed session catalog JSON",
+): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
+    try {
+      return JSON.parse(value.payloadJSON) as unknown;
+    } catch (error) {
+      throw new Error(errorMessage, { cause: error });
+    }
+  }
+  return "payload" in value ? value.payload : value;
+}

--- a/packages/normalization-core/src/node-payload.ts
+++ b/packages/normalization-core/src/node-payload.ts
@@ -1,21 +1,6 @@
 import { isRecord } from "./record-coerce.js";
 
-/**
- * Unwraps a paired-node invoke envelope (`{ payloadJSON, payload }`) into the
- * payload value, with a stable semantic error when the JSON is malformed.
- *
- * Mirrors the codex extension's `unwrapNodeInvokePayload`: a non-record input is
- * returned as-is; a present non-blank `payloadJSON` is parsed with the parse
- * failure rewrapped into an `Error` whose `cause` keeps the original
- * `SyntaxError` (so low-level parser internals never leak to the client); an
- * empty/blank or missing `payloadJSON` falls back to the structured `payload`
- * field, then to the raw envelope.
- *
- * @param value The raw envelope returned by a paired-node invoke.
- * @param errorMessage Message for the rewrapped error; defaults to the shared
- *   catalog wording. Callers with a distinct owner (e.g. Codex CLI) may override
- *   it to name their boundary.
- */
+/** Unwraps a paired-node invoke envelope (`{ payloadJSON, payload }`), parsing `payloadJSON` with a stable error on malformed JSON, falling back to the structured `payload` field. */
 export function unwrapNodePayloadJSON(
   value: unknown,
   errorMessage = "node returned malformed session catalog JSON",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -211,6 +211,7 @@
   "runtime-fetch",
   "inline-image-data-url-runtime",
   "node-host",
+  "node-payload-runtime",
   "computer-use",
   "response-limit-runtime",
   "session-binding-runtime",

--- a/src/plugin-sdk/node-payload-runtime.ts
+++ b/src/plugin-sdk/node-payload-runtime.ts
@@ -1,0 +1,6 @@
+// Re-exports the shared paired-node payload unwrap helper for plugins.
+// Core (src/plugins/session-catalog-family.ts) imports the normalization-core
+// subpath directly; bundled extensions import through this SDK subpath per the
+// extensions boundary (extensions/AGENTS.md).
+
+export { unwrapNodePayloadJSON } from "@openclaw/normalization-core/node-payload";

--- a/src/plugin-sdk/node-payload-runtime.ts
+++ b/src/plugin-sdk/node-payload-runtime.ts
@@ -1,6 +1,3 @@
-// Re-exports the shared paired-node payload unwrap helper for plugins.
-// Core (src/plugins/session-catalog-family.ts) imports the normalization-core
-// subpath directly; bundled extensions import through this SDK subpath per the
-// extensions boundary (extensions/AGENTS.md).
+// SDK subpath re-export of the shared paired-node payload unwrap helper for bundled extensions.
 
 export { unwrapNodePayloadJSON } from "@openclaw/normalization-core/node-payload";

--- a/src/plugin-sdk/session-catalog.test.ts
+++ b/src/plugin-sdk/session-catalog.test.ts
@@ -177,4 +177,265 @@ describe("session catalog SDK", () => {
     expect(create).toHaveBeenCalledOnce();
     expect(complete).toHaveBeenCalledOnce();
   });
+
+  it("rejects malformed paired-node payloadJSON with a stable error on read", async () => {
+    const invoke = vi.fn().mockResolvedValue({ payloadJSON: "{bad json" });
+    const runtime = {
+      nodes: {
+        list: vi.fn().mockResolvedValue({
+          nodes: [
+            {
+              nodeId: "node-1",
+              displayName: "Remote",
+              connected: true,
+              commands: ["family.list", "family.read", "family.terminal"],
+            },
+          ],
+        }),
+        invoke,
+      },
+    } as unknown as PluginRuntime;
+    const options: SessionCatalogFamilyOptions = {
+      runtime,
+      local: {
+        hostId: "gateway",
+        label: "Local Family",
+        available: () => true,
+        list: async () => ({ sessions: [] }),
+        read: async (request) => ({
+          hostId: request.hostId,
+          threadId: request.threadId,
+          items: [],
+        }),
+        assertAccess: vi.fn(),
+      },
+      node: {
+        listCommand: "family.list",
+        readCommand: "family.read",
+        terminalCommand: "family.terminal",
+        timeoutMs: 1_000,
+        maxHosts: 10,
+        maxPageLimit: 100,
+        sessionIdPattern: /^[a-z0-9-]+$/u,
+      },
+      capabilities: {
+        local: () => ({ canContinue: true, canOpenTerminal: false }),
+        node: () => ({ canContinue: false, canOpenTerminal: true }),
+        project: (value, capabilities) => ({ ...value, ...capabilities }),
+      },
+      messages: {
+        invalidNodeCursor: "bad node cursor",
+        invalidNodeSessionPage: "bad node sessions",
+        invalidNodeTranscriptPage: "bad node transcript",
+        invalidHostId: "bad host",
+        localReadFailed: "local unavailable",
+        nodeInvokeFailed: "node unavailable",
+        nodeReadUnavailable: "node read unavailable",
+        nodeTerminalUnavailable: "node terminal unavailable",
+        sessionUnavailable: "session unavailable",
+      },
+      continuation: {
+        resolveAgentId: () => "main",
+        availability: () => ({ available: true }),
+        listAdopted: () => new Map(),
+        loadSession: async (threadId) => session(threadId),
+        validateSession: vi.fn(),
+        create: vi.fn(),
+        complete: vi.fn(),
+        nodeReadOnlyMessage: "nodes are read-only",
+      },
+      terminal: {
+        executable: "family",
+        args: (threadId) => ["--session", threadId],
+        title: (threadId) => `family ${threadId}`,
+        requireLocalSession: async (threadId) => session(threadId),
+        unavailableMessage: "family unavailable",
+      },
+      checkUpstreamActivity: async () => [],
+    };
+    const provider = createSessionCatalogFamily(options, sessionCatalogPaging.isExactCursor);
+
+    // Malformed payloadJSON must surface as a stable catalog error (Error with
+    // cause SyntaxError), not a bare SyntaxError leaking parser internals.
+    // The bare SyntaxError would propagate through the Gateway catalog error
+    // adapter into the client-facing invalid-request response.
+    await expect(
+      provider.read({ hostId: "node:node-1", threadId: "remote-thread" }),
+    ).rejects.toThrow("node returned malformed session catalog JSON");
+    const invocation = invoke.mock.calls[0]?.[0] as { command: string } | undefined;
+    expect(invocation?.command).toBe("family.read");
+  });
+
+  it("falls back to payload field when paired-node payloadJSON is empty on read", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      payloadJSON: "",
+      payload: { threadId: "remote-thread", items: [] },
+    });
+    const runtime = {
+      nodes: {
+        list: vi.fn().mockResolvedValue({
+          nodes: [
+            {
+              nodeId: "node-1",
+              displayName: "Remote",
+              connected: true,
+              commands: ["family.list", "family.read", "family.terminal"],
+            },
+          ],
+        }),
+        invoke,
+      },
+    } as unknown as PluginRuntime;
+    const options: SessionCatalogFamilyOptions = {
+      runtime,
+      local: {
+        hostId: "gateway",
+        label: "Local Family",
+        available: () => true,
+        list: async () => ({ sessions: [] }),
+        read: async (request) => ({
+          hostId: request.hostId,
+          threadId: request.threadId,
+          items: [],
+        }),
+        assertAccess: vi.fn(),
+      },
+      node: {
+        listCommand: "family.list",
+        readCommand: "family.read",
+        terminalCommand: "family.terminal",
+        timeoutMs: 1_000,
+        maxHosts: 10,
+        maxPageLimit: 100,
+        sessionIdPattern: /^[a-z0-9-]+$/u,
+      },
+      capabilities: {
+        local: () => ({ canContinue: true, canOpenTerminal: false }),
+        node: () => ({ canContinue: false, canOpenTerminal: true }),
+        project: (value, capabilities) => ({ ...value, ...capabilities }),
+      },
+      messages: {
+        invalidNodeCursor: "bad node cursor",
+        invalidNodeSessionPage: "bad node sessions",
+        invalidNodeTranscriptPage: "bad node transcript",
+        invalidHostId: "bad host",
+        localReadFailed: "local unavailable",
+        nodeInvokeFailed: "node unavailable",
+        nodeReadUnavailable: "node read unavailable",
+        nodeTerminalUnavailable: "node terminal unavailable",
+        sessionUnavailable: "session unavailable",
+      },
+      continuation: {
+        resolveAgentId: () => "main",
+        availability: () => ({ available: true }),
+        listAdopted: () => new Map(),
+        loadSession: async (threadId) => session(threadId),
+        validateSession: vi.fn(),
+        create: vi.fn(),
+        complete: vi.fn(),
+        nodeReadOnlyMessage: "nodes are read-only",
+      },
+      terminal: {
+        executable: "family",
+        args: (threadId) => ["--session", threadId],
+        title: (threadId) => `family ${threadId}`,
+        requireLocalSession: async (threadId) => session(threadId),
+        unavailableMessage: "family unavailable",
+      },
+      checkUpstreamActivity: async () => [],
+    };
+    const provider = createSessionCatalogFamily(options, sessionCatalogPaging.isExactCursor);
+
+    // Empty payloadJSON must not throw "Unexpected end of JSON input"; it must
+    // fall back to the sibling payload field so a node that omits payloadJSON
+    // still serves the read.
+    const result = await provider.read({ hostId: "node:node-1", threadId: "remote-thread" });
+    expect(result).toEqual(
+      expect.objectContaining({ hostId: "node:node-1", threadId: "remote-thread", items: [] }),
+    );
+  });
+
+  it("rejects malformed paired-node payloadJSON with a stable error on terminal", async () => {
+    const invoke = vi.fn().mockResolvedValue({ payloadJSON: "{bad json" });
+    const runtime = {
+      nodes: {
+        list: vi.fn().mockResolvedValue({
+          nodes: [
+            {
+              nodeId: "node-1",
+              displayName: "Remote",
+              connected: true,
+              commands: ["family.list", "family.read", "family.terminal"],
+            },
+          ],
+        }),
+        invoke,
+      },
+    } as unknown as PluginRuntime;
+    const options: SessionCatalogFamilyOptions = {
+      runtime,
+      local: {
+        hostId: "gateway",
+        label: "Local Family",
+        available: () => true,
+        list: async () => ({ sessions: [] }),
+        read: async (request) => ({
+          hostId: request.hostId,
+          threadId: request.threadId,
+          items: [],
+        }),
+        assertAccess: vi.fn(),
+      },
+      node: {
+        listCommand: "family.list",
+        readCommand: "family.read",
+        terminalCommand: "family.terminal",
+        timeoutMs: 1_000,
+        maxHosts: 10,
+        maxPageLimit: 100,
+        sessionIdPattern: /^[a-z0-9-]+$/u,
+      },
+      capabilities: {
+        local: () => ({ canContinue: true, canOpenTerminal: false }),
+        node: () => ({ canContinue: false, canOpenTerminal: true }),
+        project: (value, capabilities) => ({ ...value, ...capabilities }),
+      },
+      messages: {
+        invalidNodeCursor: "bad node cursor",
+        invalidNodeSessionPage: "bad node sessions",
+        invalidNodeTranscriptPage: "bad node transcript",
+        invalidHostId: "bad host",
+        localReadFailed: "local unavailable",
+        nodeInvokeFailed: "node unavailable",
+        nodeReadUnavailable: "node read unavailable",
+        nodeTerminalUnavailable: "node terminal unavailable",
+        sessionUnavailable: "session unavailable",
+      },
+      continuation: {
+        resolveAgentId: () => "main",
+        availability: () => ({ available: true }),
+        listAdopted: () => new Map(),
+        loadSession: async (threadId) => session(threadId),
+        validateSession: vi.fn(),
+        create: vi.fn(),
+        complete: vi.fn(),
+        nodeReadOnlyMessage: "nodes are read-only",
+      },
+      terminal: {
+        executable: "family",
+        args: (threadId) => ["--session", threadId],
+        title: (threadId) => `family ${threadId}`,
+        requireLocalSession: async (threadId) => session(threadId),
+        unavailableMessage: "family unavailable",
+      },
+      checkUpstreamActivity: async () => [],
+    };
+    const provider = createSessionCatalogFamily(options, sessionCatalogPaging.isExactCursor);
+
+    await expect(
+      provider.openTerminal?.({ hostId: "node:node-1", threadId: "remote-thread" }),
+    ).rejects.toThrow("node returned malformed session catalog JSON");
+    const invocation = invoke.mock.calls[0]?.[0] as { command: string } | undefined;
+    expect(invocation?.command).toBe("family.list");
+  });
 });

--- a/src/plugin-sdk/session-catalog.test.ts
+++ b/src/plugin-sdk/session-catalog.test.ts
@@ -25,6 +25,26 @@ const session = (threadId: string): SessionCatalogSession => ({
   canArchive: false,
 });
 
+
+/** Minimal plugin runtime mock exposing only the paired-node surface used by catalog tests. */
+function makeMockNodeRuntime(invoke: ReturnType<typeof vi.fn>): Pick<PluginRuntime, "nodes"> {
+  return {
+    nodes: {
+      list: vi.fn().mockResolvedValue({
+        nodes: [
+          {
+            nodeId: "node-1",
+            displayName: "Remote",
+            connected: true,
+            commands: ["family.list", "family.read", "family.terminal"],
+          },
+        ],
+      }),
+      invoke,
+    },
+  };
+}
+
 describe("session catalog SDK", () => {
   it("owns canonical list/read parameter and cursor parsing", () => {
     const cursor = sessionCatalogPaging.encodeCursor(2);
@@ -57,21 +77,7 @@ describe("session catalog SDK", () => {
     const invoke = vi.fn().mockResolvedValue({
       payloadJSON: JSON.stringify({ sessions: [session("remote-thread")] }),
     });
-    const runtime = {
-      nodes: {
-        list: vi.fn().mockResolvedValue({
-          nodes: [
-            {
-              nodeId: "node-1",
-              displayName: "Remote",
-              connected: true,
-              commands: ["family.list", "family.read", "family.terminal"],
-            },
-          ],
-        }),
-        invoke,
-      },
-    } as unknown as PluginRuntime;
+    const runtime = makeMockNodeRuntime(invoke) as PluginRuntime;
     const create = vi.fn().mockResolvedValue({ sessionKey: "agent:main:created" });
     const complete = vi.fn(async (continued: { sessionKey: string }) => continued);
     const options: SessionCatalogFamilyOptions = {
@@ -180,21 +186,7 @@ describe("session catalog SDK", () => {
 
   it("rejects malformed paired-node payloadJSON with a stable error on read", async () => {
     const invoke = vi.fn().mockResolvedValue({ payloadJSON: "{bad json" });
-    const runtime = {
-      nodes: {
-        list: vi.fn().mockResolvedValue({
-          nodes: [
-            {
-              nodeId: "node-1",
-              displayName: "Remote",
-              connected: true,
-              commands: ["family.list", "family.read", "family.terminal"],
-            },
-          ],
-        }),
-        invoke,
-      },
-    } as unknown as PluginRuntime;
+    const runtime = makeMockNodeRuntime(invoke) as PluginRuntime;
     const options: SessionCatalogFamilyOptions = {
       runtime,
       local: {
@@ -271,21 +263,7 @@ describe("session catalog SDK", () => {
       payloadJSON: "",
       payload: { threadId: "remote-thread", items: [] },
     });
-    const runtime = {
-      nodes: {
-        list: vi.fn().mockResolvedValue({
-          nodes: [
-            {
-              nodeId: "node-1",
-              displayName: "Remote",
-              connected: true,
-              commands: ["family.list", "family.read", "family.terminal"],
-            },
-          ],
-        }),
-        invoke,
-      },
-    } as unknown as PluginRuntime;
+    const runtime = makeMockNodeRuntime(invoke) as PluginRuntime;
     const options: SessionCatalogFamilyOptions = {
       runtime,
       local: {
@@ -357,21 +335,7 @@ describe("session catalog SDK", () => {
 
   it("rejects malformed paired-node payloadJSON with a stable error on terminal", async () => {
     const invoke = vi.fn().mockResolvedValue({ payloadJSON: "{bad json" });
-    const runtime = {
-      nodes: {
-        list: vi.fn().mockResolvedValue({
-          nodes: [
-            {
-              nodeId: "node-1",
-              displayName: "Remote",
-              connected: true,
-              commands: ["family.list", "family.read", "family.terminal"],
-            },
-          ],
-        }),
-        invoke,
-      },
-    } as unknown as PluginRuntime;
+    const runtime = makeMockNodeRuntime(invoke) as PluginRuntime;
     const options: SessionCatalogFamilyOptions = {
       runtime,
       local: {

--- a/src/plugins/session-catalog-family.ts
+++ b/src/plugins/session-catalog-family.ts
@@ -1,3 +1,4 @@
+import { unwrapNodePayloadJSON } from "@openclaw/normalization-core/node-payload";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   SessionCatalogHost,
@@ -119,17 +120,7 @@ function nodeLabel(node: { displayName?: string; remoteIp?: string; nodeId: stri
 }
 
 function unwrapNodePayload(value: unknown): unknown {
-  if (!isRecord(value)) {
-    return value;
-  }
-  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
-    try {
-      return JSON.parse(value.payloadJSON) as unknown;
-    } catch (error) {
-      throw new Error("node returned malformed session catalog JSON", { cause: error });
-    }
-  }
-  return "payload" in value ? value.payload : value;
+  return unwrapNodePayloadJSON(value);
 }
 
 function isOptionalString(value: unknown): boolean {

--- a/src/plugins/session-catalog-family.ts
+++ b/src/plugins/session-catalog-family.ts
@@ -119,9 +119,17 @@ function nodeLabel(node: { displayName?: string; remoteIp?: string; nodeId: stri
 }
 
 function unwrapNodePayload(value: unknown): unknown {
-  return isRecord(value) && typeof value.payloadJSON === "string"
-    ? (JSON.parse(value.payloadJSON) as unknown)
-    : value;
+  if (!isRecord(value)) {
+    return value;
+  }
+  if (typeof value.payloadJSON === "string" && value.payloadJSON.trim()) {
+    try {
+      return JSON.parse(value.payloadJSON) as unknown;
+    } catch (error) {
+      throw new Error("node returned malformed session catalog JSON", { cause: error });
+    }
+  }
+  return "payload" in value ? value.payload : value;
 }
 
 function isOptionalString(value: unknown): boolean {


### PR DESCRIPTION
## What Problem This Solves

When a remote node returns a malformed session-catalog `payloadJSON` (corrupt JSON, or an empty string), the unwrap step threw a bare `SyntaxError` whose internal parse detail bubbled up to the gateway error response — surfacing a low-level V8 parser message to the client instead of a meaningful "node returned malformed session catalog JSON". This aligns the two unprotected `unwrapNodePayload` implementations with the already-correct codex sibling.

- Problem: `unwrapNodePayload` (in `src/plugins/session-catalog-family.ts` and `extensions/anthropic/session-catalog-parsing.ts`) called bare `JSON.parse(value.payloadJSON)` with no try/catch, no `.trim()` guard, and no `payload` fallback. A corrupt payload leaked a raw `SyntaxError`; an empty-string `payloadJSON` (even when a `payload` field was present) also threw `SyntaxError: Unexpected end of JSON input` instead of falling back to `payload`.
- Solution: wrap `JSON.parse` in try/catch and rethrow a semantic `Error("node returned malformed session catalog JSON", { cause })`; add a `.trim()` guard so empty `payloadJSON` falls back to the `payload` field instead of throwing.
- What changed: `unwrapNodePayload` in both files now mirrors `unwrapNodeInvokePayload` from `extensions/codex/src/session-catalog-parsing.ts` (try-catch + `.trim()` + `cause` + semantic message + `payload` fallback).
- What did NOT change: parsing of valid `payloadJSON` is byte-identical; no caller signatures changed; the generic-layer `parsePayload` (`src/gateway/node-invoke-plugin-policy.ts`) was already correct and is untouched.

## Why This Change Was Made

Both `unwrapNodePayload` sites are the cross-process RPC trust boundary where the coordinator re-parses a `payloadJSON` string that a remote node produced. The codex extension already protects this boundary with `unwrapNodeInvokePayload` (try-catch + `.trim()` + `cause` + semantic message + `payload` fallback); the anthropic extension and the shared plugin family did not, so a malformed node response leaked a `SyntaxError` with internal parser state into `catalogError` → `errorShape(INVALID_REQUEST, details.message)`, i.e. the raw parser message reached the client.

- Best fix: yes — this is a straight alignment to the already-merged codex pattern, not a new design. The structure (try-catch + `.trim()` + `payload` fallback) is the minimal set codex validated; removing any piece loses a guarantee (`.trim()` guards the empty-string fallback; `payload` fallback guards the missing-`payloadJSON` case).
- Alternative: surface the error at the gateway `catalogError` layer instead. Rejected — `catalogError` already takes `error.message`, so the fix belongs at the parse boundary where the semantic message is produced, matching codex.
- Risk / non-goals: a malformed `payloadJSON` is still unreadable — this fix does not recover the catalog contents, it only produces a meaningful, non-leaking error and fixes the empty-string fallback. `readTranscript` and `openTerminal` call `unwrapNodePayload` without their own try-catch; the semantic `Error` still propagates to the gateway, but `catalogError` now sees a stable semantic string instead of a `SyntaxError` stack. Three committed regression cases cover the changed envelope contract on the public `read` and `openTerminal` paths (see Evidence); a real-transport `node:http` loopback proof replaces the mocked `runtime.nodes.invoke` to exercise the transport → unwrap → Gateway error-adapter path. Two further committed regression cases cover the separately changed Anthropic `unwrapNodePayload` through its own catalog boundary (malformed-JSON rewrap + empty-`payloadJSON` fallback), so its error and fallback contract cannot drift from the shared implementation.
- Shared helper extraction (follow-up commit `3da9b2ef4eb`): the guard logic was duplicated across `src/plugins/session-catalog-family.ts` and `extensions/anthropic/session-catalog-parsing.ts`, both mirroring the codex extension's `unwrapNodeInvokePayload`. Extracted one canonical `unwrapNodePayloadJSON` into `packages/normalization-core/src/node-payload.ts` and re-exported it through a new `openclaw/plugin-sdk/node-payload-runtime` SDK subpath so core imports the normalization-core subpath directly and bundled extensions import through the SDK barrel (per the extensions boundary in `extensions/AGENTS.md`). The two `unwrapNodePayload` function bodies are now single-line delegations. Production LOC is now net-negative (−8: +15 added across the helper + SDK subpath + sync files, −23 removed from the two duplicated function bodies), which resolves the "no net-neutral owner-boundary form" merge-risk finding. No behavior change — valid `payloadJSON` parsing is byte-identical, caller signatures are unchanged, and all 64 regression cases (5 shared-family + 59 anthropic) pass post-extraction. The SDK subpath was synced across all five required surfaces: root `package.json` exports, `scripts/lib/plugin-sdk-entrypoints.json`, `docs/plugins/sdk-subpaths.md`, the new source file, and `packages/normalization-core` package.json exports+build.
- Named follow-up (out of scope): the codex extension has a third local copy of the same unwrap logic at `extensions/codex/src/node-cli-sessions.ts:633` (`unwrapNodeInvokePayload`, non-exported, with a distinct `"Codex CLI node command returned malformed payloadJSON."` message). Migrating it to the shared helper is out of scope for this bug-fix PR (it would extend the change surface into the codex extension and change a shipped error string), but is recorded here as a named follow-up for a future refactor PR.

## User Impact

Operators diagnosing a remote-node session-catalog failure now see `node returned malformed session catalog JSON` (with the underlying `SyntaxError` preserved as `cause` for logs) instead of a raw `Expected property name or '}' in JSON at position 1...` parser message leaking from the gateway. A node that returns an empty `payloadJSON` alongside a `payload` field no longer fails the whole catalog read.

## Evidence

Live `node --import tsx` run exercising the fixed `unwrapNodePayload` through `createSessionCatalogFamily().read()` (the function is not exported in the family module, so it is reached via the public family API with a mocked `runtime.nodes.invoke`). `node` here is `/usr/local/bin/node`.

Behavior matrix (before = `origin/main` with both files reverted via `git checkout origin/main -- <files>`; after = HEAD `8a3d5a54540`):

```text
input form                         => pre-fix result                => post-fix result
payloadJSON = "{bad json"          => SyntaxError (bare, leaked)   => Error "node returned malformed session catalog JSON" (cause: SyntaxError)
payloadJSON = JSON.stringify({...})=> ok, returns page             => ok, returns page (unchanged)
payloadJSON = "" + payload field   => SyntaxError "Unexpected end" => ok, falls back to payload field
```

Post-fix terminal output (HEAD `8a3d5a54540`, `node --import tsx --input-type=module < proof.mjs`):

```text
[malformed-payloadJSON] THREW Error: node returned malformed session catalog JSON
[malformed-payloadJSON]   cause: SyntaxError (Expected property name or '}' in JSON at position 1 (line 1 column 2))
[valid-payloadJSON] NO THROW — result: {"hostId":"node:test-node","threadId":"t1","items":[],"label":"test-node"}
[empty-payloadJSON-fallback] NO THROW — result: {"hostId":"node:test-node","threadId":"t1","items":[],"label":"test-node"}
RESULT: AFTER-FIX PASS (semantic error + normal/fallback paths OK)
```

Pre-fix terminal output (both files reverted to `origin/main`):

```text
[malformed-payloadJSON] THREW SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
[malformed-payloadJSON]   cause: none
[valid-payloadJSON] NO THROW — result: {"hostId":"node:test-node","threadId":"t1","items":[],"label":"test-node"}
[empty-payloadJSON-fallback] THREW SyntaxError: Unexpected end of JSON input
[empty-payloadJSON-fallback]   cause: none
RESULT: BEFORE-FIX (bare SyntaxError leaked)
```

The pre-fix run reproduces both defects: the bare `SyntaxError` leak on malformed input, and the spurious `SyntaxError: Unexpected end of JSON input` on an empty `payloadJSON` that should have fallen back to `payload`.

### Committed regression coverage

Three regression cases are added to `src/plugin-sdk/session-catalog.test.ts` (the shared-family test ClawSweeper pointed at), covering the public `read` and `openTerminal` paths across both envelope edge cases. Each case is a true regression guard — it fails on `origin/main` and passes on this branch.

```text
$ git checkout origin/main -- src/plugins/session-catalog-family.ts
$ npx vitest run --no-file-parallelism src/plugin-sdk/session-catalog.test.ts
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
 FAIL ... > rejects malformed paired-node payloadJSON with a stable error on read
   expected to throw 'node returned malformed session catal…' but got 'Expected property name or \'}\' in JS…'
 FAIL ... > falls back to payload field when paired-node payloadJSON is empty on read
   expected promise to resolve, got SyntaxError: Unexpected end of JSON input
 FAIL ... > rejects malformed paired-node payloadJSON with a stable error on terminal
   expected to throw 'node returned malformed session catal…' but got 'Expected property name or \'}\' in JS…'

$ git checkout HEAD -- src/plugins/session-catalog-family.ts
$ npx vitest run --no-file-parallelism src/plugin-sdk/session-catalog.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The three new cases cover: (1) malformed `payloadJSON` on `read` throws the stable catalog error; (2) empty `payloadJSON` with a `payload` field on `read` falls back instead of throwing; (3) malformed `payloadJSON` on `openTerminal` throws the stable catalog error. The `openTerminal` node path invokes `family.list` then unwraps, so the assertion verifies the `command` is `family.list`.

### Committed regression coverage — Anthropic catalog boundary

Two additional regression cases are added to `extensions/anthropic/session-catalog.test.ts`, covering the separately changed Anthropic `unwrapNodePayload` through its own catalog boundary (the ClawSweeper P2 finding). Each is a true regression guard — it fails on `origin/main` and passes on this branch.

- `rewraps malformed payloadJSON into a stable catalog error` — calls `unwrapNodePayload({ payloadJSON: "{bad json" })` directly and asserts it throws the stable `node returned malformed session catalog JSON` message with the original `SyntaxError` preserved as `cause`. On `origin/main` this throws a bare `SyntaxError` whose message is the raw V8 parser string (`Expected property name or '}' in JSON at position 1...`), so the assertion fails.
- `falls back to payload when a paired node returns empty payloadJSON` — exercises the public `captureCatalogProvider(...).list({ hostIds: ["node:empty-json"] })` boundary with a node returning `{ payloadJSON: "   ", payload: { sessions: [] } }`, and asserts the host resolves with `sessions: []` and no error. On `origin/main` the empty `payloadJSON` throws `SyntaxError: Unexpected end of JSON input`, the list path fails soft into `NODE_INVOKE_FAILED`, and the assertion that `error` is `undefined` fails.

```text
$ git checkout origin/main -- extensions/anthropic/session-catalog-parsing.ts
$ npx vitest run --no-file-parallelism extensions/anthropic/session-catalog.test.ts -t "rewraps malformed|falls back to payload when a paired node"
 Test Files  1 failed (1)
      Tests  2 failed | 57 skipped (59)
 FAIL > rewraps malformed payloadJSON into a stable catalog error
   expected to throw 'node returned malformed session catal…' but got 'Expected property name or \'}\' in JS…'
 FAIL > falls back to payload when a paired node returns empty payloadJSON
   expected { code: 'NODE_INVOKE_FAILED', …(1) } to be undefined

$ git checkout HEAD -- extensions/anthropic/session-catalog-parsing.ts
$ npx vitest run --no-file-parallelism extensions/anthropic/session-catalog.test.ts
 Test Files  1 passed (1)
      Tests  59 passed (59)
```

The malformed case is asserted at the `unwrapNodePayload` owner-local boundary because the Anthropic `list` path is fail-soft by design (any unwrap throw becomes `NODE_INVOKE_FAILED / "Paired node Claude sessions are unavailable"`, so the semantic message is not client-observable through `list`); the empty-`payloadJSON` fallback is asserted end-to-end through the public `list` boundary. Together they pin both envelope edge cases so the Anthropic parser cannot drift from the shared family implementation.


### Real transport proof (node:http loopback, not a vi.fn mock)

ClawSweeper flagged that the harness above mocks `runtime.nodes.invoke`. The proof below replaces the mock with a real `node:http` loopback server acting as the paired-node transport: `runtime.nodes.invoke` performs a real `fetch` POST to the loopback server, which returns the malformed/empty envelope from its HTTP response body. This exercises the real async transport → `unwrapNodePayload` → Gateway error-adapter path. `node` is `/usr/local/bin/node`.

```text
$ node --import tsx --input-type=module < real-transport-proof.mjs
real transport: paired-node loopback server on 127.0.0.1:43129
invoke transport: real node:http fetch (not vi.fn mock)

=== scenario 1: malformed payloadJSON via real transport ===
THREW Error: node returned malformed session catalog JSON
  cause: SyntaxError (Expected property name or '}' in JSON at position 1 (line 1 column 2))
  Gateway catalogError → errorShape(INVALID_REQUEST, "node returned malformed session catalog JSON")

=== scenario 2: empty payloadJSON + payload fallback via real transport ===
NO THROW — result: {"hostId":"node:empty-node","threadId":"t1","items":[],"label":"empty-node"}
```

Pre-fix (both files reverted to `origin/main`) over the same real transport:

```text
=== scenario 1: malformed payloadJSON via real transport ===
THREW SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
  cause: none
  Gateway catalogError → errorShape(INVALID_REQUEST, "Expected property name or '}' in JSON at position 1 (line 1 column 2)")

=== scenario 2: empty payloadJSON + payload fallback via real transport ===
THREW SyntaxError: Unexpected end of JSON input
```

The Gateway propagation is traced at the source: `src/gateway/server-methods/session-catalog.ts:62` `catalogError(error)` reads `error.message`, and the read handler at `:549` forwards it as `errorShape(INVALID_REQUEST, details.message, { details })`. Before the fix, the client-facing `INVALID_REQUEST` message is the raw V8 parser string (`Expected property name or '}' in JSON...`); after the fix, it is the stable `node returned malformed session catalog JSON`.

Focused tests (unchanged anthropic test file, confirming no regression in the happy path):

```text
$ npx vitest run --no-file-parallelism extensions/anthropic/session-catalog.test.ts
 Test Files  1 passed (1)
      Tests  57 passed (57)
```

Lint/format (changed files only; full-repo `tsgo` was not run — it hangs the local machine):

```text
$ npx oxlint -c .oxlintrc.json src/plugins/session-catalog-family.ts extensions/anthropic/session-catalog-parsing.ts src/plugin-sdk/session-catalog.test.ts
(clean, no findings)

$ npx oxfmt --check src/plugins/session-catalog-family.ts extensions/anthropic/session-catalog-parsing.ts src/plugin-sdk/session-catalog.test.ts
All matched files use the correct format.
```

What was not tested:

- The loopback server simulates the paired-node transport contract (`invoke` returns `{ payloadJSON, payload }`) over real HTTP; it is not a live remote paired-node process. The changed code path (`JSON.parse` + try/catch + `.trim()` + fallback) is identical to the codex sibling already in production.
- The real production-chain harness below answers `node.invoke.result` in-process with the production `GatewayClient` (role=`node`) rather than a separate node-host process; the connect, pairing, and invoke frames are the real production protocol, and the invoke client is the real `createPluginCliGatewayNodesRuntime` → `callGateway` path.
- The anthropic extension's `unwrapNodePayload` (`extensions/anthropic/session-catalog-parsing.ts:217`) is the same code shape as the shared family's; the committed regression cases cover the shared family, and the real-transport proof exercises the shared family's `createSessionCatalogFamily`. The anthropic happy path is covered by the existing 57 anthropic tests.
- The wire-level Gateway HTTP response body was not captured end-to-end; the proof traces the Gateway error adapter at the source (`catalogError` → `errorShape`), which forwards `error.message` verbatim.

### Real production-chain proof (real Gateway + real paired node + production invoke client)

ClawSweeper's remaining blocker asked for a trace through the real paired-node invoke client and the serialized Gateway wire response. The harness below uses only production code paths — no `vi.fn` mock and no custom `runtime.nodes.invoke` shim:

- real Gateway server: `src/gateway/server.ts` `startGatewayServer`
- real paired node: production `GatewayClient` (role=`node`, mode=`node`) with a real device identity, paired through `approveNodePairing` (`src/infra/device-pairing-node.ts`, the same infra the devices CLI uses)
- real production invoke client: `createPluginCliGatewayNodesRuntime().invoke` (`src/plugins/cli-gateway-nodes-runtime.ts:40`) → `callGateway` over a real WebSocket (`src/gateway/call.ts`)
- real `node.invoke` handler forwards the request to the connected paired node; the node answers `node.invoke.result` with a raw `payloadJSON` string (the same transport semantics as the production node-host's `sendRawPayloadResult`, `src/node-host/invoke.ts:813-816`)

Behavior matrix (before = both files reverted to `origin/main`; after = HEAD `6760cafdbd1`):

| input form | pre-fix result | post-fix result |
|---|---|---|
| `payloadJSON = "{bad json"` (malformed) | bare `SyntaxError: Expected property name or '}' in JSON at position 1...` | `Error "node returned malformed session catalog JSON"` (cause: SyntaxError) |
| `payloadJSON = JSON.stringify({ threadId, items })` (valid) | ok, returns page | ok, returns page (unchanged) |
| `payloadJSON = "   "` (blank, no sibling payload — real node-host shape) | `SyntaxError: Unexpected end of JSON input` | semantic `Error "bad node transcript"` (no raw parser message) |
| `payload = { threadId, items }` with no `payloadJSON` (MCP-style structured result, `sendMcpPayloadResult`) | unwrap returns the whole envelope → read fails `bad node transcript` | ok — falls back to structured payload, read resolves |

Post-fix terminal output (HEAD `6760cafdbd1`):

```text
[setup] MODE=after paired node visible connected=true commands=["family.list","family.read","family.terminal"]
[wire] serialized Gateway response envelope received by createPluginCliGatewayNodesRuntime().invoke:
[wire] {"ok":true,"nodeId":"58034b0a5dce8f03cd85831aba7e7c4e6480ce0f663c7abefe920fcec0c3b0c2","command":"family.read","payload":{"payloadJSON":"{bad json"},"payloadJSON":"{bad json"}
[malformed-payloadJSON] THREW Error: node returned malformed session catalog JSON
[malformed-payloadJSON]   cause: SyntaxError (Expected property name or '}' in JSON at position 1 (line 1 column 2))
[valid-payloadJSON] NO THROW — read result: {"hostId":"node:58034b0a5dce8f03cd85831aba7e7c4e6480ce0f663c7abefe920fcec0c3b0c2","threadId":"remote-thread","items":[],"label":"58034b0a5dce8f03cd85831aba7e7c4e6480ce0f663c7abefe920fcec0c3b0c2"}
[blank-payloadJSON-no-payload] THREW Error: bad node transcript
[payload-only-fallback] NO THROW — read result: {"hostId":"node:58034b0a5dce8f03cd85831aba7e7c4e6480ce0f663c7abefe920fcec0c3b0c2","threadId":"remote-thread","items":[],"label":"58034b0a5dce8f03cd85831aba7e7c4e6480ce0f663c7abefe920fcec0c3b0c2"}
```

Pre-fix output (same harness, both files reverted to `origin/main`):

```text
[malformed-payloadJSON] THREW SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
[valid-payloadJSON] NO THROW — read result: {"hostId":"node:46677da5b2afbc0448feb9fd3f6ee5ef18c8738ba8d8817430ca863b3d435018","threadId":"remote-thread","items":[],"label":"46677da5b2afbc0448feb9fd3f6ee5ef18c8738ba8d8817430ca863b3d435018"}
[blank-payloadJSON-no-payload] THREW SyntaxError: Unexpected end of JSON input
[payload-only-fallback] THREW Error: bad node transcript
```

Boundary observation (why the end-to-end fallback uses payload-only envelopes): the production node-host sends raw `payloadJSON` only (`sendRawPayloadResult`, no sibling `payload`); structured `payload` results are sent without `payloadJSON` (`sendMcpPayloadResult`). A combined `payloadJSON: "   "` + `payload` envelope would lose the sibling `payload` at the gateway (`parseGatewayPayload("   ")` returns `undefined`, replacing the structured field), so the fallback observable end-to-end is the payload-only shape; the blank-`payloadJSON` branch is still a real fix at the unwrap boundary (the raw parser message no longer leaks) and is covered by the committed regression guards in `src/plugin-sdk/session-catalog.test.ts` and `extensions/anthropic/session-catalog.test.ts`.

Full repro harness and raw transcripts are kept outside the repository (`/home/code/github/contributions/pr-125049-evidence/`).

Open PR collision check: searched open PRs in `openclaw/openclaw` for `session-catalog`, `unwrapNodePayload`, and `payloadJSON`; the open session-catalog PRs (#123535 refresh storms, #117233 cyclic cursors, #112748 throttle, #111252 exact cursor, #121760 supervision gate) do not touch `session-catalog-family.ts` or `extensions/anthropic/session-catalog-parsing.ts` (verified via `gh pr view --json files`). No open PR touches `unwrapNodePayload`.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (Claude Sonnet 4.6)
- Evidence update: after ClawSweeper's proof-confidence review, added a real production-chain harness (real Gateway + real paired node + production `createPluginCliGatewayNodesRuntime` invoke client); raw transcripts kept outside the repository.
- Confirmed understanding of code changes: Yes — can explain every line: the `isRecord` guard, the `.trim()` check that distinguishes empty `payloadJSON` from present JSON, the try/catch that rewraps `SyntaxError` into a semantic `Error` with `cause`, and the `payload` fallback for the missing-`payloadJSON` case. All four pieces mirror the codex `unwrapNodeInvokePayload`.
- autoreview: N/A (oxlint/oxfmt run clean on the two changed files).