### PR TITLE
refactor: finish canonicalization stragglers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI activity redaction:** route Activity tool output through the canonical browser redactor and cover dotted API-key names that previously escaped shared masking.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI activity redaction:** route Activity tool output through the canonical browser redactor and cover dotted API-key names that previously escaped shared masking.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2680,7 +2680,6 @@ src/commands/setup.ts	1
 src/commands/status-all/channels.ts	3
 src/commands/status-all/diagnosis.ts	1
 src/commands/status-all/gateway.ts	1
-src/commands/status-json-runtime.ts	1
 src/commands/status.command.ts	1
 src/commands/status.scan.bootstrap-shared.ts	1
 src/commands/status.scan.shared.ts	1

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -203,7 +203,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/ssrf-dispatcher` | Private-local after July 2026; Narrow pinned-dispatcher helpers without the broad infra runtime surface |
     | `plugin-sdk/ssrf-runtime` | Pinned-dispatcher, SSRF-guarded fetch, SSRF error, SSRF policy helpers, and loopback/private host classification |
     | `plugin-sdk/secret-input` | Secret input parsing helpers |
-    | `plugin-sdk/secret-ref-readonly` | Closed available/missing/blocked resolution for read-only env SecretRefs |
+    | `plugin-sdk/secret-ref-readonly` | Closed available/missing/blocked resolution and provider-policy checks for read-only env SecretRefs |
     | `plugin-sdk/webhook-ingress` | Webhook request/target helpers and raw websocket/body coercion |
     | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers, canonical Gateway browser-origin acceptance via `resolveAcceptedBrowserOrigin`, and `runDetachedWebhookWork` for tracked post-ack processing |
   </Accordion>

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -1,7 +1,6 @@
 // Comfy plugin module implements workflow runtime behavior.
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/extension-shared";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
@@ -21,6 +20,7 @@ import {
   normalizeSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input-runtime";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import {
   fetchWithSsrFGuard,
   isPrivateOrLoopbackHost,

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements account inspect behavior.
 import { resolveAccountWithDefaultFallback } from "openclaw/plugin-sdk/account-core";
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/extension-shared";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
@@ -8,7 +9,6 @@ import {
   hasConfiguredSecretInput,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
-import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/secret-provider-alias";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   mergeTelegramAccountConfig,
@@ -67,22 +67,6 @@ function inspectTokenFile(
     tokenSource: "tokenFile",
     tokenStatus: result.status === "available" ? "available" : "configured_unavailable",
   };
-}
-
-function canResolveEnvSecretRefInReadOnlyPath(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  id: string;
-}): boolean {
-  const providerConfig = params.cfg.secrets?.providers?.[params.provider];
-  if (!providerConfig) {
-    return params.provider === resolveDefaultSecretProviderAlias(params.cfg, "env");
-  }
-  if (providerConfig.source !== "env") {
-    return false;
-  }
-  const allowlist = providerConfig.allowlist;
-  return !allowlist || allowlist.includes(params.id);
 }
 
 function inspectTokenValue(params: { cfg: OpenClawConfig; value: unknown }): {

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -1,7 +1,6 @@
 // Telegram plugin module implements account inspect behavior.
 import { resolveAccountWithDefaultFallback } from "openclaw/plugin-sdk/account-core";
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/extension-shared";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
@@ -9,6 +8,7 @@ import {
   hasConfiguredSecretInput,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   mergeTelegramAccountConfig,

--- a/src/agents/auth-profiles/read-only-availability.ts
+++ b/src/agents/auth-profiles/read-only-availability.ts
@@ -6,6 +6,7 @@ import {
   LEGACY_DOUBLE_UNDERSCORE_ENV_MARKER_PREFIX,
   resolveSecretInputRef,
 } from "../../config/types.secrets.js";
+import { canResolveEnvSecretRefInReadOnlyPath } from "../../plugin-sdk/secret-ref-readonly.internal.js";
 import {
   isValidSecretRef,
   resolveDefaultSecretProviderAlias,
@@ -41,20 +42,23 @@ export function resolveSecretRefReadOnlyAvailability(
   if (!isSecretRef(value) || !isValidSecretRef(value)) {
     return false;
   }
+  if (value.source === "env") {
+    if (
+      !canResolveEnvSecretRefInReadOnlyPath({
+        cfg,
+        provider: value.provider,
+        id: value.id,
+      })
+    ) {
+      return false;
+    }
+    return hasSecret(env[value.id]) ? true : undefined;
+  }
   const source = cfg.secrets?.providers?.[value.provider];
   const isImplicitProvider =
-    (value.source === "env" && value.provider === resolveDefaultSecretProviderAlias(cfg, "env")) ||
-    (value.source === "store" &&
-      value.provider === resolveDefaultSecretProviderAlias(cfg, "store"));
+    value.source === "store" && value.provider === resolveDefaultSecretProviderAlias(cfg, "store");
   if ((!source && !isImplicitProvider) || (source && source.source !== value.source)) {
     return false;
-  }
-  if (value.source === "env") {
-    return source?.source === "env" && source.allowlist && !source.allowlist.includes(value.id)
-      ? false
-      : hasSecret(env[value.id])
-        ? true
-        : undefined;
   }
   if (
     value.source === "file" &&

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -12,7 +12,7 @@ import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
-import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import { canResolveEnvSecretRefInReadOnlyPath } from "../plugin-sdk/secret-ref-readonly.internal.js";
 import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
@@ -107,22 +107,6 @@ type ResolvedCustomProviderApiKey = {
   apiKey: string;
   source: string;
 };
-
-function canResolveEnvSecretRefInReadOnlyPath(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-  id: string;
-}): boolean {
-  const providerConfig = params.cfg?.secrets?.providers?.[params.provider];
-  if (!providerConfig) {
-    return params.provider === resolveDefaultSecretProviderAlias(params.cfg ?? {}, "env");
-  }
-  if (providerConfig.source !== "env") {
-    return false;
-  }
-  const allowlist = providerConfig.allowlist;
-  return !allowlist || allowlist.includes(params.id);
-}
 
 /** Resolves custom provider API keys that are usable without mutating secret stores. */
 export function resolveUsableCustomProviderApiKey(params: {

--- a/src/commands/status-json-command.test.ts
+++ b/src/commands/status-json-command.test.ts
@@ -1,6 +1,7 @@
 // Status JSON command tests cover runtime invocation and structured status JSON output.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runStatusJsonCommand } from "./status-json-command.ts";
+import { createStatusScanResultFixture } from "./status.test-support.ts";
 
 const mocks = vi.hoisted(() => ({
   writeRuntimeJson: vi.fn(),
@@ -26,14 +27,12 @@ describe("runStatusJsonCommand", () => {
       error: vi.fn(),
       exit: vi.fn(),
     } as never;
-    const scan = {
+    const scan = createStatusScanResultFixture({
       cfg: { gateway: {} },
       sourceConfig: { gateway: {} },
-      summary: { ok: true },
-      update: { root: null, installKind: "package" as const, packageManager: "npm" as const },
-      osSummary: { platform: "linux" },
+      summary: { ok: true } as never,
+      osSummary: { platform: "linux" } as never,
       memory: null,
-      memoryPlugin: null,
       tailscaleMode: "off",
       tailscaleDns: null,
       tailscaleHttpsUrl: null,
@@ -48,10 +47,9 @@ describe("runStatusJsonCommand", () => {
       gatewayProbe: null,
       gatewayProbeAuth: { token: "tok" },
       gatewaySelf: null,
-      gatewayProbeAuthWarning: null,
-      agentStatus: [],
+      gatewayProbeAuthWarning: undefined,
       secretDiagnostics: [],
-    };
+    });
     const scanStatusJsonFast = vi.fn(async () => scan);
 
     await runStatusJsonCommand({

--- a/src/commands/status-json-runtime.test.ts
+++ b/src/commands/status-json-runtime.test.ts
@@ -1,6 +1,7 @@
 // Status JSON runtime tests cover runtime status payload construction and command dependencies.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveStatusJsonOutput } from "./status-json-runtime.ts";
+import { createStatusScanResultFixture } from "./status.test-support.ts";
 
 const mocks = vi.hoisted(() => ({
   buildStatusJsonPayload: vi.fn((input) => ({ built: true, input })),
@@ -29,38 +30,37 @@ vi.mock("./status-runtime-shared.ts", () => ({
 }));
 
 function createScan() {
-  return {
+  return createStatusScanResultFixture({
     env: { OPENCLAW_STATE_DIR: "/tmp/status-json-runtime-state" },
     cfg: { update: { channel: "stable" }, gateway: {} },
     sourceConfig: { gateway: {} },
-    summary: { ok: true },
-    update: {
-      root: "/tmp/openclaw",
-      installKind: "package",
-      packageManager: "npm",
-    },
-    osSummary: { platform: "linux" },
+    summary: { ok: true } as never,
+    osSummary: { platform: "linux" } as never,
     memory: null,
-    memoryPlugin: { enabled: true },
+    memoryPlugin: { enabled: true, slot: "memory" },
     gatewayMode: "local" as const,
-    gatewayConnection: { url: "ws://127.0.0.1:18789", urlSource: "config" },
+    gatewayConnection: {
+      url: "ws://127.0.0.1:18789",
+      urlSource: "config",
+      message: "Gateway target: ws://127.0.0.1:18789",
+    },
     remoteUrlMissing: false,
     gatewayReachable: true,
-    gatewayProbe: { connectLatencyMs: 42, error: null },
     gatewayProbeAuth: { token: "tok" },
     gatewaySelf: { host: "gateway" },
-    gatewayProbeAuthWarning: null,
-    agentStatus: { agents: [{ id: "main" }], defaultId: "main" },
+    gatewayProbeAuthWarning: undefined,
+    agentStatus: { agents: [{ id: "main" }], defaultId: "main" } as never,
     secretDiagnostics: [],
     pluginCompatibility: [
       {
         pluginId: "legacy",
         code: "hook-only",
+        compatCode: "hook-only-plugin-shape",
         severity: "info",
         message: "warn",
       },
     ],
-  } satisfies Parameters<typeof resolveStatusJsonOutput>[0]["scan"];
+  });
 }
 
 function requireStatusPayloadInput() {
@@ -111,6 +111,7 @@ describe("status-json-runtime", () => {
     expect(payloadInput.surface.gatewayConnection).toStrictEqual({
       url: "ws://127.0.0.1:18789",
       urlSource: "config",
+      message: "Gateway target: ws://127.0.0.1:18789",
     });
     expect(payloadInput.surface.gatewayProbeAuth).toStrictEqual({ token: "tok" });
     expect(payloadInput.surface.gatewayService).toStrictEqual({ label: "LaunchAgent" });
@@ -123,6 +124,7 @@ describe("status-json-runtime", () => {
       {
         pluginId: "legacy",
         code: "hook-only",
+        compatCode: "hook-only-plugin-shape",
         severity: "info",
         message: "warn",
       },

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -1,61 +1,15 @@
 // Resolves runtime-only inputs for status JSON after the fast scan completes.
 // Keeps gateway health, usage, security audit, and service summaries behind explicit option gates.
 
-import type { OpenClawConfig } from "../config/types.js";
-import type { UpdateCheckResult } from "../infra/update-check.js";
 import { readBackupFreshness } from "./backup-health.js";
 import { buildStatusJsonPayload } from "./status-json-payload.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
 import { resolveStatusRuntimeSnapshot } from "./status-runtime-shared.ts";
-
-type StatusJsonScanLike = {
-  env?: NodeJS.ProcessEnv;
-  cfg: OpenClawConfig;
-  sourceConfig: OpenClawConfig;
-  summary: Record<string, unknown>;
-  update: UpdateCheckResult;
-  osSummary: unknown;
-  memory: unknown;
-  memoryPlugin: unknown;
-  gatewayMode: "local" | "remote";
-  gatewayConnection: {
-    url: string;
-    urlSource?: string;
-  };
-  remoteUrlMissing: boolean;
-  gatewayReachable: boolean;
-  gatewayProbe:
-    | {
-        connectLatencyMs?: number | null;
-        error?: string | null;
-      }
-    | null
-    | undefined;
-  gatewayProbeAuth:
-    | {
-        token?: string;
-        password?: string;
-      }
-    | null
-    | undefined;
-  gatewaySelf:
-    | {
-        host?: string | null;
-        ip?: string | null;
-        version?: string | null;
-        platform?: string | null;
-      }
-    | null
-    | undefined;
-  gatewayProbeAuthWarning?: string | null;
-  agentStatus: unknown;
-  secretDiagnostics: string[];
-  pluginCompatibility?: Array<Record<string, unknown>> | null | undefined;
-};
+import type { StatusScanResult } from "./status.scan-result.ts";
 
 /** Builds the status JSON object from a completed scan plus optional runtime/deep probes. */
 export async function resolveStatusJsonOutput(params: {
-  scan: StatusJsonScanLike;
+  scan: StatusScanResult;
   opts: {
     deep?: boolean;
     usage?: boolean;
@@ -83,8 +37,7 @@ export async function resolveStatusJsonOutput(params: {
   const payload = buildStatusJsonPayload({
     summary: scan.summary,
     surface: buildStatusOverviewSurfaceFromScan({
-      // The scan shape is intentionally narrower than the surface helper's full scan type.
-      scan: scan as never,
+      scan,
       gatewayService,
       nodeService,
     }),

--- a/src/commands/status.test-support.ts
+++ b/src/commands/status.test-support.ts
@@ -11,6 +11,7 @@ import type { buildStatusCommandOverviewRows } from "./status-overview-rows.ts";
 import type { StatusOverviewSurface } from "./status-overview-surface.ts";
 import type { AgentLocalStatus } from "./status.agent-local.js";
 import type { buildStatusCommandReportData } from "./status.command-report-data.ts";
+import type { StatusScanResult } from "./status.scan-result.ts";
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
 
 type StatusCommandOverviewRowsParams = Parameters<typeof buildStatusCommandOverviewRows>[0];
@@ -139,6 +140,8 @@ const baseStatusSummary = {
 
 const baseStatusAgentStatus = {
   defaultId: "main",
+  ownership: "sole" as const,
+  selectionRequired: false,
   bootstrapPendingCount: 1,
   totalSessions: 2,
   agents: [{ id: "main", lastActiveAgeMs: 60_000 }] as AgentLocalStatus[],
@@ -161,6 +164,36 @@ const baseStatusMemoryPlugin = {
 const baseStatusPluginCompatibility = [
   { pluginId: "a", severity: "warn", message: "legacy" },
 ] as PluginCompatibilityNotice[];
+
+export function createStatusScanResultFixture(
+  overrides: Partial<StatusScanResult> = {},
+): StatusScanResult {
+  return {
+    env: { OPENCLAW_STATE_DIR: STATUS_TEST_STATE_DIR },
+    cfg: baseStatusCfg,
+    sourceConfig: baseStatusCfg,
+    secretDiagnostics: [],
+    osSummary: {
+      platform: "linux",
+      arch: "x64",
+      release: "test",
+      label: "linux (x64)",
+    },
+    tailscaleMode: "off",
+    tailscaleDns: null,
+    tailscaleHttpsUrl: null,
+    update: baseStatusUpdate,
+    ...baseStatusGatewaySnapshot,
+    channelIssues: [],
+    channels: { rows: [], details: [] },
+    agentStatus: baseStatusAgentStatus,
+    summary: baseStatusSummary,
+    memory: baseStatusMemory,
+    memoryPlugin: baseStatusMemoryPlugin,
+    pluginCompatibility: baseStatusPluginCompatibility,
+    ...overrides,
+  };
+}
 
 function createStatusLastHeartbeat(): HeartbeatEventPayload {
   return {

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -6,7 +6,6 @@ import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-
 import { createDeferredCore } from "../shared/deferred.js";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.internal.js";
-export { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.internal.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 

--- a/src/plugin-sdk/secret-ref-readonly.ts
+++ b/src/plugin-sdk/secret-ref-readonly.ts
@@ -2,6 +2,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveSecretInputString } from "../config/types.secrets.js";
 import { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.internal.js";
 
+export { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.internal.js";
+
 export type ReadOnlyEnvSecretRefResolution =
   | { status: "available"; value: string }
   | { status: "missing" }

--- a/src/plugins/manifest-tool-availability.ts
+++ b/src/plugins/manifest-tool-availability.ts
@@ -3,7 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef, type SecretRef } from "../config/types.secrets.js";
-import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import { canResolveEnvSecretRefInReadOnlyPath } from "../plugin-sdk/secret-ref-readonly.internal.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type {
   PluginManifestCapabilityProviderAuthSignal,
@@ -64,21 +64,17 @@ function readEffectiveConfigs(params: {
 
 function hasConfiguredSecretRefInConfigPath(params: {
   config?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
   ref: SecretRef;
 }): boolean {
+  if (params.ref.source === "env") {
+    return canResolveEnvSecretRefInReadOnlyPath({
+      cfg: params.config,
+      provider: params.ref.provider,
+      id: params.ref.id,
+    });
+  }
   const providerConfig = params.config?.secrets?.providers?.[params.ref.provider];
-  if (params.ref.source !== "env") {
-    return Boolean(providerConfig && providerConfig.source === params.ref.source);
-  }
-  if (!providerConfig) {
-    return params.ref.provider === resolveDefaultSecretProviderAlias(params.config ?? {}, "env");
-  }
-  if (providerConfig.source !== "env") {
-    return false;
-  }
-  const allowlist = providerConfig.allowlist;
-  return !allowlist || allowlist.includes(params.ref.id);
+  return Boolean(providerConfig && providerConfig.source === params.ref.source);
 }
 
 function hasConfiguredValue(params: {
@@ -91,7 +87,6 @@ function hasConfiguredValue(params: {
     return (
       hasConfiguredSecretRefInConfigPath({
         config: params.config,
-        env: params.env,
         ref: secretRef,
       }) &&
       (secretRef.source !== "env" || Boolean(params.env[secretRef.id]?.trim()))

--- a/ui/src/lib/browser-redact.test.ts
+++ b/ui/src/lib/browser-redact.test.ts
@@ -16,17 +16,19 @@ describe("browser tool detail redaction", () => {
         `X-Debug: fpk_${"B".repeat(40)}`,
         "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----",
         'cookie: "sessionid=verySensitiveCookieValue"',
+        "Bearer abcdefghijkl",
+        "/Users/alice/private/config.json",
       ].join("\n"),
     );
 
-    expect(redacted).toContain("Authorization: Basic dXNlcj...b3Jk");
+    expect(redacted).toContain("Authorization: [redacted]");
     expect(redacted).toContain("refresh_token=ya29.l...alue");
     expect(redacted).toContain("client_secret=client...nder");
     expect(redacted).toContain("AIzaSy...7890");
-    expect(redacted).toContain(
-      "-----BEGIN PRIVATE KEY-----\n...redacted...\n-----END PRIVATE KEY-----",
-    );
-    expect(redacted).toContain('cookie: "sessio...alue"');
+    expect(redacted).toContain("[redacted private key]");
+    expect(redacted).toContain("cookie: [redacted]");
+    expect(redacted).toContain("Bearer [redacted]");
+    expect(redacted).toContain("[redacted path]");
     expect(redacted).not.toContain("supersecretpassword");
     expect(redacted).not.toContain("longOAuthRefreshTokenValue");
     expect(redacted).not.toContain("clientSecretValueThatShouldNotRender");
@@ -36,6 +38,8 @@ describe("browser tool detail redaction", () => {
     expect(redacted).toContain("X-Debug: fpk_BB...BBBB");
     expect(redacted).not.toContain("abc123");
     expect(redacted).not.toContain("verySensitiveCookieValue");
+    expect(redacted).not.toContain("abcdefghijkl");
+    expect(redacted).not.toContain("/Users/alice/private/config.json");
     for (const masked of ["fw-CCC...CCCC", "fw_AAA...AAAA", "fpk_BB...BBBB"]) {
       expect(redactToolDetail(masked)).toBe(masked);
     }
@@ -95,17 +99,19 @@ describe("browser tool detail redaction", () => {
     ["intact leading pair", "abcd😀xxxxxxxxwxyz", "abcd😀...wxyz"],
     ["intact trailing pair", "abcdefghijklmn😀xy", "abcdef...😀xy"],
   ])("masks tool payload tokens with a UTF-16-safe %s", (_label, token, masked) => {
-    expect(redactToolPayloadText(`{"token":"${token}"}`)).toBe(`{"token":"${masked}"}`);
+    expect(redactToolPayloadText(`{"accessToken":"${token}"}`)).toBe(`{"accessToken":"${masked}"}`);
   });
 
   it("does not trust mask-shaped input as already redacted", () => {
-    expect(redactToolPayloadText("TOKEN=abcde...wxyz")).toBe("TOKEN=abcde....wxyz");
+    expect(redactToolPayloadText("OPENAI_API_KEY=abcde...wxyz")).toBe(
+      "OPENAI_API_KEY=abcde....wxyz",
+    );
   });
 
   it("redacts replacement-template text literally without changing surrounding text", () => {
     const markerLike = "\u{e000}0\u{e001}";
-    expect(redactToolPayloadText(`${markerLike} TOKEN=$\`abcdxxxxxxxxwxyz`)).toBe(
-      `${markerLike} TOKEN=$\`abcd...wxyz`,
+    expect(redactToolPayloadText(`${markerLike} OPENAI_API_KEY=$\`abcdxxxxxxxxwxyz`)).toBe(
+      `${markerLike} OPENAI_API_KEY=$\`abcd...wxyz`,
     );
   });
 
