### PR TITLE
fix(config): record when the post-write canonical reread degrades

### DIFF
--- a/src/config/io.factory.ts
+++ b/src/config/io.factory.ts
@@ -24,6 +24,7 @@ export function createConfigIO(options: ConfigIoFactoryOptions = {}) {
   return {
     configPath: context.configPath,
     env: context.deps.env,
+    logger: context.deps.logger,
     loadConfig: (loadOptions?: { skipSuspiciousRecovery?: boolean }) =>
       loadConfigFromContext(context, loadOptions),
     readBestEffortConfig: async () =>

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -24,6 +24,7 @@ import type {
 } from "./io.types.js";
 import { ConfigRuntimeRefreshError, configWritePostCommitRollback } from "./io.types.js";
 import { rollbackConfigFileWriteIfUnchanged } from "./io.write-safety.js";
+import { formatConfigIssueSummary } from "./issue-format.js";
 import { applyMergePatch, createMergePatch } from "./merge-patch.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
 import { assertConfigWriteAllowedInCurrentMode } from "./nix-mode-write-guard.js";
@@ -390,6 +391,16 @@ async function finalizeCommittedConfigWrite(params: {
       if (freshSnapshot.exists && freshSnapshot.valid) {
         canonicalSourceConfig = freshSnapshot.sourceConfig;
         canonicalRuntimeConfig = freshSnapshot.config;
+      } else {
+        // An invalid or vanished reread means a concurrent edit beat us to the
+        // file; runtime keeps the just-written config, but that divergence must
+        // be recorded or the on-disk config silently stops matching runtime.
+        const issueSummary = formatConfigIssueSummary(freshSnapshot.issues);
+        io.logger.warn(
+          `Config (${io.configPath}): canonical reread after write was ${
+            freshSnapshot.exists ? "invalid" : "missing"
+          }; runtime keeps the written config${issueSummary ? `: ${issueSummary}` : ""}`,
+        );
       }
       if (
         !deferRuntimeActivation ||

--- a/src/config/io.write-reread.test.ts
+++ b/src/config/io.write-reread.test.ts
@@ -1,0 +1,70 @@
+// Covers the canonical reread that follows a committed config write.
+import fsNode from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { writeConfigFile } from "./io.runtime.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshotRefreshHandler,
+} from "./runtime-snapshot.js";
+import { withTempHome } from "./test-helpers.js";
+
+describe("writeConfigFile canonical reread", () => {
+  afterEach(() => {
+    setRuntimeConfigSnapshotRefreshHandler(null);
+    clearRuntimeConfigSnapshot();
+    closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("records when the post-write reread is invalid instead of silently keeping runtime state", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 18789 } }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      // Simulate a concurrent edit racing the commit: after the write renames the
+      // new config into place, every subsequent sync read sees corrupt content,
+      // so the canonical reread parses invalid.
+      let corrupted = false;
+      const realRename = fsNode.promises.rename.bind(fsNode.promises);
+      vi.spyOn(fsNode.promises, "rename").mockImplementation(async (from, to) => {
+        await realRename(from, to);
+        if (to === configPath) {
+          corrupted = true;
+        }
+      });
+      const realReadFileSync = fsNode.readFileSync.bind(fsNode);
+      vi.spyOn(fsNode, "readFileSync").mockImplementation(((target, options) => {
+        if (corrupted && target === configPath) {
+          return "{ definitely not json";
+        }
+        return realReadFileSync(target as Parameters<typeof realReadFileSync>[0], options);
+      }) as typeof fsNode.readFileSync);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // Keep runtime-snapshot finalization from re-parsing the corrupt file;
+      // this test targets only the canonical reread's recorded degradation.
+      setRuntimeConfigSnapshotRefreshHandler({ refresh: async () => true });
+
+      await withEnvAsync(
+        { OPENCLAW_CONFIG_PATH: configPath, OPENCLAW_TEST_FAST: "1" },
+        async () => {
+          await writeConfigFile({ gateway: { mode: "local", port: 19001 } });
+        },
+      );
+
+      expect(
+        warn.mock.calls.some(([line]) =>
+          String(line).includes("canonical reread after write was invalid"),
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

After a committed config write, `finalizeCommittedConfigWrite` rereads the file to pick up the canonical on-disk state. When that reread comes back invalid or missing (a concurrent edit racing the commit), the code silently keeps the just-written in-memory config — runtime and disk diverge with no recorded reason. This is the repo's worst bug class: an action path ending with no visible outcome and no recorded non-outcome.

## Why This Change Was Made

Record facts where they happen: the reread owner now warns through the config IO logger, including the invalid snapshot's issue summary, before continuing with the written config. The fallback behavior itself is correct (the write did succeed) — only the silence was the bug. `createConfigIO` now exposes `logger` on its facade (the context already carries it), parallel to `configPath`/`env`.

## User Impact

Operators debugging "my config file says X but the gateway does Y" after a config race now find the divergence recorded in logs instead of facing an undiscoverable state.

## Evidence

- New regression `src/config/io.write-reread.test.ts` simulates a post-commit corruption via fs spies: **fails pre-fix** (no warn recorded, 1 failed), passes post-fix.
- Neighboring suite unaffected: `io.write-reread.test.ts` + `io.write-config.test.ts` → 81 passed (81).
- `tsgo` core rc=0, core test shards rc=0, oxlint/oxfmt clean.
- Codex autoreview clean (0.99).
- Production delta: +12 lines (diagnostic recording; justified — silent-failure doctrine requires the recorded fact, no absorbing refactor exists that removes lines because there is no guard to delete, only silence).
