### PR TITLE
fix(security): warn on main-scoped group rooms

### DIFF
--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -30,7 +30,8 @@ If Gateway password auth is supplied only at startup, pass the same value with `
 
 **DM/trust model**
 
-- Warns when multiple DM senders share the main session and recommends secure DM mode: `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes. This is cooperative/shared-inbox hardening, not isolation for mutually untrusted operators; split trust boundaries with separate gateways (or separate OS users/hosts) for that. The same caveat applies to `session.groupScope: "main"` bindings, which merge every member of the matched room into the main session — reserve them for trusted rooms (see [Groups](/channels/groups#session-keys)).
+- Warns when multiple DM senders share the main session and recommends secure DM mode: `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes. This is cooperative/shared-inbox hardening, not isolation for mutually untrusted operators; split trust boundaries with separate gateways (or separate OS users/hosts) for that.
+- Emits `security.trust_model.group_scope_main` when global `session.groupScope="main"` or a binding override merges group/channel rooms into the main session. Every member of each matched room shares that context, so reserve this for trusted rooms (see [Groups](/channels/groups#session-keys)).
 - Emits `security.trust_model.multi_user_heuristic` when config suggests likely shared-user ingress (for example open DM/group policy, configured group targets, or wildcard sender rules) — OpenClaw's default trust model is personal-assistant (one operator), not hostile multi-tenant isolation. For intentional shared-user setups: sandbox all sessions, keep filesystem access workspace-scoped, and keep personal/private identities or credentials off that runtime.
 - Warns when small models (`<=300B` parameters) are used without sandboxing and with web/browser tools enabled.
 

--- a/src/commands/agents.binding-format.ts
+++ b/src/commands/agents.binding-format.ts
@@ -17,5 +17,8 @@ export function describeBinding(binding: AgentRouteBinding): string {
   if (match.teamId) {
     parts.push(`team=${match.teamId}`);
   }
+  if (match.roles?.length) {
+    parts.push(`roles=${match.roles.join(",")}`);
+  }
   return parts.join(" ");
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -828,6 +828,67 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   );
 }
 
+/** @internal Lists bindings selectable by at least one group/channel route under runtime precedence. */
+export function listEffectiveGroupRouteBindings(cfg: OpenClawConfig) {
+  const bindings = listBindings(cfg);
+  const usedIds = new Set<string>();
+  for (const binding of bindings) {
+    usedIds.add(normalizeAccountId(binding.match.accountId));
+    for (const value of [binding.match.peer?.id, binding.match.guildId, binding.match.teamId]) {
+      const normalized = normalizeRouteBindingId(value);
+      if (normalized) {
+        usedIds.add(normalized);
+      }
+    }
+  }
+  let sentinel = "openclaw-audit-route";
+  while (usedIds.has(sentinel)) {
+    sentinel += "-next";
+  }
+
+  const markerForIndex = (index: number) => `audit-binding-${index}`;
+  const probeCfg: OpenClawConfig = {
+    ...cfg,
+    agents: { entries: {} },
+    bindings: bindings.map((binding, index) => ({ ...binding, agentId: markerForIndex(index) })),
+  };
+
+  return bindings.filter((binding, index) => {
+    const match = normalizeBindingMatch(binding.match);
+    if (
+      match.peer.state === "invalid" ||
+      ((match.peer.state === "valid" || match.peer.state === "wildcard-kind") &&
+        match.peer.kind === "direct")
+    ) {
+      return false;
+    }
+    const peer: RoutePeer =
+      match.peer.state === "valid"
+        ? { kind: match.peer.kind, id: match.peer.id }
+        : match.peer.state === "wildcard-kind"
+          ? { kind: match.peer.kind, id: sentinel }
+          : { kind: "group", id: sentinel };
+    const accountId = match.accountPattern === "*" ? sentinel : match.accountPattern;
+    const roleWitnesses = match.roles?.map((role) => [role]) ?? [[]];
+
+    // Equality/wildcard fields need one fresh value for each open domain. Role matching
+    // is positive OR, so singleton candidate roles prove existence without sampling.
+    return roleWitnesses.some(
+      (memberRoleIds) =>
+        resolveAgentRoute({
+          cfg: probeCfg,
+          channel: binding.match.channel,
+          defaultAgentId: DEFAULT_AGENT_ID,
+          accountId,
+          peer,
+          guildId: match.guildId,
+          teamId: match.teamId,
+          memberRoleIds,
+        }).agentId === markerForIndex(index),
+    );
+  });
+}
+
 /** @internal Resolves fallback precedence for an unknown direct peer. */
 export function resolveUnknownDirectMessageRoute(
   input: Pick<ResolveAgentRouteInput, "cfg" | "channel" | "accountId" | "dmScope" | "groupScope">,

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1244,7 +1244,9 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const mainGroupScopes = listRouteBindings(cfg)
-    .filter((binding) => binding.session?.groupScope === "main")
+    .filter(
+      (binding) => binding.session?.groupScope === "main" && binding.match.peer?.kind !== "direct",
+    )
     .map(
       (binding) =>
         `- bindings[].session.groupScope="main": ${describeBinding(binding)} (agent=${binding.agentId})`,

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -13,6 +13,8 @@ import { isDangerousNetworkMode, normalizeNetworkMode } from "../agents/sandbox/
 import { getBlockedBindReason } from "../agents/sandbox/validate-sandbox-security.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { describeBinding } from "../commands/agents.binding-format.js";
+import { listRouteBindings } from "../config/bindings.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
@@ -1241,6 +1243,31 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 
 export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
+  const mainGroupScopes = listRouteBindings(cfg)
+    .filter((binding) => binding.session?.groupScope === "main")
+    .map(
+      (binding) =>
+        `- bindings[].session.groupScope="main": ${describeBinding(binding)} (agent=${binding.agentId})`,
+    );
+  if (cfg.session?.groupScope === "main") {
+    mainGroupScopes.unshift(
+      '- session.groupScope="main" (global: all group/channel rooms unless a binding overrides it)',
+    );
+  }
+  if (mainGroupScopes.length > 0) {
+    findings.push({
+      checkId: "security.trust_model.group_scope_main",
+      severity: "warn",
+      title: "Group rooms share the main session",
+      detail:
+        "The following group routing scopes merge room conversations into the agent main session:\n" +
+        mainGroupScopes.join("\n") +
+        "\nEvery member of each affected room shares the main-session context. Use this only for mutually trusted rooms.",
+      remediation:
+        'Use session.groupScope="per-group" globally and remove binding overrides, or reserve "main" for rooms whose members you trust: https://docs.openclaw.ai/channels/groups#session-keys',
+    });
+  }
+
   const signals = listPotentialMultiUserSignals(cfg);
   if (signals.length === 0) {
     return findings;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -14,7 +14,6 @@ import { getBlockedBindReason } from "../agents/sandbox/validate-sandbox-securit
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { describeBinding } from "../commands/agents.binding-format.js";
-import { listRouteBindings } from "../config/bindings.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
@@ -25,6 +24,7 @@ import {
   listDangerousPluginNodeCommands,
   resolveNodeCommandAllowlist,
 } from "../gateway/node-command-policy.js";
+import { listEffectiveGroupRouteBindings } from "../routing/resolve-route.js";
 import { collectAuditModelRefs } from "./audit-model-refs.js";
 import { GATEWAY_CONTROL_PLANE_TOOLS } from "./dangerous-tools.js";
 
@@ -1243,10 +1243,8 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 
 export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const mainGroupScopes = listRouteBindings(cfg)
-    .filter(
-      (binding) => binding.session?.groupScope === "main" && binding.match.peer?.kind !== "direct",
-    )
+  const mainGroupScopes = listEffectiveGroupRouteBindings(cfg)
+    .filter((binding) => binding.session?.groupScope === "main")
     .map(
       (binding) =>
         `- bindings[].session.groupScope="main": ${describeBinding(binding)} (agent=${binding.agentId})`,

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -221,6 +221,90 @@ describe("security audit trust model findings", () => {
         },
       },
       {
+        name: "does not warn for a main-scoped room binding shadowed by an earlier equivalent binding",
+        cfg: {
+          bindings: [
+            {
+              agentId: "isolated",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "group", id: "room-1" },
+              },
+              session: { groupScope: "per-group" },
+            },
+            {
+              agentId: "shared",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "channel", id: "room-1" },
+              },
+              session: { groupScope: "main" },
+            },
+          ],
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          expect(
+            findings.some((finding) => finding.checkId === "security.trust_model.group_scope_main"),
+          ).toBe(false);
+        },
+      },
+      {
+        name: "warns when a main-scoped room binding precedes an equivalent binding",
+        cfg: {
+          bindings: [
+            {
+              agentId: "shared",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "channel", id: "room-1" },
+              },
+              session: { groupScope: "main" },
+            },
+            {
+              agentId: "isolated",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "group", id: "room-1" },
+              },
+              session: { groupScope: "per-group" },
+            },
+          ],
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          const finding = requireGroupScopeMainFinding(findings);
+          expect(finding.detail).toContain("discord accountId=work peer=channel:room-1");
+        },
+      },
+      {
+        name: "warns for a more-specific main-scoped room binding after a broader binding",
+        cfg: {
+          bindings: [
+            {
+              agentId: "isolated",
+              match: { channel: "discord", accountId: "work" },
+              session: { groupScope: "per-group" },
+            },
+            {
+              agentId: "shared",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "group", id: "room-1" },
+              },
+              session: { groupScope: "main" },
+            },
+          ],
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          const finding = requireGroupScopeMainFinding(findings);
+          expect(finding.detail).toContain("discord accountId=work peer=group:room-1");
+        },
+      },
+      {
         name: "flags open dmPolicy when tools.elevated is enabled",
         cfg: {
           tools: { elevated: { enabled: true, allowFrom: { feishu: ["ou_123"] } } },

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -201,6 +201,26 @@ describe("security audit trust model findings", () => {
         },
       },
       {
+        name: "does not warn for a direct-only binding group scope",
+        cfg: {
+          bindings: [
+            {
+              agentId: "support",
+              match: {
+                channel: "whatsapp",
+                peer: { kind: "direct", id: "user-a" },
+              },
+              session: { groupScope: "main" },
+            },
+          ],
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          expect(
+            findings.some((finding) => finding.checkId === "security.trust_model.group_scope_main"),
+          ).toBe(false);
+        },
+      },
+      {
         name: "flags open dmPolicy when tools.elevated is enabled",
         cfg: {
           tools: { elevated: { enabled: true, allowFrom: { feishu: ["ou_123"] } } },

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -20,6 +20,16 @@ function requireMultiUserHeuristicFinding(findings: ReturnType<typeof audit>) {
   return finding;
 }
 
+function requireGroupScopeMainFinding(findings: ReturnType<typeof audit>) {
+  const finding = findings.find(
+    (entry) => entry.checkId === "security.trust_model.group_scope_main",
+  );
+  if (!finding) {
+    throw new Error("Expected group-scope main finding");
+  }
+  return finding;
+}
+
 describe("security audit trust model findings", () => {
   it("evaluates trust-model exposure findings", () => {
     const cases = [
@@ -140,6 +150,54 @@ describe("security audit trust model findings", () => {
               (finding) => finding.checkId === "security.trust_model.multi_user_heuristic",
             ),
           ).toBe(false);
+          expect(
+            findings.some((finding) => finding.checkId === "security.trust_model.group_scope_main"),
+          ).toBe(false);
+        },
+      },
+      {
+        name: "warns when global group scope shares all rooms with the main session",
+        cfg: {
+          session: { groupScope: "main" },
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          const finding = requireGroupScopeMainFinding(findings);
+          expect(finding).toMatchObject({
+            severity: "warn",
+            title: "Group rooms share the main session",
+          });
+          expect(finding.detail).toContain('session.groupScope="main"');
+          expect(finding.detail).toContain("all group/channel rooms");
+          expect(finding.remediation).toContain(
+            "https://docs.openclaw.ai/channels/groups#session-keys",
+          );
+        },
+      },
+      {
+        name: "warns with the matched room for binding group scope",
+        cfg: {
+          session: { groupScope: "per-group" },
+          bindings: [
+            {
+              agentId: "support",
+              match: {
+                channel: "discord",
+                accountId: "work",
+                peer: { kind: "channel", id: "1234567890" },
+                guildId: "9876543210",
+                roles: ["operators", "reviewers"],
+              },
+              session: { groupScope: "main" },
+            },
+          ],
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          const finding = requireGroupScopeMainFinding(findings);
+          expect(finding.severity).toBe("warn");
+          expect(finding.detail).toContain(
+            "discord accountId=work peer=channel:1234567890 guild=9876543210 roles=operators,reviewers",
+          );
+          expect(finding.detail).not.toContain("all group/channel rooms");
         },
       },
       {


### PR DESCRIPTION
Related: #124965

## What Problem This Solves

Fixes an issue where `openclaw security audit` stayed silent when global `session.groupScope="main"` or an effective group-capable binding override merged every member of matched group/channel rooms into the agent main session. That shared-context risk is stronger than the existing multi-DM-sender warning and should be visible to operators before they rely on the default personal-assistant trust model.

## Why This Change Was Made

The trust-model collector now emits `security.trust_model.group_scope_main` as a cooperative warning, lists the global scope and effective matching binding selectors, and links the group session-key guidance. Direct-only bindings are excluded because group scope has no runtime effect on DMs, and shadowed bindings are omitted according to canonical route precedence. The routing owner computes effective bindings through `resolveAgentRoute`, so the audit does not duplicate matching policy. Existing binding descriptions include role selectors so role-routed rooms are attributed accurately. This does not block startup, change routing, or rewrite configuration.

## User Impact

Operators running `openclaw security audit` now see which active global or binding-level group scopes merge room members into main-session context, with guidance to keep the default `per-group` scope or reserve `main` for mutually trusted rooms. Valid direct-only and shadowed bindings do not produce misleading group-room warnings.

Release-note context: security audit now warns when an effective `session.groupScope="main"` route shares group-room context with the main session.

## Evidence

- Initial regression test fails on pre-fix production code with `Expected group-scope main finding`, then passes on the repair: `node scripts/run-vitest.mjs src/security/audit-trust-model.test.ts`.
- Direct-only regression: the initial PR head warns for a valid DM-only binding; the repaired collector excludes it.
- Binding-precedence regression: the prior PR head warns for a later main-scoped room binding shadowed by an earlier equivalent per-group binding; the repaired collector omits it while still reporting a more-specific effective main binding.
- Focused suites: `node scripts/run-vitest.mjs src/security/audit-trust-model.test.ts src/routing/resolve-route.test.ts` — 1 audit test and 70 routing tests passed.
- Isolated live CLI proof: `openclaw security audit --json` reports an effective channel binding, omits an equivalent shadowed binding, keeps severity `warn`, and links `https://docs.openclaw.ai/channels/groups#session-keys`.
- Source-blind behavior validation: two different room IDs are reflected dynamically; a safe `per-group` fixture emits no finding; all audit commands exit 0.
- Full changed gates passed on Blacksmith Testbox `tbx_01m076v4bpwq7k7qc6m3ggt1ah`: https://github.com/openclaw/openclaw/actions/runs/32002203171
- Fresh Codex autoreview through P2: clean.
- Production LOC: +91/-0 | Tests: +162/-0 | Docs: +2/-1. The precedence follow-up was reduced from net +153 production to +59 by using the canonical resolver as the matching oracle.
- AI-assisted: yes. The implementation and proof were reviewed directly; no session transcript is attached.
