### PR TITLE
fix(ai): preserve final phase across resumed reasoning

### DIFF
--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -192,6 +192,14 @@ const openAiCoalescedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiTypedReasoningChunks = [
+  makeOpenAiChunk({ content: { type: "reasoning", text: "First thought." } }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ content: { type: "reasoning", text: "Second thought." } }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -468,6 +476,26 @@ describe("provider and transport observable parity fixtures", () => {
           },
         ]);
       }
+
+      const typedReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiTypedReasoningChunks,
+      );
+      expect(typedReasoningResult.terminal.content).toEqual([
+        { type: "thinking", thinking: "First thought." },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        { type: "thinking", thinking: "Second thought." },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
 
       const hiddenReasoningResult = await runOpenAi(
         implementation,

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -185,6 +185,13 @@ const openAiInterleavedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiCoalescedReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ content: "Final.", reasoning_content: "Second thought." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -435,30 +442,32 @@ describe("provider and transport observable parity fixtures", () => {
 
   it("marks content interrupted by native reasoning as commentary", async () => {
     for (const implementation of ["provider", "transport"] as const) {
-      const result = await runOpenAi(implementation, "success", openAiInterleavedReasoningChunks);
+      for (const chunks of [openAiInterleavedReasoningChunks, openAiCoalescedReasoningChunks]) {
+        const result = await runOpenAi(implementation, "success", chunks);
 
-      expect(result.terminal.content).toEqual([
-        {
-          type: "thinking",
-          thinking: "First thought.",
-          thinkingSignature: "reasoning_content",
-        },
-        {
-          type: "text",
-          text: "Interim.",
-          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
-        },
-        {
-          type: "thinking",
-          thinking: "Second thought.",
-          thinkingSignature: "reasoning_content",
-        },
-        {
-          type: "text",
-          text: "Final.",
-          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
-        },
-      ]);
+        expect(result.terminal.content).toEqual([
+          {
+            type: "thinking",
+            thinking: "First thought.",
+            thinkingSignature: "reasoning_content",
+          },
+          {
+            type: "text",
+            text: "Interim.",
+            textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+          },
+          {
+            type: "thinking",
+            thinking: "Second thought.",
+            thinkingSignature: "reasoning_content",
+          },
+          {
+            type: "text",
+            text: "Final.",
+            textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+          },
+        ]);
+      }
 
       const hiddenReasoningResult = await runOpenAi(
         implementation,

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -208,6 +208,15 @@ const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiInterleavedThenTrailingReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Second thought." }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({ reasoning_content: "Trailing thought." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const anthropicFailure = {
   status: 429,
   body: {
@@ -534,6 +543,39 @@ describe("provider and transport observable parity fixtures", () => {
           thinkingSignature: "reasoning_content",
         },
         { type: "text", text: " " },
+      ]);
+
+      const interleavedThenTrailingReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiInterleavedThenTrailingReasoningChunks,
+      );
+      expect(interleavedThenTrailingReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Trailing thought.",
+          thinkingSignature: "reasoning_content",
+        },
       ]);
     }
   });

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -200,6 +200,18 @@ const openAiTypedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiStructuredReasoningChunks = [
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: "First thought." }],
+  }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: "Second thought." }],
+  }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -499,6 +511,34 @@ describe("provider and transport observable parity fixtures", () => {
           textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
         },
         { type: "thinking", thinking: "Second thought." },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const structuredReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiStructuredReasoningChunks,
+      );
+      expect(structuredReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_details",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_details",
+        },
         {
           type: "text",
           text: "Final.",

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -166,6 +166,33 @@ const openAiChunks = [
   },
 ] satisfies OpenAIChunk[];
 
