### PR TITLE
fix(qa): prove recovery across three Gateway restarts

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -7120,6 +7120,72 @@ Update and merge these partial structured summaries.`,
     expect(outputText(payload)).not.toBe("Protocol note: replay unsafe after write.");
   });
 
+  it("derives three restart checkpoints from request history without server counters", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT.";
+    const recoveryPrompt =
+      "Your previous turn was interrupted by a gateway restart. Continue from the existing transcript.";
+    const tools = [
+      {
+        type: "function",
+        name: "exec",
+        parameters: {
+          type: "object",
+          properties: {
+            language: { type: "string" },
+            code: { type: "string" },
+            restartSafe: { type: "boolean" },
+          },
+          required: ["code"],
+        },
+      },
+      {
+        type: "function",
+        name: "wait",
+        parameters: {
+          type: "object",
+          properties: { runId: { type: "string" } },
+          required: ["runId"],
+        },
+      },
+    ];
+    const input: Array<Record<string, unknown>> = [makeUserInput(prompt)];
+
+    for (const checkpoint of [1, 2, 3]) {
+      const execPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+      const execCall = outputToolCall(execPayload, "exec");
+      const execArgs = outputToolArgsFromItem(execCall);
+      expect(execArgs).toMatchObject({ language: "javascript", restartSafe: true });
+      expect(execArgs.code).toContain("qa_restart_wait");
+      expect(execArgs.code).toContain(`CHECKPOINT-${checkpoint}`);
+
+      const runId = `restart-checkpoint-${checkpoint}`;
+      input.push(
+        execCall,
+        makeToolOutputWithCallId(
+          outputToolCallId(execCall, `checkpoint-exec-${checkpoint}`),
+          JSON.stringify({ status: "waiting", runId }),
+        ),
+      );
+      const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+      const waitCall = outputToolCall(waitPayload, "wait");
+      expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
+      input.push(waitCall, makeUserInput(recoveryPrompt));
+    }
+
+    const finalPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+    expect(outputText(finalPayload)).toBe("unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK");
+
+    const freshPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      tools,
+      input: [makeUserInput(prompt)],
+    });
+    expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec")).code).toContain(
+      "CHECKPOINT-1",
+    );
+  });
+
   it("routes Anthropic image generation through Code Mode when only exec and wait are visible", async () => {
     const server = await startMockServer();
     const body = (await expectAnthropicMessagesJson(server, {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -289,6 +289,8 @@ const QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE =
 const QA_STREAMING_TOOL_PROGRESS_CONTINUATION_RE =
   /^Continue with (?:the current Matrix QA scenario|the QA scenario plan and report worked, failed, and blocked items)\.$/i;
 const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
+const QA_RESTART_CHECKPOINT_COUNT = 3;
+const QA_RESTART_FINAL_TEXT = "unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK";
 const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_PROMPT_RE = /telegram visible partial failure qa check/i;
 const QA_TELEGRAM_UNSENT_FAILURE_PROMPT_RE = /telegram unsent failure qa check/i;
@@ -566,6 +568,27 @@ function isGeneratedCodeModeWaitCall(input: ResponsesInputItem[], toolCall: Resp
       isGeneratedCodeModeExecCall(findToolCallByCallId(input, item.call_id))
     );
   });
+}
+
+function readRestartCheckpointProgress(input: ResponsesInputItem[]) {
+  const checkpoints = new Set<number>();
+  for (const item of input) {
+    if (item.name !== "exec") {
+      continue;
+    }
+    const source = readGeneratedCodeModeExecSource(item);
+    if (!source?.includes("qa_restart_wait")) {
+      continue;
+    }
+    for (const match of source.matchAll(/\bCHECKPOINT-([1-3])\b/gu)) {
+      checkpoints.add(Number(match[1]));
+    }
+  }
+  const waitCount = input.filter((item) => isGeneratedCodeModeWaitCall(input, item)).length;
+  return {
+    checkpoints: [...checkpoints].toSorted((left, right) => left - right),
+    waitCount,
+  };
 }
 
 function isCodeModeControlToolOutput(body: Record<string, unknown>, input: ResponsesInputItem[]) {
@@ -883,6 +906,76 @@ async function buildResponsesPayload(
     return buildFailedResponseEvents();
   }
   const toolJson = parseToolOutputJson(scenarioToolOutput);
+  if (QA_RESTART_CODE_MODE_WAIT_PROMPT_RE.test(allInputText)) {
+    const progress = readRestartCheckpointProgress(input);
+    const currentControlCallId = extractToolOutputCallId(input);
+    const latestControlCall = input.findLast(
+      (item) => item.name === "exec" || item.name === "wait",
+    );
+    const currentControlOutputIsLatest =
+      currentControlCallId.length > 0 && latestControlCall?.call_id === currentControlCallId;
+    const nextCheckpoint = Array.from(
+      { length: QA_RESTART_CHECKPOINT_COUNT },
+      (_, index) => index + 1,
+    ).find((checkpoint) => !progress.checkpoints.includes(checkpoint));
+    if (toolOutput.includes("unsafe-probe-executed")) {
+      return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
+    }
+    if (currentControlOutputIsLatest) {
+      if (
+        codeModeControlJson?.status === "waiting" &&
+        "cellId" in codeModeControlJson &&
+        typeof codeModeControlJson.cellId === "string"
+      ) {
+        return buildRawToolCallEventsWithArgs("wait", { cell_id: codeModeControlJson.cellId });
+      }
+      if (
+        codeModeControlJson?.status === "waiting" &&
+        "runId" in codeModeControlJson &&
+        typeof codeModeControlJson.runId === "string" &&
+        hasDeclaredTool(body, "wait")
+      ) {
+        return buildToolCallEventsWithArgs("wait", { runId: codeModeControlJson.runId });
+      }
+      if (
+        toolJson?.status === "waiting" &&
+        typeof toolJson.runId === "string" &&
+        hasDeclaredTool(body, "wait")
+      ) {
+        return buildToolCallEventsWithArgs("wait", { runId: toolJson.runId });
+      }
+    }
+    if (progress.waitCount < progress.checkpoints.length) {
+      return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
+    }
+    if (nextCheckpoint !== undefined) {
+      if (nextCheckpoint > 1 && !QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)) {
+        return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
+      }
+      if (hasDeclaredTool(body, "exec")) {
+        const encodedTarget = encodeCodeModeTarget("qa_restart_wait", {});
+        return buildToolCallEventsWithArgs("exec", {
+          language: "javascript",
+          restartSafe: true,
+          code: [
+            `// ${QA_CODE_MODE_TARGET_MARKER}${encodedTarget}`,
+            'const target = ALL_TOOLS.find((tool) => tool.name === "qa_restart_wait");',
+            'if (!target) throw new Error("qa_restart_wait unavailable");',
+            "await tools.call(target.id, {});",
+            `return "CHECKPOINT-${nextCheckpoint}";`,
+          ].join("\n"),
+        });
+      }
+      return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
+    }
+    if (!QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)) {
+      return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
+    }
+    if (hasToolDefinition(body, "qa_restart_unsafe_probe")) {
+      return buildToolCallEventsWithArgs("qa_restart_unsafe_probe", {});
+    }
+    return buildAssistantEvents(QA_RESTART_FINAL_TEXT);
+  }
   if (codeModeControlJson?.status === "waiting" && hasToolDefinition(toolDeclarationBody, "wait")) {
     if ("cellId" in codeModeControlJson && typeof codeModeControlJson.cellId === "string") {
       return buildRawToolCallEventsWithArgs("wait", { cell_id: codeModeControlJson.cellId });
@@ -1050,39 +1143,6 @@ async function buildResponsesPayload(
     ) {
       return buildToolCallEventsWithArgs(targetTool, plannedArgs);
     }
-  }
-  if (QA_RESTART_CODE_MODE_WAIT_PROMPT_RE.test(allInputText)) {
-    if (QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)) {
-      if (toolOutput.includes("unsafe-probe-executed")) {
-        return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
-      }
-      if (hasToolDefinition(body, "qa_restart_unsafe_probe")) {
-        return buildToolCallEventsWithArgs("qa_restart_unsafe_probe", {});
-      }
-      return buildAssistantEvents(exactReplyDirective ?? "RESTART-CODE-MODE-WAIT-OK");
-    }
-    if (toolJson?.status === "completed" && toolJson.value === "RESTART-CODE-MODE-WAIT-OK") {
-      return buildAssistantEvents(exactReplyDirective ?? "RESTART-CODE-MODE-WAIT-OK");
-    }
-    if (
-      toolJson?.status === "waiting" &&
-      typeof toolJson.runId === "string" &&
-      hasDeclaredTool(body, "wait")
-    ) {
-      return buildToolCallEventsWithArgs("wait", { runId: toolJson.runId });
-    }
-    if (!hasCompletedToolOutput && hasDeclaredTool(body, "exec")) {
-      return buildToolCallEventsWithArgs("exec", {
-        language: "javascript",
-        restartSafe: true,
-        code: [
-          'const matches = await tools.search("qa_restart_wait");',
-          "await tools.call(matches[0].id, {});",
-          'return "RESTART-CODE-MODE-WAIT-OK";',
-        ].join("\n"),
-      });
-    }
-    return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
   }
   if (
     QA_MCP_CODE_MODE_API_FILE_PROMPT_RE.test(allInputText) ||

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -27,85 +27,6 @@ describe("qa scenario catalog causality", () => {
     expect(readQaScenarioById("long-context-progress-watchdog").sourcePath).toBe(
       "qa/scenarios/runtime/long-context-progress-watchdog.yaml",
     );
-    const gatewayRestart = requireFlowScenario(readQaScenarioById("gateway-restart-inflight-run"));
-    const gatewayRestartFlow = gatewayRestart.execution.flow;
-    const gatewayRestartContract = JSON.stringify(gatewayRestartFlow);
-    const gatewayRestartActions = gatewayRestartFlow?.steps[0]?.actions ?? [];
-    const recoveryPollIndex = gatewayRestartActions.findIndex(
-      (action) =>
-        (action as { call?: string }).call === "waitForCondition" &&
-        (action as { saveAs?: string }).saveAs === "settledRecovery",
-    );
-    const outboundIndex = gatewayRestartActions.findIndex(
-      (action) =>
-        (action as { call?: string }).call === "waitForOutboundMessage" &&
-        (action as { saveAs?: string }).saveAs === "outbound",
-    );
-    const preOutboundRecoveryAssertIndex = gatewayRestartActions.findIndex((action) =>
-      readFlowAssertExpression(action).includes(
-        "restartRecoveryRequestsBeforeOutbound.length === 1",
-      ),
-    );
-    const preOutboundHeartbeatAssertIndex = gatewayRestartActions.findIndex((action) =>
-      readFlowAssertExpression(action).includes(
-        "!String(restartRecoveryRequestsBeforeOutbound[0].prompt ?? '').includes('[OpenClaw heartbeat poll]')",
-      ),
-    );
-    const settledRequestsIndex = gatewayRestartActions.findIndex(
-      (action) => (action as { set?: string }).set === "settledRecoveryRequests",
-    );
-    const settledDedupeAssertIndex = gatewayRestartActions.findIndex((action) =>
-      readFlowAssertExpression(action).includes("settledRestartRecoveryRequests.length === 1"),
-    );
-    const recoveryPoll = gatewayRestartActions[recoveryPollIndex] as
-      | { args?: Array<{ lambda?: { expr?: string } }> }
-      | undefined;
-    const recoveryPollExpr = recoveryPoll?.args?.[0]?.lambda?.expr ?? "";
-    expect(gatewayRestart.execution.retryCount).toBe(0);
-    expect(JSON.stringify(gatewayRestart.gatewayConfigPatch)).toContain(
-      '"alsoAllow":["qa_restart_wait","qa_restart_unsafe_probe"]',
-    );
-    expect(gatewayRestartContract).toContain("plannedToolName === 'wait'");
-    expect(gatewayRestartContract).toContain("lastAssistantToolNames?.includes('wait')");
-    expect(gatewayRestartContract).toContain("restartRecoveryDeliveryContext");
-    expect(gatewayRestartContract).toContain("sendInbound");
-    expect(gatewayRestartContract).not.toContain("startAgentRun");
-    expect(gatewayRestartContract).toContain('"restartGatewayWithConfigPatch"');
-    expect(gatewayRestartContract).toContain("interruptedMatches.length === 1");
-    expect(gatewayRestartContract).toContain("restartNotices.length === 0");
-    expect(gatewayRestartContract).toContain("dispatching restart-safe recovery");
-    expect(recoveryPollIndex).toBeGreaterThanOrEqual(0);
-    expect(recoveryPollExpr).toContain(
-      "String(request.prompt ?? '').includes('Your previous turn was interrupted by a gateway restart')",
-    );
-    expect(recoveryPollExpr).toContain(
-      "String(request.allInputText ?? '').includes(config.interruptedMarker)",
-    );
-    expect(recoveryPollExpr).toContain("restartRecoveryRequests.length >= 1");
-    expect(recoveryPollExpr).toContain(
-      "String(transcript.finalText ?? '').includes(config.interruptedMarker)",
-    );
-    expect(preOutboundRecoveryAssertIndex).toBeGreaterThan(recoveryPollIndex);
-    expect(preOutboundHeartbeatAssertIndex).toBeGreaterThan(preOutboundRecoveryAssertIndex);
-    expect(outboundIndex).toBeGreaterThan(preOutboundHeartbeatAssertIndex);
-    expect(settledRequestsIndex).toBeGreaterThan(outboundIndex);
-    expect(settledDedupeAssertIndex).toBeGreaterThan(settledRequestsIndex);
-    expect(
-      gatewayRestartActions.some((action) => (action as { call?: string }).call === "sleep"),
-    ).toBe(false);
-    expect(gatewayRestartContract).toContain("recoveryPromptHeartbeat=false");
-    expect(gatewayRestartContract).toContain("liveTurnTimeoutMs(env, 180000)");
-    expect(gatewayRestartContract).toContain("id: `dm:${conversationId}`");
-    expect(gatewayRestartContract).toContain("dmScope: env.cfg.session?.dmScope");
-    expect(gatewayRestart.gatewayConfigPatch).toMatchObject({
-      plugins: {
-        slots: { memory: "none" },
-        entries: {
-          acpx: { enabled: false },
-          "memory-core": { enabled: false },
-        },
-      },
-    });
     const liveMultiRestart = requireFlowScenario(readQaScenarioById("gateway-restart-multi-live"));
     const liveMultiRestartFlow = liveMultiRestart.execution.flow;
     const liveMultiRestartContract = JSON.stringify(liveMultiRestartFlow);
@@ -215,6 +136,108 @@ describe("qa scenario catalog causality", () => {
       requiredProvider: "openai",
       requiredModel: "gpt-5.4",
     });
+  });
+
+  it("keeps the deterministic restart proof on one inbound turn across three lifecycles", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("gateway-restart-inflight-run"));
+    const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
+    const contract = JSON.stringify(scenario.execution.flow);
+    const checkpointLoop = actions.find(
+      (action): action is { forEach: { items: unknown[]; actions: unknown[] } } =>
+        typeof action === "object" && action !== null && "forEach" in action,
+    );
+    const checkpointActions = checkpointLoop?.forEach.actions ?? [];
+    const pendingWaitIndex = checkpointActions.findIndex(
+      (action) =>
+        (action as { call?: string; saveAs?: string }).call === "waitForCondition" &&
+        (action as { saveAs?: string }).saveAs === "checkpointTranscript",
+    );
+    const checkpointStoreIndex = checkpointActions.findIndex(
+      (action) =>
+        (action as { call?: string; saveAs?: string }).call === "readRawQaSessionStore" &&
+        (action as { saveAs?: string }).saveAs === "checkpointStore",
+    );
+    const checkpointPersistenceIndex = checkpointActions.findIndex((action) => {
+      const expression = readFlowAssertExpression(action);
+      return (
+        expression.includes("checkpointTranscript.userMessageCount >= 1") &&
+        expression.includes("checkpointTranscript.probeTextEndLine ?? 0") &&
+        expression.includes("restartRecoveryDeliveryContext?.channel === 'qa-channel'") &&
+        expression.includes("restartRecoveryDeliveryContext.to === `dm:${conversationId}`")
+      );
+    });
+    const restartIndex = checkpointActions.findIndex(
+      (action) => (action as { call?: string }).call === "restartGatewayWithConfigPatch",
+    );
+    const outboundIndex = actions.findIndex(
+      (action) =>
+        (action as { call?: string; saveAs?: string }).call === "waitForOutboundMessage" &&
+        (action as { saveAs?: string }).saveAs === "outbound",
+    );
+    const quietWindowIndex = actions.findIndex(
+      (action) => typeof action === "object" && action !== null && "waitForNoOutbound" in action,
+    );
+
+    expect(scenario.execution).toMatchObject({
+      retryCount: 0,
+      suiteIsolation: "isolated",
+    });
+    expect(scenario.gatewayConfigPatch).toMatchObject({
+      logging: { audit: { executionIdentity: true } },
+      plugins: {
+        slots: { memory: "none" },
+        entries: {
+          acpx: { enabled: false },
+          "memory-core": { enabled: false },
+        },
+      },
+      tools: {
+        alsoAllow: ["qa_restart_wait", "qa_restart_unsafe_probe"],
+      },
+    });
+    expect(checkpointLoop?.forEach.items).toEqual([1, 2, 3]);
+    expect(contract.match(/"sendInbound"/gu)).toHaveLength(1);
+    expect(contract).not.toContain("startAgentRun");
+    expect(contract).not.toContain("chat.send");
+    expect(contract).toContain("completedToolCallCounts.wait ?? 0) < checkpoint");
+    expect(contract).toContain("probeText: config.promptMarker");
+    expect(pendingWaitIndex).toBeGreaterThanOrEqual(0);
+    expect(checkpointStoreIndex).toBeGreaterThan(pendingWaitIndex);
+    expect(checkpointPersistenceIndex).toBeGreaterThan(checkpointStoreIndex);
+    expect(restartIndex).toBeGreaterThan(checkpointPersistenceIndex);
+    expect(contract).toContain("checkpointEntry.restartRecoveryDeliveryRunId");
+    expect(contract).toContain("checkpointEntry.restartRecoveryRuns?.find");
+    expect(contract).toContain("currentDeliveryFence.lifecycleGeneration");
+    expect(contract).toContain("runQaCli(env, ['audit', '--run', auditAnchorRunId");
+    expect(contract).toContain("capturedAuditAnchorInspection.identity.context");
+    expect(contract).toContain("postDeliveryAuditAnchorInspection.identity.context");
+    expect(contract).toContain(
+      "JSON.stringify(postDeliveryAuditAnchorIdentity) === JSON.stringify(auditAnchorIdentity)",
+    );
+    expect(contract).toContain("checkpointDeliveryRunIds.length === 3");
+    expect(contract).toContain("checkpointDeliveryRunIds[2] !== checkpointDeliveryRunIds[1]");
+    expect(contract).toContain("auditAnchorIdentity !== null");
+    expect(contract).not.toContain("finalInterruptedRunId");
+    expect(contract).not.toContain("auditedIdentities");
+    expect(contract).not.toContain("inspectQaRestartRecoveryIdentity");
+    expect(contract).not.toContain("mainRestartRecovery?.executionIdentity");
+    expect(contract).toContain("assistantToolCallCounts.exec ?? 0) === 3");
+    expect(contract).toContain("assistantToolCallCounts.wait ?? 0) >= 3");
+    expect(contract).toContain("recoveryDispatches === 3 && retainedPolicies === 3");
+    expect(contract).toContain("finalMatches.length === 1");
+    expect(contract).toContain("restartNotices.length === 0");
+    expect(contract).toContain("unsafeVisible=false");
+    expect(contract).toContain("!recoveryLogs.includes('unsafe-probe-executed')");
+    expect(restartIndex).toBeGreaterThan(checkpointPersistenceIndex);
+    expect(outboundIndex).toBeGreaterThanOrEqual(0);
+    expect(quietWindowIndex).toBeGreaterThan(outboundIndex);
+    expect(actions[quietWindowIndex]).toMatchObject({
+      waitForNoOutbound: {
+        quietMs: 3000,
+        sinceIndex: { ref: "outboundCountAfterDelivery" },
+      },
+    });
+    expect(actions.some((action) => (action as { call?: string }).call === "sleep")).toBe(false);
   });
 
   it("scopes prompt diagnostics to requests after each scenario cursor", () => {

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -1,4 +1,4 @@
-title: Gateway restart Code Mode wait recovery
+title: Gateway three-restart Code Mode wait recovery
 
 scenario:
   id: gateway-restart-inflight-run
@@ -9,6 +9,8 @@ scenario:
     secondary:
       - gateway.restart-and-stop-gateway-restart
       - session-memory.recovery-delivery
+  gatewayRuntime:
+    preserveDebugArtifacts: true
   gatewayConfigPatch:
     # Channel restart recovery deliberately fails closed when reply hooks are active.
     # This scenario isolates the replay-safe Code Mode contract from those hooks.
@@ -20,6 +22,9 @@ scenario:
           enabled: false
         memory-core:
           enabled: false
+    logging:
+      audit:
+        executionIdentity: true
     tools:
       alsoAllow:
         - qa_restart_wait
@@ -27,11 +32,11 @@ scenario:
       codeMode:
         enabled: true
         timeoutMs: 60000
-  objective: Verify replay-safe Code Mode work interrupted on its wait control reconstructs and delivers automatically after a gateway restart.
+  objective: Verify replay-safe Code Mode work reconstructs automatically through three sequential Gateway replacements while retaining one admitted turn and its audit identity.
   successCriteria:
-    - Scenario persists a Code Mode wait call before applying a restart-required config change.
-    - Gateway and qa-channel return healthy after the restart.
-    - The interrupted work reconstructs automatically under a host-owned restart-safe policy, rejects a non-replay-safe probe before execution, and emits its marker exactly once without a resend notice or manual follow-up.
+    - One qa-channel inbound turn persists three distinct pending Code Mode wait checkpoints before three restart-required config changes.
+    - Gateway and qa-channel return healthy after every restart while the delivery run and lifecycle fence rotate and the original audit identity remains stable.
+    - The interrupted work reconstructs automatically under a host-owned restart-safe policy, hides the non-replay-safe probe, and emits its marker exactly once without a resend notice or manual follow-up.
   docsRefs:
     - docs/gateway/configuration.md
     - docs/automation/tasks.md
@@ -45,16 +50,19 @@ scenario:
     runtime: openclaw
     timeoutMs: 420000
     retryCount: 0
-    summary: Restart while replay-safe Code Mode wait is executing, then verify automatic reconstruction and delivery.
+    summary: Restart three times while replay-safe Code Mode waits are pending, then verify identity-preserving automatic reconstruction and delivery.
+    suiteIsolation: isolated
+    isolationReason: Replaces the Gateway child three times and inspects one persistent in-flight session.
     config:
       requiredProviderMode: mock-openai
-      prompt: "Code Mode restart wait QA check. Reply exactly: RESTART-CODE-MODE-WAIT-OK"
-      interruptedMarker: RESTART-CODE-MODE-WAIT-OK
+      prompt: "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT. Complete three sequential restart checkpoints, then reply with exactly two lines: unsafeVisible=false and RESTART-CODE-MODE-WAIT-OK"
+      promptMarker: RESTART-CODE-MODE-PROMPT
+      finalMarker: RESTART-CODE-MODE-WAIT-OK
       restartNoticeNeedle: "couldn't safely resume"
 
 flow:
   steps:
-    - name: completes one in-flight run across restart
+    - name: completes one in-flight run across three restarts
       actions:
         - call: waitForGatewayHealthy
           args:
@@ -77,12 +85,18 @@ flow:
         - set: sessionKey
           value:
             expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: transport.accountId, peer: { kind: 'direct', id: `dm:${conversationId}` }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
-        - set: restartPatch
-          value:
-            expr: "({ gateway: { controlUi: { allowedOrigins: [`http://127.0.0.1:${64000 + Math.floor(Math.random() * 999)}`] } }, tools: { codeMode: { enabled: false } } })"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+        - set: checkpointDeliveryRunIds
+          value:
+            expr: "[]"
+        - set: checkpointLifecycleFences
+          value:
+            expr: "[]"
+        - set: auditAnchorIdentity
+          value:
+            expr: "null"
         # Real channel ingress owns the durable delivery context needed by recovery.
         # Synthetic chat/agent RPC starts cannot prove recovered channel delivery.
         - sendInbound:
@@ -96,114 +110,207 @@ flow:
             senderName: QA Restart Operator
             text:
               expr: config.prompt
-        - call: waitForCondition
-          saveAs: plannedWait
-          args:
-            - lambda:
-                async: true
-                expr: "fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`).then((requests) => requests.find((request) => request.plannedToolName === 'wait' && String(request.allInputText ?? '').includes(config.interruptedMarker)))"
-            - expr: liveTurnTimeoutMs(env, 120000)
-            - 25
-        - call: waitForCondition
-          saveAs: interruptedTranscript
-          args:
-            - lambda:
-                async: true
-                expr: "readSessionTranscriptSummary(env, sessionKey).then((summary) => summary.lastMessageRole === 'assistant' && summary.lastAssistantToolNames?.includes('wait') ? summary : undefined)"
-            - expr: liveTurnTimeoutMs(env, 120000)
-            - 25
-        - call: readRawQaSessionStore
-          saveAs: preRestartStore
-          args:
-            - ref: env
-        - set: preRestartEntry
-          value:
-            expr: preRestartStore[sessionKey]
-        - assert:
-            expr: "preRestartEntry?.restartRecoveryDeliveryContext?.channel === 'qa-channel' && preRestartEntry.restartRecoveryDeliveryContext.to === `dm:${conversationId}`"
-            message:
-              expr: "`restart recovery delivery claim missing before restart: ${JSON.stringify(preRestartEntry ?? null)}`"
-        - call: restartGatewayWithConfigPatch
-          args:
-            - env:
-                ref: env
-              patch:
-                ref: restartPatch
-        - call: waitForGatewayHealthy
-          args:
-            - ref: env
-            - 180000
-        - call: waitForQaChannelReady
-          args:
-            - ref: env
-            - 180000
-        - call: waitForCondition
-          saveAs: settledRecovery
-          args:
-            - lambda:
-                async: true
-                expr: "(async () => { const recoveryRequests = env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)) : []; const restartRecoveryRequests = recoveryRequests.filter((request) => String(request.prompt ?? '').includes('Your previous turn was interrupted by a gateway restart') && String(request.allInputText ?? '').includes(config.interruptedMarker)); const transcript = await readSessionTranscriptSummary(env, sessionKey); return restartRecoveryRequests.length >= 1 && transcript.lastMessageRole === 'assistant' && String(transcript.finalText ?? '').includes(config.interruptedMarker) ? { recoveryRequests, restartRecoveryRequests, transcript } : undefined; })()"
-            - expr: liveTurnTimeoutMs(env, 120000)
-            - 25
-        - set: recoveryRequestsBeforeOutbound
-          value:
-            expr: settledRecovery.recoveryRequests
-        - set: restartRecoveryRequestsBeforeOutbound
-          value:
-            expr: settledRecovery.restartRecoveryRequests
-        - set: postRestartTranscript
-          value:
-            expr: settledRecovery.transcript
-        - assert:
-            expr: "postRestartTranscript.lastAssistantStopReason !== 'error' && postRestartTranscript.lastAssistantStopReason !== 'aborted'"
-            message:
-              expr: "`restart recovery left an abort artifact: ${JSON.stringify(postRestartTranscript)}`"
-        - assert:
-            expr: "restartRecoveryRequestsBeforeOutbound.length === 1 && String(restartRecoveryRequestsBeforeOutbound[0].prompt ?? '').includes('Your previous turn was interrupted by a gateway restart') && String(restartRecoveryRequestsBeforeOutbound[0].allInputText ?? '').includes(config.interruptedMarker)"
-            message:
-              expr: "`expected exactly one scoped restart recovery provider request before delivery, got ${restartRecoveryRequestsBeforeOutbound.length}; total post-cursor requests=${recoveryRequestsBeforeOutbound.length}`"
-        - assert:
-            expr: "!String(restartRecoveryRequestsBeforeOutbound[0].prompt ?? '').includes('[OpenClaw heartbeat poll]')"
-            message: restart recovery provider request was replaced by a heartbeat poll
+          saveAs: inbound
+        - forEach:
+            items:
+              - 1
+              - 2
+              - 3
+            item: checkpoint
+            actions:
+              - call: waitForCondition
+                saveAs: checkpointTranscript
+                args:
+                  - lambda:
+                      async: true
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.promptMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint ? summary : undefined).catch(() => undefined)"
+                  - expr: liveTurnTimeoutMs(env, 120000)
+                  - 25
+              - assert:
+                  expr: "(checkpointTranscript.completedToolCallCounts.wait ?? 0) < checkpoint"
+                  message:
+                    expr: "`checkpoint ${checkpoint} wait was not pending before restart: ${JSON.stringify(checkpointTranscript)}`"
+              - set: checkpointRequests
+                value:
+                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => request.plannedToolName === 'qa_restart_wait' && request.plannedWireToolName === 'exec')"
+              - assert:
+                  expr: "checkpointRequests.length === checkpoint"
+                  message:
+                    expr: "`checkpoint ${checkpoint} was not issued exactly once in sequence: ${JSON.stringify(checkpointRequests)}`"
+              - call: readRawQaSessionStore
+                saveAs: checkpointStore
+                args:
+                  - ref: env
+              - set: checkpointEntry
+                value:
+                  expr: checkpointStore[sessionKey]
+              - assert:
+                  expr: "Boolean(checkpointEntry) && checkpointTranscript.userMessageCount >= 1 && checkpointTranscript.eventCursor > 0 && (checkpointTranscript.probeTextEndLine ?? 0) > 0 && checkpointEntry.restartRecoveryDeliveryContext?.channel === 'qa-channel' && checkpointEntry.restartRecoveryDeliveryContext.to === `dm:${conversationId}`"
+                  message:
+                    expr: "`checkpoint ${checkpoint} did not persist the one original prompt and canonical delivery claim: entry=${JSON.stringify(checkpointEntry ?? null)} transcript=${JSON.stringify(checkpointTranscript)}`"
+              - set: currentDeliveryRunId
+                value:
+                  expr: checkpointEntry.restartRecoveryDeliveryRunId
+              - set: currentDeliveryFence
+                value:
+                  expr: "checkpointEntry.restartRecoveryRuns?.find((candidate) => candidate.runId === currentDeliveryRunId)"
+              - assert:
+                  expr: "typeof currentDeliveryRunId === 'string' && (checkpoint === 1 || Boolean(currentDeliveryFence)) && (checkpoint <= 2 || (currentDeliveryRunId !== checkpointDeliveryRunIds.at(-1) && currentDeliveryFence.lifecycleGeneration !== checkpointLifecycleFences.at(-1).lifecycleGeneration))"
+                  message:
+                    expr: "`checkpoint ${checkpoint} did not rotate the accepted delivery run/lifecycle fence before its next generation: deliveryRun=${currentDeliveryRunId} fence=${JSON.stringify(currentDeliveryFence)} priorDeliveryRuns=${JSON.stringify(checkpointDeliveryRunIds)} priorFences=${JSON.stringify(checkpointLifecycleFences)}`"
+              - if:
+                  expr: "checkpoint > 1 && currentDeliveryRunId !== checkpointDeliveryRunIds.at(-1) && auditAnchorIdentity === null"
+                  then:
+                    - set: auditAnchorRunId
+                      value:
+                        expr: checkpointDeliveryRunIds.at(-1)
+                    - call: waitForCondition
+                      saveAs: capturedAuditAnchorInspection
+                      args:
+                        - lambda:
+                            async: true
+                            expr: "runQaCli(env, ['audit', '--run', auditAnchorRunId, '--explain', '--json'], { timeoutMs: 60000, json: true }).then((value) => value.identity?.state === 'present' ? value : undefined).catch(() => undefined)"
+                        - 60000
+                        - 250
+                    - set: capturedAuditAnchorIdentity
+                      value:
+                        expr: capturedAuditAnchorInspection.identity.context
+                    - assert:
+                        expr: "capturedAuditAnchorIdentity.runId === auditAnchorRunId"
+                        message:
+                          expr: "`checkpoint ${checkpoint} could not capture the original admitted audit identity for run ${auditAnchorRunId}: ${JSON.stringify(capturedAuditAnchorIdentity)}`"
+                    - set: auditAnchorIdentity
+                      value:
+                        expr: capturedAuditAnchorIdentity
+              - set: checkpointDeliveryRunIds
+                value:
+                  expr: "[...checkpointDeliveryRunIds, currentDeliveryRunId]"
+              - set: checkpointLifecycleFences
+                value:
+                  expr: "currentDeliveryFence ? [...checkpointLifecycleFences, currentDeliveryFence] : checkpointLifecycleFences"
+              - call: restartGatewayWithConfigPatch
+                args:
+                  - env:
+                      ref: env
+                    patch:
+                      gateway:
+                        controlUi:
+                          allowedOrigins:
+                            - expr: "`http://127.0.0.1:${64000 + checkpoint}`"
+              - call: waitForGatewayHealthy
+                args:
+                  - ref: env
+                  - 180000
+              - call: waitForQaChannelReady
+                args:
+                  - ref: env
+                  - 180000
+              - call: waitForCondition
+                args:
+                  - lambda:
+                      expr: "readGatewayLogs().slice(gatewayLogCursor).split('dispatching restart-safe recovery').length - 1 >= checkpoint ? true : undefined"
+                  - expr: liveTurnTimeoutMs(env, 120000)
+                  - 25
         - call: waitForOutboundMessage
           saveAs: outbound
           args:
             - ref: state
             - lambda:
                 params: [candidate]
