### PR TITLE
fix(ui): load earlier history into underfilled transcripts

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -498,7 +498,6 @@ suite.define(() => {
       expect(returnedSamples.every((sample) => sample.minOpacity === 1)).toBe(true);
       expect(returnedSamples.every((sample) => !sample.hiddenNotice)).toBe(true);
       expect(returnedSamples.every((sample) => !sample.loading)).toBe(true);
-      expect(await page.getByRole("button", { name: "Load older" }).count()).toBe(0);
       await expectRequestCountStable(gateway, "chat.history", historyRequestsBeforeReturn);
       if (artifactDir) {
         await page.screenshot({

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -661,6 +661,156 @@ suite.define(() => {
     await page.close();
   });
 
+  it("auto-pages an underfilled native transcript until it becomes scrollable", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await fs.mkdir(artifactDir, { recursive: true });
+    }
+    const viewport = { width: 1280, height: 900 };
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport,
+      ...(artifactDir ? { recordVideo: { dir: artifactDir, size: viewport } } : {}),
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const historyMessage = (seq: number, role: "assistant" | "user", text: string) => ({
+      __openclaw: { seq },
+      content: [{ type: role === "assistant" ? "output_text" : "input_text", text }],
+      role,
+      timestamp: 1_800_000_000_000 + seq,
+    });
+    const recent = [
+      historyMessage(21, "user", "Recent question"),
+      historyMessage(22, "assistant", "Recent answer"),
+    ];
+    // Consecutive assistant records collapse into one rendered group, so this
+    // page advances the raw offset without filling the real transcript viewport.
+    const firstOlderPage = Array.from({ length: 4 }, (_, index) =>
+      historyMessage(index + 17, "assistant", `Short older answer ${index + 17}`),
+    );
+    const secondOlderPage = Array.from({ length: 16 }, (_, index) => {
+      const seq = index + 1;
+      const role = seq % 2 === 0 ? "assistant" : "user";
+      return historyMessage(
+        seq,
+        role,
+        `Scrollable older ${role} message ${seq}\n${"Transcript detail line\n".repeat(3)}`,
+      );
+    });
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["chat.history"],
+      featureMethods: ["chat.metadata", "chat.startup"],
+      methodResponses: {
+        "chat.startup": {
+          messages: recent,
+          hasMore: true,
+          nextOffset: 2,
+          totalMessages: 30,
+          sessionId: "native-underfill-pagination",
+          thinkingLevel: null,
+        },
+        "chat.history": {
+          cases: [
+            {
+              match: { offset: 2 },
+              response: {
+                messages: firstOlderPage,
+                hasMore: true,
+                nextOffset: 6,
+                totalMessages: 30,
+                sessionId: "native-underfill-pagination",
+                thinkingLevel: null,
+              },
+            },
+            {
+              match: { offset: 6 },
+              response: {
+                messages: secondOlderPage,
+                hasMore: true,
+                nextOffset: 22,
+                totalMessages: 30,
+                sessionId: "native-underfill-pagination",
+                thinkingLevel: null,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const thread = pane.locator(".chat-thread");
+      await page.getByText("Recent answer", { exact: true }).waitFor();
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("chat.history")).map(
+            (request) => (request.params as { offset?: number } | undefined)?.offset,
+          ),
+        )
+        .toEqual([2]);
+      await pane.locator(".chat-history-loading").waitFor();
+      expect(await thread.evaluate((element) => element.scrollHeight <= element.clientHeight)).toBe(
+        true,
+      );
+      if (artifactDir) {
+        await page.screenshot({
+          path: path.join(artifactDir, "00-native-history-initial-underfill-loading.png"),
+          fullPage: true,
+        });
+      }
+
+      await gateway.deferNext("chat.history", { offset: 6 });
+      await gateway.resolveDeferred("chat.history");
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("chat.history")).map(
+            (request) => (request.params as { offset?: number } | undefined)?.offset,
+          ),
+        )
+        .toEqual([2, 6]);
+      await pane.locator(".chat-history-loading").waitFor();
+      expect(await thread.evaluate((element) => element.scrollHeight <= element.clientHeight)).toBe(
+        true,
+      );
+      if (artifactDir) {
+        await page.screenshot({
+          path: path.join(artifactDir, "01-native-history-continued-auto-load.png"),
+          fullPage: true,
+        });
+      }
+
+      await gateway.resolveDeferred("chat.history");
+      await expect
+        .poll(() => thread.evaluate((element) => element.scrollHeight > element.clientHeight))
+        .toBe(true);
+      await expect.poll(() => pane.locator(".chat-history-loading").count()).toBe(0);
+      expect(await pane.locator(".chat-history-sentinel").count()).toBe(1);
+      if (artifactDir) {
+        await page.screenshot({
+          path: path.join(artifactDir, "02-native-history-final-scrollable.png"),
+          fullPage: true,
+        });
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(
+        (await gateway.getRequests("chat.history")).map(
+          (request) => (request.params as { offset?: number } | undefined)?.offset,
+        ),
+      ).toEqual([2, 6]);
+    } finally {
+      await suite.closeBrowserContext(context);
+      if (artifactDir && proofVideo) {
+        await proofVideo.saveAs(path.join(artifactDir, "native-history-auto-pagination.webm"));
+      }
+    }
+  });
+
   it("shows loaded native history before fetching and revealing an earlier page", async () => {
     const page = await suite.browser.newPage({ viewport: { width: 1280, height: 800 } });
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -373,7 +373,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected historyObserverBootstrap = false;
   protected historyObserverArmed = false;
   protected historyAutoLoadBlocked = false;
-  protected historyBootstrapPagesLoaded = 0;
   protected historyIntentConsumed = false;
   protected historyIntentTimer: number | null = null;
   protected historyTouchY: number | null = null;

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -471,52 +471,6 @@ describe("chat pane native history pagination", () => {
     expect(pane.historyAutoLoadBlocked).toBe(false);
   });
 
-  it("stops non-scrollable bootstrap after one older page", async () => {
-    const request = vi.fn(async () => ({
-      messages: [nativeHistoryMessage(3), nativeHistoryMessage(4)],
-      hasMore: true,
-      nextOffset: 4,
-      totalMessages: 6,
-    }));
-    const client = { request } as unknown as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    state.chatMessages = [nativeHistoryMessage(5), nativeHistoryMessage(6)];
-    state.chatHistoryPagination = { hasMore: true, nextOffset: 2, totalMessages: 6 };
-    const thread = document.createElement("div");
-    thread.className = "chat-thread";
-    Object.defineProperty(thread, "scrollHeight", { value: 100 });
-    Object.defineProperty(thread, "clientHeight", { value: 200 });
-    const sentinel = document.createElement("div");
-    sentinel.className = "chat-history-sentinel";
-    thread.append(sentinel);
-    pane.append(thread);
-    class FakeIntersectionObserver {
-      constructor(private readonly callback: IntersectionObserverCallback) {}
-      disconnect() {}
-      observe() {
-        this.callback(
-          [{ isIntersecting: true } as IntersectionObserverEntry],
-          this as unknown as IntersectionObserver,
-        );
-      }
-    }
-    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
-    try {
-      pane.syncHistoryObserver();
-      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-      await vi.waitFor(() =>
-        expect(state.chatMessages.map(nativeHistorySeq)).toEqual([3, 4, 5, 6]),
-      );
-
-      pane.syncHistoryObserver();
-
-      expect(request).toHaveBeenCalledOnce();
-      expect(pane.historyAutoLoadBlocked).toBe(true);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
   it("reuses an unchanged armed history observer across pane updates", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -28,7 +28,6 @@ import {
 } from "./chat-history.ts";
 import { ChatPaneReplyNavigation } from "./chat-pane-reply-navigation.ts";
 import {
-  CHAT_HISTORY_BOOTSTRAP_PAGE_LIMIT,
   CHAT_HISTORY_INTENT_EDGE_PX,
   CHAT_HISTORY_INTENT_IDLE_MS,
   CHAT_HISTORY_TOUCH_INTENT_PX,
@@ -66,7 +65,6 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
     this.loadingOlder = false;
     this.historyObserverArmed = false;
     this.historyAutoLoadBlocked = false;
-    this.historyBootstrapPagesLoaded = 0;
     this.historyIntentConsumed = false;
     this.historyTouchY = null;
     if (this.historyIntentTimer !== null) {
@@ -114,10 +112,7 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
     }
     this.transcriptScrollTop ??= root.scrollTop;
     const threadIsScrollable = root.scrollHeight > root.clientHeight;
-    const bootstrap =
-      !this.historyObserverArmed &&
-      !threadIsScrollable &&
-      this.historyBootstrapPagesLoaded < CHAT_HISTORY_BOOTSTRAP_PAGE_LIMIT;
+    const bootstrap = !this.historyObserverArmed && !threadIsScrollable;
     if (this.historyAutoLoadBlocked) {
       this.clearHistoryObserver();
       return;
@@ -143,9 +138,6 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           this.historyObserverArmed = false;
-          if (bootstrap) {
-            this.historyBootstrapPagesLoaded += 1;
-          }
           void this.loadOlderMessages();
         }
       },

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -397,7 +397,6 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       this.catalogCursor = undefined;
       this.olderCursorsSeen.clear();
       this.historyObserverArmed = false;
-      this.historyBootstrapPagesLoaded = 0;
       this.transcriptScrollTop = null;
       this.historyObserver?.disconnect();
       this.historyObserver = null;

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -238,9 +238,6 @@ export const CHAT_AUTOTYPE_EXEMPT_SELECTOR =
 export const CHAT_SPACE_ACTIVATION_SELECTOR =
   "a[href], button, summary, [role='button'], [role='checkbox'], [role='link'], [role='radio'], [role='switch']";
 export const CHAT_MODAL_SELECTOR = "dialog[open], [aria-modal='true']";
-// One automatic page can fill a short initial tail without serially walking a
-// collapsed or sparse transcript to exhaustion.
-export const CHAT_HISTORY_BOOTSTRAP_PAGE_LIMIT = 1;
 
 export const NEW_SESSION_ACTIVE_RUN_MESSAGE =
   "Start a new session after the active run or queued messages finish.";


### PR DESCRIPTION
Related: #110771

## What Problem This Solves

Fixes an issue where opening a paginated Control UI session could leave most of the transcript viewport empty when projection collapsed the first older page. Earlier history remained stranded behind the manual **Show earlier** action even though the visible pane still had room to display it.

## Why This Change Was Made

The transcript now keeps observing its earlier-history sentinel after each successful page while the rendered pane is still shorter than its viewport. It stops as soon as the transcript becomes scrollable, history is exhausted, or a request fails, while preserving the existing scroll-to-top intent gate, single-flight loading, cursor progress checks, viewport anchoring, and manual retry path.

The obsolete one-page bootstrap counter and its lifecycle state were deleted rather than replaced with another limit.

## User Impact

Opening a clipped session now fills the visible transcript automatically. Scrolling a longer session to the top continues to load earlier history automatically, without requiring repeated clicks on **Show earlier**.

## Evidence

- Pre-fix Chromium regression: expected pagination offsets `[2, 6]`, but only `[2]` was requested; the second page never loaded.
- Focused Chromium E2E: underfilled transcript loaded offsets `2` and `6` without click, wheel, keyboard, touch, or synthetic scroll, then made no third request after the transcript became scrollable.
- Existing scroll-to-top/anchor E2E passed.
- `ui/src/pages/chat/chat-pane-history.test.ts`: 25/25 passed.
- AWS Crabbox changed gate: `run_7e64a9f50e40` on `cbx_8273c2236521`, exit 0 (`coreTests`, `ui`).
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +1/-14 (net -13). Tests: +150/-47.

### Initial underfilled viewport

![Initial underfilled transcript viewport while earlier history loads](https://github.com/user-attachments/assets/5fd697a8-21f1-4d52-8452-4a7c38e14c77)

### Continued automatic loading

![Transcript continuing to load earlier history automatically](https://github.com/user-attachments/assets/25a6fb3d-a939-46c2-baa7-b5957a05c549)

### Final scrollable transcript

![Final scrollable transcript after automatic history pagination](https://github.com/user-attachments/assets/b2e0c6e9-9c9e-411a-ba76-8da643ebb09e)

AI-assisted; the implementation and proof were reviewed against the owning transcript pagination and virtualization boundaries.
