### PR TITLE
feat(approvals): add request kind discriminant

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3195,9 +3195,7 @@ src/infra/approval-errors.ts	5
 src/infra/approval-gateway-resolver.ts	5
 src/infra/approval-handler-bootstrap.ts	1
 src/infra/approval-handler-runtime.ts	15
-src/infra/approval-native-runtime.ts	1
 src/infra/approval-presentation.ts	3
-src/infra/approval-view-model.ts	6
 src/infra/backup-archive-publication.ts	6
 src/infra/backup-create-stream.ts	3
 src/infra/backup-create.ts	3
@@ -3508,10 +3506,9 @@ src/plugin-sdk/allowlist-config-edit.ts	6
 src/plugin-sdk/api-baseline-declaration-print.ts	1
 src/plugin-sdk/api-baseline.ts	1
 src/plugin-sdk/approval-auth-helpers.ts	1
-src/plugin-sdk/approval-handler-runtime.ts	2
+src/plugin-sdk/approval-handler-runtime.ts	1
 src/plugin-sdk/approval-native-helpers.ts	1
 src/plugin-sdk/approval-reaction-binding.ts	2
-src/plugin-sdk/approval-reaction-runtime.ts	1
 src/plugin-sdk/channel-config-helpers.ts	24
 src/plugin-sdk/channel-config-ui-hints.ts	1
 src/plugin-sdk/channel-entry-contract.ts	6

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -299,6 +299,7 @@ function buildPendingApprovalContent(params: {
     params.view.approvalKind === "plugin"
       ? buildPluginApprovalPendingReplyPayload({
           request: {
+            approvalKind: "plugin",
             id: params.view.approvalId,
             request: {
               title: params.view.title,

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -214,6 +214,7 @@ function buildFilterCheckRequest(params: {
 }): ApprovalRequest {
   if (params.metadata.approvalKind === "plugin") {
     return {
+      approvalKind: "plugin",
       id: params.metadata.approvalId,
       request: {
         title: "Plugin Approval Required",
@@ -226,6 +227,7 @@ function buildFilterCheckRequest(params: {
     };
   }
   return {
+    approvalKind: "exec",
     id: params.metadata.approvalId,
     request: {
       command: "",

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -6,6 +6,7 @@ import {
 import {
   createNativeApprovalChannelRouteGates,
   doesApprovalRequestSelectChannelAccount,
+  resolveApprovalKind,
   resolveApprovalRequestSessionConversation,
 } from "openclaw/plugin-sdk/approval-native-runtime";
 import type {
@@ -60,15 +61,6 @@ type SlackForwardTarget = Parameters<
 const DEFAULT_APPROVAL_FORWARDING_MODE: ApprovalForwardingMode = "session";
 const SLACK_DM_CHANNEL_ID_RE = /^D[A-Z0-9]{8,}$/i;
 const SLACK_USER_ID_RE = /^[UW][A-Z0-9]{8,}$/i;
-
-function resolveSlackApprovalKind(request: SlackNativeApprovalRequest): SlackApprovalKind {
-  const isExec = "command" in request.request;
-  const isPlugin = "title" in request.request && "description" in request.request;
-  if (isExec === isPlugin) {
-    throw new Error("Slack approval request payload does not identify exactly one owner");
-  }
-  return isExec ? "exec" : "plugin";
-}
 
 function isSlackApprovalTransportEnabled(params: {
   cfg: OpenClawConfig;
@@ -446,7 +438,7 @@ export function shouldHandleSlackNativeApprovalRequest(params: {
   ) {
     return false;
   }
-  const approvalKind = params.approvalKind ?? resolveSlackApprovalKind(params.request);
+  const approvalKind = resolveApprovalKind(params.request, params.approvalKind);
   if (approvalKind === "plugin") {
     return (
       shouldHandleSlackPluginViaNativeClientConfig(params) ||

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -242,6 +242,7 @@ function buildDiagnosticsApprovalRequest(params: HandleCommandsParams): ExecAppr
       config: params.cfg,
     });
   return {
+    approvalKind: "exec",
     id: "diagnostics-private-route",
     request: {
       command: buildGatewayDiagnosticsExportJsonCommand(),

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -144,6 +144,7 @@ function buildTrajectoryExportApprovalRequest(
       config: params.cfg,
     });
   return {
+    approvalKind: "exec",
     id: "trajectory-export-private-route",
     request: {
       command: request.command,

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -100,6 +100,7 @@ function buildMcpShowPrivateRouteRequest(params: HandleCommandsParams): ExecAppr
       config: params.cfg,
     });
   return {
+    approvalKind: "exec",
     id: "mcp-show-private-route",
     request: {
       command: params.command.commandBodyNormalized,

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -169,7 +169,7 @@ function createApprovalRuntime(params: {
       // routing. The RPC storage-unavailable respond path does not apply to
       // this runtime-internal caller.
       const decisionPromise = manager.register(record, timeoutMs);
-      const requestEvent = buildRequestedApprovalEvent(record);
+      const requestEvent = buildRequestedApprovalEvent(record, "plugin");
       const forwardRequest = params.context.forwardPluginApprovalRequest;
       const iosPushRequest = params.context.pluginApprovalIosPushDelivery?.handleRequested?.bind(
         params.context.pluginApprovalIosPushDelivery,

--- a/src/gateway/server-methods/approval-record-lookup.ts
+++ b/src/gateway/server-methods/approval-record-lookup.ts
@@ -77,16 +77,23 @@ export function isApprovalRecordVisibleToClient<TPayload>(params: {
 export function listVisiblePendingApprovalRequests<TPayload>(params: {
   manager: ExecApprovalManager<TPayload>;
   client?: GatewayClient | null;
-}): Array<{ id: string; request: TPayload; createdAtMs: number; expiresAtMs: number }> {
+  approvalKind?: "exec" | "plugin";
+}): Array<{
+  approvalKind?: "exec" | "plugin";
+  id: string;
+  request: TPayload;
+  createdAtMs: number;
+  expiresAtMs: number;
+}> {
   return params.manager
     .listPendingRecords()
     .filter((record) => isApprovalRecordVisibleToClient({ record, client: params.client ?? null }))
-    .map(({ id, request, createdAtMs, expiresAtMs }) => ({
-      id,
-      request,
-      createdAtMs,
-      expiresAtMs,
-    }));
+    .map(({ id, request, createdAtMs, expiresAtMs }) => {
+      const approval = { id, request, createdAtMs, expiresAtMs };
+      return params.approvalKind
+        ? Object.assign(approval, { approvalKind: params.approvalKind })
+        : approval;
+    });
 }
 
 function resolveLookupError(params: {

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -50,7 +50,11 @@ type ApprovalTurnSourceFields = {
   turnSourceAccountId?: string | null;
 };
 
-type RequestedApprovalEvent<TPayload extends ApprovalTurnSourceFields> = {
+type RequestedApprovalEvent<
+  TPayload extends ApprovalTurnSourceFields,
+  TKind extends "exec" | "plugin" = "exec" | "plugin",
+> = {
+  approvalKind?: TKind;
   id: string;
   request: TPayload;
   createdAtMs: number;
@@ -137,10 +141,15 @@ export function registerPendingApprovalRecord<TPayload>(params: {
 }
 
 /** Builds the gateway event payload broadcast when an approval starts waiting. */
-export function buildRequestedApprovalEvent<TPayload extends ApprovalTurnSourceFields>(
+export function buildRequestedApprovalEvent<
+  TPayload extends ApprovalTurnSourceFields,
+  TKind extends "exec" | "plugin",
+>(
   record: ExecApprovalRecord<TPayload>,
-): RequestedApprovalEvent<TPayload> {
+  approvalKind?: TKind,
+): RequestedApprovalEvent<TPayload, TKind> {
   return {
+    ...(approvalKind ? { approvalKind } : {}),
     id: record.id,
     request: record.request,
     createdAtMs: record.createdAtMs,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -133,7 +133,11 @@ export function createExecApprovalHandlers(
       );
     },
     "exec.approval.list": async ({ respond, client }) => {
-      respond(true, listVisiblePendingApprovalRequests({ manager, client }), undefined);
+      respond(
+        true,
+        listVisiblePendingApprovalRequests({ manager, client, approvalKind: "exec" }),
+        undefined,
+      );
     },
     "exec.approval.request": async ({ params, respond, context, client }) => {
       if (
@@ -423,7 +427,7 @@ export function createExecApprovalHandlers(
       if (!decisionPromise) {
         return;
       }
-      const requestEvent: ExecApprovalRequest = buildRequestedApprovalEvent(record);
+      const requestEvent: ExecApprovalRequest = buildRequestedApprovalEvent(record, "exec");
       const forwardRequest = opts?.forwarder?.handleRequested.bind(opts.forwarder);
       const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
       await handlePendingApprovalRequest({

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -305,6 +305,7 @@ describe("createPluginApprovalHandlers", () => {
 
       const requestedBroadcast = broadcastCall(opts);
       expect(requestedBroadcast.event).toBe("plugin.approval.requested");
+      expect(requestedBroadcast.payload.approvalKind).toBe("plugin");
       expect(requestedBroadcast.payload.id).toBeTypeOf("string");
       expect(requestedBroadcast.options).toEqual({ dropIfSlow: true });
 
@@ -796,6 +797,7 @@ describe("createPluginApprovalHandlers", () => {
       const approvals = requireArray(listCall.result, "approval list");
       expect(approvals).toHaveLength(1);
       const approval = requireRecord(approvals[0], "approval");
+      expect(approval.approvalKind).toBe("plugin");
       const listedApprovalId = expectPluginApprovalId(approval.id, "listed approval id");
       const request = requireRecord(approval.request, "approval request");
       expect(request.title).toBe("Sensitive action");

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -60,7 +60,11 @@ export function createPluginApprovalHandlers(
 ): GatewayRequestHandlers {
   return {
     "plugin.approval.list": async ({ respond, client }) => {
-      respond(true, listVisiblePendingApprovalRequests({ manager, client }), undefined);
+      respond(
+        true,
+        listVisiblePendingApprovalRequests({ manager, client, approvalKind: "plugin" }),
+        undefined,
+      );
     },
     "plugin.approval.request": async ({ params, client, respond, context }) => {
       if (
@@ -243,7 +247,7 @@ export function createPluginApprovalHandlers(
         return;
       }
 
-      const requestEvent = buildRequestedApprovalEvent(record);
+      const requestEvent = buildRequestedApprovalEvent(record, "plugin");
       const forwardRequest = opts?.forwarder?.handlePluginApprovalRequested?.bind(opts.forwarder);
       const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
 

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2609,16 +2609,24 @@ describe("exec approval handlers", () => {
 
   function getRequestedExecApprovalPayload(
     broadcasts: Array<{ event: string; payload: unknown }>,
-  ): { id: string; request: Record<string, unknown> } {
+  ): { approvalKind: "exec"; id: string; request: Record<string, unknown> } {
     const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
     if (!requested) {
       throw new Error("exec approval requested broadcast missing");
     }
-    const payload = requested.payload as { id?: unknown; request?: Record<string, unknown> };
+    const payload = requested.payload as {
+      approvalKind?: unknown;
+      id?: unknown;
+      request?: Record<string, unknown>;
+    };
+    if (payload.approvalKind !== "exec") {
+      throw new Error("exec approval requested kind missing");
+    }
     if (typeof payload.id !== "string" || payload.id.length === 0) {
       throw new Error("exec approval requested id missing");
     }
     return {
+      approvalKind: payload.approvalKind,
       id: payload.id,
       request: payload.request ?? {},
     };
@@ -2626,7 +2634,7 @@ describe("exec approval handlers", () => {
 
   async function waitForRequestedExecApprovalPayload(
     broadcasts: Array<{ event: string; payload: unknown }>,
-  ): Promise<{ id: string; request: Record<string, unknown> }> {
+  ): Promise<{ approvalKind: "exec"; id: string; request: Record<string, unknown> }> {
     await waitForFast(
       () => {
         expect(broadcasts.some((entry) => entry.event === "exec.approval.requested")).toBe(true);
@@ -3055,7 +3063,7 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(listRespond)).toBe(true);
     const approvals = mockCallArg(listRespond, 0, 1) as Array<Record<string, unknown>>;
     const approval = approvals.find((entry) => entry.id === "approval-list-1");
-    expectRecordFields(approval, { id: "approval-list-1" });
+    expectRecordFields(approval, { approvalKind: "exec", id: "approval-list-1" });
     expectRecordFields((approval as Record<string, unknown>).request, { command: "echo ok" });
     expect(mockCallArg(listRespond, 0, 2)).toBeUndefined();
 

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -1,10 +1,11 @@
 import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
 import type { ApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+import type { ApprovalRequest } from "./approval-types.js";
+import type { ExecApprovalResolved } from "./exec-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
 export type GatewayApprovalEventKind = "exec" | "plugin";
-export type GatewayApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+export type GatewayApprovalRequest = ApprovalRequest;
 export type GatewayApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
 
 export type GatewayApprovalEventSubscriber = {

--- a/src/infra/approval-handler-runtime-types.ts
+++ b/src/infra/approval-handler-runtime-types.ts
@@ -2,20 +2,20 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ChannelApprovalNativePlannedTarget } from "./approval-native-delivery.js";
 import type { PreparedChannelNativeApprovalTarget } from "./approval-native-runtime-types.js";
-import type { ChannelApprovalKind } from "./approval-types.js";
+import type { ApprovalRequestInput, ChannelApprovalKind } from "./approval-types.js";
 import type {
   ExpiredApprovalView,
   PendingApprovalView,
   ResolvedApprovalView,
 } from "./approval-view-model.types.js";
 import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+import type { ExecApprovalResolved } from "./exec-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
 export type { ChannelApprovalKind } from "./approval-types.js";
 
-/** Union of approval request events a native approval handler can receive. */
-export type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+/** Backward-compatible approval request accepted by public plugin callbacks. */
+export type ApprovalRequest = ApprovalRequestInput;
 /** Union of approval resolution events a native approval handler can finalize. */
 export type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
 

--- a/src/infra/approval-handler-runtime.test.ts
+++ b/src/infra/approval-handler-runtime.test.ts
@@ -9,7 +9,9 @@ import {
   createApprovalNativeRuntimeAdapterStubs,
   type ApprovalNativeRuntimeAdapterStubParams,
 } from "./approval-handler.test-helpers.js";
+import type { NormalizedApprovalRequest } from "./approval-types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
+import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
 type ApprovalCapability = NonNullable<
   Parameters<typeof createChannelApprovalHandlerFromCapability>[0]["capability"]
@@ -38,8 +40,9 @@ function makeSequentialPendingBindingMock() {
     .mockResolvedValueOnce({ bindingId: "bound-2" });
 }
 
-function makeExecApprovalRequest(id: string): ExecApprovalRequest {
+function makeExecApprovalRequest(id: string): NormalizedApprovalRequest<ExecApprovalRequest> {
   return {
+    approvalKind: "exec",
     id,
     expiresAtMs: Date.now() + 60_000,
     request: {
@@ -137,7 +140,7 @@ describe("createChannelApprovalHandlerFromCapability", () => {
     expectApprovalRuntime(runtime);
   });
 
-  it("derives kind from the original typed request when stop-time cleanup unbinds", async () => {
+  it("derives kind once before stop-time cleanup unbinds", async () => {
     const unbindPending = vi.fn();
     const shouldHandle = vi.fn().mockReturnValue(true);
     const runtime = await createTestApprovalHandler(
@@ -149,8 +152,9 @@ describe("createChannelApprovalHandlerFromCapability", () => {
     );
 
     const approvalRuntime = expectApprovalRuntime(runtime);
-    const request = {
+    const request: PluginApprovalRequest = {
       id: "custom:1",
+      createdAtMs: Date.now(),
       expiresAtMs: Date.now() + 60_000,
       request: {
         title: "Plugin approval",
@@ -158,11 +162,12 @@ describe("createChannelApprovalHandlerFromCapability", () => {
         turnSourceChannel: "test",
         turnSourceTo: "origin-chat",
       },
-    } as never;
+    };
+    const normalizedRequest = { ...request, approvalKind: "plugin" as const };
 
     await approvalRuntime.handleRequested(request);
     expect(shouldHandle).toHaveBeenCalledWith(
-      expect.objectContaining({ request, approvalKind: "plugin" }),
+      expect.objectContaining({ request: normalizedRequest, approvalKind: "plugin" }),
     );
     await approvalRuntime.stop();
 
@@ -170,7 +175,7 @@ describe("createChannelApprovalHandlerFromCapability", () => {
     const stopUnbind = firstCallArg(unbindPending) as
       | { request?: unknown; approvalKind?: string }
       | undefined;
-    expect(stopUnbind?.request).toBe(request);
+    expect(stopUnbind?.request).toEqual(normalizedRequest);
     expect(stopUnbind?.approvalKind).toBe("plugin");
   });
 
@@ -185,20 +190,22 @@ describe("createChannelApprovalHandlerFromCapability", () => {
       }),
     );
     const approvalRuntime = expectApprovalRuntime(runtime);
-    const request = {
+    const request: PluginApprovalRequest = {
       id: "plugin:legacy-owned-id",
+      createdAtMs: Date.now(),
       expiresAtMs: Date.now() + 60_000,
       request: {
         title: "Plugin approval",
         description: "Allow the plugin action",
       },
-    } as never;
+    };
+    const normalizedRequest = { ...request, approvalKind: "plugin" as const };
 
     await approvalRuntime.handleRequested(request);
 
-    expect(resolveApprovalKind).toHaveBeenCalledWith(request);
+    expect(resolveApprovalKind).toHaveBeenCalledWith(normalizedRequest);
     expect(shouldHandle).toHaveBeenCalledWith(
-      expect.objectContaining({ request, approvalKind: "plugin" }),
+      expect.objectContaining({ request: normalizedRequest, approvalKind: "plugin" }),
     );
     await approvalRuntime.stop();
   });

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -23,11 +23,11 @@ import type {
   ChannelNativeApprovalTransportSpec,
 } from "./approval-native-runtime-types.js";
 import { createChannelNativeApprovalRuntime } from "./approval-native-runtime.js";
+import { normalizeApprovalRequest } from "./approval-types.js";
 import {
   buildExpiredApprovalView,
   buildPendingApprovalView,
   buildResolvedApprovalView,
-  resolveApprovalRequestKind,
 } from "./approval-view-model.js";
 import type {
   ExpiredApprovalView,
@@ -458,7 +458,10 @@ export async function createChannelApprovalHandlerFromCapability(params: {
   const log = createSubsystemLogger(params.label);
   const activeEntries = new Map<string, ActiveApprovalEntries>();
   let stopped = false;
-  const resolveApprovalKind = nativeRuntime.resolveApprovalKind ?? resolveApprovalRequestKind;
+  const resolveApprovalKind = (request: ApprovalRequest): ChannelApprovalKind => {
+    const normalizedRequest = normalizeApprovalRequest(request);
+    return nativeRuntime.resolveApprovalKind?.(normalizedRequest) ?? normalizedRequest.approvalKind;
+  };
   const baseContext: ChannelApprovalCapabilityHandlerContext = {
     cfg: params.cfg,
     accountId: params.accountId,

--- a/src/infra/approval-native-runtime.test.ts
+++ b/src/infra/approval-native-runtime.test.ts
@@ -288,11 +288,12 @@ describe("createChannelNativeApprovalRuntime", () => {
       createdAtMs: 0,
       expiresAtMs: 60_000,
     } as const;
+    const normalizedRequest = { ...request, approvalKind: "plugin" as const };
     await runtime.handleRequested(request);
 
-    expect(resolveApprovalKind).toHaveBeenCalledWith(request);
+    expect(resolveApprovalKind).toHaveBeenCalledWith(normalizedRequest);
     expect(buildPendingContent).toHaveBeenCalledWith(
-      expect.objectContaining({ request, approvalKind: "exec" }),
+      expect.objectContaining({ request: normalizedRequest, approvalKind: "exec" }),
     );
   });
 

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -15,17 +15,21 @@ import type {
   PreparedChannelNativeApprovalTarget,
 } from "./approval-native-runtime-types.js";
 import { classifyApprovalRequestChannelRoute } from "./approval-request-account-binding.js";
-import { resolveApprovalRequestKind, type ChannelApprovalKind } from "./approval-types.js";
+import type {
+  ApprovalRequestInput,
+  ChannelApprovalKind,
+  NormalizedApprovalRequest,
+} from "./approval-types.js";
 import {
   createExecApprovalChannelRuntime,
   type ExecApprovalChannelRuntime,
   type ExecApprovalChannelRuntimeAdapter,
 } from "./exec-approval-channel-runtime.js";
 import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
-import type { ExecApprovalResolved, ExecApprovalRequest } from "./exec-approvals.js";
-import type { PluginApprovalResolved, PluginApprovalRequest } from "./plugin-approvals.js";
+import type { ExecApprovalResolved } from "./exec-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequest = ApprovalRequestInput;
 type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
 
 export type { PreparedChannelNativeApprovalTarget } from "./approval-native-runtime-types.js";
@@ -188,9 +192,6 @@ export function createChannelNativeApprovalRuntime<
   >,
 ): ExecApprovalChannelRuntime<TRequest, TResolved> {
   const nowMs = adapter.nowMs ?? Date.now;
-  const resolveApprovalKind =
-    adapter.resolveApprovalKind ??
-    ((request: TRequest): ChannelApprovalKind => resolveApprovalRequestKind(request));
   const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
     adapter.eventKinds ?? ["exec"],
   );
@@ -202,7 +203,8 @@ export function createChannelNativeApprovalRuntime<
     channel: adapter.channel,
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
-    shouldHandle: (request) => adapter.shouldHandle(request as TRequest),
+    // SAFETY: the route coordinator receives only normalized requests from this runtime.
+    shouldHandle: (request) => adapter.shouldHandle(request as NormalizedApprovalRequest<TRequest>),
     classifyRoute: (request) =>
       classifyApprovalRequestChannelRoute({
         cfg: adapter.cfg,
@@ -236,7 +238,7 @@ export function createChannelNativeApprovalRuntime<
     eventKinds: adapter.eventKinds,
     isConfigured: adapter.isConfigured,
     shouldHandle: (request) => {
-      const approvalKind = resolveApprovalKind(request);
+      const approvalKind = adapter.resolveApprovalKind?.(request) ?? request.approvalKind;
       const selection = routeReporter.selectRequest({
         approvalKind,
         request,
@@ -281,7 +283,7 @@ export function createChannelNativeApprovalRuntime<
     },
     nowMs,
     deliverRequested: async (request) => {
-      const approvalKind = resolveApprovalKind(request);
+      const approvalKind = adapter.resolveApprovalKind?.(request) ?? request.approvalKind;
       let deliveryPlan: ChannelApprovalNativeDeliveryPlan = {
         targets: [],
         originTarget: null,

--- a/src/infra/approval-request-account-binding.ts
+++ b/src/infra/approval-request-account-binding.ts
@@ -12,7 +12,10 @@ import {
 } from "../utils/delivery-context.shared.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { matchesApprovalRequestFilters } from "./approval-request-filters.js";
-import type { ApprovalRequestChannelRouteClass } from "./approval-types.js";
+import {
+  resolveApprovalRequestKind,
+  type ApprovalRequestChannelRouteClass,
+} from "./approval-types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
@@ -30,7 +33,9 @@ function resolveApprovalForwardAccountIds(params: {
   defaultAccountId?: string | null;
 }): string[] {
   const forwarding =
-    "command" in params.request.request ? params.cfg.approvals?.exec : params.cfg.approvals?.plugin;
+    resolveApprovalRequestKind(params.request) === "exec"
+      ? params.cfg.approvals?.exec
+      : params.cfg.approvals?.plugin;
   const channel = normalizeOptionalChannel(params.channel);
   if (!forwarding?.enabled || (forwarding.mode !== "targets" && forwarding.mode !== "both")) {
     return [];
@@ -60,7 +65,9 @@ function hasApprovalForwardTarget(params: {
   channel?: string | null;
 }): boolean {
   const forwarding =
-    "command" in params.request.request ? params.cfg.approvals?.exec : params.cfg.approvals?.plugin;
+    resolveApprovalRequestKind(params.request) === "exec"
+      ? params.cfg.approvals?.exec
+      : params.cfg.approvals?.plugin;
   if (
     !forwarding?.enabled ||
     (forwarding.mode !== "targets" && forwarding.mode !== "both") ||

--- a/src/infra/approval-types.ts
+++ b/src/infra/approval-types.ts
@@ -1,16 +1,72 @@
 // Approval kind is shared by exec and plugin approval routing surfaces.
+import type { ExecApprovalRequest } from "./exec-approvals.js";
+import type { PluginApprovalRequest } from "./plugin-approvals.js";
+
 export type ChannelApprovalKind = "exec" | "plugin";
 export type ApprovalRequestChannelRouteClass = "bound-or-explicit" | "unbound";
 
-/** Resolve approval ownership from the typed request payload, never from id spelling. */
-export function resolveApprovalRequestKind(request: { request: object }): ChannelApprovalKind {
+/** Backward-compatible request shape accepted from Gateway events and replay. */
+export type ApprovalRequestInput = ExecApprovalRequest | PluginApprovalRequest;
+
+/** Canonical request shape used after the Gateway read boundary. */
+export type ApprovalRequest =
+  | (ExecApprovalRequest & { approvalKind: "exec" })
+  | (PluginApprovalRequest & { approvalKind: "plugin" });
+
+export type NormalizedApprovalRequest<TRequest extends ApprovalRequestInput> =
+  TRequest extends ExecApprovalRequest
+    ? TRequest & { approvalKind: "exec" }
+    : TRequest extends PluginApprovalRequest
+      ? TRequest & { approvalKind: "plugin" }
+      : never;
+
+function deriveApprovalRequestKind(request: { request: object }): ChannelApprovalKind {
   const isExec = "command" in request.request;
   const isPlugin = "title" in request.request && "description" in request.request;
   if (isExec === isPlugin) {
     throw new Error("approval request payload does not identify exactly one owner");
   }
-  if (isExec) {
-    return "exec";
+  return isExec ? "exec" : "plugin";
+}
+
+function isExecApprovalRequest(request: ApprovalRequestInput): request is ExecApprovalRequest {
+  return deriveApprovalRequestKind(request) === "exec";
+}
+
+function hasExecApprovalKind(
+  request: ExecApprovalRequest,
+): request is ExecApprovalRequest & { approvalKind: "exec" } {
+  return request.approvalKind === "exec";
+}
+
+function hasPluginApprovalKind(
+  request: PluginApprovalRequest,
+): request is PluginApprovalRequest & { approvalKind: "plugin" } {
+  return request.approvalKind === "plugin";
+}
+
+/**
+ * Normalizes old wire/persisted requests at the read boundary. The payload remains
+ * authoritative so untrusted descriptive metadata can never select an approval owner.
+ * Return a copy so deriving metadata never changes legacy serialized input.
+ */
+export function normalizeApprovalRequest<TRequest extends ApprovalRequestInput>(
+  request: TRequest,
+): NormalizedApprovalRequest<TRequest>;
+export function normalizeApprovalRequest(request: ApprovalRequestInput): ApprovalRequest {
+  if (isExecApprovalRequest(request)) {
+    if (hasExecApprovalKind(request)) {
+      return request;
+    }
+    return { ...request, approvalKind: "exec" };
   }
-  return "plugin";
+  if (hasPluginApprovalKind(request)) {
+    return request;
+  }
+  return { ...request, approvalKind: "plugin" };
+}
+
+/** Resolve approval ownership from the typed request payload, never from id spelling. */
+export function resolveApprovalRequestKind(request: { request: object }): ChannelApprovalKind {
+  return deriveApprovalRequestKind(request);
 }

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -1,6 +1,7 @@
 // Tests approval view model formatting for prompts and decisions.
 import { describe, expect, it } from "vitest";
-import { buildPendingApprovalView, resolveApprovalRequestKind } from "./approval-view-model.js";
+import { normalizeApprovalRequest, resolveApprovalRequestKind } from "./approval-types.js";
+import { buildPendingApprovalView } from "./approval-view-model.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
@@ -58,6 +59,21 @@ describe("buildPendingApprovalView", () => {
       approvalKind: "plugin",
       decision: "allow-once",
     });
+  });
+
+  it("does not trust conflicting approval kind metadata", () => {
+    const request: PluginApprovalRequest = {
+      id: "plugin-approval",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        title: "Use protected tool",
+        description: "The plugin needs operator consent.",
+      },
+    };
+    Object.defineProperty(request, "approvalKind", { value: "exec", enumerable: true });
+
+    expect(normalizeApprovalRequest(request).approvalKind).toBe("plugin");
   });
 
   it("keeps the fail-closed plugin decision in channel-facing actions", () => {

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -1,5 +1,5 @@
 // Builds approval prompt view models from request and resolution events.
-import { resolveApprovalRequestKind } from "./approval-types.js";
+import { normalizeApprovalRequest } from "./approval-types.js";
 import type {
   ApprovalMetadataView,
   ApprovalRequest,
@@ -20,8 +20,6 @@ import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "./plugin-
 import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
 type ApprovalPhase = "pending" | "resolved" | "expired";
-
-export { resolveApprovalRequestKind } from "./approval-types.js";
 
 function buildExecMetadata(request: ExecApprovalRequest): ApprovalMetadataView[] {
   const metadata: ApprovalMetadataView[] = [];
@@ -105,31 +103,29 @@ function buildPluginViewBase<TPhase extends ApprovalPhase>(
 
 /** Builds the presentation model for an unresolved exec or plugin approval. */
 export function buildPendingApprovalView(request: ApprovalRequest): PendingApprovalView {
-  const approvalKind = resolveApprovalRequestKind(request);
-  if (approvalKind === "plugin") {
-    const pluginRequest = request as PluginApprovalRequest;
+  const normalizedRequest = normalizeApprovalRequest(request);
+  if (normalizedRequest.approvalKind === "plugin") {
     return {
-      ...buildPluginViewBase(pluginRequest, "pending"),
+      ...buildPluginViewBase(normalizedRequest, "pending"),
       actions: buildTypedApprovalActionDescriptors({
-        approvalCommandId: pluginRequest.id,
-        approvalKind,
+        approvalCommandId: normalizedRequest.id,
+        approvalKind: normalizedRequest.approvalKind,
         allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions(
-          pluginRequest.request,
+          normalizedRequest.request,
         ),
       }),
-      expiresAtMs: pluginRequest.expiresAtMs,
+      expiresAtMs: normalizedRequest.expiresAtMs,
     };
   }
-  const execRequest = request as ExecApprovalRequest;
   return {
-    ...buildExecViewBase(execRequest, "pending"),
+    ...buildExecViewBase(normalizedRequest, "pending"),
     actions: buildTypedApprovalActionDescriptors({
-      approvalCommandId: execRequest.id,
-      approvalKind,
-      ask: execRequest.request.ask,
-      allowedDecisions: resolveExecApprovalRequestAllowedDecisions(execRequest.request),
+      approvalCommandId: normalizedRequest.id,
+      approvalKind: normalizedRequest.approvalKind,
+      ask: normalizedRequest.request.ask,
+      allowedDecisions: resolveExecApprovalRequestAllowedDecisions(normalizedRequest.request),
     }),
-    expiresAtMs: execRequest.expiresAtMs,
+    expiresAtMs: normalizedRequest.expiresAtMs,
   };
 }
 
@@ -138,18 +134,16 @@ export function buildResolvedApprovalView(
   request: ApprovalRequest,
   resolved: ApprovalResolved,
 ): ResolvedApprovalView {
-  const approvalKind = resolveApprovalRequestKind(request);
-  if (approvalKind === "plugin") {
-    const pluginRequest = request as PluginApprovalRequest;
+  const normalizedRequest = normalizeApprovalRequest(request);
+  if (normalizedRequest.approvalKind === "plugin") {
     return {
-      ...buildPluginViewBase(pluginRequest, "resolved"),
+      ...buildPluginViewBase(normalizedRequest, "resolved"),
       decision: resolved.decision,
       resolvedBy: resolved.resolvedBy,
     };
   }
-  const execRequest = request as ExecApprovalRequest;
   return {
-    ...buildExecViewBase(execRequest, "resolved"),
+    ...buildExecViewBase(normalizedRequest, "resolved"),
     decision: resolved.decision,
     resolvedBy: resolved.resolvedBy,
   };
@@ -157,9 +151,9 @@ export function buildResolvedApprovalView(
 
 /** Builds the presentation model shown when an approval can no longer be acted on. */
 export function buildExpiredApprovalView(request: ApprovalRequest): ExpiredApprovalView {
-  const approvalKind = resolveApprovalRequestKind(request);
-  if (approvalKind === "plugin") {
-    return buildPluginViewBase(request as PluginApprovalRequest, "expired");
+  const normalizedRequest = normalizeApprovalRequest(request);
+  if (normalizedRequest.approvalKind === "plugin") {
+    return buildPluginViewBase(normalizedRequest, "expired");
   }
-  return buildExecViewBase(request as ExecApprovalRequest, "expired");
+  return buildExecViewBase(normalizedRequest, "expired");
 }

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -3,14 +3,10 @@ import type {
   MessagePresentationAction,
   MessagePresentationButton,
 } from "../interactive/payload.js";
-import type { ChannelApprovalKind } from "./approval-types.js";
+import type { ApprovalRequestInput, ChannelApprovalKind } from "./approval-types.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
-import type {
-  ExecApprovalDecision,
-  ExecApprovalRequest,
-  ExecApprovalResolved,
-} from "./exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+import type { ExecApprovalDecision, ExecApprovalResolved } from "./exec-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
 type ApprovalPhase = "pending" | "resolved" | "expired";
 
@@ -113,6 +109,6 @@ export type ExpiredApprovalView = ExecApprovalExpiredView | PluginApprovalExpire
 export type ApprovalViewModel = PendingApprovalView | ResolvedApprovalView | ExpiredApprovalView;
 
 /** Stored approval request variants accepted by the view-model builders. */
-export type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+export type ApprovalRequest = ApprovalRequestInput;
 /** Stored approval resolution variants accepted by resolved view builders. */
 export type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;

--- a/src/infra/embedded-plugin-approval-broker.test.ts
+++ b/src/infra/embedded-plugin-approval-broker.test.ts
@@ -33,6 +33,7 @@ describe("EmbeddedPluginApprovalBroker", () => {
       "broker.listPending()[0] test invariant",
     );
 
+    expect(approval.approvalKind).toBe("plugin");
     expect(approval?.request.toolName).toBe("skill_workshop");
     expect(events[0]).toEqual({
       event: "plugin.approval.requested",

--- a/src/infra/embedded-plugin-approval-broker.ts
+++ b/src/infra/embedded-plugin-approval-broker.ts
@@ -49,6 +49,7 @@ export class EmbeddedPluginApprovalBroker {
     const id = `plugin:${randomUUID()}`;
     const createdAtMs = Date.now();
     const record: PluginApprovalRequest = {
+      approvalKind: "plugin",
       id,
       request: params.request,
       createdAtMs,

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -699,6 +699,53 @@ describe("createExecApprovalChannelRuntime", () => {
     });
   });
 
+  it("round-trips old-shape replay requests without mutating their serialized form", async () => {
+    const oldShapeRequest = createPluginReplayRequest("plugin:old-shape");
+    const oldShapeJson = JSON.stringify(oldShapeRequest);
+    mockReplayLists({ plugin: [oldShapeRequest] });
+    const deliverRequested = vi.fn(async (request) => [{ id: request.id }]);
+    const finalizeResolved = vi.fn(async () => undefined);
+    const runtime = createExecApprovalChannelRuntime<
+      { id: string },
+      PluginApprovalRequest,
+      PluginApprovalResolved
+    >({
+      label: "test/plugin-old-shape-replay",
+      clientDisplayName: "Test Plugin Old Shape Replay",
+      cfg: {} as never,
+      eventKinds: ["plugin"],
+      isConfigured: () => true,
+      shouldHandle: () => true,
+      deliverRequested,
+      finalizeResolved,
+    });
+
+    await runtime.start();
+    await vi.waitFor(() => {
+      expect(deliverRequested).toHaveBeenCalledWith({
+        ...oldShapeRequest,
+        approvalKind: "plugin",
+      });
+    });
+
+    await runtime.handleResolved({
+      id: oldShapeRequest.id,
+      decision: "allow-once",
+      ts: 1500,
+    });
+
+    expect(finalizeResolved).toHaveBeenCalledWith({
+      request: { ...oldShapeRequest, approvalKind: "plugin" },
+      resolved: {
+        id: oldShapeRequest.id,
+        decision: "allow-once",
+        ts: 1500,
+      },
+      entries: [{ id: oldShapeRequest.id }],
+    });
+    expect(JSON.stringify(oldShapeRequest)).toBe(oldShapeJson);
+  });
+
   it("does not block start on pending approval replay delivery", async () => {
     mockReplayLists({ exec: [createExecReplayRequest()] });
     const pendingDelivery = createDeferred<Array<{ id: string }>>();

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -13,6 +13,11 @@ import {
   isGatewayNativeApprovalMethod,
   type GatewayNativeApprovalMethod,
 } from "./approval-gateway-runtime-methods.js";
+import {
+  normalizeApprovalRequest,
+  type ApprovalRequestInput,
+  type NormalizedApprovalRequest,
+} from "./approval-types.js";
 import { formatErrorMessage } from "./errors.js";
 import type {
   ExecApprovalChannelRuntime,
@@ -20,14 +25,14 @@ import type {
   ExecApprovalChannelRuntimeEventKind,
 } from "./exec-approval-channel-runtime.types.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 export type {
   ExecApprovalChannelRuntime,
   ExecApprovalChannelRuntimeAdapter,
   ExecApprovalChannelRuntimeEventKind,
 } from "./exec-approval-channel-runtime.types.js";
 
-type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequestEvent = ApprovalRequestInput;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
 type ApprovalReplayMethod = Extract<
   GatewayNativeApprovalMethod,
@@ -64,7 +69,7 @@ export function isExecApprovalChannelRuntimeTerminalStartError(
 }
 
 type PendingApprovalValue<TPending, TRequest extends ApprovalRequestEvent> = {
-  request: TRequest;
+  request: NormalizedApprovalRequest<TRequest>;
   entries: TPending[];
 };
 
@@ -141,12 +146,13 @@ export function createExecApprovalChannelRuntime<
   };
 
   const handleRequested = async (
-    request: TRequest,
+    requestInput: TRequest,
     opts?: { ignoreIfInactive?: boolean; alreadyAccepted?: boolean },
   ): Promise<void> => {
     if (opts?.ignoreIfInactive && !shouldKeepRunning()) {
       return;
     }
+    const request = normalizeApprovalRequest(requestInput);
     if (pending.has(request.id)) {
       log.debug(`ignored duplicate request ${request.id}`);
       return;
@@ -296,8 +302,10 @@ export function createExecApprovalChannelRuntime<
           // Subscribe before replay so a request created during the list calls is not lost.
           unsubscribeGatewayRuntime = gatewayRuntime.subscribe({
             eventKinds,
+            // SAFETY: Gateway-owned subscribers publish the canonical normalized request union.
             shouldHandle: (request) =>
-              shouldKeepRunning() && adapter.shouldHandle(request as TRequest),
+              shouldKeepRunning() &&
+              adapter.shouldHandle(request as NormalizedApprovalRequest<TRequest>),
             onRequested: (request) => {
               spawn(
                 "error handling approval request",

--- a/src/infra/exec-approval-channel-runtime.types.ts
+++ b/src/infra/exec-approval-channel-runtime.types.ts
@@ -1,9 +1,10 @@
 // Defines channel-native approval runtime contracts.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ApprovalRequestInput, NormalizedApprovalRequest } from "./approval-types.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
-type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequestEvent = ApprovalRequestInput;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
 
 /** Approval event families a channel-native approval runtime can subscribe to. */
@@ -22,15 +23,18 @@ export type ExecApprovalChannelRuntimeAdapter<
   /** Defaults to exec-only; include plugin when the adapter can handle plugin approvals. */
   eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
   isConfigured: () => boolean;
-  shouldHandle: (request: TRequest) => boolean;
-  deliverRequested: (request: TRequest) => Promise<TPending[]>;
+  shouldHandle: (request: NormalizedApprovalRequest<TRequest>) => boolean;
+  deliverRequested: (request: NormalizedApprovalRequest<TRequest>) => Promise<TPending[]>;
   beforeGatewayClientStart?: () => Promise<void> | void;
   finalizeResolved: (params: {
-    request: TRequest;
+    request: NormalizedApprovalRequest<TRequest>;
     resolved: TResolved;
     entries: TPending[];
   }) => Promise<void>;
-  finalizeExpired?: (params: { request: TRequest; entries: TPending[] }) => Promise<void>;
+  finalizeExpired?: (params: {
+    request: NormalizedApprovalRequest<TRequest>;
+    entries: TPending[];
+  }) => Promise<void>;
   onStopped?: () => Promise<void> | void;
   nowMs?: () => number;
 };

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -181,6 +181,7 @@ function buildTargetKey(target: ExecApprovalForwardTarget): string {
 
 function buildSyntheticApprovalRequest(routeRequest: ApprovalRouteRequest): ExecApprovalRequest {
   return {
+    approvalKind: "exec",
     id: SYNTHETIC_APPROVAL_REQUEST_ID,
     request: {
       command: "",

--- a/src/infra/exec-approval-session-target.ts
+++ b/src/infra/exec-approval-session-target.ts
@@ -7,9 +7,9 @@ import {
   doesApprovalRequestMatchChannelAccount,
   resolvePersistedApprovalRequestSessionEntry,
 } from "./approval-request-account-binding.js";
+import { normalizeApprovalRequest, type ApprovalRequestInput } from "./approval-types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import { resolveSessionDeliveryTarget } from "./outbound/targets.js";
-import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
 /** Delivery target recovered from an approval request's live turn-source or stored session. */
 export type ExecApprovalSessionTarget = {
@@ -31,7 +31,7 @@ export type ApprovalRequestSessionConversation = {
   parentConversationCandidates: string[];
 };
 
-type ApprovalRequestLike = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequestLike = ApprovalRequestInput;
 type ApprovalRequestOriginTargetResolver<TTarget> = {
   cfg: OpenClawConfig;
   request: ApprovalRequestLike;
@@ -56,26 +56,24 @@ function normalizeExecApprovalThreadValue(
   return normalized ? normalized : undefined;
 }
 
-function isExecApprovalRequest(request: ApprovalRequestLike): request is ExecApprovalRequest {
-  return "command" in request.request;
-}
-
 function toExecLikeApprovalRequest(request: ApprovalRequestLike): ExecApprovalRequest {
-  if (isExecApprovalRequest(request)) {
-    return request;
+  const normalizedRequest = normalizeApprovalRequest(request);
+  if (normalizedRequest.approvalKind === "exec") {
+    return normalizedRequest;
   }
   return {
-    id: request.id,
+    approvalKind: "exec",
+    id: normalizedRequest.id,
     request: {
-      command: request.request.title,
-      sessionKey: request.request.sessionKey ?? undefined,
-      turnSourceChannel: request.request.turnSourceChannel ?? undefined,
-      turnSourceTo: request.request.turnSourceTo ?? undefined,
-      turnSourceAccountId: request.request.turnSourceAccountId ?? undefined,
-      turnSourceThreadId: request.request.turnSourceThreadId ?? undefined,
+      command: normalizedRequest.request.title,
+      sessionKey: normalizedRequest.request.sessionKey ?? undefined,
+      turnSourceChannel: normalizedRequest.request.turnSourceChannel ?? undefined,
+      turnSourceTo: normalizedRequest.request.turnSourceTo ?? undefined,
+      turnSourceAccountId: normalizedRequest.request.turnSourceAccountId ?? undefined,
+      turnSourceThreadId: normalizedRequest.request.turnSourceThreadId ?? undefined,
     },
-    createdAtMs: request.createdAtMs,
-    expiresAtMs: request.expiresAtMs,
+    createdAtMs: normalizedRequest.createdAtMs,
+    expiresAtMs: normalizedRequest.expiresAtMs,
   };
 }
 

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -206,6 +206,8 @@ export type ExecApprovalRequestPayload = {
 };
 
 export type ExecApprovalRequest = {
+  /** Descriptive wire metadata; readers derive it from the payload when absent. */
+  approvalKind?: "exec";
   id: string;
   request: ExecApprovalRequestPayload;
   createdAtMs: number;

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -36,6 +36,8 @@ export type PluginApprovalRequestPayload = {
 
 /** Timed plugin approval request persisted while awaiting a decision. */
 export type PluginApprovalRequest = {
+  /** Descriptive wire metadata; readers derive it from the payload when absent. */
+  approvalKind?: "plugin";
   id: string;
   request: PluginApprovalRequestPayload;
   createdAtMs: number;

--- a/src/plugin-sdk/approval-handler-runtime.ts
+++ b/src/plugin-sdk/approval-handler-runtime.ts
@@ -2,6 +2,7 @@
  * Runtime SDK subpath for approval handler adapters and approval view text helpers.
  */
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import { normalizeApprovalRequest } from "../infra/approval-types.js";
 import type {
   ExpiredApprovalView,
   ResolvedApprovalView,
@@ -74,10 +75,11 @@ export function buildChannelApprovalExpiredText(params: {
   request: ApprovalRequest;
   view: ExpiredApprovalView;
 }): string {
-  if (params.view.approvalKind === "plugin") {
-    return buildPluginApprovalExpiredMessage(params.request as PluginApprovalRequest);
+  const request = normalizeApprovalRequest(params.request);
+  if (request.approvalKind === "plugin") {
+    return buildPluginApprovalExpiredMessage(request);
   }
-  return `⏱️ Exec approval expired. ID: ${params.request.id}`;
+  return `⏱️ Exec approval expired. ID: ${request.id}`;
 }
 
 /** Resolves the account id prepared for approval routing with planned/context fallback order. */

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -9,6 +9,7 @@ import type {
 } from "../config/types.approvals.js";
 import { doesApprovalRequestSelectChannelAccount } from "../infra/approval-request-account-binding.js";
 import { matchesApprovalRequestFilters } from "../infra/approval-request-filters.js";
+import { resolveApprovalRequestKind } from "../infra/approval-types.js";
 import {
   getExecApprovalReplyMetadata,
   type ExecApprovalReplyMetadata,
@@ -443,7 +444,7 @@ export function resolveApprovalKind(
   if (approvalKind) {
     return approvalKind;
   }
-  return "command" in request.request ? "exec" : "plugin";
+  return resolveApprovalRequestKind(request);
 }
 
 function resolveApprovalForwardingConfig(params: {

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -1,5 +1,6 @@
 import { sanitizeForPromptLiteral } from "../agents/sanitize-for-prompt.js";
 import { formatApprovalDisplayPath } from "../infra/approval-display-paths.js";
+import { normalizeApprovalRequest } from "../infra/approval-types.js";
 import { buildPendingApprovalView } from "../infra/approval-view-model.js";
 import type { ApprovalRequest, PendingApprovalView } from "../infra/approval-view-model.types.js";
 import {
@@ -9,7 +10,6 @@ import {
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 /**
  * @deprecated Compatibility subpath for shipped approval reaction helpers.
  * New plugin code should use the focused approval runtime/reply subpaths.
@@ -411,10 +411,7 @@ function buildMetadataPayload(params: {
   text: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 }): ReplyPayload {
-  const sessionKey =
-    params.request.request && "sessionKey" in params.request.request
-      ? params.request.request.sessionKey
-      : null;
+  const sessionKey = params.request.request.sessionKey ?? null;
   return withoutPresentation(
     buildApprovalPendingReplyPayload({
       approvalKind: params.view.approvalKind,
@@ -476,38 +473,48 @@ export function buildApprovalReactionPendingContent(params: {
   nowMs: number;
 }): ApprovalReactionPendingContent {
   const reactionPayload = buildApprovalPendingPromptPayload(params);
-  const manualFallbackPayload =
-    params.view.approvalKind === "plugin"
-      ? (() => {
-          const payload = buildPluginApprovalPendingReplyPayload({
-            request: params.request as PluginApprovalRequest,
-            nowMs: params.nowMs,
-            allowedDecisions: reactionPayload.allowedDecisions,
-          });
-          return withoutPresentation({
-            ...payload,
-            text: replaceApprovalIdPlaceholder(payload.text, params.request.id),
-          });
-        })()
-      : withoutPresentation(
-          buildExecApprovalPendingReplyPayload({
-            approvalId: params.request.id,
-            approvalSlug: params.request.id.slice(0, 8),
-            approvalCommandId: params.request.id,
-            warningText: params.view.warningText ?? undefined,
-            ask: params.view.ask ?? null,
-            agentId: params.view.agentId ?? null,
-            allowedDecisions: reactionPayload.allowedDecisions,
-            command: params.view.commandText,
-            cwd: params.view.cwd ?? undefined,
-            host: params.view.host === "node" ? "node" : "gateway",
-            nodeId: params.view.nodeId ?? undefined,
-            sessionKey: params.view.sessionKey ?? null,
-            expiresAtMs: params.request.expiresAtMs,
-            nowMs: params.nowMs,
-          } satisfies ExecApprovalPendingReplyParams),
-        );
-  return { reactionPayload, manualFallbackPayload };
+  const request = normalizeApprovalRequest(params.request);
+  if (params.view.approvalKind === "plugin") {
+    if (request.approvalKind !== "plugin") {
+      throw new Error("approval request and view kinds do not match");
+    }
+    const payload = buildPluginApprovalPendingReplyPayload({
+      request,
+      nowMs: params.nowMs,
+      allowedDecisions: reactionPayload.allowedDecisions,
+    });
+    return {
+      reactionPayload,
+      manualFallbackPayload: withoutPresentation({
+        ...payload,
+        text: replaceApprovalIdPlaceholder(payload.text, request.id),
+      }),
+    };
+  }
+  if (request.approvalKind !== "exec") {
+    throw new Error("approval request and view kinds do not match");
+  }
+  return {
+    reactionPayload,
+    manualFallbackPayload: withoutPresentation(
+      buildExecApprovalPendingReplyPayload({
+        approvalId: request.id,
+        approvalSlug: request.id.slice(0, 8),
+        approvalCommandId: request.id,
+        warningText: params.view.warningText ?? undefined,
+        ask: params.view.ask ?? null,
+        agentId: params.view.agentId ?? null,
+        allowedDecisions: reactionPayload.allowedDecisions,
+        command: params.view.commandText,
+        cwd: params.view.cwd ?? undefined,
+        host: params.view.host === "node" ? "node" : "gateway",
+        nodeId: params.view.nodeId ?? undefined,
+        sessionKey: params.view.sessionKey ?? null,
+        expiresAtMs: request.expiresAtMs,
+        nowMs: params.nowMs,
+      } satisfies ExecApprovalPendingReplyParams),
+    ),
+  };
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Exec and plugin approval requests shared a structural union whose owner was repeatedly inferred from nested payload fields. That made routing consumers carry duplicate shape probes and gave new producers no explicit request-family metadata.

## Why This Change Was Made

Adds optional `approvalKind` metadata to both request variants and writes it from all Gateway, embedded broker, forwarding, and Matrix producers. `src/infra/approval-types.ts` owns the canonical normalized union and one payload-authoritative normalizer: missing or conflicting metadata is derived from the existing request payload, so the field remains descriptive and never grants authorization.

The normalizer preserves identity for canonical requests but copies legacy/mismatched inputs, keeping old serialized messages unchanged. Existing legacy ownership overrides remain compatible. No existing field is removed or renamed.

Serialization surface map:

- Gateway protocol: requested events and list projections now emit optional `approvalKind`; existing RPC parameter schemas are unchanged, so no protocol version bump is needed.
- SQLite: the transient request wrapper is not persisted. `operator_approvals` already stores its canonical owner `kind` and safe presentation, so this deliberately uses derive-at-read and makes no schema change.
- Plugin SDK: existing request shapes remain source-compatible; approval handler/reaction runtimes normalize once before discriminant-based branching.
- UI/native clients: existing readers continue routing by event family and tolerate the additive field; no reader requires it.

## User Impact

New approval messages carry an explicit `exec` or `plugin` discriminator. Old rows and in-flight messages without it remain valid and behave identically. Conflicting untrusted metadata cannot change approval ownership or authorization.

Production LOC: +265/-158 (net +107) | Tests: +99/-17 | Tooling: +1/-4

The production growth is the additive request metadata, canonical normalized union, and producer/type propagation required to make approval ownership explicit across Gateway and plugin boundaries.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/infra/approval-view-model.test.ts src/infra/exec-approval-channel-runtime.test.ts src/infra/approval-handler-runtime.test.ts src/infra/approval-request-filters.test.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/server-methods.test.ts src/infra/embedded-plugin-approval-broker.test.ts` — 302 tests passed on latest Main.
- Legacy replay regression proves an old request without `approvalKind` is normalized for delivery/resolution while its serialized input remains byte-identical.
- Gateway requested-event and list tests prove both exec and plugin producers emit their discriminants.
- `node scripts/run-vitest.mjs src/infra/approval-native-runtime.test.ts src/infra/approval-handler-runtime.test.ts src/infra/exec-approval-channel-runtime.test.ts` — 43 tests passed after aligning the deprecated-override sibling with canonical normalized inputs.
- `node scripts/check-changed.mjs` — passed all core/extension typechecks, lint, SDK surface, schema/storage, and import-cycle gates.
- `pnpm lint` — full core/extensions/scripts lint passed.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- No protocol version, SQLite schema, or existing-field compatibility change.