-                expr: "candidate.conversation.id === conversationId && candidate.text.includes(config.interruptedMarker)"
+                expr: "candidate.conversation.id === conversationId && candidate.text.includes(config.finalMarker)"
             - expr: liveTurnTimeoutMs(env, 180000)
             - sinceIndex:
                 ref: startIndex
-        - set: settledRecoveryRequests
+        - set: outboundCountAfterDelivery
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - waitForNoOutbound:
+            quietMs: 3000
+            sinceIndex:
+              ref: outboundCountAfterDelivery
+        - assert:
+            expr: "auditAnchorIdentity !== null"
+            message: third replacement completed without capturing the original admitted audit identity
+        - set: auditAnchorRunId
+          value:
+            expr: auditAnchorIdentity.runId
+        - call: waitForCondition
+          saveAs: postDeliveryAuditAnchorInspection
+          args:
+            - lambda:
+                async: true
+                expr: "runQaCli(env, ['audit', '--run', auditAnchorRunId, '--explain', '--json'], { timeoutMs: 60000, json: true }).then((value) => value.identity?.state === 'present' ? value : undefined).catch(() => undefined)"
+            - 60000
+            - 250
+        - set: postDeliveryAuditAnchorIdentity
+          value:
+            expr: postDeliveryAuditAnchorInspection.identity.context
+        - assert:
+            expr: "postDeliveryAuditAnchorIdentity.runId === auditAnchorRunId && postDeliveryAuditAnchorIdentity.contextId === auditAnchorIdentity.contextId && postDeliveryAuditAnchorIdentity.executionId === auditAnchorIdentity.executionId && JSON.stringify(postDeliveryAuditAnchorIdentity) === JSON.stringify(auditAnchorIdentity)"
+            message:
+              expr: "`original admitted audit identity changed after the third replacement: anchor=${JSON.stringify(auditAnchorIdentity)} afterDelivery=${JSON.stringify(postDeliveryAuditAnchorIdentity)}`"
+        - call: readSessionTranscriptSummary
+          saveAs: finalTranscript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - set: settledRequests
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)) : []"
-        - set: settledRestartRecoveryRequests
+        - set: finalMatches
           value:
-            expr: "settledRecoveryRequests.filter((request) => String(request.prompt ?? '').includes('Your previous turn was interrupted by a gateway restart') && String(request.allInputText ?? '').includes(config.interruptedMarker))"
-        - assert:
-            expr: "settledRestartRecoveryRequests.length === 1 && settledRestartRecoveryRequests[0].cursor === restartRecoveryRequestsBeforeOutbound[0].cursor"
-            message:
-              expr: "`restart recovery provider request was duplicated after delivery: before=${JSON.stringify(restartRecoveryRequestsBeforeOutbound)} settled=${JSON.stringify(settledRestartRecoveryRequests)}`"
-        - set: interruptedMatches
+            expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && candidate.text.includes(config.finalMarker))"
+        - set: inboundMatches
           value:
-            expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && candidate.text.includes(config.interruptedMarker))"
-        - assert:
-            expr: "interruptedMatches.length === 1"
-            message:
-              expr: "`expected exactly one automatically recovered marker, got ${interruptedMatches.length}; outbound=${recentOutboundSummary(state)}`"
+            expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'inbound' && candidate.conversation.id === conversationId && candidate.text.includes(config.promptMarker))"
         - set: restartNotices
           value:
             expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && candidate.text.includes(config.restartNoticeNeedle))"
         - assert:
