### PR TITLE
fix(slack): batch Enterprise Grid messages

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -1006,7 +1006,7 @@ describe("createSlackMessageHandler", () => {
         channel: "C111",
         user: "U111",
         ts: "1709000000.000800",
-        text: "relay message",
+        text: "enterprise message",
       } as never,
       {
         source: "message",

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -17,6 +17,8 @@ const onFlushCallbacks: Array<
     createFlush: typeof createTestInboundDebounceFlush,
   ) => InboundDebounceFlush
 > = [];
+const buildKeyCallbacks: Array<(entry: Record<string, unknown>) => string | null | undefined> = [];
+const shouldDebounceCallbacks: Array<(entry: Record<string, unknown>) => boolean> = [];
 const prepareSlackMessageMock = vi.fn(
   async (_params?: {
     ctx: Parameters<typeof createSlackMessageHandler>[0]["ctx"];
@@ -36,11 +38,15 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   return {
     ...actual,
     createChannelInboundDebouncer: (params: {
+      buildKey: (entry: Record<string, unknown>) => string | null | undefined;
+      shouldDebounce: (entry: Record<string, unknown>) => boolean;
       onFlush: (
         entries: Array<Record<string, unknown>>,
         createFlush: typeof createTestInboundDebounceFlush,
       ) => InboundDebounceFlush;
     }) => {
+      buildKeyCallbacks.push(params.buildKey);
+      shouldDebounceCallbacks.push(params.shouldDebounce);
       onFlushCallbacks.push(params.onFlush);
       return {
         debounceMs: 10,
@@ -131,6 +137,8 @@ describe("createSlackMessageHandler", () => {
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
     onFlushCallbacks.length = 0;
+    buildKeyCallbacks.length = 0;
+    shouldDebounceCallbacks.length = 0;
     prepareSlackMessageMock.mockClear();
     dispatchPreparedSlackMessageMock.mockClear();
     resolveThreadTsMock.mockClear();
@@ -563,6 +571,90 @@ describe("createSlackMessageHandler", () => {
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 
+  it("batches enterprise messages and settles every durable ingress claim", async () => {
+    const firstLifecycle = {
+      admission: "exclusive" as const,
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => undefined),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => undefined),
+    };
+    const secondLifecycle = {
+      admission: "exclusive" as const,
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => undefined),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => undefined),
+    };
+    const eventScope = { teamId: "T111", client: {} as never };
+    const { handler } = createHandlerWithTracker();
+    const firstHandled = handler(
+      {
+        type: "message",
+        channel: "D111",
+        user: "U111",
+        ts: "1709000000.000410",
+        text: "first enterprise message",
+      } as never,
+      {
+        source: "message",
+        eventScope,
+        awaitDispatch: true,
+        turnAdoptionLifecycle: firstLifecycle,
+      },
+    );
+    await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(1));
+    expect(firstLifecycle.onDeferred).toHaveBeenCalledOnce();
+    const firstEntry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(shouldDebounceCallbacks[0]?.(firstEntry)).toBe(true);
+    const secondWorkspaceEntry = {
+      ...firstEntry,
+      opts: {
+        ...(firstEntry.opts as Record<string, unknown>),
+        eventScope: { teamId: "T222", client: {} as never },
+      },
+    };
+    expect(buildKeyCallbacks[0]?.(firstEntry)).not.toBe(
+      buildKeyCallbacks[0]?.(secondWorkspaceEntry),
+    );
+
+    const secondHandled = handler(
+      {
+        type: "message",
+        channel: "D111",
+        user: "U111",
+        ts: "1709000000.000420",
+        text: "second enterprise message",
+      } as never,
+      {
+        source: "message",
+        eventScope,
+        awaitDispatch: true,
+        turnAdoptionLifecycle: secondLifecycle,
+      },
+    );
+    await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(2));
+    expect(secondLifecycle.onDeferred).toHaveBeenCalledOnce();
+
+    const entries = enqueueMock.mock.calls.map((call) => call[0]) as Array<Record<string, unknown>>;
+    await runOnFlush(entries);
+    await expect(Promise.all([firstHandled, secondHandled])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          text: "first enterprise message\nsecond enterprise message",
+        }),
+        opts: expect.objectContaining({ eventScope }),
+      }),
+    );
+    expect(firstLifecycle.onAdopted).toHaveBeenCalledOnce();
+    expect(secondLifecycle.onAdopted).toHaveBeenCalledOnce();
+  });
+
   it("waits for debounced dispatch completion when requested by relay delivery", async () => {
     const { handler } = createHandlerWithTracker();
     const handled = handler(
@@ -628,9 +720,7 @@ describe("createSlackMessageHandler", () => {
     };
     expect(prepared.turnAdoptionLifecycle?.admission).toBe("exclusive");
     expect(prepared.turnAdoptionLifecycle?.abortSignal).toBe(turnAdoptionLifecycle.abortSignal);
-    await prepared.turnAdoptionLifecycle?.onAdopted();
     expect(turnAdoptionLifecycle.onAdopted).toHaveBeenCalledTimes(1);
-    prepared.turnAdoptionLifecycle?.onDeferred();
     expect(turnAdoptionLifecycle.onDeferred).toHaveBeenCalledTimes(1);
   });
 
@@ -894,7 +984,7 @@ describe("createSlackMessageHandler", () => {
     }
   });
 
-  it("leaves relay session conflict retries to unacknowledged redelivery", async () => {
+  it("leaves enterprise session conflict retries to durable ingress redelivery", async () => {
     dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
       new Error("Slack dispatch failed", {
         cause: new Error(
@@ -903,6 +993,13 @@ describe("createSlackMessageHandler", () => {
       }),
     );
     const { handler } = createHandlerWithTracker();
+    const turnAdoptionLifecycle = {
+      admission: "exclusive" as const,
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => undefined),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => undefined),
+    };
     const handled = handler(
       {
         type: "message",
@@ -911,7 +1008,12 @@ describe("createSlackMessageHandler", () => {
         ts: "1709000000.000800",
         text: "relay message",
       } as never,
-      { source: "message", awaitDispatch: true },
+      {
+        source: "message",
+        eventScope: { teamId: "T111", client: {} as never },
+        awaitDispatch: true,
+        turnAdoptionLifecycle,
+      },
     );
 
     await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(1));

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -529,9 +529,6 @@ function combineSlackIngressTurnLifecycles(
     onFailed: async (error) => {
       await Promise.all(lifecycles.map((lifecycle) => lifecycle.onFailed?.(error)));
     },
-    onCancelled: async () => {
-      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onCancelled?.()));
-    },
     onAbandoned: async () => {
       await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
     },

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -63,6 +63,8 @@ type IngressSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
 
 type QueuedSlackMessageOptions = IngressSlackMessageOptions & {
   dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
+  /** Durable ingress released its lane while this entry waits in the debounce buffer. */
+  deferredForDebounce?: boolean;
 };
 
 function createSlackDispatchCompletion(): SlackDispatchCompletion {
@@ -154,22 +156,30 @@ export function createSlackMessageHandler(params: {
     channel: "slack",
     buildKey: (entry) =>
       buildSlackDebounceKey(entry.message, ctx.accountId, entry.opts.eventScope?.teamId),
-    shouldDebounce: (entry) =>
-      !entry.opts.eventScope && shouldDebounceSlackMessage(entry.message, ctx.cfg),
+    shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: (entries, createFlush) =>
       createFlush({
         dispatch: async (admissionLifecycle) => {
+          const turnAdoptionLifecycle = combineSlackIngressTurnLifecycles(
+            entries.map((entry) => entry.opts.turnAdoptionLifecycle),
+          );
+          const deferredForDebounce = entries.some((entry) => entry.opts.deferredForDebounce);
+          const settleDeferredIngress = async () => {
+            if (deferredForDebounce) {
+              await turnAdoptionLifecycle?.onAdopted();
+            }
+          };
           const retryEntries = (sourceError: unknown): boolean => {
             if (
               !isRetryableSlackInboundError(sourceError) ||
-              entries.some((entry) => entry.opts.eventScope)
+              entries.some((entry) => entry.opts.turnAdoptionLifecycle)
             ) {
               return false;
             }
             const nextEntries = entries
               .map((entry) => {
-                // Relay delivery owns retry until its dispatch completion is acknowledged.
-                // Scheduling here as well can race the router redelivery and duplicate a reply.
+                // Awaited delivery owns retry outside this in-memory queue. Scheduling here as
+                // well can race durable ingress redelivery and duplicate a reply.
                 if (entry.opts.dispatchCompletion) {
                   return null;
                 }
@@ -269,6 +279,7 @@ export function createSlackMessageHandler(params: {
               const last = latestSurviving;
               if (!last) {
                 releaseClaims();
+                await settleDeferredIngress();
                 return;
               }
               const teamId = last.opts.eventScope?.teamId;
@@ -304,7 +315,8 @@ export function createSlackMessageHandler(params: {
               const {
                 dispatchCompletion: _completion,
                 awaitDispatch: _awaitDispatch,
-                turnAdoptionLifecycle,
+                turnAdoptionLifecycle: _lastTurnAdoptionLifecycle,
+                deferredForDebounce: _deferredForDebounce,
                 ...lastOpts
               } = last.opts;
               let prepared: Awaited<ReturnType<typeof prepareSlackMessage>>;
@@ -329,11 +341,13 @@ export function createSlackMessageHandler(params: {
                     // The gate already produced a sender-visible notice. Commit the
                     // logical claim so a later message/app_mention twin cannot repeat it.
                     await commitClaims();
+                    await settleDeferredIngress();
                     return;
                   }
                   // Gated before dispatch: release so the surviving twin can run the
                   // same gate; nothing visible was produced, so no duplicate risk.
                   releaseClaims();
+                  await settleDeferredIngress();
                   return;
                 }
                 // Commit at adoption (durable turn ownership), release on abandonment;
@@ -383,6 +397,7 @@ export function createSlackMessageHandler(params: {
                   // Dispatch finished without adoption or deferral (skip/no-reply):
                   // deliberate terminal handling, release for gate-idempotent twins.
                   releaseClaims();
+                  await settleDeferredIngress();
                 }
               } catch (error) {
                 releaseClaims(error);
@@ -444,8 +459,7 @@ export function createSlackMessageHandler(params: {
       ctx.accountId,
       teamId,
     );
-    const canDebounce =
-      !opts.eventScope && debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
+    const canDebounce = debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
     if (!canDebounce && conversationKey) {
       const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
       if (pendingKeys && pendingKeys.size > 0) {
@@ -461,10 +475,17 @@ export function createSlackMessageHandler(params: {
       pendingTopLevelDebounceKeys.set(conversationKey, pendingKeys);
     }
     const dispatchCompletion = opts.awaitDispatch ? createSlackDispatchCompletion() : undefined;
+    const deferredForDebounce = canDebounce && Boolean(opts.turnAdoptionLifecycle);
+    if (deferredForDebounce) {
+      // Durable ingress keeps the claim but releases its conversation lane so another event can
+      // join this batch. The combined flush lifecycle settles every retained claim together.
+      opts.turnAdoptionLifecycle?.onDeferred();
+    }
     await debouncer.enqueue({
       message: resolvedMessage,
       opts: {
         ...opts,
+        ...(deferredForDebounce ? { deferredForDebounce: true } : {}),
         ...(dispatchCompletion
           ? {
               dispatchCompletion: {
@@ -481,5 +502,38 @@ export function createSlackMessageHandler(params: {
   return async (message, opts) => {
     const dispatchCompletion = await enqueueSlackMessage(message, opts);
     await dispatchCompletion?.promise;
+  };
+}
+
+function combineSlackIngressTurnLifecycles(
+  candidates: Array<SlackIngressTurnLifecycle | undefined>,
+): SlackIngressTurnLifecycle | undefined {
+  const lifecycles = Array.from(new Set(candidates.filter((candidate) => candidate !== undefined)));
+  if (lifecycles.length === 0) {
+    return undefined;
+  }
+  if (lifecycles.length === 1) {
+    return lifecycles[0];
+  }
+  return {
+    admission: "exclusive",
+    abortSignal: AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+    onAdopted: async () => {
+      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAdopted()));
+    },
+    onDeferred: () => {
+      for (const lifecycle of lifecycles) {
+        lifecycle.onDeferred();
+      }
+    },
+    onFailed: async (error) => {
+      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onFailed?.(error)));
+    },
+    onCancelled: async () => {
+      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onCancelled?.()));
+    },
+    onAbandoned: async () => {
+      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
+    },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Enterprise Grid users sending rapid consecutive Slack messages would have every message dispatched separately even when inbound debounce was configured.

## Why This Change Was Made

Enterprise events now use the existing team-qualified debounce key and temporarily release each durable ingress lane while the message waits in the in-memory batch. A combined lifecycle settles every durable claim together, while durable ingress remains the sole retry owner so failures cannot race a second in-memory retry.

Commands, media messages, relay delivery, and unqualified workspace routing are unchanged.

## User Impact

Rapid text messages from the same sender in the same Enterprise Grid DM or thread can be combined into one agent turn. Messages from different workspaces remain isolated by `teamId`.

## Evidence

- Before the production change, the new regression failed because the first Enterprise durable ingress lifecycle was never deferred into the batch.
- `pnpm test extensions/slack/src/monitor/message-handler.test.ts --run` — 25 tests passed.
- The regression verifies combined text, distinct workspace keys, preservation of the scoped client, and settlement of every durable ingress claim.
- Existing retry coverage verifies that Enterprise failures remain owned by durable ingress redelivery rather than a competing in-memory retry.

AI-assisted; I reviewed and understand the lifecycle and retry behavior in this change.
