### PR TITLE
fix(gateway): tolerate locked terminal cleanup

### DIFF
--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -45,6 +45,36 @@ describe("worker environment service", () => {
     expect(prune).toHaveBeenCalledOnce();
   });
 
+  it.each(["SQLITE_BUSY", "SQLITE_LOCKED"])(
+    "continues reconciliation when terminal cleanup fails with %s",
+    async (code) => {
+      const prune = vi
+        .spyOn(support.testState.store, "pruneTerminalEnvironments")
+        .mockImplementation(() => {
+          throw Object.assign(new Error("database is locked"), { code });
+        });
+
+      await expect(
+        support.createService(support.createProvider()).reconcileOnce(),
+      ).resolves.toBeUndefined();
+      expect(prune).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("propagates non-lock terminal cleanup failures", async () => {
+    const error = Object.assign(new Error("disk I/O error"), { code: "SQLITE_IOERR" });
+    const prune = vi
+      .spyOn(support.testState.store, "pruneTerminalEnvironments")
+      .mockImplementation(() => {
+        throw error;
+      });
+
+    await expect(support.createService(support.createProvider()).reconcileOnce()).rejects.toBe(
+      error,
+    );
+    expect(prune).toHaveBeenCalledOnce();
+  });
+
   it("waits for timed-out provider work during shutdown", async () => {
     let finishProvision: (() => void) | undefined;
     const provisionPending = new Promise<void>((resolve) => {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -11,6 +11,7 @@ import { onSessionIdentityMutation } from "../../config/sessions/session-accesso
 import type { OpenClawConfig } from "../../config/types.js";
 import type { SecretRef } from "../../config/types.secrets.js";
 import { withTimeout } from "../../infra/fs-safe.js";
+import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type {
   WorkerProfile,
@@ -351,7 +352,15 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
           ),
       );
     await runTasksWithConcurrency({ tasks, limit: 8 });
-    store.pruneTerminalEnvironments();
+    try {
+      store.pruneTerminalEnvironments();
+    } catch (error) {
+      // Pruning is opportunistic and retries on the next sweep; lock contention must not
+      // turn a healthy worker reconciliation into a startup or periodic-reconcile failure.
+      if (!isSqliteLockError(error)) {
+        throw error;
+      }
+    }
   };
 
   const reconcileOnce = () => {


### PR DESCRIPTION
Related: #124302

## What Problem This Solves

Fixes an issue where transient SQLite lock contention during terminal worker-environment cleanup could abort the reconciliation pass.

## Why This Change Was Made

The cleanup is opportunistic, so `SQLITE_BUSY` and `SQLITE_LOCKED` are tolerated through the shared SQLite classifier while every other failure still propagates. This is the remaining independent repair from Jacqueline Henriksen's #124302; #124309 already superseded that PR's deferred-startup lifecycle rewrite.

## User Impact

Gateway worker-environment reconciliation continues through temporary database lock contention without hiding storage, schema, or corruption errors.

## Evidence

- Testbox run [31995631083](https://github.com/openclaw/openclaw/actions/runs/31995631083): focused `service-lifetime.test.ts`, 11/11 passed.
- `oxfmt --check`: passed.
- `git diff --check`: passed.
- Fresh autoreview: no actionable findings.

Co-authored-by: Jacqueline Henriksen (@jjjhenriksen)