+            expr: "inboundMatches.length === 1 && inboundMatches[0].id === inbound.id"
+            message:
+              expr: "`expected one real qa-channel inbound turn, got ${inboundMatches.length}`"
+        - assert:
+            expr: "finalMatches.length === 1 && outbound.text.split(config.finalMarker).length - 1 === 1"
+            message:
+              expr: "`expected exactly one automatically recovered marker, got ${finalMatches.length}; outbound=${recentOutboundSummary(state)}`"
+        - assert:
             expr: "restartNotices.length === 0"
             message:
               expr: "`automatic recovery emitted ${restartNotices.length} resend notice(s); outbound=${recentOutboundSummary(state)}`"
+        - assert:
+            expr: "outbound.text.includes('unsafeVisible=false') && !settledRequests.some((request) => request.plannedToolName === 'qa_restart_unsafe_probe') && !String(finalTranscript.finalText ?? '').includes('unsafe-probe-executed')"
+            message:
+              expr: "`unsafe probe became visible or executed: outbound=${outbound.text} requests=${JSON.stringify(settledRequests)} transcript=${JSON.stringify(finalTranscript)}`"
+        - assert:
+            expr: "(finalTranscript.assistantToolCallCounts.exec ?? 0) === 3 && (finalTranscript.assistantToolCallCounts.wait ?? 0) >= 3 && checkpointDeliveryRunIds.length === 3 && new Set(checkpointDeliveryRunIds).size >= 2 && checkpointDeliveryRunIds[2] !== checkpointDeliveryRunIds[1] && auditAnchorIdentity !== null"
+            message:
+              expr: "`expected three checkpoint pairs, accepted-delivery rotation, and one stable audit anchor: transcript=${JSON.stringify(finalTranscript)} deliveryRuns=${JSON.stringify(checkpointDeliveryRunIds)} auditAnchor=${JSON.stringify(auditAnchorIdentity)}`"
+        - assert:
+            expr: "finalTranscript.lastAssistantStopReason !== 'error' && finalTranscript.lastAssistantStopReason !== 'aborted'"
+            message:
+              expr: "`restart recovery left a terminal artifact: ${JSON.stringify(finalTranscript)}`"
         - set: recoveryLogs
           value:
             expr: readGatewayLogs().slice(gatewayLogCursor)
