### PR TITLE
fix(agents): report recovered tool retries

### DIFF
--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -279,6 +279,142 @@ function toolCallEvents(name, args) {
   ];
 }
 
+function editRecoveryFixtureError(reason) {
+  return responseEvents(`OPENCLAW_E2E_EDIT_FAILURE_FIXTURE_ERROR reason=${reason}`);
+}
+
+function collectEditRecoveryOutputs(body) {
+  const input = Array.isArray(body?.input) ? body.input : [];
+  const outputs = new Map();
+  for (const item of input) {
+    if (item?.type !== "function_call_output") {
+      continue;
+    }
+    if (typeof item.call_id !== "string" || typeof item.output !== "string") {
+      return null;
+    }
+    const existing = outputs.get(item.call_id);
+    if (existing !== undefined && existing !== item.output) {
+      return null;
+    }
+    outputs.set(item.call_id, item.output);
+  }
+  return outputs;
+}
+
+function isEditFailureOutput(output, path) {
+  try {
+    const parsed = JSON.parse(output);
+    return (
+      parsed?.status === "error" &&
+      parsed?.tool === "edit" &&
+      typeof parsed.error === "string" &&
+      parsed.error.startsWith(`Could not find the exact text in ${path}.`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function editRecoveryToolStep(name, args, accept, errorReason) {
+  return { kind: "tool", name, args, call: buildMockFunctionCall(name, args), accept, errorReason };
+}
+
+const editRecoveryPath = "issue-46548-edit-recovery.txt";
+const editRecoverySeedStep = editRecoveryToolStep(
+  "write",
+  { path: editRecoveryPath, content: "before\n" },
+  (output) => output === `Successfully wrote 7 bytes to ${editRecoveryPath}`,
+  "seed-result-mismatch",
+);
+const editRecoveryFailureStep = editRecoveryToolStep(
+  "edit",
+  { path: editRecoveryPath, edits: [{ oldText: "absent\n", newText: "after\n" }] },
+  (output) => isEditFailureOutput(output, editRecoveryPath),
+  "edit-result-mismatch",
+);
+const editRecoveryRetryStep = editRecoveryToolStep(
+  "edit",
+  { path: editRecoveryPath, edits: [{ oldText: "before\n", newText: "after\n" }] },
+  (output) => output === `Successfully replaced 1 block(s) in ${editRecoveryPath}.`,
+  "retry-result-mismatch",
+);
+
+const editRecoveryScenarios = Object.freeze([
+  {
+    trigger: "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED",
+    steps: [
+      editRecoverySeedStep,
+      editRecoveryFailureStep,
+      { kind: "final", text: "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED_FINAL" },
+    ],
+  },
+  {
+    trigger: "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY",
+    steps: [
+      editRecoverySeedStep,
+      editRecoveryFailureStep,
+      editRecoveryRetryStep,
+      { kind: "final", text: "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY_FINAL" },
+    ],
+  },
+]);
+
+function resolveEditRecoveryScenario(bodyText) {
+  const matches = editRecoveryScenarios.filter((scenario) => bodyText.includes(scenario.trigger));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function resolveEditRecoveryPrefix(scenario, outputs) {
+  const toolSteps = scenario.steps.filter((step) => step.kind === "tool");
+  const expectedCallIds = new Set(toolSteps.map((step) => step.call.item.call_id));
+  if ([...outputs.keys()].some((callId) => !expectedCallIds.has(callId))) {
+    return { kind: "error", reason: "impossible-prefix" };
+  }
+
+  let completed = 0;
+  for (const step of toolSteps) {
+    const output = outputs.get(step.call.item.call_id);
+    if (output === undefined) {
+      break;
+    }
+    if (!step.accept(output)) {
+      return { kind: "error", reason: step.errorReason };
+    }
+    completed += 1;
+  }
+  if (completed !== outputs.size) {
+    return { kind: "error", reason: "impossible-prefix" };
+  }
+
+  const next = scenario.steps[completed];
+  return next.kind === "final" ? next : { kind: "tool", name: next.name, args: next.args };
+}
+
+function editRecoveryEvents(body, bodyText) {
+  if (!bodyText.includes("OPENCLAW_E2E_EDIT_FAILURE_")) {
+    return null;
+  }
+  const scenario = resolveEditRecoveryScenario(bodyText);
+  if (!scenario) {
+    return editRecoveryFixtureError("invalid-scenario");
+  }
+  if (!hasDeclaredTool(bodyText, "write") || !hasDeclaredTool(bodyText, "edit")) {
+    return editRecoveryFixtureError("tool-not-declared");
+  }
+  const outputs = collectEditRecoveryOutputs(body);
+  if (!outputs) {
+    return editRecoveryFixtureError("malformed-tool-output");
+  }
+  const decision = resolveEditRecoveryPrefix(scenario, outputs);
+  if (decision.kind === "error") {
+    return editRecoveryFixtureError(decision.reason);
+  }
+  return decision.kind === "final"
+    ? responseEvents(decision.text)
+    : toolCallEvents(decision.name, decision.args);
+}
+
 function writeResponsesEvents(res, stream, events) {
   if (stream === false) {
     const completed = events.find((event) => event.type === "response.completed");
@@ -586,6 +722,11 @@ const server = http.createServer((req, res) => {
       const draftEvents = progressDraftEvents(body, bodyText);
       if (draftEvents) {
         writeResponsesEvents(res, body.stream, draftEvents);
+        return;
+      }
+      const editRecovery = editRecoveryEvents(body, bodyText);
+      if (editRecovery) {
+        writeResponsesEvents(res, body.stream, editRecovery);
         return;
       }
       const responseText = resolveResponseText(bodyText);

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -69,6 +69,7 @@ function createFixture() {
     getLastAssistantUsage: vi.fn(() => undefined),
     getLastCompactionTokensAfter: vi.fn(() => undefined),
     getLastToolError: vi.fn(() => undefined),
+    getLastToolRecovery: vi.fn(() => undefined),
     getLatestMcpAppChannelView: vi.fn(() => undefined),
     getLatestMcpConnectAction: vi.fn(() => undefined),
     getMessagingToolSentMediaUrls: vi.fn(() => []),

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -5,6 +5,7 @@ import { buildTraceToolSummary, normalizeEmbeddedRunAttemptResult } from "./run-
 function completeResult(params?: {
   successfulNestedToolNames?: string[];
   latestMcpAppChannelView?: { viewId: string };
+  lastToolRecovery?: { toolName: string };
   clientToolCallSlots?: Array<{
     toolCallId: string;
     name: string;
@@ -43,6 +44,7 @@ function completeResult(params?: {
       getLastAssistantTextMessageIndex: () => undefined,
       getLastCompactionTokensAfter: () => undefined,
       getLastToolError: () => undefined,
+      getLastToolRecovery: () => params?.lastToolRecovery,
       getLatestMcpAppChannelView: () => params?.latestMcpAppChannelView,
       getLatestMcpConnectAction: () => undefined,
       getMessagingToolSentMediaUrls: () => [],
@@ -81,6 +83,12 @@ function completeResult(params?: {
 }
 
 describe("attempt result projection", () => {
+  it("projects the last recovered tool", () => {
+    expect(completeResult({ lastToolRecovery: { toolName: "write" } }).lastToolRecovery).toEqual({
+      toolName: "write",
+    });
+  });
+
   it("counts each failed tool call in the trace summary", () => {
     expect(
       buildTraceToolSummary({

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -178,6 +178,7 @@ export function completeEmbeddedAttemptResult(
     getLastAssistantTextMessageIndex,
     getLastCompactionTokensAfter,
     getLastToolError,
+    getLastToolRecovery,
     getLatestMcpAppChannelView,
     getLatestMcpConnectAction,
     getMessagingToolSentMediaUrls,
@@ -323,6 +324,7 @@ export function completeEmbeddedAttemptResult(
     completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined;
   const didSendDeterministicApprovalPromptNow = didSendDeterministicApprovalPrompt();
   const lastToolError = getLastToolError();
+  const lastToolRecovery = getLastToolRecovery();
   const heartbeatToolResponse = getHeartbeatToolResponse();
   const messagingToolSourceReplyPayloads = getMessagingToolSourceReplyPayloads();
   const hasToolMediaBlockReplyNow = hasToolMediaBlockReply();
@@ -332,6 +334,7 @@ export function completeEmbeddedAttemptResult(
     didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
     heartbeatToolResponse,
     lastToolError,
+    lastToolRecovery,
     toolMediaUrls: pendingToolMediaReply?.mediaUrls,
     toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
     toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
@@ -411,6 +414,7 @@ export function completeEmbeddedAttemptResult(
     successfulNestedToolNames: state.successfulNestedToolNames,
     acceptedSessionSpawns,
     lastToolError,
+    lastToolRecovery,
     didSendViaMessagingTool: didSendViaMessagingTool(),
     didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
     messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -155,6 +155,7 @@ function createSubscriptionMock(): SubscriptionMock {
     didSendViaMessagingTool: () => false,
     didSendDeterministicApprovalPrompt: () => false,
     getLastToolError: () => undefined,
+    getLastToolRecovery: () => undefined,
     getUsageTotals: () => undefined,
     getLastAssistantUsage: () => undefined,
     getAssistantTurnCount: () => 0,

--- a/src/agents/embedded-agent-runner/run/attempt-terminal-evidence.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-terminal-evidence.ts
@@ -53,6 +53,7 @@ type TerminalAttemptState = Pick<
   | "didSendDeterministicApprovalPrompt"
   | "heartbeatToolResponse"
   | "lastToolError"
+  | "lastToolRecovery"
   | "toolMediaUrls"
   | "toolAudioAsVoice"
   | "toolTrustedLocalMedia"
@@ -80,6 +81,7 @@ export function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean 
     attempt.didSendDeterministicApprovalPrompt ||
     attempt.heartbeatToolResponse ||
     attempt.lastToolError ||
+    attempt.lastToolRecovery ||
     attempt.toolMediaUrls?.some((url) => url.trim().length > 0) ||
     attempt.toolAudioAsVoice ||
     attempt.toolTrustedLocalMedia ||

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -1,5 +1,6 @@
 // Coverage for terminal attempt trajectory status classification.
 import { describe, expect, it } from "vitest";
+import { hasAttemptTerminalState } from "./attempt-terminal-evidence.js";
 import {
   resolveAttemptTrajectoryTerminal,
   resolveTerminalAssistantTexts,
@@ -44,6 +45,17 @@ describe("attempt trajectory status", () => {
     expect(
       resolveAttemptTrajectoryTerminal(baseParams({ assistantTexts: ["Visible answer."] })),
     ).toEqual({ status: "success" });
+  });
+
+  it("records a recovery receipt without assistant text as successful terminal output", () => {
+    const hasTerminalOutput = hasAttemptTerminalState({
+      lastToolRecovery: { toolName: "write" },
+    });
+
+    expect(hasTerminalOutput).toBe(true);
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ hasTerminalOutput }))).toEqual({
+      status: "success",
+    });
   });
 
   it("records length-limited visible text as success with no synthesized payload", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -685,6 +685,28 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     }
   });
 
+  it("keeps a quiet heartbeat response with a recovered mutation receipt", () => {
+    const payloads = buildPayloads({
+      heartbeatToolResponse: {
+        outcome: "no_change",
+        notify: false,
+        summary: "Nothing needs attention.",
+      },
+      isHeartbeatTrigger: true,
+      lastToolRecovery: { toolName: "write" },
+    });
+
+    expect(payloads.map((payload) => payload.text)).toStrictEqual([
+      "HEARTBEAT_OK",
+      "✅ ✍️ Write succeeded after retry.",
+    ]);
+    expect(resolveHeartbeatToolResponseFromReplyResult(payloads)).toEqual({
+      outcome: "no_change",
+      notify: false,
+      summary: "Nothing needs attention.",
+    });
+  });
+
   it("marks plain-text heartbeat replies with unresolved mutating failures", () => {
     const payloads = buildPayloads({
       assistantTexts: ["The heartbeat check completed."],

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -23,6 +23,7 @@ import {
   isSilentReplyPayloadText,
   SILENT_REPLY_TOKEN,
 } from "../../../auto-reply/tokens.js";
+import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { hasReplyPayloadContent } from "../../../interactive/payload.js";
 import type { AssistantMessage } from "../../../llm/types.js";
@@ -54,7 +55,7 @@ import {
   sanitizeAssistantVisibleStreamText,
 } from "../../embedded-agent-utils.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
-import type { ToolErrorSummary } from "../../tool-error-summary.js";
+import type { ToolErrorSummary, ToolRecoverySummary } from "../../tool-error-summary.js";
 import { buildSourceReplyPayloadState } from "./source-reply-payloads.js";
 import { buildFailureWarning } from "./tool-error-warning.js";
 import { hasExplicitMutatingToolFailureAcknowledgement } from "./tool-failure-acknowledgement.js";
@@ -136,6 +137,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastAssistant: AssistantMessage | undefined;
   currentAssistant?: AssistantMessage | null;
   lastToolError?: ToolErrorSummary;
+  lastToolRecovery?: ToolRecoverySummary;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
   isHeartbeatTrigger?: boolean;
@@ -410,6 +412,12 @@ export function buildEmbeddedRunPayloads(params: {
     if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
       hasUserFacingFailureAcknowledgement = true;
     }
+  }
+  if (params.lastToolRecovery) {
+    const toolLabel = formatToolAggregate(params.lastToolRecovery.toolName, undefined, {
+      markdown: useMarkdown,
+    });
+    replyItems.push({ text: `✅ ${toolLabel} succeeded after retry.` });
   }
   if (params.lastToolError) {
     // Surface mutating failures unless the assistant explicitly acknowledged the failed action.

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -169,7 +169,7 @@ export function buildEmbeddedRunPayloads(params: {
     params.lastToolError.mutatingAction === true
       ? { toolName: params.lastToolError.toolName }
       : undefined;
-  if (params.heartbeatToolResponse && !heartbeatTerminalToolFailure) {
+  if (params.heartbeatToolResponse && !heartbeatTerminalToolFailure && !params.lastToolRecovery) {
     return [createHeartbeatToolResponsePayload(params.heartbeatToolResponse)];
   }
   // Internal source replies always need transcript/UI mirrors. Only a

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -178,6 +178,7 @@ export function prepareEmbeddedRunTerminal(input: {
     lastAssistant: payloadAssistant,
     currentAssistant: attempt.yieldDetected ? null : (payloadAssistant ?? null),
     lastToolError: attempt.lastToolError,
+    lastToolRecovery: attempt.lastToolRecovery,
     config: runParams.config,
     isCronTrigger: runParams.trigger === "cron",
     isHeartbeatTrigger: runParams.trigger === "heartbeat",

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -29,7 +29,7 @@ import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { SandboxContext } from "../../sandbox/types.js";
 import type { AuthStorage, ModelRegistry } from "../../sessions/index.js";
-import type { ToolErrorSummary } from "../../tool-error-summary.js";
+import type { ToolErrorSummary, ToolRecoverySummary } from "../../tool-error-summary.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { EmbeddedRunReplayMetadata, EmbeddedRunReplayState } from "../replay-state.js";
 import type { EmbeddedRunLivenessState } from "../types.js";
@@ -87,6 +87,7 @@ type EmbeddedRunAttemptToolTerminalObservation = {
 
 type EmbeddedRunAttemptToolTerminalResolution = {
   lastToolError?: ToolErrorSummary;
+  lastToolRecovery?: ToolRecoverySummary;
   executionStarted: boolean;
   executedArguments?: Record<string, unknown>;
   sideEffectEvidence: boolean;
@@ -303,6 +304,7 @@ export type EmbeddedRunAttemptResult = {
   /** Completed message_end snapshot owned by this model attempt. */
   currentAttemptCompletedAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
+  lastToolRecovery?: ToolRecoverySummary;
   didSendViaMessagingTool: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -811,6 +811,36 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("keeps a recovery-only token-limited terminal working", async () => {
+    const onAgentEvent = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "length",
+        content: [],
+      },
+      { onAgentEvent, onBeforeTerminalDelivery },
+    );
+    ctx.state.livenessState = "working";
+    ctx.state.assistantTexts = [];
+    ctx.state.lastToolRecovery = { toolName: "write" };
+
+    await handleAgentEnd(ctx);
+
+    expect(onBeforeTerminalDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ incompleteTerminalAssistant: false }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "length",
+        livenessState: "working",
+      },
+    });
+  });
+
   it("preserves token-limited terminal tool media before runner finalization", async () => {
     const onAgentEvent = vi.fn();
     const ctx = createContext(

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -104,6 +104,7 @@ export function handleAgentEnd(
     didSendDeterministicApprovalPrompt: ctx.state.deterministicApprovalPromptSent,
     heartbeatToolResponse: ctx.state.heartbeatToolResponse,
     lastToolError: ctx.state.lastToolError,
+    lastToolRecovery: ctx.state.lastToolRecovery,
     toolMediaUrls: [...ctx.state.pendingToolMediaUrls, ...deferredMediaUrls],
     toolAudioAsVoice:
       ctx.state.pendingToolAudioAsVoice ||

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -234,6 +234,7 @@ export async function handleToolExecutionEnd(
       : {}),
   });
   ctx.state.lastToolError = terminal.lastToolError;
+  ctx.state.lastToolRecovery = terminal.lastToolRecovery;
   const toolErrorSummary = ctx.state.lastToolError
     ? summarizeToolValidationError(ctx.state.lastToolError)
     : undefined;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -575,15 +575,15 @@ export async function emitToolResultOutput(params: {
     const message = error instanceof Error ? error.message : String(error);
     ctx.log.warn(`failed to deliver exec approval prompt: ${message}`);
     const approvalMeta = meta ? `${meta} · approval prompt delivery` : "approval prompt delivery";
-    ctx.state.lastToolError = (
-      ctx.params.observeToolTerminal ?? resolveFallbackToolTerminalObserver(ctx)
-    )({
+    const terminal = (ctx.params.observeToolTerminal ?? resolveFallbackToolTerminalObserver(ctx))({
       toolName,
       meta: approvalMeta,
       executionStarted: false,
       outcome: "failure",
       failure: { error: `Approval prompt delivery failed: ${message}` },
-    }).lastToolError;
+    });
+    ctx.state.lastToolError = terminal.lastToolError;
+    ctx.state.lastToolRecovery = terminal.lastToolRecovery;
     ctx.state.deterministicApprovalPromptSent = false;
   };
   const hasStructuredMedia = Boolean(

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -30,7 +30,7 @@ import type { McpAppChannelView } from "./mcp-ui-resource.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
-import type { ToolErrorSummary } from "./tool-error-summary.js";
+import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import type { NormalizedUsage } from "./usage.js";
 
 type EmbeddedSubscribeLogger = {
@@ -106,6 +106,7 @@ export type EmbeddedAgentSubscribeState = {
    */
   assistantTurnCount: number;
   lastToolError?: ToolErrorSummary;
+  lastToolRecovery?: ToolRecoverySummary;
   latestMcpAppChannelView?: McpAppChannelView;
   latestMcpConnectAction?: McpConnectAction;
 
@@ -351,6 +352,7 @@ type ToolHandlerState = Pick<
   | "itemStartedCount"
   | "itemCompletedCount"
   | "lastToolError"
+  | "lastToolRecovery"
   | "latestMcpAppChannelView"
   | "latestMcpConnectAction"
   | "pendingMessagingTargets"

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -77,6 +77,7 @@ export function createEmbeddedAgentSubscribeState(
     itemCompletedCount: 0,
     assistantTurnCount: 0,
     lastToolError: undefined,
+    lastToolRecovery: undefined,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",
     reasoningMode,
     includeReasoning: reasoningMode === "on" && canShowReasoning,

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -660,6 +660,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       }),
     didSendDeterministicApprovalPrompt: () => state.deterministicApprovalPromptSent,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
+    getLastToolRecovery: () => (state.lastToolRecovery ? { ...state.lastToolRecovery } : undefined),
     getUsageTotals,
     getLastAssistantUsage,
     getCompactionCount: () => compactionCount,

--- a/src/agents/tool-error-state.test.ts
+++ b/src/agents/tool-error-state.test.ts
@@ -26,11 +26,14 @@ describe("unresolved tool mutation errors", () => {
     expect(JSON.stringify(bothFailed)).not.toContain(actionA.error);
 
     const afterBRecovers = state.recordSuccess(actionB);
-    expect(afterBRecovers).toMatchObject({
-      actionFingerprint: actionA.actionFingerprint,
-      error: actionA.error,
+    expect(afterBRecovers).toEqual({
+      kind: "unresolved",
+      lastToolError: actionA,
     });
-    expect(state.recordSuccess(actionA)).toBeUndefined();
+    expect(state.recordSuccess(actionA)).toEqual({
+      kind: "recovered",
+      lastToolRecovery: { toolName: "message" },
+    });
   });
 
   it("updates repeated failures for the same action without duplicating state", () => {
@@ -66,6 +69,9 @@ describe("unresolved tool mutation errors", () => {
     const latest = state.recordFailure(actionA);
 
     expect(latest.error).toBe("A failed again");
-    expect(state.recordSuccess(actionA)?.error).toBe("B failed");
+    expect(state.recordSuccess(actionA)).toMatchObject({
+      kind: "unresolved",
+      lastToolError: { error: "B failed" },
+    });
   });
 });

--- a/src/agents/tool-error-state.test.ts
+++ b/src/agents/tool-error-state.test.ts
@@ -2,6 +2,83 @@ import { describe, expect, it } from "vitest";
 import { createToolErrorState } from "./tool-error-state.js";
 
 describe("unresolved tool mutation errors", () => {
+  it("preserves recovery across unrelated failures until the same action fails again", () => {
+    const recoveredAction = {
+      toolName: "write",
+      error: "write failed",
+      mutatingAction: true,
+      actionFingerprint: "tool=write|path=/tmp/a",
+    } as const;
+    const unrelatedAction = {
+      toolName: "message",
+      error: "send failed",
+      mutatingAction: true,
+      actionFingerprint: "tool=message|action=send|to=channel:b",
+    } as const;
+    const state = createToolErrorState();
+
+    state.recordFailure(recoveredAction);
+    expect(state.recordSuccess(recoveredAction)).toEqual({
+      lastToolRecovery: { toolName: "write" },
+    });
+    expect(state.recordFailure(unrelatedAction)).toEqual({
+      lastToolError: unrelatedAction,
+      lastToolRecovery: { toolName: "write" },
+    });
+    expect(state.recordFailure(recoveredAction)).toEqual({
+      lastToolError: recoveredAction,
+    });
+  });
+
+  it("keeps a multi-target recovery until every recovered target fails again", () => {
+    const targetA = {
+      toolName: "apply_patch",
+      error: "A failed",
+      mutatingAction: true,
+      actionFingerprint: "tool=apply_patch|patch=one",
+      fileTarget: { path: "/tmp/a" },
+    } as const;
+    const targetB = {
+      ...targetA,
+      error: "B failed",
+      fileTarget: { path: "/tmp/b" },
+    } as const;
+    const state = createToolErrorState();
+
+    state.recordFailure(targetA);
+    state.recordFailure(targetB);
+    expect(state.recordSuccess(targetA, [targetA.fileTarget, targetB.fileTarget])).toMatchObject({
+      lastToolRecovery: { toolName: "apply_patch" },
+    });
+    expect(state.recordFailure(targetA)).toMatchObject({
+      lastToolRecovery: { toolName: "apply_patch" },
+    });
+    expect(state.recordFailure(targetB).lastToolRecovery).toBeUndefined();
+  });
+
+  it("replaces an older receipt when a later tool call recovers", () => {
+    const actionA = {
+      toolName: "write",
+      error: "A failed",
+      mutatingAction: true,
+      actionFingerprint: "tool=write|path=/tmp/a",
+    } as const;
+    const actionB = {
+      ...actionA,
+      error: "B failed",
+      actionFingerprint: "tool=write|path=/tmp/b",
+    } as const;
+    const state = createToolErrorState();
+
+    state.recordFailure(actionA);
+    state.recordSuccess(actionA);
+    state.recordFailure(actionB);
+    expect(state.recordSuccess(actionB)).toMatchObject({
+      lastToolRecovery: { toolName: "write" },
+    });
+    expect(state.recordFailure(actionB).lastToolRecovery).toBeUndefined();
+  });
+
   it("retains action A after action B fails and then succeeds", () => {
     const actionA = {
       toolName: "message",
@@ -19,7 +96,7 @@ describe("unresolved tool mutation errors", () => {
     const state = createToolErrorState();
     state.recordFailure(actionA);
     const bothFailed = state.recordFailure(actionB);
-    expect(bothFailed).toMatchObject({
+    expect(bothFailed.lastToolError).toMatchObject({
       actionFingerprint: actionB.actionFingerprint,
     });
     expect(Object.getOwnPropertySymbols(bothFailed)).toHaveLength(0);
@@ -46,7 +123,7 @@ describe("unresolved tool mutation errors", () => {
 
     const state = createToolErrorState();
     state.recordFailure(first);
-    expect(state.recordFailure(latest)).toEqual(latest);
+    expect(state.recordFailure(latest)).toEqual({ lastToolError: latest });
   });
 
   it("moves a repeated action failure to the latest public position", () => {
@@ -67,7 +144,7 @@ describe("unresolved tool mutation errors", () => {
     state.recordFailure(actionB);
     const latest = state.recordFailure(actionA);
 
-    expect(latest.error).toBe("A failed again");
+    expect(latest.lastToolError?.error).toBe("A failed again");
     expect(state.recordSuccess(actionA)).toMatchObject({
       lastToolError: { error: "B failed" },
       lastToolRecovery: { toolName: "message" },

--- a/src/agents/tool-error-state.test.ts
+++ b/src/agents/tool-error-state.test.ts
@@ -26,12 +26,11 @@ describe("unresolved tool mutation errors", () => {
     expect(JSON.stringify(bothFailed)).not.toContain(actionA.error);
 
     const afterBRecovers = state.recordSuccess(actionB);
-    expect(afterBRecovers).toEqual({
-      kind: "unresolved",
+    expect(afterBRecovers).toMatchObject({
       lastToolError: actionA,
+      lastToolRecovery: { toolName: "message" },
     });
     expect(state.recordSuccess(actionA)).toEqual({
-      kind: "recovered",
       lastToolRecovery: { toolName: "message" },
     });
   });
@@ -70,8 +69,8 @@ describe("unresolved tool mutation errors", () => {
 
     expect(latest.error).toBe("A failed again");
     expect(state.recordSuccess(actionA)).toMatchObject({
-      kind: "unresolved",
       lastToolError: { error: "B failed" },
+      lastToolRecovery: { toolName: "message" },
     });
   });
 });

--- a/src/agents/tool-error-state.ts
+++ b/src/agents/tool-error-state.ts
@@ -1,22 +1,31 @@
-import type { ToolErrorSummary } from "./tool-error-summary.js";
+import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import { isSameToolMutationAction } from "./tool-mutation.js";
+
+type ToolSuccessState =
+  | { kind: "clear" }
+  | { kind: "recovered"; lastToolRecovery: ToolRecoverySummary }
+  | { kind: "unresolved"; lastToolError: ToolErrorSummary };
 
 type ToolErrorState = {
   recordFailure: (failure: ToolErrorSummary) => ToolErrorSummary;
   recordSuccess: (
     success: Pick<ToolErrorSummary, "toolName" | "meta" | "actionFingerprint" | "fileTarget">,
-  ) => ToolErrorSummary | undefined;
+  ) => ToolSuccessState;
 };
 
 /** Keep attempt-local mutation recovery state outside the public error summary. */
 export function createToolErrorState(): ToolErrorState {
   let nonMutatingFailure: ToolErrorSummary | undefined;
   let unresolvedMutations: ToolErrorSummary[] = [];
+  // Latch recovery through later successes until terminal payload assembly.
+  // A later failure supersedes it; clearing on reads would lose the retry receipt.
+  let lastToolRecovery: ToolRecoverySummary | undefined;
 
   const current = () => unresolvedMutations.at(-1) ?? nonMutatingFailure;
 
   return {
     recordFailure(failure) {
+      lastToolRecovery = undefined;
       if (failure.mutatingAction !== true) {
         if (unresolvedMutations.length === 0) {
           nonMutatingFailure = failure;
@@ -36,12 +45,21 @@ export function createToolErrorState(): ToolErrorState {
     recordSuccess(success) {
       if (unresolvedMutations.length === 0) {
         nonMutatingFailure = undefined;
-        return undefined;
+        return lastToolRecovery ? { kind: "recovered", lastToolRecovery } : { kind: "clear" };
       }
+      const unresolvedCount = unresolvedMutations.length;
       unresolvedMutations = unresolvedMutations.filter(
         (entry) => !isSameToolMutationAction(entry, success),
       );
-      return current();
+      const unresolved = current();
+      if (unresolved) {
+        return { kind: "unresolved", lastToolError: unresolved };
+      }
+      if (unresolvedMutations.length < unresolvedCount) {
+        lastToolRecovery = { toolName: success.toolName };
+        return { kind: "recovered", lastToolRecovery };
+      }
+      return { kind: "clear" };
     },
   };
 }

--- a/src/agents/tool-error-state.ts
+++ b/src/agents/tool-error-state.ts
@@ -1,10 +1,10 @@
 import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import { isSameToolMutationAction } from "./tool-mutation.js";
 
-type ToolSuccessState =
-  | { kind: "clear" }
-  | { kind: "recovered"; lastToolRecovery: ToolRecoverySummary }
-  | { kind: "unresolved"; lastToolError: ToolErrorSummary };
+type ToolSuccessState = {
+  lastToolError?: ToolErrorSummary;
+  lastToolRecovery?: ToolRecoverySummary;
+};
 
 type ToolErrorState = {
   recordFailure: (failure: ToolErrorSummary) => ToolErrorSummary;
@@ -45,21 +45,20 @@ export function createToolErrorState(): ToolErrorState {
     recordSuccess(success) {
       if (unresolvedMutations.length === 0) {
         nonMutatingFailure = undefined;
-        return lastToolRecovery ? { kind: "recovered", lastToolRecovery } : { kind: "clear" };
+        return lastToolRecovery ? { lastToolRecovery } : {};
       }
       const unresolvedCount = unresolvedMutations.length;
       unresolvedMutations = unresolvedMutations.filter(
         (entry) => !isSameToolMutationAction(entry, success),
       );
-      const unresolved = current();
-      if (unresolved) {
-        return { kind: "unresolved", lastToolError: unresolved };
-      }
       if (unresolvedMutations.length < unresolvedCount) {
         lastToolRecovery = { toolName: success.toolName };
-        return { kind: "recovered", lastToolRecovery };
       }
-      return { kind: "clear" };
+      const lastToolError = current();
+      return {
+        ...(lastToolError ? { lastToolError } : {}),
+        ...(lastToolRecovery ? { lastToolRecovery } : {}),
+      };
     },
   };
 }

--- a/src/agents/tool-error-state.ts
+++ b/src/agents/tool-error-state.ts
@@ -1,36 +1,61 @@
 import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import { isSameToolMutationAction } from "./tool-mutation.js";
 
-type ToolSuccessState = {
+type ToolAction = Pick<ToolErrorSummary, "toolName" | "meta" | "actionFingerprint" | "fileTarget">;
+
+type ToolTerminalState = {
   lastToolError?: ToolErrorSummary;
   lastToolRecovery?: ToolRecoverySummary;
 };
 
+type ToolRecoveryState = {
+  actions: ToolAction[];
+  summary: ToolRecoverySummary;
+};
+
 type ToolErrorState = {
-  recordFailure: (failure: ToolErrorSummary) => ToolErrorSummary;
+  recordFailure: (failure: ToolErrorSummary) => ToolTerminalState;
   recordSuccess: (
-    success: Pick<ToolErrorSummary, "toolName" | "meta" | "actionFingerprint" | "fileTarget">,
-  ) => ToolSuccessState;
+    success: ToolAction,
+    fileTargets?: readonly NonNullable<ToolAction["fileTarget"]>[],
+  ) => ToolTerminalState;
 };
 
 /** Keep attempt-local mutation recovery state outside the public error summary. */
 export function createToolErrorState(): ToolErrorState {
   let nonMutatingFailure: ToolErrorSummary | undefined;
   let unresolvedMutations: ToolErrorSummary[] = [];
-  // Latch recovery through later successes until terminal payload assembly.
-  // A later failure supersedes it; clearing on reads would lose the retry receipt.
-  let lastToolRecovery: ToolRecoverySummary | undefined;
+  // Keep the recovered action identity until terminal delivery. Only another
+  // failure of that action invalidates its receipt; unrelated failures do not.
+  let recovery: ToolRecoveryState | undefined;
 
   const current = () => unresolvedMutations.at(-1) ?? nonMutatingFailure;
+  const terminalState = (): ToolTerminalState => {
+    const lastToolError = current();
+    return {
+      ...(lastToolError ? { lastToolError } : {}),
+      ...(recovery ? { lastToolRecovery: recovery.summary } : {}),
+    };
+  };
 
   return {
     recordFailure(failure) {
-      lastToolRecovery = undefined;
+      if (recovery) {
+        const recoveredIndex = recovery.actions.findIndex((action) =>
+          isSameToolMutationAction(action, failure),
+        );
+        if (recoveredIndex >= 0) {
+          recovery.actions.splice(recoveredIndex, 1);
+          if (recovery.actions.length === 0) {
+            recovery = undefined;
+          }
+        }
+      }
       if (failure.mutatingAction !== true) {
         if (unresolvedMutations.length === 0) {
           nonMutatingFailure = failure;
         }
-        return current() ?? failure;
+        return terminalState();
       }
       nonMutatingFailure = undefined;
       const sameIndex = unresolvedMutations.findIndex((entry) =>
@@ -40,25 +65,37 @@ export function createToolErrorState(): ToolErrorState {
         unresolvedMutations.splice(sameIndex, 1);
       }
       unresolvedMutations.push(failure);
-      return failure;
+      return terminalState();
     },
-    recordSuccess(success) {
+    recordSuccess(success, fileTargets) {
       if (unresolvedMutations.length === 0) {
         nonMutatingFailure = undefined;
-        return lastToolRecovery ? { lastToolRecovery } : {};
+        return terminalState();
       }
-      const unresolvedCount = unresolvedMutations.length;
-      unresolvedMutations = unresolvedMutations.filter(
-        (entry) => !isSameToolMutationAction(entry, success),
-      );
-      if (unresolvedMutations.length < unresolvedCount) {
-        lastToolRecovery = { toolName: success.toolName };
+      const successes = fileTargets?.map((fileTarget) => ({ ...success, fileTarget })) ?? [success];
+      const recoveredActions: ToolAction[] = [];
+      const remainingMutations: ToolErrorSummary[] = [];
+      for (const entry of unresolvedMutations) {
+        const matchingSuccess = successes.find((candidate) =>
+          isSameToolMutationAction(entry, candidate),
+        );
+        if (matchingSuccess) {
+          if (!recoveredActions.includes(matchingSuccess)) {
+            recoveredActions.push(matchingSuccess);
+          }
+        } else {
+          remainingMutations.push(entry);
+        }
       }
-      const lastToolError = current();
-      return {
-        ...(lastToolError ? { lastToolError } : {}),
-        ...(lastToolRecovery ? { lastToolRecovery } : {}),
-      };
+      unresolvedMutations = remainingMutations;
+      const recoveredToolName = recoveredActions.at(-1)?.toolName;
+      if (recoveredToolName) {
+        recovery = {
+          actions: recoveredActions,
+          summary: { toolName: recoveredToolName },
+        };
+      }
+      return terminalState();
     },
   };
 }

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -34,6 +34,8 @@ export type ToolErrorSummary = {
   terminalDiagnostic?: ProcessTerminalDiagnostic;
 };
 
+export type ToolRecoverySummary = Pick<ToolErrorSummary, "toolName">;
+
 const EXEC_LIKE_TOOL_NAMES = new Set(["exec", "bash"]);
 
 /** Detects shell-execution tools that share retry and mutation semantics. */

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -36,6 +36,7 @@ describe("tool terminal outcome observer", () => {
       error: "A failed",
       actionFingerprint: expect.stringContaining("to=channel:a"),
     });
+    expect(afterB.lastToolRecovery).toEqual({ toolName: "message" });
     expect(
       observe({ toolName: "heartbeat_respond", arguments: {}, outcome: "success" }).lastToolError,
     ).toMatchObject({ error: "A failed" });

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -72,6 +72,23 @@ describe("tool terminal outcome observer", () => {
     expect(payloads.map((payload) => payload.text)).toEqual(["✅ ✍️ Write succeeded after retry."]);
     expect(JSON.stringify(payloads)).not.toContain("TOP_SECRET");
     expect(JSON.stringify(payloads)).not.toContain("/tmp/demo.txt");
+
+    const afterUnrelatedFailure = observe({
+      toolName: "message",
+      arguments: { action: "send", to: "channel:other", message: "hello" },
+      outcome: "failure",
+      failure: { error: "send failed" },
+    });
+    expect(afterUnrelatedFailure.lastToolError).toMatchObject({ error: "send failed" });
+    expect(afterUnrelatedFailure.lastToolRecovery).toEqual({ toolName: "write" });
+
+    const afterSameTargetFailure = observe({
+      toolName: "edit",
+      arguments: { path: "/tmp/demo.txt", oldText: "after", newText: "later" },
+      outcome: "failure",
+      failure: { error: "second edit failed" },
+    });
+    expect(afterSameTargetFailure.lastToolRecovery).toBeUndefined();
   });
 
   it("uses host execution and adjusted-argument evidence before fallback facts", () => {

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -44,6 +44,35 @@ describe("tool terminal outcome observer", () => {
     ).toBeUndefined();
   });
 
+  it("surfaces the successful cross-tool recovery without leaking failure details", () => {
+    const observe = createToolTerminalObserver("run-edit-recovery");
+
+    observe({
+      toolName: "edit",
+      arguments: { path: "/tmp/demo.txt", oldText: "missing", newText: "after" },
+      outcome: "failure",
+      failure: { error: "Could not find TOP_SECRET text in /tmp/demo.txt" },
+    });
+    const recovered = observe({
+      toolName: "write",
+      arguments: { path: "/tmp/demo.txt", content: "after" },
+      outcome: "success",
+    });
+    const afterRead = observe({
+      toolName: "read",
+      arguments: { path: "/tmp/demo.txt" },
+      outcome: "success",
+    });
+    const payloads = buildPayloads({ lastToolRecovery: afterRead.lastToolRecovery });
+
+    expect(recovered.lastToolError).toBeUndefined();
+    expect(recovered.lastToolRecovery).toEqual({ toolName: "write" });
+    expect(afterRead.lastToolRecovery).toEqual({ toolName: "write" });
+    expect(payloads.map((payload) => payload.text)).toEqual(["✅ ✍️ Write succeeded after retry."]);
+    expect(JSON.stringify(payloads)).not.toContain("TOP_SECRET");
+    expect(JSON.stringify(payloads)).not.toContain("/tmp/demo.txt");
+  });
+
   it("uses host execution and adjusted-argument evidence before fallback facts", () => {
     const runId = "run-2";
     const toolCallId = "call-1";

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -88,9 +88,8 @@ export function createToolTerminalObserver(
           ...success,
           ...(fileTarget ? { fileTarget } : {}),
         });
-        lastToolError = successState.kind === "unresolved" ? successState.lastToolError : undefined;
-        lastToolRecovery =
-          successState.kind === "recovered" ? successState.lastToolRecovery : undefined;
+        lastToolError = successState.lastToolError;
+        lastToolRecovery = successState.lastToolRecovery;
       }
     }
 

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -71,10 +71,12 @@ export function createToolTerminalObserver(
           : {}),
       };
       for (const fileTarget of (mutatingAction ? fileTargets : undefined) ?? [undefined]) {
-        lastToolError = errors.recordFailure({
+        const failureState = errors.recordFailure({
           ...failure,
           ...(fileTarget ? { fileTarget } : {}),
         });
+        lastToolError = failureState.lastToolError;
+        lastToolRecovery = failureState.lastToolRecovery;
       }
     } else {
       const success = {
@@ -83,14 +85,9 @@ export function createToolTerminalObserver(
         ...(observation.ownerMutation ? { ownerKey: observation.ownerMutation.ownerKey } : {}),
         ...(mutation.actionFingerprint ? { actionFingerprint: mutation.actionFingerprint } : {}),
       };
-      for (const fileTarget of fileTargets ?? [undefined]) {
-        const successState = errors.recordSuccess({
-          ...success,
-          ...(fileTarget ? { fileTarget } : {}),
-        });
-        lastToolError = successState.lastToolError;
-        lastToolRecovery = successState.lastToolRecovery;
-      }
+      const successState = errors.recordSuccess(success, fileTargets);
+      lastToolError = successState.lastToolError;
+      lastToolRecovery = successState.lastToolRecovery;
     }
 
     return {

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -7,7 +7,7 @@ import {
 import { extractApplyPatchTargets } from "./apply-patch-targets.js";
 import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
 import { createToolErrorState } from "./tool-error-state.js";
-import type { ToolErrorSummary } from "./tool-error-summary.js";
+import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import type { FileTarget } from "./tool-mutation.js";
 import { buildToolMutationState } from "./tool-mutation.js";
 
@@ -57,6 +57,7 @@ export function createToolTerminalObserver(
       (mutation.fileTarget ? [mutation.fileTarget] : undefined);
 
     let lastToolError: ToolErrorSummary | undefined;
+    let lastToolRecovery: ToolRecoverySummary | undefined;
     if (observation.outcome === "failure") {
       const mutatingAction = executionStarted && mutation.mutatingAction;
       const failure: ToolErrorSummary = {
@@ -83,15 +84,19 @@ export function createToolTerminalObserver(
         ...(mutation.actionFingerprint ? { actionFingerprint: mutation.actionFingerprint } : {}),
       };
       for (const fileTarget of fileTargets ?? [undefined]) {
-        lastToolError = errors.recordSuccess({
+        const successState = errors.recordSuccess({
           ...success,
           ...(fileTarget ? { fileTarget } : {}),
         });
+        lastToolError = successState.kind === "unresolved" ? successState.lastToolError : undefined;
+        lastToolRecovery =
+          successState.kind === "recovered" ? successState.lastToolRecovery : undefined;
       }
     }
 
     return {
       ...(lastToolError ? { lastToolError } : {}),
+      ...(lastToolRecovery ? { lastToolRecovery } : {}),
       executionStarted,
       ...(executedArguments ? { executedArguments } : {}),
       sideEffectEvidence: executionStarted && !mutation.replaySafe,

--- a/test/e2e/qa-lab/runtime/tool-recovery-channel-delivery.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/tool-recovery-channel-delivery.product-proof.e2e.test.ts
@@ -1,0 +1,138 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  startQaBusServer,
+  startQaGatewayChild,
+} from "../../../../extensions/qa-lab/api.js";
+import { getFreePort } from "../../../../src/test-utils/ports.js";
+
+const RECOVERY_MARKER = "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY";
+const FINAL_MARKER = `${RECOVERY_MARKER}_FINAL`;
+const FIXTURE_PATH = "issue-46548-edit-recovery.txt";
+const TIMEOUT_MS = 120_000;
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const results = await Promise.allSettled(
+    cleanups
+      .splice(0)
+      .toReversed()
+      .map((cleanup) => cleanup()),
+  );
+  const failures = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "tool recovery delivery proof cleanup failed");
+  }
+});
+
+async function startEditRecoveryProvider(repoRoot: string) {
+  const port = await getFreePort();
+  const child = spawn(
+    process.execPath,
+    [path.join(repoRoot, "scripts/e2e/mock-openai-server.mjs")],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, MOCK_PORT: String(port) },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  const appendOutput = (chunk: Buffer | string) => {
+    output = `${output}${String(chunk)}`.slice(-16_000);
+  };
+  child.stdout.on("data", appendOutput);
+  child.stderr.on("data", appendOutput);
+  const deadline = Date.now() + 10_000;
+  while (!output.includes(`mock-openai listening on ${port}`)) {
+    if (child.exitCode !== null) {
+      throw new Error(`edit recovery provider exited early (${child.exitCode}): ${output}`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`edit recovery provider did not start: ${output}`);
+    }
+    await sleep(25);
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    stop: async () => {
+      if (child.exitCode !== null) {
+        return;
+      }
+      child.kill("SIGTERM");
+      await Promise.race([
+        once(child, "exit"),
+        sleep(5_000, undefined, { ref: false }).then(() => {
+          child.kill("SIGKILL");
+        }),
+      ]);
+    },
+  };
+}
+
+async function waitForRecoveryDelivery(state: ReturnType<typeof createQaBusState>, cursor: number) {
+  await state.waitForCursorAdvance(cursor, TIMEOUT_MS, (snapshot) => {
+    const text = snapshot.messages
+      .slice(cursor)
+      .filter((message) => message.direction === "outbound")
+      .map((message) => message.text)
+      .join("\n");
+    return text.includes(FINAL_MARKER) && text.includes("Edit succeeded after retry");
+  });
+  const outbound = state
+    .getSnapshot()
+    .messages.slice(cursor)
+    .filter((message) => message.direction === "outbound");
+  return { outbound, text: outbound.map((message) => message.text).join("\n") };
+}
+
+describe.runIf(process.env.OPENCLAW_TOOL_RECOVERY_CHANNEL_PROOF === "1")(
+  "tool recovery channel delivery product proof",
+  () => {
+    it(
+      "delivers a redacted recovery receipt through the gateway and qa-channel",
+      { timeout: TIMEOUT_MS + 30_000 },
+      async () => {
+        const repoRoot = process.cwd();
+        const provider = await startEditRecoveryProvider(repoRoot);
+        cleanups.push(() => provider.stop());
+        const state = createQaBusState();
+        const bus = await startQaBusServer({ state });
+        cleanups.push(() => bus.stop());
+        const gateway = await startQaGatewayChild({
+          repoRoot,
+          useRepoCli: true,
+          providerBaseUrl: `${provider.baseUrl}/v1`,
+          providerMode: "mock-openai",
+          transport: createQaChannelTransport(state),
+          transportBaseUrl: bus.baseUrl,
+          enabledPluginIds: ["qa-lab"],
+          controlUiEnabled: false,
+        });
+        cleanups.push(() => gateway.stop());
+
+        const cursor = state.getSnapshot().messages.length;
+        state.addInboundMessage({
+          conversation: { id: "tool-recovery-proof", kind: "direct" },
+          senderId: "tool-recovery-proof",
+          senderName: "Tool Recovery Proof",
+          text: `Run ${RECOVERY_MARKER}.`,
+        });
+        const delivery = await waitForRecoveryDelivery(state, cursor);
+
+        expect(delivery.text).toContain(FINAL_MARKER);
+        expect(delivery.text).toContain("✅ 📝 Edit succeeded after retry.");
+        expect(delivery.text).not.toContain(FIXTURE_PATH);
+        expect(delivery.text).not.toContain("Could not find the exact text");
+        expect(delivery.outbound.every((message) => message.isError !== true)).toBe(true);
+      },
+    );
+  },
+);

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -141,6 +141,232 @@ async function withMockServer(
 }
 
 describe("mock OpenAI response markers", () => {
+  const editRecoveryPath = "issue-46548-edit-recovery.txt";
+  const editRecoveryTools = [
+    { name: "write", parameters: { type: "object" }, type: "function" },
+    { name: "edit", parameters: { type: "object" }, type: "function" },
+  ];
+  const editRecoveryTranscript = {
+    seed: {
+      name: "write",
+      args: { path: editRecoveryPath, content: "before\n" },
+      output: `Successfully wrote 7 bytes to ${editRecoveryPath}`,
+    },
+    failure: {
+      name: "edit",
+      args: {
+        path: editRecoveryPath,
+        edits: [{ oldText: "absent\n", newText: "after\n" }],
+      },
+      output: JSON.stringify({
+        status: "error",
+        tool: "edit",
+        error: `Could not find the exact text in ${editRecoveryPath}. The old text must match exactly`,
+      }),
+    },
+    retry: {
+      name: "edit",
+      args: {
+        path: editRecoveryPath,
+        edits: [{ oldText: "before\n", newText: "after\n" }],
+      },
+      output: `Successfully replaced 1 block(s) in ${editRecoveryPath}.`,
+    },
+  };
+
+  async function postResponses(baseUrl: string, body: Record<string, unknown>) {
+    const response = await fetch(`${baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...body, stream: false }),
+    });
+    return { response, body: await response.json() };
+  }
+
+  function outputFor(callId: string, output: string) {
+    return { type: "function_call_output", call_id: callId, output };
+  }
+
+  function appendOutput(
+    input: Array<Record<string, unknown>>,
+    response: { body: { output?: Array<{ call_id?: unknown }> } },
+    output: string,
+  ) {
+    const callId = response.body.output?.[0]?.call_id;
+    if (typeof callId !== "string") {
+      throw new Error("edit recovery response omitted call_id");
+    }
+    input.push(outputFor(callId, output));
+  }
+
+  function createEditRecoveryConversation(baseUrl: string, marker: string) {
+    const input: Array<Record<string, unknown>> = [{ content: `Run ${marker}.`, role: "user" }];
+    const request = () =>
+      postResponses(baseUrl, {
+        input,
+        tools: editRecoveryTools,
+      });
+    return {
+      input,
+      request,
+      appendOutput: (response: Awaited<ReturnType<typeof request>>, output: string) =>
+        appendOutput(input, response, output),
+    };
+  }
+
+  function expectToolCall(
+    response: Awaited<ReturnType<ReturnType<typeof createEditRecoveryConversation>["request"]>>,
+    name: string,
+    args: Record<string, unknown>,
+  ) {
+    expect(response.body.output?.[0]).toMatchObject({
+      arguments: JSON.stringify(args),
+      name,
+      type: "function_call",
+    });
+  }
+
+  async function completeTool(
+    conversation: ReturnType<typeof createEditRecoveryConversation>,
+    name: string,
+    args: Record<string, unknown>,
+    output: string,
+  ) {
+    const response = await conversation.request();
+    expectToolCall(response, name, args);
+    conversation.appendOutput(response, output);
+    return response;
+  }
+
+  async function driveEditRecovery(
+    conversation: ReturnType<typeof createEditRecoveryConversation>,
+    options: { retry: boolean; replaySeed?: boolean },
+  ) {
+    const seed = await conversation.request();
+    expectToolCall(seed, editRecoveryTranscript.seed.name, editRecoveryTranscript.seed.args);
+    if (options.replaySeed) {
+      const replay = await conversation.request();
+      expect(replay.body.output).toEqual(seed.body.output);
+    }
+    conversation.appendOutput(seed, editRecoveryTranscript.seed.output);
+    const responses = [seed];
+    const remainingSteps = options.retry
+      ? [editRecoveryTranscript.failure, editRecoveryTranscript.retry]
+      : [editRecoveryTranscript.failure];
+    for (const step of remainingSteps) {
+      responses.push(await completeTool(conversation, step.name, step.args, step.output));
+    }
+    const final = await conversation.request();
+    expect(final.body.output?.[0]?.content?.[0]?.text).toBe(
+      options.retry
+        ? "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY_FINAL"
+        : "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED_FINAL",
+    );
+    responses.push(final);
+    return responses;
+  }
+
+  it("drives deterministic edit recovery sequencing and replay at the HTTP boundary", async () => {
+    await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
+      const unresolved = createEditRecoveryConversation(
+        baseUrl,
+        "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED",
+      );
+      const matchedRetry = createEditRecoveryConversation(
+        baseUrl,
+        "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY",
+      );
+      expect((await driveEditRecovery(unresolved, { retry: false })).length).toBe(3);
+      expect(
+        (await driveEditRecovery(matchedRetry, { retry: true, replaySeed: true })).length,
+      ).toBe(4);
+    });
+  });
+
+  it("keeps interleaved edit recovery transcripts independent", async () => {
+    await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
+      const unresolved = createEditRecoveryConversation(
+        baseUrl,
+        "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED",
+      );
+      const matchedRetry = createEditRecoveryConversation(
+        baseUrl,
+        "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY",
+      );
+      for (const conversation of [unresolved, matchedRetry]) {
+        await completeTool(
+          conversation,
+          editRecoveryTranscript.seed.name,
+          editRecoveryTranscript.seed.args,
+          editRecoveryTranscript.seed.output,
+        );
+      }
+      for (const conversation of [unresolved, matchedRetry]) {
+        await completeTool(
+          conversation,
+          editRecoveryTranscript.failure.name,
+          editRecoveryTranscript.failure.args,
+          editRecoveryTranscript.failure.output,
+        );
+      }
+      const unresolvedFinal = await unresolved.request();
+      expect(unresolvedFinal.body.output?.[0]?.content?.[0]?.text).toBe(
+        "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED_FINAL",
+      );
+      await completeTool(
+        matchedRetry,
+        editRecoveryTranscript.retry.name,
+        editRecoveryTranscript.retry.args,
+        editRecoveryTranscript.retry.output,
+      );
+      expect((await matchedRetry.request()).body.output?.[0]?.content?.[0]?.text).toBe(
+        "OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY_FINAL",
+      );
+    });
+  });
+
+  it("returns fixture errors for missing tools, malformed outcomes, and impossible prefixes", async () => {
+    await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
+      const missingTools = await postResponses(baseUrl, {
+        input: [{ content: "Run OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED.", role: "user" }],
+      });
+      expect(missingTools.body.output?.[0]?.content?.[0]?.text).toContain(
+        "OPENCLAW_E2E_EDIT_FAILURE_FIXTURE_ERROR",
+      );
+
+      const malformedPrefix = await postResponses(baseUrl, {
+        input: [
+          { content: "Run OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED.", role: "user" },
+          outputFor("wrong-call-id", "not a write result"),
+        ],
+        tools: editRecoveryTools,
+      });
+      expect(malformedPrefix.body.output?.[0]?.content?.[0]?.text).toContain(
+        "OPENCLAW_E2E_EDIT_FAILURE_FIXTURE_ERROR",
+      );
+
+      const conversation = createEditRecoveryConversation(
+        baseUrl,
+        "OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED",
+      );
+      const seed = await conversation.request();
+      const seedCallId = seed.body.output?.[0]?.call_id;
+      if (typeof seedCallId !== "string") {
+        throw new Error("malformed edit recovery seed response omitted call_id");
+      }
+      const malformedOutcome = await postResponses(baseUrl, {
+        input: [
+          { content: "Run OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED.", role: "user" },
+          outputFor(seedCallId, "not a write result"),
+        ],
+        tools: editRecoveryTools,
+      });
+      expect(malformedOutcome.body.output?.[0]?.content?.[0]?.text).toContain(
+        "OPENCLAW_E2E_EDIT_FAILURE_FIXTURE_ERROR",
+      );
+    });
+  });
+
   it("echoes dynamic OpenClaw E2E markers", async () => {
     await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
       for (const marker of ["OPENCLAW_E2E_SEED_0_123", "OPENCLAW_E2E_ANDROID_OK"]) {


### PR DESCRIPTION
## Problem

After a mutating tool failure recovered on retry, channels suppressed the stale failure but gave users no confirmation that the retry succeeded.

## Root cause

The attempt owner retained only unresolved errors. It could not represent a recovered mutation independently, so terminal payload assembly lost the receipt—especially when another mutation remained unresolved or failed later. The lifecycle classifier also omitted recovery-only output when deciding whether an attempt had terminal state.

## Fix

- retain one attempt-local recovery event, bound to the exact mutation identities recovered by that tool call
- preserve it through unrelated later outcomes; invalidate only identities that fail again
- emit a tool-name-only `succeeded after retry` receipt; never expose raw errors or paths
- treat recovery as terminal output and preserve structured heartbeat replies while appending its receipt
- add deterministic edit-failure/retry mock-provider scenarios plus real Gateway → `qa-channel` proof, reusable by Telegram E2E

## Maintainer decision

Ayaan approved the tested receipt model by directing this issue be handled as an OpenClaw bug-fix PR with final user-visible Telegram proof. A recovered retry emits its separate concise receipt even when an unrelated mutation remains unresolved; terminal delivery preserves both facts.

## Proof

- original red on `816ae22921f`: edit failure → matching write success expected recovery, received `undefined`; no-prose attempt expected terminal output, received `false`
- ordering red: recovery A → unrelated failure B expected both facts, received only B; covered again for same-action invalidation, later recovery replacement, and multi-target recovery
- heartbeat red: expected `HEARTBEAT_OK` plus recovery receipt, received only `HEARTBEAT_OK`
- mixed-outcome red: A failed, B failed, then B recovered; expected B recovery alongside A error, received no recovery
- settlement integration red from CI: `TypeError: getLastToolRecovery is not a function`; fixture repaired at its typed owner
- lifecycle red: recovery-only length terminal classified `incompleteTerminalAssistant: true`; green now preserves it as terminal output
- green focused Vitest: 16 files, 475 tests passed
- product proof: 1/1 passed through mock OpenAI provider → real Gateway child → `qa-channel`; delivered `✅ 📝 Edit succeeded after retry.` with no fixture path/raw error leak
- `pnpm tsgo`; `pnpm check:test-types`; `pnpm build`
- Oxfmt, type-aware Oxlint, `git diff --check`, and `node --check` passed across all 25 changed files
- Distill and Greybeard: PASS
- exact-head CI: green after rerunning GitHub `429 Too Many Requests` bootstrap failures; relevant CodeQL, lint, production types, test types, build, and changed-path tests passed on `21baa98668a5f2b2d5e4c3bfc49e4f8c066b2c79`
- exact-head ClawSweeper: PASS; 0 findings, 0 security concerns, no maintainer decision, 0 Rank-up moves

Production delta: +108/-28 (net +80). Test and test-support delta: +715/-7. Production growth is the owner-bound identity state needed to preserve recovery across independent and multi-target mutations; no provider/channel special case or parallel runtime path.

## Final Telegram Desktop transcript

Exact head `21baa98668a5f2b2d5e4c3bfc49e4f8c066b2c79`, real Telegram userbot, streaming disabled, run after the zero-move ClawSweeper gate:

- unresolved scenario: `OPENCLAW_E2E_EDIT_FAILURE_UNRESOLVED_FINAL`, then `⚠️ 📝 Edit failed`; the raw edit failure reason and fixture path were not disclosed
- matched-retry scenario: `OPENCLAW_E2E_EDIT_FAILURE_MATCHED_RETRY_FINAL`, then `✅ 📝 Edit succeeded after retry.`; no stale failure warning
- provider evidence: write `before\n` (`call_mock_write_f2690b0756`), failing edit of `absent\n` (`call_mock_edit_a9875977fa`), successful same-path edit of `before\n` (`call_mock_edit_53b5e0cab0`)
- side effects: two new SUT messages per scenario; zero edits, deletions, reactions, or typing events
- cleanup: both temporary OpenClaw workspaces removed after exit

## Freshness

GitHub may report this head `BEHIND`. Per `openclaw-fast-lane.md`: “BEHIND merges; main moves about every four minutes. Rebase only CONFLICTING.” Exact-head local proof above ran after the final code change at `21baa98668a5f2b2d5e4c3bfc49e4f8c066b2c79`; no rebase requested for freshness-only drift.

Addresses the retry-confirmation half of #46548. The separate failure-reason disclosure policy remains open.