+function makeOpenAiChunk(
+  delta: Record<string, unknown>,
+  finishReason: string | null = null,
+): OpenAIChunk {
+  return {
+    id: "chatcmpl-parity",
+    model: "gpt-5.5-response",
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+const openAiInterleavedReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Second thought." }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
+const openAiTrailingReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Answer." }),
+  makeOpenAiChunk({ reasoning_content: "Trailing thought." }),
+  makeOpenAiChunk({ content: " " }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const anthropicFailure = {
   status: 429,
   body: {
@@ -220,9 +247,12 @@ async function observeStream(stream: AssistantMessageEventStreamLike): Promise<{
   };
 }
 
-function resetOpenAiMock(outcome: ParityFixture["outcome"]): void {
+function resetOpenAiMock(
+  outcome: ParityFixture["outcome"],
+  chunks: readonly OpenAIChunk[] = openAiChunks,
+): void {
   openAiMockState.payloads = [];
-  openAiMockState.chunks = outcome === "success" ? [...openAiChunks] : [];
+  openAiMockState.chunks = outcome === "success" ? [...chunks] : [];
   openAiMockState.error =
     outcome === "error"
       ? Object.assign(new Error("synthetic OpenAI rejection"), {
@@ -237,8 +267,11 @@ function resetOpenAiMock(outcome: ParityFixture["outcome"]): void {
 async function runOpenAi(
   implementation: "provider" | "transport",
   outcome: ParityFixture["outcome"],
+  chunks: readonly OpenAIChunk[] = openAiChunks,
+  emitReasoning = true,
 ): Promise<ParityOutput> {
-  resetOpenAiMock(outcome);
+  resetOpenAiMock(outcome, chunks);
+  const model = emitReasoning ? openAiModel : { ...openAiModel, reasoning: false };
   const [{ streamOpenAICompletions }, { createOpenAICompletionsTransportStreamFn }] =
     await Promise.all([
       import("./providers/openai-completions.js"),
@@ -246,12 +279,12 @@ async function runOpenAi(
     ]);
   const stream =
     implementation === "provider"
-      ? streamOpenAICompletions(openAiModel, context, {
+      ? streamOpenAICompletions(model, context, {
           apiKey: "sk-test",
           reasoningEffort: "medium",
         })
       : await Promise.resolve(
-          createOpenAICompletionsTransportStreamFn()(openAiModel, context, {
+          createOpenAICompletionsTransportStreamFn()(model, context, {
             apiKey: "sk-test",
             reasoningEffort: "medium",
           } as never),
@@ -398,5 +431,73 @@ describe("provider and transport observable parity fixtures", () => {
     ).toMatchFileSnapshot(
       path.join(import.meta.dirname, "../test/fixtures/provider-transport-parity", snapshot),
     );
+  });
+
+  it("marks content interrupted by native reasoning as commentary", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(implementation, "success", openAiInterleavedReasoningChunks);
+
+      expect(result.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const hiddenReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiInterleavedReasoningChunks,
+        false,
+      );
+      expect(hiddenReasoningResult.terminal.content).toEqual([
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const trailingReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiTrailingReasoningChunks,
+      );
+      expect(trailingReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "text", text: "Answer." },
+        {
+          type: "thinking",
+          thinking: "Trailing thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "text", text: " " },
+      ]);
+    }
   });
 });

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -189,7 +189,8 @@ export const streamOpenAICompletions: StreamFunction<
 
       let textBlock: TextContent | null = null;
       let thinkingBlock: ThinkingContent | null = null;
-      let lastInterruptedTextBlock: TextContent | null = null;
+      let pendingInterruptedTextBlock: TextContent | null = null;
+      let confirmedInterruptedTextBlock: TextContent | null = null;
       let hasFinishReason = false;
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
@@ -292,6 +293,10 @@ export const streamOpenAICompletions: StreamFunction<
         sealNativeReasoningBeforeText();
         const block = ensureTextBlock();
         block.text += delta;
+        if (pendingInterruptedTextBlock && delta.trim()) {
+          confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
+          pendingInterruptedTextBlock = null;
+        }
         stream.push({
           type: "text_delta",
           contentIndex: getContentIndex(block),
@@ -376,7 +381,7 @@ export const streamOpenAICompletions: StreamFunction<
         // Resumed reasoning makes the preceding visible text interim. Preserve
         // the candidate boundary only if later text confirms a final answer.
         if (textBlock.text.trim()) {
-          lastInterruptedTextBlock = textBlock;
+          pendingInterruptedTextBlock = textBlock;
         }
         finishBlock(textBlock);
         textBlock = null;
@@ -604,8 +609,8 @@ export const streamOpenAICompletions: StreamFunction<
               : "Provider returned an invalid tool call"),
         );
       }
-      if (output.stopReason !== "toolUse" && lastInterruptedTextBlock) {
-        tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+      if (output.stopReason !== "toolUse" && confirmedInterruptedTextBlock) {
+        tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
       }
       // Tool completion is irreversible: confirm the terminal before closing
       // blocks, then preserve their original text/thinking/tool event order.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -381,6 +381,16 @@ export const streamOpenAICompletions: StreamFunction<
         finishBlock(textBlock);
         textBlock = null;
       };
+      const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+        if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
+          reasoningTagTextPartitioner.markStrict();
+        }
+        // Let following text finish syntax already owned by the Markdown
+        // parser; otherwise packet batching cannot erase a lane boundary.
+        if (!hasFollowingVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
+          sealTextBeforeReasoning();
+        }
+      };
 
       const guardedOpenaiStream = withFirstStreamEventTimeout(hookedOpenAIStream, {
         provider: model.provider,
@@ -476,12 +486,7 @@ export const streamOpenAICompletions: StreamFunction<
             );
             const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
-              reasoningTagTextPartitioner.markStrict();
-              // Let same-chunk text finish syntax already owned by the Markdown
-              // parser; otherwise packet batching cannot erase a lane boundary.
-              if (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
-                sealTextBeforeReasoning();
-              }
+              beginReasoning(hasSameChunkVisibleText, true);
             }
             if (shouldEmitReasoning && foundReasoningField) {
               const delta = deltaFields[foundReasoningField];
@@ -493,11 +498,13 @@ export const streamOpenAICompletions: StreamFunction<
                 appendThinkingDelta(thinkingSignature, delta);
               }
             }
-            for (const contentDelta of contentDeltas) {
+            const lastVisibleTextIndex = contentDeltas.findLastIndex(
+              (delta) => delta.kind === "text",
+            );
+            for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
               if (contentDelta.kind === "thinking") {
-                if (reasoningTagTextPartitioner.hasPending()) {
-                  reasoningTagTextPartitioner.markStrict();
-                }
+                const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
+                beginReasoning(hasLaterVisibleText);
                 if (shouldEmitReasoning) {
                   appendThinkingDelta(contentDelta.signature, contentDelta.text);
                 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -23,6 +23,8 @@ import {
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
+  readOpenAICompletionsReasoningBatch,
+  type OpenAICompletionsContentDelta,
 } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
@@ -150,6 +152,12 @@ export const streamOpenAICompletions: StreamFunction<
     try {
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
       const compat = resolveOpenAICompletionsCompat(model);
+      const visibleReasoningDetailTypes = new Set(compat.visibleReasoningDetailTypes);
+      const shouldEmitReasoning = Boolean(
+        model.reasoning &&
+        options?.reasoningEffort &&
+        isOpenAICompletionsThinkingEnabled(options.reasoningEffort),
+      );
       const cacheRetention = resolveCacheRetention(options?.cacheRetention);
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
       const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
@@ -314,6 +322,23 @@ export const streamOpenAICompletions: StreamFunction<
           partial: output,
         });
       };
+      const appendReasoningDeltas = (reasoningDeltas: readonly OpenAICompletionsContentDelta[]) => {
+        for (const reasoningDelta of reasoningDeltas) {
+          if (reasoningDelta.kind === "thinking") {
+            if (!shouldEmitReasoning) {
+              continue;
+            }
+            const signature = reasoningDelta.signature;
+            const thinkingSignature =
+              model.provider === "opencode-go" && signature === "reasoning"
+                ? "reasoning_content"
+                : signature;
+            appendThinkingDelta(thinkingSignature, reasoningDelta.text);
+          } else {
+            appendTextDelta(reasoningDelta.text);
+          }
+        }
+      };
       const ensureToolCallBlock = (toolCall: StreamingToolCallDelta) => {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
@@ -465,47 +490,27 @@ export const streamOpenAICompletions: StreamFunction<
             choice.finish_reason,
           )) {
             const choiceDelta = normalizedDelta.delta;
-            // Some endpoints return reasoning in reasoning_content (llama.cpp),
-            // or reasoning (other openai compatible endpoints)
-            // Use the first non-empty reasoning field to avoid duplication
-            // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
-            const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
             const deltaFields = choiceDelta as Record<string, unknown>;
-            const shouldEmitReasoning = Boolean(
-              model.reasoning &&
-              options?.reasoningEffort &&
-              isOpenAICompletionsThinkingEnabled(options.reasoningEffort),
+            const reasoningBatch = readOpenAICompletionsReasoningBatch(
+              deltaFields,
+              visibleReasoningDetailTypes,
             );
-            let foundReasoningField: string | null = null;
-            for (const field of reasoningFields) {
-              const value = deltaFields[field];
-              if (typeof value === "string" && value.length > 0) {
-                foundReasoningField = field;
-                break;
-              }
-            }
+            const reasoningDeltas = reasoningBatch.deltas;
+            const hasReasoningThinking = reasoningBatch.hasThinking;
             const contentDeltas = readOpenAICompletionsContentDeltas(
               choiceDelta.content,
               choiceDelta.refusal,
-              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
+              reasoningBatch.mirroredThinking,
             );
-            const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
-            if (foundReasoningField) {
-              beginReasoning(hasSameChunkVisibleText, true);
-            }
-            if (shouldEmitReasoning && foundReasoningField) {
-              const delta = deltaFields[foundReasoningField];
-              if (typeof delta === "string" && delta.length > 0) {
-                const thinkingSignature =
-                  model.provider === "opencode-go" && foundReasoningField === "reasoning"
-                    ? "reasoning_content"
-                    : foundReasoningField;
-                appendThinkingDelta(thinkingSignature, delta);
-              }
-            }
             const lastVisibleTextIndex = contentDeltas.findLastIndex(
               (delta) => delta.kind === "text",
             );
+            const hasSameChunkVisibleText =
+              reasoningBatch.hasVisibleText || lastVisibleTextIndex !== -1;
+            if (hasReasoningThinking) {
+              beginReasoning(hasSameChunkVisibleText, true);
+              appendReasoningDeltas(reasoningDeltas);
+            }
             for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
               if (contentDelta.kind === "thinking") {
                 const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
@@ -514,8 +519,11 @@ export const streamOpenAICompletions: StreamFunction<
                   appendThinkingDelta(contentDelta.signature, contentDelta.text);
                 }
               } else {
-                appendPartitionedContent(contentDelta.text, Boolean(foundReasoningField));
+                appendPartitionedContent(contentDelta.text, hasReasoningThinking);
               }
+            }
+            if (!hasReasoningThinking) {
+              appendReasoningDeltas(reasoningDeltas);
             }
 
             const toolCallDeltas = normalizedDelta.toolCalls;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -43,6 +43,7 @@ import type {
 import {
   clearPendingCommentaryText,
   rememberPendingCommentaryTags,
+  tagInterruptedTextPhases,
   tagPendingCommentaryText,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
@@ -188,6 +189,7 @@ export const streamOpenAICompletions: StreamFunction<
 
       let textBlock: TextContent | null = null;
       let thinkingBlock: ThinkingContent | null = null;
+      let lastInterruptedTextBlock: TextContent | null = null;
       let hasFinishReason = false;
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
@@ -363,6 +365,22 @@ export const streamOpenAICompletions: StreamFunction<
           }
         }
       };
+      const sealTextBeforeReasoning = () => {
+        if (!textBlock && !reasoningTagTextPartitioner.hasPending()) {
+          return;
+        }
+        flushPartitionedContent();
+        if (!textBlock) {
+          return;
+        }
+        // Resumed reasoning makes the preceding visible text interim. Preserve
+        // the candidate boundary only if later text confirms a final answer.
+        if (textBlock.text.trim()) {
+          lastInterruptedTextBlock = textBlock;
+        }
+        finishBlock(textBlock);
+        textBlock = null;
+      };
 
       const guardedOpenaiStream = withFirstStreamEventTimeout(hookedOpenAIStream, {
         provider: model.provider,
@@ -451,8 +469,19 @@ export const streamOpenAICompletions: StreamFunction<
                 break;
               }
             }
+            const contentDeltas = readOpenAICompletionsContentDeltas(
+              choiceDelta.content,
+              choiceDelta.refusal,
+              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
+            );
+            const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
               reasoningTagTextPartitioner.markStrict();
+              // Same-chunk text can complete buffered Markdown or tag syntax;
+              // only a standalone reasoning delta confirms a lane resumption.
+              if (!hasSameChunkVisibleText) {
+                sealTextBeforeReasoning();
+              }
             }
             if (shouldEmitReasoning && foundReasoningField) {
               const delta = deltaFields[foundReasoningField];
@@ -464,11 +493,7 @@ export const streamOpenAICompletions: StreamFunction<
                 appendThinkingDelta(thinkingSignature, delta);
               }
             }
-            for (const contentDelta of readOpenAICompletionsContentDeltas(
-              choiceDelta.content,
-              choiceDelta.refusal,
-              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
-            )) {
+            for (const contentDelta of contentDeltas) {
               if (contentDelta.kind === "thinking") {
                 if (reasoningTagTextPartitioner.hasPending()) {
                   reasoningTagTextPartitioner.markStrict();
@@ -571,6 +596,9 @@ export const streamOpenAICompletions: StreamFunction<
               ? "Request was aborted"
               : "Provider returned an invalid tool call"),
         );
+      }
+      if (output.stopReason !== "toolUse" && lastInterruptedTextBlock) {
+        tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
       }
       // Tool completion is irreversible: confirm the terminal before closing
       // blocks, then preserve their original text/thinking/tool event order.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -477,9 +477,9 @@ export const streamOpenAICompletions: StreamFunction<
             const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
               reasoningTagTextPartitioner.markStrict();
-              // Same-chunk text can complete buffered Markdown or tag syntax;
-              // only a standalone reasoning delta confirms a lane resumption.
-              if (!hasSameChunkVisibleText) {
+              // Let same-chunk text finish syntax already owned by the Markdown
+              // parser; otherwise packet batching cannot erase a lane boundary.
+              if (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
                 sealTextBeforeReasoning();
               }
             }

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -168,7 +168,7 @@ describe("openai completions stream", () => {
     expectRecordFields(output.content[0], expected);
   });
 
-  it("preserves reasoning_details item order when visible text and thinking are interleaved", async () => {
+  it("preserves explicitly visible reasoning_details without phase reclassification", async () => {
     const model = makeCompletionsModel({
       id: "openrouter/minimax/minimax-m2.7",
       name: "MiniMax M2.7",

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -233,6 +233,56 @@ describe("openai completions stream", () => {
     expectRecordFields(output.content[2], { type: "text", text: " Visible third." });
   });
 
+  it("phases text interrupted by resumed reasoning_details", async () => {
+    const model = makeCompletionsModel({
+      id: "openrouter/qwen/qwen3-235b-a22b",
+      name: "Qwen3 235B A22B",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+    const output = createAssistantOutput(model);
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          reasoning_details: [{ type: "reasoning.text", text: "First thought." }],
+        }),
+        makeCompletionsChunk({ content: "Interim." }),
+        makeCompletionsChunk({
+          reasoning_details: [{ type: "reasoning.text", text: "Second thought." }],
+        }),
+        makeCompletionsChunk({ content: "Final." }),
+        makeCompletionsChunk({}, "stop"),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "First thought.",
+        thinkingSignature: "reasoning_details",
+      },
+      {
+        type: "text",
+        text: "Interim.",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
+      {
+        type: "thinking",
+        thinking: "Second thought.",
+        thinkingSignature: "reasoning_details",
+      },
+      {
+        type: "text",
+        text: "Final.",
+        textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+      },
+    ]);
+  });
+
   it("keeps fallback thinking when reasoning_details only carries visible text", async () => {
     const model = makeCompletionsModel({
       id: "openrouter/minimax/minimax-m2.7",

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -29,6 +29,7 @@ import {
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
+  readOpenAICompletionsReasoningBatch,
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
@@ -84,6 +85,7 @@ export async function processCompletionsStream(
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
   const emitReasoning = options?.emitReasoning ?? true;
   const compat = getCompat(model as OpenAIModeModel);
+  const visibleReasoningDetailTypes = new Set(compat.visibleReasoningDetailTypes);
   const shouldFilterDeepSeekDsmlText = compat.thinkingFormat === "deepseek";
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText ? createDeepSeekTextFilter() : null;
   const deepSeekToolCallRecoverer = shouldFilterDeepSeekDsmlText ? createDsmlRecoverer() : null;
@@ -214,6 +216,22 @@ export async function processCompletionsStream(
       queuePostToolCallDelta({ kind: "text", text });
     } else {
       appendTextDelta(text);
+    }
+  };
+  const appendReasoningDeltas = (reasoningDeltas: readonly CompletionsReasoningDelta[]) => {
+    for (const reasoningDelta of reasoningDeltas) {
+      if (reasoningDelta.kind === "thinking" && !emitReasoning) {
+        continue;
+      }
+      if (currentBlock?.type === "toolCall") {
+        queuePostToolCallDelta({ ...reasoningDelta });
+        continue;
+      }
+      if (reasoningDelta.kind === "text") {
+        appendTextDelta(reasoningDelta.text);
+      } else if (emitReasoning) {
+        appendThinkingDelta(reasoningDelta);
+      }
     }
   };
   const appendRecoveredToolCall = (toolCall: RecoveredDeepSeekDsmlToolCall) => {
@@ -410,52 +428,27 @@ export async function processCompletionsStream(
     }
     for (const normalizedDelta of normalizeToolCallDeltas(rawChoiceDelta, choice.finish_reason)) {
       const choiceDelta = normalizedDelta.delta;
-      const reasoningDeltas = getCompletionsReasoningDeltas(
+      const reasoningBatch = readOpenAICompletionsReasoningBatch(
         choiceDelta as Record<string, unknown>,
-        compat.visibleReasoningDetailTypes,
+        visibleReasoningDetailTypes,
       );
-      const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
+      const reasoningDeltas = reasoningBatch.deltas;
+      const hasReasoningThinking = reasoningBatch.hasThinking;
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
         choiceDelta.refusal,
-        reasoningDeltas
-          .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
-          .map((reasoningDelta) => reasoningDelta.text),
+        reasoningBatch.mirroredThinking,
       );
-      const hasSameChunkVisibleText =
-        reasoningDeltas.some((delta) => delta.kind === "text") ||
-        contentDeltas.some((delta) => delta.kind === "text");
-      if (hasMirroredReasoning) {
-        beginReasoning(hasSameChunkVisibleText, true);
-      }
-      // Compat-classified visible details are explicit output items. Preserve
-      // their order with adjacent structured thinking instead of inferring commentary.
-      const appendReasoningDeltas = () => {
-        for (const reasoningDelta of reasoningDeltas) {
-          if (reasoningDelta.kind === "thinking" && !emitReasoning) {
-            continue;
-          }
-          if (currentBlock?.type === "toolCall") {
-            queuePostToolCallDelta({ ...reasoningDelta });
-            continue;
-          }
-          if (reasoningDelta.kind === "text") {
-            appendTextDelta(reasoningDelta.text);
-          } else if (emitReasoning) {
-            appendThinkingDelta(reasoningDelta);
-          }
-        }
-      };
-      // The dedicated field owns reasoning order/signature; a distinct content
-      // thought follows it, while an exact mirror was removed by the decoder.
-      if (hasMirroredReasoning) {
-        appendReasoningDeltas();
-      }
       const lastVisibleTextIndex = contentDeltas.findLastIndex((delta) => delta.kind === "text");
+      const hasSameChunkVisibleText = reasoningBatch.hasVisibleText || lastVisibleTextIndex !== -1;
+      if (hasReasoningThinking) {
+        beginReasoning(hasSameChunkVisibleText, true);
+        appendReasoningDeltas(reasoningDeltas);
+      }
       for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
         if (contentDelta.kind === "text") {
-          const routedDeltas = hasMirroredReasoning
+          const routedDeltas = hasReasoningThinking
             ? reasoningTagTextPartitioner.push(contentDelta.text)
             : reasoningTagTextPartitioner.pushVisible(contentDelta.text);
           for (const routedDelta of routedDeltas) {
@@ -467,8 +460,8 @@ export async function processCompletionsStream(
           appendRoutedContentDelta(contentDelta);
         }
       }
-      if (!hasMirroredReasoning) {
-        appendReasoningDeltas();
+      if (!hasReasoningThinking) {
+        appendReasoningDeltas(reasoningDeltas);
       }
       const toolCallDeltas = normalizedDelta.toolCalls;
       if (toolCallDeltas.length > 0) {
@@ -582,59 +575,6 @@ export async function processCompletionsStream(
   if (output.stopReason === "toolUse") {
     tagPendingCommentaryText(output.content);
   }
-}
-
-function getCompletionsReasoningDeltas(
-  delta: Record<string, unknown>,
-  visibleReasoningDetailTypes: readonly string[],
-): CompletionsReasoningDelta[] {
-  const output: CompletionsReasoningDelta[] = [];
-  const pushDelta = (next: CompletionsReasoningDelta) => {
-    const previous = output[output.length - 1];
-    if (!previous || previous.kind !== next.kind) {
-      output.push(next);
-      return;
-    }
-    if (next.kind === "thinking" && previous.kind === "thinking") {
-      if (previous.signature !== next.signature) {
-        output.push(next);
-        return;
-      }
-      previous.text += next.text;
-      return;
-    }
-    previous.text += next.text;
-  };
-  const reasoningDetails = delta.reasoning_details;
-  let usedReasoningThinkingDetails = false;
-  if (Array.isArray(reasoningDetails)) {
-    const visibleTypes = new Set(visibleReasoningDetailTypes);
-    for (const item of reasoningDetails) {
-      const detail = item as { type?: unknown; text?: unknown };
-      if (typeof detail.text !== "string" || !detail.text) {
-        continue;
-      }
-      if (detail.type === "reasoning.text") {
-        usedReasoningThinkingDetails = true;
-        pushDelta({ kind: "thinking", signature: "reasoning_details", text: detail.text });
-        continue;
-      }
-      if (typeof detail.type === "string" && visibleTypes.has(detail.type)) {
-        pushDelta({ kind: "text", text: detail.text });
-      }
-    }
-  }
-  if (!usedReasoningThinkingDetails) {
-    const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"] as const;
-    for (const field of reasoningFields) {
-      const value = delta[field];
-      if (typeof value === "string" && value.length > 0) {
-        pushDelta({ kind: "thinking", signature: field, text: value });
-        break;
-      }
-    }
-  }
-  return output;
 }
 
 function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -429,6 +429,8 @@ export async function processCompletionsStream(
       if (hasMirroredReasoning) {
         beginReasoning(hasSameChunkVisibleText, true);
       }
+      // Compat-classified visible details are explicit output items. Preserve
+      // their order with adjacent structured thinking instead of inferring commentary.
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
           if (reasoningDelta.kind === "thinking" && !emitReasoning) {

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -102,7 +102,8 @@ export async function processCompletionsStream(
     | { type: "thinking"; thinking: string; thinkingSignature?: string }
     | ToolCallBlock
     | null = null;
-  let lastInterruptedTextBlock: TextBlock | null = null;
+  let pendingInterruptedTextBlock: TextBlock | null = null;
+  let confirmedInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
   let pendingPostToolCallBytes = 0;
   let isFlushingPendingPostToolCallDeltas = false;
@@ -166,6 +167,10 @@ export async function processCompletionsStream(
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
     currentBlock.text += text;
+    if (pendingInterruptedTextBlock && text.trim()) {
+      confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
+      pendingInterruptedTextBlock = null;
+    }
     pushStreamEvent({
       type: "text_delta",
       contentIndex: blockIndex(),
@@ -333,7 +338,7 @@ export async function processCompletionsStream(
     // Resumed reasoning makes the preceding visible text interim. Preserve
     // the candidate boundary only if later text confirms a final answer.
     if (currentBlock.text.trim()) {
-      lastInterruptedTextBlock = currentBlock;
+      pendingInterruptedTextBlock = currentBlock;
     }
     currentBlock = null;
   };
@@ -562,12 +567,12 @@ export async function processCompletionsStream(
     },
   });
   if (
-    lastInterruptedTextBlock &&
+    confirmedInterruptedTextBlock &&
     output.stopReason !== "toolUse" &&
     output.stopReason !== "error" &&
     output.stopReason !== "aborted"
   ) {
-    tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+    tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
   }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -337,6 +337,16 @@ export async function processCompletionsStream(
     }
     currentBlock = null;
   };
+  const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+    if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
+      reasoningTagTextPartitioner.markStrict();
+    }
+    // Let following text finish syntax already owned by the Markdown
+    // parser; otherwise packet batching cannot erase a lane boundary.
+    if (!hasFollowingVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
+      sealTextBeforeReasoning();
+    }
+  };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   const guardedStream = withFirstStreamEventTimeout(responseStream as AsyncIterable<unknown>, {
     provider: model.provider,
@@ -400,9 +410,6 @@ export async function processCompletionsStream(
         compat.visibleReasoningDetailTypes,
       );
       const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
-      const hasDedicatedReasoning = reasoningDeltas.some(
-        (delta) => delta.kind === "thinking" && delta.signature !== "reasoning_details",
-      );
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
@@ -411,17 +418,11 @@ export async function processCompletionsStream(
           .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
           .map((reasoningDelta) => reasoningDelta.text),
       );
-      const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
+      const hasSameChunkVisibleText =
+        reasoningDeltas.some((delta) => delta.kind === "text") ||
+        contentDeltas.some((delta) => delta.kind === "text");
       if (hasMirroredReasoning) {
-        reasoningTagTextPartitioner.markStrict();
-        // Let same-chunk text finish syntax already owned by the Markdown
-        // parser; otherwise packet batching cannot erase a lane boundary.
-        if (
-          hasDedicatedReasoning &&
-          (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax())
-        ) {
-          sealTextBeforeReasoning();
-        }
+        beginReasoning(hasSameChunkVisibleText, true);
       }
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
@@ -444,7 +445,8 @@ export async function processCompletionsStream(
       if (hasMirroredReasoning) {
         appendReasoningDeltas();
       }
-      for (const contentDelta of contentDeltas) {
+      const lastVisibleTextIndex = contentDeltas.findLastIndex((delta) => delta.kind === "text");
+      for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
         if (contentDelta.kind === "text") {
           const routedDeltas = hasMirroredReasoning
             ? reasoningTagTextPartitioner.push(contentDelta.text)
@@ -453,9 +455,8 @@ export async function processCompletionsStream(
             appendPartitionedVisibleDelta(routedDelta);
           }
         } else {
-          if (reasoningTagTextPartitioner.hasPending()) {
-            reasoningTagTextPartitioner.markStrict();
-          }
+          const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
+          beginReasoning(hasLaterVisibleText);
           appendRoutedContentDelta(contentDelta);
         }
       }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -10,6 +10,7 @@ import { mapOpenAIStopReason } from "../providers/openai-stop-reason.js";
 import {
   clearPendingCommentaryText,
   rememberPendingCommentaryTags,
+  tagInterruptedTextPhases,
   tagPendingCommentaryText,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
@@ -95,11 +96,13 @@ export async function processCompletionsStream(
     partialArgs: string;
     thoughtSignature?: string;
   };
+  type TextBlock = { type: "text"; text: string; textSignature?: string };
   let currentBlock:
-    | { type: "text"; text: string }
+    | TextBlock
     | { type: "thinking"; thinking: string; thinkingSignature?: string }
     | ToolCallBlock
     | null = null;
+  let lastInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
   let pendingPostToolCallBytes = 0;
   let isFlushingPendingPostToolCallDeltas = false;
@@ -314,10 +317,25 @@ export async function processCompletionsStream(
     }
     appendThinkingDelta({ text: "" });
   };
-  const flushReasoningTagTextPartitionerAtEnd = () => {
+  const flushReasoningTagTextPartitioner = () => {
     for (const delta of reasoningTagTextPartitioner.flush()) {
       appendPartitionedVisibleDelta(delta);
     }
+  };
+  const sealTextBeforeReasoning = () => {
+    if (currentBlock?.type !== "text" && !reasoningTagTextPartitioner.hasPending()) {
+      return;
+    }
+    flushReasoningTagTextPartitioner();
+    if (currentBlock?.type !== "text") {
+      return;
+    }
+    // Resumed reasoning makes the preceding visible text interim. Preserve
+    // the candidate boundary only if later text confirms a final answer.
+    if (currentBlock.text.trim()) {
+      lastInterruptedTextBlock = currentBlock;
+    }
+    currentBlock = null;
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   const guardedStream = withFirstStreamEventTimeout(responseStream as AsyncIterable<unknown>, {
@@ -382,9 +400,9 @@ export async function processCompletionsStream(
         compat.visibleReasoningDetailTypes,
       );
       const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
-      if (hasMirroredReasoning) {
-        reasoningTagTextPartitioner.markStrict();
-      }
+      const hasDedicatedReasoning = reasoningDeltas.some(
+        (delta) => delta.kind === "thinking" && delta.signature !== "reasoning_details",
+      );
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
@@ -393,6 +411,15 @@ export async function processCompletionsStream(
           .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
           .map((reasoningDelta) => reasoningDelta.text),
       );
+      const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
+      if (hasMirroredReasoning) {
+        reasoningTagTextPartitioner.markStrict();
+        // Same-chunk text can complete buffered Markdown or tag syntax;
+        // only a standalone reasoning delta confirms a lane resumption.
+        if (hasDedicatedReasoning && !hasSameChunkVisibleText) {
+          sealTextBeforeReasoning();
+        }
+      }
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
           if (reasoningDelta.kind === "thinking" && !emitReasoning) {
@@ -435,7 +462,7 @@ export async function processCompletionsStream(
       const toolCallDeltas = normalizedDelta.toolCalls;
       if (toolCallDeltas.length > 0) {
         sawNativeToolCallDelta = true;
-        flushReasoningTagTextPartitionerAtEnd();
+        flushReasoningTagTextPartitioner();
         rememberPendingCommentaryTags(
           provisionalCommentaryTags,
           tagPendingCommentaryText(output.content),
@@ -502,7 +529,7 @@ export async function processCompletionsStream(
     emitReasoningUsageActivity(hasReasoningUsageActivity);
     await cooperativeScheduler.afterEvent();
   }
-  flushReasoningTagTextPartitionerAtEnd();
+  flushReasoningTagTextPartitioner();
   flushDeepSeekToolCallRecovererAtEnd();
   flushDeepSeekTextFilterAtEnd();
   currentBlock = null;
@@ -530,6 +557,14 @@ export async function processCompletionsStream(
       });
     },
   });
+  if (
+    lastInterruptedTextBlock &&
+    output.stopReason !== "toolUse" &&
+    output.stopReason !== "error" &&
+    output.stopReason !== "aborted"
+  ) {
+    tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+  }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);
   }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -414,9 +414,12 @@ export async function processCompletionsStream(
       const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
       if (hasMirroredReasoning) {
         reasoningTagTextPartitioner.markStrict();
-        // Same-chunk text can complete buffered Markdown or tag syntax;
-        // only a standalone reasoning delta confirms a lane resumption.
-        if (hasDedicatedReasoning && !hasSameChunkVisibleText) {
+        // Let same-chunk text finish syntax already owned by the Markdown
+        // parser; otherwise packet batching cannot erase a lane boundary.
+        if (
+          hasDedicatedReasoning &&
+          (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax())
+        ) {
           sealTextBeforeReasoning();
         }
       }

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -40,6 +40,120 @@ export type OpenAICompletionsContentDelta =
   | { kind: "thinking"; signature?: string; text: string }
   | { kind: "text"; text: string; source?: "refusal" };
 
+type OpenAICompletionsReasoningBatch = {
+  readonly deltas: readonly OpenAICompletionsContentDelta[];
+  readonly mirroredThinking: readonly string[];
+  readonly hasThinking: boolean;
+  readonly hasVisibleText: boolean;
+};
+
+type MutableOpenAICompletionsReasoningBatch = {
+  deltas: OpenAICompletionsContentDelta[];
+  mirroredThinking: string[];
+  hasThinking: boolean;
+  hasVisibleText: boolean;
+};
+
+const EMPTY_OPENAI_COMPLETIONS_REASONING_BATCH: OpenAICompletionsReasoningBatch = {
+  deltas: [],
+  mirroredThinking: [],
+  hasThinking: false,
+  hasVisibleText: false,
+};
+
+const OPENAI_COMPLETIONS_REASONING_FIELDS = [
+  "reasoning_content",
+  "reasoning",
+  "reasoning_text",
+] as const;
+
+function appendOpenAICompletionsReasoningDelta(
+  batch: MutableOpenAICompletionsReasoningBatch,
+  next: OpenAICompletionsContentDelta,
+): void {
+  if (next.kind === "thinking") {
+    batch.hasThinking = true;
+  } else {
+    batch.hasVisibleText = true;
+  }
+  const previous = batch.deltas[batch.deltas.length - 1];
+  if (!previous || previous.kind !== next.kind) {
+    batch.deltas.push(next);
+    if (next.kind === "thinking") {
+      batch.mirroredThinking.push(next.text);
+    }
+    return;
+  }
+  if (next.kind === "thinking" && previous.kind === "thinking") {
+    if (previous.signature !== next.signature) {
+      batch.deltas.push(next);
+      batch.mirroredThinking.push(next.text);
+      return;
+    }
+    previous.text += next.text;
+    batch.mirroredThinking[batch.mirroredThinking.length - 1] += next.text;
+    return;
+  }
+  previous.text += next.text;
+}
+
+function createOpenAICompletionsReasoningBatch(): MutableOpenAICompletionsReasoningBatch {
+  return {
+    deltas: [],
+    mirroredThinking: [],
+    hasThinking: false,
+    hasVisibleText: false,
+  };
+}
+
+export function readOpenAICompletionsReasoningBatch(
+  delta: Record<string, unknown>,
+  visibleReasoningDetailTypes: ReadonlySet<string>,
+): OpenAICompletionsReasoningBatch {
+  let batch: MutableOpenAICompletionsReasoningBatch | undefined;
+  const reasoningDetails = delta.reasoning_details;
+  let usedReasoningThinkingDetails = false;
+  if (Array.isArray(reasoningDetails)) {
+    for (const item of reasoningDetails) {
+      const detail = item as { type?: unknown; text?: unknown };
+      if (typeof detail.text !== "string" || !detail.text) {
+        continue;
+      }
+      if (detail.type === "reasoning.text") {
+        usedReasoningThinkingDetails = true;
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, {
+          kind: "thinking",
+          signature: "reasoning_details",
+          text: detail.text,
+        });
+        continue;
+      }
+      // Compat-classified visible details are explicit output items. Preserve
+      // their order with adjacent structured thinking instead of inferring commentary.
+      if (typeof detail.type === "string" && visibleReasoningDetailTypes.has(detail.type)) {
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, { kind: "text", text: detail.text });
+      }
+    }
+  }
+  if (!usedReasoningThinkingDetails) {
+    for (const field of OPENAI_COMPLETIONS_REASONING_FIELDS) {
+      const value = delta[field];
+      if (typeof value === "string" && value.length > 0) {
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, {
+          kind: "thinking",
+          signature: field,
+          text: value,
+        });
+        break;
+      }
+    }
+  }
+  return batch ?? EMPTY_OPENAI_COMPLETIONS_REASONING_BATCH;
+}
+
 type OpenAIModeCompatInput = Omit<OpenAICompletionsCompat, "thinkingFormat"> & {
   thinkingFormat?: string;
   requiresStringContent?: boolean;

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -18,21 +18,51 @@ function encodeAssistantTextSignatureV1(id: string, phase?: "commentary" | "fina
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
 }
 
-/** Tags unphased narration before a tool-call event becomes consumer-visible. */
-export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
+function tagUnphasedText(
+  content: ReadonlyArray<unknown>,
+  phase: "commentary" | "final_answer",
+  idPrefix: string,
+): PendingCommentaryTags {
   const textBlocks = content.filter(isAssistantTextPhaseBlock);
-  let commentaryIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
+  let phaseIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
   const tagged: PendingCommentaryTags = new Map();
   for (const block of textBlocks) {
     if (block.text.trim().length === 0 || block.textSignature !== undefined) {
       continue;
     }
-    const signature = encodeAssistantTextSignatureV1(`commentary-${commentaryIndex}`, "commentary");
+    const signature = encodeAssistantTextSignatureV1(`${idPrefix}-${phaseIndex}`, phase);
     block.textSignature = signature;
     tagged.set(block, signature);
-    commentaryIndex += 1;
+    phaseIndex += 1;
   }
   return tagged;
+}
+
+/** Tags unphased narration before a tool-call event becomes consumer-visible. */
+export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
+  return tagUnphasedText(content, "commentary", "commentary");
+}
+
+/** Records the confirmed final-answer boundary after reasoning resumes. */
+export function tagInterruptedTextPhases(
+  content: ReadonlyArray<unknown>,
+  interruptedText: unknown,
+): void {
+  const interruptedTextIndex = content.indexOf(interruptedText);
+  if (interruptedTextIndex === -1) {
+    return;
+  }
+  const finalAnswerIndex = content.findIndex(
+    (block, index) =>
+      index > interruptedTextIndex &&
+      isAssistantTextPhaseBlock(block) &&
+      block.text.trim().length > 0,
+  );
+  if (finalAnswerIndex === -1) {
+    return;
+  }
+  tagUnphasedText(content.slice(0, finalAnswerIndex), "commentary", "commentary");
+  tagUnphasedText(content.slice(finalAnswerIndex), "final_answer", "final-answer");
 }
 
 /** Rolls back only the exact provisional signatures created by this transport turn. */

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -721,6 +721,19 @@ describe("createReasoningTagTextPartitioner", () => {
     expect(partitioner.isInsideReasoning()).toBe(false);
   });
 
+  it("distinguishes buffered syntax from strict visible text", () => {
+    const syntax = createReasoningTagTextPartitioner();
+    const visible = createReasoningTagTextPartitioner();
+
+    expect(syntax.pushVisible("Use `<thi")).toEqual([]);
+    expect(syntax.hasPendingSyntax()).toBe(true);
+
+    visible.markStrict();
+    expect(visible.pushVisible("Interim answer.")).toEqual([]);
+    expect(visible.hasPending()).toBe(true);
+    expect(visible.hasPendingSyntax()).toBe(false);
+  });
+
   it("accepts later content after an intermediate flush boundary", () => {
     const partitioner = createReasoningTagTextPartitioner();
 

--- a/packages/markdown-core/src/reasoning-tags.ts
+++ b/packages/markdown-core/src/reasoning-tags.ts
@@ -81,6 +81,8 @@ export interface ReasoningTagTextPartitioner {
   pushVisible(chunk: string): ReasoningTagTextDelta[];
   flush(): ReasoningTagTextDelta[];
   hasPending(): boolean;
+  /** Whether more input can change buffered Markdown or reasoning-tag ownership. */
+  hasPendingSyntax(): boolean;
   isInsideReasoning(): boolean;
 }
 
@@ -573,6 +575,11 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
         (holdStart !== undefined && holdStart < source.length) ||
         reduction.depth > 0 ||
         emitted < source.length
+      );
+    },
+    hasPendingSyntax() {
+      return (
+        pendingTagProbe !== undefined || heldBacktickStart !== undefined || reduction.depth > 0
       );
     },
     isInsideReasoning() {


### PR DESCRIPTION
## Problem

OpenAI-compatible streams shaped as `reasoning -> interim content -> reasoning -> final content` left both text segments unphased. Final delivery therefore joined the interim text into the user-visible answer. The failure also occurred with coalesced packets, structured `reasoning_details`, hidden reasoning, and a trailing reasoning-only suffix.

## Root cause

The two OpenAI-completions producers decoded reasoning differently and treated resumed reasoning as another delta without closing the active text lane or retaining a boundary confirmed by later visible text. Packet boundaries accidentally determined text-block shape. The channel layer received ambiguous unphased text and correctly preserved it.

## Fix

- decode top-level and structured reasoning once at the shared OpenAI transport boundary
- split the active text lane at producer-owned reasoning boundaries
- retain pending and confirmed interruption boundaries separately
- tag interrupted text `commentary` and the confirmed suffix `final_answer`
- preserve encrypted tool signatures and compat-configured explicitly visible structured output
- cover both producers, hidden reasoning, coalesced packets, structured content, and trailing reasoning

Supersedes #96969 with a producer-owned fix. Thanks @SymbolStar for the report and reproduction analysis. Addresses #96849.

## Proof

- pre-fix owner test: SDK producer merged structured `Interim.Final.` into one unphased block
- exact-head owner suite: 4 files, 68 tests passed
- broader focused suite before the final decoder-only consolidation: 17 files, 471 tests passed
- targeted Oxlint, Oxfmt, and `git diff --check`: passed
- Distill: zero findings on the exact diff
- Greybeard: zero findings on the exact diff
- repo-wide `pnpm tsgo`: blocked by untouched `packages/terminal-core/src/ansi.ts:194` (`TS2554`); the previous exact branch head passed remote CI, and this PR does not modify terminal-core

Exact pushed head: `466aa01dd9ead80c044c8a0f23573701469f4ed3`.

Production delta: +324/-135. Growth centralizes structured reasoning decoding, records pending/confirmed phase boundaries across the two existing producer implementations, and exposes one allocation-free Markdown parser ownership fact. No channel/provider-specific guard or compatibility path. Test delta: +289/-6; assertion-safety baseline: +2/-2.

## Phase-aware delivery contract

The owner regression drives both production producers through:

```text
reasoning_details(A) -> content(INTERIM) -> reasoning_details(B) -> content(FINAL) -> stop
```

Both now emit thinking A, `INTERIM` as `commentary`, thinking B, and `FINAL` as `final_answer`. Canonical delivery therefore returns only `FINAL`. A trailing reasoning-only suffix leaves the last confirmed final boundary intact.

## Pre-fix compatible-provider capture

Redacted Telegram harness capture on main drove the documented generic `openai-completions` route with:

```text
reasoning_content([redacted A]) -> content(INTERMEDIATE) ->
reasoning_content([redacted B]) -> content(FINAL)
```

Gateway evidence recorded `provider=openai` and `api=openai-completions`. Telegram received one final SUT message after 4111 ms containing both `INTERMEDIATE` and `FINAL`, with neither hidden reasoning marker. This proves the reported stream shape leaked interim visible content on main; it does not claim that the current MiniMax service still emits that shape. Bundled MiniMax defaults to `anthropic-messages`, while its optional OpenAI-compatible configuration remains documented.

## Overlap

Open PR #96969 is the only exact overlap. Its consumer heuristic drops legitimate unphased text across providers; this PR replaces it at the producer owner boundary. Broad searches found no second open repair.