+        - set: recoveryDispatches
+          value:
+            expr: "recoveryLogs.split('dispatching restart-safe recovery').length - 1"
+        - set: retainedPolicies
+          value:
+            expr: "recoveryLogs.split('restart-safe recovery tool policy retained').length - 1"
         - assert:
-            expr: "recoveryLogs.includes('dispatching restart-safe recovery') && recoveryLogs.includes('restart-safe recovery tool policy retained')"
+            expr: "recoveryDispatches === 3 && retainedPolicies === 3"
             message:
-              expr: "`restart-safe host policy was not observed; logs=${recoveryLogs}`"
-      detailsExpr: "`session=${sessionKey} plannedTool=${plannedWait.plannedToolName} persistedTail=${interruptedTranscript.lastMessageRole}/${interruptedTranscript.lastAssistantStopReason}/${interruptedTranscript.lastAssistantToolNames?.join(',')} recoveredTail=${postRestartTranscript.lastMessageRole}/${postRestartTranscript.lastAssistantStopReason}/${postRestartTranscript.lastAssistantContentTypes?.join(',')} recoveredMarkers=${interruptedMatches.length} resendNotices=${restartNotices.length} restartSafePolicy=true recoveryPromptHeartbeat=false\\n${outbound.text}`"
+              expr: "`expected exactly three restart-safe dispatches and retained policies; dispatches=${recoveryDispatches} retained=${retainedPolicies}`"
+        - assert:
+            expr: "!recoveryLogs.includes('unsafe-probe-executed')"
+            message: non-replay-safe QA probe executed during recovery
+        - assert:
+            expr: "!recoveryLogs.split(String.fromCharCode(10)).some((line) => line.includes('tool policy removed') && line.includes('qa_restart_wait'))"
+            message: replay-safe QA checkpoint tool was removed before Code Mode catalog construction
+        - call: assertNoGatewayLogSentinels
+          args:
+            - sinceIndex:
+                ref: gatewayLogCursor
+      detailsExpr: "`inboundMessageId=${inbound.id} session=${sessionKey} restarts=3 execs=${finalTranscript.assistantToolCallCounts.exec ?? 0} waits=${finalTranscript.assistantToolCallCounts.wait ?? 0} deliveryRunIds=${checkpointDeliveryRunIds.join(',')} auditAnchorRunId=${auditAnchorIdentity.runId} recoveryDispatches=${recoveryDispatches} retainedPolicies=${retainedPolicies} finalDeliveries=${finalMatches.length} resendNotices=${restartNotices.length}\n${outbound.text}`"

