### PR TITLE
fix(android): restore the 11sp size of link-preview and code-block labels

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.Dispatchers
@@ -189,7 +188,7 @@ private fun ChatLinkPreview(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(3.dp),
       ) {
-        Text(domain, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(domain, style = ClawTheme.type.captionSmall, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
         when (val preview = result) {
           null -> Text(nativeString("Loading preview…"), style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
           LinkPreviewResult.Failed -> Text(nativeString("No preview available"), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
@@ -523,7 +522,7 @@ fun ChatCodeBlock(
       if (!language.isNullOrBlank()) {
         Text(
           text = language.uppercase(Locale.US),
-          style = ClawTheme.type.caption.copy(letterSpacing = 0.4.sp),
+          style = ClawTheme.type.captionSmall,
           color = ClawTheme.colors.textMuted,
         )
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawTheme.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawTheme.kt
@@ -98,6 +98,7 @@ internal data class ClawTypography(
   val body: TextStyle,
   val label: TextStyle,
   val caption: TextStyle,
+  val captionSmall: TextStyle,
   val mono: TextStyle,
 )
 
@@ -260,6 +261,14 @@ private fun clawTypography(fontFamily: FontFamily) =
         fontSize = 12.5.sp,
         lineHeight = 16.sp,
         letterSpacing = 0.sp,
+      ),
+    captionSmall =
+      TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 14.sp,
+        letterSpacing = 0.4.sp,
       ),
     mono =
       TextStyle(


### PR DESCRIPTION
Follow-up to #125020.

## What Problem This Solves

Two small labels in the Android chat got bigger than they should be: the domain line on an expanded link
preview, and the language tag on a code block. Both are subordinate metadata that should sit quietly under the
content, and at 12.5sp they compete with it.

This was a known cost of #125020. That PR deleted the duplicate `MobileColors`/`mobile*` palette, and the
retired `mobileCaption2` style was 11sp / 14sp line / 0.4 letterSpacing. `ClawTypography` had no 11sp step, so
its two call sites were bumped to `type.caption` at 12.5sp rather than blocking the consolidation.

## Why This Change Was Made

`ClawTypography` gains one first-class `captionSmall` step carrying exactly the retired metrics, and the two
sites move onto it. The important distinction from what #125020 deliberately avoided: this is a real step in
the canonical scale, not a local `.copy()` at a call site or a second parallel type system — the shared
`caption` step is untouched, so the ~41 files using it are unaffected.

Scope is deliberately just those two sites. #125020 also moved a set of former **12sp** labels (collapsed
preview text, outbox status/action labels, image-state labels, markdown table headers) to 12.5sp, and those
stay put: a 12sp step sitting beside a 12.5sp step is not a type scale, it is the near-duplicate token pair
that PR just removed, and half a point is imperceptible. Verified against history that these two were the only
former `mobileCaption2` consumers.

## User Impact

The link-preview domain and code-block language tag return to their original size and read as metadata again.
Nothing else changes. Production LOC is +11/−3 (net +8) — the new scale step, partly paid for by deleting a
`.copy(letterSpacing = 0.4.sp)` override at the code-block label, which the token now carries natively and
which also retired an `sp` import.

## Evidence

**Before / after — dark**

| Before | After |
| --- | --- |
| <img width="360" src="https://github.com/user-attachments/assets/9501a246-b4d0-4100-8eb1-edb9e94bd106" /> | <img width="360" src="https://github.com/user-attachments/assets/641cce7b-17fa-4df4-af03-60a1e71f8d81" /> |

**Before / after — light**

| Before | After |
| --- | --- |
| <img width="360" src="https://github.com/user-attachments/assets/0876c7a5-bb34-4fe2-88cc-fff3fd884a73" /> | <img width="360" src="https://github.com/user-attachments/assets/03e813c5-5142-473a-bbcc-6f80034f4e1b" /> |

Captured from the deterministic `AndroidScreenshotScene.Chat` fixture, which gained a code block and a URL
preview in #125020 — so both changed sites are covered. Matched pairs in both themes this time; #125020
shipped dark-only pairs and that gap is closed here.

**Layout safety.** The domain label is `maxLines = 1` with ellipsis, so a size change could alter truncation.
Measured: the new styling renders 213 scaled units narrower, so it cannot truncate earlier than before. No
clipping or overlap at 11sp in either theme.

**Tests.** `pnpm android:format` and `pnpm android:lint` clean. Focused Gradle run green — 66 tests, zero
failures across `ChatMessageViewsTest`, `ChatTimelineTest`, `ChatMarkdownTest` and `AndroidScreenshotFixtureTest`.
Fresh autoreview clean.
