### PR TITLE
feat(ui): add session hovercards

### DIFF
--- a/ui/src/components/app-sidebar-catalog-menu.ts
+++ b/ui/src/components/app-sidebar-catalog-menu.ts
@@ -1,5 +1,6 @@
 // Owns catalog-row menu state, actions, focus anchor, and rendering for AppSidebar.
 import { html, nothing } from "lit";
+import type { CatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.ts";
 import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
 import "./catalog-session-menu.ts";
@@ -23,6 +24,15 @@ export class SidebarCatalogMenuController {
 
   get isOpen(): boolean {
     return this.state !== null;
+  }
+
+  isOpenFor(key: CatalogSessionKey): boolean {
+    const openKey = this.state?.key;
+    return (
+      openKey?.catalogId === key.catalogId &&
+      openKey.hostId === key.hostId &&
+      openKey.threadId === key.threadId
+    );
   }
 
   open(

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -23,6 +23,7 @@ import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
   formatSidebarTimestamp,
+  normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
   type CatalogSessionMenuRequest,
   visibleCatalogHosts,
@@ -75,6 +76,7 @@ type SessionCatalogGroupsParams = {
     y: number,
     trigger?: HTMLElement,
   ) => void;
+  isMenuOpen: (key: CatalogSessionKey) => boolean;
 };
 
 function renderSessionRunSpinner(showTitle = true) {
@@ -395,11 +397,9 @@ function renderCatalogSessionRow(
   params: SessionCatalogGroupsParams,
   projectChild = false,
 ) {
-  const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
-  const timestamp =
-    typeof rawTimestamp === "number" && rawTimestamp < 1_000_000_000_000
-      ? rawTimestamp * 1000
-      : rawTimestamp;
+  const timestamp = normalizeCatalogTimestamp(
+    session.recencyAt ?? session.updatedAt ?? session.createdAt,
+  );
   const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
   if (adoptedRow) {
     const label = session.name || session.threadId;
@@ -515,6 +515,7 @@ function renderCatalogSessionRow(
             title=${t("chat.sidebar.openSessionMenu")}
             aria-label=${t("chat.sidebar.openSessionMenu")}
             aria-haspopup="menu"
+            aria-expanded=${String(params.isMenuOpen(catalogKey))}
             @click=${(event: MouseEvent) => {
               event.stopPropagation();
               const trigger = event.currentTarget as HTMLElement;

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -22,6 +22,7 @@ import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
   formatSidebarTimestamp,
+  normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
   type CatalogSessionMenuRequest,
   visibleCatalogHosts,
@@ -74,6 +75,7 @@ type SessionCatalogGroupsParams = {
     y: number,
     trigger?: HTMLElement,
   ) => void;
+  isMenuOpen: (key: CatalogSessionKey) => boolean;
 };
 
 function renderSessionRunSpinner(showTitle = true) {
@@ -394,11 +396,9 @@ function renderCatalogSessionRow(
   params: SessionCatalogGroupsParams,
   projectChild = false,
 ) {
-  const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
-  const timestamp =
-    typeof rawTimestamp === "number" && rawTimestamp < 1_000_000_000_000
-      ? rawTimestamp * 1000
-      : rawTimestamp;
+  const timestamp = normalizeCatalogTimestamp(
+    session.recencyAt ?? session.updatedAt ?? session.createdAt,
+  );
   const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
   if (adoptedRow) {
     const label = session.name || session.threadId;
@@ -514,6 +514,7 @@ function renderCatalogSessionRow(
             title=${t("chat.sidebar.openSessionMenu")}
             aria-label=${t("chat.sidebar.openSessionMenu")}
             aria-haspopup="menu"
+            aria-expanded=${String(params.isMenuOpen(catalogKey))}
             @click=${(event: MouseEvent) => {
               event.stopPropagation();
               const trigger = event.currentTarget as HTMLElement;

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -1,8 +1,15 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SessionCatalogHost } from "../../../packages/gateway-protocol/src/index.ts";
+import type {
+  SessionCatalog,
+  SessionCatalogHost,
+} from "../../../packages/gateway-protocol/src/index.ts";
 import { i18n } from "../i18n/index.ts";
-import { formatSidebarTimestamp, visibleCatalogHosts } from "./app-sidebar-session-catalogs.ts";
+import {
+  findCatalogSessionHovercardRow,
+  formatSidebarTimestamp,
+  visibleCatalogHosts,
+} from "./app-sidebar-session-catalogs.ts";
 
 describe("formatSidebarTimestamp", () => {
   afterEach(async () => {
@@ -30,6 +37,72 @@ describe("formatSidebarTimestamp", () => {
 
     expect(formatSidebarTimestamp(Date.now() + 30_000)).toBe("in 30s");
     expect(formatSidebarTimestamp(Date.now() + 5 * 60_000)).toBe("in 5m");
+  });
+});
+
+describe("findCatalogSessionHovercardRow", () => {
+  it("distinguishes repository context from a plain workspace cwd", () => {
+    const catalogSession = (threadId: string, name: string) => ({
+      threadId,
+      name,
+      status: "idle",
+      archived: false,
+      canContinue: true,
+      canArchive: false,
+    });
+    const catalog: SessionCatalog = {
+      id: "codex",
+      label: "Codex",
+      capabilities: { continueSession: true, archive: true },
+      hosts: [
+        {
+          hostId: "gateway:codex",
+          label: "Local Codex",
+          kind: "gateway",
+          connected: true,
+          sessions: [
+            {
+              ...catalogSession("project", "Project"),
+              cwd: "/work/openclaw",
+              gitBranch: "feature/hovercard",
+            },
+            {
+              ...catalogSession("workspace", "Workspace"),
+              cwd: "/work/release-notes",
+            },
+            {
+              ...catalogSession("pull-request", "Pull request"),
+              cwd: "/work/pull-request",
+              pullRequest: { numbers: [125068], state: "open" },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      findCatalogSessionHovercardRow({
+        catalogs: [catalog],
+        sessionKey: "catalog:codex:gateway%3Acodex:project",
+      })?.workContext,
+    ).toEqual({
+      kind: "project",
+      name: "openclaw",
+      path: "/work/openclaw",
+      branch: "feature/hovercard",
+    });
+    expect(
+      findCatalogSessionHovercardRow({
+        catalogs: [catalog],
+        sessionKey: "catalog:codex:gateway%3Acodex:workspace",
+      })?.workContext,
+    ).toEqual({ kind: "workspace", name: "release-notes", path: "/work/release-notes" });
+    expect(
+      findCatalogSessionHovercardRow({
+        catalogs: [catalog],
+        sessionKey: "catalog:codex:gateway%3Acodex:pull-request",
+      })?.workContext,
+    ).toEqual({ kind: "project", name: "pull-request", path: "/work/pull-request" });
   });
 });
 

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type {
   SessionCatalog,
   SessionCatalogHost,
@@ -6,10 +7,13 @@ import type {
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
+import { repoName } from "../lib/session-display.ts";
 import type {
   CatalogSessionContinuedDetail,
   CatalogSessionKey,
 } from "../lib/sessions/catalog-key.ts";
+import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
+import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
 
 export function formatSidebarTimestamp(timestampMs: number | null | undefined): string {
   const now = Date.now();
@@ -25,6 +29,45 @@ export function formatSidebarTimestamp(timestampMs: number | null | undefined): 
     fallback: "",
     suffix: timestampMs != null && timestampMs > now,
   });
+}
+
+export function normalizeCatalogTimestamp(timestamp: number | undefined): number | undefined {
+  return timestamp !== undefined && timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp;
+}
+
+export function findCatalogSessionHovercardRow(params: {
+  catalogs: readonly SessionCatalog[];
+  sessionKey: string;
+  liveRow?: SidebarSessionHovercardRow;
+}): SidebarSessionHovercardRow | undefined {
+  for (const catalog of params.catalogs) {
+    for (const host of catalog.hosts) {
+      for (const session of host.sessions) {
+        const key =
+          session.sessionKey ??
+          buildCatalogSessionKey({
+            catalogId: catalog.id,
+            hostId: host.hostId,
+            threadId: session.threadId,
+          });
+        if (key !== params.sessionKey) {
+          continue;
+        }
+        const cwd = normalizeOptionalString(session.cwd);
+        return {
+          ...params.liveRow,
+          label: session.name || session.threadId,
+          createdActor: params.liveRow?.createdActor ?? session.createdActor,
+          createdAt: params.liveRow?.createdAt ?? normalizeCatalogTimestamp(session.createdAt),
+          updatedAt: params.liveRow?.updatedAt ?? normalizeCatalogTimestamp(session.updatedAt),
+          workContext: cwd
+            ? { project: repoName(cwd), branch: normalizeOptionalString(session.gitBranch) }
+            : params.liveRow?.workContext,
+        };
+      }
+    }
+  }
+  return params.liveRow;
 }
 
 /** Session keys already adopted into OpenClaw sessions; the regular list hides

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -54,6 +54,9 @@ export function findCatalogSessionHovercardRow(params: {
           continue;
         }
         const cwd = normalizeOptionalString(session.cwd);
+        const branch = normalizeOptionalString(session.gitBranch);
+        // A catalog cwd is authoritative workspace context, but it does not by
+        // itself prove repository identity; only projected Git facts do that.
         return {
           ...params.liveRow,
           label: session.name || session.threadId,
@@ -61,7 +64,14 @@ export function findCatalogSessionHovercardRow(params: {
           createdAt: params.liveRow?.createdAt ?? normalizeCatalogTimestamp(session.createdAt),
           updatedAt: params.liveRow?.updatedAt ?? normalizeCatalogTimestamp(session.updatedAt),
           workContext: cwd
-            ? { project: repoName(cwd), branch: normalizeOptionalString(session.gitBranch) }
+            ? branch || session.pullRequest
+              ? {
+                  kind: "project",
+                  name: repoName(cwd),
+                  path: cwd,
+                  ...(branch ? { branch } : {}),
+                }
+              : { kind: "workspace", name: repoName(cwd), path: cwd }
             : params.liveRow?.workContext,
         };
       }

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -353,6 +353,7 @@ function renderSessionCatalog(params: {
       terminalAvailable: snapshot.terminalAvailable,
       onOpenTerminal: openCatalogSessionInTerminal,
       onOpenMenu: (request, x, y, trigger) => host.openCatalogMenu(request, x, y, trigger),
+      isMenuOpen: (key) => host.sidebarMenus.catalogMenu.isOpenFor(key),
     })}
   `;
 }

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -326,6 +326,7 @@ function renderSessionCatalog(params: {
       terminalAvailable: snapshot.terminalAvailable,
       onOpenTerminal: openCatalogSessionInTerminal,
       onOpenMenu: (request, x, y, trigger) => host.openCatalogMenu(request, x, y, trigger),
+      isMenuOpen: (key) => host.sidebarMenus.catalogMenu.isOpenFor(key),
     })}
   `;
 }

--- a/ui/src/components/app-sidebar-session-lookup.ts
+++ b/ui/src/components/app-sidebar-session-lookup.ts
@@ -1,0 +1,85 @@
+import type { SessionCatalog } from "../../../packages/gateway-protocol/src/index.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
+import { findCatalogSessionHovercardRow } from "./app-sidebar-session-catalogs.ts";
+import {
+  findProjectedSidebarSession,
+  type SidebarSessionNavigationState,
+} from "./app-sidebar-session-navigation-logic.ts";
+import type {
+  SidebarRecentSession,
+  SidebarSessionHovercardRow,
+} from "./app-sidebar-session-types.ts";
+import type { SessionDataController } from "./session-data-controller.ts";
+
+type SidebarSessionLookupData = Pick<
+  SessionDataController,
+  | "activeSessionLineageRoot"
+  | "activeSessionLineageSelectedRow"
+  | "childSessionRowsByParent"
+  | "sessionResultsByAgent"
+>;
+
+type SidebarSessionLookupSource = {
+  readonly sessionData: SidebarSessionLookupData;
+  getSessionNavigationState(): SidebarSessionNavigationState;
+  visibleSessionCatalogs(): readonly SessionCatalog[];
+};
+
+export function findActiveSidebarLineageRow(
+  sessionData: SidebarSessionLookupData,
+  sessionKey: string,
+): GatewaySessionRow | undefined {
+  return [
+    sessionData.activeSessionLineageSelectedRow,
+    sessionData.activeSessionLineageRoot,
+    ...Object.values(sessionData.childSessionRowsByParent).flat(),
+  ].find(
+    (row): row is GatewaySessionRow =>
+      row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
+  );
+}
+
+export function findSidebarHovercardRow(
+  source: SidebarSessionLookupSource,
+  sessionKey: string,
+): SidebarSessionHovercardRow | undefined {
+  const navigationState = source.getSessionNavigationState();
+  const child = findActiveSidebarLineageRow(source.sessionData, sessionKey);
+  const liveRow =
+    findProjectedSidebarSession({
+      sessionKey,
+      navigationState,
+      sessionResultsByAgent: source.sessionData.sessionResultsByAgent,
+    }) ?? (child ? navigationState.toSidebarSession(child, true) : undefined);
+  return findCatalogSessionHovercardRow({
+    catalogs: source.visibleSessionCatalogs(),
+    sessionKey,
+    liveRow,
+  });
+}
+
+/** Merge adopted catalog sessions into the visible PR-indicator rows so an
+    adopted session hidden from the regular list still surfaces its PR state. */
+export function mergeAdoptedSessionPullRequestRows(input: {
+  rows: SidebarRecentSession[];
+  adopted: ReadonlySet<string>;
+  sessionsResult: SessionsListResult | null;
+  sessionResultsByAgent: Record<string, SessionsListResult>;
+  navigationState: SidebarSessionNavigationState;
+}): SidebarRecentSession[] {
+  if (input.adopted.size === 0) {
+    return input.rows;
+  }
+  const byKey = new Map(input.rows.map((row) => [row.key, row]));
+  const liveRows = [
+    ...(input.sessionsResult?.sessions ?? []),
+    ...Object.values(input.sessionResultsByAgent).flatMap((result) => result.sessions),
+  ];
+  for (const row of liveRows) {
+    if (input.adopted.has(row.key) && !byKey.has(row.key)) {
+      byKey.set(row.key, input.navigationState.toSidebarSession(row));
+    }
+  }
+  return [...byKey.values()];
+}

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -735,28 +735,3 @@ export function applySidebarSessionOwnerFilter(input: {
     activeOwnerId,
   };
 }
-
-/** Merge adopted catalog sessions into the visible PR-indicator rows so an
-    adopted session hidden from the regular list still surfaces its PR state. */
-export function mergeAdoptedSessionPullRequestRows(input: {
-  rows: SidebarRecentSession[];
-  adopted: ReadonlySet<string>;
-  sessionsResult: SessionsListResult | null;
-  sessionResultsByAgent: Record<string, SessionsListResult>;
-  navigationState: SidebarSessionNavigationState;
-}): SidebarRecentSession[] {
-  if (input.adopted.size === 0) {
-    return input.rows;
-  }
-  const byKey = new Map(input.rows.map((row) => [row.key, row]));
-  const liveRows = [
-    ...(input.sessionsResult?.sessions ?? []),
-    ...Object.values(input.sessionResultsByAgent).flatMap((result) => result.sessions),
-  ];
-  for (const row of liveRows) {
-    if (input.adopted.has(row.key) && !byKey.has(row.key)) {
-      byKey.set(row.key, input.navigationState.toSidebarSession(row));
-    }
-  }
-  return [...byKey.values()];
-}

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -10,6 +10,7 @@ import {
   isCronSessionKey,
   resolveChannelSessionInfo,
   resolveSessionDisplayName,
+  resolveSessionWorkContext,
   resolveSessionWorkSubtitle,
 } from "../lib/session-display.ts";
 import { isSessionRunActive } from "../lib/session-run-state.ts";
@@ -213,6 +214,7 @@ export function buildSidebarSessionNavigationState(input: {
       label: resolveSessionDisplayName(row.key, row, { includeSubagentPrefix: false }),
       userLabel: row.label,
       subtitle: resolveSessionWorkSubtitle(row),
+      workContext: resolveSessionWorkContext(row),
       href: sessionNavigationTarget({
         face: resolveSessionPreferredFace(row),
         sessionKey: row.key,
@@ -269,6 +271,7 @@ export function buildSidebarSessionNavigationState(input: {
       spawnedBy: row.spawnedBy,
       forkSource: row.forkSource,
       status: row.status,
+      createdAt: row.createdAt,
       startedAt: row.startedAt,
       updatedAt: row.updatedAt,
       endedAt: row.endedAt,

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -737,28 +737,3 @@ export function applySidebarSessionOwnerFilter(input: {
     activeOwnerId,
   };
 }
-
-/** Merge adopted catalog sessions into the visible PR-indicator rows so an
-    adopted session hidden from the regular list still surfaces its PR state. */
-export function mergeAdoptedSessionPullRequestRows(input: {
-  rows: SidebarRecentSession[];
-  adopted: ReadonlySet<string>;
-  sessionsResult: SessionsListResult | null;
-  sessionResultsByAgent: Record<string, SessionsListResult>;
-  navigationState: SidebarSessionNavigationState;
-}): SidebarRecentSession[] {
-  if (input.adopted.size === 0) {
-    return input.rows;
-  }
-  const byKey = new Map(input.rows.map((row) => [row.key, row]));
-  const liveRows = [
-    ...(input.sessionsResult?.sessions ?? []),
-    ...Object.values(input.sessionResultsByAgent).flatMap((result) => result.sessions),
-  ];
-  for (const row of liveRows) {
-    if (input.adopted.has(row.key) && !byKey.has(row.key)) {
-      byKey.set(row.key, input.navigationState.toSidebarSession(row));
-    }
-  }
-  return [...byKey.values()];
-}

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -23,9 +23,13 @@ import {
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
   adoptedCatalogSessionKeys,
-  findCatalogSessionHovercardRow,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
+import {
+  findActiveSidebarLineageRow,
+  findSidebarHovercardRow,
+  mergeAdoptedSessionPullRequestRows,
+} from "./app-sidebar-session-lookup.ts";
 import {
   applySidebarSessionOwnerFilter,
   buildReconciledSidebarZone,
@@ -40,7 +44,6 @@ import {
   findSidebarMainSessionRow,
   findProjectedSidebarSession,
   someSidebarSessionInTree,
-  mergeAdoptedSessionPullRequestRows,
   partitionSidebarVisibleSections,
   promoteSidebarSessionCreatedOrder,
   resolveSidebarAgentChipSubtitle,
@@ -66,7 +69,6 @@ import {
   resolveSidebarSessionSortMode,
   storeSidebarSessionSortMode,
   type SidebarRecentSession,
-  type SidebarSessionHovercardRow,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
@@ -273,24 +275,13 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return this.sessionKey.trim() || this.context?.gateway.snapshot.sessionKey.trim() || "";
   }
 
-  private activeLineageRow(sessionKey: string): GatewaySessionRow | undefined {
-    return [
-      this.sessionData.activeSessionLineageSelectedRow,
-      this.sessionData.activeSessionLineageRoot,
-      ...Object.values(this.sessionData.childSessionRowsByParent).flat(),
-    ].find(
-      (row): row is GatewaySessionRow =>
-        row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
-    );
-  }
-
   getSessionNavigationState(): SidebarSessionNavigationState {
     const routeSessionKey = this.getRouteSessionKey();
     return buildSidebarSessionNavigationState({
       context: this.context,
       routeSessionKey,
       sessionsResult: this.sessionData.sessionsResult,
-      activeSession: this.activeLineageRow(routeSessionKey),
+      activeSession: findActiveSidebarLineageRow(this.sessionData, routeSessionKey),
       sessionsAgentId: this.sessionData.sessionsAgentId,
       showCron: this.sessionsShowCron,
       showSystem: this.sessionsShowSystem,
@@ -585,16 +576,8 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     });
   }
 
-  findSidebarHovercardRowByKey(sessionKey: string): SidebarSessionHovercardRow | undefined {
-    const child = this.activeLineageRow(sessionKey);
-    const liveRow =
-      this.findSidebarSessionByKey(sessionKey) ??
-      (child ? this.getSessionNavigationState().toSidebarSession(child, true) : undefined);
-    return findCatalogSessionHovercardRow({
-      catalogs: this.visibleSessionCatalogs(),
-      sessionKey,
-      liveRow,
-    });
+  findSidebarHovercardRowByKey(sessionKey: string) {
+    return findSidebarHovercardRow(this, sessionKey);
   }
 
   /** The list follows the chip-selected agent without flashing stale rows mid-switch. */

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -23,6 +23,7 @@ import {
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
   adoptedCatalogSessionKeys,
+  findCatalogSessionHovercardRow,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
 import {
@@ -65,6 +66,7 @@ import {
   resolveSidebarSessionSortMode,
   storeSidebarSessionSortMode,
   type SidebarRecentSession,
+  type SidebarSessionHovercardRow,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
@@ -580,6 +582,18 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       sessionKey,
       navigationState,
       sessionResultsByAgent: this.sessionData.sessionResultsByAgent,
+    });
+  }
+
+  findSidebarHovercardRowByKey(sessionKey: string): SidebarSessionHovercardRow | undefined {
+    const child = this.activeLineageRow(sessionKey);
+    const liveRow =
+      this.findSidebarSessionByKey(sessionKey) ??
+      (child ? this.getSessionNavigationState().toSidebarSession(child, true) : undefined);
+    return findCatalogSessionHovercardRow({
+      catalogs: this.visibleSessionCatalogs(),
+      sessionKey,
+      liveRow,
     });
   }
 

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -23,6 +23,7 @@ import {
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
   adoptedCatalogSessionKeys,
+  findCatalogSessionHovercardRow,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
 import {
@@ -65,6 +66,7 @@ import {
   resolveSidebarSessionSortMode,
   storeSidebarSessionSortMode,
   type SidebarRecentSession,
+  type SidebarSessionHovercardRow,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
@@ -579,6 +581,18 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       sessionKey,
       navigationState,
       sessionResultsByAgent: this.sessionData.sessionResultsByAgent,
+    });
+  }
+
+  findSidebarHovercardRowByKey(sessionKey: string): SidebarSessionHovercardRow | undefined {
+    const child = this.activeLineageRow(sessionKey);
+    const liveRow =
+      this.findSidebarSessionByKey(sessionKey) ??
+      (child ? this.getSessionNavigationState().toSidebarSession(child, true) : undefined);
+    return findCatalogSessionHovercardRow({
+      catalogs: this.visibleSessionCatalogs(),
+      sessionKey,
+      liveRow,
     });
   }
 

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -23,9 +23,13 @@ import {
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
   adoptedCatalogSessionKeys,
-  findCatalogSessionHovercardRow,
   visibleSessionCatalogProjection,
 } from "./app-sidebar-session-catalogs.ts";
+import {
+  findActiveSidebarLineageRow,
+  findSidebarHovercardRow,
+  mergeAdoptedSessionPullRequestRows,
+} from "./app-sidebar-session-lookup.ts";
 import {
   applySidebarSessionOwnerFilter,
   buildReconciledSidebarZone,
@@ -40,7 +44,6 @@ import {
   findSidebarMainSessionRow,
   findProjectedSidebarSession,
   someSidebarSessionInTree,
-  mergeAdoptedSessionPullRequestRows,
   partitionSidebarVisibleSections,
   promoteSidebarSessionCreatedOrder,
   resolveSidebarAgentChipSubtitle,
@@ -66,7 +69,6 @@ import {
   resolveSidebarSessionSortMode,
   storeSidebarSessionSortMode,
   type SidebarRecentSession,
-  type SidebarSessionHovercardRow,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
@@ -266,24 +268,13 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return this.sessionKey.trim() || this.context?.gateway.snapshot.sessionKey.trim() || "";
   }
 
-  private activeLineageRow(sessionKey: string): GatewaySessionRow | undefined {
-    return [
-      this.sessionData.activeSessionLineageSelectedRow,
-      this.sessionData.activeSessionLineageRoot,
-      ...Object.values(this.sessionData.childSessionRowsByParent).flat(),
-    ].find(
-      (row): row is GatewaySessionRow =>
-        row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
-    );
-  }
-
   getSessionNavigationState(): SidebarSessionNavigationState {
     const routeSessionKey = this.getRouteSessionKey();
     return buildSidebarSessionNavigationState({
       context: this.context,
       routeSessionKey,
       sessionsResult: this.sessionData.sessionsResult,
-      activeSession: this.activeLineageRow(routeSessionKey),
+      activeSession: findActiveSidebarLineageRow(this.sessionData, routeSessionKey),
       sessionsAgentId: this.sessionData.sessionsAgentId,
       showCron: this.sessionsShowCron,
       showSystem: this.sessionsShowSystem,
@@ -584,16 +575,8 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     });
   }
 
-  findSidebarHovercardRowByKey(sessionKey: string): SidebarSessionHovercardRow | undefined {
-    const child = this.activeLineageRow(sessionKey);
-    const liveRow =
-      this.findSidebarSessionByKey(sessionKey) ??
-      (child ? this.getSessionNavigationState().toSidebarSession(child, true) : undefined);
-    return findCatalogSessionHovercardRow({
-      catalogs: this.visibleSessionCatalogs(),
-      sessionKey,
-      liveRow,
-    });
+  findSidebarHovercardRowByKey(sessionKey: string) {
+    return findSidebarHovercardRow(this, sessionKey);
   }
 
   /** The list follows the chip-selected agent without flashing stale rows mid-switch. */

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -76,6 +76,7 @@ export interface SessionListHost {
   >;
   readonly sidebarMenus: Pick<
     SidebarMenusController,
+    | "catalogMenu"
     | "catalogViewMenuPosition"
     | "openCatalogViewMenu"
     | "openSessionGroupMenu"

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -75,6 +75,7 @@ export interface SessionListHost {
   >;
   readonly sidebarMenus: Pick<
     SidebarMenusController,
+    | "catalogMenu"
     | "catalogViewMenuPosition"
     | "openCatalogViewMenu"
     | "openSessionGroupMenu"

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -12,6 +12,7 @@ import type { SessionRunStatus } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
+import type { SessionWorkContext } from "../lib/session-display.ts";
 import {
   normalizeCatalogProjectGrouping,
   type CatalogProjectGrouping,
@@ -75,6 +76,7 @@ export type SidebarRecentSession = {
   userLabel?: string;
   /** Compact repo/branch/node line for work sessions. */
   subtitle?: string;
+  workContext?: SessionWorkContext;
   href: string;
   active: boolean;
   visuallyActive: boolean;
@@ -118,6 +120,7 @@ export type SidebarRecentSession = {
   spawnedBy?: string;
   forkSource?: { sessionKey: string; sessionId: string; entryId?: string };
   status?: SessionRunStatus;
+  createdAt?: number;
   startedAt?: number;
   updatedAt?: number | null;
   endedAt?: number;
@@ -131,6 +134,19 @@ export type SidebarRecentSession = {
   runningChildCount: number;
   failedChildCount: number;
 };
+
+export type SidebarSessionHovercardRow = Pick<
+  SidebarRecentSession,
+  | "createdActor"
+  | "createdAt"
+  | "channelAvatarUrl"
+  | "label"
+  | "lastMessagePreview"
+  | "participantCount"
+  | "participants"
+  | "updatedAt"
+  | "workContext"
+>;
 
 export const enum RowVisibilityReason {
   Any = 0,

--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -162,6 +162,15 @@ export const toolIcons = {
     <circle cx="18" cy="18" r="3" />
     <path d="M13 6h3a2 2 0 0 1 2 2v7" />
     <path d="M6 9v12" />`),
+  gitPullRequestDraft: strokeIcon(svg` <circle cx="6" cy="6" r="3" />
+    <circle cx="18" cy="18" r="3" />
+    <path d="M6 9v12" />
+    <path d="M18 6v.01" />
+    <path d="M18 11v.01" />`),
+  gitPullRequestClosed: strokeIcon(svg` <circle cx="6" cy="6" r="3" />
+    <path d="M6 9v12" />
+    <path d="m15 9 6 6" />
+    <path d="m21 9-6 6" />`),
   gitMerge: strokeIcon(svg` <circle cx="6" cy="6" r="3" />
     <circle cx="18" cy="18" r="3" />
     <path d="M6 21V9a9 9 0 0 0 9 9" />`),

--- a/ui/src/components/portaled-hovercard.ts
+++ b/ui/src/components/portaled-hovercard.ts
@@ -11,6 +11,7 @@ export class PortaledHovercardController {
   cardFocusInside = false;
 
   private closeTimer: number | null = null;
+  private exitCleanup: (() => void) | null = null;
   private anchor: HTMLElement | null = null;
   private openTimer: number | null = null;
   private placement: PortaledHovercardPlacement = "vertical";
@@ -40,7 +41,7 @@ export class PortaledHovercardController {
     }
   }
 
-  scheduleClose(): void {
+  scheduleClose(delayMs = this.closeDelayMs): void {
     this.clearClose();
     if (this.held) {
       return;
@@ -55,7 +56,7 @@ export class PortaledHovercardController {
       if (!this.held) {
         this.close();
       }
-    }, this.closeDelayMs);
+    }, delayMs);
   }
 
   markTrigger(trigger: HTMLElement): void {
@@ -82,11 +83,42 @@ export class PortaledHovercardController {
     });
   }
 
-  clearCard(): void {
+  clearCard(exitDurationMs = 0): void {
     this.stopPositioning?.();
     this.stopPositioning = null;
-    this.card?.remove();
+    this.exitCleanup?.();
+    this.exitCleanup = null;
+    const card = this.card;
     this.card = null;
+    if (!card) {
+      return;
+    }
+    if (exitDurationMs <= 0 || !card.isConnected) {
+      card.remove();
+      return;
+    }
+    card.dataset.open = "false";
+    card.style.pointerEvents = "none";
+    let exitTimer: number | null = null;
+    const finish = () => {
+      if (exitTimer !== null) {
+        window.clearTimeout(exitTimer);
+        exitTimer = null;
+      }
+      card.removeEventListener("transitionend", handleTransitionEnd);
+      card.remove();
+      if (this.exitCleanup === finish) {
+        this.exitCleanup = null;
+      }
+    };
+    const handleTransitionEnd = (event: TransitionEvent) => {
+      if (event.target === card && event.propertyName === "opacity") {
+        finish();
+      }
+    };
+    card.addEventListener("transitionend", handleTransitionEnd);
+    exitTimer = window.setTimeout(finish, exitDurationMs + 50);
+    this.exitCleanup = finish;
   }
 
   position(): void {
@@ -95,7 +127,7 @@ export class PortaledHovercardController {
     }
   }
 
-  reset(): void {
+  reset(exitDurationMs = 0): void {
     if (this.openTimer !== null) {
       window.clearTimeout(this.openTimer);
       this.openTimer = null;
@@ -106,7 +138,7 @@ export class PortaledHovercardController {
     this.focusInside = false;
     this.cardFocusInside = false;
     clearPortaledHovercardTrigger(this.trigger);
-    this.clearCard();
+    this.clearCard(exitDurationMs);
     this.anchor = null;
     this.trigger = null;
   }
@@ -164,25 +196,21 @@ function positionPortaledHovercard(
   placement: PortaledHovercardPlacement,
 ): void {
   const anchorRect = anchor.getBoundingClientRect();
-  const cardRect = card.getBoundingClientRect();
-  const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
-  const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
+  const cardWidth = card.offsetWidth;
+  const cardHeight = card.offsetHeight;
+  const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardWidth - VIEWPORT_PADDING);
+  const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardHeight - VIEWPORT_PADDING);
   if (placement === "horizontal") {
-    const fitsRight = anchorRect.right + CARD_GAP + cardRect.width + VIEWPORT_PADDING <= innerWidth;
-    const left = fitsRight
-      ? anchorRect.right + CARD_GAP
-      : anchorRect.left - cardRect.width - CARD_GAP;
+    const fitsRight = anchorRect.right + CARD_GAP + cardWidth + VIEWPORT_PADDING <= innerWidth;
+    const left = fitsRight ? anchorRect.right + CARD_GAP : anchorRect.left - cardWidth - CARD_GAP;
     card.dataset.side = fitsRight ? "right" : "left";
     card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, left), maxLeft)}px`;
     card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.top), maxTop)}px`;
     return;
   }
-  const fitsBelow =
-    anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
+  const fitsBelow = anchorRect.bottom + CARD_GAP + cardHeight + VIEWPORT_PADDING <= innerHeight;
   const side = fitsBelow ? "bottom" : "top";
-  const top = fitsBelow
-    ? anchorRect.bottom + CARD_GAP
-    : anchorRect.top - cardRect.height - CARD_GAP;
+  const top = fitsBelow ? anchorRect.bottom + CARD_GAP : anchorRect.top - cardHeight - CARD_GAP;
   card.dataset.side = side;
   card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
   card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -16,7 +16,12 @@ function row(overrides: Partial<SidebarRecentSession> = {}): SidebarRecentSessio
     updatedAt: Date.now() - 5 * 60_000,
     createdActor: { type: "human", id: "alice", label: "Alice Baker" },
     subtitle: "openclaw ⎇ feature/session-hovercard",
-    workContext: { project: "openclaw", branch: "feature/session-hovercard" },
+    workContext: {
+      kind: "project",
+      name: "openclaw",
+      path: "/work/openclaw",
+      branch: "feature/session-hovercard",
+    },
     children: [],
     ...overrides,
   } as SidebarRecentSession;
@@ -120,9 +125,9 @@ describe("renderSessionHovercard", () => {
     await avatar?.updateComplete;
 
     await vi.waitFor(() => {
-      expect(avatar?.querySelector(".session-hovercard__creator-avatar-fallback")?.textContent).toBe(
-        "AB",
-      );
+      expect(
+        avatar?.querySelector(".session-hovercard__creator-avatar-fallback")?.textContent,
+      ).toBe("AB");
     });
     expect(avatar?.querySelector("img.channel-avatar")).toBeNull();
     expect(container.querySelector("openclaw-viewer-avatar")).toBeNull();
@@ -215,6 +220,27 @@ describe("renderSessionHovercard", () => {
 
     expect(container.querySelector(".session-hovercard__section--metadata")).not.toBeNull();
     expect(container.querySelector(".session-hovercard__context-text")).toBeNull();
+  });
+
+  it("labels an authoritative non-repository cwd as a workspace", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        row: row({
+          workContext: {
+            kind: "workspace",
+            name: "release-notes",
+            path: "/workspaces/release-notes",
+          },
+        }),
+      }),
+      container,
+    );
+
+    const context = container.querySelector('[aria-label="Workspace: release-notes"]');
+    expect(context?.getAttribute("aria-label")).toBe("Workspace: release-notes");
+    expect(context?.getAttribute("title")).toBe("Workspace: /workspaces/release-notes");
+    expect(context?.textContent).toContain("release-notes");
   });
 
   it("falls back to a flat branch row and spaced create-PR link", () => {

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -11,9 +11,12 @@ function row(overrides: Partial<SidebarRecentSession> = {}): SidebarRecentSessio
   return {
     key: "agent:main:work",
     label: "Ship the release",
+    createdAt: Date.now() - 2 * 60 * 60_000,
     startedAt: Date.now() - 2 * 60 * 60_000,
     updatedAt: Date.now() - 5 * 60_000,
-    owner: { actor: { type: "human", id: "alice", label: "Alice Baker" } },
+    createdActor: { type: "human", id: "alice", label: "Alice Baker" },
+    subtitle: "openclaw ⎇ feature/session-hovercard",
+    workContext: { project: "openclaw", branch: "feature/session-hovercard" },
     children: [],
     ...overrides,
   } as SidebarRecentSession;
@@ -46,22 +49,30 @@ describe("renderSessionHovercard", () => {
     vi.useRealTimers();
   });
 
-  it("renders initials and synchronous row metadata without inventing a progress section", () => {
+  it("renders header and session metadata without inventing optional sections", () => {
     const container = document.createElement("div");
     render(renderSessionHovercard({ row: row() }), container);
 
     expect(container.querySelector(".session-hovercard__title")?.textContent).toBe(
       "Ship the release",
     );
-    expect(container.querySelector("span.session-hovercard__avatar")?.textContent).toBe("AB");
-    expect(container.querySelector("openclaw-channel-avatar")).toBeNull();
-    const metadata = container.querySelector(".session-hovercard__meta")?.textContent ?? "";
-    expect(metadata).toContain("Alice Baker");
-    expect(metadata).toContain("created");
-    expect(metadata).toContain("updated");
+    expect(container.querySelector(".session-hovercard__created-age")?.textContent).toBe("2 hr");
+    expect(container.querySelector(".session-hovercard__meta")?.textContent).toBe("Updated 5m ago");
+    expect(container.querySelector(".session-hovercard__identity-row")?.textContent).toContain(
+      "Alice Baker",
+    );
+    expect(
+      [...container.querySelectorAll(".session-hovercard__context-text")].map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["openclaw", "feature/session-hovercard"]);
+    expect(
+      [...container.querySelectorAll(".session-hovercard__section")].map((section) =>
+        [...section.classList].find((name) => name.startsWith("session-hovercard__section--")),
+      ),
+    ).toEqual(["session-hovercard__section--header", "session-hovercard__section--metadata"]);
     expect(container.querySelector(".session-progress-card")).toBeNull();
     expect(container.querySelector(".session-hovercard__excerpt")).toBeNull();
-    expect(container.querySelector(".session-hovercard__divider")).toBeNull();
   });
 
   it("renders the channel avatar with gateway auth instead of an initials span", () => {
@@ -70,7 +81,7 @@ describe("renderSessionHovercard", () => {
     render(
       renderSessionHovercard({
         row: row({ channelAvatarUrl }),
-        channelAvatarAuth: {
+        avatarAuth: {
           authTokens: ["device-token", "saved-token"],
           authReady: true,
         },
@@ -84,12 +95,12 @@ describe("renderSessionHovercard", () => {
         authTokens: readonly string[];
         authReady: boolean;
       }
-    >("openclaw-channel-avatar");
+    >("openclaw-channel-avatar.session-hovercard__creator-avatar");
     expect(avatar).not.toBeNull();
     expect(avatar?.routeUrl).toBe(channelAvatarUrl);
     expect(avatar?.authTokens).toEqual(["device-token", "saved-token"]);
     expect(avatar?.authReady).toBe(true);
-    expect(container.querySelector("span.session-hovercard__avatar")).toBeNull();
+    expect(container.querySelector("openclaw-viewer-avatar")).toBeNull();
   });
 
   it("keeps initials visible inside the channel avatar while auth is unavailable", async () => {
@@ -97,7 +108,7 @@ describe("renderSessionHovercard", () => {
     render(
       renderSessionHovercard({
         row: row({ channelAvatarUrl: "/__openclaw__/channel-avatar/pending" }),
-        channelAvatarAuth: { authTokens: [], authReady: false },
+        avatarAuth: { authTokens: [], authReady: false },
       }),
       container,
     );
@@ -109,13 +120,15 @@ describe("renderSessionHovercard", () => {
     await avatar?.updateComplete;
 
     await vi.waitFor(() => {
-      expect(avatar?.querySelector(".session-hovercard__avatar-fallback")?.textContent).toBe("AB");
+      expect(avatar?.querySelector(".session-hovercard__creator-avatar-fallback")?.textContent).toBe(
+        "AB",
+      );
     });
     expect(avatar?.querySelector("img.channel-avatar")).toBeNull();
-    expect(container.querySelector("span.session-hovercard__avatar")).toBeNull();
+    expect(container.querySelector("openclaw-viewer-avatar")).toBeNull();
   });
 
-  it("renders bounded linked PR chips with state, CI, and diff facts", () => {
+  it("renders bounded flat PR rows with accessible state, CI, and diff facts", () => {
     const container = document.createElement("div");
     render(
       renderSessionHovercard({
@@ -161,27 +174,50 @@ describe("renderSessionHovercard", () => {
               url: "https://github.com/openclaw/openclaw/pull/104",
               state: "closed",
             },
+            {
+              number: 105,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Fifth",
+              url: "https://github.com/openclaw/openclaw/pull/105",
+              state: "open",
+            },
           ],
         }),
       }),
       container,
     );
 
-    const links = [...container.querySelectorAll<HTMLAnchorElement>(".session-hovercard__pr-chip")];
-    expect(links).toHaveLength(3);
+    const links = [...container.querySelectorAll<HTMLAnchorElement>(".session-hovercard__pr-row")];
+    expect(links).toHaveLength(4);
     expect(links[0]?.href).toBe("https://github.com/openclaw/openclaw/pull/101");
     expect(links[0]?.target).toBe("_blank");
     expect(links[0]?.rel).toContain("noopener");
     expect(links[0]?.querySelector(".session-hovercard__pr-number")?.textContent).toBe("#101");
-    expect(links[0]?.querySelector(".session-hovercard__pr-state")?.textContent).toBe("Open");
-    expect(links[0]?.querySelector("[data-checks='passing']")?.textContent).toBe("✓");
+    expect(
+      links[0]?.querySelector(".session-hovercard__pr-state-icon")?.getAttribute("title"),
+    ).toBe("Open · CI checks passing");
+    expect(links[0]?.querySelector(".session-hovercard__pr-state-icon svg")).not.toBeNull();
     expect(links[0]?.querySelector(".session-hovercard__files")?.textContent).toBe("2 files");
     expect(links[0]?.querySelector(".session-hovercard__additions")?.textContent).toBe("+7");
     expect(links[0]?.querySelector(".session-hovercard__deletions")?.textContent).toBe("−3");
     expect(container.querySelector(".session-hovercard__more")?.textContent).toBe("+1 more");
+    expect(container.querySelector(".session-hovercard__section--header")).toBeNull();
   });
 
-  it("falls back to branch and diff chips with a create-PR link", () => {
+  it("does not present a node-only subtitle as a project", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({ row: row({ subtitle: "macbook", workContext: undefined }) }),
+      container,
+    );
+
+    expect(container.querySelector(".session-hovercard__section--metadata")).not.toBeNull();
+    expect(container.querySelector(".session-hovercard__context-text")).toBeNull();
+  });
+
+  it("falls back to a flat branch row and spaced create-PR link", () => {
     const container = document.createElement("div");
     render(
       renderSessionHovercard({
@@ -201,14 +237,14 @@ describe("renderSessionHovercard", () => {
       container,
     );
 
-    expect(container.querySelector(".session-hovercard__branch-chip")?.textContent).toBe(
+    expect(container.querySelector(".session-hovercard__branch-name")?.textContent).toBe(
       "openclaw/openclaw · feature",
     );
     expect(container.querySelector(".session-hovercard__files")?.textContent).toBe("3 files");
     expect(container.querySelector(".session-hovercard__additions")?.textContent).toBe("+12");
     expect(container.querySelector(".session-hovercard__deletions")?.textContent).toBe("−4");
     const createLink = container.querySelector<HTMLAnchorElement>(".session-hovercard__no-pr a");
-    expect(createLink?.textContent).toBe("No PR yet");
+    expect(createLink?.textContent).toBe("Create PR");
     expect(createLink?.href).toBe("https://github.com/openclaw/openclaw/pull/new/feature");
   });
 
@@ -239,8 +275,64 @@ describe("renderSessionHovercard", () => {
     );
 
     expect(container.querySelector(".session-progress-card")?.textContent).toContain("Release");
+    expect(
+      container.querySelector(".session-hovercard__progress-footer:last-child"),
+    ).not.toBeNull();
     expect(container.querySelector(".session-hovercard__excerpt")).toBeNull();
     expect(container.textContent).not.toContain("This must not appear.");
+  });
+
+  it("deduplicates creator and self from the compact participant identity", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        selfUserId: "self",
+        row: row({
+          participants: [
+            { type: "human", id: "alice", label: "Alice Baker" },
+            { type: "human", id: "self", label: "You" },
+            { type: "human", id: "mira", label: "Mira" },
+            { type: "human", id: "riley", label: "Riley" },
+            { type: "human", id: "mira", label: "Mira duplicate" },
+          ],
+          participantCount: 7,
+        }),
+      }),
+      container,
+    );
+
+    expect(
+      container
+        .querySelector(".session-hovercard__identity-copy")
+        ?.textContent?.replace(/\s+/gu, " ")
+        .trim(),
+    ).toBe("Alice Baker · with Mira, Riley +3");
+    expect(
+      container.querySelector(".session-hovercard__identity-row")?.getAttribute("aria-label"),
+    ).toBe("Alice Baker, Mira, Riley 3 more participants");
+  });
+
+  it("keeps authoritative overflow when the participant projection is truncated", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        selfUserId: "self",
+        row: row({
+          participants: [
+            { type: "human", id: "mira", label: "Mira" },
+            { type: "human", id: "riley", label: "Riley" },
+            { type: "human", id: "sam", label: "Sam" },
+            { type: "human", id: "lee", label: "Lee" },
+          ],
+          participantCount: 5,
+        }),
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".session-hovercard__participants-more")?.textContent).toBe(
+      "+2",
+    );
   });
 
   it("renders nothing when no session facts are known", () => {

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -241,17 +241,25 @@ function renderSessionContext(
     ${context
       ? html`<div
             class="session-hovercard__context-row"
-            aria-label=${`${t("sessionHovercard.projectLabel")}: ${context.project}`}
-            title=${`${t("sessionHovercard.projectLabel")}: ${context.project}`}
+            aria-label=${`${t(
+              context.kind === "project"
+                ? "sessionHovercard.projectLabel"
+                : "sessionHovercard.workspaceLabel",
+            )}: ${context.name}`}
+            title=${`${t(
+              context.kind === "project"
+                ? "sessionHovercard.projectLabel"
+                : "sessionHovercard.workspaceLabel",
+            )}: ${context.path}`}
           >
             <span class="session-hovercard__context-icon" aria-hidden="true">${icons.folder}</span>
             <span
               class="session-hovercard__context-value session-hovercard__context-text"
-              title=${context.project}
-              >${context.project}</span
+              title=${context.path}
+              >${context.name}</span
             >
           </div>
-          ${context.branch
+          ${context.kind === "project" && context.branch
             ? html`<div
                 class="session-hovercard__context-row"
                 aria-label=${`${t("sessionHovercard.branchLabel")}: ${context.branch}`}

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -4,13 +4,16 @@ import type {
   ControlUiSessionPullRequest,
   ControlUiSessionPullRequestSnapshot,
 } from "../../../src/gateway/control-ui-contract.js";
-import { t } from "../i18n/index.ts";
+import { i18n, t } from "../i18n/index.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
-import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
+import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
+import { icons } from "./icons.ts";
 import { sessionOwnerInitials } from "./session-owner-chip.ts";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
+import "./viewer-facepile.ts";
 
-const MAX_VISIBLE_PULL_REQUESTS = 3;
+const MAX_VISIBLE_PULL_REQUESTS = 4;
+const MAX_VISIBLE_PARTICIPANTS = 3;
 
 type SessionHovercardAvatarAuth = {
   authTokens: readonly string[];
@@ -26,19 +29,31 @@ function pullRequestStateLabel(state: ControlUiSessionPullRequest["state"]): str
   return t(`sessionHovercard.states.${state}`);
 }
 
-function checksPresentation(checks: NonNullable<ControlUiSessionPullRequest["checks"]>): {
-  glyph: string;
-  label: string;
-} {
+function checksLabel(checks: NonNullable<ControlUiSessionPullRequest["checks"]>): string {
   switch (checks.state) {
     case "passing":
-      return { glyph: "✓", label: t("sessionHovercard.checks.passing") };
+      return t("sessionHovercard.checks.passing");
     case "failing":
-      return { glyph: "✗", label: t("sessionHovercard.checks.failing") };
+      return t("sessionHovercard.checks.failing");
     case "pending":
-      return { glyph: "○", label: t("sessionHovercard.checks.pending") };
+      return t("sessionHovercard.checks.pending");
     default:
       return checks.state satisfies never;
+  }
+}
+
+function pullRequestStateIcon(state: ControlUiSessionPullRequest["state"]) {
+  switch (state) {
+    case "open":
+      return icons.gitPullRequest;
+    case "draft":
+      return icons.gitPullRequestDraft;
+    case "merged":
+      return icons.gitMerge;
+    case "closed":
+      return icons.gitPullRequestClosed;
+    default:
+      return state satisfies never;
   }
 }
 
@@ -69,75 +84,222 @@ function renderDiffStats(item: { additions?: number; deletions?: number; changed
   </span>`;
 }
 
-function renderHeader(
-  row: SidebarRecentSession | undefined,
-  channelAvatarAuth: SessionHovercardAvatarAuth | undefined,
-) {
+function renderHeader(row: SidebarSessionHovercardRow | undefined) {
   if (!row) {
     return nothing;
   }
-  const owner = row.owner?.actor ?? row.createdActor;
-  const ownerLabel = owner?.label?.trim() || owner?.id?.trim();
-  const initials = owner ? sessionOwnerInitials(owner) : "";
-  const avatarFallback = initials
-    ? html`<span class="session-hovercard__avatar-fallback" aria-hidden="true">${initials}</span>`
-    : nothing;
-  const created = formatRelativeTimestamp(row.startedAt, { fallback: "" });
-  const updated = formatRelativeTimestamp(row.updatedAt, { fallback: "" });
-  const metadata = [
-    ownerLabel,
-    created ? t("sessionHovercard.created", { time: created }) : undefined,
-    updated ? t("sessionHovercard.updated", { time: updated }) : undefined,
-  ].filter((value): value is string => Boolean(value));
-  if (row.channelAvatarUrl) {
-    ensureChannelAvatarElement();
-  }
+  const hasCreatedAt = typeof row.createdAt === "number" && Number.isFinite(row.createdAt);
+  const created = hasCreatedAt
+    ? formatRelativeTimestamp(row.createdAt, { calendarUnits: true, fallback: "" })
+    : "";
+  const age = hasCreatedAt
+    ? formatRelativeTimestamp(row.createdAt, {
+        calendarUnits: true,
+        fallback: "",
+        suffix: false,
+      })
+    : "";
+  const updated = formatRelativeTimestamp(row.updatedAt, { calendarUnits: true, fallback: "" });
   return html`<header class="session-hovercard__header">
-    ${row.channelAvatarUrl
-      ? html`<openclaw-channel-avatar
-          class="session-hovercard__avatar"
-          .routeUrl=${row.channelAvatarUrl}
-          .authTokens=${channelAvatarAuth?.authTokens ?? []}
-          .authReady=${channelAvatarAuth?.authReady ?? false}
-          .fallback=${avatarFallback}
-        ></openclaw-channel-avatar>`
-      : initials
-        ? html`<span class="session-hovercard__avatar" aria-hidden="true">${initials}</span>`
-        : nothing}
     <span class="session-hovercard__heading">
       <span class="session-hovercard__title">${row.label}</span>
-      ${metadata.length > 0
-        ? html`<span class="session-hovercard__meta">${metadata.join(" · ")}</span>`
+      ${updated
+        ? html`<span class="session-hovercard__meta"
+            >${t("channels.hub.updatedAgo", { ago: updated })}</span
+          >`
         : nothing}
     </span>
+    ${age
+      ? html`<span
+          class="session-hovercard__created-age"
+          data-created-at=${String(row.createdAt)}
+          title=${created}
+          >${age}</span
+        >`
+      : nothing}
   </header>`;
 }
 
-function renderPullRequestChip(pullRequest: ControlUiSessionPullRequest) {
+function sessionWorkContext(row: SidebarSessionHovercardRow | undefined) {
+  return row?.workContext;
+}
+
+function renderSessionContext(
+  row: SidebarSessionHovercardRow | undefined,
+  selfUserId?: string,
+  avatarAuth?: SessionHovercardAvatarAuth,
+) {
+  const creator = row?.createdActor;
+  const creatorLabel = creator?.label?.trim() || creator?.id?.trim();
+  const creatorInitials = creator ? sessionOwnerInitials(creator) : "";
+  const avatarFallback = creatorInitials
+    ? html`<span class="session-hovercard__creator-avatar-fallback" aria-hidden="true"
+        >${creatorInitials}</span
+      >`
+    : nothing;
+  const context = sessionWorkContext(row);
+  const participantIds = new Set<string>();
+  let excludedProjectedCount = 0;
+  const participants = (row?.participants ?? []).filter((participant) => {
+    const id = participant.id?.trim();
+    if (!id || participantIds.has(id)) {
+      return false;
+    }
+    participantIds.add(id);
+    if (id === creator?.id || id === selfUserId) {
+      excludedProjectedCount += 1;
+      return false;
+    }
+    return true;
+  });
+  const visibleParticipants = participants.slice(0, MAX_VISIBLE_PARTICIPANTS);
+  const participantNames = visibleParticipants.map(
+    (participant) => participant.label || participant.id || "",
+  );
+  const formattedParticipantNames = new Intl.ListFormat(i18n.getLocale(), {
+    style: "long",
+    type: "unit",
+  }).format(participantNames);
+  const hiddenParticipantCount = Math.max(
+    0,
+    Math.max(participants.length, (row?.participantCount ?? 0) - excludedProjectedCount) -
+      visibleParticipants.length,
+  );
+  const participantSummary = [
+    formattedParticipantNames,
+    hiddenParticipantCount > 0
+      ? t("sessionHovercard.moreParticipantsLabel", { count: String(hiddenParticipantCount) })
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (!creatorLabel && !context && visibleParticipants.length === 0) {
+    return nothing;
+  }
+  if (row?.channelAvatarUrl) {
+    ensureChannelAvatarElement();
+  }
+  return html`<div class="session-hovercard__context">
+    ${creatorLabel || visibleParticipants.length > 0
+      ? html`<div
+          class="session-hovercard__context-row session-hovercard__identity-row"
+          aria-label=${[creatorLabel, participantSummary].filter(Boolean).join(", ")}
+        >
+          ${row?.channelAvatarUrl
+            ? html`<openclaw-channel-avatar
+                class="session-hovercard__creator-avatar"
+                .routeUrl=${row.channelAvatarUrl}
+                .authTokens=${avatarAuth?.authTokens ?? []}
+                .authReady=${avatarAuth?.authReady ?? false}
+                .fallback=${avatarFallback}
+                aria-hidden="true"
+              ></openclaw-channel-avatar>`
+            : creator?.id
+              ? html`<openclaw-viewer-avatar
+                  class="session-hovercard__creator-avatar"
+                  .user=${{
+                    id: creator.id,
+                    name: creator.label,
+                    avatarUrl: creator.avatarUrl,
+                    watchedSessions: [],
+                  }}
+                  .markAsViewer=${false}
+                  variant="session"
+                  aria-hidden="true"
+                ></openclaw-viewer-avatar>`
+              : html`<span class="session-hovercard__context-icon" aria-hidden="true"
+                  >${icons.users}</span
+                >`}
+          <span class="session-hovercard__identity-copy">
+            ${creatorLabel
+              ? html`<span class="session-hovercard__identity-name">${creatorLabel}</span>`
+              : nothing}
+            ${creatorLabel && visibleParticipants.length > 0
+              ? html`<span class="session-hovercard__identity-separator" aria-hidden="true"
+                  >·</span
+                >`
+              : nothing}
+            ${visibleParticipants.length > 0
+              ? html`<span class="session-hovercard__participants">
+                  <span class="session-hovercard__participant"
+                    >${t("sessionsView.withParticipant", {
+                      name: formattedParticipantNames,
+                    })}</span
+                  >
+                  ${hiddenParticipantCount > 0
+                    ? html`<span class="session-hovercard__participants-more"
+                        >${t("sessionHovercard.moreParticipants", {
+                          count: String(hiddenParticipantCount),
+                        })}</span
+                      >`
+                    : nothing}
+                </span>`
+              : nothing}
+          </span>
+        </div>`
+      : nothing}
+    ${context
+      ? html`<div
+            class="session-hovercard__context-row"
+            aria-label=${`${t("sessionHovercard.projectLabel")}: ${context.project}`}
+            title=${`${t("sessionHovercard.projectLabel")}: ${context.project}`}
+          >
+            <span class="session-hovercard__context-icon" aria-hidden="true">${icons.folder}</span>
+            <span
+              class="session-hovercard__context-value session-hovercard__context-text"
+              title=${context.project}
+              >${context.project}</span
+            >
+          </div>
+          ${context.branch
+            ? html`<div
+                class="session-hovercard__context-row"
+                aria-label=${`${t("sessionHovercard.branchLabel")}: ${context.branch}`}
+                title=${`${t("sessionHovercard.branchLabel")}: ${context.branch}`}
+              >
+                <span class="session-hovercard__context-icon" aria-hidden="true"
+                  >${icons.gitBranch}</span
+                >
+                <span
+                  class="session-hovercard__context-value session-hovercard__context-text"
+                  title=${context.branch}
+                  >${context.branch}</span
+                >
+              </div>`
+            : nothing}`
+      : nothing}
+  </div>`;
+}
+
+function renderPullRequestRow(pullRequest: ControlUiSessionPullRequest) {
   const state = pullRequestStateLabel(pullRequest.state);
-  const checks = pullRequest.checks ? checksPresentation(pullRequest.checks) : null;
+  const checks = pullRequest.checks ? checksLabel(pullRequest.checks) : null;
+  const details = [
+    checks,
+    pullRequest.changedFiles === undefined ? null : changedFilesLabel(pullRequest.changedFiles),
+    pullRequest.additions === undefined ? null : `+${pullRequest.additions.toLocaleString()}`,
+    pullRequest.deletions === undefined ? null : `−${pullRequest.deletions.toLocaleString()}`,
+  ].filter((detail): detail is string => Boolean(detail));
   return html`<a
-    class="session-hovercard__chip session-hovercard__pr-chip"
+    class="session-hovercard__pr-row"
     data-state=${pullRequest.state}
     href=${pullRequest.url}
     target="_blank"
     rel="noopener noreferrer"
-    aria-label=${t("sessionHovercard.pullRequestLabel", {
+    aria-label=${`${t("sessionHovercard.pullRequestLabel", {
       number: String(pullRequest.number),
       state,
-    })}
+    })}${details.length > 0 ? `, ${details.join(", ")}` : ""}`}
   >
+    <span
+      class="session-hovercard__pr-state-icon"
+      role="img"
+      data-checks=${pullRequest.checks?.state ?? nothing}
+      aria-label=${checks ? `${state} · ${checks}` : state}
+      title=${checks ? `${state} · ${checks}` : state}
+      >${pullRequestStateIcon(pullRequest.state)}</span
+    >
     <span class="session-hovercard__pr-number">#${pullRequest.number}</span>
-    <span class="session-hovercard__pr-state">${state}</span>
-    ${checks
-      ? html`<span
-          class="session-hovercard__checks"
-          data-checks=${pullRequest.checks?.state}
-          aria-label=${checks.label}
-          title=${checks.label}
-          >${checks.glyph}</span
-        >`
-      : nothing}
     ${renderDiffStats(pullRequest)}
   </a>`;
 }
@@ -149,8 +311,8 @@ function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot 
   if (snapshot.pullRequests.length > 0) {
     const visible = snapshot.pullRequests.slice(0, MAX_VISIBLE_PULL_REQUESTS);
     const hiddenCount = snapshot.pullRequests.length - visible.length;
-    return html`<div class="session-hovercard__chips">
-      ${visible.map(renderPullRequestChip)}
+    return html`<div class="session-hovercard__pr-list">
+      ${visible.map(renderPullRequestRow)}
       ${hiddenCount > 0
         ? html`<span class="session-hovercard__more"
             >${t("sessionHovercard.more", { count: String(hiddenCount) })}</span
@@ -163,9 +325,11 @@ function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot 
     return nothing;
   }
   const noPullRequest = t("sessionHovercard.noPrYet");
+  const createPullRequest = t("chat.pullRequests.createPr");
   return html`
-    <div class="session-hovercard__chips">
-      <span class="session-hovercard__chip session-hovercard__branch-chip"
+    <div class="session-hovercard__branch-row">
+      <span class="session-hovercard__branch-icon" aria-hidden="true">${icons.gitBranch}</span>
+      <span class="session-hovercard__branch-name"
         >${branch.owner}/${branch.repo} · ${branch.branch}</span
       >
       ${renderDiffStats(branch)}
@@ -173,7 +337,7 @@ function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot 
     <div class="session-hovercard__no-pr">
       ${branch.createUrl
         ? html`<a href=${branch.createUrl} target="_blank" rel="noopener noreferrer"
-            >${noPullRequest}</a
+            >${createPullRequest}</a
           >`
         : noPullRequest}
     </div>
@@ -181,13 +345,25 @@ function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot 
 }
 
 export function renderSessionHovercard(input: {
-  row?: SidebarRecentSession;
-  channelAvatarAuth?: SessionHovercardAvatarAuth;
+  row?: SidebarSessionHovercardRow;
+  selfUserId?: string;
+  avatarAuth?: SessionHovercardAvatarAuth;
   pullRequests?: ControlUiSessionPullRequestSnapshot;
   progressCard?: ProgressCard | null;
 }) {
   const hasPullRequestDetails = Boolean(
     input.pullRequests && (input.pullRequests.pullRequests.length > 0 || input.pullRequests.branch),
+  );
+  const creatorId = input.row?.createdActor?.id;
+  const hasOtherParticipant = input.row?.participants?.some((participant) => {
+    const id = participant.id?.trim();
+    return Boolean(id && id !== creatorId && id !== input.selfUserId);
+  });
+  const hasContext = Boolean(
+    input.row?.channelAvatarUrl ||
+    input.row?.createdActor ||
+    sessionWorkContext(input.row) ||
+    hasOtherParticipant,
   );
   const lastMessagePreview = input.progressCard
     ? undefined
@@ -196,14 +372,30 @@ export function renderSessionHovercard(input: {
     return nothing;
   }
   return html`<div class="session-hovercard">
-    ${renderHeader(input.row, input.channelAvatarAuth)}
-    ${renderPullRequestDetails(input.pullRequests)}
+    ${input.row
+      ? html`<section class="session-hovercard__section session-hovercard__section--header">
+          ${renderHeader(input.row)}
+        </section>`
+      : nothing}
+    ${hasContext
+      ? html`<section class="session-hovercard__section session-hovercard__section--metadata">
+          ${renderSessionContext(input.row, input.selfUserId, input.avatarAuth)}
+        </section>`
+      : nothing}
+    ${hasPullRequestDetails
+      ? html`<section class="session-hovercard__section session-hovercard__section--prs">
+          ${renderPullRequestDetails(input.pullRequests)}
+        </section>`
+      : nothing}
+    ${lastMessagePreview
+      ? html`<section class="session-hovercard__section session-hovercard__section--optional">
+          <div class="session-hovercard__excerpt">${lastMessagePreview}</div>
+        </section>`
+      : nothing}
     ${input.progressCard
-      ? html`<div class="session-hovercard__divider" role="presentation"></div>
-          ${renderSessionProgressCard(input.progressCard, "hovercard")}`
-      : lastMessagePreview
-        ? html`<div class="session-hovercard__divider" role="presentation"></div>
-            <div class="session-hovercard__excerpt">${lastMessagePreview}</div>`
-        : nothing}
+      ? html`<footer class="session-hovercard__section session-hovercard__progress-footer">
+          ${renderSessionProgressCard(input.progressCard, "hovercard")}
+        </footer>`
+      : nothing}
   </div>`;
 }

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -1,11 +1,11 @@
 import type { ProgressCard } from "@openclaw/gateway-protocol";
+import { bucketRelativeTimeMs, type RelativeTimeUnit } from "@openclaw/normalization-core";
 import { html, nothing } from "lit";
 import type {
   ControlUiSessionPullRequest,
   ControlUiSessionPullRequestSnapshot,
 } from "../../../src/gateway/control-ui-contract.js";
 import { i18n, t } from "../i18n/index.ts";
-import { formatRelativeTimestamp } from "../lib/format.ts";
 import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
 import { sessionOwnerInitials } from "./session-owner-chip.ts";
@@ -14,6 +14,8 @@ import "./viewer-facepile.ts";
 
 const MAX_VISIBLE_PULL_REQUESTS = 4;
 const MAX_VISIBLE_PARTICIPANTS = 3;
+
+type SessionAgeUnit = RelativeTimeUnit | "week" | "month" | "year";
 
 type SessionHovercardAvatarAuth = {
   authTokens: readonly string[];
@@ -84,19 +86,63 @@ function renderDiffStats(item: { additions?: number; deletions?: number; changed
   </span>`;
 }
 
+function sessionAgeBucket(diffMs: number): { value: number; unit: SessionAgeUnit } {
+  const days = Math.abs(diffMs) / (24 * 60 * 60_000);
+  if (days >= 365) {
+    return { value: Math.max(1, Math.round(days / 365)), unit: "year" };
+  }
+  if (days >= 28) {
+    return { value: Math.max(1, Math.round(days / 30)), unit: "month" };
+  }
+  if (days >= 7) {
+    return { value: Math.max(1, Math.round(days / 7)), unit: "week" };
+  }
+  if (days >= 1) {
+    return { value: Math.max(1, Math.round(days)), unit: "day" };
+  }
+  return bucketRelativeTimeMs(Math.abs(diffMs));
+}
+
+function formatSessionAge(timestamp: number | null | undefined, suffix: boolean): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return "";
+  }
+  const diff = timestamp - Date.now();
+  const { value, unit } = sessionAgeBucket(diff);
+  if (suffix) {
+    if (unit === "second" && diff <= 0) {
+      return t("common.justNow");
+    }
+    return new Intl.RelativeTimeFormat(i18n.getLocale(), {
+      numeric: "always",
+      style: "narrow",
+    }).format(diff <= 0 ? -value : value, unit);
+  }
+  if (i18n.getLocale().toLowerCase().startsWith("en")) {
+    const compactSuffix: Partial<Record<SessionAgeUnit, string>> = {
+      day: "d",
+      week: "w",
+      month: "mo",
+      year: "y",
+    };
+    const unitSuffix = compactSuffix[unit];
+    if (unitSuffix) {
+      return `${value}${unitSuffix}`;
+    }
+  }
+  return new Intl.NumberFormat(i18n.getLocale(), {
+    style: "unit",
+    unit,
+    unitDisplay: "short",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
 function renderHeader(row: SidebarSessionHovercardRow) {
   const hasCreatedAt = typeof row.createdAt === "number" && Number.isFinite(row.createdAt);
-  const created = hasCreatedAt
-    ? formatRelativeTimestamp(row.createdAt, { calendarUnits: true, fallback: "" })
-    : "";
-  const age = hasCreatedAt
-    ? formatRelativeTimestamp(row.createdAt, {
-        calendarUnits: true,
-        fallback: "",
-        suffix: false,
-      })
-    : "";
-  const updated = formatRelativeTimestamp(row.updatedAt, { calendarUnits: true, fallback: "" });
+  const created = hasCreatedAt ? formatSessionAge(row.createdAt, true) : "";
+  const age = hasCreatedAt ? formatSessionAge(row.createdAt, false) : "";
+  const updated = formatSessionAge(row.updatedAt, true);
   return html`<header class="session-hovercard__header">
     <span class="session-hovercard__heading">
       <span class="session-hovercard__title">${row.label}</span>

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -84,10 +84,7 @@ function renderDiffStats(item: { additions?: number; deletions?: number; changed
   </span>`;
 }
 
-function renderHeader(row: SidebarSessionHovercardRow | undefined) {
-  if (!row) {
-    return nothing;
-  }
+function renderHeader(row: SidebarSessionHovercardRow) {
   const hasCreatedAt = typeof row.createdAt === "number" && Number.isFinite(row.createdAt);
   const created = hasCreatedAt
     ? formatRelativeTimestamp(row.createdAt, { calendarUnits: true, fallback: "" })
@@ -110,18 +107,9 @@ function renderHeader(row: SidebarSessionHovercardRow | undefined) {
         : nothing}
     </span>
     ${age
-      ? html`<span
-          class="session-hovercard__created-age"
-          data-created-at=${String(row.createdAt)}
-          title=${created}
-          >${age}</span
-        >`
+      ? html`<span class="session-hovercard__created-age" title=${created}>${age}</span>`
       : nothing}
   </header>`;
-}
-
-function sessionWorkContext(row: SidebarSessionHovercardRow | undefined) {
-  return row?.workContext;
 }
 
 function renderSessionContext(
@@ -137,7 +125,7 @@ function renderSessionContext(
         >${creatorInitials}</span
       >`
     : nothing;
-  const context = sessionWorkContext(row);
+  const context = row?.workContext;
   const participantIds = new Set<string>();
   let excludedProjectedCount = 0;
   const participants = (row?.participants ?? []).filter((participant) => {
@@ -370,7 +358,7 @@ export function renderSessionHovercard(input: {
   const hasContext = Boolean(
     input.row?.channelAvatarUrl ||
     input.row?.createdActor ||
-    sessionWorkContext(input.row) ||
+    input.row?.workContext ||
     hasOtherParticipant,
   );
   const lastMessagePreview = input.progressCard

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -73,7 +73,7 @@ describe("renderSessionProgressCard", () => {
     const container = document.createElement("div");
     const completed = {
       ...progressCard,
-      steps: progressCard.steps?.map((step) => ({ ...step, status: "completed" as const })),
+      steps: progressCard.steps?.map(({ step }) => ({ step, status: "completed" as const })),
     };
     render(
       renderSessionProgressCard(completed, "composer", () => undefined),

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -43,7 +43,7 @@ describe("renderSessionProgressCard", () => {
       },
       {
         label: "Wire the checklist, in progress",
-        marker: expect.stringContaining("<circle"),
+        marker: expect.stringContaining("session-run-spinner"),
         status: "session-progress-card__step--in_progress",
       },
       {
@@ -59,7 +59,7 @@ describe("renderSessionProgressCard", () => {
     ).not.toBeNull();
     expect(
       card?.querySelector(
-        ".session-progress-card__step--in_progress .session-progress-card__step-marker circle",
+        ".session-progress-card__step--in_progress .session-progress-card__step-marker .session-run-spinner",
       ),
     ).not.toBeNull();
     expect(
@@ -71,7 +71,7 @@ describe("renderSessionProgressCard", () => {
 
   it.each([
     ["completed", "path"],
-    ["in_progress", "circle"],
+    ["in_progress", ".session-run-spinner"],
     ["pending", "polyline"],
   ] as const)("uses the %s marker in the composer summary", (status, markerSelector) => {
     const container = document.createElement("div");

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -48,7 +48,7 @@ describe("renderSessionProgressCard", () => {
       },
       {
         label: "Run focused tests, pending",
-        marker: expect.stringContaining("<circle"),
+        marker: expect.stringContaining("<polyline"),
         status: "session-progress-card__step--pending",
       },
     ]);
@@ -64,7 +64,26 @@ describe("renderSessionProgressCard", () => {
     ).not.toBeNull();
     expect(
       card?.querySelector(
-        ".session-progress-card__step--pending .session-progress-card__step-marker circle",
+        ".session-progress-card__step--pending .session-progress-card__step-marker polyline",
+      ),
+    ).not.toBeNull();
+  });
+
+  it.each([
+    ["completed", "path"],
+    ["in_progress", "circle"],
+    ["pending", "polyline"],
+  ] as const)("uses the %s marker in the composer summary", (status, markerSelector) => {
+    const container = document.createElement("div");
+    const card = {
+      ...progressCard,
+      steps: [{ step: "Current step", status }],
+    };
+    render(renderSessionProgressCard(card, "composer"), container);
+
+    expect(
+      container.querySelector(
+        `.session-progress-card__current-marker[data-status="${status}"] ${markerSelector}`,
       ),
     ).not.toBeNull();
   });

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -30,6 +30,7 @@ describe("renderSessionProgressCard", () => {
     expect(
       [...(card?.querySelectorAll(".session-progress-card__step") ?? [])].map((step) => ({
         label: step.getAttribute("aria-label"),
+        marker: step.querySelector(".session-progress-card__step-marker")?.innerHTML,
         status: [...step.classList].find((name) =>
           name.startsWith("session-progress-card__step--"),
         ),
@@ -37,16 +38,49 @@ describe("renderSessionProgressCard", () => {
     ).toEqual([
       {
         label: "Inspect the route, completed",
+        marker: expect.stringContaining("<path"),
         status: "session-progress-card__step--completed",
       },
       {
         label: "Wire the checklist, in progress",
+        marker: expect.stringContaining("<circle"),
         status: "session-progress-card__step--in_progress",
       },
       {
         label: "Run focused tests, pending",
+        marker: expect.stringContaining("<circle"),
         status: "session-progress-card__step--pending",
       },
     ]);
+    expect(
+      card?.querySelector(
+        ".session-progress-card__step--completed .session-progress-card__step-marker path",
+      ),
+    ).not.toBeNull();
+    expect(
+      card?.querySelector(
+        ".session-progress-card__step--in_progress .session-progress-card__step-marker circle",
+      ),
+    ).not.toBeNull();
+    expect(
+      card?.querySelector(
+        ".session-progress-card__step--pending .session-progress-card__step-marker circle",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("keeps a disclosure affordance beside a completed dismissible composer card", () => {
+    const container = document.createElement("div");
+    const completed = {
+      ...progressCard,
+      steps: progressCard.steps?.map((step) => ({ ...step, status: "completed" as const })),
+    };
+    render(
+      renderSessionProgressCard(completed, "composer", () => undefined),
+      container,
+    );
+
+    expect(container.querySelector(".session-progress-card__dismiss")).not.toBeNull();
+    expect(container.querySelector(".session-progress-card__chevron svg")).not.toBeNull();
   });
 });

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -70,7 +70,6 @@ describe("renderSessionProgressCard", () => {
   });
 
   it.each([
-    ["completed", "path"],
     ["in_progress", ".session-run-spinner"],
     ["pending", "polyline"],
   ] as const)("uses the %s marker in the composer summary", (status, markerSelector) => {

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -41,6 +41,7 @@ function progressStepMarker(status: ProgressCardStep["status"]) {
     case "pending":
       return icons.clock;
   }
+  return status satisfies never;
 }
 
 function renderMarkdown(markdown: string | undefined) {

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -37,7 +37,7 @@ function progressStepMarker(status: ProgressCardStep["status"]) {
     case "completed":
       return icons.check;
     case "in_progress":
-      return icons.circle;
+      return html`<span class="session-run-spinner"></span>`;
     case "pending":
       return icons.clock;
   }

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -49,12 +49,17 @@ function renderSteps(card: ProgressCard) {
   return html`<ol class="session-progress-card__steps">
     ${steps.map((step) => {
       const statusLabel = t(STATUS_LABEL_KEYS[step.status]);
-      const marker = step.status === "completed" ? "✓" : step.status === "in_progress" ? "▸" : "▢";
+      const marker = step.status === "completed" ? icons.check : icons.circle;
       return html`<li
         class="session-progress-card__step session-progress-card__step--${step.status}"
         aria-label=${t("sessionProgressCard.stepLabel", { status: statusLabel, step: step.step })}
       >
-        <span class="session-progress-card__step-marker" aria-hidden="true">${marker}</span>
+        <span
+          class="session-progress-card__step-marker"
+          data-status=${step.status}
+          aria-hidden="true"
+          >${marker}</span
+        >
         <span class="session-progress-card__step-text">${step.step}</span>
       </li>`;
     })}
@@ -102,12 +107,18 @@ export function renderSessionProgressCard(
     : nothing;
   if (placement === "composer") {
     const current = currentProgressStep(card.steps ?? []);
+    const currentMarker = current?.status === "completed" ? icons.check : icons.circle;
     return html`<details
       class="session-progress-card session-progress-card--composer"
       data-progress-card-placement="composer"
     >
       <summary class="session-progress-card__summary" aria-label=${countLabel}>
-        <span class="session-progress-card__current-marker" aria-hidden="true">▸</span>
+        <span
+          class="session-progress-card__current-marker"
+          data-status=${current?.status ?? "pending"}
+          aria-hidden="true"
+          >${currentMarker}</span
+        >
         <span class="session-progress-card__current"
           >${current?.step ?? t("sessionProgressCard.noteLabel")}</span
         >
@@ -117,6 +128,7 @@ export function renderSessionProgressCard(
             >`
           : nothing}
         ${dismiss}
+        <span class="session-progress-card__chevron" aria-hidden="true">${icons.chevronDown}</span>
       </summary>
       ${renderBody(card)}
     </details>`;

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -32,6 +32,17 @@ function currentProgressStep(steps: readonly ProgressCardStep[]): ProgressCardSt
   );
 }
 
+function progressStepMarker(status: ProgressCardStep["status"]) {
+  switch (status) {
+    case "completed":
+      return icons.check;
+    case "in_progress":
+      return icons.circle;
+    case "pending":
+      return icons.clock;
+  }
+}
+
 function renderMarkdown(markdown: string | undefined) {
   if (!markdown) {
     return nothing;
@@ -49,7 +60,6 @@ function renderSteps(card: ProgressCard) {
   return html`<ol class="session-progress-card__steps">
     ${steps.map((step) => {
       const statusLabel = t(STATUS_LABEL_KEYS[step.status]);
-      const marker = step.status === "completed" ? icons.check : icons.circle;
       return html`<li
         class="session-progress-card__step session-progress-card__step--${step.status}"
         aria-label=${t("sessionProgressCard.stepLabel", { status: statusLabel, step: step.step })}
@@ -58,7 +68,7 @@ function renderSteps(card: ProgressCard) {
           class="session-progress-card__step-marker"
           data-status=${step.status}
           aria-hidden="true"
-          >${marker}</span
+          >${progressStepMarker(step.status)}</span
         >
         <span class="session-progress-card__step-text">${step.step}</span>
       </li>`;
@@ -107,7 +117,7 @@ export function renderSessionProgressCard(
     : nothing;
   if (placement === "composer") {
     const current = currentProgressStep(card.steps ?? []);
-    const currentMarker = current?.status === "completed" ? icons.check : icons.circle;
+    const currentStatus = current?.status ?? "pending";
     return html`<details
       class="session-progress-card session-progress-card--composer"
       data-progress-card-placement="composer"
@@ -115,9 +125,9 @@ export function renderSessionProgressCard(
       <summary class="session-progress-card__summary" aria-label=${countLabel}>
         <span
           class="session-progress-card__current-marker"
-          data-status=${current?.status ?? "pending"}
+          data-status=${currentStatus}
           aria-hidden="true"
-          >${currentMarker}</span
+          >${progressStepMarker(currentStatus)}</span
         >
         <span class="session-progress-card__current"
           >${current?.step ?? t("sessionProgressCard.noteLabel")}</span

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -475,7 +475,15 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
                 (element) => element instanceof HTMLAnchorElement && element.href === focusedHref,
               )
             : undefined) ?? focusables[focusedCardIndex];
-        nextFocused?.focus({ preventScroll: true });
+        if (nextFocused) {
+          nextFocused.focus({ preventScroll: true });
+        } else {
+          this.hovercard.cardFocusInside = false;
+          this.suppressFocusOpen = true;
+          this.activeTrigger?.focus({ preventScroll: true });
+          this.suppressFocusOpen = false;
+          this.hovercard.focusInside = document.activeElement === this.activeTrigger;
+        }
       }
       this.hovercard.position();
       return;

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -289,6 +289,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
         this.hovercard.markTrigger(trigger);
         if (this.open) {
           this.showCurrent();
+        } else {
+          this.animateNextOpen = animateEntry;
+          const generation = ++this.loadGeneration;
+          this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
         }
       }
       return;

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -31,12 +31,10 @@ const SKIP_DELAY_MS = 300;
 const ROW_CARD_BRIDGE_MS = 220;
 const CLOSE_DELAY_MS = 100;
 const EXIT_DURATION_MS = 100;
-const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 let nextHovercardId = 0;
 
-function sessionHovercardSuppressed(target: HTMLElement, owner: ParentNode = target): boolean {
+function sessionHovercardMenuOpen(owner: ParentNode): boolean {
   return (
-    target.closest(HOVER_SUPPRESSED_SCOPE) !== null ||
     owner.querySelector(
       '[data-session-menu][aria-expanded="true"], [data-catalog-session-menu][aria-expanded="true"]',
     ) !== null
@@ -70,7 +68,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private readonly activeTargetObserver = new MutationObserver(() => {
     if (
       this.activeTarget &&
-      (!this.contains(this.activeTarget) || sessionHovercardSuppressed(this.activeTarget, this))
+      (!this.contains(this.activeTarget) || sessionHovercardMenuOpen(this))
     ) {
       this.close();
       return;
@@ -189,7 +187,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     const target = sessionProgressHoverTargetFromEvent(event);
-    if (!target || sessionHovercardSuppressed(target, this)) {
+    if (!target || sessionHovercardMenuOpen(this)) {
       return;
     }
     const delayed = this.delayed;
@@ -227,7 +225,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     const trigger = target?.matches(".sidebar-recent-session")
       ? focused?.closest<HTMLElement>("a.sidebar-recent-session__link")
       : focused;
-    if (!target || !trigger || sessionHovercardSuppressed(target, this)) {
+    if (!target || !trigger || sessionHovercardMenuOpen(this)) {
       return;
     }
     this.activate(target, trigger, 0, false);
@@ -306,7 +304,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.hovercard.markTrigger(trigger);
     this.activeTargetObserver.observe(this, {
       attributes: true,
-      attributeFilter: ["aria-expanded", "data-hover-suppressed"],
+      attributeFilter: ["aria-expanded"],
       childList: true,
       subtree: true,
     });
@@ -323,7 +321,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       generation !== this.loadGeneration ||
       this.activeSessionKey !== sessionKey ||
       !target ||
-      sessionHovercardSuppressed(target, this) ||
+      sessionHovercardMenuOpen(this) ||
       !this.hovercard.held
     ) {
       return;

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -25,9 +25,12 @@ import {
   sessionProgressHoverTargetFromEvent,
 } from "./session-progress-hovercard-target.ts";
 
-const OPEN_DELAY_MS = 400;
+const OPEN_DELAY_MS = 450;
+const SWEEP_OPEN_DELAY_MS = 80;
 const SKIP_DELAY_MS = 300;
+const ROW_CARD_BRIDGE_MS = 220;
 const CLOSE_DELAY_MS = 100;
+const EXIT_DURATION_MS = 100;
 const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 let nextHovercardId = 0;
 
@@ -55,9 +58,13 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private suppressFocusOpen = false;
   private open = false;
   private delayed = true;
+  private animateNextOpen = true;
   private skipDelayTimer: number | null = null;
   private lastProgressCard: ProgressCard | null = null;
-  private readonly hovercard = new PortaledHovercardController(() => this.close(), CLOSE_DELAY_MS);
+  private readonly hovercard = new PortaledHovercardController(
+    () => this.close(true),
+    CLOSE_DELAY_MS,
+  );
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
   private readonly activeTargetObserver = new MutationObserver(() => {
@@ -122,6 +129,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.addEventListener("focusin", this.handleFocusIn);
     this.addEventListener("focusout", this.handleFocusOut);
     this.addEventListener("keydown", this.handleKeyDown);
+    this.addEventListener("click", this.handleClick);
     this.addEventListener(SESSION_MENU_OPEN_EVENT, this.handleSessionMenuOpen);
     this.sessionLinkTitler.connect();
     this.connectStore();
@@ -133,6 +141,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.removeEventListener("focusin", this.handleFocusIn);
     this.removeEventListener("focusout", this.handleFocusOut);
     this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("click", this.handleClick);
     this.removeEventListener(SESSION_MENU_OPEN_EVENT, this.handleSessionMenuOpen);
     this.sessionLinkTitler.disconnect();
     this.disconnectStore();
@@ -183,7 +192,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (!target || sessionHovercardSuppressed(target)) {
       return;
     }
-    this.activate(target, target, this.delayed ? OPEN_DELAY_MS : 0);
+    const delayed = this.delayed;
+    this.activate(target, target, delayed ? OPEN_DELAY_MS : SWEEP_OPEN_DELAY_MS, delayed);
     this.hovercard.pointerInside = true;
   };
 
@@ -196,7 +206,16 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     this.hovercard.pointerInside = false;
-    this.hovercard.scheduleClose();
+    const card = this.hovercard.card;
+    const side = card?.dataset.side;
+    const rect = target.getBoundingClientRect();
+    const movingTowardCard =
+      (event.relatedTarget instanceof Node && card?.contains(event.relatedTarget)) ||
+      (side === "right" && event.clientX >= rect.right) ||
+      (side === "left" && event.clientX <= rect.left) ||
+      (side === "bottom" && event.clientY >= rect.bottom) ||
+      (side === "top" && event.clientY <= rect.top);
+    this.hovercard.scheduleClose(movingTowardCard ? ROW_CARD_BRIDGE_MS : CLOSE_DELAY_MS);
   };
 
   private readonly handleFocusIn = (event: FocusEvent) => {
@@ -211,7 +230,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (!target || !trigger || sessionHovercardSuppressed(target)) {
       return;
     }
-    this.activate(target, trigger, 0);
+    this.activate(target, trigger, 0, false);
     this.hovercard.focusInside = true;
   };
 
@@ -241,13 +260,24 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
   };
 
+  private readonly handleClick = (event: Event) => {
+    if (sessionProgressHoverTargetFromEvent(event)) {
+      this.close();
+    }
+  };
+
   private readonly handleSessionMenuOpen = (event: Event) => {
     if (sessionProgressHoverTargetFromEvent(event) === this.activeTarget) {
       this.close();
     }
   };
 
-  private activate(target: HTMLElement, trigger: HTMLElement, delay: number): void {
+  private activate(
+    target: HTMLElement,
+    trigger: HTMLElement,
+    delay: number,
+    animateEntry: boolean,
+  ): void {
     const sessionKey = target.dataset.sessionKey;
     if (!sessionKey) {
       return;
@@ -263,11 +293,12 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       }
       return;
     }
-    this.close();
+    this.close(delay > 0);
     this.activeTarget = target;
     this.activeTrigger = trigger;
     this.activeSessionKey = sessionKey;
     this.open = false;
+    this.animateNextOpen = animateEntry;
     this.lastProgressCard = null;
     this.progressCards?.watch(this, [sessionKey]);
     this.hovercard.markTrigger(trigger);
@@ -395,6 +426,13 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       `openclaw-session-progress-hovercard-${nextHovercardId}`,
       "session-progress-hovercard",
     );
+    const animateEntry = this.animateNextOpen;
+    this.animateNextOpen = false;
+    if (animateEntry) {
+      card.dataset.open = "false";
+    } else {
+      card.dataset.instant = "true";
+    }
     card.dataset.revision = revision;
     card.setAttribute("aria-label", t("sessionHovercard.ariaLabel"));
     render(
@@ -419,6 +457,14 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
     this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false);
+    if (animateEntry) {
+      void card.offsetWidth;
+      window.setTimeout(() => {
+        if (this.hovercard.card === card && this.open) {
+          card.dataset.open = "true";
+        }
+      }, 0);
+    }
   }
 
   private readonly handleCardPointerEnter = () => {
@@ -465,11 +511,12 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     return [...(this.hovercard.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
   }
 
-  private close(): void {
+  private close(animateExit = false): void {
     const wasOpen = this.open;
-    this.hovercard.reset();
+    this.hovercard.reset(animateExit ? EXIT_DURATION_MS : 0);
     this.loadGeneration += 1;
     this.open = false;
+    this.animateNextOpen = true;
     this.lastProgressCard = null;
     this.activeTargetObserver.disconnect();
     this.progressCards?.unwatch(this);

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -423,17 +423,30 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (this.hovercard.card?.dataset.revision === revision) {
       return;
     }
-    nextHovercardId += 1;
-    const card = createPortaledHovercard(
-      `openclaw-session-progress-hovercard-${nextHovercardId}`,
-      "session-progress-hovercard",
-    );
-    const animateEntry = this.animateNextOpen;
-    this.animateNextOpen = false;
-    if (animateEntry) {
-      card.dataset.open = "false";
-    } else {
-      card.dataset.instant = "true";
+    const mountedCard = this.hovercard.card;
+    const focusedCardElement =
+      mountedCard?.contains(document.activeElement) && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const focusedCardIndex = focusedCardElement
+      ? this.cardFocusables().indexOf(focusedCardElement)
+      : -1;
+    const focusedHref =
+      focusedCardElement instanceof HTMLAnchorElement ? focusedCardElement.href : null;
+    const animateEntry = !mountedCard && this.animateNextOpen;
+    let card = mountedCard;
+    if (!card) {
+      nextHovercardId += 1;
+      card = createPortaledHovercard(
+        `openclaw-session-progress-hovercard-${nextHovercardId}`,
+        "session-progress-hovercard",
+      );
+      this.animateNextOpen = false;
+      if (animateEntry) {
+        card.dataset.open = "false";
+      } else {
+        card.dataset.instant = "true";
+      }
     }
     card.dataset.revision = revision;
     card.setAttribute("aria-label", t("sessionHovercard.ariaLabel"));
@@ -451,6 +464,20 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       this.hovercard.clearCard();
       this.hovercard.pointerOverCard = false;
       this.hovercard.cardFocusInside = false;
+      return;
+    }
+    if (mountedCard) {
+      if (focusedCardElement && !card.contains(document.activeElement)) {
+        const focusables = this.cardFocusables();
+        const nextFocused =
+          (focusedHref
+            ? focusables.find(
+                (element) => element instanceof HTMLAnchorElement && element.href === focusedHref,
+              )
+            : undefined) ?? focusables[focusedCardIndex];
+        nextFocused?.focus({ preventScroll: true });
+      }
+      this.hovercard.position();
       return;
     }
     card.addEventListener("pointerenter", this.handleCardPointerEnter);

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -25,8 +25,20 @@ import {
   sessionProgressHoverTargetFromEvent,
 } from "./session-progress-hovercard-target.ts";
 
-const OPEN_DELAY_MS = 350;
+const OPEN_DELAY_MS = 400;
+const SKIP_DELAY_MS = 300;
+const CLOSE_DELAY_MS = 100;
+const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 let nextHovercardId = 0;
+
+function sessionHovercardSuppressed(target: HTMLElement): boolean {
+  return (
+    target.closest(HOVER_SUPPRESSED_SCOPE) !== null ||
+    target.querySelector(
+      '[data-session-menu][aria-expanded="true"], [data-catalog-session-menu][aria-expanded="true"]',
+    ) !== null
+  );
+}
 
 export class SessionProgressHovercardProvider extends ReactiveElement {
   private applicationClient: GatewayBrowserClient | null = null;
@@ -40,14 +52,24 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private activeTrigger: HTMLElement | null = null;
   private activeSessionKey: string | null = null;
   private activePullRequestKey: string | null = null;
+  private suppressFocusOpen = false;
   private open = false;
+  private delayed = true;
+  private skipDelayTimer: number | null = null;
   private lastProgressCard: ProgressCard | null = null;
-  private readonly hovercard = new PortaledHovercardController(() => this.close());
+  private readonly hovercard = new PortaledHovercardController(() => this.close(), CLOSE_DELAY_MS);
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
   private readonly activeTargetObserver = new MutationObserver(() => {
-    if (this.activeTarget && !this.contains(this.activeTarget)) {
+    if (
+      this.activeTarget &&
+      (!this.contains(this.activeTarget) || sessionHovercardSuppressed(this.activeTarget))
+    ) {
       this.close();
+      return;
+    }
+    if (this.open) {
+      this.showCurrent();
     }
   });
 
@@ -115,6 +137,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.sessionLinkTitler.disconnect();
     this.disconnectStore();
     this.close();
+    this.clearSkipDelayTimer();
     super.disconnectedCallback();
   }
 
@@ -157,10 +180,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     const target = sessionProgressHoverTargetFromEvent(event);
-    if (!target) {
+    if (!target || sessionHovercardSuppressed(target)) {
       return;
     }
-    this.activate(target, target, OPEN_DELAY_MS);
+    this.activate(target, target, this.delayed ? OPEN_DELAY_MS : 0);
     this.hovercard.pointerInside = true;
   };
 
@@ -177,9 +200,15 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleFocusIn = (event: FocusEvent) => {
+    if (this.suppressFocusOpen) {
+      return;
+    }
     const target = sessionProgressHoverTargetFromEvent(event);
-    const trigger = event.target instanceof HTMLElement ? event.target : target;
-    if (!target || !trigger) {
+    const focused = event.target instanceof HTMLElement ? event.target : null;
+    const trigger = target?.matches(".sidebar-recent-session")
+      ? focused?.closest<HTMLElement>("a.sidebar-recent-session__link")
+      : focused;
+    if (!target || !trigger || sessionHovercardSuppressed(target)) {
       return;
     }
     this.activate(target, trigger, 0);
@@ -220,7 +249,18 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
 
   private activate(target: HTMLElement, trigger: HTMLElement, delay: number): void {
     const sessionKey = target.dataset.sessionKey;
-    if (!sessionKey || (target === this.activeTarget && sessionKey === this.activeSessionKey)) {
+    if (!sessionKey) {
+      return;
+    }
+    if (target === this.activeTarget && sessionKey === this.activeSessionKey) {
+      if (trigger !== this.activeTrigger) {
+        this.hovercard.reset();
+        this.activeTrigger = trigger;
+        this.hovercard.markTrigger(trigger);
+        if (this.open) {
+          this.showCurrent();
+        }
+      }
       return;
     }
     this.close();
@@ -231,7 +271,12 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.lastProgressCard = null;
     this.progressCards?.watch(this, [sessionKey]);
     this.hovercard.markTrigger(trigger);
-    this.activeTargetObserver.observe(this, { childList: true, subtree: true });
+    this.activeTargetObserver.observe(this, {
+      attributes: true,
+      attributeFilter: ["aria-expanded", "data-hover-suppressed"],
+      childList: true,
+      subtree: true,
+    });
     const generation = ++this.loadGeneration;
     this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
   }
@@ -244,11 +289,15 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (
       generation !== this.loadGeneration ||
       this.activeSessionKey !== sessionKey ||
+      !target ||
+      sessionHovercardSuppressed(target) ||
       !this.hovercard.held
     ) {
       return;
     }
     this.open = true;
+    this.delayed = false;
+    this.clearSkipDelayTimer();
     this.watchPullRequests(sessionKey);
     this.showCurrent();
     try {
@@ -295,7 +344,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     const sidebarRow =
       this.querySelector<AppSidebarSessionNavigationElement>(
         "openclaw-app-sidebar",
-      )?.findSidebarSessionByKey(sessionKey);
+      )?.findSidebarHovercardRowByKey(sessionKey);
     const pullRequests = this.activePullRequestKey
       ? this.pullRequests?.get(this.activePullRequestKey)
       : undefined;
@@ -326,11 +375,14 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
         : null,
       row: sidebarRow
         ? {
-            channelAvatarUrl: sidebarRow.channelAvatarUrl,
             label: sidebarRow.label,
+            channelAvatarUrl: sidebarRow.channelAvatarUrl,
             lastMessagePreview: sidebarRow.lastMessagePreview,
-            owner: sidebarRow.owner?.actor ?? sidebarRow.createdActor,
-            startedAt: sidebarRow.startedAt,
+            createdActor: sidebarRow.createdActor,
+            participants: sidebarRow.participants,
+            participantCount: sidebarRow.participantCount,
+            workContext: sidebarRow.workContext,
+            createdAt: sidebarRow.createdAt,
             updatedAt: sidebarRow.updatedAt,
           }
         : null,
@@ -348,7 +400,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     render(
       renderSessionHovercard({
         row: sidebarRow,
-        channelAvatarAuth,
+        selfUserId: this.applicationContext?.gateway.snapshot.selfUser?.id,
+        avatarAuth: channelAvatarAuth,
         pullRequests,
         progressCard: this.lastProgressCard,
       }),
@@ -403,7 +456,9 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     event.preventDefault();
     const trigger = this.activeTrigger;
     this.close();
+    this.suppressFocusOpen = true;
     trigger?.focus({ preventScroll: true });
+    this.suppressFocusOpen = false;
   };
 
   private cardFocusables(): HTMLElement[] {
@@ -411,6 +466,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   }
 
   private close(): void {
+    const wasOpen = this.open;
     this.hovercard.reset();
     this.loadGeneration += 1;
     this.open = false;
@@ -421,5 +477,19 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.activeTarget = null;
     this.activeTrigger = null;
     this.activeSessionKey = null;
+    if (wasOpen) {
+      this.clearSkipDelayTimer();
+      this.skipDelayTimer = window.setTimeout(() => {
+        this.skipDelayTimer = null;
+        this.delayed = true;
+      }, SKIP_DELAY_MS);
+    }
+  }
+
+  private clearSkipDelayTimer(): void {
+    if (this.skipDelayTimer !== null) {
+      window.clearTimeout(this.skipDelayTimer);
+      this.skipDelayTimer = null;
+    }
   }
 }

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -34,10 +34,10 @@ const EXIT_DURATION_MS = 100;
 const HOVER_SUPPRESSED_SCOPE = "[data-hover-suppressed]";
 let nextHovercardId = 0;
 
-function sessionHovercardSuppressed(target: HTMLElement): boolean {
+function sessionHovercardSuppressed(target: HTMLElement, owner: ParentNode = target): boolean {
   return (
     target.closest(HOVER_SUPPRESSED_SCOPE) !== null ||
-    target.querySelector(
+    owner.querySelector(
       '[data-session-menu][aria-expanded="true"], [data-catalog-session-menu][aria-expanded="true"]',
     ) !== null
   );
@@ -70,7 +70,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private readonly activeTargetObserver = new MutationObserver(() => {
     if (
       this.activeTarget &&
-      (!this.contains(this.activeTarget) || sessionHovercardSuppressed(this.activeTarget))
+      (!this.contains(this.activeTarget) || sessionHovercardSuppressed(this.activeTarget, this))
     ) {
       this.close();
       return;
@@ -189,7 +189,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     const target = sessionProgressHoverTargetFromEvent(event);
-    if (!target || sessionHovercardSuppressed(target)) {
+    if (!target || sessionHovercardSuppressed(target, this)) {
       return;
     }
     const delayed = this.delayed;
@@ -227,7 +227,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     const trigger = target?.matches(".sidebar-recent-session")
       ? focused?.closest<HTMLElement>("a.sidebar-recent-session__link")
       : focused;
-    if (!target || !trigger || sessionHovercardSuppressed(target)) {
+    if (!target || !trigger || sessionHovercardSuppressed(target, this)) {
       return;
     }
     this.activate(target, trigger, 0, false);
@@ -266,10 +266,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
   };
 
-  private readonly handleSessionMenuOpen = (event: Event) => {
-    if (sessionProgressHoverTargetFromEvent(event) === this.activeTarget) {
-      this.close();
-    }
+  private readonly handleSessionMenuOpen = () => {
+    this.close();
   };
 
   private activate(
@@ -325,7 +323,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       generation !== this.loadGeneration ||
       this.activeSessionKey !== sessionKey ||
       !target ||
-      sessionHovercardSuppressed(target) ||
+      sessionHovercardSuppressed(target, this) ||
       !this.hovercard.held
     ) {
       return;

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -68,6 +68,54 @@ async function emitPullRequestSnapshot(
             title: "Restore the session hovercard",
             url: "https://github.com/openclaw/openclaw/pull/417",
           },
+          {
+            additions: 72,
+            branch: "steipete/session-hovercard-unify",
+            changedFiles: 4,
+            checks: { state: "pending", passed: 8, failed: 0, skipped: 0, running: 5 },
+            deletions: 12,
+            number: 418,
+            owner: "openclaw",
+            repo: "openclaw",
+            state: "draft",
+            title: "Follow-up polish",
+            url: "https://github.com/openclaw/openclaw/pull/418",
+          },
+          {
+            additions: 14,
+            branch: "steipete/session-hovercard-unify",
+            changedFiles: 2,
+            checks: { state: "failing", passed: 10, failed: 2, skipped: 0, running: 0 },
+            deletions: 21,
+            number: 419,
+            owner: "openclaw",
+            repo: "openclaw",
+            state: "closed",
+            title: "Accessibility follow-up",
+            url: "https://github.com/openclaw/openclaw/pull/419",
+          },
+          {
+            additions: 83,
+            branch: "steipete/session-hovercard-unify",
+            changedFiles: 6,
+            checks: { state: "passing", passed: 18, failed: 0, skipped: 1, running: 0 },
+            deletions: 29,
+            number: 420,
+            owner: "openclaw",
+            repo: "openclaw",
+            state: "merged",
+            title: "Merged hovercard follow-up",
+            url: "https://github.com/openclaw/openclaw/pull/420",
+          },
+          {
+            branch: "steipete/session-hovercard-unify",
+            number: 421,
+            owner: "openclaw",
+            repo: "openclaw",
+            state: "open",
+            title: "Hidden by summary",
+            url: "https://github.com/openclaw/openclaw/pull/421",
+          },
         ],
         rateLimited: false,
         status: "ready",
@@ -189,12 +237,21 @@ suite.define(() => {
             status: 200,
           });
         });
+        await page.addInitScript(() => {
+          localStorage.setItem("openclaw:sidebar:sessions:collapsed-sections", "[]");
+        });
         const gateway = await installMockGateway(page, {
           featureMethods: [
             "chat.metadata",
             "chat.startup",
             "progressCard.get",
             SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+          ],
+          presenceUsers: [
+            { self: true, id: "profile-self", name: "You" },
+            { id: "profile-mira", name: "Mira" },
+            { id: "profile-riley", name: "Riley" },
+            { id: "profile-ada", name: "Ada King" },
           ],
           historyMessages: [
             {
@@ -238,13 +295,26 @@ suite.define(() => {
               },
               {
                 createdActor: { type: "human", id: "profile-ada", label: "Ada King" },
+                createdAt: now - 89 * 24 * 60 * 60_000,
                 key: sessionKey,
                 kind: "direct",
                 label: "Other session",
                 displayName: "Other session",
                 channelAvatarUrl,
-                startedAt: now - 2 * 60 * 60_000,
-                updatedAt: now - 15 * 60_000,
+                participants: [
+                  { type: "human", id: "profile-ada", label: "Ada King" },
+                  { type: "human", id: "profile-self", label: "You" },
+                  { type: "human", id: "profile-mira", label: "Mira" },
+                  { type: "human", id: "profile-riley", label: "Riley" },
+                ],
+                participantCount: 6,
+                startedAt: now - 89 * 24 * 60 * 60_000,
+                updatedAt: now - 21 * 24 * 60 * 60_000,
+                worktree: {
+                  id: "wt-hovercard-proof",
+                  branch: "feature/session-hovercards",
+                  repoRoot: "/work/openclaw",
+                },
               },
             ]),
           },
@@ -267,9 +337,29 @@ suite.define(() => {
           .poll(() => card.locator(".session-hovercard__title").textContent())
           .toBe("Other session");
         await expect
-          .poll(() => card.locator(".session-hovercard__meta").textContent())
+          .poll(() => card.locator(".session-progress-card__heading").textContent())
+          .toContain("1/3");
+        await expect.poll(() => card.locator(".session-hovercard__pr-row").count()).toBe(4);
+        await captureProof(page, "sidebar-row-hovercard-maximum.png");
+        await expect
+          .poll(() => card.locator(".session-hovercard__identity-row").textContent())
           .toContain("Ada King");
-        const avatar = card.locator("openclaw-channel-avatar.session-hovercard__avatar");
+        expect(await card.locator(".session-hovercard__identity-row").textContent()).toContain(
+          "Mira",
+        );
+        expect(await card.locator(".session-hovercard__identity-row").textContent()).not.toContain(
+          "You",
+        );
+        expect(await card.locator(".session-hovercard__context-text").allTextContents()).toEqual([
+          "openclaw",
+          "feature/session-hovercards",
+        ]);
+        await expect
+          .poll(() => card.locator(".session-hovercard__created-age").textContent())
+          .toBe("3mo");
+        const avatar = card.locator(
+          "openclaw-channel-avatar.session-hovercard__creator-avatar",
+        );
         await avatar.waitFor({ state: "visible" });
         await expect.poll(() => avatar.locator("img.channel-avatar").count()).toBe(1);
         expect(
@@ -279,12 +369,14 @@ suite.define(() => {
             naturalWidth: image.naturalWidth,
           })),
         ).toEqual({ complete: true, naturalHeight: 64, naturalWidth: 64 });
-        expect(await card.locator("span.session-hovercard__avatar").count()).toBe(0);
-        const pullRequest = card.locator(".session-hovercard__pr-chip");
+        expect(await card.locator("openclaw-viewer-avatar").count()).toBe(0);
+        const pullRequest = card.locator(".session-hovercard__pr-row").first();
         await expect
           .poll(() => pullRequest.locator(".session-hovercard__pr-number").textContent())
           .toBe("#417");
-        expect(await pullRequest.locator(".session-hovercard__checks").textContent()).toBe("✓");
+        expect(
+          await pullRequest.locator(".session-hovercard__pr-state-icon").getAttribute("title"),
+        ).toBe("Open · CI checks passing");
         expect(await pullRequest.locator(".session-hovercard__files").textContent()).toBe(
           "7 files",
         );
@@ -317,6 +409,40 @@ suite.define(() => {
         await expect
           .poll(() => card.locator(".session-progress-card__step--pending").textContent())
           .toContain("Publish");
+        expect(
+          await card
+            .locator(
+              ".session-progress-card__step--completed .session-progress-card__step-marker svg",
+            )
+            .count(),
+        ).toBe(1);
+        expect(
+          await card
+            .locator(
+              ".session-progress-card__step--in_progress .session-progress-card__step-marker circle",
+            )
+            .count(),
+        ).toBe(1);
+        expect(
+          await card
+            .locator(
+              ".session-progress-card__step--pending .session-progress-card__step-marker circle",
+            )
+            .count(),
+        ).toBe(1);
+        const markerPresentation = await card
+          .locator(".session-progress-card__step-marker")
+          .evaluateAll((markers) =>
+            markers.slice(1).map((marker) => ({
+              color: getComputedStyle(marker).color,
+              dot: getComputedStyle(marker, "::after").content,
+            })),
+          );
+        expect(markerPresentation[0]?.dot).not.toBe("none");
+        expect(markerPresentation[0]?.dot).not.toBe(markerPresentation[1]?.dot);
+        expect(await card.locator(".session-hovercard__progress-footer:last-child").count()).toBe(
+          1,
+        );
         expect(await page.evaluate(() => "__progressCardPwned" in window)).toBe(false);
         await captureProof(page, "sidebar-row-hovercard-avatar.png");
         await captureProof(page, "sidebar-row-hovercard-progress.png");
@@ -336,7 +462,7 @@ suite.define(() => {
           .poll(() => card.locator(".session-hovercard__title").textContent())
           .toBe("Other session");
         await expect
-          .poll(() => card.locator(".session-hovercard__pr-number").textContent())
+          .poll(() => card.locator(".session-hovercard__pr-number").first().textContent())
           .toBe("#417");
         await expect.poll(() => card.locator("strong").textContent()).toContain("Building");
         await captureProof(page, "chat-link-hovercard-progress.png");
@@ -396,6 +522,168 @@ suite.define(() => {
           )
           .toBe(3);
         await captureProof(page, "hovercard-updated.png");
+      },
+    );
+  });
+
+  it("honors cold, bridge, sweep, and menu-suppression timing on real sidebar rows", async () => {
+    const selectedSessionKey = "agent:main:timing-selected";
+    const firstSessionKey = "agent:main:timing-first";
+    const secondSessionKey = "agent:main:timing-second";
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          methodResponses: {
+            "progressCard.get": { card: null },
+            "sessions.list": chatSessionListResponse([
+              { key: selectedSessionKey, kind: "direct", label: "Selected", updatedAt: 3 },
+              { key: firstSessionKey, kind: "direct", label: "First timing row", updatedAt: 2 },
+              { key: secondSessionKey, kind: "direct", label: "Second timing row", updatedAt: 1 },
+            ]),
+          },
+          sessionKey: selectedSessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        const first = page.locator(`[data-session-key="${firstSessionKey}"]`);
+        const second = page.locator(`[data-session-key="${secondSessionKey}"]`);
+        const card = page.locator(".session-progress-hovercard");
+        await first.waitFor({ state: "visible" });
+
+        const pointer = async (locator: typeof first, type: "pointerover" | "pointerout") =>
+          locator.dispatchEvent(type, {
+            bubbles: true,
+            composed: true,
+            pointerType: "mouse",
+            relatedTarget: null,
+          });
+
+        await first.hover();
+        expect(await card.count()).toBe(0);
+        await card.waitFor({ state: "visible" });
+        await pointer(first, "pointerout");
+        await card.hover();
+        expect(await card.count()).toBe(1);
+        await page.mouse.move(900, 800);
+        await expect.poll(() => card.count()).toBe(0);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        await first.hover();
+        expect(await card.count()).toBe(0);
+        await card.waitFor({ state: "visible" });
+
+        await second.hover();
+        await expect
+          .poll(() => card.locator(".session-hovercard__title").textContent())
+          .toBe("Second timing row");
+
+        await card.hover();
+        expect(await card.count()).toBe(1);
+        await page.mouse.move(900, 800);
+        await expect.poll(() => card.count()).toBe(0);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        await first.hover();
+        await card.waitFor({ state: "visible" });
+        await first
+          .getByRole("button", { name: "Open session menu: First timing row" })
+          .dispatchEvent("click");
+        await expect.poll(() => card.count()).toBe(0);
+        await expect
+          .poll(() => page.locator("openclaw-session-menu").getByRole("menuitem").count())
+          .toBeGreaterThan(0);
+      },
+    );
+  });
+
+  it("renders and dismisses synthetic catalog-session hovercards", async () => {
+    const selectedSessionKey = "agent:main:catalog-selected";
+    const catalogSessionKey = "catalog:codex:gateway%3Acodex:thread-1";
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "progressCard.get",
+            "sessions.catalog.list",
+          ],
+          methodResponses: {
+            "progressCard.get": { card: null },
+            "sessions.list": chatSessionListResponse([
+              { key: selectedSessionKey, kind: "direct", label: "Selected", updatedAt: 1 },
+            ]),
+            "sessions.catalog.list": {
+              catalogs: [
+                {
+                  id: "codex",
+                  label: "Codex",
+                  capabilities: { continueSession: true, archive: true },
+                  hosts: [
+                    {
+                      hostId: "gateway:codex",
+                      label: "Local Codex",
+                      kind: "gateway",
+                      connected: true,
+                      sessions: [
+                        {
+                          threadId: "thread-1",
+                          name: "Catalog release review",
+                          cwd: "/work/openclaw",
+                          gitBranch: "catalog-hovercard",
+                          createdAt: nowSeconds - 2 * 60 * 60,
+                          updatedAt: nowSeconds - 5 * 60,
+                          status: "stored",
+                          archived: false,
+                          canContinue: true,
+                          canArchive: true,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          sessionKey: selectedSessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        const row = page.locator(`[data-session-key="${catalogSessionKey}"]`);
+        await row.waitFor({ state: "visible" });
+        await row.hover();
+        const card = page.locator(".session-progress-hovercard");
+        await card.waitFor({ state: "visible" });
+        expect(await card.locator(".session-hovercard__title").textContent()).toBe(
+          "Catalog release review",
+        );
+        expect(await card.locator(".session-hovercard__created-age").textContent()).toBe("2 hr");
+        expect(await card.locator(".session-hovercard__context-text").allTextContents()).toEqual([
+          "openclaw",
+          "catalog-hovercard",
+        ]);
+
+        await row.getByRole("button", { name: "Open session menu" }).dispatchEvent("click");
+        await expect.poll(() => card.count()).toBe(0);
+        await expect
+          .poll(() => page.locator("openclaw-catalog-session-menu").getByRole("menuitem").count())
+          .toBeGreaterThan(0);
       },
     );
   });
@@ -489,6 +777,11 @@ suite.define(() => {
         await expect
           .poll(() => page.locator(":focus").getAttribute("href"))
           .toBe("https://example.com/build");
+        await page.keyboard.press("Escape");
+        await expect.poll(() => card.count()).toBe(0);
+        expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);
+        expect(await trigger.getAttribute("aria-haspopup")).toBeNull();
+        expect(await trigger.getAttribute("aria-expanded")).toBeNull();
         await captureProof(page, "keyboard-focus.png");
       },
     );
@@ -552,12 +845,14 @@ suite.define(() => {
         const card = page.locator(".session-progress-hovercard");
         await card.waitFor({ state: "visible" });
         expect(["left", "right"]).toContain(await card.getAttribute("data-side"));
-        const avatar = card.locator("openclaw-channel-avatar.session-hovercard__avatar");
+        const avatar = card.locator(
+          "openclaw-channel-avatar.session-hovercard__creator-avatar",
+        );
         await expect
-          .poll(() => avatar.locator(".session-hovercard__avatar-fallback").textContent())
+          .poll(() => avatar.locator(".session-hovercard__creator-avatar-fallback").textContent())
           .toBe("AK");
         expect(await avatar.locator("img.channel-avatar").count()).toBe(0);
-        expect(await card.locator("span.session-hovercard__avatar").count()).toBe(0);
+        expect(await card.locator("openclaw-viewer-avatar").count()).toBe(0);
         await expect
           .poll(() => card.locator(".session-hovercard__excerpt").textContent())
           .toBe(lastMessagePreview);

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -578,6 +578,17 @@ suite.define(() => {
         await page.waitForTimeout(300);
 
         await first.hover();
+        await first.locator("a.sidebar-recent-session__link").focus();
+        await card.waitFor({ state: "visible" });
+        await expect
+          .poll(() => card.locator(".session-hovercard__title").textContent())
+          .toBe("First timing row");
+        await page.keyboard.press("Escape");
+        await expect.poll(() => card.count()).toBe(0);
+        await page.mouse.move(900, 800);
+        await page.waitForTimeout(300);
+
+        await first.hover();
         expect(await card.count()).toBe(0);
         await card.waitFor({ state: "visible" });
 

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -804,6 +804,27 @@ suite.define(() => {
         await expect
           .poll(() => page.locator(":focus").getAttribute("href"))
           .toBe("https://example.com/build");
+        await gateway.setMethodResponse("progressCard.get", {
+          cases: [
+            { match: { sessionKey: selectedSessionKey }, response: { card: null } },
+            {
+              match: { sessionKey },
+              response: {
+                card: {
+                  markdown: "Updated build: [Open build log](https://example.com/build)",
+                  revision: 2,
+                  sessionKey,
+                  updatedAt: 2,
+                },
+              },
+            },
+          ],
+        });
+        await gateway.emitGatewayEvent("progressCard.changed", { revision: 2, sessionKey });
+        await expect.poll(() => card.textContent()).toContain("Updated build");
+        await expect
+          .poll(() => page.locator(":focus").getAttribute("href"))
+          .toBe("https://example.com/build");
         await page.keyboard.press("Escape");
         await expect.poll(() => card.count()).toBe(0);
         expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -204,7 +204,6 @@ suite.define(() => {
     const now = Date.now();
     const selectedSessionKey = "agent:main:selected";
     const sessionKey = "agent:main:other-session";
-    const channelAvatarUrl = `/__openclaw__/channel-avatar/${encodeURIComponent(sessionKey)}`;
     const initialMarkdown = [
       "**Building** phase 2",
       "",
@@ -227,16 +226,6 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
-        await page.route(`**${channelAvatarUrl}`, async (route) => {
-          expect(await route.request().headerValue("authorization")).toBe(
-            "Bearer e2e-device-token",
-          );
-          await route.fulfill({
-            body: `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="32" fill="#b84cff"/><circle cx="24" cy="27" r="5" fill="white"/><circle cx="43" cy="27" r="5" fill="white"/><path d="M19 43c8 6 19 6 27 0" fill="none" stroke="white" stroke-width="4" stroke-linecap="round"/></svg>`,
-            contentType: "image/svg+xml",
-            status: 200,
-          });
-        });
         await page.addInitScript(() => {
           localStorage.setItem("openclaw:sidebar:sessions:collapsed-sections", "[]");
         });
@@ -300,7 +289,6 @@ suite.define(() => {
                 kind: "direct",
                 label: "Other session",
                 displayName: "Other session",
-                channelAvatarUrl,
                 participants: [
                   { type: "human", id: "profile-ada", label: "Ada King" },
                   { type: "human", id: "profile-self", label: "You" },
@@ -357,19 +345,12 @@ suite.define(() => {
         await expect
           .poll(() => card.locator(".session-hovercard__created-age").textContent())
           .toBe("3mo");
-        const avatar = card.locator(
-          "openclaw-channel-avatar.session-hovercard__creator-avatar",
-        );
+        const avatar = card.locator("openclaw-viewer-avatar.session-hovercard__creator-avatar");
         await avatar.waitFor({ state: "visible" });
-        await expect.poll(() => avatar.locator("img.channel-avatar").count()).toBe(1);
-        expect(
-          await avatar.locator("img.channel-avatar").evaluate((image: HTMLImageElement) => ({
-            complete: image.complete,
-            naturalHeight: image.naturalHeight,
-            naturalWidth: image.naturalWidth,
-          })),
-        ).toEqual({ complete: true, naturalHeight: 64, naturalWidth: 64 });
-        expect(await card.locator("openclaw-viewer-avatar").count()).toBe(0);
+        await expect
+          .poll(async () => (await avatar.locator(".viewer-avatar").textContent())?.trim())
+          .toBe("AK");
+        expect(await card.locator("openclaw-channel-avatar").count()).toBe(0);
         const pullRequest = card.locator(".session-hovercard__pr-row").first();
         await expect
           .poll(() => pullRequest.locator(".session-hovercard__pr-number").textContent())
@@ -457,7 +438,11 @@ suite.define(() => {
         await card.waitFor({ state: "visible" });
         await waitForPullRequestSubscription(gateway, sessionKey);
         await emitPullRequestSnapshot(gateway, sessionKey);
-        expect(["bottom", "top"]).toContain(await card.getAttribute("data-side"));
+        await expect
+          .poll(async () =>
+            ["bottom", "top"].includes((await card.getAttribute("data-side")) ?? ""),
+          )
+          .toBe(true);
         await expect
           .poll(() => card.locator(".session-hovercard__title").textContent())
           .toBe("Other session");
@@ -558,29 +543,49 @@ suite.define(() => {
         const card = page.locator(".session-progress-hovercard");
         await first.waitFor({ state: "visible" });
 
-        const pointer = async (locator: typeof first, type: "pointerover" | "pointerout") =>
+        const pointer = async (
+          locator: typeof first,
+          type: "pointerover" | "pointerout",
+          coordinates: { clientX?: number; clientY?: number } = {},
+        ) =>
           locator.dispatchEvent(type, {
             bubbles: true,
             composed: true,
+            ...coordinates,
             pointerType: "mouse",
             relatedTarget: null,
           });
 
         await first.hover();
         expect(await card.count()).toBe(0);
+        await page.waitForTimeout(300);
+        expect(await card.count()).toBe(0);
         await card.waitFor({ state: "visible" });
-        await pointer(first, "pointerout");
+        const firstBounds = await first.boundingBox();
+        expect(firstBounds).not.toBeNull();
+        await pointer(first, "pointerout", {
+          clientX: (firstBounds?.x ?? 0) + (firstBounds?.width ?? 0),
+          clientY: (firstBounds?.y ?? 0) + (firstBounds?.height ?? 0) / 2,
+        });
+        await page.waitForTimeout(150);
+        expect(await card.count()).toBe(1);
         await card.hover();
         expect(await card.count()).toBe(1);
         await page.mouse.move(900, 800);
+        await page.waitForTimeout(50);
+        expect(await card.count()).toBe(1);
         await expect.poll(() => card.count()).toBe(0);
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        await page.waitForTimeout(300);
 
         await first.hover();
         expect(await card.count()).toBe(0);
         await card.waitFor({ state: "visible" });
 
         await second.hover();
+        await page.waitForTimeout(40);
+        expect(await card.locator(".session-hovercard__title").textContent()).toBe(
+          "First timing row",
+        );
         await expect
           .poll(() => card.locator(".session-hovercard__title").textContent())
           .toBe("Second timing row");
@@ -589,7 +594,7 @@ suite.define(() => {
         expect(await card.count()).toBe(1);
         await page.mouse.move(900, 800);
         await expect.poll(() => card.count()).toBe(0);
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        await page.waitForTimeout(300);
 
         await first.hover();
         await card.waitFor({ state: "visible" });
@@ -762,6 +767,9 @@ suite.define(() => {
           .toBe(1);
 
         await card.waitFor({ state: "visible" });
+        await expect
+          .poll(() => card.evaluate((element) => getComputedStyle(element).opacity))
+          .toBe("1");
         expect(await card.getAttribute("role")).toBe("dialog");
         expect(await trigger.getAttribute("aria-haspopup")).toBe("dialog");
         expect(await trigger.getAttribute("aria-expanded")).toBe("true");
@@ -787,10 +795,12 @@ suite.define(() => {
     );
   });
 
-  it("shows the latest turn when the session has no progress card", async () => {
+  it("shows the latest turn and authenticates channel avatars", async () => {
     const now = Date.now();
     const sessionKey = "agent:main:no-progress-card";
+    const avatarSessionKey = "agent:main:channel-avatar";
     const channelAvatarUrl = `/__openclaw__/channel-avatar/${encodeURIComponent(sessionKey)}`;
+    const successfulChannelAvatarUrl = `/__openclaw__/channel-avatar/${encodeURIComponent(avatarSessionKey)}`;
     const lastMessagePreview =
       "The final release notes are ready for review, including <strong>plain text</strong>, rollout details, verification notes, compatibility guidance, and a concise operator checklist.";
 
@@ -807,6 +817,16 @@ suite.define(() => {
             "Bearer e2e-device-token",
           );
           await route.fulfill({ status: 404 });
+        });
+        await page.route(`**${successfulChannelAvatarUrl}`, async (route) => {
+          expect(await route.request().headerValue("authorization")).toBe(
+            "Bearer e2e-device-token",
+          );
+          await route.fulfill({
+            body: `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="32" fill="#64748b"/><text x="32" y="40" fill="white" font-size="24" text-anchor="middle">A</text></svg>`,
+            contentType: "image/svg+xml",
+            status: 200,
+          });
         });
         const gateway = await installMockGateway(page, {
           featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
@@ -830,6 +850,14 @@ suite.define(() => {
                 lastMessagePreview,
                 updatedAt: now - 5 * 60_000,
               },
+              {
+                channelAvatarUrl: successfulChannelAvatarUrl,
+                createdActor: { type: "human", id: "profile-ada", label: "Ada King" },
+                key: avatarSessionKey,
+                kind: "direct",
+                label: "Channel avatar",
+                updatedAt: now - 6 * 60_000,
+              },
             ]),
           },
           sessionKey,
@@ -845,9 +873,7 @@ suite.define(() => {
         const card = page.locator(".session-progress-hovercard");
         await card.waitFor({ state: "visible" });
         expect(["left", "right"]).toContain(await card.getAttribute("data-side"));
-        const avatar = card.locator(
-          "openclaw-channel-avatar.session-hovercard__creator-avatar",
-        );
+        const avatar = card.locator("openclaw-channel-avatar.session-hovercard__creator-avatar");
         await expect
           .poll(() => avatar.locator(".session-hovercard__creator-avatar-fallback").textContent())
           .toBe("AK");
@@ -863,6 +889,27 @@ suite.define(() => {
             .locator(".session-hovercard__excerpt")
             .evaluate((element) => getComputedStyle(element).webkitLineClamp),
         ).toBe("2");
+
+        const avatarRow = page.locator(
+          `.sidebar-recent-session[data-session-key="${avatarSessionKey}"]`,
+        );
+        await avatarRow.hover();
+        await expect
+          .poll(() => card.locator(".session-hovercard__title").textContent())
+          .toBe("Channel avatar");
+        const successfulAvatar = card.locator(
+          "openclaw-channel-avatar.session-hovercard__creator-avatar",
+        );
+        await expect.poll(() => successfulAvatar.locator("img.channel-avatar").count()).toBe(1);
+        expect(
+          await successfulAvatar
+            .locator("img.channel-avatar")
+            .evaluate((image: HTMLImageElement) => ({
+              complete: image.complete,
+              naturalHeight: image.naturalHeight,
+              naturalWidth: image.naturalWidth,
+            })),
+        ).toEqual({ complete: true, naturalHeight: 64, naturalWidth: 64 });
         await captureProof(page, "sidebar-row-hovercard-last-turn.png");
       },
     );

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -825,6 +825,26 @@ suite.define(() => {
         await expect
           .poll(() => page.locator(":focus").getAttribute("href"))
           .toBe("https://example.com/build");
+        await gateway.setMethodResponse("progressCard.get", {
+          cases: [
+            { match: { sessionKey: selectedSessionKey }, response: { card: null } },
+            {
+              match: { sessionKey },
+              response: {
+                card: {
+                  markdown: "Updated build complete",
+                  revision: 3,
+                  sessionKey,
+                  updatedAt: 3,
+                },
+              },
+            },
+          ],
+        });
+        await gateway.emitGatewayEvent("progressCard.changed", { revision: 3, sessionKey });
+        await expect.poll(() => card.textContent()).toContain("Updated build complete");
+        expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);
+        expect(await card.count()).toBe(1);
         await page.keyboard.press("Escape");
         await expect.poll(() => card.count()).toBe(0);
         expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -616,6 +616,9 @@ suite.define(() => {
         await expect
           .poll(() => page.locator("openclaw-session-menu").getByRole("menuitem").count())
           .toBeGreaterThan(0);
+        await second.dispatchEvent("pointerover", { pointerType: "mouse" });
+        await page.waitForTimeout(500);
+        expect(await card.count()).toBe(0);
       },
     );
   });
@@ -700,6 +703,11 @@ suite.define(() => {
         await expect
           .poll(() => page.locator("openclaw-catalog-session-menu").getByRole("menuitem").count())
           .toBeGreaterThan(0);
+        await page
+          .locator(`[data-session-key="${selectedSessionKey}"]`)
+          .dispatchEvent("pointerover", { pointerType: "mouse" });
+        await page.waitForTimeout(500);
+        expect(await card.count()).toBe(0);
       },
     );
   });

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -400,14 +400,14 @@ suite.define(() => {
         expect(
           await card
             .locator(
-              ".session-progress-card__step--in_progress .session-progress-card__step-marker circle",
+              ".session-progress-card__step--in_progress .session-progress-card__step-marker .session-run-spinner",
             )
             .count(),
         ).toBe(1);
         expect(
           await card
             .locator(
-              ".session-progress-card__step--pending .session-progress-card__step-marker circle",
+              ".session-progress-card__step--pending .session-progress-card__step-marker polyline",
             )
             .count(),
         ).toBe(1);
@@ -417,10 +417,22 @@ suite.define(() => {
             markers.slice(1).map((marker) => ({
               color: getComputedStyle(marker).color,
               dot: getComputedStyle(marker, "::after").content,
+              spinnerAnimation:
+                marker.querySelector(".session-run-spinner") instanceof HTMLElement
+                  ? getComputedStyle(marker.querySelector(".session-run-spinner") as HTMLElement)
+                      .animationName
+                  : null,
+              spinnerColor:
+                marker.querySelector(".session-run-spinner") instanceof HTMLElement
+                  ? getComputedStyle(marker.querySelector(".session-run-spinner") as HTMLElement)
+                      .borderTopColor
+                  : null,
             })),
           );
-        expect(markerPresentation[0]?.dot).not.toBe("none");
-        expect(markerPresentation[0]?.dot).not.toBe(markerPresentation[1]?.dot);
+        expect(markerPresentation[0]?.dot).toBe("none");
+        expect(markerPresentation[0]?.spinnerAnimation).toBe("session-run-spin");
+        expect(markerPresentation[0]?.spinnerColor).toBe(markerPresentation[1]?.color);
+        expect(markerPresentation[1]?.dot).toBe("none");
         expect(await card.locator(".session-hovercard__progress-footer:last-child").count()).toBe(
           1,
         );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -171,6 +171,7 @@ export const en: TranslationMap = {
     moreParticipants: "+{count}",
     moreParticipantsLabel: "{count} more participants",
     projectLabel: "Project",
+    workspaceLabel: "Workspace",
     branchLabel: "Branch",
     noPrYet: "No PR yet",
     more: "+{count} more",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -168,8 +168,10 @@ export const en: TranslationMap = {
   },
   sessionHovercard: {
     ariaLabel: "Session information",
-    created: "created {time}",
-    updated: "updated {time}",
+    moreParticipants: "+{count}",
+    moreParticipantsLabel: "{count} more participants",
+    projectLabel: "Project",
+    branchLabel: "Branch",
     noPrYet: "No PR yet",
     more: "+{count} more",
     changedFile: "{count} file",

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -23,16 +23,13 @@ type FormatTimeAgoOptions = {
 };
 
 type FormatRelativeTimestampOptions = {
-  calendarUnits?: boolean;
   dateFallback?: boolean;
   timezone?: string;
   fallback?: string;
   suffix?: boolean;
 };
 
-type DisplayTimeUnit = RelativeTimeUnit | "millisecond" | "week" | "month" | "year";
-
-function formatUnit(value: number, unit: DisplayTimeUnit): string {
+function formatUnit(value: number, unit: RelativeTimeUnit | "millisecond"): string {
   return new Intl.NumberFormat(i18n.getLocale(), {
     style: "unit",
     unit,
@@ -41,39 +38,11 @@ function formatUnit(value: number, unit: DisplayTimeUnit): string {
   }).format(value);
 }
 
-function formatRelative(
-  value: number,
-  unit: RelativeTimeUnit | "week" | "month" | "year",
-  numeric: "always" | "auto" = "auto",
-): string {
+function formatRelative(value: number, unit: RelativeTimeUnit): string {
   return new Intl.RelativeTimeFormat(i18n.getLocale(), {
-    numeric,
+    numeric: "auto",
     style: "narrow",
   }).format(value, unit);
-}
-
-function formatCompactRelativeUnit(
-  value: number,
-  unit: RelativeTimeUnit | "week" | "month" | "year",
-) {
-  if (i18n.getLocale().toLowerCase().startsWith("en")) {
-    const suffixes: Partial<Record<RelativeTimeUnit | "week" | "month" | "year", string>> = {
-      day: "d",
-      week: "w",
-      month: "mo",
-      year: "y",
-    };
-    const suffix = suffixes[unit];
-    if (suffix) {
-      return `${new Intl.NumberFormat(i18n.getLocale(), { maximumFractionDigits: 0 }).format(value)}${suffix}`;
-    }
-  }
-  return new Intl.NumberFormat(i18n.getLocale(), {
-    style: "unit",
-    unit,
-    unitDisplay: "short",
-    maximumFractionDigits: 0,
-  }).format(value);
 }
 
 export function formatTimeAgo(
@@ -105,19 +74,7 @@ export function formatRelativeTimestamp(
 
   const diff = timestampMs - Date.now();
   const isPast = diff <= 0;
-  const absoluteDiff = Math.abs(diff);
-  const days = absoluteDiff / (24 * 60 * 60_000);
-  const calendarBucket =
-    options.calendarUnits && days >= 365
-      ? { value: Math.max(1, Math.round(days / 365)), unit: "year" as const }
-      : options.calendarUnits && days >= 28
-        ? { value: Math.max(1, Math.round(days / 30)), unit: "month" as const }
-        : options.calendarUnits && days >= 7
-          ? { value: Math.max(1, Math.round(days / 7)), unit: "week" as const }
-          : options.calendarUnits && days >= 1
-            ? { value: Math.max(1, Math.round(days)), unit: "day" as const }
-            : bucketRelativeTimeMs(absoluteDiff);
-  const { value, unit } = calendarBucket;
+  const { value, unit } = bucketRelativeTimeMs(Math.abs(diff));
   if (unit === "second") {
     if (options.suffix === false) {
       return formatUnit(value, unit);
@@ -138,11 +95,7 @@ export function formatRelativeTimestamp(
   }
 
   const signedValue = isPast ? -value : value;
-  return options.suffix === false
-    ? options.calendarUnits
-      ? formatCompactRelativeUnit(value, unit)
-      : formatUnit(value, unit)
-    : formatRelative(signedValue, unit, options.calendarUnits ? "always" : "auto");
+  return options.suffix === false ? formatUnit(value, unit) : formatRelative(signedValue, unit);
 }
 
 export function formatDurationCompact(ms?: number | null): string | undefined {

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -23,13 +23,16 @@ type FormatTimeAgoOptions = {
 };
 
 type FormatRelativeTimestampOptions = {
+  calendarUnits?: boolean;
   dateFallback?: boolean;
   timezone?: string;
   fallback?: string;
   suffix?: boolean;
 };
 
-function formatUnit(value: number, unit: RelativeTimeUnit | "millisecond"): string {
+type DisplayTimeUnit = RelativeTimeUnit | "millisecond" | "week" | "month" | "year";
+
+function formatUnit(value: number, unit: DisplayTimeUnit): string {
   return new Intl.NumberFormat(i18n.getLocale(), {
     style: "unit",
     unit,
@@ -38,11 +41,39 @@ function formatUnit(value: number, unit: RelativeTimeUnit | "millisecond"): stri
   }).format(value);
 }
 
-function formatRelative(value: number, unit: RelativeTimeUnit): string {
+function formatRelative(
+  value: number,
+  unit: RelativeTimeUnit | "week" | "month" | "year",
+  numeric: "always" | "auto" = "auto",
+): string {
   return new Intl.RelativeTimeFormat(i18n.getLocale(), {
-    numeric: "auto",
+    numeric,
     style: "narrow",
   }).format(value, unit);
+}
+
+function formatCompactRelativeUnit(
+  value: number,
+  unit: RelativeTimeUnit | "week" | "month" | "year",
+) {
+  if (i18n.getLocale().toLowerCase().startsWith("en")) {
+    const suffixes: Partial<Record<RelativeTimeUnit | "week" | "month" | "year", string>> = {
+      day: "d",
+      week: "w",
+      month: "mo",
+      year: "y",
+    };
+    const suffix = suffixes[unit];
+    if (suffix) {
+      return `${new Intl.NumberFormat(i18n.getLocale(), { maximumFractionDigits: 0 }).format(value)}${suffix}`;
+    }
+  }
+  return new Intl.NumberFormat(i18n.getLocale(), {
+    style: "unit",
+    unit,
+    unitDisplay: "short",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 export function formatTimeAgo(
@@ -74,7 +105,19 @@ export function formatRelativeTimestamp(
 
   const diff = timestampMs - Date.now();
   const isPast = diff <= 0;
-  const { value, unit } = bucketRelativeTimeMs(Math.abs(diff));
+  const absoluteDiff = Math.abs(diff);
+  const days = absoluteDiff / (24 * 60 * 60_000);
+  const calendarBucket =
+    options.calendarUnits && days >= 365
+      ? { value: Math.max(1, Math.round(days / 365)), unit: "year" as const }
+      : options.calendarUnits && days >= 28
+        ? { value: Math.max(1, Math.round(days / 30)), unit: "month" as const }
+        : options.calendarUnits && days >= 7
+          ? { value: Math.max(1, Math.round(days / 7)), unit: "week" as const }
+          : options.calendarUnits && days >= 1
+            ? { value: Math.max(1, Math.round(days)), unit: "day" as const }
+            : bucketRelativeTimeMs(absoluteDiff);
+  const { value, unit } = calendarBucket;
   if (unit === "second") {
     if (options.suffix === false) {
       return formatUnit(value, unit);
@@ -95,7 +138,11 @@ export function formatRelativeTimestamp(
   }
 
   const signedValue = isPast ? -value : value;
-  return options.suffix === false ? formatUnit(value, unit) : formatRelative(signedValue, unit);
+  return options.suffix === false
+    ? options.calendarUnits
+      ? formatCompactRelativeUnit(value, unit)
+      : formatUnit(value, unit)
+    : formatRelative(signedValue, unit, options.calendarUnits ? "always" : "auto");
 }
 
 export function formatDurationCompact(ms?: number | null): string | undefined {

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveChannelSessionInfo,
   resolveSessionDisplayName,
+  resolveSessionWorkContext,
   resolveSessionWorkSubtitle,
 } from "./session-display.ts";
 
@@ -258,6 +259,40 @@ describe("resolveSessionWorkSubtitle", () => {
         execNode: "11c38726acc6fac280357576c87acc6fac280357",
       }),
     ).toBe("clawdbot ⎇ wt-1 · …0357");
+  });
+});
+
+describe("resolveSessionWorkContext", () => {
+  it("projects only repository or authoritative workspace facts", () => {
+    expect(
+      resolveSessionWorkContext({
+        worktree: { branch: "openclaw/session-ui", repoRoot: "/repo/openclaw" },
+      }),
+    ).toEqual({
+      kind: "project",
+      name: "openclaw",
+      path: "/repo/openclaw",
+      branch: "session-ui",
+    });
+    expect(
+      resolveSessionWorkContext({
+        spawnedWorkspaceDir: "/workspaces/release-notes",
+        spawnedCwd: "/stale/cwd",
+      }),
+    ).toEqual({
+      kind: "workspace",
+      name: "release-notes",
+      path: "/workspaces/release-notes",
+    });
+    expect(
+      resolveSessionWorkContext({
+        execNode: "remote-node",
+        execCwd: "/remote/workspace",
+        spawnedWorkspaceDir: "/local/workspace",
+        worktree: { branch: "openclaw/local-branch", repoRoot: "/gateway/repo" },
+      }),
+    ).toEqual({ kind: "workspace", name: "workspace", path: "/remote/workspace" });
+    expect(resolveSessionWorkContext({ execCwd: "/stale/local-routing-cwd" })).toBeUndefined();
   });
 });
 

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -66,12 +66,14 @@ export function resolveChannelSessionInfo(
 type SessionWorktreeDisplayRow = {
   worktree?: { branch?: string; repoRoot?: string };
   execNode?: string;
+  execCwd?: string;
+  spawnedWorkspaceDir?: string;
+  spawnedCwd?: string;
 };
 
-export type SessionWorkContext = {
-  project: string;
-  branch?: string;
-};
+export type SessionWorkContext =
+  | { kind: "project"; name: string; path: string; branch?: string }
+  | { kind: "workspace"; name: string; path: string };
 
 /** Basename shown for a repository path on every Control UI surface. */
 export function repoName(repoRoot: string): string {
@@ -81,29 +83,53 @@ export function repoName(repoRoot: string): string {
 export function resolveSessionWorkContext(
   row: SessionWorktreeDisplayRow,
 ): SessionWorkContext | undefined {
+  if (row.execNode) {
+    const workspacePath = normalizeOptionalString(row.execCwd);
+    return workspacePath
+      ? { kind: "workspace", name: repoName(workspacePath), path: workspacePath }
+      : undefined;
+  }
   const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
-  if (!repoRoot) {
+  if (repoRoot) {
+    const branch = normalizeOptionalString(row.worktree?.branch);
+    return {
+      kind: "project",
+      name: repoName(repoRoot),
+      path: repoRoot,
+      branch: branch?.startsWith(WORKTREE_BRANCH_PREFIX)
+        ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
+        : branch,
+    };
+  }
+
+  // Match the chat workspace owner: local spawned sessions own their recorded
+  // workspace first, then their spawned cwd.
+  const workspacePath =
+    normalizeOptionalString(row.spawnedWorkspaceDir) ?? normalizeOptionalString(row.spawnedCwd);
+  if (!workspacePath) {
     return undefined;
   }
-  const branch = normalizeOptionalString(row.worktree?.branch);
   return {
-    project: repoName(repoRoot),
-    branch: branch?.startsWith(WORKTREE_BRANCH_PREFIX)
-      ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
-      : branch,
+    kind: "workspace",
+    name: repoName(workspacePath),
+    path: workspacePath,
   };
 }
 
 /** Compact "repo ⎇ branch" (plus node host) line for worktree/work sessions. */
 export function resolveSessionWorkSubtitle(row: SessionWorktreeDisplayRow): string | undefined {
-  const context = resolveSessionWorkContext(row);
   // execNode is often a raw node id (long hex); never render it in full.
   const rawNode = normalizeOptionalString(row.execNode);
   const node = rawNode ? shortenOpaqueIdRuns(rawNode) : undefined;
-  const checkout = context
-    ? context.branch
-      ? `${context.project} ⎇ ${context.branch}`
-      : context.project
+  const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
+  const rawBranch = normalizeOptionalString(row.worktree?.branch);
+  const branch = rawBranch?.startsWith(WORKTREE_BRANCH_PREFIX)
+    ? rawBranch.slice(WORKTREE_BRANCH_PREFIX.length)
+    : rawBranch;
+  const checkout = repoRoot
+    ? branch
+      ? `${repoName(repoRoot)} ⎇ ${branch}`
+      : repoName(repoRoot)
     : undefined;
   if (checkout && node) {
     // Checkout first: it names the work; the node is routing detail.

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -68,23 +68,43 @@ type SessionWorktreeDisplayRow = {
   execNode?: string;
 };
 
+export type SessionWorkContext = {
+  project: string;
+  branch?: string;
+};
+
 /** Basename shown for a repository path on every Control UI surface. */
 export function repoName(repoRoot: string): string {
   return repoRoot.split(/[\\/]/).findLast(Boolean) ?? repoRoot;
 }
 
+export function resolveSessionWorkContext(
+  row: SessionWorktreeDisplayRow,
+): SessionWorkContext | undefined {
+  const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
+  if (!repoRoot) {
+    return undefined;
+  }
+  const branch = normalizeOptionalString(row.worktree?.branch);
+  return {
+    project: repoName(repoRoot),
+    branch: branch?.startsWith(WORKTREE_BRANCH_PREFIX)
+      ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
+      : branch,
+  };
+}
+
 /** Compact "repo ⎇ branch" (plus node host) line for worktree/work sessions. */
 export function resolveSessionWorkSubtitle(row: SessionWorktreeDisplayRow): string | undefined {
-  const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
-  const branch = normalizeOptionalString(row.worktree?.branch);
+  const context = resolveSessionWorkContext(row);
   // execNode is often a raw node id (long hex); never render it in full.
   const rawNode = normalizeOptionalString(row.execNode);
   const node = rawNode ? shortenOpaqueIdRuns(rawNode) : undefined;
-  const repo = repoRoot ? repoName(repoRoot) : undefined;
-  const shortBranch = branch?.startsWith(WORKTREE_BRANCH_PREFIX)
-    ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
-    : branch;
-  const checkout = repo ? (shortBranch ? `${repo} ⎇ ${shortBranch}` : repo) : undefined;
+  const checkout = context
+    ? context.branch
+      ? `${context.project} ⎇ ${context.branch}`
+      : context.project
+    : undefined;
   if (checkout && node) {
     // Checkout first: it names the work; the node is routing detail.
     return `${checkout} · ${node}`;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -12,6 +12,8 @@
   --card-highlight: rgba(255, 255, 255, 0.04);
   --popover: #191c24;
   --popover-foreground: #f0f0f2;
+  --session-hovercard-surface: color-mix(in srgb, var(--card) 94%, black 6%);
+  --session-hovercard-progress-surface: color-mix(in srgb, var(--card) 58%, var(--bg) 42%);
 
   /* Panel */
   --panel: #0e1015;
@@ -504,6 +506,12 @@
   --card-highlight: rgba(60, 42, 24, 0.03);
   --popover: #ffffff;
   --popover-foreground: #211e1a;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 54%,
+    var(--panel-strong) 46%
+  );
 
   --panel: #faf9f7;
   --panel-strong: #f4f1ec;
@@ -724,6 +732,12 @@
   --card-highlight: rgba(0, 0, 0, 0.02);
   --popover: #ffffff;
   --popover-foreground: #18181b;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 52%,
+    var(--panel-strong) 48%
+  );
 
   --panel: #f9f9fb;
   --panel-strong: #f2f2f5;
@@ -867,6 +881,12 @@
   --card-highlight: rgba(80, 50, 20, 0.02);
   --popover: #ffffff;
   --popover-foreground: #2c2118;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 48%,
+    var(--panel-strong) 52%
+  );
 
   --panel: #f7f2ec;
   --panel-strong: #f0e8e0;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -12,6 +12,8 @@
   --card-highlight: rgba(255, 255, 255, 0.04);
   --popover: #191c24;
   --popover-foreground: #f0f0f2;
+  --session-hovercard-surface: color-mix(in srgb, var(--card) 94%, black 6%);
+  --session-hovercard-progress-surface: color-mix(in srgb, var(--card) 58%, var(--bg) 42%);
 
   /* Panel */
   --panel: #0e1015;
@@ -485,6 +487,12 @@
   --card-highlight: rgba(60, 42, 24, 0.03);
   --popover: #ffffff;
   --popover-foreground: #211e1a;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 54%,
+    var(--panel-strong) 46%
+  );
 
   --panel: #faf9f7;
   --panel-strong: #f4f1ec;
@@ -695,6 +703,12 @@
   --card-highlight: rgba(0, 0, 0, 0.02);
   --popover: #ffffff;
   --popover-foreground: #18181b;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 52%,
+    var(--panel-strong) 48%
+  );
 
   --panel: #f9f9fb;
   --panel-strong: #f2f2f5;
@@ -838,6 +852,12 @@
   --card-highlight: rgba(80, 50, 20, 0.02);
   --popover: #ffffff;
   --popover-foreground: #2c2118;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 48%,
+    var(--panel-strong) 52%
+  );
 
   --panel: #f7f2ec;
   --panel-strong: #f0e8e0;

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -514,24 +514,6 @@
   color: var(--session-progress-neutral);
 }
 
-.session-progress-card__current-marker[data-status="in_progress"],
-.session-progress-card__step-marker[data-status="in_progress"] {
-  position: relative;
-}
-
-.session-progress-card__current-marker[data-status="in_progress"]::after,
-.session-progress-card__step-marker[data-status="in_progress"]::after {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 4px;
-  height: 4px;
-  border-radius: var(--radius-full);
-  background: var(--session-progress-neutral);
-  content: "";
-  transform: translate(-50%, -50%);
-}
-
 .session-progress-card__current {
   min-width: 0;
   overflow: hidden;

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -478,12 +478,12 @@
 .session-progress-card__step-marker {
   display: inline-flex;
   box-sizing: border-box;
-  width: 16px;
-  height: 16px;
-  min-width: 16px;
-  min-height: 16px;
-  max-width: 16px;
-  max-height: 16px;
+  width: 14px;
+  height: 14px;
+  min-width: 14px;
+  min-height: 14px;
+  max-width: 14px;
+  max-height: 14px;
   align-items: center;
   justify-content: center;
   align-self: start;
@@ -497,12 +497,12 @@
 
 .session-progress-card__current-marker svg,
 .session-progress-card__step-marker svg {
-  width: 16px;
-  height: 16px;
-  min-width: 16px;
-  min-height: 16px;
-  max-width: 16px;
-  max-height: 16px;
+  width: 14px;
+  height: 14px;
+  min-width: 14px;
+  min-height: 14px;
+  max-width: 14px;
+  max-height: 14px;
   margin: 0;
   transform: none;
   stroke-width: 1.5px;
@@ -516,6 +516,8 @@
 
 .session-progress-card__current-marker > .session-run-spinner,
 .session-progress-card__step-marker > .session-run-spinner {
+  width: 14px;
+  height: 14px;
   border-color: color-mix(in srgb, var(--session-progress-neutral) 28%, transparent);
   border-top-color: var(--session-progress-neutral);
 }
@@ -596,7 +598,7 @@
 
 .session-progress-card__step {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
+  grid-template-columns: 14px minmax(0, 1fr);
   align-items: start;
   gap: var(--space-2);
   color: var(--muted);

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -7,6 +7,8 @@
 }
 
 .session-hovercard {
+  --session-hovercard-context-icon-size: var(--space-4);
+
   display: grid;
   gap: 0;
   min-width: 0;
@@ -48,7 +50,7 @@
   display: grid;
   width: 100%;
   grid-template-rows: auto auto;
-  gap: 2px;
+  gap: var(--space-1);
   min-width: 0;
 }
 
@@ -103,7 +105,7 @@
 
 .session-hovercard__context-row {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
+  grid-template-columns: var(--session-hovercard-context-icon-size) minmax(0, 1fr);
   align-items: center;
   column-gap: var(--space-2);
   min-width: 0;
@@ -115,16 +117,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
   align-self: center;
   color: var(--muted);
 }
 
 .session-hovercard__context-icon svg {
   display: block;
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
   flex: none;
   stroke-width: 1.5px;
   stroke-linecap: round;
@@ -195,8 +197,8 @@
 .session-hovercard__creator-avatar .viewer-avatar {
   display: block;
   box-sizing: border-box;
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
   aspect-ratio: 1;
   flex: 0 0 auto;
   flex-shrink: 0;
@@ -209,6 +211,12 @@
   box-shadow: none;
 }
 
+.session-hovercard__creator-avatar .channel-avatar {
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
+  box-shadow: none;
+}
+
 .session-hovercard__creator-avatar .viewer-avatar img {
   width: 100%;
   height: 100%;
@@ -217,8 +225,8 @@
 
 .session-hovercard__creator-avatar-fallback {
   display: grid;
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent-subtle) 70%, var(--panel-strong));
   color: var(--text);
@@ -230,9 +238,9 @@
 .session-hovercard__pr-row,
 .session-hovercard__branch-row {
   display: grid;
-  grid-template-columns: 16px auto minmax(0, 1fr);
+  grid-template-columns: var(--session-hovercard-context-icon-size) auto minmax(0, 1fr);
   align-items: center;
-  gap: var(--space-2);
+  column-gap: var(--space-2);
   min-width: 0;
   color: var(--muted);
   font-size: var(--control-ui-text-sm);
@@ -240,8 +248,15 @@
   text-decoration: none;
 }
 
+.session-hovercard__pr-row {
+  font-family: var(--mono);
+  font-size: var(--control-ui-text-xs);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.35;
+}
+
 .session-hovercard__branch-row {
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+  grid-template-columns: var(--session-hovercard-context-icon-size) minmax(0, 1fr) auto;
 }
 
 .session-hovercard__pr-state-icon,
@@ -249,14 +264,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
 }
 
 .session-hovercard__pr-state-icon svg,
 .session-hovercard__branch-icon svg {
-  width: 16px;
-  height: 16px;
+  width: var(--session-hovercard-context-icon-size);
+  height: var(--session-hovercard-context-icon-size);
   stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -303,7 +318,26 @@
 }
 
 .session-hovercard__pr-row .session-hovercard__diff {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: baseline;
+  column-gap: var(--space-2);
   justify-self: end;
+  font: inherit;
+}
+
+.session-hovercard__pr-row .session-hovercard__files {
+  grid-column: 1;
+  justify-self: end;
+}
+
+.session-hovercard__pr-row .session-hovercard__additions {
+  grid-column: 2;
+}
+
+.session-hovercard__pr-row .session-hovercard__deletions {
+  grid-column: 3;
 }
 
 .session-hovercard__branch-name {

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -514,6 +514,12 @@
   color: var(--session-progress-neutral);
 }
 
+.session-progress-card__current-marker > .session-run-spinner,
+.session-progress-card__step-marker > .session-run-spinner {
+  border-color: color-mix(in srgb, var(--session-progress-neutral) 28%, transparent);
+  border-top-color: var(--session-progress-neutral);
+}
+
 .session-progress-card__current {
   min-width: 0;
   overflow: hidden;

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -1,4 +1,6 @@
 .session-progress-card {
+  --session-progress-neutral: var(--muted);
+
   box-sizing: border-box;
   min-width: 0;
   color: var(--text);
@@ -6,141 +8,329 @@
 
 .session-hovercard {
   display: grid;
-  gap: var(--space-3);
+  gap: 0;
   min-width: 0;
+}
+
+.session-hovercard__section {
+  min-width: 0;
+  padding: 12px 16px;
+  background: transparent;
+}
+
+.session-hovercard__section + .session-hovercard__section {
+  border-top: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
+}
+
+.session-hovercard__section--header {
+  padding-block: 14px 12px;
+}
+
+.session-hovercard__section--metadata,
+.session-hovercard__section--prs {
+  padding-block: 11px;
+}
+
+.session-hovercard__section--optional {
+  padding-block: 12px;
 }
 
 .session-hovercard__header {
-  display: flex;
-  align-items: center;
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: var(--space-3);
   min-width: 0;
-}
-
-.session-hovercard__avatar,
-.session-hovercard__avatar-fallback {
-  display: grid;
-  width: 34px;
-  height: 34px;
-  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--accent-subtle) 70%, var(--panel-strong));
-  color: var(--text);
-  flex: 0 0 34px;
-  font-size: var(--control-ui-text-xs);
-  font-weight: 700;
-  place-items: center;
-}
-
-.session-hovercard__avatar > .channel-avatar {
-  box-sizing: border-box;
-  width: 34px;
-  height: 34px;
-  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
-  flex: 0 0 34px;
 }
 
 .session-hovercard__heading {
   display: grid;
+  width: 100%;
+  grid-template-rows: auto auto;
   gap: 2px;
   min-width: 0;
 }
 
 .session-hovercard__title {
-  overflow: hidden;
   color: var(--text);
-  font-size: var(--control-ui-text-sm);
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+  white-space: normal;
+}
+
+.session-hovercard__meta {
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1.35;
+  overflow-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.session-hovercard__no-pr,
+.session-hovercard__more {
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.4;
+}
+
+.session-hovercard__created-age {
+  align-self: start;
+  justify-self: end;
+  min-width: max-content;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.session-hovercard__pr-list {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.session-hovercard__context {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.session-hovercard__context-row {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--space-2);
+  min-width: 0;
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.4;
+}
+
+.session-hovercard__context-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  align-self: center;
+  color: var(--muted);
+}
+
+.session-hovercard__context-icon svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.session-hovercard__context-label {
+  color: var(--muted);
+}
+
+.session-hovercard__context-value {
+  min-width: 0;
+  overflow-wrap: break-word;
+  color: var(--muted);
+  font-weight: 450;
+}
+
+.session-hovercard__context-text {
+  display: block;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.session-hovercard__meta,
-.session-hovercard__no-pr,
-.session-hovercard__more {
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  line-height: 1.35;
-}
-
-.session-hovercard__chips {
+.session-hovercard__identity-copy {
   display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  flex-wrap: wrap;
-}
-
-.session-hovercard__chip,
-.session-hovercard__diff {
-  display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: 5px;
   min-width: 0;
-  border: 1px solid color-mix(in srgb, currentColor 24%, var(--border));
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, currentColor 8%, transparent);
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  line-height: 1.4;
+  overflow: hidden;
+  color: var(--text);
+  white-space: nowrap;
 }
 
-.session-hovercard__chip {
-  padding: 3px 8px;
+.session-hovercard__participants {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-weight: 450;
+  white-space: nowrap;
+}
+
+.session-hovercard__identity-name {
+  flex: none;
+  font-weight: 500;
+}
+
+.session-hovercard__identity-separator {
+  flex: none;
+  color: var(--muted);
+}
+
+.session-hovercard__participant {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-hovercard__participants-more {
+  flex: none;
+  color: var(--muted);
+}
+
+.session-hovercard__creator-avatar,
+.session-hovercard__creator-avatar .viewer-avatar {
+  display: block;
+  box-sizing: border-box;
+  width: 16px;
+  height: 16px;
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-full);
+  outline: 0;
+  overflow: hidden;
+  align-self: center;
+  box-shadow: none;
+}
+
+.session-hovercard__creator-avatar .viewer-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.session-hovercard__creator-avatar-fallback {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent-subtle) 70%, var(--panel-strong));
+  color: var(--text);
+  font-size: 8px;
+  font-weight: 700;
+  place-items: center;
+}
+
+.session-hovercard__pr-row,
+.session-hovercard__branch-row {
+  display: grid;
+  grid-template-columns: 16px auto minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.4;
   text-decoration: none;
 }
 
+.session-hovercard__branch-row {
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+}
+
+.session-hovercard__pr-state-icon,
+.session-hovercard__branch-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.session-hovercard__pr-state-icon svg,
+.session-hovercard__branch-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .session-hovercard__diff {
-  padding: 3px 7px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
   font-family: var(--mono);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
-.session-hovercard__pr-chip[data-state="open"] {
-  color: var(--ok);
+.session-hovercard__pr-row[data-state="open"] {
+  --session-pr-state-color: var(--ok);
 }
 
-.session-hovercard__pr-chip[data-state="draft"] {
-  color: var(--muted);
+.session-hovercard__pr-row[data-state="draft"] {
+  --session-pr-state-color: var(--muted);
 }
 
-.session-hovercard__pr-chip[data-state="merged"] {
-  color: var(--pr-merged);
+.session-hovercard__pr-row[data-state="merged"] {
+  --session-pr-state-color: var(--pr-merged);
 }
 
-.session-hovercard__pr-chip[data-state="closed"] {
-  color: var(--danger);
+.session-hovercard__pr-row[data-state="closed"] {
+  --session-pr-state-color: var(--danger);
 }
 
 .session-hovercard__pr-number,
-.session-hovercard__pr-state,
 .session-hovercard__files {
   color: currentColor;
 }
 
-.session-hovercard__checks[data-checks="passing"],
+.session-hovercard__pr-number {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.session-hovercard__pr-state-icon {
+  color: var(--session-pr-state-color, var(--muted));
+}
+
+.session-hovercard__pr-row .session-hovercard__diff {
+  justify-self: end;
+}
+
+.session-hovercard__branch-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-hovercard__additions {
   color: var(--ok);
 }
 
-.session-hovercard__checks[data-checks="failing"],
 .session-hovercard__deletions {
   color: var(--danger);
 }
 
-.session-hovercard__checks[data-checks="pending"] {
-  color: var(--warn);
-}
-
 .session-hovercard__no-pr a {
-  color: inherit;
+  color: var(--accent);
   text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentcolor 45%, transparent);
   text-underline-offset: 2px;
 }
 
-.session-hovercard__divider {
-  height: 1px;
-  background: var(--border);
+.session-hovercard__branch-row + .session-hovercard__no-pr {
+  margin-top: var(--space-2);
+  padding-left: calc(16px + var(--space-2));
 }
 
 .session-hovercard__excerpt {
@@ -153,6 +343,21 @@
   font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   overflow-wrap: anywhere;
+}
+
+.session-hovercard__progress-footer {
+  padding-block: 12px 14px;
+  border-radius: 0 0 calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px);
+  background: var(--session-hovercard-progress-surface);
+}
+
+.session-hovercard__progress-footer .session-progress-card__heading {
+  margin-bottom: var(--space-3);
+}
+
+.session-hovercard__progress-footer .session-progress-card__heading-actions {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
 }
 
 .session-progress-card--composer {
@@ -196,7 +401,7 @@
 
 .session-progress-card__summary {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
   align-items: center;
   gap: 7px;
   min-width: 0;
@@ -211,6 +416,25 @@
   display: none;
 }
 
+.session-progress-card__chevron {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  transition: transform 0.16s var(--ease-out);
+}
+
+.session-progress-card__chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+.session-progress-card--composer:not([open]) .session-progress-card__chevron {
+  transform: rotate(-90deg);
+}
+
 .session-progress-card__summary:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
   outline-offset: -2px;
@@ -219,19 +443,59 @@
 .session-progress-card__current-marker,
 .session-progress-card__step-marker {
   display: inline-flex;
-  width: 14px;
+  box-sizing: border-box;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 16px;
+  max-height: 16px;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
+  align-self: start;
+  flex: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0;
+  line-height: 0;
+  transform: none;
+}
+
+.session-progress-card__current-marker svg,
+.session-progress-card__step-marker svg {
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 16px;
+  max-height: 16px;
+  margin: 0;
+  transform: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .session-progress-card__current-marker {
-  color: var(--accent);
-  transition: transform var(--duration-fast) ease;
+  color: var(--session-progress-neutral);
 }
 
-.session-progress-card--composer[open] .session-progress-card__current-marker {
-  transform: rotate(90deg);
+.session-progress-card__current-marker[data-status="in_progress"],
+.session-progress-card__step-marker[data-status="in_progress"] {
+  position: relative;
+}
+
+.session-progress-card__current-marker[data-status="in_progress"]::after,
+.session-progress-card__step-marker[data-status="in_progress"]::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: var(--session-progress-neutral);
+  content: "";
+  transform: translate(-50%, -50%);
 }
 
 .session-progress-card__current {
@@ -279,8 +543,6 @@
 
 .session-progress-card__markdown + .session-progress-card__steps {
   margin-top: var(--space-3);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
 }
 
 .session-progress-card__markdown progress {
@@ -304,7 +566,7 @@
 
 .session-progress-card__steps {
   display: grid;
-  gap: 4px;
+  row-gap: var(--space-2);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -312,9 +574,9 @@
 
 .session-progress-card__step {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
-  align-items: baseline;
-  gap: 7px;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
   color: var(--muted);
   font-size: var(--control-ui-text-sm);
   line-height: 1.4;
@@ -334,16 +596,15 @@
 }
 
 .session-progress-card__step--in_progress .session-progress-card__step-marker {
-  color: var(--accent);
+  color: var(--session-progress-neutral);
 }
 
 .session-progress-card__step--pending .session-progress-card__step-marker {
-  color: color-mix(in srgb, var(--muted) 72%, transparent);
+  color: var(--session-progress-neutral);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .session-progress-card--composer,
-  .session-progress-card__current-marker {
+  .session-progress-card--composer {
     animation: none;
     transition: none;
   }

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -1,5 +1,6 @@
 .session-progress-card {
   --session-progress-neutral: var(--muted);
+  --session-progress-marker-size: 14px;
 
   box-sizing: border-box;
   min-width: 0;
@@ -16,7 +17,7 @@
 
 .session-hovercard__section {
   min-width: 0;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   background: transparent;
 }
 
@@ -131,10 +132,6 @@
   stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.session-hovercard__context-label {
-  color: var(--muted);
 }
 
 .session-hovercard__context-value {
@@ -364,7 +361,7 @@
 
 .session-hovercard__branch-row + .session-hovercard__no-pr {
   margin-top: var(--space-2);
-  padding-left: calc(16px + var(--space-2));
+  padding-left: calc(var(--session-hovercard-context-icon-size) + var(--space-2));
 }
 
 .session-hovercard__excerpt {
@@ -478,12 +475,8 @@
 .session-progress-card__step-marker {
   display: inline-flex;
   box-sizing: border-box;
-  width: 14px;
-  height: 14px;
-  min-width: 14px;
-  min-height: 14px;
-  max-width: 14px;
-  max-height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
   align-items: center;
   justify-content: center;
   align-self: start;
@@ -492,19 +485,13 @@
   margin: 0;
   font-size: 0;
   line-height: 0;
-  transform: none;
 }
 
 .session-progress-card__current-marker svg,
 .session-progress-card__step-marker svg {
-  width: 14px;
-  height: 14px;
-  min-width: 14px;
-  min-height: 14px;
-  max-width: 14px;
-  max-height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
   margin: 0;
-  transform: none;
   stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -516,8 +503,8 @@
 
 .session-progress-card__current-marker > .session-run-spinner,
 .session-progress-card__step-marker > .session-run-spinner {
-  width: 14px;
-  height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
   border-color: color-mix(in srgb, var(--session-progress-neutral) 28%, transparent);
   border-top-color: var(--session-progress-neutral);
 }
@@ -598,7 +585,7 @@
 
 .session-progress-card__step {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
+  grid-template-columns: var(--session-progress-marker-size) minmax(0, 1fr);
   align-items: start;
   gap: var(--space-2);
   color: var(--muted);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -830,13 +830,13 @@ openclaw-session-progress-hovercard-provider {
 .session-progress-hovercard {
   position: fixed;
   z-index: 1990;
-  width: min(380px, calc(100vw - 24px));
+  width: min(296px, calc(100vw - 24px));
   max-height: min(520px, calc(100vh - 24px));
-  padding: 14px 16px;
+  padding: 0;
   overflow: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: var(--card);
+  background: var(--session-hovercard-surface);
   box-shadow: var(--shadow-lg);
   color: var(--text);
   pointer-events: none;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -828,6 +828,9 @@ openclaw-session-progress-hovercard-provider {
 }
 
 .session-progress-hovercard {
+  --session-hovercard-shift-x: 0;
+  --session-hovercard-shift-y: 0;
+
   position: fixed;
   z-index: 1990;
   width: min(296px, calc(100vw - 24px));
@@ -840,11 +843,58 @@ openclaw-session-progress-hovercard-provider {
   box-shadow: var(--shadow-lg);
   color: var(--text);
   pointer-events: none;
+  opacity: 0;
+  transform: translate3d(var(--session-hovercard-shift-x), var(--session-hovercard-shift-y), 0)
+    scale(0.99);
+  transition:
+    opacity 100ms var(--ease-out),
+    transform 100ms var(--ease-out);
+}
+
+.session-progress-hovercard[data-side="right"] {
+  --session-hovercard-shift-x: -4px;
+  transform-origin: top left;
+}
+
+.session-progress-hovercard[data-side="left"] {
+  --session-hovercard-shift-x: 4px;
+  transform-origin: top right;
+}
+
+.session-progress-hovercard[data-side="bottom"] {
+  --session-hovercard-shift-y: -4px;
+  transform-origin: top left;
+}
+
+.session-progress-hovercard[data-side="top"] {
+  --session-hovercard-shift-y: 4px;
+  transform-origin: bottom left;
+}
+
+.session-progress-hovercard[data-open="true"] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  transition-duration: 150ms;
+}
+
+.session-progress-hovercard[data-instant="true"][data-open="true"] {
+  transition: none;
 }
 
 @media (hover: hover) {
-  .session-progress-hovercard {
+  .session-progress-hovercard[data-open="true"] {
     pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-progress-hovercard {
+    transform: none;
+    transition: opacity 80ms linear;
+  }
+
+  .session-progress-hovercard[data-open="true"] {
+    transform: none;
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -815,6 +815,9 @@ openclaw-session-progress-hovercard-provider {
 }
 
 .session-progress-hovercard {
+  --session-hovercard-shift-x: 0;
+  --session-hovercard-shift-y: 0;
+
   position: fixed;
   z-index: 1990;
   width: min(296px, calc(100vw - 24px));
@@ -827,11 +830,58 @@ openclaw-session-progress-hovercard-provider {
   box-shadow: var(--shadow-lg);
   color: var(--text);
   pointer-events: none;
+  opacity: 0;
+  transform: translate3d(var(--session-hovercard-shift-x), var(--session-hovercard-shift-y), 0)
+    scale(0.99);
+  transition:
+    opacity 100ms var(--ease-out),
+    transform 100ms var(--ease-out);
+}
+
+.session-progress-hovercard[data-side="right"] {
+  --session-hovercard-shift-x: -4px;
+  transform-origin: top left;
+}
+
+.session-progress-hovercard[data-side="left"] {
+  --session-hovercard-shift-x: 4px;
+  transform-origin: top right;
+}
+
+.session-progress-hovercard[data-side="bottom"] {
+  --session-hovercard-shift-y: -4px;
+  transform-origin: top left;
+}
+
+.session-progress-hovercard[data-side="top"] {
+  --session-hovercard-shift-y: 4px;
+  transform-origin: bottom left;
+}
+
+.session-progress-hovercard[data-open="true"] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  transition-duration: 150ms;
+}
+
+.session-progress-hovercard[data-instant="true"][data-open="true"] {
+  transition: none;
 }
 
 @media (hover: hover) {
-  .session-progress-hovercard {
+  .session-progress-hovercard[data-open="true"] {
     pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-progress-hovercard {
+    transform: none;
+    transition: opacity 80ms linear;
+  }
+
+  .session-progress-hovercard[data-open="true"] {
+    transform: none;
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -817,13 +817,13 @@ openclaw-session-progress-hovercard-provider {
 .session-progress-hovercard {
   position: fixed;
   z-index: 1990;
-  width: min(380px, calc(100vw - 24px));
+  width: min(296px, calc(100vw - 24px));
   max-height: min(520px, calc(100vh - 24px));
-  padding: 14px 16px;
+  padding: 0;
   overflow: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: var(--card);
+  background: var(--session-hovercard-surface);
   box-shadow: var(--shadow-lg);
   color: var(--text);
   pointer-events: none;


### PR DESCRIPTION
## What Problem This Solves

The baseline session hovercard exposes too little context to distinguish similar sessions or understand active work without navigating away. Catalog-backed sessions also need the same session, repository, pull-request, participant, and progress facts as regular sidebar rows.

This replaces the earlier stacked exploration in #123594 with one self-contained Control UI change against `main`.

## Why This Change Was Made

- Resolves regular, lineage, and catalog rows through one sidebar lookup before rendering.
- Keeps authoritative session, participant, workspace/project, branch, pull-request, latest-turn, and progress data in the owning UI boundaries.
- Uses one portaled hovercard interaction path for pointer and keyboard access, menu suppression, focus recovery, viewport collision, and reduced motion.
- Keeps mock data inside the existing Control UI test harness; no fixture or demo behavior ships in production.
- Removes dead hover suppression and presentation residue found during closeout, and fixes the progress-marker exhaustive return required by lint.

## User Impact

Hovering or focusing a session now shows a bounded card with its title and age, creator/participants, workspace or repository branch, up to four pull requests with state/check/diff facts, and current progress or latest-turn context. Catalog sessions use the same presentation.

Opening a session menu closes and suppresses the card, keyboard focus remains recoverable, and the card stays viewport-contained. Touch navigation continues to use the mobile sidebar drawer without introducing hover-only behavior.

## Evidence

- Exact head: `baf5e085ff429d48dae818278bebf8f2b6a32a5c`
- Current-main integration baseline: `3e0ee38c06e628b8468b6999fe3f655398dcd4db`
- Focused units: 4 files, 50 tests passed.
- Focused Chromium E2E: 1 file, 8 tests passed, including rich rendering, refresh, collision, pointer timing, menu suppression, catalog rows, focus recovery, and latest-turn fallback.
- Visual matrix: 8 isolated Playwright states passed on both refs (desktop and mobile drawer × items, empty, approval, update); rich hovercard before/after and live progress refresh were also captured and inspected.
- `node scripts/check-changed.mjs`: passed (structural guards, formatting, dead exports, i18n, test/UI typechecks, lint, and styles).
- Closeout review: no actionable findings (confidence 0.98).
- Current-main merge tree is clean: `889639067c7181bb6452410859bc00e3f03aa31f`.
- Current-main merged build: startup JS `345531 B` gzip, below the `345561 B` limit.
- Diff classification: production `+1237/-258` (net `+979`); tests `+750/-57` (net `+693`); total `+1987/-315` across 24 files.

Visual direction was approved for this closeout. The optional rebase was skipped to preserve the existing history as requested; focused exact-head validation and a clean merge-tree/build check against current `main` cover the integration risk for the lander.
