### PR TITLE
fix(sandbox): queue reads behind in-flight writes to the same file

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -43,6 +43,7 @@ import {
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentTool, AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import { resolveSandboxFileMutationQueueKey } from "./sandbox/file-mutation-identity.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import {
   createEditTool,
@@ -1242,6 +1243,7 @@ export function wrapReadToolWithSkillContent(
 
 function createSandboxReadOperations(params: SandboxToolParams) {
   return {
+    resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
     resolvePath: (filePath: string) => {
       const normalizedMediaSource = normalizeMediaReferenceSource(filePath);
       if (classifyMediaReferenceSource(normalizedMediaSource).isMediaStoreUrl) {
@@ -1266,6 +1268,7 @@ function createSandboxReadOperations(params: SandboxToolParams) {
 function createSandboxWriteOperations(params: SandboxToolParams) {
   return withMemoryWriteProvenance(
     {
+      resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
       mkdir: async (dir: string) => {
         await params.bridge.mkdirp({ filePath: dir, cwd: params.root });
       },
@@ -1284,6 +1287,7 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
 function createSandboxEditOperations(params: SandboxToolParams) {
   return withMemoryWriteProvenance(
     {
+      resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
       readFile: (absolutePath: string) =>
         params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
       writeFile: (absolutePath: string, content: string) =>
@@ -1294,6 +1298,15 @@ function createSandboxEditOperations(params: SandboxToolParams) {
     } as const,
     params.memoryWriteProvenance,
   );
+}
+
+async function resolveSandboxFileQueueKey(params: SandboxToolParams, absolutePath: string) {
+  return await resolveSandboxFileMutationQueueKey({
+    bridge: params.bridge,
+    root: params.root,
+    filePath: absolutePath,
+    cwd: params.root,
+  });
 }
 
 async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: string) {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1243,7 +1243,8 @@ export function wrapReadToolWithSkillContent(
 
 function createSandboxReadOperations(params: SandboxToolParams) {
   return {
-    resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
+    resolveQueueKey: (absolutePath: string, signal?: AbortSignal) =>
+      resolveSandboxFileQueueKey(params, absolutePath, signal),
     resolvePath: (filePath: string) => {
       const normalizedMediaSource = normalizeMediaReferenceSource(filePath);
       if (classifyMediaReferenceSource(normalizedMediaSource).isMediaStoreUrl) {
@@ -1268,7 +1269,8 @@ function createSandboxReadOperations(params: SandboxToolParams) {
 function createSandboxWriteOperations(params: SandboxToolParams) {
   return withMemoryWriteProvenance(
     {
-      resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
+      resolveQueueKey: (absolutePath: string, signal?: AbortSignal) =>
+        resolveSandboxFileQueueKey(params, absolutePath, signal),
       mkdir: async (dir: string) => {
         await params.bridge.mkdirp({ filePath: dir, cwd: params.root });
       },
@@ -1287,7 +1289,8 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
 function createSandboxEditOperations(params: SandboxToolParams) {
   return withMemoryWriteProvenance(
     {
-      resolveQueueKey: (absolutePath: string) => resolveSandboxFileQueueKey(params, absolutePath),
+      resolveQueueKey: (absolutePath: string, signal?: AbortSignal) =>
+        resolveSandboxFileQueueKey(params, absolutePath, signal),
       readFile: (absolutePath: string) =>
         params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
       writeFile: (absolutePath: string, content: string) =>
@@ -1300,12 +1303,17 @@ function createSandboxEditOperations(params: SandboxToolParams) {
   );
 }
 
-async function resolveSandboxFileQueueKey(params: SandboxToolParams, absolutePath: string) {
+async function resolveSandboxFileQueueKey(
+  params: SandboxToolParams,
+  absolutePath: string,
+  signal?: AbortSignal,
+) {
   return await resolveSandboxFileMutationQueueKey({
     bridge: params.bridge,
     root: params.root,
     filePath: absolutePath,
     cwd: params.root,
+    signal,
   });
 }
 

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -20,9 +20,11 @@ import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js
 import { preserveAtPrefixedRelativePath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import { resolveSandboxFileMutationQueueKey } from "./sandbox/file-mutation-identity.js";
 import {
-  withFileMutationQueue,
-  withFileMutationQueues,
+  resolveFileMutationQueueKey,
+  withFileMutationQueueKey,
+  withFileMutationQueueKeys,
 } from "./sessions/tools/file-mutation-queue.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
@@ -187,7 +189,7 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
 
     if (hunk.kind === "add") {
       const target = await resolvePatchPath(hunk.path, options);
-      await withFileMutationQueue(target.resolved, async () => {
+      await withFileMutationQueueKey(target.queueKey, async () => {
         await assertPatchParentPath(hunk.path, options);
         await ensureDir(target.resolved, fileOps);
         await createPatchTarget({
@@ -203,15 +205,15 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
 
     if (hunk.kind === "delete") {
       const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
-      await withFileMutationQueue(target.resolved, () => fileOps.remove(target.resolved));
+      await withFileMutationQueueKey(target.queueKey, () => fileOps.remove(target.resolved));
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
 
     const target = await resolvePatchPath(hunk.path, options);
     const moveTarget = hunk.movePath ? await resolvePatchPath(hunk.movePath, options) : undefined;
-    await withFileMutationQueues(
-      [target.resolved, ...(moveTarget ? [moveTarget.resolved] : [])],
+    await withFileMutationQueueKeys(
+      [target.queueKey, ...(moveTarget ? [moveTarget.queueKey] : [])],
       async () => {
         const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
           readFile: (pathLocal) => fileOps.readFile(pathLocal),
@@ -362,7 +364,7 @@ async function resolvePatchPath(
   rawFilePath: string,
   options: ApplyPatchOptions,
   aliasPolicy: PathAliasPolicy = PATH_ALIAS_POLICIES.strict,
-): Promise<{ resolved: string; display: string }> {
+): Promise<{ resolved: string; queueKey: string; display: string }> {
   if (options.sandbox) {
     const filePath = await preserveAtPrefixedRelativePath(
       rawFilePath,
@@ -384,6 +386,12 @@ async function resolvePatchPath(
     }
     return {
       resolved: resolved.hostPath ?? resolved.containerPath,
+      queueKey: await resolveSandboxFileMutationQueueKey({
+        bridge: options.sandbox.bridge,
+        root: options.sandbox.root,
+        filePath,
+        cwd: options.cwd,
+      }),
       display: resolved.relativePath || resolved.containerPath,
     };
   }
@@ -403,6 +411,7 @@ async function resolvePatchPath(
     : resolvePathFromInput(filePath, options.cwd);
   return {
     resolved,
+    queueKey: await resolveFileMutationQueueKey(resolved),
     display: toDisplayPath(resolved, options.cwd),
   };
 }

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -24,7 +24,7 @@ import { resolveSandboxFileMutationQueueKey } from "./sandbox/file-mutation-iden
 import {
   resolveFileMutationQueueKey,
   withFileMutationQueueKeyResolution,
-  withFileMutationQueueKeyResolutions,
+  withFileMutationQueueKeysResolution,
 } from "./sessions/tools/file-mutation-queue.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
@@ -230,13 +230,13 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
     const moveTargetResolution = hunk.movePath
       ? resolvePatchPath(hunk.movePath, options)
       : undefined;
-    await withFileMutationQueueKeyResolutions(
-      [
+    await withFileMutationQueueKeysResolution(
+      Promise.all([
         targetResolution.then((target) => target.queueKey),
         ...(moveTargetResolution
           ? [moveTargetResolution.then((moveTarget) => moveTarget.queueKey)]
           : []),
-      ],
+      ]),
       async () => {
         const target = await targetResolution;
         const moveTarget = moveTargetResolution ? await moveTargetResolution : undefined;

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -23,8 +23,8 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 import { resolveSandboxFileMutationQueueKey } from "./sandbox/file-mutation-identity.js";
 import {
   resolveFileMutationQueueKey,
-  withFileMutationQueueKey,
-  withFileMutationQueueKeys,
+  withFileMutationQueueKeyResolution,
+  withFileMutationQueueKeyResolutions,
 } from "./sessions/tools/file-mutation-queue.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
@@ -188,33 +188,58 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
     }
 
     if (hunk.kind === "add") {
-      const target = await resolvePatchPath(hunk.path, options);
-      await withFileMutationQueueKey(target.queueKey, async () => {
-        await assertPatchParentPath(hunk.path, options);
-        await ensureDir(target.resolved, fileOps);
-        await createPatchTarget({
-          target,
-          contents: hunk.contents,
-          ops: fileOps,
-          hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
-        });
-      });
+      const targetResolution = resolvePatchPath(hunk.path, options);
+      await withFileMutationQueueKeyResolution(
+        targetResolution.then((target) => target.queueKey),
+        async () => {
+          const target = await targetResolution;
+          await assertPatchParentPath(hunk.path, options);
+          await ensureDir(target.resolved, fileOps);
+          await createPatchTarget({
+            target,
+            contents: hunk.contents,
+            ops: fileOps,
+            hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
+          });
+        },
+      );
+      const target = await targetResolution;
       recordSummary(summary, seen, "added", target.display);
       continue;
     }
 
     if (hunk.kind === "delete") {
-      const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
-      await withFileMutationQueueKey(target.queueKey, () => fileOps.remove(target.resolved));
+      const targetResolution = resolvePatchPath(
+        hunk.path,
+        options,
+        PATH_ALIAS_POLICIES.unlinkTarget,
+      );
+      await withFileMutationQueueKeyResolution(
+        targetResolution.then((target) => target.queueKey),
+        async () => {
+          const target = await targetResolution;
+          await fileOps.remove(target.resolved);
+        },
+      );
+      const target = await targetResolution;
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
 
-    const target = await resolvePatchPath(hunk.path, options);
-    const moveTarget = hunk.movePath ? await resolvePatchPath(hunk.movePath, options) : undefined;
-    await withFileMutationQueueKeys(
-      [target.queueKey, ...(moveTarget ? [moveTarget.queueKey] : [])],
+    const targetResolution = resolvePatchPath(hunk.path, options);
+    const moveTargetResolution = hunk.movePath
+      ? resolvePatchPath(hunk.movePath, options)
+      : undefined;
+    await withFileMutationQueueKeyResolutions(
+      [
+        targetResolution.then((target) => target.queueKey),
+        ...(moveTargetResolution
+          ? [moveTargetResolution.then((moveTarget) => moveTarget.queueKey)]
+          : []),
+      ],
       async () => {
+        const target = await targetResolution;
+        const moveTarget = moveTargetResolution ? await moveTargetResolution : undefined;
         const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
           readFile: (pathLocal) => fileOps.readFile(pathLocal),
         });
@@ -391,6 +416,7 @@ async function resolvePatchPath(
         root: options.sandbox.root,
         filePath,
         cwd: options.cwd,
+        signal: options.signal,
       }),
       display: resolved.relativePath || resolved.containerPath,
     };

--- a/src/agents/sandbox/file-mutation-identity.ts
+++ b/src/agents/sandbox/file-mutation-identity.ts
@@ -1,6 +1,22 @@
 import { resolveIdentityPathViaExistingAncestorSync } from "../../infra/boundary-path.js";
 import type { SandboxFsBridge } from "./fs-bridge.types.js";
 
+type SandboxFileIdentityParams = {
+  filePath: string;
+  cwd?: string;
+  signal?: AbortSignal;
+};
+
+export const SANDBOX_FILE_IDENTITY = Symbol.for("openclaw.sandboxFileIdentity");
+
+type SandboxFileIdentityBridge = SandboxFsBridge & {
+  [SANDBOX_FILE_IDENTITY](params: SandboxFileIdentityParams): string | Promise<string>;
+};
+
+function hasSandboxFileIdentity(bridge: SandboxFsBridge): bridge is SandboxFileIdentityBridge {
+  return SANDBOX_FILE_IDENTITY in bridge;
+}
+
 export async function resolveSandboxFileMutationQueueKey(params: {
   bridge: SandboxFsBridge;
   root: string;
@@ -9,8 +25,8 @@ export async function resolveSandboxFileMutationQueueKey(params: {
   signal?: AbortSignal;
 }): Promise<string> {
   let identity: string;
-  if (params.bridge.resolveFileIdentity) {
-    identity = await params.bridge.resolveFileIdentity({
+  if (hasSandboxFileIdentity(params.bridge)) {
+    identity = await params.bridge[SANDBOX_FILE_IDENTITY]({
       filePath: params.filePath,
       cwd: params.cwd,
       signal: params.signal,

--- a/src/agents/sandbox/file-mutation-identity.ts
+++ b/src/agents/sandbox/file-mutation-identity.ts
@@ -1,0 +1,25 @@
+import { resolveIdentityPathViaExistingAncestorSync } from "../../infra/boundary-path.js";
+import type { SandboxFsBridge } from "./fs-bridge.types.js";
+
+export async function resolveSandboxFileMutationQueueKey(params: {
+  bridge: SandboxFsBridge;
+  root: string;
+  filePath: string;
+  cwd?: string;
+}): Promise<string> {
+  let identity: string;
+  if (params.bridge.resolveFileIdentity) {
+    identity = await params.bridge.resolveFileIdentity({
+      filePath: params.filePath,
+      cwd: params.cwd,
+    });
+  } else {
+    // Shipped plugin bridges may predate physical identity support. Their resolved bridge path
+    // preserves the prior SDK contract while current bridges canonicalize aliases.
+    const resolved = params.bridge.resolvePath({ filePath: params.filePath, cwd: params.cwd });
+    identity = resolved.hostPath
+      ? resolveIdentityPathViaExistingAncestorSync(resolved.hostPath)
+      : resolved.containerPath;
+  }
+  return `${params.root}\0${identity}`;
+}

--- a/src/agents/sandbox/file-mutation-identity.ts
+++ b/src/agents/sandbox/file-mutation-identity.ts
@@ -6,12 +6,14 @@ export async function resolveSandboxFileMutationQueueKey(params: {
   root: string;
   filePath: string;
   cwd?: string;
+  signal?: AbortSignal;
 }): Promise<string> {
   let identity: string;
   if (params.bridge.resolveFileIdentity) {
     identity = await params.bridge.resolveFileIdentity({
       filePath: params.filePath,
       cwd: params.cwd,
+      signal: params.signal,
     });
   } else {
     // Shipped plugin bridges may predate physical identity support. Their resolved bridge path

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -25,7 +25,11 @@ export type SandboxFsBridge = {
    * Returns one backend-owned physical identity for file-operation ordering.
    * Optional to preserve the shipped plugin bridge contract; older bridges use resolvePath identity.
    */
-  resolveFileIdentity?(params: { filePath: string; cwd?: string }): Promise<string>;
+  resolveFileIdentity?(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<string>;
   /** Reads a safely opened regular file, rejecting growth beyond an optional byte limit. */
   readFile(params: {
     filePath: string;

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -21,6 +21,11 @@ export type SandboxFsStat = {
 /** Filesystem operations exposed across the sandbox boundary. */
 export type SandboxFsBridge = {
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath;
+  /**
+   * Returns one backend-owned physical identity for file-operation ordering.
+   * Optional to preserve the shipped plugin bridge contract; older bridges use resolvePath identity.
+   */
+  resolveFileIdentity?(params: { filePath: string; cwd?: string }): Promise<string>;
   /** Reads a safely opened regular file, rejecting growth beyond an optional byte limit. */
   readFile(params: {
     filePath: string;

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -21,15 +21,6 @@ export type SandboxFsStat = {
 /** Filesystem operations exposed across the sandbox boundary. */
 export type SandboxFsBridge = {
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath;
-  /**
-   * Returns one backend-owned physical identity for file-operation ordering.
-   * Optional to preserve the shipped plugin bridge contract; older bridges use resolvePath identity.
-   */
-  resolveFileIdentity?(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<string>;
   /** Reads a safely opened regular file, rejecting growth beyond an optional byte limit. */
   readFile(params: {
     filePath: string;

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createSandboxedReadTool, createSandboxedWriteTool } from "../agent-tools.read.js";
-import { withFileMutationQueueKey } from "../sessions/tools/file-mutation-queue.js";
 import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-helper.js";
 import { createSandbox } from "./fs-bridge.test-helpers.js";
 import {
@@ -129,13 +128,21 @@ describe("remote sandbox fs bridge", () => {
           bridge.resolveFileIdentity!({ filePath: hostPath, cwd: workspaceDir }),
         ).resolves.toBe(aliasIdentity);
 
-        const blockerStarted = createDeferred();
-        const releaseBlocker = createDeferred();
-        const blocker = withFileMutationQueueKey(`${workspaceDir}\0${aliasIdentity}`, async () => {
-          blockerStarted.resolve();
-          await releaseBlocker.promise;
+        const resolveFileIdentity = bridge.resolveFileIdentity!.bind(bridge);
+        const writeIdentityStarted = createDeferred();
+        const releaseWriteIdentity = createDeferred();
+        const readIdentityResolved = createDeferred();
+        vi.spyOn(bridge, "resolveFileIdentity").mockImplementation(async (params) => {
+          if (params.filePath === remotePath) {
+            writeIdentityStarted.resolve();
+            await releaseWriteIdentity.promise;
+          }
+          const identity = await resolveFileIdentity(params);
+          if (params.filePath === hostPath) {
+            readIdentityResolved.resolve();
+          }
+          return identity;
         });
-        await blockerStarted.promise;
         const statSpy = vi.spyOn(bridge, "stat");
         const writeTool = createSandboxedWriteTool({ root: workspaceDir, bridge });
         const readTool = createSandboxedReadTool({ root: workspaceDir, bridge });
@@ -143,15 +150,16 @@ describe("remote sandbox fs bridge", () => {
           path: remotePath,
           content: "remote snapshot",
         });
+        await writeIdentityStarted.promise;
         const readResult = readTool.execute("read", { path: hostPath });
         void readResult.catch(() => {});
+        await readIdentityResolved.promise;
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
         expect(statSpy).not.toHaveBeenCalled();
 
-        releaseBlocker.resolve();
-        await blocker;
+        releaseWriteIdentity.resolve();
         const [, result] = await Promise.all([writeResult, readResult]);
         expect(statSpy).toHaveBeenCalled();
         expect(result.content).toEqual(

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createSandboxedReadTool, createSandboxedWriteTool } from "../agent-tools.read.js";
+import { resolveSandboxFileMutationQueueKey } from "./file-mutation-identity.js";
 import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-helper.js";
 import { createSandbox } from "./fs-bridge.test-helpers.js";
 import {
@@ -120,29 +121,43 @@ describe("remote sandbox fs bridge", () => {
         const bridge = createRemoteShellSandboxFsBridge({ sandbox, runtime });
         const remotePath = path.join(remoteWorkspaceDir, "race-target.txt");
         const hostPath = path.join(workspaceDir, "race-target.txt");
-        const aliasIdentity = await bridge.resolveFileIdentity!({
+        const aliasIdentity = await resolveSandboxFileMutationQueueKey({
+          bridge,
+          root: workspaceDir,
           filePath: remotePath,
           cwd: workspaceDir,
         });
         await expect(
-          bridge.resolveFileIdentity!({ filePath: hostPath, cwd: workspaceDir }),
+          resolveSandboxFileMutationQueueKey({
+            bridge,
+            root: workspaceDir,
+            filePath: hostPath,
+            cwd: workspaceDir,
+          }),
         ).resolves.toBe(aliasIdentity);
 
-        const resolveFileIdentity = bridge.resolveFileIdentity!.bind(bridge);
         const writeIdentityStarted = createDeferred();
         const releaseWriteIdentity = createDeferred();
         const readIdentityResolved = createDeferred();
-        vi.spyOn(bridge, "resolveFileIdentity").mockImplementation(async (params) => {
-          if (params.filePath === remotePath) {
+        const runRemoteShellScript = runtime.runRemoteShellScript.bind(runtime);
+        let identityCallCount = 0;
+        runtime.runRemoteShellScript = async (command) => {
+          const isTargetIdentity =
+            command.script.includes('target="$1"') && command.args?.[0] === remotePath;
+          if (!isTargetIdentity) {
+            return await runRemoteShellScript(command);
+          }
+          const identityCall = ++identityCallCount;
+          if (identityCall === 1) {
             writeIdentityStarted.resolve();
             await releaseWriteIdentity.promise;
           }
-          const identity = await resolveFileIdentity(params);
-          if (params.filePath === hostPath) {
+          const result = await runRemoteShellScript(command);
+          if (identityCall === 2) {
             readIdentityResolved.resolve();
           }
-          return identity;
-        });
+          return result;
+        };
         const statSpy = vi.spyOn(bridge, "stat");
         const writeTool = createSandboxedWriteTool({ root: workspaceDir, bridge });
         const readTool = createSandboxedReadTool({ root: workspaceDir, bridge });

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -2,7 +2,10 @@
 // the pinned mutation helper and remote stat/path guards.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createSandboxedReadTool, createSandboxedWriteTool } from "../agent-tools.read.js";
+import { withFileMutationQueueKey } from "../sessions/tools/file-mutation-queue.js";
 import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-helper.js";
 import { createSandbox } from "./fs-bridge.test-helpers.js";
 import {
@@ -101,6 +104,64 @@ describe("remote sandbox fs bridge", () => {
       }),
     ).resolves.toMatchObject({ code: SANDBOX_CREATE_EXISTS_EXIT_CODE });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "orders sandbox tools through one remote alias identity",
+    async () => {
+      await withTempDir("openclaw-remote-fs-queue-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "host-workspace");
+        const remoteWorkspaceDir = path.join(stateDir, "remote-workspace");
+        await fs.mkdir(workspaceDir);
+        await fs.mkdir(remoteWorkspaceDir);
+        const sandbox = createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir });
+        const { runtime } = createLocalRemoteRuntime({
+          remoteWorkspaceDir,
+          remoteAgentWorkspaceDir: remoteWorkspaceDir,
+        });
+        const bridge = createRemoteShellSandboxFsBridge({ sandbox, runtime });
+        const remotePath = path.join(remoteWorkspaceDir, "race-target.txt");
+        const hostPath = path.join(workspaceDir, "race-target.txt");
+        const aliasIdentity = await bridge.resolveFileIdentity!({
+          filePath: remotePath,
+          cwd: workspaceDir,
+        });
+        await expect(
+          bridge.resolveFileIdentity!({ filePath: hostPath, cwd: workspaceDir }),
+        ).resolves.toBe(aliasIdentity);
+
+        const blockerStarted = createDeferred();
+        const releaseBlocker = createDeferred();
+        const blocker = withFileMutationQueueKey(`${workspaceDir}\0${aliasIdentity}`, async () => {
+          blockerStarted.resolve();
+          await releaseBlocker.promise;
+        });
+        await blockerStarted.promise;
+        const statSpy = vi.spyOn(bridge, "stat");
+        const writeTool = createSandboxedWriteTool({ root: workspaceDir, bridge });
+        const readTool = createSandboxedReadTool({ root: workspaceDir, bridge });
+        const writeResult = writeTool.execute("write", {
+          path: remotePath,
+          content: "remote snapshot",
+        });
+        const readResult = readTool.execute("read", { path: hostPath });
+        void readResult.catch(() => {});
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(statSpy).not.toHaveBeenCalled();
+
+        releaseBlocker.resolve();
+        await blocker;
+        const [, result] = await Promise.all([writeResult, readResult]);
+        expect(statSpy).toHaveBeenCalled();
+        expect(result.content).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: "text", text: "remote snapshot" }),
+          ]),
+        );
+      });
+    },
+  );
 
   it.each([
     {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -65,6 +65,16 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     };
   }
 
+  async resolveFileIdentity(params: { filePath: string; cwd?: string }): Promise<string> {
+    const target = this.resolveTarget(params);
+    const { canonicalPath } = await this.resolveCanonicalPath({
+      containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
+      action: "identify files",
+    });
+    return canonicalPath;
+  }
+
   async readFile(params: {
     filePath: string;
     cwd?: string;

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -9,6 +9,7 @@ import type {
   SandboxBackendCommandResult,
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
+import { SANDBOX_FILE_IDENTITY } from "./file-mutation-identity.js";
 import {
   SANDBOX_CREATE_EXISTS_EXIT_CODE,
   SANDBOX_PINNED_MUTATION_PYTHON,
@@ -65,7 +66,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     };
   }
 
-  async resolveFileIdentity(params: {
+  async [SANDBOX_FILE_IDENTITY](params: {
     filePath: string;
     cwd?: string;
     signal?: AbortSignal;

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -65,12 +65,17 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     };
   }
 
-  async resolveFileIdentity(params: { filePath: string; cwd?: string }): Promise<string> {
+  async resolveFileIdentity(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<string> {
     const target = this.resolveTarget(params);
     const { canonicalPath } = await this.resolveCanonicalPath({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "identify files",
+      signal: params.signal,
     });
     return canonicalPath;
   }

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -32,7 +32,7 @@ import {
   stripBom,
   validateNoOpEditTargets,
 } from "./edit-diff.js";
-import { withFileMutationQueue } from "./file-mutation-queue.js";
+import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
 import { type PersistedFileStat, verifyPersistedUtf8File } from "./file-write-verification.js";
 import { resolveToCwd } from "./path-utils.js";
 import { invalidArgText, shortenPath, str } from "./render-utils.js";
@@ -96,6 +96,8 @@ const EDIT_MISMATCH_HINT_LIMIT = 800;
  * Override these to delegate file editing to remote systems (for example SSH).
  */
 export interface EditOperations {
+  /** Resolve the physical identity used to order this backend's file operations. */
+  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
   /** Read file contents as a Buffer */
   readFile: (absolutePath: string) => Promise<Buffer>;
   /** Write content to a file */
@@ -407,8 +409,9 @@ export function createEditToolDefinition(
       void ctx;
       const { path, edits: originalEdits } = validateEditInput(input);
       const absolutePath = resolveToCwd(path, cwd);
+      const queueKey = await resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey);
 
-      return withFileMutationQueue(absolutePath, async () => {
+      return withFileMutationQueueKey(queueKey, async () => {
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -32,7 +32,10 @@ import {
   stripBom,
   validateNoOpEditTargets,
 } from "./edit-diff.js";
-import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
+import {
+  resolveFileMutationQueueKey,
+  withFileMutationQueueKeyResolution,
+} from "./file-mutation-queue.js";
 import { type PersistedFileStat, verifyPersistedUtf8File } from "./file-write-verification.js";
 import { resolveToCwd } from "./path-utils.js";
 import { invalidArgText, shortenPath, str } from "./render-utils.js";
@@ -97,7 +100,7 @@ const EDIT_MISMATCH_HINT_LIMIT = 800;
  */
 export interface EditOperations {
   /** Resolve the physical identity used to order this backend's file operations. */
-  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
+  resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>;
   /** Read file contents as a Buffer */
   readFile: (absolutePath: string) => Promise<Buffer>;
   /** Write content to a file */
@@ -409,9 +412,9 @@ export function createEditToolDefinition(
       void ctx;
       const { path, edits: originalEdits } = validateEditInput(input);
       const absolutePath = resolveToCwd(path, cwd);
-      const queueKey = await resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey);
+      const queueKey = resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey, signal);
 
-      return withFileMutationQueueKey(queueKey, async () => {
+      return withFileMutationQueueKeyResolution(queueKey, async () => {
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }

--- a/src/agents/sessions/tools/file-mutation-queue.ts
+++ b/src/agents/sessions/tools/file-mutation-queue.ts
@@ -3,9 +3,7 @@
  *
  * Serializes edits/writes targeting the same real file while allowing independent files to mutate in parallel.
  */
-import { realpathSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
-import { hasErrnoCode } from "../../../infra/errors.js";
+import { resolveIdentityPathViaExistingAncestorSync } from "../../../infra/boundary-path.js";
 import { resolveGlobalMap } from "../../../shared/global-singleton.js";
 
 const fileMutationTails = resolveGlobalMap<string, Promise<void>>(
@@ -13,22 +11,15 @@ const fileMutationTails = resolveGlobalMap<string, Promise<void>>(
   "close-only",
 );
 
-function getMutationQueueKey(filePath: string): string {
-  const resolvedPath = resolve(filePath);
-  const missingSegments: string[] = [];
-  let candidate = resolvedPath;
-  while (true) {
-    try {
-      return resolve(realpathSync.native(candidate), ...missingSegments.toReversed());
-    } catch (error) {
-      const parent = dirname(candidate);
-      if (!hasErrnoCode(error, "ENOENT") || parent === candidate) {
-        return resolvedPath;
-      }
-      missingSegments.push(basename(candidate));
-      candidate = parent;
-    }
-  }
+function resolveLocalFileMutationQueueKey(filePath: string): string {
+  return resolveIdentityPathViaExistingAncestorSync(filePath);
+}
+
+export async function resolveFileMutationQueueKey(
+  filePath: string,
+  resolveQueueKey?: (absolutePath: string) => string | Promise<string>,
+): Promise<string> {
+  return await (resolveQueueKey?.(filePath) ?? resolveLocalFileMutationQueueKey(filePath));
 }
 
 /**
@@ -39,11 +30,22 @@ export async function withFileMutationQueue<T>(filePath: string, fn: () => Promi
   return await withFileMutationQueues([filePath], fn);
 }
 
-export async function withFileMutationQueues<T>(
+export async function withFileMutationQueueKey<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  return await withFileMutationQueueKeys([key], fn);
+}
+
+async function withFileMutationQueues<T>(
   filePaths: readonly string[],
   fn: () => Promise<T>,
 ): Promise<T> {
-  const keys = [...new Set(filePaths.map(getMutationQueueKey))].toSorted();
+  return await withFileMutationQueueKeys(filePaths.map(resolveLocalFileMutationQueueKey), fn);
+}
+
+export async function withFileMutationQueueKeys<T>(
+  queueKeys: readonly string[],
+  fn: () => Promise<T>,
+): Promise<T> {
+  const keys = [...new Set(queueKeys)].toSorted();
   const current = Promise.all(
     keys.map((key) => (fileMutationTails.get(key) ?? Promise.resolve()).catch(() => undefined)),
   ).then(fn);

--- a/src/agents/sessions/tools/file-mutation-queue.ts
+++ b/src/agents/sessions/tools/file-mutation-queue.ts
@@ -1,14 +1,19 @@
+import { getAgentToolExecutionContext } from "../../../../packages/agent-core/src/tool-execution-context.js";
 /**
  * Per-file mutation queue.
  *
- * Serializes edits/writes targeting the same real file while allowing independent files to mutate in parallel.
+ * Serializes reads and mutations targeting the same real file while allowing independent files to run in parallel.
  */
 import { resolveIdentityPathViaExistingAncestorSync } from "../../../infra/boundary-path.js";
-import { resolveGlobalMap } from "../../../shared/global-singleton.js";
+import { resolveGlobalMap, resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 
 const fileMutationTails = resolveGlobalMap<string, Promise<void>>(
   Symbol.for("openclaw.fileMutationTails"),
   "close-only",
+);
+const keyAdmissions = resolveGlobalSingleton(
+  Symbol.for("openclaw.fileMutationKeyAdmissions"),
+  () => ({ fallbackScope: {}, tails: new WeakMap<object, Promise<void>>() }),
 );
 
 function resolveLocalFileMutationQueueKey(filePath: string): string {
@@ -17,9 +22,50 @@ function resolveLocalFileMutationQueueKey(filePath: string): string {
 
 export async function resolveFileMutationQueueKey(
   filePath: string,
-  resolveQueueKey?: (absolutePath: string) => string | Promise<string>,
+  resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>,
+  signal?: AbortSignal,
 ): Promise<string> {
-  return await (resolveQueueKey?.(filePath) ?? resolveLocalFileMutationQueueKey(filePath));
+  return await (resolveQueueKey?.(filePath, signal) ?? resolveLocalFileMutationQueueKey(filePath));
+}
+
+/**
+ * Preserve source-call admission while backend-owned physical identities resolve concurrently.
+ * Registration is ordered per assistant message; file operations still use only fileMutationTails.
+ */
+export async function withFileMutationQueueKeyResolution<T>(
+  keyResolution: Promise<string>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await withFileMutationQueueKeyResolutions([keyResolution], fn);
+}
+
+export async function withFileMutationQueueKeyResolutions<T>(
+  keyResolutions: readonly Promise<string>[],
+  fn: () => Promise<T>,
+): Promise<T> {
+  const scope = getAgentToolExecutionContext()?.assistantMessage ?? keyAdmissions.fallbackScope;
+  const previousAdmission = keyAdmissions.tails.get(scope) ?? Promise.resolve();
+  for (const keyResolution of keyResolutions) {
+    void keyResolution.catch(() => undefined);
+  }
+  let operation!: Promise<T>;
+  const admission = previousAdmission.then(async () => {
+    const keys = await Promise.all(keyResolutions);
+    operation = enqueueFileMutationQueueKeys(keys, fn);
+  });
+  const tail = admission.then(
+    () => undefined,
+    () => undefined,
+  );
+  keyAdmissions.tails.set(scope, tail);
+  const cleanup = () => {
+    if (keyAdmissions.tails.get(scope) === tail) {
+      keyAdmissions.tails.delete(scope);
+    }
+  };
+  tail.then(cleanup, cleanup);
+  await admission;
+  return await operation;
 }
 
 /**
@@ -30,18 +76,14 @@ export async function withFileMutationQueue<T>(filePath: string, fn: () => Promi
   return await withFileMutationQueues([filePath], fn);
 }
 
-export async function withFileMutationQueueKey<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  return await withFileMutationQueueKeys([key], fn);
-}
-
 async function withFileMutationQueues<T>(
   filePaths: readonly string[],
   fn: () => Promise<T>,
 ): Promise<T> {
-  return await withFileMutationQueueKeys(filePaths.map(resolveLocalFileMutationQueueKey), fn);
+  return await enqueueFileMutationQueueKeys(filePaths.map(resolveLocalFileMutationQueueKey), fn);
 }
 
-export async function withFileMutationQueueKeys<T>(
+function enqueueFileMutationQueueKeys<T>(
   queueKeys: readonly string[],
   fn: () => Promise<T>,
 ): Promise<T> {
@@ -64,5 +106,5 @@ export async function withFileMutationQueueKeys<T>(
     }
   };
   tail.then(cleanup, cleanup);
-  return await current;
+  return current;
 }

--- a/src/agents/sessions/tools/file-mutation-queue.ts
+++ b/src/agents/sessions/tools/file-mutation-queue.ts
@@ -36,21 +36,22 @@ export async function withFileMutationQueueKeyResolution<T>(
   keyResolution: Promise<string>,
   fn: () => Promise<T>,
 ): Promise<T> {
-  return await withFileMutationQueueKeyResolutions([keyResolution], fn);
+  return await withFileMutationQueueKeysResolution(
+    keyResolution.then((key) => [key]),
+    fn,
+  );
 }
 
-export async function withFileMutationQueueKeyResolutions<T>(
-  keyResolutions: readonly Promise<string>[],
+export async function withFileMutationQueueKeysResolution<T>(
+  keysResolution: Promise<readonly string[]>,
   fn: () => Promise<T>,
 ): Promise<T> {
   const scope = getAgentToolExecutionContext()?.assistantMessage ?? keyAdmissions.fallbackScope;
   const previousAdmission = keyAdmissions.tails.get(scope) ?? Promise.resolve();
-  for (const keyResolution of keyResolutions) {
-    void keyResolution.catch(() => undefined);
-  }
+  void keysResolution.catch(() => undefined);
   let operation!: Promise<T>;
   const admission = previousAdmission.then(async () => {
-    const keys = await Promise.all(keyResolutions);
+    const keys = await keysResolution;
     operation = enqueueFileMutationQueueKeys(keys, fn);
   });
   const tail = admission.then(

--- a/src/agents/sessions/tools/file-mutation-queue.ts
+++ b/src/agents/sessions/tools/file-mutation-queue.ts
@@ -4,7 +4,8 @@
  * Serializes edits/writes targeting the same real file while allowing independent files to mutate in parallel.
  */
 import { realpathSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
+import { hasErrnoCode } from "../../../infra/errors.js";
 import { resolveGlobalMap } from "../../../shared/global-singleton.js";
 
 const fileMutationTails = resolveGlobalMap<string, Promise<void>>(
@@ -14,10 +15,19 @@ const fileMutationTails = resolveGlobalMap<string, Promise<void>>(
 
 function getMutationQueueKey(filePath: string): string {
   const resolvedPath = resolve(filePath);
-  try {
-    return realpathSync.native(resolvedPath);
-  } catch {
-    return resolvedPath;
+  const missingSegments: string[] = [];
+  let candidate = resolvedPath;
+  while (true) {
+    try {
+      return resolve(realpathSync.native(candidate), ...missingSegments.toReversed());
+    } catch (error) {
+      const parent = dirname(candidate);
+      if (!hasErrnoCode(error, "ENOENT") || parent === candidate) {
+        return resolvedPath;
+      }
+      missingSegments.push(basename(candidate));
+      candidate = parent;
+    }
   }
 }
 

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -55,8 +55,7 @@ export function resolveToCwd(filePath: string, cwd: string): string {
   return isAbsolute(expanded) ? expanded : resolvePath(cwd, expanded);
 }
 
-/** Equivalent filename spellings worth probing after an exact read path misses. */
-export function getReadPathVariants(filePath: string): string[] {
+function collectReadPathVariants(filePath: string, includeNfd: boolean): string[] {
   const variants = new Set<string>();
   const fileName = basename(filePath);
   const parentPrefix = filePath.slice(0, filePath.length - fileName.length);
@@ -70,11 +69,21 @@ export function getReadPathVariants(filePath: string): string[] {
       variants.add(`${parentPrefix}${quoted.normalize("NFC")}`);
       // macOS filesystems resolve NFC/NFD spellings to the same entry; probing both
       // makes one file look ambiguous. Other platforms can store both distinctly.
-      if (process.platform !== "darwin") {
+      if (includeNfd) {
         variants.add(`${parentPrefix}${quoted.normalize("NFD")}`);
       }
     }
   }
   variants.delete(filePath);
   return [...variants];
+}
+
+/** Equivalent filename spellings worth probing after an exact read path misses. */
+export function getReadPathVariants(filePath: string): string[] {
+  return collectReadPathVariants(filePath, process.platform !== "darwin");
+}
+
+/** Every spelling an exact read or its fallback probes can accept. */
+export function getReadQueuePaths(filePath: string): string[] {
+  return [filePath, ...collectReadPathVariants(filePath, true)];
 }

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -8,8 +8,10 @@ import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
+import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { createReadTool, createReadToolDefinition } from "./read.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./truncate.js";
+import { createWriteToolDefinition } from "./write.js";
 
 const decodeWindowsTextFileBufferMock = vi.hoisted(() =>
   vi.fn(({ buffer }: { buffer: Buffer }) => buffer.toString("utf8")),
@@ -780,5 +782,44 @@ describe("read tool", () => {
 
     expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
     expect(textContent(result)).toBe(`${path.resolve("/workspace", "legacy.txt")}:c4e3bac3`);
+  });
+
+  it("waits for a queued write before reading the same new file", async () => {
+    const tempDir = tempDirs.make("openclaw-read-write-order-");
+    const filePath = path.join(tempDir, "race-target.txt");
+    const blockerStarted = Promise.withResolvers<void>();
+    const releaseBlocker = Promise.withResolvers<void>();
+    const blocker = withFileMutationQueue(filePath, async () => {
+      blockerStarted.resolve();
+      await releaseBlocker.promise;
+    });
+    await blockerStarted.promise;
+    const writeResult = createWriteToolDefinition(tempDir).execute(
+      "write",
+      { path: filePath, content: "first snapshot" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const readResult = createReadToolDefinition(tempDir).execute(
+      "read",
+      { path: filePath },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const readBeforeWrite = await Promise.race([
+      readResult.then(
+        () => "settled" as const,
+        () => "settled" as const,
+      ),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+    ]);
+
+    releaseBlocker.resolve();
+    await blocker;
+    const [, result] = await Promise.all([writeResult, readResult]);
+    expect(readBeforeWrite).toBe("pending");
+    expect(textContent(result)).toBe("first snapshot");
   });
 });

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -826,4 +826,43 @@ describe("read tool", () => {
     expect(readAccess).toHaveBeenCalledOnce();
     expect(textContent(result)).toBe("first snapshot");
   });
+
+  it("queues every accepted Unicode spelling before reading a new file", async () => {
+    const tempDir = tempDirs.make("openclaw-read-unicode-order-");
+    const writePath = path.join(tempDir, "caf\u00e9.txt");
+    const readPath = path.join(tempDir, "cafe\u0301.txt");
+    const blockerStarted = createDeferred();
+    const releaseBlocker = createDeferred();
+    const blocker = withFileMutationQueue(writePath, async () => {
+      blockerStarted.resolve();
+      await releaseBlocker.promise;
+    });
+    await blockerStarted.promise;
+
+    const writeResult = createWriteToolDefinition(tempDir).execute(
+      "write",
+      { path: writePath, content: "normalized snapshot" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const readAccess = vi.fn(async (absolutePath: string) => await fs.access(absolutePath));
+    const readResult = createReadToolDefinition(tempDir, {
+      operations: {
+        access: readAccess,
+        readFile: async (absolutePath) => await fs.readFile(absolutePath),
+      },
+    }).execute("read", { path: readPath }, undefined, undefined, {} as never);
+    void readResult.catch(() => {});
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(readAccess).not.toHaveBeenCalled();
+
+    releaseBlocker.resolve();
+    await blocker;
+    const [, result] = await Promise.all([writeResult, readResult]);
+    expect(readAccess).toHaveBeenCalled();
+    expect(textContent(result)).toContain("normalized snapshot");
+  });
 });

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -785,26 +785,31 @@ describe("read tool", () => {
     expect(textContent(result)).toBe(`${path.resolve("/workspace", "legacy.txt")}:c4e3bac3`);
   });
 
-  it("waits for a queued write before reading the same new file", async () => {
+  it("waits for an aliased queued write before reading the same new file", async () => {
     const tempDir = tempDirs.make("openclaw-read-write-order-");
-    const filePath = path.join(tempDir, "race-target.txt");
+    const realDir = path.join(tempDir, "real");
+    const aliasDir = path.join(tempDir, "alias");
+    await fs.mkdir(realDir);
+    await fs.symlink(realDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
+    const writePath = path.join(aliasDir, "race-target.txt");
+    const readPath = path.join(realDir, "race-target.txt");
     const blockerStarted = createDeferred();
     const releaseBlocker = createDeferred();
-    const blocker = withFileMutationQueue(filePath, async () => {
+    const blocker = withFileMutationQueue(writePath, async () => {
       blockerStarted.resolve();
       await releaseBlocker.promise;
     });
     await blockerStarted.promise;
     const writeResult = createWriteToolDefinition(tempDir).execute(
       "write",
-      { path: filePath, content: "first snapshot" },
+      { path: writePath, content: "first snapshot" },
       undefined,
       undefined,
       {} as never,
     );
     const readResult = createReadToolDefinition(tempDir).execute(
       "read",
-      { path: filePath },
+      { path: readPath },
       undefined,
       undefined,
       {} as never,

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
 import { withFileMutationQueue } from "./file-mutation-queue.js";
@@ -787,8 +788,8 @@ describe("read tool", () => {
   it("waits for a queued write before reading the same new file", async () => {
     const tempDir = tempDirs.make("openclaw-read-write-order-");
     const filePath = path.join(tempDir, "race-target.txt");
-    const blockerStarted = Promise.withResolvers<void>();
-    const releaseBlocker = Promise.withResolvers<void>();
+    const blockerStarted = createDeferred();
+    const releaseBlocker = createDeferred();
     const blocker = withFileMutationQueue(filePath, async () => {
       blockerStarted.resolve();
       await releaseBlocker.promise;
@@ -813,7 +814,9 @@ describe("read tool", () => {
         () => "settled" as const,
         () => "settled" as const,
       ),
-      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 25);
+      }),
     ]);
 
     releaseBlocker.resolve();

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -795,6 +795,7 @@ describe("read tool", () => {
     const readPath = path.join(realDir, "race-target.txt");
     const blockerStarted = createDeferred();
     const releaseBlocker = createDeferred();
+    const readAccess = vi.fn(async (absolutePath: string) => await fs.access(absolutePath));
     const blocker = withFileMutationQueue(writePath, async () => {
       blockerStarted.resolve();
       await releaseBlocker.promise;
@@ -807,27 +808,22 @@ describe("read tool", () => {
       undefined,
       {} as never,
     );
-    const readResult = createReadToolDefinition(tempDir).execute(
-      "read",
-      { path: readPath },
-      undefined,
-      undefined,
-      {} as never,
-    );
-    const readBeforeWrite = await Promise.race([
-      readResult.then(
-        () => "settled" as const,
-        () => "settled" as const,
-      ),
-      new Promise<"pending">((resolve) => {
-        setTimeout(() => resolve("pending"), 25);
-      }),
-    ]);
+    const readResult = createReadToolDefinition(tempDir, {
+      operations: {
+        access: readAccess,
+        readFile: async (absolutePath) => await fs.readFile(absolutePath),
+      },
+    }).execute("read", { path: readPath }, undefined, undefined, {} as never);
+    void readResult.catch(() => {});
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(readAccess).not.toHaveBeenCalled();
 
     releaseBlocker.resolve();
     await blocker;
     const [, result] = await Promise.all([writeResult, readResult]);
-    expect(readBeforeWrite).toBe("pending");
+    expect(readAccess).toHaveBeenCalledOnce();
     expect(textContent(result)).toBe("first snapshot");
   });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -31,7 +31,10 @@ import { processImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeType } from "../../utils/mime.js";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
+import {
+  resolveFileMutationQueueKey,
+  withFileMutationQueueKeyResolution,
+} from "./file-mutation-queue.js";
 import { normalizePositiveLimit } from "./limits.js";
 import { getReadPathVariants, resolveToCwd } from "./path-utils.js";
 import {
@@ -103,7 +106,7 @@ const COMPACT_RESOURCE_FILE_NAMES = new Set(["AGENTS.md", "AGENTS.MD", "CLAUDE.m
  */
 export interface ReadOperations {
   /** Resolve the physical identity used to order this backend's file operations. */
-  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
+  resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>;
   /** Resolve a user-supplied path for this read backend. */
   resolvePath?: (filePath: string, cwd: string) => string | Promise<string>;
   /** Decode text bytes for this backend. Custom backends default to UTF-8. */
@@ -524,11 +527,12 @@ export function createReadToolDefinition(
               // Share write/edit ordering through byte capture only. Decode the
               // immutable snapshot below after releasing the path queue.
               const absoluteInputPath = resolveToCwd(path, cwd);
-              const queueKey = await resolveFileMutationQueueKey(
+              const queueKey = resolveFileMutationQueueKey(
                 absoluteInputPath,
                 ops.resolveQueueKey,
+                signal,
               );
-              const snapshot = await withFileMutationQueueKey(queueKey, async () => {
+              const snapshot = await withFileMutationQueueKeyResolution(queueKey, async () => {
                 const resolved = await resolveReadToolPath(ops, path, cwd);
                 if (aborted) {
                   return undefined;

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -31,6 +31,7 @@ import { processImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeType } from "../../utils/mime.js";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
+import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { normalizePositiveLimit } from "./limits.js";
 import { getReadPathVariants, resolveToCwd } from "./path-utils.js";
 import {
@@ -518,11 +519,22 @@ export function createReadToolDefinition(
             let note: string | undefined;
             let buffer: Buffer;
             try {
-              ({ absolutePath, note } = await resolveReadToolPath(ops, path, cwd));
-              if (aborted) {
+              // Share write/edit ordering through byte capture only. Decode the
+              // immutable snapshot below after releasing the path queue.
+              const snapshot = await withFileMutationQueue(resolveToCwd(path, cwd), async () => {
+                const resolved = await resolveReadToolPath(ops, path, cwd);
+                if (aborted) {
+                  return undefined;
+                }
+                return {
+                  ...resolved,
+                  buffer: await ops.readFile(resolved.absolutePath),
+                };
+              });
+              if (!snapshot) {
                 return;
               }
-              buffer = await ops.readFile(absolutePath);
+              ({ absolutePath, note, buffer } = snapshot);
             } catch (error) {
               if (aborted) {
                 return;

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -33,10 +33,10 @@ import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import {
   resolveFileMutationQueueKey,
-  withFileMutationQueueKeyResolution,
+  withFileMutationQueueKeysResolution,
 } from "./file-mutation-queue.js";
 import { normalizePositiveLimit } from "./limits.js";
-import { getReadPathVariants, resolveToCwd } from "./path-utils.js";
+import { getReadPathVariants, getReadQueuePaths, resolveToCwd } from "./path-utils.js";
 import {
   createReadToolDetails,
   readToolInputSchema,
@@ -243,12 +243,18 @@ async function resolveLocalReadPath(filePath: string, cwd: string): Promise<stri
   return resolveToCwd(filePath, cwd);
 }
 
-async function resolveReadToolPath(
+async function resolveReadToolInputPath(
   ops: ReadOperations,
   filePath: string,
   cwd: string,
+): Promise<string> {
+  return await (ops.resolvePath?.(filePath, cwd) ?? resolveToCwd(filePath, cwd));
+}
+
+async function resolveReadToolPathFromAbsolute(
+  ops: ReadOperations,
+  absolutePath: string,
 ): Promise<{ absolutePath: string; note?: string }> {
-  const absolutePath = await (ops.resolvePath?.(filePath, cwd) ?? resolveToCwd(filePath, cwd));
   try {
     await ops.access(absolutePath);
     return { absolutePath };
@@ -526,22 +532,30 @@ export function createReadToolDefinition(
             try {
               // Share write/edit ordering through byte capture only. Decode the
               // immutable snapshot below after releasing the path queue.
-              const absoluteInputPath = resolveToCwd(path, cwd);
-              const queueKey = resolveFileMutationQueueKey(
-                absoluteInputPath,
-                ops.resolveQueueKey,
-                signal,
+              const inputPathResolution = resolveReadToolInputPath(ops, path, cwd);
+              const queueKeysResolution = inputPathResolution.then(
+                async (absoluteInputPath) =>
+                  await Promise.all(
+                    getReadQueuePaths(absoluteInputPath).map(
+                      async (candidate) =>
+                        await resolveFileMutationQueueKey(candidate, ops.resolveQueueKey, signal),
+                    ),
+                  ),
               );
-              const snapshot = await withFileMutationQueueKeyResolution(queueKey, async () => {
-                const resolved = await resolveReadToolPath(ops, path, cwd);
-                if (aborted) {
-                  return undefined;
-                }
-                return {
-                  ...resolved,
-                  buffer: await ops.readFile(resolved.absolutePath),
-                };
-              });
+              const snapshot = await withFileMutationQueueKeysResolution(
+                queueKeysResolution,
+                async () => {
+                  const absoluteInputPath = await inputPathResolution;
+                  const resolved = await resolveReadToolPathFromAbsolute(ops, absoluteInputPath);
+                  if (aborted) {
+                    return undefined;
+                  }
+                  return {
+                    ...resolved,
+                    buffer: await ops.readFile(resolved.absolutePath),
+                  };
+                },
+              );
               if (!snapshot) {
                 return;
               }

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -31,7 +31,7 @@ import { processImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeType } from "../../utils/mime.js";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { withFileMutationQueue } from "./file-mutation-queue.js";
+import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
 import { normalizePositiveLimit } from "./limits.js";
 import { getReadPathVariants, resolveToCwd } from "./path-utils.js";
 import {
@@ -102,6 +102,8 @@ const COMPACT_RESOURCE_FILE_NAMES = new Set(["AGENTS.md", "AGENTS.MD", "CLAUDE.m
  * Override these to delegate file reading to remote systems (for example SSH).
  */
 export interface ReadOperations {
+  /** Resolve the physical identity used to order this backend's file operations. */
+  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
   /** Resolve a user-supplied path for this read backend. */
   resolvePath?: (filePath: string, cwd: string) => string | Promise<string>;
   /** Decode text bytes for this backend. Custom backends default to UTF-8. */
@@ -521,7 +523,12 @@ export function createReadToolDefinition(
             try {
               // Share write/edit ordering through byte capture only. Decode the
               // immutable snapshot below after releasing the path queue.
-              const snapshot = await withFileMutationQueue(resolveToCwd(path, cwd), async () => {
+              const absoluteInputPath = resolveToCwd(path, cwd);
+              const queueKey = await resolveFileMutationQueueKey(
+                absoluteInputPath,
+                ops.resolveQueueKey,
+              );
+              const snapshot = await withFileMutationQueueKey(queueKey, async () => {
                 const resolved = await resolveReadToolPath(ops, path, cwd);
                 if (aborted) {
                   return undefined;

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -20,7 +20,7 @@ import type { AgentTool } from "../../runtime/index.js";
 import { textResult } from "../../tools/common.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { generateDiffString, generateUnifiedPatch } from "./edit-diff.js";
-import { withFileMutationQueue } from "./file-mutation-queue.js";
+import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
 import { type PersistedFileStat, verifyPersistedUtf8File } from "./file-write-verification.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
@@ -72,6 +72,8 @@ const WriteToolOutputSchema = Type.Union([
  * Override these to delegate file writing to remote systems (for example SSH).
  */
 export interface WriteOperations {
+  /** Resolve the physical identity used to order this backend's file operations. */
+  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
   /** Write content to a file */
   writeFile: (absolutePath: string, content: string) => Promise<void>;
   /** Create directory recursively */
@@ -539,7 +541,8 @@ export function createWriteToolDefinition(
       void ctx;
       const absolutePath = resolveToCwd(path, cwd);
       const dir = dirname(absolutePath);
-      return withFileMutationQueue(absolutePath, async () => {
+      const queueKey = await resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey);
+      return withFileMutationQueueKey(queueKey, async () => {
         const precheck = await readOriginalWriteState(absolutePath, content, ops);
         if (signal?.aborted) {
           throw new Error("Operation aborted");

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -20,7 +20,10 @@ import type { AgentTool } from "../../runtime/index.js";
 import { textResult } from "../../tools/common.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { generateDiffString, generateUnifiedPatch } from "./edit-diff.js";
-import { resolveFileMutationQueueKey, withFileMutationQueueKey } from "./file-mutation-queue.js";
+import {
+  resolveFileMutationQueueKey,
+  withFileMutationQueueKeyResolution,
+} from "./file-mutation-queue.js";
 import { type PersistedFileStat, verifyPersistedUtf8File } from "./file-write-verification.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
@@ -73,7 +76,7 @@ const WriteToolOutputSchema = Type.Union([
  */
 export interface WriteOperations {
   /** Resolve the physical identity used to order this backend's file operations. */
-  resolveQueueKey?: (absolutePath: string) => string | Promise<string>;
+  resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>;
   /** Write content to a file */
   writeFile: (absolutePath: string, content: string) => Promise<void>;
   /** Create directory recursively */
@@ -541,8 +544,8 @@ export function createWriteToolDefinition(
       void ctx;
       const absolutePath = resolveToCwd(path, cwd);
       const dir = dirname(absolutePath);
-      const queueKey = await resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey);
-      return withFileMutationQueueKey(queueKey, async () => {
+      const queueKey = resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey, signal);
+      return withFileMutationQueueKeyResolution(queueKey, async () => {
         const precheck = await readOriginalWriteState(absolutePath, content, ops);
         if (signal?.aborted) {
           throw new Error("Operation aborted");


### PR DESCRIPTION
## What Problem This Solves

Same-turn tool calls can run in parallel. A write and read of the same new sandbox file could race. The read could return `File not found` even though the accepted write finished moments later.

## Why This Change Was Made

`write`, `edit`, and `apply_patch` already share one per-file operation queue. `read` now joins that queue through path resolution, access, and byte capture. The queue releases before image handling, text decoding, truncation, and result formatting.

Sandbox bridges now own physical file identity. This makes host-mirror, remote-workspace, and filesystem-alias spellings converge before the operation is registered. When identity lookup is asynchronous, registration keeps the provider's tool-call order even if the later lookup finishes first. Identity lookups still run concurrently, and operations on different files remain parallel.

Bridge identity stays internal. The public `SandboxFsBridge` contract is unchanged, and existing plugin bridges retain their resolved-path identity behavior. This change adds no retry, configuration, protocol, or storage path.

## User Impact

An agent can write and read one file in the same turn without an intermittent stale or missing-file result. Independent files do not wait for the write to finish.

## Evidence

### Live red and green

A real Telegram Test Server direct-message turn used one provider response with three parallel calls:

1. Write `same-turn-written-by-provider` through the remote workspace path.
2. Read the same new file through its host mirror.
3. Read a seeded `parallel-control.txt` file.

The proof delayed the real write for 1.5 seconds before file creation.

| Revision | Same-file read | Different-file read | Final files |
| --- | --- | --- | --- |
| Exact `main` at `ef858c0f1bb` | `File not found` before the write finished | `parallel-control` during the delay | Both requested values |
| Exact head `4954c13058c` | `same-turn-written-by-provider` | `parallel-control` during the delay | Both requested values |

Current `main` advanced to `599b46c49bb` after the red run. The queue, sandbox bridge, tool, and agent-loop files are unchanged from the proven revision.

The final Telegram reply was:

```text
WRITE=accepted; SAME_PATH=same-turn-written-by-provider; DIFFERENT_PATH=parallel-control
```

The retained provider requests contain the real tool results. The filesystem timeline records the full pre-creation delay. The final command read both values from disk. The exact build records `4954c13058cd0c3c26607e977378a49611b95f6c` in its build metadata.

### Regression support

- The remote bridge regression delays the earlier write's identity lookup and lets the later read resolve the same identity first.
- Before the repair, it fails because the read reaches `stat` before the write registers.
- The accepted Unicode fallback spellings have a separate pre-fix delayed-write regression.
- After the repair, 11 focused files pass with 239 tests and one platform case skipped.
- Exact-head `check-changed` passes production and test types, lint, formatting, dead exports, import cycles, and repository guards.
- The Plugin SDK surface check passes all 147 public subpaths and 339 total entrypoints.
- The exact-head full build passes.

### Scope

- Production: +275/-47, net +228.
- Tests: +169/-1, net +168.
- The production growth establishes one shared owner boundary across read, write, edit, apply-patch, local aliases, and remote aliases. No narrower consumer guard can represent those identities or preserve asynchronous admission order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
