### PR TITLE
fix(gateway): reject outdated workers during pending recovery

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -1,4 +1,5 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { supportsWorkerExecutionContextLaunch } from "./admission.js";
 import { placementTurnOwner, type WorkerPlacementExecutionMode } from "./placement-record.js";
 import type {
   createWorkerSessionPlacementStore,
@@ -17,10 +18,7 @@ export type WorkerStartingDispatchPlacement = Extract<
   WorkerDispatchPlacement,
   { state: "starting" }
 >;
-export type WorkerDrainingDispatchPlacement = Extract<
-  WorkerDispatchPlacement,
-  { state: "draining" }
->;
+type WorkerDrainingDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "draining" }>;
 type WorkerReconcilingDispatchPlacement = Extract<
   WorkerDispatchPlacement,
   { state: "reconciling" }
@@ -93,6 +91,27 @@ export function isUnavailableEnvironment(
     environment.state === "destroyed" ||
     environment.state === "failed" ||
     environment.state === "orphaned"
+  );
+}
+
+export function isCurrentActiveWorkerEnvironment(
+  placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
+  environment: ReturnType<WorkerEnvironmentService["get"]>,
+): boolean {
+  return Boolean(
+    environment &&
+    environment.state === "attached" &&
+    placement.environmentId &&
+    environment.environmentId === placement.environmentId &&
+    placement.activeOwnerEpoch !== null &&
+    environment.ownerEpoch === placement.activeOwnerEpoch &&
+    placement.workerBundleHash &&
+    environment.bootstrapReceipt?.bundleHash === placement.workerBundleHash &&
+    // A persisted bundle hash can still match a worker using an older launch shape.
+    // Recovery may reuse only the currently admitted execution-context dialect.
+    supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt) &&
+    environment.attachedSessionIds.length === 1 &&
+    environment.attachedSessionIds[0] === placement.sessionId,
   );
 }
 

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -1,10 +1,9 @@
-import type {
-  PlacementFailureActions,
-  WorkerActivationBarrier,
-  WorkerActiveDispatchPlacement,
-  WorkerDispatchEnvironmentService,
-  WorkerDispatchPlacementStore,
-  WorkerDrainingDispatchPlacement,
+import {
+  isCurrentActiveWorkerEnvironment,
+  type PlacementFailureActions,
+  type WorkerActivationBarrier,
+  type WorkerDispatchEnvironmentService,
+  type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
 import { placementTurnOwner } from "./placement-record.js";
 import type { WorkerEnvironmentService } from "./service.js";
@@ -51,24 +50,6 @@ export type PlacementRecoveryDeps = {
     agentId: string;
   }) => Promise<WorkerWorkspaceResultConflict | undefined>;
 };
-
-function sameActiveEnvironment(
-  placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
-  environment: ReturnType<WorkerEnvironmentService["get"]>,
-): boolean {
-  return Boolean(
-    environment &&
-    environment.state === "attached" &&
-    placement.environmentId &&
-    environment.environmentId === placement.environmentId &&
-    placement.activeOwnerEpoch !== null &&
-    environment.ownerEpoch === placement.activeOwnerEpoch &&
-    placement.workerBundleHash &&
-    environment.bootstrapReceipt?.bundleHash === placement.workerBundleHash &&
-    environment.attachedSessionIds.length === 1 &&
-    environment.attachedSessionIds[0] === placement.sessionId,
-  );
-}
 
 function pendingWorkerLossError(
   environment: ReturnType<WorkerEnvironmentService["get"]>,
@@ -323,7 +304,7 @@ export async function recoverPendingWorkspaceResults(
         });
         continue;
       }
