### PR TITLE
test(qa): cover Discord progress draft lifecycle

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -48,6 +48,11 @@ on:
         required: false
         default: false
         type: boolean
+      discord_provider_mode:
+        description: Provider mode for the Discord live transport lane
+        required: false
+        default: live-frontier
+        type: string
       run_whatsapp:
         description: Run the WhatsApp live lane
         required: false
@@ -92,6 +97,14 @@ on:
         description: Optional comma-separated Discord scenario ids
         required: false
         type: string
+      discord_provider_mode:
+        description: Provider mode for the Discord live transport lane
+        required: false
+        default: live-frontier
+        type: choice
+        options:
+          - live-frontier
+          - mock-openai
       whatsapp_scenario:
         description: Optional comma-separated WhatsApp scenario ids
         required: false
@@ -749,11 +762,24 @@ jobs:
           OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "1800000"
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           INPUT_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && inputs.discord_scenario || '' }}
+          PROVIDER_MODE: ${{ inputs.discord_provider_mode || 'live-frontier' }}
         run: |
           set -euo pipefail
 
           output_dir=".artifacts/qa-e2e/discord-live-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           scenario_args=()
+          provider_args=(--provider-mode "${PROVIDER_MODE}")
+
+          if [[ "${PROVIDER_MODE}" == "live-frontier" ]]; then
+            provider_args+=(
+              --model openai/gpt-5.6-luna
+              --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}"
+              --fast
+            )
+          elif [[ "${PROVIDER_MODE}" != "mock-openai" ]]; then
+            echo "Unsupported Discord provider mode: ${PROVIDER_MODE}" >&2
+            exit 2
+          fi
 
           if [[ -n "${INPUT_SCENARIO// }" ]]; then
             IFS=',' read -r -a raw_scenarios <<<"${INPUT_SCENARIO}"
@@ -770,10 +796,7 @@ jobs:
           pnpm openclaw qa discord \
             --repo-root . \
             --output-dir "${output_dir}" \
-            --provider-mode live-frontier \
-            --model openai/gpt-5.6-luna \
-            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
-            --fast \
+            "${provider_args[@]}" \
             --credential-source convex \
             --credential-role ci \
             "${scenario_args[@]}"

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -609,6 +609,9 @@ Discord YAML module scenarios (`qa/scenarios/channels/discord-*.yaml`):
 - `discord-canary`
 - `discord-mention-gating`
 - `discord-native-help-command-registration`
+- `discord-progress-draft-lifecycle` - runs a deterministic tool turn, verifies
+  the final answer has no synthesized activity receipt, and confirms the
+  working draft is deleted after the final lands.
 - `discord-voice-autojoin` - opt-in voice scenario. Runs by itself, enables
   `channels.discord.voice.autoJoin`, and verifies the SUT bot's current
   Discord voice state is the target voice/stage channel. Convex Discord

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -52,6 +52,12 @@ export type DiscordQaScenarioRun =
       input: string;
     }
   | {
+      kind: "progress-draft-lifecycle";
+      finalMarker: string;
+      input: string;
+      progressLabel: string;
+    }
+  | {
       kind: "thread-reply-filepath-attachment";
       expectedAttachmentFilename: string;
       input: string;
@@ -283,6 +289,23 @@ export const discordQaStatusReactionsToolOnlyScenario: DiscordQaScenarioImplemen
   },
 };
 