@@ -115,9 +121,9 @@ describe("browser tool detail redaction", () => {
     );
   });
 
-  it("prefers an outer credential match over a nested one", () => {
-    expect(redactToolPayloadText('cookie: "TOKEN=abcdefghijklmno&abcdefghij"')).toBe(
-      'cookie: "TOKEN=...ghij"',
+  it("fully redacts a nested credential after the outer match", () => {
+    expect(redactToolPayloadText('client_secret: "TOKEN=abcdefghijklmno&abcdefghij"')).toBe(
+      'client_secret: "TOKEN=[redacted]"',
     );
   });
 });

--- a/ui/src/lib/browser-redact.ts
+++ b/ui/src/lib/browser-redact.ts
@@ -14,6 +14,30 @@ const SECRET_DETAIL_PATTERNS = DEFAULT_REDACT_PATTERNS.map((source) => {
   const flags = patternFlags.includes("g") ? patternFlags : `${patternFlags}g`;
   return new RegExp(patternSource, flags);
 });
+const SENSITIVE_TEXT_PATTERNS: Array<[RegExp, string]> = [
+  [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
+  [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
+  [
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)"(?:\\.|[^"\\\r\n])*"/gi,
+    '$1$2$3"[redacted]"',
+  ],
+  [
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)'(?:\\.|[^'\\\r\n])*'/gi,
+    "$1$2$3'[redacted]'",
+  ],
+  [
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,
+    "$1$2[redacted]",
+  ],
+  [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    "[redacted private key]",
+  ],
+  [
+    /(^|[\s"'`=])(?:\/Users\/|\/home\/|\/var\/folders\/|[A-Za-z]:\\)[^\s"'`,;]+/g,
+    "$1[redacted path]",
+  ],
+];
 
 function redactToken(value: string): string {
   if (value.length <= 10) {
@@ -78,7 +102,10 @@ export function redactToolDetail(detail: string): string {
       return redactMatch(match, groups, offset < 0 ? "" : input.slice(offset + match.length));
     });
   }
-  return redacted;
+  return SENSITIVE_TEXT_PATTERNS.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    redacted,
+  );
 }
 
 export const redactToolPayloadText = redactToolDetail;

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -1,6 +1,7 @@
 // Control UI module implements activity model behavior.
 import { asNullableObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeNullableString as toTrimmedString } from "@openclaw/normalization-core/string-coerce";
