### PR TITLE
fix: show startup progress after new-session navigation

### DIFF
--- a/src/gateway/chat-abort.snapshot-budget.test.ts
+++ b/src/gateway/chat-abort.snapshot-budget.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { boundInFlightRunSnapshotForChatHistory } from "./chat-abort.js";
+
+describe("boundInFlightRunSnapshotForChatHistory phase priority", () => {
+  it("keeps recorded progress ahead of a startup phase under a tight byte cap", () => {
+    const event = {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool" as const,
+      ts: 1_000,
+      data: { phase: "start", name: "read", toolCallId: "tool-1", args: {} },
+    };
+    const expected = {
+      runId: "run-1",
+      text: "",
+      events: [event],
+    };
+    const messages: unknown[] = [];
+    const maxBytes = jsonUtf8Bytes(messages) + jsonUtf8Bytes(expected);
+
+    const result = boundInFlightRunSnapshotForChatHistory({
+      snapshot: {
+        runId: "run-1",
+        text: "x".repeat(1_000),
+        phase: "waiting_for_response",
+        events: [event],
+      },
+      messages,
+      maxBytes,
+    });
+
+    expect(result).toEqual(expected);
+    expect(result).not.toHaveProperty("phase");
+    expect(jsonUtf8Bytes(messages) + jsonUtf8Bytes(result)).toBeLessThanOrEqual(maxBytes);
+  });
+});

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -6,6 +6,7 @@ import {
   resolveDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
+import type { ChatRunStartupPhase } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { OperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
@@ -105,6 +106,7 @@ type InFlightRunSnapshot = {
   runId: string;
   text: string;
   startedAt?: number;
+  phase?: ChatRunStartupPhase;
   plan?: ChatRunPlanSnapshot;
   events?: AgentEventPayload[];
 };
@@ -419,10 +421,12 @@ export function resolveInFlightRunSnapshot(params: {
   );
   const plan = run?.planSnapshot;
   const events = run?.progressSnapshot?.events;
+  const phase = run?.startupPhase;
   return {
     runId: best.runId,
     text: projected.suppress ? "" : projected.text,
     startedAt: best.startedAtMs,
+    ...(phase ? { phase } : {}),
     ...(plan ? { plan } : {}),
     ...(events?.length ? { events } : {}),
   };
@@ -467,6 +471,13 @@ export function boundInFlightRunSnapshotForChatHistory(params: {
         break;
       }
       events.shift();
+    }
+  }
+
+  if (params.snapshot.phase !== undefined) {
+    const candidate = { ...bounded, phase: params.snapshot.phase };
+    if (messagesBytes + jsonUtf8Bytes(candidate) <= params.maxBytes) {
+      bounded = candidate;
     }
   }
 

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -1,3 +1,4 @@
+import type { ChatRunStartupPhase } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { AgentPlanStep } from "../channels/streaming.js";
 // Gateway chat run state registries.
 // Tracks active runs, delta buffers, tool recipients, and session subscribers.
@@ -105,6 +106,8 @@ type ChatRunRecord = {
   bufferProjection?: { source: string; suppress: boolean };
   planSnapshot?: ChatRunPlanSnapshot;
   progressSnapshot?: ChatRunProgressSnapshot;
+  /** Latest pre-output phase; real assistant/tool activity clears it before replay. */
+  startupPhase?: ChatRunStartupPhase;
   /** Last time any buffered assistant text changed, including suppressed raw buffers. */
   bufferUpdatedAt?: number;
   deltaSentAt?: number;
@@ -267,6 +270,7 @@ export function createChatRunState(): ChatRunState {
     delete record.bufferProjection;
     delete record.planSnapshot;
     delete record.progressSnapshot;
+    delete record.startupPhase;
     delete record.bufferUpdatedAt;
     delete record.deltaSentAt;
     delete record.deltaLastBroadcastLen;

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1049,6 +1049,7 @@ export function createAgentEventHandler({
       return;
     }
     const now = Date.now();
+    delete run.startupPhase;
     run.rawBuffer = mergedRawText;
     run.bufferUpdatedAt = now;
     const waitedMs = now - (run.deltaSentAt ?? 0);
@@ -1508,11 +1509,13 @@ export function createAgentEventHandler({
       // Persist the client-facing identity after run/session remapping. Route
       // changes discard transient UI rows, so history replay must use the same
       // payload identity as live delivery or tool results cannot reconcile.
+      delete chatRunState.getOrCreate(clientRunId).startupPhase;
       chatRunState.recordProgressEvent(clientRunId, agentPayload);
     }
     if (evt.stream === "run_status") {
       const phase = readChatRunStartupPhase(evt.data?.phase);
       if (phase && chatLink && isControlUiVisible && sessionKey && !isAborted) {
+        chatRunState.getOrCreate(clientRunId).startupPhase = phase;
         const payload = {
           runId: clientRunId,
           sessionKey,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -897,6 +897,13 @@ describe("gateway server chat", () => {
             progressText: "Autoreview is running",
           },
         });
+        handler({
+          runId: "provider-run",
+          seq: 7,
+          stream: "run_status",
+          ts: 1_007,
+          data: { phase: "starting_model" },
+        });
 
         const responses: Array<{ ok: boolean; payload?: unknown }> = [];
         await callDirectChat(method, {
@@ -914,6 +921,7 @@ describe("gateway server chat", () => {
           runId: "run-active",
           text: "",
           startedAt: 1_000,
+          phase: "starting_model",
           events: [
             {
               runId: "run-active",

--- a/ui/src/components/working-phrase.test.ts
+++ b/ui/src/components/working-phrase.test.ts
@@ -4,7 +4,7 @@ import "./working-phrase.ts";
 
 // Mirrors WORKING_PHRASE_SHOW_AFTER_MS / WORKING_PHRASE_ROTATE_EVERY_MS in
 // working-phrase.ts (knip forbids test-only exports).
-const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
+const WORKING_PHRASE_SHOW_AFTER_MS = 8_000;
 const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
 
 type WorkingPhraseElement = HTMLElement & {

--- a/ui/src/components/working-phrase.ts
+++ b/ui/src/components/working-phrase.ts
@@ -33,7 +33,7 @@ const PHRASE_KEYS = [
 
 /** Quiet grace period before the first phrase appears. Mirrored as literals
  * in working-phrase.test.ts (knip forbids test-only exports). */
-const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
+const WORKING_PHRASE_SHOW_AFTER_MS = 8_000;
 /** How long each phrase holds before rotating to the next. */
 const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
 

--- a/ui/src/components/working-phrase.ts
+++ b/ui/src/components/working-phrase.ts
@@ -1,7 +1,7 @@
 // Whimsical long-wait status word ("Clawing…") for the chat working row.
 // Silent for the first stretch of a run, then rotates through crab-themed
 // gerunds so long quiet runs feel alive without claiming progress data the
-// UI does not have. Decorative only — the row keeps its sr-only "Working…".
+// UI does not have. Decorative only — the row keeps its visible "Working…".
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -134,19 +134,26 @@ suite.define(() => {
     // reading is exactly the fastForward below, not inflated by real time.
     await pauseVirtualClock(currentPage);
     await currentPage.getByRole("button", { name: "Send message" }).click();
-    await gateway.waitForRequest("chat.send");
+    const send = await gateway.waitForRequest("chat.send");
+    const runId = String((send.params as { idempotencyKey?: unknown }).idempotencyKey);
     await currentPage.locator(".chat-working-indicator").waitFor();
+    await currentPage.getByText("Working…", { exact: true }).waitFor();
+    await gateway.emitGatewayEvent("chat", {
+      runId,
+      sessionKey: "main",
+      state: "status",
+      phase: "starting_model",
+    });
 
     await currentPage.clock.fastForward(177_000);
 
     await expect
       .poll(() => currentPage.locator(".chat-working-indicator__elapsed").textContent())
       .toBe("2m 57s");
-    const workingLabel = currentPage.locator(".chat-working-indicator__status > .sr-only");
-    expect(await workingLabel.textContent()).toBe("Working…");
-    expect(
-      await currentPage.locator(".chat-working-indicator__status > span:not(.sr-only)").count(),
-    ).toBe(0);
+    await currentPage.getByText("Waiting for a response…", { exact: true }).waitFor();
+    await expect
+      .poll(() => currentPage.locator("openclaw-working-phrase").textContent())
+      .toMatch(/·\s\S+…/);
   });
 
   it("clears shared session activity when chat final arrives first", async () => {

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -113,11 +113,9 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
 
       await page.getByText("saved 875.3k tokens", { exact: true }).waitFor();
       await page.locator(".chat-working-indicator").waitFor();
-      const workingLabel = page.locator(".chat-working-indicator__status > .sr-only");
+      const workingLabel = page.locator(".chat-working-indicator__status > span");
       expect(await workingLabel.textContent()).toBe("Working…");
-      expect(
-        await page.locator(".chat-working-indicator__status > span:not(.sr-only)").count(),
-      ).toBe(0);
+      expect(await page.locator(".chat-working-indicator__status > .sr-only").count()).toBe(0);
       await page.clock.fastForward(177_000);
       await expect
         .poll(() => page.locator(".chat-working-indicator__elapsed").textContent())

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -102,7 +102,16 @@ suite.define(() => {
       await chatModuleBlocked;
       await route.continue();
     });
+    const createdSessions = createdSessionListResult(SESSION_KEY);
+    for (const session of createdSessions.sessions) {
+      Object.assign(session, {
+        activeRunIds: [RUN_ID],
+        hasActiveRun: true,
+        status: "running",
+      });
+    }
     const gateway = await installMockGateway(page, {
+      inFlightRun: { runId: RUN_ID, text: "", phase: "starting_model" },
       methodResponses: {
         "sessions.create": {
           key: SESSION_KEY,
@@ -110,7 +119,12 @@ suite.define(() => {
           runId: RUN_ID,
           runStarted: true,
         },
-        "sessions.list": createdSessionListResult(SESSION_KEY),
+        "sessions.list": createdSessions,
+      },
+      sessionInfo: {
+        activeRunIds: [RUN_ID],
+        hasActiveRun: true,
+        key: SESSION_KEY,
       },
     });
     try {
@@ -198,6 +212,10 @@ suite.define(() => {
       await gateway.resolveDeferred("chat.startup");
       await waitForCommittedChatRoute(page);
       await page.locator("openclaw-chat-page").waitFor();
+      await captureProof(page, "03-chat-route-ready.png");
+      await expect
+        .poll(() => page.locator(".chat-working-indicator__status").textContent())
+        .toContain("Waiting for a response…");
       await expect
         .poll(() =>
           page.evaluate(
@@ -206,7 +224,6 @@ suite.define(() => {
           ),
         )
         .toBe(true);
-      await captureProof(page, "03-chat-route-ready.png");
     } finally {
       releaseChatModule();
       await context.close();

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -183,6 +183,20 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatStreamStartedAt).toBe(123_456);
   });
 
+  it("restores the active startup phase after navigation misses its live event", async () => {
+    const history = activeHistory("run-reconnected");
+    Object.assign(history.inFlightRun!, { phase: "starting_model" });
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunStartup).toEqual({
+      state: "status",
+      runId: "run-reconnected",
+      phase: "starting_model",
+    });
+  });
+
   it("adopts an active snapshot while binding its durable session identity", async () => {
     const history = activeHistory("run-reconnected");
     history.sessionId = "current-session";

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -283,6 +283,7 @@ export type ChatHistoryResult = {
     runId: string;
     text?: string;
     startedAt?: number;
+    phase?: ChatRunStartupPhase;
     events?: Array<{
       runId: string;
       seq: number;
@@ -1746,7 +1747,15 @@ async function loadChatHistoryUncached(
       const tail = mergeInFlightAssistantTails(snapshotTail, liveTail);
       state.chatStream = tail;
       state.chatStreamStartedAt = snapshotStartedAt ?? state.chatStreamStartedAt ?? Date.now();
-      state.chatRunStartup = { state: "activity", runId: inFlightRunId };
+      // A live status or activity transition observed while history was pending
+      // outranks the older snapshot; route adoption has no such local fact.
+      const retainedStartup =
+        state.chatRunStartup?.runId === inFlightRunId ? state.chatRunStartup : null;
+      state.chatRunStartup =
+        retainedStartup ??
+        (res.inFlightRun.phase
+          ? { state: "status", runId: inFlightRunId, phase: res.inFlightRun.phase }
+          : { state: "activity", runId: inFlightRunId });
       // Disconnect cleanup intentionally removes transient activity rows while
       // retaining the owned run. Replay fills that gap; per-identity sequence
       // fences keep a delayed snapshot from replacing newer live progress.

--- a/ui/src/pages/chat/components/chat-composer-state.ts
+++ b/ui/src/pages/chat/components/chat-composer-state.ts
@@ -83,10 +83,14 @@ export function isCurrentSessionSubmittedProgress(
 // working spark and the composer's sr-only announcement. A fresh terminal
 // toast masks stale abortable rows so neither surface flashes back to working.
 export function isChatRunWorking(
-  props: Pick<ChatComposerProps, "canAbort" | "onAbort" | "runStatus" | "queue" | "sessionKey">,
+  props: Pick<
+    ChatComposerProps,
+    "canAbort" | "onAbort" | "queue" | "runStatus" | "sessionKey" | "startupStatus"
+  >,
 ): boolean {
   const canAbort = Boolean(props.canAbort && props.onAbort);
   return (
+    Boolean(props.startupStatus) ||
     (canAbort && !hasTerminalRunStatus(props.runStatus)) ||
     props.queue.some((item) =>
       isCurrentSessionSubmittedProgress(item, props.sessionKey, props.runStatus),

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -8,6 +8,7 @@ import type { SlashCommandDef } from "../../../lib/chat/commands.ts";
 import type { ControlUiFollowUpMode } from "../../../lib/chat/follow-up-mode.ts";
 import type { ProviderUsageDisplayProps } from "../../../lib/provider-quota-summary.ts";
 import type { SessionToolOverrides } from "../../../lib/sessions/patch.ts";
+import type { ChatRunStartupStatus } from "../chat-run-startup.ts";
 import type { ComposerDictationController } from "../composer-dictation.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../input-history.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
@@ -76,6 +77,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   sending: boolean;
   canAbort?: boolean;
   runStatus?: ChatRunUiStatus | null;
+  startupStatus?: ChatRunStartupStatus | null;
   waitingApproval?: boolean;
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1578,12 +1578,10 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
-    expect(container.querySelector(".chat-working-indicator__status > .sr-only")?.textContent).toBe(
+    expect(container.querySelector(".chat-working-indicator__status > .sr-only")).toBeNull();
+    expect(container.querySelector(".chat-working-indicator__status > span")?.textContent).toBe(
       "Working…",
     );
-    expect(
-      container.querySelectorAll(".chat-working-indicator__status > span:not(.sr-only)"),
-    ).toHaveLength(0);
     expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
 
@@ -1780,7 +1778,7 @@ describe("grouped chat rendering", () => {
     expect(first).toEqual(decision ? [decision] : []);
   });
 
-  it("keeps the synthetic progress word screen-reader-only across runs", () => {
+  it("keeps the working label visible while the whimsical phrase stays decorative", () => {
     const statusFor = (startedAt: number) => {
       const container = document.createElement("div");
       render(
@@ -1797,7 +1795,7 @@ describe("grouped chat rendering", () => {
       };
     };
 
-    const expected = { hidden: "Working…", visibleLabels: 0, decorativePhrases: 1 };
+    const expected = { hidden: undefined, visibleLabels: 1, decorativePhrases: 1 };
     expect(statusFor(1_000)).toEqual(expected);
     expect(statusFor(1_500)).toEqual(expected);
     expect(statusFor(8_000)).toEqual(expected);

--- a/ui/src/pages/chat/components/chat-working-indicator.test.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.test.ts
@@ -106,4 +106,18 @@ describe("renderChatWorkingIndicator", () => {
   it("keeps approval waits on the default claw even for surprising keys", () => {
     expect(surpriseClassesFor(findRenderKey(true), true)).toEqual([]);
   });
+
+  it("keeps long-wait whimsy available alongside a truthful startup phase", () => {
+    const container = document.createElement("div");
+    render(
+      renderChatWorkingIndicator(
+        { kind: "reading-indicator", key: "run:startup", startedAt: 1 },
+        { startupPhase: "starting_model" },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Waiting for a response…");
+    expect(container.querySelector("openclaw-working-phrase")).not.toBeNull();
+  });
 });

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -130,6 +130,15 @@ export function renderChatWorkingIndicator(
   // Streaming tokens are the real liveness signal; the whimsical phrase only
   // covers the stretch before any usage data exists.
   const hasTokens = options.outputTokens !== null && options.outputTokens !== undefined;
+  const workingPhrase = hasTokens
+    ? nothing
+    : html`
+        <openclaw-working-phrase
+          aria-hidden="true"
+          .startMs=${part.startedAt}
+          .seed=${part.key}
+        ></openclaw-working-phrase>
+      `;
   // The animated claw stays decorative; the text status exposes progress without
   // announcing every elapsed-time tick to screen readers.
   return html`
@@ -160,23 +169,15 @@ export function renderChatWorkingIndicator(
                   class="chat-working-indicator__elapsed"
                   .startMs=${part.startedAt}
                 ></openclaw-elapsed-time>
-                ${renderLiveOutputTokens(options.outputTokens)}
+                ${renderLiveOutputTokens(options.outputTokens)} ${workingPhrase}
               `
             : html`
-                <span class=${continuation ? "" : "sr-only"}>${t("common.working")}</span>
+                <span>${t("common.working")}</span>
                 <openclaw-elapsed-time
                   class="chat-working-indicator__elapsed"
                   .startMs=${part.startedAt}
                 ></openclaw-elapsed-time>
-                ${hasTokens
-                  ? renderLiveOutputTokens(options.outputTokens)
-                  : html`
-                      <openclaw-working-phrase
-                        aria-hidden="true"
-                        .startMs=${part.startedAt}
-                        .seed=${part.key}
-                      ></openclaw-working-phrase>
-                    `}
+                ${renderLiveOutputTokens(options.outputTokens)} ${workingPhrase}
               `}
       </span>
     </div>

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
 import type { ConsoleMessage, Frame, Locator, Page, Request } from "playwright";
 import type { InlineConfig, Plugin, PreviewServer, ViteDevServer } from "vite";
+import type { ChatRunStartupPhase } from "../../../packages/gateway-protocol/src/index.js";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
 import type { ModelCatalogEntry } from "../api/types.ts";
@@ -286,6 +287,7 @@ export type ControlUiMockGatewayScenario = {
     runId: string;
     text?: string;
     startedAt?: number;
+    phase?: ChatRunStartupPhase;
     events?: unknown[];
     plan?: unknown;
   } | null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a new chat would see only the claw and elapsed timer when startup status events arrived before navigation completed.

## Why This Change Was Made

The Gateway now records the latest startup phase in the canonical in-flight run snapshot and the Control UI restores that phase after navigation or reconnect. Newer live activity still takes precedence, while the working row is visible immediately and adds the existing rotating phrase after eight seconds.

## User Impact

New sessions now show truthful progress such as **Waiting for a response…** instead of a silent timer. Longer waits gain a secondary phrase without replacing the real phase.

## Evidence

- Live source-Gateway browser proof: immediate **Working…**, **Waiting for a response…** at about 1.1s, secondary **Molting…** at 8s, completed response at about 11.3s.
- Focused Gateway/UI suites: 192 tests passed.
- Snapshot byte-budget regression: 48 focused tests passed.
- Control UI browser suites: 7 tests passed, including the real new-session navigation race.
- `pnpm check:changed` completed successfully.
- Fresh Codex autoreview: no actionable findings; TruffleHog clean.
- Production LOC: +48/-14. Tests and test support: +108/-9.