+export const discordQaProgressDraftLifecycleScenario: DiscordQaScenarioImplementation = {
+  buildRun: (sutApplicationId) => {
+    const suffix = randomUUID().slice(0, 8).toUpperCase();
+    const finalMarker = `DISCORD_QA_PROGRESS_FINAL_${suffix}`;
+    return {
+      kind: "progress-draft-lifecycle",
+      finalMarker,
+      progressLabel: `Discord progress QA ${suffix}`,
+      input: [
+        `<@${sutApplicationId}> Tool progress QA check:`,
+        "call the exec tool exactly once with this exact command before answering: `sleep 5`.",
+        `After that command completes, reply exactly \`${finalMarker}\`.`,
+      ].join(" "),
+    };
+  },
+};
+
 export const discordQaThreadReplyFilepathAttachmentScenario: DiscordQaScenarioImplementation = {
   buildRun: () => {
     const token = `DISCORD_QA_THREAD_FILE_${randomUUID().slice(0, 8).toUpperCase()}`;
@@ -369,6 +392,7 @@ function buildDiscordQaConfig(
     sutBotToken: string;
   },
   options: {
+    progressDraftLabel?: string;
     statusReactionsToolOnly?: boolean;
     voiceChannelAccess?: {
       channelId: string;
@@ -457,6 +481,18 @@ function buildDiscordQaConfig(
           [params.sutAccountId]: {
             enabled: true,
             token: params.sutBotToken,
+            ...(options.progressDraftLabel
+              ? {
+                  streaming: {
+                    mode: "progress" as const,
+                    progress: {
+                      commentary: false,
+                      label: options.progressDraftLabel,
+                      toolProgress: true,
+                    },
+                  },
+                }
+              : {}),
             allowBots: options.statusReactionsToolOnly ? true : "mentions",
             groupPolicy: "allowlist",
             guilds: {
@@ -629,6 +665,54 @@ async function getChannelMessage(params: { token: string; channelId: string; mes
     {
       timeoutMs: 15_000,
     },
+  );
+}
+
+async function waitForDiscordMessageText(params: {
+  token: string;
+  channelId: string;
+  messageId: string;
+  textIncludes: string[];
+  timeoutMs: number;
+}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < params.timeoutMs) {
+    const message = await getChannelMessage(params);
+    const normalized = normalizeDiscordObservedMessage(message);
+    if (normalized && params.textIncludes.every((text) => normalized.text.includes(text))) {
+      return normalized;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+  throw new Error(
+    `timed out after ${params.timeoutMs}ms waiting for Discord message ${params.messageId} text`,
+  );
+}
+
+async function waitForDiscordMessageDeleted(params: {
+  token: string;
+  channelId: string;
+  messageId: string;
+  timeoutMs: number;
+}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < params.timeoutMs) {
+    try {
+      await getChannelMessage(params);
+    } catch (error) {
+      if (error instanceof DiscordApiError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+  throw new Error(
+    `timed out after ${params.timeoutMs}ms waiting for Discord message ${params.messageId} deletion`,
   );
 }
 
@@ -1433,6 +1517,8 @@ const testing = {
   renderDiscordThreadReplyAttachmentHtml,
   resolveDiscordQaRuntimeEnv,
   waitForDiscordChannelRunning,
+  waitForDiscordMessageDeleted,
+  waitForDiscordMessageText,
   waitForDiscordVoiceState,
   writeDiscordStatusReactionEvidence,
 };

--- a/extensions/qa-lab/src/live-transports/discord/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-environment.ts
@@ -92,6 +92,9 @@ export function createDiscordQaScenarioEnvironment(params: {
                       },
                     }
                   : {}),
+                ...(run.kind === "progress-draft-lifecycle"
+                  ? { progressDraftLabel: run.progressLabel }
+                  : {}),
                 statusReactionsToolOnly: run.kind === "status-reactions-tool-only",
               },
             );

--- a/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
@@ -10,6 +10,7 @@ export {
   discordQaCanaryScenario,
   discordQaMentionGatingScenario,
   discordQaNativeHelpCommandRegistrationScenario,
+  discordQaProgressDraftLifecycleScenario,
   discordQaStatusReactionsToolOnlyScenario,
   discordQaThreadReplyFilepathAttachmentScenario,
   discordQaVoiceAutojoinScenario,
@@ -70,6 +71,68 @@ export async function runDiscordScenario(
       throw new Error(result.details);
     }
     return { details: result.details, artifacts: result.artifactPaths };
+  }
+  if (run.kind === "progress-draft-lifecycle") {
+    const deadline = Date.now() + scenario.timeoutMs;
+    const remainingMs = () => Math.max(1, deadline - Date.now());
+    const sent = await discordQaScenarioSupport.testing.sendChannelMessage(
+      environment.runtimeEnv.driverBotToken,
+      environment.runtimeEnv.channelId,
+      run.input,
+    );
+    const draft = await discordQaScenarioSupport.testing.pollChannelMessages({
+      token: environment.runtimeEnv.driverBotToken,
+      channelId: environment.runtimeEnv.channelId,
+      afterSnowflake: sent.id,
+      timeoutMs: remainingMs(),
+      observedMessages: environment.observedMessages,
+      observationScenarioId: scenario.id,
+      observationScenarioTitle: scenario.title,
+      triggerMessageId: sent.id,
+      triggerTimestamp: sent.timestamp,
+      predicate: (message) => message.senderId === environment.sutIdentity.id,
+    });
+    await discordQaScenarioSupport.testing.waitForDiscordMessageText({
+      token: environment.runtimeEnv.driverBotToken,
+      channelId: environment.runtimeEnv.channelId,
+      messageId: draft.message.messageId,
+      textIncludes: [run.progressLabel, "🛠️ Exec"],
+      timeoutMs: remainingMs(),
+    });
+    const final = await discordQaScenarioSupport.testing.pollChannelMessages({
+      token: environment.runtimeEnv.driverBotToken,
+      channelId: environment.runtimeEnv.channelId,
+      afterSnowflake: draft.message.messageId,
+      timeoutMs: remainingMs(),
+      observedMessages: environment.observedMessages,
+      observationScenarioId: scenario.id,
+      observationScenarioTitle: scenario.title,
+      triggerMessageId: sent.id,
+      triggerTimestamp: sent.timestamp,
+      predicate: (message) =>
+        message.senderId === environment.sutIdentity.id && message.text.includes(run.finalMarker),
+    });
+    discordQaScenarioSupport.testing.assertDiscordScenarioReply({
+      expectedTextIncludes: [run.finalMarker],
+      message: final.message,
+    });
+    const forbiddenReceipt = [
+      /(?:^|\n)-#(?:\s|$)/u,
+      /🛠️\s*\d+\s+tool calls?/iu,
+      /⏱️\s*\d+(?:\.\d+)?s\b/u,
+    ].find((pattern) => pattern.test(final.message.text));
+    if (forbiddenReceipt) {
+      throw new Error(
+        `Discord final reply retained synthesized activity receipt ${forbiddenReceipt}`,
+      );
+    }
+    await discordQaScenarioSupport.testing.waitForDiscordMessageDeleted({
+      token: environment.runtimeEnv.driverBotToken,
+      channelId: environment.runtimeEnv.channelId,
+      messageId: draft.message.messageId,
+      timeoutMs: remainingMs(),
+    });
+    return { details: "progress draft observed; receipt-free final landed; draft deleted" };
   }
   const sent = await discordQaScenarioSupport.testing.sendChannelMessage(
     environment.runtimeEnv.driverBotToken,

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -27,7 +27,7 @@ describe("qa scenario catalog channel contracts", () => {
       (scenario) => scenario.execution.flowKind === "module",
     );
 
-    expect(moduleFlows).toHaveLength(145);
+    expect(moduleFlows).toHaveLength(146);
     expect(moduleFlows.every((scenario) => scenario.execution.flow)).toBe(true);
   });
 

--- a/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
+++ b/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
@@ -20,7 +20,6 @@ scenario:
   execution:
     kind: flow
     channel: discord
-    providerMode: mock-openai
     timeoutMs: 90000
     retryCount: 0
     suiteIsolation: isolated

--- a/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
+++ b/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
@@ -20,6 +20,7 @@ scenario:
   execution:
     kind: flow
     channel: discord
+    providerMode: mock-openai
     timeoutMs: 90000
     retryCount: 0
     suiteIsolation: isolated

--- a/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
+++ b/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
@@ -1,0 +1,33 @@
+title: Discord progress draft retires after a receipt-free final
+scenario:
+  id: discord-progress-draft-lifecycle
+  surface: channels
+  coverage:
+    primary:
+      - agent-runtime.streaming-replies-delivery
+  regressionRefs:
+    - openclaw/openclaw#124972
+  objective: Verify a real Discord tool-progress draft stays transient and does not synthesize activity into the final answer.
+  successCriteria:
+    - A tool-using turn creates a visible Discord progress draft while the tool is running.
+    - The final answer contains no tool-count, elapsed-time, or Discord subtext receipt.
+    - The working draft is deleted only after the final answer lands.
+  codeRefs:
+    - extensions/discord/src/monitor/message-handler.process.ts
+    - extensions/discord/src/monitor/message-handler.draft-preview.ts
+    - extensions/discord/src/monitor/message-handler.process-progress.ts
+    - extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
+  execution:
+    kind: flow
+    channel: discord
+    providerMode: mock-openai
+    timeoutMs: 90000
+    retryCount: 0
+    suiteIsolation: isolated
+    isolationReason: Enables Discord progress streaming and observes one real draft create/final/delete lifecycle.
+flow:
+  module: ./live-transports/discord/scenario-runtime.js
+  call: runDiscordScenario
+  args:
+    - { expr: discordScenarioContext }
+    - { moduleExport: discordQaProgressDraftLifecycleScenario }


### PR DESCRIPTION
## What Problem This Solves

Discord had no QA Lab scenario covering the progress-draft terminal lifecycle, so the removal of synthesized per-turn activity receipts in #124972 had only unit coverage. A regression could restore the `-#`, tool-call count, or elapsed-time footer without a real Discord transport check catching it.

## Why This Change Was Made

This adds one deterministic `mock-openai` Discord scenario that holds a real tool turn open long enough to observe its progress draft, captures the distinct final reply, rejects every legacy receipt signature, and verifies the working draft is deleted after Discord accepts the final. The implementation extends the existing Discord QA runtime and REST helpers; it adds no product seam. A narrow provider-mode input lets the existing credentialed Discord workflow select the mock provider without changing its live-frontier default.

Error-final draft retention is intentionally not claimed here: current Discord cleanup clears an `isError` draft, and existing unit coverage expects that behavior. Changing product behavior was outside this test-only change. The adopted-thread terminal path is also not reachable through the current live adapter because the mock provider has no active-turn Discord thread-create fixture; the existing thread scenario bypasses active-turn adoption.

## User Impact

Maintainers gain real-transport regression coverage for Discord's normal successful progress-draft lifecycle. Finished Discord replies remain clean, with no synthesized tool/timing footer and no orphaned progress message left above the answer.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab` — 197 files passed; 2,718 tests passed; 2 skipped.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed all selected lanes after the delegated Daytona backend hit its documented 10 GiB capacity limit.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
- [Credentialed Discord job](https://github.com/openclaw/openclaw/actions/runs/31999963640/job/95299081603) on exact head `012a153b051a7369471cb98d23a38cc0384c1487` — passed with `channel.live=true`, `provider.fixture=mock-openai`, and `progress draft observed; receipt-free final landed; draft deleted`.
- Receipt negative control was not executed: local Convex credentials are unavailable, and the hosted secret-bearing workflow only accepts committed open-PR heads. Running a transient pre-#124972 production regression would require publishing it to another PR head rather than reverting it locally. The assertion matches that prior implementation's exact `-# … 🛠️ N tool calls … ⏱️ Ns` suffix.
