### PR TITLE
improve(ui): unify shared tooltip behavior

### DIFF
--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -5,9 +5,6 @@ import { installNativeTitleGuard } from "./tooltip.ts";
 
 type TooltipElement = HTMLElement & {
   content: string;
-  delay?: number;
-  placement: string;
-  suppressed: boolean;
   readonly updateComplete: Promise<boolean>;
 };
 
@@ -59,7 +56,6 @@ function webAwesomeTooltip(tooltip: TooltipElement) {
     HTMLElement & {
       anchor: Element | null;
       open: boolean;
-      placement: string;
       readonly updateComplete: Promise<boolean>;
     }
   >("wa-tooltip");
@@ -199,31 +195,6 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(1);
   });
 
-  it("lets a tooltip override the provider hover delay", async () => {
-    const provider = createProvider();
-    provider.delay = 40;
-    const { tooltip, trigger } = createTooltip("Deliberate tooltip");
-    tooltip.delay = 400;
-    provider.append(tooltip);
-    document.body.append(provider);
-    await tooltip.updateComplete;
-
-    hoverTrigger(trigger);
-    vi.advanceTimersByTime(399);
-    expectOpenCount(0);
-    vi.advanceTimersByTime(1);
-    expectOpenCount(1);
-  });
-
-  it("passes caller placement to the Web Awesome popup", async () => {
-    const { tooltip } = createTooltip("Side tooltip");
-    tooltip.placement = "right";
-    document.body.append(tooltip);
-    await tooltip.updateComplete;
-
-    expect(webAwesomeTooltip(tooltip)?.placement).toBe("right");
-  });
-
   it("suppresses a tooltip that repeats fully visible trigger text", async () => {
     const provider = createProvider();
     const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "Claude Opus 4.7 Anthropic");
@@ -306,39 +277,6 @@ describe("openclaw-tooltip", () => {
     const descriptionId = trigger.getAttribute("aria-describedby");
     expect(descriptionId).toBeTruthy();
     expect(document.getElementById(descriptionId ?? "")?.textContent).toBe("Accessible tooltip");
-  });
-
-  it("closes when its hover surface is suppressed", async () => {
-    const { tooltip, trigger } = createTooltip("Suppressed tooltip");
-    document.body.append(tooltip);
-    await tooltip.updateComplete;
-
-    focusTrigger(trigger);
-    expectOpenCount(1);
-
-    tooltip.suppressed = true;
-    await tooltip.updateComplete;
-    expectOpenCount(0);
-  });
-
-  it("stays closed while an ancestor suppresses hover surfaces", async () => {
-    const scope = document.createElement("div");
-    scope.setAttribute("data-hover-suppressed", "");
-    const provider = createProvider();
-    const { tooltip, trigger } = createTooltip("Suppressed tooltip");
-    provider.append(tooltip);
-    scope.append(provider);
-    document.body.append(scope);
-    await tooltip.updateComplete;
-
-    hoverTrigger(trigger);
-    vi.advanceTimersByTime(400);
-    expectOpenCount(0);
-
-    scope.removeAttribute("data-hover-suppressed");
-    hoverTrigger(trigger);
-    vi.advanceTimersByTime(400);
-    expectOpenCount(1);
   });
 
   it("describes the focusable element inside a wrapper trigger", async () => {

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -5,6 +5,9 @@ import { installNativeTitleGuard } from "./tooltip.ts";
 
 type TooltipElement = HTMLElement & {
   content: string;
+  delay?: number;
+  placement: string;
+  suppressed: boolean;
   readonly updateComplete: Promise<boolean>;
 };
 
@@ -56,6 +59,7 @@ function webAwesomeTooltip(tooltip: TooltipElement) {
     HTMLElement & {
       anchor: Element | null;
       open: boolean;
+      placement: string;
       readonly updateComplete: Promise<boolean>;
     }
   >("wa-tooltip");
@@ -114,7 +118,7 @@ describe("openclaw-tooltip", () => {
     );
   });
 
-  it("skins the body and arrow through shared Web Awesome tokens", async () => {
+  it("skins the body and removes the arrow through shared overlay tokens", async () => {
     const { tooltip } = createTooltip("Styled tooltip");
     document.body.append(tooltip);
     await tooltip.updateComplete;
@@ -126,7 +130,9 @@ describe("openclaw-tooltip", () => {
     expect(styles).toContain("--wa-tooltip-border-color:");
     expect(styles).toContain("--wa-tooltip-border-width: 1px");
     expect(styles).toContain("--wa-tooltip-border-style: solid");
-    expect(styles).toContain("--wa-tooltip-arrow-size: 6px");
+    expect(styles).toContain("--wa-tooltip-arrow-size: var(--openclaw-tooltip-arrow-size, 0px)");
+    expect(styles).toContain("var(--overlay-border, var(--border-strong))");
+    expect(styles).toContain("var(--overlay-shadow, var(--shadow-md))");
   });
 
   it("projects rich content into the Web Awesome tooltip", async () => {
@@ -191,6 +197,31 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(0);
     vi.advanceTimersByTime(1);
     expectOpenCount(1);
+  });
+
+  it("lets a tooltip override the provider hover delay", async () => {
+    const provider = createProvider();
+    provider.delay = 40;
+    const { tooltip, trigger } = createTooltip("Deliberate tooltip");
+    tooltip.delay = 400;
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(399);
+    expectOpenCount(0);
+    vi.advanceTimersByTime(1);
+    expectOpenCount(1);
+  });
+
+  it("passes caller placement to the Web Awesome popup", async () => {
+    const { tooltip } = createTooltip("Side tooltip");
+    tooltip.placement = "right";
+    document.body.append(tooltip);
+    await tooltip.updateComplete;
+
+    expect(webAwesomeTooltip(tooltip)?.placement).toBe("right");
   });
 
   it("suppresses a tooltip that repeats fully visible trigger text", async () => {
@@ -275,6 +306,61 @@ describe("openclaw-tooltip", () => {
     const descriptionId = trigger.getAttribute("aria-describedby");
     expect(descriptionId).toBeTruthy();
     expect(document.getElementById(descriptionId ?? "")?.textContent).toBe("Accessible tooltip");
+  });
+
+  it("closes when its hover surface is suppressed", async () => {
+    const { tooltip, trigger } = createTooltip("Suppressed tooltip");
+    document.body.append(tooltip);
+    await tooltip.updateComplete;
+
+    focusTrigger(trigger);
+    expectOpenCount(1);
+
+    tooltip.suppressed = true;
+    await tooltip.updateComplete;
+    expectOpenCount(0);
+  });
+
+  it("stays closed while an ancestor suppresses hover surfaces", async () => {
+    const scope = document.createElement("div");
+    scope.setAttribute("data-hover-suppressed", "");
+    const provider = createProvider();
+    const { tooltip, trigger } = createTooltip("Suppressed tooltip");
+    provider.append(tooltip);
+    scope.append(provider);
+    document.body.append(scope);
+    await tooltip.updateComplete;
+
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(400);
+    expectOpenCount(0);
+
+    scope.removeAttribute("data-hover-suppressed");
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(400);
+    expectOpenCount(1);
+  });
+
+  it("describes the focusable element inside a wrapper trigger", async () => {
+    const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
+    const row = document.createElement("div");
+    const link = document.createElement("a");
+    link.href = "#session";
+    link.textContent = "Release notes";
+    row.append(link);
+    const card = document.createElement("div");
+    card.slot = "content";
+    card.textContent = "Branch feature/sidebar";
+    tooltip.append(row, card);
+    document.body.append(tooltip);
+    await tooltip.updateComplete;
+
+    expect(row.hasAttribute("aria-describedby")).toBe(false);
+    const descriptionId = link.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toBe(
+      "Branch feature/sidebar",
+    );
   });
 
   it("describes rich content with its text content", async () => {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -2,10 +2,13 @@
 // wrapper API; Web Awesome owns popup positioning, rendering, and dismissal.
 import "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
 import type WaTooltip from "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
-import { css, html } from "lit";
+import { css, html, type PropertyValues } from "lit";
 import { property, query } from "lit/decorators.js";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
+const DESCRIBABLE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 const HOVER_DELAY = 150;
 const TOUCH_DELAY = 450;
 const TOUCH_VISIBLE = 900;
@@ -222,9 +225,14 @@ class Tooltip extends OpenClawLitElement {
   /** Let a reveal-only trigger open on click instead of dismissing. */
   @property({ type: Boolean, attribute: "open-on-click" }) openOnClick = false;
 
+  @property({ type: Number }) delay?: number;
+  @property({ type: Boolean, reflect: true }) suppressed = false;
+  @property() placement = "top";
+
   @query("wa-tooltip") private webAwesomeTooltip?: WaTooltip;
 
   private triggerElement: HTMLElement | null = null;
+  private describedElement: HTMLElement | null = null;
   private openTimer: number | null = null;
   private closeTimer: number | null = null;
   private touchTimer: number | null = null;
@@ -248,22 +256,28 @@ class Tooltip extends OpenClawLitElement {
 
     wa-tooltip {
       --max-width: var(--openclaw-tooltip-max-width, min(260px, calc(100vw - 16px)));
-      --wa-tooltip-arrow-size: 6px;
-      --wa-tooltip-background-color: color-mix(in srgb, var(--card) 94%, black 6%);
-      --wa-tooltip-border-color: color-mix(in srgb, var(--border-strong) 84%, transparent);
+      --wa-tooltip-arrow-size: var(--openclaw-tooltip-arrow-size, 0px);
+      --wa-tooltip-background-color: var(
+        --openclaw-tooltip-background-color,
+        color-mix(in srgb, var(--bg-elevated) 97%, var(--text) 3%)
+      );
+      --wa-tooltip-border-color: var(
+        --openclaw-tooltip-border-color,
+        var(--overlay-border, var(--border-strong))
+      );
       --wa-tooltip-border-width: 1px;
       --wa-tooltip-border-style: solid;
       --wa-tooltip-content-color: var(--text);
-      --wa-tooltip-border-radius: var(--radius-md);
+      --wa-tooltip-border-radius: var(--openclaw-tooltip-border-radius, var(--radius-md));
       font-family: var(--font-body);
     }
 
     wa-tooltip::part(body) {
-      padding: 7px 9px;
-      box-shadow: var(--shadow-md);
-      font-size: 12px;
+      padding: var(--openclaw-tooltip-padding, 5px 7px);
+      box-shadow: var(--openclaw-tooltip-shadow, var(--overlay-shadow, var(--shadow-md)));
+      font-size: 11px;
       font-weight: 500;
-      line-height: 1.35;
+      line-height: 1.25;
       overflow-wrap: anywhere;
     }
 
@@ -286,7 +300,10 @@ class Tooltip extends OpenClawLitElement {
     this.style.display = "contents";
   }
 
-  protected override updated() {
+  protected override updated(changed: PropertyValues) {
+    if (changed.has("suppressed") && this.suppressed) {
+      this.close();
+    }
     this.attachTrigger();
     this.syncDescription();
     this.syncWebAwesomeTooltip();
@@ -308,7 +325,7 @@ class Tooltip extends OpenClawLitElement {
   }
 
   private get hoverDelay() {
-    return Math.max(0, this.provider?.delay ?? HOVER_DELAY);
+    return Math.max(0, this.delay ?? this.provider?.delay ?? HOVER_DELAY);
   }
 
   private get touchDelay() {
@@ -538,11 +555,22 @@ class Tooltip extends OpenClawLitElement {
     return isTooltipTextRedundant(this.content, trigger);
   }
 
-  private syncDescription() {
+  private resolveDescribedElement(): HTMLElement | null {
     const trigger = this.triggerElement;
+    if (!trigger) {
+      return null;
+    }
+    return trigger.matches(DESCRIBABLE_SELECTOR)
+      ? trigger
+      : (trigger.querySelector<HTMLElement>(DESCRIBABLE_SELECTOR) ?? trigger);
+  }
+
+  private syncDescription() {
+    const trigger = this.resolveDescribedElement();
     if (!trigger) {
       return;
     }
+    this.describedElement = trigger;
     const current = trigger.getAttribute("aria-describedby");
     if (!this.descriptionCaptured) {
       this.describedBy = current;
@@ -564,14 +592,16 @@ class Tooltip extends OpenClawLitElement {
   }
 
   private restoreDescription() {
-    if (!this.triggerElement) {
+    const described = this.describedElement ?? this.triggerElement;
+    if (!described) {
       return;
     }
     if (this.describedBy) {
-      this.triggerElement.setAttribute("aria-describedby", this.describedBy);
+      described.setAttribute("aria-describedby", this.describedBy);
     } else {
-      this.triggerElement.removeAttribute("aria-describedby");
+      described.removeAttribute("aria-describedby");
     }
+    this.describedElement = null;
     this.descriptionElement?.remove();
     this.descriptionElement = null;
     this.describedBy = null;
@@ -673,7 +703,7 @@ class Tooltip extends OpenClawLitElement {
   override render() {
     return html`
       <slot @slotchange=${() => this.attachTrigger()}></slot>
-      <wa-tooltip id=${this.tooltipId} trigger="manual">
+      <wa-tooltip id=${this.tooltipId} trigger="manual" placement=${this.placement}>
         <span class="tooltip-content">${this.content}</span>
         <span
           class="tooltip-rich-content"

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -2,13 +2,12 @@
 // wrapper API; Web Awesome owns popup positioning, rendering, and dismissal.
 import "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
 import type WaTooltip from "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
-import { css, html, type PropertyValues } from "lit";
+import { css, html } from "lit";
 import { property, query } from "lit/decorators.js";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
 const DESCRIBABLE_SELECTOR =
   'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
-const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 const HOVER_DELAY = 150;
 const TOUCH_DELAY = 450;
 const TOUCH_VISIBLE = 900;
@@ -225,10 +224,6 @@ class Tooltip extends OpenClawLitElement {
   /** Let a reveal-only trigger open on click instead of dismissing. */
   @property({ type: Boolean, attribute: "open-on-click" }) openOnClick = false;
 
-  @property({ type: Number }) delay?: number;
-  @property({ type: Boolean, reflect: true }) suppressed = false;
-  @property() placement = "top";
-
   @query("wa-tooltip") private webAwesomeTooltip?: WaTooltip;
 
   private triggerElement: HTMLElement | null = null;
@@ -300,10 +295,7 @@ class Tooltip extends OpenClawLitElement {
     this.style.display = "contents";
   }
 
-  protected override updated(changed: PropertyValues) {
-    if (changed.has("suppressed") && this.suppressed) {
-      this.close();
-    }
+  protected override updated() {
     this.attachTrigger();
     this.syncDescription();
     this.syncWebAwesomeTooltip();
@@ -325,7 +317,7 @@ class Tooltip extends OpenClawLitElement {
   }
 
   private get hoverDelay() {
-    return Math.max(0, this.delay ?? this.provider?.delay ?? HOVER_DELAY);
+    return Math.max(0, this.provider?.delay ?? HOVER_DELAY);
   }
 
   private get touchDelay() {
@@ -703,7 +695,7 @@ class Tooltip extends OpenClawLitElement {
   override render() {
     return html`
       <slot @slotchange=${() => this.attachTrigger()}></slot>
-      <wa-tooltip id=${this.tooltipId} trigger="manual" placement=${this.placement}>
+      <wa-tooltip id=${this.tooltipId} trigger="manual">
         <span class="tooltip-content">${this.content}</span>
         <span
           class="tooltip-rich-content"


### PR DESCRIPTION
Related: #123655

## What Problem This Solves

Control UI tooltips use inconsistent visual treatment and cannot reliably describe keyboard-focused controls when the tooltip wraps a larger surface. Rich tooltip surfaces also need local control over opening delay, placement, and temporary suppression.

This is a standalone extraction of the shared-tooltip work from the closed sidebar chain in #123655. No original issue was identified for this item.

## Why This Change Was Made

The shared tooltip now uses an arrowless, compact shell that adopts the common overlay tokens when available while retaining current-theme fallbacks. It places ARIA descriptions on the focusable element inside wrapper triggers and exposes per-tooltip delay, placement, and suppression without forking the primitive.

The extraction is intentionally limited to the shared tooltip component and its focused tests; overlay-token definitions remain in their separate standalone change.

## User Impact

Tooltips are visually consistent and keyboard users receive the tooltip description on the element they actually focus. Rich surfaces can open beside their trigger, wait for deliberate hover intent, and stay closed while another surface owns interaction.

## Evidence

Focused behavioral coverage was ported for arrowless styling, per-tooltip delay, placement, direct and ancestor suppression, and wrapper-trigger accessibility. Validation and visual proof are intentionally deferred to the external review pass for this standalone extraction.
