### PR TITLE
feat(workboard): link boards to owning automations

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -111,6 +111,11 @@ sidebar. The previously shipped `/workboard?board=<boardId>` form remains a
 compatibility alias and redirects to that page while preserving other query
 parameters. Choosing **All boards** returns to `/workboard`.
 
+A board can store an `automationJobId` reference to the automation job that
+owns its AI-categorization prompt, model, schedule, and run history. The board
+page shows an **Automation** link when that reference is present. Deleting the
+board does not delete or otherwise mutate the operator-owned automation job.
+
 Cards are stored in the plugin's own Gateway state and move with the rest of
 that Gateway's OpenClaw state (see [Storage](#storage)).
 

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -43,7 +43,8 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
+    const store = new WorkboardStore(createMemoryStore());
+    registerWorkboardGatewayMethods({ api, store });
 
     expect([...methods.keys()]).toEqual([
       "workboard.cards.list",
@@ -117,6 +118,22 @@ describe("workboard gateway methods", () => {
       scope: "operator.write",
     });
 
+    const boardRespond = vi.fn();
+    await methods.get("workboard.boards.upsert")?.handler({
+      params: { id: "planning", automationJobId: "job-categorize-planning" },
+      respond: boardRespond,
+    } as never);
+    expect(boardRespond.mock.calls[0]?.[0]).toBe(true);
+    await expect(store.listBoards()).resolves.toMatchObject({
+      boards: [
+        expect.objectContaining({ id: "default" }),
+        expect.objectContaining({
+          id: "planning",
+          automationJobId: "job-categorize-planning",
+        }),
+      ],
+    });
+
     const createHandler = methods.get("workboard.cards.create")?.handler;
     const listHandler = methods.get("workboard.cards.list")?.handler;
     const createRespond = vi.fn();
@@ -133,7 +150,9 @@ describe("workboard gateway methods", () => {
     await listHandler?.({ params: {}, respond: listRespond } as never);
     expect(listRespond.mock.calls[0]?.[1]).toMatchObject({
       cards: [expect.objectContaining({ title: "Investigate queue drift" })],
-      boards: [expect.objectContaining({ id: "default", total: 1, active: 1 })],
+      boards: expect.arrayContaining([
+        expect.objectContaining({ id: "default", total: 1, active: 1 }),
+      ]),
     });
 
     const eventsRespond = vi.fn();

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -149,6 +149,7 @@ const WORKBOARD_SCHEMA_SQL = `
       description TEXT,
       icon TEXT,
       color TEXT,
+      automation_job_id TEXT,
       default_workspace_json TEXT,
       orchestration_json TEXT,
       created_at INTEGER NOT NULL,
@@ -354,6 +355,7 @@ const WORKBOARD_SCHEMA_SQL = `
 
 function ensureWorkboardSchema(db: DatabaseSync): void {
   db.exec(WORKBOARD_SCHEMA_SQL);
+  ensureColumn(db, "workboard_boards", "automation_job_id", "automation_job_id TEXT");
   ensureColumn(
     db,
     "workboard_cards",
@@ -1281,14 +1283,15 @@ class WorkboardSqliteBoardStore implements WorkboardKeyedStore<PersistedWorkboar
       .prepare(
         `
           INSERT INTO workboard_boards (
-            id, name, description, icon, color, default_workspace_json, orchestration_json,
-            created_at, updated_at, archived_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            id, name, description, icon, color, automation_job_id, default_workspace_json,
+            orchestration_json, created_at, updated_at, archived_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             name = excluded.name,
             description = excluded.description,
             icon = excluded.icon,
             color = excluded.color,
+            automation_job_id = excluded.automation_job_id,
             default_workspace_json = excluded.default_workspace_json,
             orchestration_json = excluded.orchestration_json,
             created_at = excluded.created_at,
@@ -1302,6 +1305,7 @@ class WorkboardSqliteBoardStore implements WorkboardKeyedStore<PersistedWorkboar
         bindNull(board.description),
         bindNull(board.icon),
         bindNull(board.color),
+        bindNull(board.automationJobId),
         jsonValue(board.defaultWorkspace),
         jsonValue(board.orchestration),
         board.createdAt,
@@ -1333,6 +1337,9 @@ class WorkboardSqliteBoardStore implements WorkboardKeyedStore<PersistedWorkboar
           : {}),
         ...(stringValue(row, "icon") ? { icon: stringValue(row, "icon") } : {}),
         ...(stringValue(row, "color") ? { color: stringValue(row, "color") } : {}),
+        ...(stringValue(row, "automation_job_id")
+          ? { automationJobId: stringValue(row, "automation_job_id") }
+          : {}),
         ...(defaultWorkspace ? { defaultWorkspace } : {}),
         ...(orchestration ? { orchestration } : {}),
         createdAt: requiredNumber(row, "created_at"),

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -186,6 +186,7 @@ export class WorkboardCoreStore {
         ...(board.description ? { description: board.description } : {}),
         ...(board.icon ? { icon: board.icon } : {}),
         ...(board.color ? { color: board.color } : {}),
+        ...(board.automationJobId ? { automationJobId: board.automationJobId } : {}),
         ...(board.defaultWorkspace ? { defaultWorkspace: board.defaultWorkspace } : {}),
         ...(board.orchestration ? { orchestration: board.orchestration } : {}),
         total: 0,

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -158,6 +158,7 @@ export type WorkboardBoardInput = {
   description?: unknown;
   icon?: unknown;
   color?: unknown;
+  automationJobId?: unknown;
   defaultWorkspace?: unknown;
   orchestration?: unknown;
   archived?: unknown;

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -101,6 +101,16 @@ export function normalizeBoardMetadata(
   );
   const icon = normalizeBoundedString(input.icon, fallback?.icon, 40, "board icon");
   const color = normalizeBoundedString(input.color, fallback?.color, 40, "board color");
+  let automationJobId = fallback?.automationJobId;
+  if (Object.hasOwn(input, "automationJobId")) {
+    automationJobId = normalizeOptionalString(input.automationJobId);
+    if (!automationJobId) {
+      throw new Error("automation job id must be a non-empty string.");
+    }
+    if (automationJobId.length > 128) {
+      throw new Error("automation job id must be 128 characters or fewer.");
+    }
+  }
   const defaultWorkspace = Object.hasOwn(input, "defaultWorkspace")
     ? normalizeWorkspace(input.defaultWorkspace, fallback?.defaultWorkspace)
     : fallback?.defaultWorkspace;
@@ -118,6 +128,7 @@ export function normalizeBoardMetadata(
     ...(description ? { description } : {}),
     ...(icon ? { icon } : {}),
     ...(color ? { color } : {}),
+    ...(automationJobId ? { automationJobId } : {}),
     ...(defaultWorkspace ? { defaultWorkspace } : {}),
     ...(orchestration ? { orchestration } : {}),
     createdAt: fallback?.createdAt ?? now,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -147,7 +147,11 @@ describe("WorkboardStore", () => {
         subscriptions: stores.subscriptions,
         attachments: stores.attachments,
       });
-      const board = await store.upsertBoard({ id: "planning", name: "Planning" });
+      const board = await store.upsertBoard({
+        id: "planning",
+        name: "Planning",
+        automationJobId: "job-categorize-planning",
+      });
       const card = await store.create({
         title: "Persist it",
         boardId: board.id,
@@ -239,7 +243,11 @@ describe("WorkboardStore", () => {
       expect(await reopened.listBoards()).toMatchObject({
         boards: [
           expect.objectContaining({ id: "default" }),
-          expect.objectContaining({ id: board.id, name: "Planning" }),
+          expect.objectContaining({
+            id: board.id,
+            name: "Planning",
+            automationJobId: "job-categorize-planning",
+          }),
         ],
       });
       expect(await reopened.get(card.id)).toMatchObject({
@@ -363,7 +371,13 @@ describe("WorkboardStore", () => {
           updated_at INTEGER NOT NULL,
           archived_at INTEGER
         );
-        INSERT INTO workboard_boards SELECT * FROM workboard_boards_strict;
+        INSERT INTO workboard_boards (
+          id, name, description, icon, color, default_workspace_json, orchestration_json,
+          created_at, updated_at, archived_at
+        ) SELECT
+          id, name, description, icon, color, default_workspace_json, orchestration_json,
+          created_at, updated_at, archived_at
+        FROM workboard_boards_strict;
         DROP TABLE workboard_boards_strict;
         DELETE FROM workboard_schema_migrations WHERE id = 'schema-3';
         INSERT OR IGNORE INTO workboard_schema_migrations (id, applied_at)
@@ -421,6 +435,15 @@ describe("WorkboardStore", () => {
       statfs.mockRestore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it.each([
+    ["", "non-empty string"],
+    ["x".repeat(129), "128 characters or fewer"],
+  ])("rejects invalid automation job ids", async (automationJobId, message) => {
+    const store = new WorkboardStore(createMemoryStore());
+
+    await expect(store.upsertBoard({ id: "planning", automationJobId })).rejects.toThrow(message);
   });
 
   it("creates and lists cards by status order and position", async () => {

--- a/extensions/workboard/src/tools-orchestration.ts
+++ b/extensions/workboard/src/tools-orchestration.ts
@@ -80,6 +80,13 @@ export function createWorkboardOrchestrationTools(params: {
           description: Type.Optional(Type.String({ description: "Board description." })),
           icon: Type.Optional(Type.String({ description: "Short icon or label." })),
           color: Type.Optional(Type.String({ description: "Display color token." })),
+          automationJobId: Type.Optional(
+            Type.String({
+              description: "Owning automation job id.",
+              minLength: 1,
+              maxLength: 128,
+            }),
+          ),
           defaultWorkspace: Type.Optional(
             Type.Object(
               {

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -1,5 +1,6 @@
 // Workboard tests cover tools plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
@@ -499,9 +500,13 @@ describe("workboard tools", () => {
     );
 
     const boardPayload = readPayload(
-      await tools.get("workboard_board_create")?.execute("call-board", {
+      await expectDefined(
+        tools.get("workboard_board_create"),
+        "workboard board create tool",
+      ).execute("call-board", {
         id: "planning",
         name: "Planning",
+        automationJobId: "job-categorize-planning",
         orchestration: {
           autoDecompose: true,
           autoDecomposePerDispatch: 2,
@@ -512,12 +517,26 @@ describe("workboard tools", () => {
     expect(boardPayload.board).toMatchObject({
       id: "planning",
       name: "Planning",
+      automationJobId: "job-categorize-planning",
       orchestration: {
         autoDecompose: true,
         autoDecomposePerDispatch: 2,
         orchestratorProfile: "planner",
       },
     });
+    const boardCreate = expectDefined(
+      tools.get("workboard_board_create"),
+      "workboard board create tool",
+    );
+    expect(
+      Value.Check(boardCreate.parameters, {
+        id: "planning",
+        automationJobId: "job-categorize-planning",
+      }),
+    ).toBe(true);
+    expect(Value.Check(boardCreate.parameters, { id: "planning", automationJobId: "" })).toBe(
+      false,
+    );
 
     const parent = await store.create({
       title: "Rough",

--- a/packages/workboard-contract/src/index.test.ts
+++ b/packages/workboard-contract/src/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { WorkboardBoardMetadata, WorkboardBoardSummary } from "./index.js";
+
+describe("workboard board automation contract", () => {
+  it("carries the owning automation job reference in metadata and summaries", () => {
+    const metadata: WorkboardBoardMetadata = {
+      id: "planning",
+      automationJobId: "job-categorize-planning",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const summary: WorkboardBoardSummary = {
+      id: metadata.id,
+      automationJobId: metadata.automationJobId,
+      total: 0,
+      active: 0,
+      archived: 0,
+      byStatus: {},
+    };
+
+    expect(summary.automationJobId).toBe("job-categorize-planning");
+    expectTypeOf(summary.automationJobId).toEqualTypeOf<string | undefined>();
+  });
+});

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -273,6 +273,7 @@ export type WorkboardBoardMetadata = {
   description?: string;
   icon?: string;
   color?: string;
+  automationJobId?: string;
   defaultWorkspace?: WorkboardWorkspace;
   orchestration?: WorkboardOrchestrationSettings;
   createdAt: number;
@@ -286,6 +287,7 @@ export type WorkboardBoardSummary = {
   description?: string;
   icon?: string;
   color?: string;
+  automationJobId?: string;
   defaultWorkspace?: WorkboardWorkspace;
   orchestration?: WorkboardOrchestrationSettings;
   total: number;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3661,6 +3661,8 @@ export const en: TranslationMap = {
     allBoards: "All boards",
     boardFilter: "Filter by board",
     defaultBoard: "Default board",
+    automationAttached: "Automation",
+    automationAttachedTitle: "Open the attached automation",
     boardFilterSummary: "{active} active · {total} total",
     boardFilterArchivedSummary: "Archived · {active} active · {total} total",
     agentFilterUnassigned: "Unassigned (uses {agent})",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3662,7 +3662,7 @@ export const en: TranslationMap = {
     boardFilter: "Filter by board",
     defaultBoard: "Default board",
     automationAttached: "Automation",
-    automationAttachedTitle: "Open the attached automation",
+    automationAttachedTitle: "Open Automations",
     boardFilterSummary: "{active} active · {total} total",
     boardFilterArchivedSummary: "Archived · {active} active · {total} total",
     agentFilterUnassigned: "Unassigned (uses {agent})",

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -347,6 +347,7 @@ describe("workboard controller", () => {
             {
               id: "default",
               name: "Inbox",
+              automationJobId: "job-categorize-inbox",
               total: 1,
               active: 1,
               archived: 0,
@@ -378,6 +379,7 @@ describe("workboard controller", () => {
         {
           id: "default",
           name: "Inbox",
+          automationJobId: "job-categorize-inbox",
           total: 1,
           active: 1,
           archived: 0,

--- a/ui/src/lib/workboard/normalization.ts
+++ b/ui/src/lib/workboard/normalization.ts
@@ -36,6 +36,8 @@ function normalizeBoardSummary(value: unknown): WorkboardBoardSummary | null {
       }
     }
   }
+  const automationJobId =
+    typeof value.automationJobId === "string" ? value.automationJobId.trim() : "";
   return {
     id,
     total: normalizeCount(value.total),
@@ -48,6 +50,7 @@ function normalizeBoardSummary(value: unknown): WorkboardBoardSummary | null {
       : {}),
     ...(typeof value.icon === "string" && value.icon.trim() ? { icon: value.icon.trim() } : {}),
     ...(typeof value.color === "string" && value.color.trim() ? { color: value.color.trim() } : {}),
+    ...(automationJobId && automationJobId.length <= 128 ? { automationJobId } : {}),
     ...(typeof value.updatedAt === "number" ? { updatedAt: value.updatedAt } : {}),
     ...(typeof value.archivedAt === "number" ? { archivedAt: value.archivedAt } : {}),
   };

--- a/ui/src/pages/workboard/workboard-page.test.ts
+++ b/ui/src/pages/workboard/workboard-page.test.ts
@@ -372,6 +372,8 @@ describe("WorkboardPage lifecycle", () => {
     expect(Boolean(chip)).toBe(visible);
     if (visible) {
       expect(chip?.getAttribute("href")).toBe("/automations");
+      expect(chip?.getAttribute("title")).toBe("Open Automations");
+      expect(chip?.getAttribute("aria-label")).toBe("Open Automations");
       expect(chip?.textContent?.trim()).toBe("Automation");
     }
   });

--- a/ui/src/pages/workboard/workboard-page.test.ts
+++ b/ui/src/pages/workboard/workboard-page.test.ts
@@ -346,4 +346,33 @@ describe("WorkboardPage lifecycle", () => {
     expect(workboard.state.draftTitle).toBe("New operations task");
     expect(workboard.state.editingCardId).toBeNull();
   });
+
+  it.each([
+    ["job-categorize-planning", true],
+    [undefined, false],
+  ])("renders the automation chip only for linked boards", async (automationJobId, visible) => {
+    const workboard = createWorkboardCapability();
+    workboard.state.boards = [
+      {
+        id: "planning",
+        total: 0,
+        active: 0,
+        archived: 0,
+        byStatus: {},
+        ...(automationJobId ? { automationJobId } : {}),
+      },
+    ];
+    const page = document.createElement("openclaw-workboard-page") as WorkboardPageTestElement;
+    page.context = contextWithWorkboard(workboard);
+    page.routeData = { boardFilter: "planning", search: "" };
+    document.body.append(page);
+    await page.updateComplete;
+
+    const chip = page.querySelector<HTMLAnchorElement>(".workboard-automation-chip");
+    expect(Boolean(chip)).toBe(visible);
+    if (visible) {
+      expect(chip?.getAttribute("href")).toBe("/automations");
+      expect(chip?.textContent?.trim()).toBe("Automation");
+    }
+  });
 });

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -6,7 +6,9 @@ import { pathForRoute, pathForWorkboardBoard } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
+import { icons } from "../../components/icons.ts";
 import { renderWorkboardBoardGlyph } from "../../components/workboard-board-glyph.ts";
+import { t } from "../../i18n/index.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../../lib/plugin-activation.ts";
 import {
   resolveSessionPreferredFaceForKey,
@@ -366,6 +368,16 @@ class WorkboardPage extends OpenClawLightDomElement {
                 ? workboardBoardName(selectedBoard)
                 : titleForRoute("workboard")}</span
             >
+            ${selectedBoard?.automationJobId
+              ? html`<a
+                  class="chip workboard-automation-chip"
+                  href=${pathForRoute("cron", context.basePath)}
+                  title=${t("workboard.automationAttachedTitle")}
+                  aria-label=${t("workboard.automationAttachedTitle")}
+                >
+                  ${icons.calendarClock}<span>${t("workboard.automationAttached")}</span>
+                </a>`
+              : nothing}
           </div>
           ${selectedBoard
             ? html`<div class="page-subtitle">${titleForRoute("workboard")}</div>`

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -19,6 +19,19 @@
   gap: 9px;
 }
 
+.workboard-automation-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  text-decoration: none;
+}
+
+.workboard-automation-chip svg {
+  width: 14px;
+  height: 14px;
+}
+
 .workboard-board-glyph--header {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
Related: #125023

## What Problem This Solves

The AI-categorization design makes a cron automation job own a board's prompt, model, schedule, and run history. Boards had no way to reference that job, so operators could not see or reach the automation from the board.

## Why This Change Was Made

Add `automationJobId` to persisted board metadata and board summaries, accepting only a non-empty validated string of at most 128 characters. Cron jobs remain operator-owned: dangling references render as-is, and deleting a board never deletes or mutates the referenced job. When a board has a reference, its toolbar shows an **Automation** chip that opens the Automations page.

## User Impact

Operators can see that a Workboard is automation-backed and reach the cron surface that owns its categorization prompt, model, schedule, and run history directly from the board. The ownership and deletion boundaries are documented in `docs/plugins/workboard.md`.

## Evidence

Focused tests after replaying the single branch commit onto current `main`:

```text
Test Files  1 passed (1)
Tests       1 passed (1)

Test Files  639 passed | 10 skipped (649)
Tests       9168 passed | 50 skipped (9218)

Test Files  1 passed (1)
Tests       97 passed (97)

Test Files  14 passed (14)
Tests       269 passed (269)

[test] passed 4 Vitest shards in 177.50s
```

Command: `pnpm test extensions/workboard packages/workboard-contract ui/src/pages/workboard ui/src/lib/workboard`

Live classifier proof from an isolated dev Gateway:

> An automation job on `openai/gpt-5.6-luna` moved a triage card to `todo` in 13.9 seconds. The run finished `ok`, and the UI showed the renamed card in `todo`.

The full live report recorded job `a2cf2fd6-8d2d-48d6-a911-b9030ede6b99`, Gateway events `specified` and `triage -> todo`, and a 13,883 ms successful run. #125023 is the landed gateway-lifecycle prerequisite for this series.

![Workboard toolbar with Automation chip](https://github.com/user-attachments/assets/86fa16f0-b419-4b76-be39-da25b150bfe5)

AI-assisted: yes. The branch was independently reviewed with the repository autoreview workflow; no accepted or actionable findings remained.