+import { redactToolPayloadText } from "../../lib/browser-redact.ts";
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 
 const ACTIVITY_ENTRY_LIMIT = 100;
@@ -42,31 +43,6 @@ type ActivityEvent = {
   agentId?: string;
   data: Record<string, unknown>;
 };
-
-const SECRET_PATTERNS: Array<[RegExp, string]> = [
-  [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
-  [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
-  [
-    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)"(?:\\.|[^"\\\r\n])*"/gi,
-    '$1$2$3"[redacted]"',
-  ],
-  [
-    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)'(?:\\.|[^'\\\r\n])*'/gi,
-    "$1$2$3'[redacted]'",
-  ],
-  [
-    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,
-    "$1$2[redacted]",
-  ],
-  [
-    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
-    "[redacted private key]",
-  ],
-  [
-    /(^|[\s"'`=])(?:\/Users\/|\/home\/|\/var\/folders\/|[A-Za-z]:\\)[^\s"'`,;]+/g,
-    "$1[redacted path]",
-  ],
-];
 
 export function parseActivityEvent(
   payload: unknown,
@@ -136,19 +112,12 @@ function stringifyOutput(value: unknown): string | null {
   }
 }
 
-function redactSensitiveText(value: string): string {
-  return SECRET_PATTERNS.reduce(
-    (text, [pattern, replacement]) => text.replace(pattern, replacement),
-    value,
-  );
-}
-
 function buildOutputPreview(value: unknown): { text?: string; truncated: boolean } {
   const raw = stringifyOutput(value);
   if (!raw) {
     return { truncated: false };
   }
-  const redacted = redactSensitiveText(raw);
+  const redacted = redactToolPayloadText(raw);
   const truncated = truncateText(redacted, ACTIVITY_OUTPUT_PREVIEW_LIMIT);
   return { text: truncated.text, truncated: truncated.truncated };
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves several canonicalization stragglers where read-only SecretRef policy, Control UI tool-output redaction, and status scan typing had local copies that could drift from their owners. The Activity fork also covered dotted API-key names that the shared browser redactor missed.

## Why This Change Was Made

Routes Telegram inspection, Comfy workflow resolution, model-auth discovery, manifest availability, and auth-profile availability through the canonical read-only SecretRef policy while preserving policy-before-environment lookup. Plugin consumers use the focused `secret-ref-readonly` SDK subpath rather than the broad `extension-shared` barrel. Moves Activity's stricter patterns into the shared browser redactor, and replaces the status JSON shadow type plus `as never` cast with the canonical `StatusScanResult` contract.

Production LOC: +61/-144 (net -83). Tests: +73/-34. Docs: +1/-1. Tooling baseline: +0/-1.

## User Impact

Control UI Activity keeps redacting dotted names such as `app.api.key`, now through the shared browser owner used by other tool-output surfaces. Read-only credential availability keeps the same blocked-versus-missing behavior, and status JSON behavior is unchanged while future scan-shape drift becomes a type error.

## Evidence

- Focused SecretRef/status proof: 9 files, 139 tests passed across 7 Vitest shards.
- Focused Control UI proof: 4 files, 62 tests passed.
- Post-fixture status rerun: 4 files, 12 tests passed across 3 Vitest shards.
- Narrow SDK import proof: SecretRef SDK, Telegram inspection, and Comfy provider tests passed (40 tests across 3 Vitest shards).
- `node scripts/check-changed.mjs`: passed on Blacksmith Testbox, including core/UI/extension production and test typechecks, full selected lint, formatting, ratchets, dead-export scan, and architecture guards.
- Plugin SDK export/surface gates passed with the total export count unchanged; the predicate moved between existing public subpaths without adding SDK surface.
- Autoreview: clean; no accepted/actionable findings.
- Mocked Chromium Activity proof passed on both current `main` and this PR. The images are intentionally identical: Activity's private patterns already masked dotted keys before this refactor, and the PR preserves that visible behavior while moving the policy into the shared redactor. Browser-redactor and Activity tests prove the shared owner catches the same dotted-key cases after migration.

Before (current `main`):

![Activity before canonicalization](https://github.com/user-attachments/assets/8c5b8b8e-291e-4184-a22b-41aa160ed4e8)

After (this PR):

![Activity after canonicalization](https://github.com/user-attachments/assets/aaf88fc9-3a8b-41b6-9929-7663c9181204)
