### PR TITLE
fix(onepassword): explain untrusted CLI paths

### DIFF
--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -106,7 +106,10 @@ Before apply, status can report that the provider itself is not configured yet;
 `prerequisites ready: yes` confirms that the trusted `op` executable and an
 accepted non-empty token file are ready. After apply, `ready: yes` confirms both the
 provider wiring and prerequisites. Missing or unsafe prerequisites produce
-actionable next steps without printing the token or raw resolver errors.
+actionable next steps without printing token or secret values. An unsafe `op`
+executable also reports the redacted, plugin-owned path-validation error so
+ownership and write-access problems can be repaired directly. Unexpected
+resolver errors remain hidden.
 
 Manual provider configuration uses the existing plugin id:
 

--- a/extensions/onepassword/onepassword-op-path.d.ts
+++ b/extensions/onepassword/onepassword-op-path.d.ts
@@ -1,3 +1,5 @@
+export class OnePasswordCliPathTrustError extends Error {}
+
 export function resolveTrustedOnePasswordCli(options?: {
   configuredPath?: string;
   pathEnv?: string;

--- a/extensions/onepassword/onepassword-op-path.js
+++ b/extensions/onepassword/onepassword-op-path.js
@@ -7,6 +7,8 @@ function errorCode(error) {
 
 const resolveTrustedExecutablePath = pluginSecretRefSetup.resolveTrustedExecutablePath;
 
+export class OnePasswordCliPathTrustError extends Error {}
+
 export async function resolveTrustedOnePasswordCli(options = {}) {
   const configuredPath = options.configuredPath?.trim();
   if (configuredPath && !path.isAbsolute(configuredPath)) {
@@ -27,7 +29,7 @@ export async function resolveTrustedOnePasswordCli(options = {}) {
       if (errorCode(error) === "ENOENT" || errorCode(error) === "ENOTDIR") {
         continue;
       }
-      unsafeError = new Error(
+      unsafeError = new OnePasswordCliPathTrustError(
         `Refusing unsafe 1Password CLI path "${candidate}": ${error instanceof Error ? error.message : String(error)}`,
         { cause: error },
       );

--- a/extensions/onepassword/onepassword-op-path.js
+++ b/extensions/onepassword/onepassword-op-path.js
@@ -5,7 +5,7 @@ function errorCode(error) {
   return error && typeof error === "object" && "code" in error ? error.code : undefined;
 }
 
-const resolveTrustedExecutablePath = pluginSecretRefSetup.resolveTrustedExecutablePath;
+const { isTrustedPathPolicyError, resolveTrustedExecutablePath } = pluginSecretRefSetup;
 
 export class OnePasswordCliPathTrustError extends Error {}
 
@@ -28,6 +28,9 @@ export async function resolveTrustedOnePasswordCli(options = {}) {
     } catch (error) {
       if (errorCode(error) === "ENOENT" || errorCode(error) === "ENOTDIR") {
         continue;
+      }
+      if (!isTrustedPathPolicyError(error)) {
+        throw error;
       }
       unsafeError = new OnePasswordCliPathTrustError(
         `Refusing unsafe 1Password CLI path "${candidate}": ${error instanceof Error ? error.message : String(error)}`,

--- a/extensions/onepassword/src/secret-ref-cli.test.ts
+++ b/extensions/onepassword/src/secret-ref-cli.test.ts
@@ -21,14 +21,17 @@ function captureStdout() {
   return () => output;
 }
 
-function createProgram(config: OpenClawConfig = {}): Command {
+function createProgram(
+  config: OpenClawConfig = {},
+  options: { env?: NodeJS.ProcessEnv; tokenFile?: string } = {},
+): Command {
   const program = new Command().exitOverride();
   const onepassword = program.command("onepassword");
   registerOnePasswordSecretRefCommands({
     command: onepassword,
     config,
-    tokenFile: path.join(os.tmpdir(), "openclaw-onepassword-missing-token"),
-    env: { PATH: "" },
+    tokenFile: options.tokenFile ?? path.join(os.tmpdir(), "openclaw-onepassword-missing-token"),
+    env: options.env ?? { PATH: "" },
   });
   return program;
 }
@@ -258,6 +261,7 @@ describe("1Password readiness", () => {
     ).resolves.toEqual({
       opCommand: "/trusted/op",
       opBinaryPath: "/trusted/op",
+      opError: null,
       opStatus: "ready",
       tokenFile: "/state/credentials/onepassword/service-account-token",
       tokenFileStatus: "ready",
@@ -288,6 +292,7 @@ describe("1Password readiness", () => {
     ).resolves.toEqual({
       opCommand: "op",
       opBinaryPath: null,
+      opError: null,
       opStatus: "untrusted",
       tokenFile: "/missing-token",
       tokenFileStatus: "missing-or-unsafe",
@@ -297,6 +302,31 @@ describe("1Password readiness", () => {
 });
 
 describe("1Password CLI status", () => {
+  it.skipIf(process.platform === "win32")(
+    "explains why a discovered op executable is untrusted",
+    async () => {
+      const tempDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-op-untrusted-")),
+      );
+      const executable = path.join(tempDir, "op");
+      const output = captureStdout();
+      try {
+        await fs.writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+        await fs.chmod(tempDir, 0o777);
+        await createProgram({}, { env: { PATH: tempDir } }).parseAsync(
+          ["onepassword", "secretref", "status"],
+          { from: "user" },
+        );
+        expect(output().split("\n")).toContain(
+          `op error: Refusing unsafe 1Password CLI path "${executable}": path is writable by another user: ${tempDir}`,
+        );
+      } finally {
+        await fs.chmod(tempDir, 0o700);
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("discovers a configured custom provider alias", async () => {
     const result = await runStatus({
       secrets: {

--- a/extensions/onepassword/src/secret-ref-cli.test.ts
+++ b/extensions/onepassword/src/secret-ref-cli.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { encodeOnePasswordSecretId } from "../onepassword-secret-id.js";
 import { registerOnePasswordSecretRefCommands, testing } from "./secret-ref-cli.js";
@@ -11,6 +12,8 @@ type OnePasswordPlan = {
   providerUpserts: Record<string, unknown>;
   targets: Array<Record<string, unknown>>;
 };
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function captureStdout() {
   let output = "";
@@ -305,9 +308,7 @@ describe("1Password CLI status", () => {
   it.skipIf(process.platform === "win32")(
     "explains why a discovered op executable is untrusted",
     async () => {
-      const tempDir = await fs.realpath(
-        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-op-untrusted-")),
-      );
+      const tempDir = await fs.realpath(tempDirs.make("openclaw-op-untrusted-", os.tmpdir()));
       const executable = path.join(tempDir, "op");
       const output = captureStdout();
       try {
@@ -322,8 +323,24 @@ describe("1Password CLI status", () => {
         );
       } finally {
         await fs.chmod(tempDir, 0o700);
-        await fs.rm(tempDir, { recursive: true, force: true });
       }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does not expose unexpected executable-resolution errors",
+    async () => {
+      const output = captureStdout();
+      const overlongDirectory = `/${"a".repeat(4096)}`;
+
+      await createProgram({}, { env: { PATH: overlongDirectory } }).parseAsync(
+        ["onepassword", "secretref", "status"],
+        { from: "user" },
+      );
+
+      expect(output()).toContain("op status: untrusted\n");
+      expect(output()).not.toContain("op error:");
+      expect(output()).not.toContain("ENAMETOOLONG");
     },
   );
 

--- a/extensions/onepassword/src/secret-ref-cli.ts
+++ b/extensions/onepassword/src/secret-ref-cli.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import {
   DEFAULT_SECRET_FILE_MAX_BYTES,
@@ -8,7 +9,10 @@ import {
 import { createPluginSecretRefSetupCli } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { resolveTrustedOnePasswordCli } from "../onepassword-op-path.js";
+import {
+  OnePasswordCliPathTrustError,
+  resolveTrustedOnePasswordCli,
+} from "../onepassword-op-path.js";
 import { encodeOnePasswordSecretId } from "../onepassword-secret-id.js";
 
 const ONEPASSWORD_PROVIDER_ALIAS = "onepassword";
@@ -58,6 +62,7 @@ type StatusOptions = {
 type SecretRefReadiness = {
   opCommand: string;
   opBinaryPath: string | null;
+  opError: string | null;
   opStatus: "ready" | "not-found" | "untrusted";
   tokenFile: string;
   tokenFileStatus: "ready" | "missing-or-unsafe";
@@ -92,7 +97,7 @@ async function inspectSecretRefReadiness(
       }));
   const configuredOpCommand = normalizeOptionalString(params.env.CLAW_1PASSWORD_OP);
   const opCommand = configuredOpCommand ?? "op";
-  const { opBinaryPath, opStatus } = await (async () => {
+  const { opBinaryPath, opError, opStatus } = await (async () => {
     try {
       const resolvedPath =
         (await resolveTrustedCli({
@@ -101,10 +106,16 @@ async function inspectSecretRefReadiness(
         })) ?? null;
       return {
         opBinaryPath: resolvedPath,
+        opError: null,
         opStatus: resolvedPath ? ("ready" as const) : ("not-found" as const),
       };
-    } catch {
-      return { opBinaryPath: null, opStatus: "untrusted" as const };
+    } catch (error) {
+      return {
+        opBinaryPath: null,
+        opError:
+          error instanceof OnePasswordCliPathTrustError ? formatErrorMessage(error.message) : null,
+        opStatus: "untrusted" as const,
+      };
     }
   })();
 
@@ -118,6 +129,7 @@ async function inspectSecretRefReadiness(
   return {
     opCommand,
     opBinaryPath,
+    opError,
     opStatus,
     tokenFile: params.tokenFile,
     tokenFileStatus,
@@ -172,6 +184,9 @@ async function runStatus(
   }
   writeLine(`op command: ${readiness.opCommand}`);
   writeLine(`op status: ${readiness.opStatus}`);
+  if (readiness.opError) {
+    writeLine(`op error: ${readiness.opError}`);
+  }
   if (readiness.opBinaryPath) {
     writeLine(`op binary: ${readiness.opBinaryPath}`);
   }

--- a/src/plugin-sdk/secret-ref-runtime.ts
+++ b/src/plugin-sdk/secret-ref-runtime.ts
@@ -17,6 +17,7 @@ import {
 import { createPrivateWindowsPlanFile } from "../secrets/private-plan-file.js";
 import { resolveSecretPlanTargetByPathCore } from "../secrets/target-registry-query.js";
 import {
+  isTrustedPathPolicyError,
   resolveTrustedExecutablePath,
   resolveTrustedPlanDirectoryPath,
 } from "../secrets/trusted-plan-path.js";
@@ -439,6 +440,7 @@ export const pluginSecretRefSetup = {
   assertValidProviderAlias: assertValidPluginSecretProviderAlias,
   buildPlan: buildPluginSecretRefSetupPlan,
   parseTargetSpecifier: parsePluginSecretTargetSpecifier,
+  isTrustedPathPolicyError,
   resolveTrustedDirectoryPath: resolveTrustedPlanDirectoryPath,
   resolveTrustedExecutablePath,
   writePlanFile: writeSecretPlanFile,

--- a/src/secrets/trusted-plan-path.ts
+++ b/src/secrets/trusted-plan-path.ts
@@ -6,6 +6,17 @@ import { trustedPlanPathPolicy } from "./trusted-plan-path-policy.js";
 
 const { isSafeWindowsDirectoryAclSummary, isTrustedOwner } = trustedPlanPathPolicy;
 
+class TrustedPathPolicyError extends Error {}
+
+// Callers may expose only producer-authored policy failures; raw filesystem errors stay opaque.
+export function isTrustedPathPolicyError(error: unknown): boolean {
+  return error instanceof TrustedPathPolicyError;
+}
+
+function rejectPathPolicy(message: string): never {
+  throw new TrustedPathPolicyError(message);
+}
+
 async function readShebangInterpreter(targetPath: string): Promise<string | undefined> {
   const handle = await fs.open(targetPath, "r");
   try {
@@ -16,12 +27,12 @@ async function readShebangInterpreter(targetPath: string): Promise<string | unde
     }
     const newline = buffer.indexOf(0x0a, 2);
     if (newline < 0) {
-      throw new Error(`script interpreter line is too long: ${targetPath}`);
+      rejectPathPolicy(`script interpreter line is too long: ${targetPath}`);
     }
     const line = buffer.subarray(2, newline).toString("utf8").trim();
     const interpreter = line.split(/\s+/u, 1)[0];
     if (!interpreter || !path.isAbsolute(interpreter)) {
-      throw new Error(`script interpreter must be an absolute path: ${targetPath}`);
+      rejectPathPolicy(`script interpreter must be an absolute path: ${targetPath}`);
     }
     return interpreter;
   } finally {
@@ -45,7 +56,7 @@ async function assertTrustedPathChain(
     ]);
     const after = await fs.lstat(currentPath);
     if (!stat.ok || !permissions.ok || permissions.source === "unknown") {
-      throw new Error(`permissions could not be verified: ${currentPath}`);
+      rejectPathPolicy(`permissions could not be verified: ${currentPath}`);
     }
     if (
       before.isSymbolicLink() ||
@@ -55,18 +66,18 @@ async function assertTrustedPathChain(
       before.dev !== after.dev ||
       before.ino !== after.ino
     ) {
-      throw new Error(`path changed during permission verification: ${currentPath}`);
+      rejectPathPolicy(`path changed during permission verification: ${currentPath}`);
     }
     const expectedDirectory = !first || targetType === "directory";
     if (stat.isDir !== expectedDirectory) {
-      throw new Error(`unexpected path type: ${currentPath}`);
+      rejectPathPolicy(`unexpected path type: ${currentPath}`);
     }
     // TrustedInstaller legitimately owns Windows system paths. Targets remain strict unless a
     // caller validates a pinned system executable through the dedicated resolver below.
     const allowWindowsTrustedInstaller =
       !first || (first && options.allowWindowsTargetTrustedInstaller === true);
     if (!isTrustedOwner(stat, permissions, process.platform, allowWindowsTrustedInstaller)) {
-      throw new Error(`path is not owned by the current user or root: ${currentPath}`);
+      rejectPathPolicy(`path is not owned by the current user or root: ${currentPath}`);
     }
     const stickyDirectory =
       stat.isDir && permissions.mode != null && (permissions.mode & 0o1000) !== 0;
@@ -81,7 +92,7 @@ async function assertTrustedPathChain(
       // Windows directories commonly allow adding new children or carry inherit-only full
       // control for each child's eventual owner. Executable parents reject child creation.
       if (!safeWindowsDirectory) {
-        throw new Error(`path is writable by another user: ${currentPath}`);
+        rejectPathPolicy(`path is writable by another user: ${currentPath}`);
       }
     }
     validatedEntries.push({ path: currentPath, dev: after.dev, ino: after.ino });
@@ -97,7 +108,7 @@ async function assertTrustedPathChain(
   for (const entry of validatedEntries.toReversed()) {
     const current = await fs.lstat(entry.path);
     if (current.isSymbolicLink() || current.dev !== entry.dev || current.ino !== entry.ino) {
-      throw new Error(`path changed after permission verification: ${entry.path}`);
+      rejectPathPolicy(`path changed after permission verification: ${entry.path}`);
     }
   }
 }
@@ -110,26 +121,26 @@ async function assertTrustedPath(
   const resolvedPath = await fs.realpath(targetPath);
   const targetStat = await fs.stat(resolvedPath);
   if (!targetStat.isFile()) {
-    throw new Error(`path is not a regular file: ${resolvedPath}`);
+    rejectPathPolicy(`path is not a regular file: ${resolvedPath}`);
   }
   await fs.access(resolvedPath, fsSync.constants.X_OK);
   await assertTrustedPathChain(resolvedPath, "file", options);
   if (process.platform === "win32" && path.extname(resolvedPath).toLowerCase() !== ".exe") {
-    throw new Error(`Windows executable must be an .exe file: ${resolvedPath}`);
+    rejectPathPolicy(`Windows executable must be an .exe file: ${resolvedPath}`);
   }
   const interpreter = await readShebangInterpreter(resolvedPath);
   if (interpreter) {
     if (validatedScripts.has(resolvedPath)) {
-      throw new Error(`script interpreter cycle detected: ${resolvedPath}`);
+      rejectPathPolicy(`script interpreter cycle detected: ${resolvedPath}`);
     }
     validatedScripts.add(resolvedPath);
     if (path.basename(interpreter).toLowerCase() === "env") {
-      throw new Error(`script interpreter may not use env indirection: ${resolvedPath}`);
+      rejectPathPolicy(`script interpreter may not use env indirection: ${resolvedPath}`);
     }
     const resolvedInterpreter = await assertTrustedPath(interpreter, validatedScripts);
     // The kernel launches the literal shebang path, so aliases cannot use an unverified link.
     if (resolvedInterpreter !== interpreter) {
-      throw new Error(`script interpreter path must be canonical: ${interpreter}`);
+      rejectPathPolicy(`script interpreter path must be canonical: ${interpreter}`);
     }
   }
   return resolvedPath;
@@ -137,7 +148,7 @@ async function assertTrustedPath(
 
 export async function resolveTrustedExecutablePath(targetPath: string): Promise<string> {
   if (!path.isAbsolute(targetPath)) {
-    throw new Error(`Executable path must be absolute: ${targetPath}`);
+    rejectPathPolicy(`Executable path must be absolute: ${targetPath}`);
   }
   return await assertTrustedPath(targetPath);
 }
@@ -146,7 +157,7 @@ export async function resolveTrustedWindowsSystemExecutablePath(
   targetPath: string,
 ): Promise<string> {
   if (!path.isAbsolute(targetPath)) {
-    throw new Error(`Executable path must be absolute: ${targetPath}`);
+    rejectPathPolicy(`Executable path must be absolute: ${targetPath}`);
   }
   return await assertTrustedPath(targetPath, new Set(), {
     allowWindowsTargetTrustedInstaller: true,
@@ -155,7 +166,7 @@ export async function resolveTrustedWindowsSystemExecutablePath(
 
 export async function resolveTrustedPlanDirectoryPath(targetPath: string): Promise<string> {
   if (!path.isAbsolute(targetPath)) {
-    throw new Error(`Directory path must be absolute: ${targetPath}`);
+    rejectPathPolicy(`Directory path must be absolute: ${targetPath}`);
   }
   const resolvedPath = await fs.realpath(targetPath);
   await assertTrustedPathChain(resolvedPath, "directory");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running OpenClaw under a limited macOS account would see only `op status: untrusted` when the discovered 1Password CLI was owned by another local user, such as an administrator-owned Homebrew installation. The status output hid the exact ownership or write-access failure needed to repair the setup.

## Why This Change Was Made

The existing executable trust policy remains unchanged and fail-closed. The 1Password plugin now gives its unsafe-path wrapper a dedicated error type and exposes only that plugin-owned, redacted diagnostic from `secretref status`; arbitrary resolver failures remain hidden.

This keeps the original no-secret-output contract while making the common multi-user Homebrew failure actionable. It does not add a managed CLI copy/install path or weaken trust for code-signed/admin-owned executables.

## User Impact

Operators now see the rejected `op` candidate and the exact unsafe path component, for example an owner mismatch or group/other-writable directory, alongside `op status: untrusted`. They can repair or copy the executable to a path controlled by the OpenClaw user without guessing why trust validation failed.

## Evidence

### Proof

| Before | After |
| --- | --- |
| `secretref status` reports only `untrusted` | `secretref status` identifies the unsafe path and ownership failure |
| ![Before: SecretRef status reports only that the 1Password CLI is untrusted](https://github.com/user-attachments/assets/d81164c1-6791-45a2-88c0-5f1634be37e2) | ![After: SecretRef status identifies the unsafe 1Password CLI path and ownership failure](https://github.com/user-attachments/assets/566eb4dc-a183-4b48-a9e2-c58313f11137) |

### Validation

- Regression test exercises the real `onepassword secretref status` boundary with a discovered executable under a world-writable directory. It failed before the production change because output stopped at `op status: untrusted`, and now asserts the complete single diagnostic line.
- Unexpected injected resolver errors remain absent from readiness output.
- `node scripts/run-vitest.mjs extensions/onepassword/src/secret-ref-cli.test.ts extensions/onepassword/src/op-path.test.ts` — 26 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` — passed, including production/test typechecks, lint, docs formatting, plugin boundaries, dead-export scan, and policy guards.
- `pnpm lint:docs docs/plugins/onepassword.md` — passed with 0 issues.
- TruffleHog scan from autoreview — clean. The Codex review stage was attempted twice but could not run because the workspace reported that it was out of credits.

Production delta: +24/-5 lines (net +19). The growth establishes the typed plugin diagnostic boundary and carries it through the public status result; tests are +33/-3 and docs are +4/-1.

No exact duplicate issue or PR was found. Related #119925 and #118926 cover generic exec-provider Homebrew symlink behavior, not cross-user ownership or the 1Password status diagnostic.

## AI Assistance

This PR was prepared with assistance from OpenAI Codex using GPT-5.6 (model identifier `gpt-5.6-sol`). The author reviewed the implementation and validation evidence.
