### PR TITLE
fix(discord): restore voice auto-join on multi-agent gateways

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test-support.ts
+++ b/extensions/discord/src/voice/manager.e2e.test-support.ts
@@ -44,6 +44,7 @@ export type TestRealtimeSessionEntry = {
 };
 
 export type TestRealtimeBridgeParams = {
+  agentId?: string;
   audioSink: { sendAudio: (audio: Buffer) => void };
   autoRespondToAudio?: boolean;
   cfg?: unknown;

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -61,6 +61,7 @@ defineDiscordVoiceTests(
         "provider resolve options",
       );
       expect(providerOptions.configuredProviderId).toBeUndefined();
+      expect(providerOptions.agentId).toBe("agent-1");
       expect(providerOptions.defaultModel).toBe("gpt-realtime-2");
       expect(requireRecord(providerOptions.providerConfigs, "provider configs").openai).toEqual({
         model: "provider-default",
@@ -71,6 +72,7 @@ defineDiscordVoiceTests(
         voice: "cedar",
         minBargeInAudioEndMs: 500,
       });
+      expect(lastRealtimeBridgeParams().agentId).toBe("agent-1");
     });
 
     it("keeps agent-proxy realtime transcripts on the audio turn speaker context", async () => {

--- a/extensions/discord/src/voice/voice-following.test.ts
+++ b/extensions/discord/src/voice/voice-following.test.ts
@@ -529,7 +529,7 @@ defineDiscordVoiceTests(
         if (channelId === "1002") {
           backupFetches += 1;
           if (backupFetches > 1) {
-            return null;
+            throw new Error("followed channel unavailable");
           }
         }
         return {

--- a/extensions/discord/src/voice/voice-session.lifecycle.test.ts
+++ b/extensions/discord/src/voice/voice-session.lifecycle.test.ts
@@ -615,6 +615,30 @@ defineDiscordVoiceTests(
       ]);
     });
 
+    it("keeps cancellation authoritative when channel lookup later rejects", async () => {
+      let rejectChannelLookup!: (reason: unknown) => void;
+      const client = createClient();
+      client.fetchChannel.mockImplementationOnce(
+        async () =>
+          await new Promise<never>((_, reject) => {
+            rejectChannelLookup = reject;
+          }),
+      );
+      const manager = createManager(undefined, client);
+
+      const join = manager.join({ guildId: "g1", channelId: "1001" });
+      await vi.waitFor(() => expect(client.fetchChannel).toHaveBeenCalledOnce());
+      await manager.leave({ guildId: "g1" });
+      rejectChannelLookup(missingAccessError);
+
+      await expect(join).resolves.toEqual({
+        ok: false,
+        message: "Discord voice join was cancelled.",
+        guildId: "g1",
+        channelId: "1001",
+      });
+    });
+
     it("removes voice listeners on leave", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);

--- a/extensions/discord/src/voice/voice-session.lifecycle.test.ts
+++ b/extensions/discord/src/voice/voice-session.lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { DiscordError } from "../internal/discord.js";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
@@ -7,6 +8,7 @@ defineDiscordVoiceTests(
     expect,
     it,
     vi,
+    ChannelType,
     requireRecord,
     mockCall,
     lastMockCall,
@@ -21,6 +23,7 @@ defineDiscordVoiceTests(
     createRealtimeVoiceBridgeSessionMock,
     realtimeSessionMock,
     managerModule,
+    createClient,
     createManager,
     makeVoiceConfig,
     createAgentProxyManager,
@@ -500,6 +503,116 @@ defineDiscordVoiceTests(
 
       expect(result.ok).toBe(true);
       expectConnectedStatus(manager, "1001");
+    });
+
+    const missingAccessError = new DiscordError(new Response(null, { status: 403 }), {
+      message: "Missing Access",
+      code: 50001,
+    });
+    const unknownChannelError = new DiscordError(new Response(null, { status: 404 }), {
+      message: "Unknown Channel",
+      code: 10003,
+    });
+    const networkError = new TypeError("fetch failed");
+
+    it.each([
+      {
+        name: "preserves Discord 403 / 50001 Missing Access",
+        response: missingAccessError,
+        expected: {
+          ok: false,
+          message: "Failed to resolve Discord channel 1001: Missing Access",
+          guildId: "g1",
+          channelId: "1001",
+        },
+      },
+      {
+        name: "preserves Discord 404 / 10003 Unknown Channel",
+        response: unknownChannelError,
+        expected: {
+          ok: false,
+          message: "Failed to resolve Discord channel 1001: Unknown Channel",
+          guildId: "g1",
+          channelId: "1001",
+        },
+      },
+      {
+        name: "preserves generic network failures",
+        response: networkError,
+        expected: {
+          ok: false,
+          message: "Failed to resolve Discord channel 1001: fetch failed",
+          guildId: "g1",
+          channelId: "1001",
+        },
+      },
+      {
+        name: "rejects a fetched GuildText channel",
+        response: { id: "1001", guildId: "g1", type: ChannelType.GuildText },
+        expected: { ok: false, message: "Channel 1001 is not a voice channel." },
+      },
+      {
+        name: "accepts a fetched GuildVoice channel",
+        response: { id: "1001", guildId: "g1", type: ChannelType.GuildVoice },
+        expected: {
+          ok: true,
+          message: "Joined <#1001>.",
+          guildId: "g1",
+          channelId: "1001",
+        },
+      },
+      {
+        name: "accepts a fetched GuildStageVoice channel",
+        response: { id: "1001", guildId: "g1", type: ChannelType.GuildStageVoice },
+        expected: {
+          ok: true,
+          message: "Joined <#1001>.",
+          guildId: "g1",
+          channelId: "1001",
+        },
+      },
+    ])("$name", async ({ response, expected }) => {
+      const client = createClient();
+      client.fetchChannel.mockImplementationOnce(async () => {
+        if (response instanceof Error) {
+          throw response;
+        }
+        return response as never;
+      });
+      const manager = createManager(undefined, client);
+
+      await expect(manager.join({ guildId: "g1", channelId: "1001" })).resolves.toEqual(expected);
+    });
+
+    it("continues autoJoin after a channel resolution failure", async () => {
+      const client = createClient();
+      client.fetchChannel.mockRejectedValueOnce(missingAccessError).mockResolvedValueOnce({
+        id: "2001",
+        guildId: "g2",
+        guild: { id: "g2", name: "Guild 2" },
+        type: ChannelType.GuildVoice,
+      });
+      const manager = createManager(
+        makeVoiceConfig({
+          autoJoin: [
+            { guildId: "g1", channelId: "1001" },
+            { guildId: "g2", channelId: "2001" },
+          ],
+        }),
+        client,
+      );
+
+      await expect(manager.autoJoin()).resolves.toBeUndefined();
+
+      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      expect(manager.status()).toEqual([
+        {
+          ok: true,
+          message: "connected: guild g2 channel 2001",
+          guildId: "g2",
+          channelId: "2001",
+        },
+      ]);
     });
 
     it("removes voice listeners on leave", async () => {

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -158,6 +158,12 @@ export class DiscordVoiceSessions {
     const { guildId, channelId } = params;
     const voiceConfig = this.params.discordConfig.voice;
     const voiceMode = resolveDiscordVoiceMode(voiceConfig);
+    const cancelledJoinResult = (): VoiceOperationResult => ({
+      ok: false,
+      message: "Discord voice join was cancelled.",
+      guildId,
+      channelId,
+    });
 
     const existing = this.params.sessions.get(guildId);
     if (existing && existing.channelId === channelId) {
@@ -206,12 +212,7 @@ export class DiscordVoiceSessions {
       // A leave or replacement can invalidate the join while the REST lookup is pending;
       // cancellation remains authoritative over a stale lookup failure.
       if (authority && !authority.isCurrent()) {
-        return {
-          ok: false,
-          message: "Discord voice join was cancelled.",
-          guildId,
-          channelId,
-        };
+        return cancelledJoinResult();
       }
       return {
         ok: false,
@@ -221,12 +222,7 @@ export class DiscordVoiceSessions {
       };
     }
     if (authority && !authority.isCurrent()) {
-      return {
-        ok: false,
-        message: "Discord voice join was cancelled.",
-        guildId,
-        channelId,
-      };
+      return cancelledJoinResult();
     }
     if (!isVoiceChannel(channelInfo.type)) {
       return { ok: false, message: `Channel ${channelId} is not a voice channel.` };
@@ -328,12 +324,7 @@ export class DiscordVoiceSessions {
         voiceSdk,
         reason: `cancelled join guild ${guildId} channel ${channelId}`,
       });
-      return {
-        ok: false,
-        message: "Discord voice join was cancelled.",
-        guildId,
-        channelId,
-      };
+      return cancelledJoinResult();
     }
     if (this.params.destroyed()) {
       destroyVoiceConnectionSafely({

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -199,7 +199,17 @@ export class DiscordVoiceSessions {
       await this.leave({ guildId }, { preserveFollowState: options?.preserveFollowState });
     }
 
-    const channelInfo = await this.params.client.fetchChannel(channelId).catch(() => null);
+    let channelInfo: Awaited<ReturnType<Client["fetchChannel"]>>;
+    try {
+      channelInfo = await this.params.client.fetchChannel(channelId);
+    } catch (err) {
+      return {
+        ok: false,
+        message: `Failed to resolve Discord channel ${channelId}: ${formatErrorMessage(err)}`,
+        guildId,
+        channelId,
+      };
+    }
     if (authority && !authority.isCurrent()) {
       return {
         ok: false,
@@ -208,7 +218,7 @@ export class DiscordVoiceSessions {
         channelId,
       };
     }
-    if (!channelInfo || ("type" in channelInfo && !isVoiceChannel(channelInfo.type))) {
+    if (!isVoiceChannel(channelInfo.type)) {
       return { ok: false, message: `Channel ${channelId} is not a voice channel.` };
     }
     const channelGuildId = "guildId" in channelInfo ? channelInfo.guildId : undefined;

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -203,6 +203,16 @@ export class DiscordVoiceSessions {
     try {
       channelInfo = await this.params.client.fetchChannel(channelId);
     } catch (err) {
+      // A leave or replacement can invalidate the join while the REST lookup is pending;
+      // cancellation remains authoritative over a stale lookup failure.
+      if (authority && !authority.isCurrent()) {
+        return {
+          ok: false,
+          message: "Discord voice join was cancelled.",
+          guildId,
+          channelId,
+        };
+      }
       return {
         ok: false,
         message: `Failed to resolve Discord channel ${channelId}: ${formatErrorMessage(err)}`,

--- a/extensions/openai/realtime-voice-browser-auth.test.ts
+++ b/extensions/openai/realtime-voice-browser-auth.test.ts
@@ -181,6 +181,42 @@ describe("OpenAI realtime voice browser authentication", () => {
     expect(FakeWebSocket.instances).toHaveLength(0);
   });
 
+  it("resolves native bridge API-key profiles in the requested agent scope", async () => {
+    resolveProviderAuthProfileApiKeyMock.mockResolvedValueOnce("test-api-key-profile");
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const cfg = {
+      agents: { list: [{ id: "main" }, { id: "voice-agent" }] },
+    } as never;
+    const bridge = provider.createBridge({
+      agentId: "voice-agent",
+      cfg,
+      providerConfig: { model: "gpt-realtime-2" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    openSocket(socket);
+    emitServerEvent(socket, { type: "session.updated" });
+    await connecting;
+
+    expect(resolveProviderAuthProfileApiKeyMock).toHaveBeenCalledWith({
+      provider: "openai",
+      cfg,
+      agentDir: expect.stringContaining("voice-agent"),
+      profileTypes: ["api_key"],
+      includeExternalCliAuth: false,
+    });
+    const options = socket.args[1] as { headers?: Record<string, string> } | undefined;
+    expect(options?.headers?.Authorization).toBe("Bearer test-api-key-profile");
+    bridge.close();
+  });
+
   it("keeps explicit OpenAI realtime API keys as the advanced override", () => {
     vi.stubEnv("OPENAI_API_KEY", "test-api-key-env");
     resolveProviderAuthProfileApiKeyMock.mockResolvedValueOnce("test-api-key-profile");

--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -180,6 +180,31 @@ describe("OpenAI realtime voice provider routing", () => {
     });
   });
 
+  it("checks Platform API-key profiles in the requested agent scope", () => {
+    isProviderAuthProfileConfiguredMock.mockImplementation(
+      ({ agentDir }: { agentDir?: string }) => agentDir?.includes("voice-agent") === true,
+    );
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const cfg = {
+      agents: { list: [{ id: "main" }, { id: "voice-agent" }] },
+    } as never;
+
+    expect(
+      provider.isConfigured({
+        agentId: "voice-agent",
+        cfg,
+        providerConfig: {},
+      }),
+    ).toBe(true);
+    expect(isProviderAuthProfileConfiguredMock).toHaveBeenCalledWith({
+      provider: "openai",
+      cfg,
+      agentDir: expect.stringContaining("voice-agent"),
+      profileTypes: ["api_key"],
+      includeExternalCliAuth: false,
+    });
+  });
+
   it("routes gpt-live Platform sessions through the native quicksilver broker", async () => {
     const { broker, createBrowserSession } = createQuicksilverBrowserBrokerFixture();
     const provider = buildOpenAIRealtimeVoiceProvider({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -214,6 +214,7 @@ async function createOpenAIRealtimeBrowserSession(
           createBridge: ({ apiKey, callId, onTerminal }) => {
             const bridge = new OpenAIRealtimeBridge({
               cfg: req.cfg,
+              agentId: req.agentId,
               providerConfig: req.providerConfig,
               apiKey,
               callId,

--- a/src/talk/provider-resolver.test.ts
+++ b/src/talk/provider-resolver.test.ts
@@ -101,6 +101,31 @@ describe("realtime voice provider resolver", () => {
     });
   });
 
+  it("passes the requested agent scope to explicitly selected provider checks", () => {
+    const isConfigured = vi.fn(() => true);
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "agent-scoped",
+      label: "Agent scoped",
+      isConfigured,
+      createBridge: () => {
+        throw new Error("unused");
+      },
+    };
+
+    resolveConfiguredRealtimeVoiceProvider({
+      agentId: "voice-agent",
+      cfg: {},
+      configuredProviderId: provider.id,
+      providers: [provider],
+    });
+
+    expect(isConfigured).toHaveBeenCalledWith({
+      agentId: "voice-agent",
+      cfg: {},
+      providerConfig: {},
+    });
+  });
+
   it("keeps browser-only providers out of bridge auto-selection", () => {
     const isBrowserSessionConfigured = vi.fn(
       ({ agentId }: { agentId?: string }) => agentId === "voice-agent",

--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -96,7 +96,7 @@ describe("realtime voice bridge session runtime", () => {
     expect(sendMark).toHaveBeenCalledWith("mark-1");
   });
 
-  it("passes the requested audio format to the provider bridge", () => {
+  it("passes the requested agent scope and audio format to the provider bridge", () => {
     let request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
     const provider: RealtimeVoiceProviderPlugin = {
       id: "test",
@@ -110,11 +110,13 @@ describe("realtime voice bridge session runtime", () => {
 
     createRealtimeVoiceBridgeSession({
       provider,
+      agentId: "voice-agent",
       providerConfig: {},
       audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
       audioSink: { sendAudio: vi.fn() },
     });
 
+    expect(expectBridgeRequest(request).agentId).toBe("voice-agent");
     expect(expectBridgeRequest(request).audioFormat).toEqual(
       REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord voice channel lookup failures such as `Missing Access`, `Unknown Channel`, or network errors were reported as “not a voice channel,” hiding the actual remediation. It also preserves cancellation when a pending lookup rejects after the join has already been stopped.

A parallel repair, #125111, landed the broad routed-agent propagation while this PR was in review. This PR retains the remaining OpenAI browser sideband bridge propagation so that bridge construction keeps the browser session’s selected agent scope.

## Why This Change Was Made

Channel lookup failures now remain structured `ok: false` voice-operation results, and channel-type validation runs only after a successful fetch. A single canonical cancelled-join result is reused at every lifecycle exit, including the deferred lookup-error path.

The remaining browser bridge call now forwards the already-required `agentId`; it does not add a fallback, change credential order, or broaden provider authority.

## User Impact

Discord voice operators receive the actual access, missing-channel, or transport error instead of a misleading type error. Cancelled joins remain cancelled, later auto-join entries continue, and browser-owned realtime bridges retain the selected agent scope.

## Evidence

- Live reproduction before the repairs: the configured Discord channel was confirmed as voice type `2`, while the bot lookup returned `403 / 50001 Missing Access`; OpenClaw reported the wrong channel type.
- The production Discord ACL was repaired independently. On deployed main containing #125111, Molty resolved the configured voice channel, selected the routed agent, and logged a real `voice: joined` outcome.
- Pre-fix regressions failed for `Missing Access`, `Unknown Channel`, network failure, and deferred lookup rejection after cancellation.
- Focused rebased-head proof passed 203 tests across Discord voice, Talk, and OpenAI surfaces; the lifecycle suite separately passed 45/45.
- Core and extension production/test TypeScript checks, focused typed lint, formatting, architecture guards, and `git diff --check` passed.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/32004624981
- ClawSweeper’s cancellation-precedence finding and rank-up moves were addressed; its final review found no blocking patch defect.
- Fresh Codex-backed autoreviews reported no accepted/actionable findings.
- Landed head: `6b6074356bd4762f19c046f832b1969b1ab527cf`
- Landed commit: https://github.com/openclaw/openclaw/commit/ab143955aa43f2f3a29dd7a28cf93854b23cb163
- Production LOC: +22/-10 (net +12). Tests/support: +230/-2.
- AI-assisted; the final implementation, lifecycle ordering, and owner boundaries were manually reviewed.

Pre-merge production testing of the exact PR head would have required a second connection using the live Discord bot identity, evicting the running production connection. The normal managed deployment subsequently advanced to `d6b2e14f6333d6c064c998c46ecda3b2ece5239a` with matching source/build stamps; Molty resolved the configured channel, the OpenAI realtime bridge became ready, and Discord logged `voice: joined`. The automatic post-start database integrity verifier also passed.
