### PR TITLE
[BACKPORT] test(slack): align Enterprise event context keys with release

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -433,13 +433,13 @@ describe("registerSlackMessageEvents", () => {
       name: "message_changed",
       event: makeChangedEvent({ channel: "C123", user: "U123" }),
       expectedText: "Slack message edited in #direct.",
-      expectedContextKey: "slack:message:changed:C123:123.456:Ev-enterprise-subtype",
+      expectedContextKey: "slack:message:changed:C123:123.456",
     },
     {
       name: "message_deleted",
       event: makeDeletedEvent({ channel: "C123", user: "U123" }),
       expectedText: "Slack message deleted in #direct.",
-      expectedContextKey: "slack:message:deleted:C123:123.456:Ev-enterprise-subtype",
+      expectedContextKey: "slack:message:deleted:C123:123.456",
     },
   ])(
     "routes enterprise $name through the authorized system-event path",


### PR DESCRIPTION
## What Problem This Solves

The #125009 backport carries two system-event test expectations from `main` that include an event-id suffix unavailable on the older release branch.

## Why This Change Was Made

The release branch intentionally uses its existing context-key format. This follow-up keeps the new Enterprise Grid coverage while asserting that established release contract.

## User Impact

No runtime behavior changes. The focused Slack message-event suite can validate the #125009 backport on the release branch.

## Evidence

- Changes only two expected context-key strings in the backported Slack tests.
- `./node_modules/.bin/oxfmt --check extensions/slack/src/monitor/events/messages.ts extensions/slack/src/monitor/events/messages.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` (169 tests passed)

Backport-Of: #125009
Release-Target: sjf_openclaw_2026-07-31