--- a/src/agents/admitted-run-context.test.ts
+++ b/src/agents/admitted-run-context.test.ts
@@ -117,6 +117,38 @@ describe("prepared run admission", () => {
     expect(work).toEqual({ kind: "retry-reference", token });
   });
 
+  it("adopts an original retry token only for its explicitly bound operational run", async () => {
+    const token = createExecutionIdentityAdmissionToken("original-run");
+    let work: ExecutionIdentityAdmissionWork | undefined;
+    cleanupSink = configureExecutionIdentityAdmissionSink((candidate) => {
+      work = candidate;
+      return true;
+    });
+    const rejected = createExecutionIdentityRecoveryAdmission({
+      retryOnly: true,
+      token,
+      expectedOperationalRunId: facts.runId,
+    });
+
+    expect(rejected.consume("other-operational-run")).toEqual({ accepted: false });
+    expect(rejected.consume(facts.runId)).toEqual({ accepted: false });
+
+    const { runtime, ...admissionFacts } = facts;
+    const admitted = await prepareAgentRunAdmission({
+      cfg: enabledConfig,
+      facts: admissionFacts,
+      operationalRunInstance: createOperationalRunInstanceRef(facts.runId),
+      recovery: createExecutionIdentityRecoveryAdmission({
+        retryOnly: true,
+        token,
+        expectedOperationalRunId: facts.runId,
+      }),
+    }).admit(runtime.kind);
+
+    expect(admitted.executionIdentityToken).toBe(token);
+    expect(work).toEqual({ kind: "retry-reference", token });
+  });
+
   it("keeps missing or mismatched recovery identity unbound", async () => {
     const sink = vi.fn((_work: ExecutionIdentityAdmissionWork) => true);
     cleanupSink = configureExecutionIdentityAdmissionSink(sink);

--- a/src/agents/admitted-run-context.ts
+++ b/src/agents/admitted-run-context.ts
@@ -126,6 +126,7 @@ type ExecutionIdentityRecoveryAdmission = Readonly<{
 export function createExecutionIdentityRecoveryAdmission(params: {
   retryOnly: boolean;
   token?: ExecutionIdentityAdmissionToken;
+  expectedOperationalRunId?: string;
 }): ExecutionIdentityRecoveryAdmission {
   let consumed = false;
   return Object.freeze({
@@ -135,7 +136,18 @@ export function createExecutionIdentityRecoveryAdmission(params: {
         return Object.freeze({ accepted: false });
       }
       consumed = true;
-      const token = params.token?.runId === runId ? params.token : undefined;
+      if (
+        params.expectedOperationalRunId !== undefined &&
+        params.expectedOperationalRunId !== runId
+      ) {
+        return Object.freeze({ accepted: false });
+      }
+      // The trusted recovery resolver binds the current operational owner separately.
+      // Without that explicit binding, only the token's original run may redeem it.
+      const token =
+        params.expectedOperationalRunId !== undefined || params.token?.runId === runId
+          ? params.token
+          : undefined;
       return Object.freeze({ accepted: true, ...(token ? { token } : {}) });
     },
   });

--- a/src/agents/main-session-recovery/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.test.ts
@@ -565,7 +565,7 @@ describe("main session recovery state", () => {
     expect(entry.mainRestartRecovery?.reservation).toBeUndefined();
   });
 
-  it("rekeys stored execution identity when a new lifecycle rotates the recovery run", () => {
+  it("preserves stored execution identity when a new lifecycle rotates the recovery run", () => {
     const storedToken = createExecutionIdentityAdmissionToken("recovery-old", {
       contextId: "context-1",
       executionId: "execution-1",
@@ -590,23 +590,32 @@ describe("main session recovery state", () => {
       reservation: {
         executionIdentityAdmission: {
           kind: "retry-reference",
-          token: {
-            tokenVersion: 1,
-            contextId: "context-1",
-            executionId: "execution-1",
-            runId: "recovery-new",
-            createdAt: 123,
-          },
+          token: storedToken,
         },
       },
     });
-    expect(entry.mainRestartRecovery?.executionIdentity).toEqual({
-      tokenVersion: 1,
-      contextId: "context-1",
-      executionId: "execution-1",
-      runId: "recovery-new",
-      createdAt: 123,
-    });
+    expect(entry.mainRestartRecovery?.executionIdentity).toBe(storedToken);
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "admit_recovery",
+        lifecycleGeneration: "generation-new",
+        now: 201,
+        runId: "recovery-new",
+        sessionId: "session-1",
+      }),
+    ).toEqual({ kind: "admitted_recovery" });
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "bind_admitted_execution_identity",
+        attempt: 1,
+        cycleId: "cycle-1",
+        lifecycleGeneration: "generation-new",
+        runId: "recovery-new",
+        sessionId: "session-1",
+        token: storedToken,
+      }),
+    ).toEqual({ kind: "no_change" });
   });
 
   it("preserves a stored execution identity when the recovery run is unchanged", () => {

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -1,4 +1,3 @@
-import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
   sanitizePendingFinalDeliveryText,
@@ -383,13 +382,7 @@ export function transitionMainSessionRecovery(
       }
       const retryExecutionIdentity =
         command.executionIdentity.state === "enabled" && state.executionIdentity
-          ? state.executionIdentity.runId === command.runId
-            ? state.executionIdentity
-            : createExecutionIdentityAdmissionToken(command.runId, {
-                contextId: state.executionIdentity.contextId,
-                executionId: state.executionIdentity.executionId,
-                now: state.executionIdentity.createdAt,
-              })
+          ? state.executionIdentity
           : undefined;
       const executionIdentityAdmission = retryExecutionIdentity
         ? ({ kind: "retry-reference", token: retryExecutionIdentity } as const)
@@ -429,8 +422,7 @@ export function transitionMainSessionRecovery(
         !entry.restartRecoveryRuns?.some(
           (run) =>
             run.runId === command.runId && run.lifecycleGeneration === command.lifecycleGeneration,
-        ) ||
-        command.token.runId !== command.runId
+        )
       ) {
         return { kind: "rejected", reason: "stale_reservation" };
       }
@@ -438,6 +430,9 @@ export function transitionMainSessionRecovery(
         return JSON.stringify(state.executionIdentity) === JSON.stringify(command.token)
           ? { kind: "no_change" }
           : { kind: "rejected", reason: "stale_reservation" };
+      }
+      if (command.token.runId !== command.runId) {
+        return { kind: "rejected", reason: "stale_reservation" };
       }
       updateRecoveryState(entry, state, { executionIdentity: command.token });
       return { kind: "applied" };

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -1434,7 +1434,7 @@ describe("main-session-restart-recovery", () => {
     ).toBe(2);
   });
 
-  it("rekeys recovery identity after a prior-lifecycle recovery was admitted", async () => {
+  it("preserves recovery identity when a prior-lifecycle delivery run rotates", async () => {
     const previousRecoveryRunId = "recovery-run-a";
     const sourceRunId = "channel-run";
     const previousExecutionIdentity = createExecutionIdentityAdmissionToken(previousRecoveryRunId, {
@@ -1487,13 +1487,7 @@ describe("main-session-restart-recovery", () => {
         });
         expect(gatewayAdmission?.consume(dispatchedRunId)).toEqual({
           accepted: true,
-          token: {
-            tokenVersion: 1,
-            contextId: previousExecutionIdentity.contextId,
-            executionId: previousExecutionIdentity.executionId,
-            runId: dispatchedRunId,
-            createdAt: previousExecutionIdentity.createdAt,
-          },
+          token: previousExecutionIdentity,
         });
         const recoveryMessage = {
           role: "user" as const,
@@ -1523,20 +1517,15 @@ describe("main-session-restart-recovery", () => {
       idempotencyKey: dispatchedRunId,
       to: "discord:dm:123",
     });
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
-      mainRestartRecovery: {
-        executionIdentity: {
-          tokenVersion: 1,
-          contextId: previousExecutionIdentity.contextId,
-          executionId: previousExecutionIdentity.executionId,
-          runId: dispatchedRunId,
-          createdAt: previousExecutionIdentity.createdAt,
-        },
-      },
+    const recoveredEntry = loadSessionEntry({ sessionKey, storePath });
+    expect(recoveredEntry).toMatchObject({
       restartRecoveryDeliveryContext: discordDeliveryContext,
       restartRecoveryDeliveryRunId: dispatchedRunId,
       restartRecoveryDeliverySourceRunId: sourceRunId,
     });
+    expect(recoveredEntry?.mainRestartRecovery?.executionIdentity).toEqual(
+      previousExecutionIdentity,
+    );
     const transcript = await loadTestTranscript(sessionKey, storePath);
     expect(
       transcript

--- a/src/gateway/agent-turn/agent-restart-recovery-context.test.ts
+++ b/src/gateway/agent-turn/agent-restart-recovery-context.test.ts
@@ -96,7 +96,7 @@ describe("resolveAgentRestartRecoveryExecutionIdentityAdmission", () => {
     createdAt: 1,
   };
 
-  it("rehydrates the durable token for capture and exact retry without runtime reconstruction", () => {
+  it("rehydrates the durable token across rotated operational recovery runs", () => {
     const sessionEntry = {
       ...matchingParams.sessionEntry,
       mainRestartRecovery: {
@@ -110,20 +110,20 @@ describe("resolveAgentRestartRecoveryExecutionIdentityAdmission", () => {
       collectionEnabled: true,
       isRestartRecoveryResumeRun: true,
       retryOnly: false,
-      runId: token.runId,
+      runId: "recovery-run-2",
       sessionEntry,
     });
     const retry = resolveAgentRestartRecoveryExecutionIdentityAdmission({
       collectionEnabled: true,
       isRestartRecoveryResumeRun: true,
       retryOnly: true,
-      runId: token.runId,
+      runId: "recovery-run-3",
       sessionEntry,
     });
     expect(first).toMatchObject({ retryOnly: false, consume: expect.any(Function) });
     expect(retry).toMatchObject({ retryOnly: true, consume: expect.any(Function) });
-    expect(first?.consume(token.runId)).toEqual({ accepted: true, token });
-    expect(retry?.consume(token.runId)).toEqual({ accepted: true, token });
+    expect(first?.consume("recovery-run-2")).toEqual({ accepted: true, token });
+    expect(retry?.consume("recovery-run-3")).toEqual({ accepted: true, token });
   });
 
   it("returns no token for ordinary runs and refuses lost recovery evidence", () => {

--- a/src/gateway/agent-turn/agent-restart-recovery-context.ts
+++ b/src/gateway/agent-turn/agent-restart-recovery-context.ts
@@ -31,13 +31,17 @@ export function resolveAgentRestartRecoveryExecutionIdentityAdmission(params: {
   const stored = (params.sessionEntry as InternalSessionEntry | undefined)?.mainRestartRecovery
     ?.executionIdentity;
   if (!stored) {
-    return createExecutionIdentityRecoveryAdmission({ retryOnly: params.retryOnly });
+    return createExecutionIdentityRecoveryAdmission({
+      retryOnly: params.retryOnly,
+      expectedOperationalRunId: params.runId,
+    });
   }
   const token = parseExecutionIdentityAdmissionToken(stored);
-  if (token.runId !== params.runId) {
-    throw new Error("restart recovery execution identity token disagrees with the admitted run");
-  }
-  return createExecutionIdentityRecoveryAdmission({ token, retryOnly: params.retryOnly });
+  return createExecutionIdentityRecoveryAdmission({
+    token,
+    retryOnly: params.retryOnly,
+    expectedOperationalRunId: params.runId,
+  });
 }
 
 /** Rehydrates durable channel authority only for the exact host-owned recovery run. */


### PR DESCRIPTION
Follow-up to #124746.

## What Problem This Solves

Fixes an issue where a qa-channel turn interrupted by several sequential Gateway replacements could not be proven deterministically in CI, and execution-identity collection could lose its durable retry reference when the recovery delivery run rotated.

## Why This Change Was Made

The existing mock restart scenario now drives three pending Code Mode checkpoints through real qa-channel ingress and derives each mock-openai response from transcript history rather than process-global counters. Recovery keeps the original execution-identity admission token byte-identical while separately binding each new operational delivery run, preserving the immutable audit record without weakening run-lifecycle fencing or the live GPT-5.4 scenario.

## User Impact

Operators get safer repeated Gateway restart recovery when execution-identity auditing is enabled: delivery run IDs can rotate without replacing the original admitted audit identity. Maintainers also get a deterministic CI-safe regression that proves three restarts, persisted channel delivery context, automatic reconstruction, and exactly-once final delivery.

AI-assisted; the implementation and resulting behavior were reviewed and verified against the owning recovery, audit, and qa-channel boundaries.

## Evidence

- Pre-fix deterministic QA failure: three recoveries and the final marker completed, but the scenario timed out waiting for `identity.state=present` on a rotated delivery run. The owner trace showed recovery had rekeyed an immutable retry token that durable audit verification intentionally requires byte-identical.
- Exact-head focused tests: 5 Vitest shards, 6 files, 498 tests passed.
- Exact-head mock QA scenario: `gateway-restart-inflight-run` passed in 189.1s with 3 exec checkpoints, 3 pending waits, 3 recovery dispatches, 3 retained restart-safe policies, rotated delivery run IDs, stable original audit identity, 1 final delivery, and 0 resend notices.
- Full changed gate: Testbox `tbx_01m06ybhbs6wwd3tvq6fy7sy3e`, all typecheck/lint/import-cycle/guard lanes passed. Backing run: https://github.com/openclaw/openclaw/actions/runs/31993281508
- Fresh autoreview on the rebased branch: clean, no accepted/actionable findings.
- Production delta: +11 lines across the recovery owner and trusted Gateway resolver. The remaining growth is deterministic QA fixture/scenario and regression coverage.
