### PR TITLE
perf(test): consolidate Control UI package fixtures

### DIFF
--- a/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
+++ b/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
@@ -180,23 +180,6 @@ function installPackedPackage(root: string, tarball: string) {
 }
 
 describe("packaged Control UI postinstall inventory", () => {
-  it.each(CONTROL_UI_FILES)(
-    "rejects a real npm package when postinstall would delete %s",
-    (omittedFile) => {
-      const inventory = ["dist/index.js", ...CONTROL_UI_FILES].filter(
-        (relativePath) => relativePath !== omittedFile,
-      );
-      withPackedPackage(inventory, ({ tarball }) => {
-        const result = checkPackedPackage(tarball);
-
-        expect(result.status, result.stdout).not.toBe(0);
-        expect(result.stderr).toContain(
-          `postinstall inventory omits Control UI file ${omittedFile}`,
-        );
-      });
-    },
-  );
-
   it("proves actual npm postinstall deletes an omitted dashboard from a falsely accepted package", () => {
     withPackedPackage(["dist/index.js"], ({ root, tarball }) => {
       const validation = checkPackedPackage(tarball);
@@ -207,9 +190,12 @@ describe("packaged Control UI postinstall inventory", () => {
       }
 
       expect(validation.status, validation.stdout).not.toBe(0);
-      expect(validation.stderr).toContain(
-        "postinstall inventory omits Control UI file dist/control-ui/index.html",
-      );
+      const validationErrors = validation.stderr.split(/\r?\n/u);
+      for (const relativePath of CONTROL_UI_FILES) {
+        expect
+          .soft(validationErrors)
+          .toContain(`postinstall inventory omits Control UI file ${relativePath}`);
+      }
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI package-tarball test repeated a full roughly 24 MiB package copy, `npm pack`, package validator run, and tarball cleanup for each of four table cases. That made a narrow generic-enumeration assertion pay the cost of four complete package fixtures.

## Why This Change Was Made

The four table cases now share the inventory they are meant to prove instead of rebuilding the entire package fixture each time. The retained end-to-end case still performs the real `npm pack`, package validator, and offline install flow. It now asserts all four exact Control UI inventory errors, verifies `dist/index.js` survives, and verifies every Control UI file is deleted.

Two tempting shortcuts were rejected during fault testing: an index-only validator caused three asset-message failures, and bypassing the `app.js.gz` postinstall deletion failed the installed-file assertion. Production behavior was restored; this PR changes only the test fixture.

## User Impact

No product behavior changes. The package-fixture test keeps the same real package, validator, and offline-install coverage while removing redundant setup work.

## Evidence

- Test-only diff: one file, +6/-20; production +0/-0.
- Same-Testbox A/B run: https://github.com/openclaw/openclaw/actions/runs/31995006286
  - Wall time: 12.285s average to 7.015s average, -5.270s / -42.9%.
  - Test body: -58.5%.
  - Peak RSS: flat.
- Targeted suite: 3/3 passing.
- Validator and postinstall siblings: 80/80 passing.
- Retained package case: +3 assertions passing.
- Installed executable help smoke passed.
- Full changed gate passed.
- Fresh autoreview: clean, 0.99 confidence; deslop made no changes.

No changelog, release, publication, version, or product-source change is needed.