-      if (!sameActiveEnvironment(active, environment)) {
+      if (!isCurrentActiveWorkerEnvironment(active, environment)) {
         if (hasPreparedResult) {
           // Verification did not publish this prepared snapshot before the
           // crash. Preserve the fence for retry or operator inspection.

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE,
+  WORKER_LAUNCH_V2_PROTOCOL_FEATURE,
+  type WorkerAdmissionHandshake,
+} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import * as support from "./service.test-support.js";
@@ -10,10 +16,59 @@ import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation
 describe("worker placement restart recovery", () => {
   support.setupWorkerEnvironmentServiceSuite();
 
+  it("does not recover a pending result through a worker with the legacy launch dialect", async () => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const originalHarness = createHarness(placements);
+    const active = originalHarness.placements.seedActive(2);
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placements.claimTurn({
+      sessionId: active.sessionId,
+      sessionKey: active.sessionKey,
+      agentId: active.agentId,
+      claimId: "legacy-worker-claim",
+      runId: "legacy-worker-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placements.markWorkspaceResultPending(claim);
+
+    const restartedStore = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 2_000,
+    });
+    const restartedHarness = createHarness(restartedStore);
+    restartedHarness.markEnvironmentOwnerEpoch(2);
+    restartedHarness.markEnvironmentProtocolFeatures([WORKER_LAUNCH_V2_PROTOCOL_FEATURE]);
+
+    await restartedHarness.service.reconcile();
+
+    expect(restartedHarness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: "Pending cloud workspace result lost its worker: session-1",
+    });
+    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+    expect(restartedHarness.environments.startTunnel).not.toHaveBeenCalled();
+  });
+
   it.each(["bundle", "provider"] as const)(
     "keeps stale pending recovery fenced when %s recovery is unavailable",
     async (failure) => {
-      let currentBundle: WorkerInstallationArtifact = support.BUNDLE_ARTIFACT;
+      const currentReceipt: WorkerAdmissionHandshake = {
+        ...support.BOOTSTRAP_RECEIPT,
+        protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+      };
+      let currentBundle: WorkerInstallationArtifact = {
+        ...support.BUNDLE_ARTIFACT,
+        protocolFeatures: currentReceipt.protocolFeatures,
+      };
       const recoveryState = { started: false };
       support.testState.prepareInstallation = vi.fn(async (install) => {
         if (install === "bundle" && recoveryState.started && failure === "bundle") {
@@ -52,7 +107,13 @@ describe("worker placement restart recovery", () => {
         resolveWorkspaceResultConflict: async () => undefined,
       });
       const environmentId = "worker-stale-recovery";
-      support.seedReady(environmentId);
+      const bootstrapping = support.seedBootstrapping(environmentId);
+      support.testState.store.transition({
+        environmentId,
+        from: bootstrapping.state,
+        to: "ready",
+        patch: support.readyPatch(environmentId, currentReceipt),
+      });
       const attached = await workerService.attachSession({
         environmentId,
         ownerEpoch: 1,

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -1,10 +1,10 @@
 import { supportsWorkerExecutionContextLaunch } from "./admission.js";
 import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider.js";
 import {
+  isCurrentActiveWorkerEnvironment,
   isUnavailableEnvironment,
   type WorkerActiveDispatchPlacement,
   type WorkerDispatchPlacement,
-  type WorkerDrainingDispatchPlacement,
   type WorkerFailedDispatchPlacement,
   type WorkerStartingDispatchPlacement,
 } from "./placement-dispatch-failure.js";
@@ -13,33 +13,6 @@ import {
   type PlacementRecoveryDeps,
 } from "./placement-dispatch-pending-results.js";
 import type { WorkerEnvironmentService } from "./service.js";
-
-function supportsCurrentWorkerLaunch(
-  environment: ReturnType<WorkerEnvironmentService["get"]>,
-): boolean {
-  // A persisted bundle hash can still match a worker with an older launch shape.
-  // Require the admitted receipt so restart recovery never revives that contract.
-  return supportsWorkerExecutionContextLaunch(environment?.bootstrapReceipt);
-}
-
-function sameActiveEnvironment(
-  placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
-  environment: ReturnType<WorkerEnvironmentService["get"]>,
-): boolean {
-  return Boolean(
-    environment &&
-    environment.state === "attached" &&
-    placement.environmentId &&
-    environment.environmentId === placement.environmentId &&
-    placement.activeOwnerEpoch !== null &&
-    environment.ownerEpoch === placement.activeOwnerEpoch &&
-    placement.workerBundleHash &&
-    environment.bootstrapReceipt?.bundleHash === placement.workerBundleHash &&
-    supportsCurrentWorkerLaunch(environment) &&
-    environment.attachedSessionIds.length === 1 &&
-    environment.attachedSessionIds[0] === placement.sessionId,
-  );
-}
 
 function isStartingPlacement(
   placement: WorkerDispatchPlacement,
@@ -114,7 +87,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       );
       return;
     }
-    if (!environment || !sameActiveEnvironment(placement, environment)) {
+    if (!environment || !isCurrentActiveWorkerEnvironment(placement, environment)) {
       await failure.reclaimActive(
         placement,
         environment,
@@ -155,7 +128,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       environment &&
       expectedBundle &&
       environment.bootstrapReceipt?.bundleHash === expectedBundle &&
-      supportsCurrentWorkerLaunch(environment) &&
+      supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt) &&
       hasSyncedWorkspace;
     if (!canResume) {
       const error = new Error("Interrupted worker dispatch cannot safely resume");
@@ -282,7 +255,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         );
         continue;
       }
-      if (!sameActiveEnvironment(placement, environment)) {
+      if (!isCurrentActiveWorkerEnvironment(placement, environment)) {
         await failure.reclaimActive(
           placement,
           environment,

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -19,7 +19,11 @@ import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import { hashWorkerCredential } from "./credential.js";
 import { createWorkerInferenceStore } from "./inference-store.js";
 import { createWorkerEnvironmentService, type WorkerEnvironmentService } from "./service.js";
-import { createWorkerEnvironmentStore, type WorkerEnvironmentStore } from "./store.js";
+import {
+  createWorkerEnvironmentStore,
+  type WorkerEnvironmentStore,
+  type WorkerEnvironmentTransitionPatch,
+} from "./store.js";
 
 export function waitForFast<T>(
   callback: () => T | Promise<T>,
@@ -292,7 +296,10 @@ export function seedReadyDesktop(environmentId: string, desktop: WorkerDesktopEn
   });
 }
 
-export function readyPatch(environmentId: string, receipt = BOOTSTRAP_RECEIPT) {
+export function readyPatch(
+  environmentId: string,
+  receipt: NonNullable<WorkerEnvironmentTransitionPatch["bootstrapReceipt"]> = BOOTSTRAP_RECEIPT,
+) {
   return {
     bootstrapReceipt: receipt,
     credential: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway restart recovery could reuse a worker that matched the saved bundle and placement ownership but did not support the current execution-context launch contract. A durable pending workspace result could therefore cross into tunnel recovery through an outdated worker instead of failing closed for reprovisioning.

## Why This Change Was Made

The full active-worker reuse invariant now has one owner. Active-placement adoption, runtime reconciliation, and pending workspace-result recovery all consume the same predicate, including its current execution-context capability check. The two divergent local predicates and an obsolete exported type surface are removed.

No protocol, config, storage schema, migration, or compatibility surface changes. Current workers behave as before; only outdated workers are rejected from pending-result recovery.

### Provenance

- #111244 (`8631832048cf`, 2026-07-19) split pending-result recovery into `placement-dispatch-pending-results.ts` and carried a copy of the then-current active-environment predicate.
- #120534 (`73a9eed95ba2`, authored by @joshavant and manually squash-merged 2026-08-11) added the `worker-execution-context-v1` fence to the original restart-recovery predicate, but the split copy was not updated. That made the duplicated policy drift and left pending-result recovery able to accept the legacy launch shape.

## User Impact

After a Gateway restart, a pending worker result can no longer be recovered through an outdated worker launch dialect. The placement fails closed and can be reprovisioned instead of using stale execution-context semantics.

Production LOC: +34/-61 (net -27) | Tests/test support: +72/-4 (net +68).

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch.test.ts` failed exactly because the dialect-mismatched pending result became `reclaimed` rather than `failed` (49 passed, 1 failed). The same regression now lives in the dedicated restart-recovery suite.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch.test.ts src/gateway/worker-environments/placement-dispatch-recovery.test.ts` — 2 files, 52 tests passed.
- Post-rebase changed gate: linked-worktree-safe `node scripts/check-changed.mjs` (the repository `pnpm check:changed` owner) — success on Blacksmith Testbox, run https://github.com/openclaw/openclaw/actions/runs/31997453361. Core/core-test typechecks, changed-file lint, dead exports, import cycles, database-first, schema, sidecar, pairing, formatting, and selected guards passed.
- P1-depth structured autoreview on exact branch diff: clean; no accepted/actionable findings.

Best-fix verdict: best. The placement-failure boundary already owns the shared environment/placement types and failure policy, so it is the canonical home for the reusable invariant. Keeping a second pending-result predicate, adding only a consumer-side feature check, or preserving an alias would leave the same drift class in place.
