### PR TITLE
[BACKPORT] fix(slack): honor bot policy for Enterprise Grid messages

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -358,6 +358,18 @@ describe("registerSlackMessageEvents", () => {
 
   it.each([
     {
+      name: "message with bot identity",
+      event: {
+        type: "message",
+        bot_id: "B_OTHER",
+        channel: "C123",
+        channel_type: "channel",
+        user: "U_OTHER",
+        text: "<@U_BOT> hello",
+        ts: "123.456",
+      },
+    },
+    {
       name: "file_share with bot_id",
       event: {
         type: "message",
@@ -381,20 +393,29 @@ describe("registerSlackMessageEvents", () => {
         ts: "123.456",
       },
     },
-  ])("drops enterprise bot-authored $name events before dispatch", async ({ event }) => {
+  ])("passes enterprise bot-authored $name to policy-aware dispatch", async ({ event }) => {
     const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+    const client = {};
     await handler({
       event,
       body: { api_app_id: "A_TEST" },
       context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
-      client: {},
+      client,
     });
 
-    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    expect(handleSlackMessage).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        source: "message",
+        awaitDispatch: true,
+        eventScope: expect.objectContaining({ teamId: "T111", client }),
+      }),
+    );
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("drops bot-authored enterprise app_mention events before dispatch", async () => {
+  it("drops bot-authored enterprise app_mention events in favor of the message event", async () => {
     const { handler, handleSlackMessage } = createEnterpriseHandlers("app_mention");
     await handler({
       event: { ...makeAppMentionEvent(), bot_id: "B_OTHER" },
@@ -407,16 +428,59 @@ describe("registerSlackMessageEvents", () => {
     expect(inboundLogLines()).toEqual([]);
   });
 
-  it("drops unsupported enterprise message subtypes before system events or dispatch", async () => {
-    const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
-    await handler({
+  it.each([
+    {
+      name: "message_changed",
       event: makeChangedEvent({ channel: "C123", user: "U123" }),
+      expectedText: "Slack message edited in #direct.",
+      expectedContextKey: "slack:message:changed:C123:123.456:Ev-enterprise-subtype",
+    },
+    {
+      name: "message_deleted",
+      event: makeDeletedEvent({ channel: "C123", user: "U123" }),
+      expectedText: "Slack message deleted in #direct.",
+      expectedContextKey: "slack:message:deleted:C123:123.456:Ev-enterprise-subtype",
+    },
+  ])(
+    "routes enterprise $name through the authorized system-event path",
+    async ({ event, expectedText, expectedContextKey }) => {
+      const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+      await handler({
+        event,
+        body: { api_app_id: "A_TEST", event_id: "Ev-enterprise-subtype" },
+        context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
+        client: {},
+      });
+
+      expect(handleSlackMessage).not.toHaveBeenCalled();
+      expect(messageQueueMock).toHaveBeenCalledOnce();
+      expect(messageQueueMock).toHaveBeenCalledWith(expectedText, {
+        contextKey: expectedContextKey,
+        sessionKey: "agent:main:main",
+      });
+    },
+  );
+
+  it("passes enterprise thread_broadcast through listener-scoped dispatch", async () => {
+    const { handler, handleSlackMessage } = createEnterpriseHandlers("message");
+    const event = makeThreadBroadcastEvent({ channel: "C123", user: "U123" });
+    const client = {};
+    await handler({
+      event,
       body: { api_app_id: "A_TEST" },
       context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
-      client: {},
+      client,
     });
 
-    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    expect(handleSlackMessage).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        source: "message",
+        awaitDispatch: true,
+        eventScope: expect.objectContaining({ teamId: "T111", client }),
+      }),
+    );
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -250,14 +250,6 @@ export function registerSlackMessageEvents(params: {
       // Subtype handlers do not enter the regular message pipeline. Observe any explicit
       // type here so edits and deletes share the same authoritative conversation cache.
       ctx.rememberSlackChannelType(message.channel, message.channel_type, eventScope);
-      if (eventScope && isBotAuthoredEnterpriseEvent(message)) {
-        logVerbose("slack: drop enterprise bot-authored message");
-        return;
-      }
-      if (eventScope && message.subtype && message.subtype !== "file_share") {
-        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
-        return;
-      }
       const assistantChangedInbound = resolveAssistantMessageChangedInbound({
         event: message,
         ctx,


### PR DESCRIPTION
## What Problem This Solves

The canonical release branch needs the Enterprise Grid Slack message-policy fix that landed in #125009.

## Why This Change Was Made

This applies the final merged source change as one backport commit so Enterprise Grid messages reach the existing policy-aware dispatch and system-event paths.

## User Impact

Enterprise Grid Slack messages, including bot-authored messages and supported message subtypes, are handled by the configured policy instead of being dropped before dispatch.

## Evidence

- Applied the authoritative final merge commit from #125009 cleanly to the canonical release branch.
- Backport changes only the two Slack message-event files changed by the source PR.
- Focused formatting and Slack message-event tests will be recorded before merge.

Backport-Of: #125009
Release-Target: sjf_openclaw_2026-07-31
