### PR TITLE
fix(node-host): recover MCP catalogs and sessions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1687,7 +1687,7 @@ src/agents/agent-bundle-mcp-manager-api.ts	2
 src/agents/agent-bundle-mcp-manager-lifecycle.ts	1
 src/agents/agent-bundle-mcp-materialize.ts	4
 src/agents/agent-bundle-mcp-runtime-shared.ts	2
-src/agents/agent-bundle-mcp-runtime.ts	10
+src/agents/agent-bundle-mcp-runtime.ts	9
 src/agents/agent-command-restart-recovery.ts	4
 src/agents/agent-command.ts	1
 src/agents/agent-hooks/compaction-safeguard.ts	19
@@ -3489,7 +3489,7 @@ src/node-host/invoke-agent-cli-claude-params.ts	4
 src/node-host/invoke-agent-cli-claude.ts	2
 src/node-host/invoke-file-commands.ts	1
 src/node-host/invoke-payload.ts	5
-src/node-host/invoke.ts	8
+src/node-host/invoke.ts	7
 src/node-host/mcp.ts	3
 src/node-host/node-worker-bundle-installer.ts	1
 src/node-host/node-worker-supervisor.ts	1

--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -51,6 +51,8 @@ const ROOT_TEST_ENTRY_GLOBS = [
   "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts!",
   "test/e2e/qa-lab/runtime/docker-e2e-lane.ts!",
   "test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts!",
+  // The Gateway/node MCP parity tests spawn this transport fixture by path.
+  "test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs!",
   // The identity scenario spawns this process-isolated repeated-turn driver by path.
   "test/e2e/qa-lab/runtime/agent-run-identity-repeated-turn-child.ts!",
   // Invoked directly by the Docker image-auth scenario.

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -205,6 +205,12 @@ require re-pairing because the approved command family is unchanged. Restart
 `openclaw node run` or `openclaw node restart` to apply node MCP config changes;
 the node host does not watch this config.
 
+Server-advertised tool-list changes apply live and replace the published node
+catalog. If an MCP transport closes or a stateful Streamable HTTP session
+expires, the node withdraws that server's stale tools and reconnects with
+bounded backoff. The failed call that detects an expired session is not replayed;
+a later call can use the replacement connection after its tools are republished.
+
 Gateway operators can ignore all agent-visible tools published by paired nodes,
 including node-hosted MCP tools, with
 `gateway.nodes.pluginTools.enabled: false`. Exact command denies such as

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -20,7 +20,7 @@ import type {
   McpToolCatalog,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
-import { mcpContentBlockToAgentContent } from "./mcp-content.js";
+import { projectMcpCallToolResultContent } from "./mcp-content.js";
 import { isMcpToolAllowed } from "./mcp-tool-filter.js";
 import { buildMcpAppCanvasPayload, fetchMcpAppView } from "./mcp-ui-resource.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -100,27 +100,9 @@ function toAgentToolResult(params: {
   toolName: string;
   result: CallToolResult;
 }): AgentToolResult<unknown> {
-  const sourceContent = Array.isArray(params.result.content) ? params.result.content : [];
-  const content: AgentToolResult<unknown>["content"] = sourceContent.map(
-    mcpContentBlockToAgentContent,
-  );
-  const structuredContentBlock =
-    params.result.structuredContent !== undefined
-      ? ({
-          type: "text",
-          text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
-        } as const)
-      : null;
-  // Structured results replace mirrored text, but original non-text blocks
-  // still carry images, linked resources, and audio that the JSON cannot mirror.
-  const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
-    ? [
-        structuredContentBlock,
-        ...sourceContent
-          .filter((block) => block.type !== "text")
-          .map(mcpContentBlockToAgentContent),
-      ]
-    : content.length > 0
+  const content = projectMcpCallToolResultContent(params.result);
+  const normalizedContent: AgentToolResult<unknown>["content"] =
+    content.length > 0
       ? content
       : ([
           {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -5787,12 +5787,6 @@ process.on("SIGINT", shutdown);`,
         } else {
           expect(secondCatalog.servers.slow).toBeDefined();
         }
-        await waitForFileText(
-          slowLogPath,
-          "slow first initialize",
-          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
-        );
-
         await expect(runtime.callTool("trigger", "poke", {})).resolves.toMatchObject({
           content: [{ type: "text", text: "poked" }],
           isError: false,

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1,9 +1,5 @@
 /** Session-scoped MCP runtime catalog loader and transport lifecycle. */
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js";
-import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   ErrorCode,
@@ -57,6 +53,12 @@ import type {
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
 import {
+  connectMcpClient,
+  disposeMcpClient,
+  isStatefulMcpHttpSessionExpired,
+  McpClientConnectTimeoutError,
+} from "./mcp-client-lifecycle.js";
+import {
   normalizeMcpCodexToolAnnotations,
   resolveMcpCodexToolApprovalMode,
 } from "./mcp-codex-tool-approval.js";
@@ -67,7 +69,6 @@ import {
 import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "./mcp-metadata.js";
 import { collectMcpPaginatedItems } from "./mcp-pagination.js";
-import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { isMcpToolAllowed, normalizeMcpToolFilter } from "./mcp-tool-filter.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
@@ -121,53 +122,6 @@ type McpServerBackoffState = {
 };
 
 export { createMcpJsonSchemaValidator as createBundleMcpJsonSchemaValidator };
-
-async function connectWithTimeout(
-  serverName: string,
-  client: Client,
-  transport: Transport,
-  timeoutMs: number,
-): Promise<void> {
-  const abortController = new AbortController();
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  let deadlineExpired = false;
-  try {
-    // Client.connect() owns both transport startup and the initialize round trip.
-    // Give the SDK the deadline so initialize is cancelled, while the outer race
-    // also bounds transports whose start() has not reached initialize yet.
-    await Promise.race([
-      client.connect(transport, {
-        signal: abortController.signal,
-        timeout: timeoutMs,
-        maxTotalTimeout: timeoutMs,
-      }),
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => {
-          deadlineExpired = true;
-          abortController.abort();
-          reject(new Error("MCP connect deadline expired"));
-        }, timeoutMs);
-      }),
-    ]);
-  } catch (error) {
-    if (deadlineExpired || (isRecord(error) && error.code === ErrorCode.RequestTimeout)) {
-      if (transport instanceof OpenClawStdioClientTransport) {
-        await transport.forceClose();
-      }
-      // Closing the SDK client settles its pending initialize request. Without
-      // this, later runtime disposal waits its full teardown timeout even though
-      // the stdio child is already dead.
-      await settleWithin(client.close(), Math.min(timeoutMs, 1_000));
-      throw new Error(
-        `MCP server "${serverName}" timed out: did not complete initialize within ${timeoutMs / 1_000}s`,
-        { cause: error },
-      );
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
 
 function redactMcpDiagnosticError(error: unknown): string {
   return redactToolPayloadText(redactSensitiveUrlLikeString(String(error)));
@@ -266,6 +220,13 @@ function setBundleMcpDisposeTimeoutMsForTest(timeoutMs?: number): void {
       : undefined;
 }
 
+function disposeBundleMcpSession(session: BundleMcpSession): Promise<void> {
+  return disposeMcpClient(
+    session,
+    getBundleMcpTestState().disposeTimeoutMs ?? BUNDLE_MCP_DISPOSE_TIMEOUT_MS,
+  );
+}
+
 function buildMcpClientCapabilities(mcpAppsEnabled: boolean): ClientCapabilities {
   return mcpAppsEnabled
     ? {
@@ -303,53 +264,6 @@ function summarizeServerCapabilities(capabilities: ServerCapabilities | undefine
       : undefined,
   };
 }
-async function settleWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  return await Promise.race([
-    promise.then(
-      () => true,
-      () => true,
-    ),
-    new Promise<void>((resolve) => {
-      timer = setTimeout(() => {
-        resolve();
-      }, timeoutMs);
-      timer.unref?.();
-    }).then(() => false),
-  ]).finally(() => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  });
-}
-
-async function disposeSession(session: BundleMcpSession) {
-  session.detachStderr?.();
-  const timeoutMs = getBundleMcpTestState().disposeTimeoutMs ?? BUNDLE_MCP_DISPOSE_TIMEOUT_MS;
-  const closed = await settleWithin(
-    (async () => {
-      if (session.transportType === "streamable-http") {
-        await (session.transport as StreamableHTTPClientTransport)
-          .terminateSession()
-          .catch(() => {});
-      }
-      await session.transport.close().catch(() => {});
-      await session.client.close().catch(() => {});
-    })(),
-    timeoutMs,
-  );
-  if (!closed) {
-    // Force-close transport and client so a hung terminateSession() DELETE
-    // gets its AbortSignal triggered by teardown. Stdio owns a process group,
-    // so force it dead before disposal can report completion.
-    const transportClose =
-      session.transport instanceof OpenClawStdioClientTransport
-        ? session.transport.forceClose()
-        : session.transport.close();
-    await settleWithin(Promise.allSettled([transportClose, session.client.close()]), timeoutMs);
-  }
-}
-
 function createDisposedError(sessionId: string): Error {
   return new Error(`bundle-mcp runtime disposed for session ${sessionId}`);
 }
@@ -486,12 +400,20 @@ export function createSessionMcpRuntime(params: {
     if (session.connected) {
       return;
     }
-    session.connectPromise ??= connectWithTimeout(
-      session.serverName,
-      session.client,
-      session.transport,
-      connectionTimeoutMs,
-    )
+    session.connectPromise ??= connectMcpClient({
+      client: session.client,
+      transport: session.transport,
+      timeoutMs: connectionTimeoutMs,
+    })
+      .catch((error: unknown) => {
+        if (error instanceof McpClientConnectTimeoutError) {
+          throw new Error(
+            `MCP server "${session.serverName}" timed out: did not complete initialize within ${connectionTimeoutMs / 1_000}s`,
+            { cause: error },
+          );
+        }
+        throw error;
+      })
       .then(() => {
         session.connected = true;
       })
@@ -509,7 +431,7 @@ export function createSessionMcpRuntime(params: {
     }
     session.retiring = true;
     sessions.delete(serverName);
-    await disposeSession(session);
+    await disposeBundleMcpSession(session);
     return true;
   };
   const localRequestTimeouts = new WeakSet<object>();
@@ -580,12 +502,7 @@ export function createSessionMcpRuntime(params: {
     } catch (error) {
       // A stateful server uses HTTP 404 to invalidate an expired MCP session.
       // Reinitialize a fresh client, but never replay a possibly mutating call.
-      const sessionExpired =
-        session.transportType === "streamable-http" &&
-        session.transport instanceof StreamableHTTPClientTransport &&
-        session.transport.sessionId !== undefined &&
-        error instanceof StreamableHTTPError &&
-        error.code === 404;
+      const sessionExpired = isStatefulMcpHttpSessionExpired(session, error);
       let recycleReason: "expired HTTP session" | "repeated request timeouts" | undefined;
       if (sessionExpired && !requestSignal?.aborted) {
         recycleReason = "expired HTTP session";
@@ -1012,7 +929,7 @@ export function createSessionMcpRuntime(params: {
         };
       } catch (error) {
         await Promise.allSettled(
-          Array.from(sessions.values(), (session) => disposeSession(session)),
+          Array.from(sessions.values(), (session) => disposeBundleMcpSession(session)),
         );
         sessions.clear();
         throw error;
@@ -1172,7 +1089,7 @@ export function createSessionMcpRuntime(params: {
       catalogInFlight = undefined;
       const sessionsToClose = Array.from(sessions.values());
       sessions.clear();
-      await Promise.allSettled(sessionsToClose.map((session) => disposeSession(session)));
+      await Promise.allSettled(sessionsToClose.map((session) => disposeBundleMcpSession(session)));
     },
   };
   return runtime;

--- a/src/agents/mcp-client-lifecycle.ts
+++ b/src/agents/mcp-client-lifecycle.ts
@@ -1,0 +1,144 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
+
+type LifecycleSession = {
+  client: Pick<Client, "close">;
+  transport: Transport & { terminateSession?: () => Promise<void> };
+  transportType: "stdio" | "sse" | "streamable-http";
+  detachStderr?: () => void;
+};
+
+export class McpClientConnectTimeoutError extends Error {}
+
+/** Matches the SDK's terminal signal for an expired stateful Streamable HTTP session. */
+export function isStatefulMcpHttpSessionExpired(
+  session: Pick<LifecycleSession, "transport" | "transportType">,
+  error: unknown,
+): boolean {
+  return (
+    session.transportType === "streamable-http" &&
+    session.transport instanceof StreamableHTTPClientTransport &&
+    session.transport.sessionId !== undefined &&
+    error instanceof StreamableHTTPError &&
+    error.code === 404
+  );
+}
+
+export async function connectMcpClient(params: {
+  client: Pick<Client, "connect" | "close">;
+  transport: Transport;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const deadline = AbortSignal.timeout(params.timeoutMs);
+  const signal = params.signal ? AbortSignal.any([params.signal, deadline]) : deadline;
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("MCP startup aborted"));
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+  try {
+    await Promise.race([
+      params.client.connect(params.transport, {
+        signal,
+        timeout: params.timeoutMs,
+        maxTotalTimeout: params.timeoutMs,
+      }),
+      aborted,
+    ]);
+  } catch (error) {
+    if (deadline.aborted || (isRecord(error) && error.code === ErrorCode.RequestTimeout)) {
+      await disposeMcpClient(
+        {
+          client: params.client,
+          transport: params.transport,
+          transportType:
+            params.transport instanceof OpenClawStdioClientTransport
+              ? "stdio"
+              : params.transport instanceof StreamableHTTPClientTransport
+                ? "streamable-http"
+                : "sse",
+        },
+        Math.min(params.timeoutMs, 1_000),
+      );
+      throw new McpClientConnectTimeoutError(
+        `MCP server connection timed out after ${params.timeoutMs}ms`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+async function settleWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return await Promise.race([
+    promise.then(
+      () => true,
+      () => true,
+    ),
+    new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+      timer.unref?.();
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+async function ignoreCloseFailure(close: () => void | PromiseLike<unknown>): Promise<void> {
+  try {
+    await close();
+  } catch {
+    // Disposal is best-effort, but each later close step must still run.
+  }
+}
+
+export async function disposeMcpClient(
+  session: LifecycleSession,
+  timeoutMs = 5_000,
+): Promise<void> {
+  session.detachStderr?.();
+  const closed = await settleWithin(
+    (async () => {
+      if (session.transportType === "streamable-http") {
+        await ignoreCloseFailure(() => session.transport.terminateSession?.());
+      }
+      await ignoreCloseFailure(() => session.transport.close());
+      await ignoreCloseFailure(() => session.client.close());
+    })(),
+    timeoutMs,
+  );
+  if (closed) {
+    return;
+  }
+
+  // Closing an HTTP transport aborts a hung DELETE. Stdio owns a process
+  // group, so force it dead before disposal can report completion.
+  const { transport } = session;
+  const closeTransport =
+    session.transportType === "stdio" && transport instanceof OpenClawStdioClientTransport
+      ? () => transport.forceClose()
+      : () => transport.close();
+  await settleWithin(
+    Promise.all([
+      ignoreCloseFailure(closeTransport),
+      ignoreCloseFailure(() => session.client.close()),
+    ]),
+    timeoutMs,
+  );
+}

--- a/src/agents/mcp-content.ts
+++ b/src/agents/mcp-content.ts
@@ -1,30 +1,75 @@
-import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentToolResult } from "./runtime/index.js";
 
 type McpAgentContentBlock = AgentToolResult<unknown>["content"][number];
 
-/** Converts the full MCP content union into the agent text/image contract. */
-export function mcpContentBlockToAgentContent(block: ContentBlock): McpAgentContentBlock {
+function stringifyMcpContent(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Converts untrusted MCP content into the agent text/image contract. */
+export function mcpContentBlockToAgentContent(block: unknown): McpAgentContentBlock {
+  if (!isRecord(block)) {
+    return { type: "text", text: stringifyMcpContent(block) };
+  }
   switch (block.type) {
     case "text":
-      return { type: "text", text: block.text };
+      if (typeof block.text === "string") {
+        return { type: "text", text: block.text };
+      }
+      break;
     case "image":
-      if (block.data && block.mimeType) {
+      if (typeof block.data === "string" && typeof block.mimeType === "string") {
         return { type: "image", data: block.data, mimeType: block.mimeType };
       }
-      return { type: "text", text: JSON.stringify(block) };
+      break;
     case "audio":
-      return { type: "text", text: `[audio ${block.mimeType}]` };
+      if (typeof block.mimeType === "string") {
+        return { type: "text", text: `[audio ${block.mimeType}]` };
+      }
+      break;
     case "resource_link": {
-      const label = block.title ?? block.name;
+      if (typeof block.uri !== "string") {
+        break;
+      }
+      const label =
+        typeof block.title === "string"
+          ? block.title
+          : typeof block.name === "string"
+            ? block.name
+            : undefined;
       return { type: "text", text: label ? `[${label}] ${block.uri}` : block.uri };
     }
     case "resource": {
-      const resource = block.resource;
-      const text = "text" in resource ? resource.text : undefined;
-      return { type: "text", text: text ?? resource.uri };
+      if (!isRecord(block.resource) || typeof block.resource.uri !== "string") {
+        break;
+      }
+      const text = typeof block.resource.text === "string" ? block.resource.text : undefined;
+      return { type: "text", text: text ?? block.resource.uri };
     }
-    default:
-      return { type: "text", text: JSON.stringify(block) };
   }
+  return { type: "text", text: stringifyMcpContent(block) };
+}
+
+export function projectMcpCallToolResultContent(result: {
+  content?: unknown;
+  structuredContent?: unknown;
+}): AgentToolResult<unknown>["content"] {
+  const sourceContent = Array.isArray(result.content) ? result.content : [];
+  if (isRecord(result.structuredContent)) {
+    return [
+      {
+        type: "text",
+        text: `structuredContent:\n${JSON.stringify(result.structuredContent, null, 2)}`,
+      },
+      ...sourceContent
+        .filter((block) => !isRecord(block) || block.type !== "text")
+        .map(mcpContentBlockToAgentContent),
+    ];
+  }
+  return sourceContent.map(mcpContentBlockToAgentContent);
 }

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -12,6 +12,7 @@ import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";
+import { isToolResultError } from "./tool-result-error.js";
 import { compactToolSearchCatalogEntry, createToolSearchCatalogRef } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -260,8 +261,10 @@ describe("createNodePluginTools", () => {
           { type: "text", text: "first" },
           { type: "text", text: "second" },
           { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
+          { type: "image", data: 42, mimeType: "image/png" },
         ],
         structuredContent: { hits: 2 },
+        isError: true,
       },
     });
 
@@ -286,12 +289,24 @@ describe("createNodePluginTools", () => {
     expect(tool.executionMode).toBe("sequential");
     expect(getPluginToolMeta(tool)?.mcp?.node).toEqual({ id: "node-1" });
     expect(result.content).toEqual([
+      { type: "text", text: 'structuredContent:\n{\n  "hits": 2\n}' },
       { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
-      { type: "text", text: "first" },
-      { type: "text", text: "second" },
       { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
-      { type: "text", text: '{\n  "hits": 2\n}' },
+      { type: "text", text: '{"type":"image","data":42,"mimeType":"image/png"}' },
     ]);
+    expect(result.details).toEqual({
+      content: [
+        { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+        { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
+        { type: "image", data: 42, mimeType: "image/png" },
+      ],
+      structuredContent: { hits: 2 },
+      isError: true,
+      status: "error",
+    });
+    expect(isToolResultError(result)).toBe(true);
   });
 
   it("projects node MCP schemas and calls through the exact namespace catalog entry", async () => {

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -9,6 +9,7 @@ import {
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
+import { projectMcpCallToolResultContent } from "./mcp-content.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolPolicyName } from "./tool-policy.js";
 import { jsonResult } from "./tools/common.js";
@@ -36,31 +37,13 @@ function mapMcpPayloadToAgentToolResult(payload: unknown): AgentToolResult<unkno
   if (!isRecord(payload)) {
     return jsonResult(payload);
   }
-  const rawContent = Array.isArray(payload.content) ? payload.content : [];
-  const content: AgentToolResult<unknown>["content"] = [];
-  for (const block of rawContent) {
-    if (!isRecord(block)) {
-      continue;
-    }
-    if (block.type === "text" && typeof block.text === "string") {
-      content.push({ type: "text", text: block.text });
-    } else if (
-      block.type === "image" &&
-      typeof block.data === "string" &&
-      typeof block.mimeType === "string"
-    ) {
-      content.push({ type: "image", data: block.data, mimeType: block.mimeType });
-    }
-  }
-  const structuredText = isRecord(payload.structuredContent)
-    ? JSON.stringify(payload.structuredContent, null, 2)
-    : "";
-  if (structuredText) {
-    content.push({ type: "text", text: structuredText });
-  }
+  const content = projectMcpCallToolResultContent({
+    content: payload.content,
+    structuredContent: payload.structuredContent,
+  });
   return {
     content,
-    details: payload,
+    details: payload.isError === true ? { ...payload, status: "error" } : payload,
   };
 }
 

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -73,14 +73,24 @@ describe("mcp.tools.call.v1", () => {
     });
   });
 
-  it("maps MCP tool errors and unavailable servers to failed invokes", async () => {
+  it("returns MCP tool errors as results while thrown failures fail the invoke", async () => {
     const toolError = await invokeMcp(
-      managerWith(async () => ({ isError: true, content: [{ type: "text", text: "bad query" }] })),
+      managerWith(async () => ({
+        isError: true,
+        content: [{ type: "text", text: "bad query" }],
+        structuredContent: { retryable: true },
+      })),
       { server: "docs", tool: "search" },
     );
-    expect(toolError).toMatchObject({
-      ok: false,
-      error: { code: "MCP_TOOL_ERROR", message: "bad query" },
+    expect(toolError).toEqual({
+      id: "invoke-mcp",
+      nodeId: "node-1",
+      ok: true,
+      payload: {
+        content: [{ type: "text", text: "bad query" }],
+        structuredContent: { retryable: true },
+        isError: true,
+      },
     });
 
     const unavailable = await invokeMcp(

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,7 +1,6 @@
 /** Node-host command dispatcher for system commands, approvals, env policy, and plugin commands. */
 import fs from "node:fs";
 import path from "node:path";
-import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
@@ -958,10 +957,7 @@ type McpInvokeContentBlock =
   | { type: "image"; data: string; mimeType: string };
 
 function normalizeMcpContentBlock(block: unknown): McpInvokeContentBlock | null {
-  if (!isRecord(block)) {
-    return null;
-  }
-  return mcpContentBlockToAgentContent(block as ContentBlock);
+  return isRecord(block) ? mcpContentBlockToAgentContent(block) : null;
 }
 
 function serializedJsonBytes(value: unknown): number {
@@ -972,16 +968,17 @@ function serializedJsonBytes(value: unknown): number {
 function boundMcpToolResultPayload(result: {
   content: readonly unknown[];
   structuredContent?: Record<string, unknown>;
-}): { content: McpInvokeContentBlock[]; structuredContent?: Record<string, unknown> } {
+  isError?: boolean;
+}): {
+  content: McpInvokeContentBlock[];
+  structuredContent?: Record<string, unknown>;
+  isError?: true;
+} {
   const normalizedBlocks = result.content
     .map(normalizeMcpContentBlock)
     .filter((block): block is McpInvokeContentBlock => block !== null);
   const totalTextBytes = normalizedBlocks.reduce<number>(
-    (total, block) =>
-      total +
-      (isRecord(block) && block.type === "text" && typeof block.text === "string"
-        ? Buffer.byteLength(block.text)
-        : 0),
+    (total, block) => total + (block.type === "text" ? Buffer.byteLength(block.text) : 0),
     0,
   );
   let remainingTextBytes =
@@ -991,15 +988,8 @@ function boundMcpToolResultPayload(result: {
   let markedTruncated = false;
   const textBoundedContent: McpInvokeContentBlock[] = [];
   for (const block of normalizedBlocks) {
-    if (
-      block.type === "image" &&
-      typeof block.data === "string" &&
-      typeof block.mimeType === "string"
-    ) {
+    if (block.type === "image") {
       textBoundedContent.push(block);
-      continue;
-    }
-    if (block.type !== "text" || typeof block.text !== "string") {
       continue;
     }
     if (totalTextBytes <= MCP_TEXT_CONTENT_MAX_BYTES) {
@@ -1027,7 +1017,10 @@ function boundMcpToolResultPayload(result: {
   }
   const payloadMarker = { type: "text" as const, text: MCP_PAYLOAD_TRUNCATION_MARKER };
   const reservedMarkerBytes = serializedJsonBytes(payloadMarker) + 1;
-  let usedBytes = Buffer.byteLength('{"content":[]}');
+  const isError = result.isError === true;
+  let usedBytes = Buffer.byteLength(
+    JSON.stringify({ content: [], ...(isError ? { isError } : {}) }),
+  );
   let payloadTruncated = false;
   const content: McpInvokeContentBlock[] = [];
   for (const block of textBoundedContent) {
@@ -1052,19 +1045,11 @@ function boundMcpToolResultPayload(result: {
   if (payloadTruncated) {
     content.push(payloadMarker);
   }
-  return { content, ...(structuredContent ? { structuredContent } : {}) };
-}
-
-function mcpToolErrorMessage(result: { content: readonly unknown[] }): string {
-  const text = result.content
-    .filter(
-      (block): block is { type: "text"; text: string } =>
-        isRecord(block) && block.type === "text" && typeof block.text === "string",
-    )
-    .map((block) => block.text.trim())
-    .filter(Boolean)
-    .join("\n");
-  return truncateUtf16Safe(text || "MCP tool returned an error", 1_024);
+  return {
+    content,
+    ...(structuredContent ? { structuredContent } : {}),
+    ...(isError ? { isError } : {}),
+  };
 }
 
 async function handleMcpToolsCall(
@@ -1090,10 +1075,6 @@ async function handleMcpToolsCall(
       timeoutMs: frame.timeoutMs ?? undefined,
       ...(signal ? { signal } : {}),
     });
-    if (result.isError) {
-      await sendErrorResult(client, frame, "MCP_TOOL_ERROR", mcpToolErrorMessage(result));
-      return;
-    }
     await sendMcpPayloadResult(client, frame, boundMcpToolResultPayload(result));
   } catch (error) {
     if (error instanceof NodeHostMcpError) {

--- a/src/node-host/mcp.recovery.test.ts
+++ b/src/node-host/mcp.recovery.test.ts
@@ -1,0 +1,452 @@
+/** Behavior tests for live node-host MCP catalog and connection recovery. */
+
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startNodeHostMcpManager } from "./mcp.js";
+
+function tool(name: string, inputSchema: Tool["inputSchema"] = { type: "object" }): Tool {
+  return { name, inputSchema };
+}
+
+function createClient(params: {
+  tools?: () => Tool[];
+  connect?: () => Promise<void>;
+  list?: () => Promise<{ tools: Tool[] }>;
+  call?: () => Promise<CallToolResult>;
+}) {
+  const call =
+    params.call ??
+    (async (): Promise<CallToolResult> => ({ content: [{ type: "text", text: "ok" }] }));
+  return {
+    onclose: undefined as (() => void) | undefined,
+    connect: vi.fn(params.connect ?? (async () => {})),
+    listTools: vi.fn(params.list ?? (async () => ({ tools: params.tools?.() ?? [] }))),
+    callTool: vi.fn(call),
+    close: vi.fn(async () => {}),
+  };
+}
+
+const stdioTransport = {
+  transport: {} as never,
+  transportType: "stdio" as const,
+  connectionTimeoutMs: 100,
+  requestTimeoutMs: 100,
+};
+
+function httpTransport(sessionId?: string) {
+  const transport = new StreamableHTTPClientTransport(
+    new URL("http://127.0.0.1:1/mcp"),
+    sessionId ? { sessionId } : undefined,
+  );
+  transport.close = vi.fn(async () => {});
+  transport.terminateSession = vi.fn(async () => {});
+  return {
+    transport,
+    transportType: "streamable-http" as const,
+    connectionTimeoutMs: 100,
+    requestTimeoutMs: 100,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("node host MCP live lifecycle", () => {
+  it("refreshes additions, removals, and schemas without replacing descriptor authority", async () => {
+    let listed = [tool("before")];
+    let notifyToolsChanged: (() => void) | undefined;
+    const client = createClient({ tools: () => listed });
+    const onDescriptorsChanged = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: (_serverName, options) => {
+          notifyToolsChanged = options.onToolsChanged;
+          return client;
+        },
+        resolveTransport: () => stdioTransport,
+        onDescriptorsChanged,
+        warn: vi.fn(),
+      },
+    );
+    const descriptorAuthority = manager.descriptors;
+
+    listed = [
+      tool("after", {
+        type: "object",
+        properties: { revision: { type: "number" } },
+        required: ["revision"],
+      }),
+    ];
+    notifyToolsChanged?.();
+
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual(["after"]),
+    );
+    expect(manager.descriptors).toBe(descriptorAuthority);
+    expect(manager.descriptors[0]?.parameters).toEqual(listed[0]?.inputSchema);
+    expect(onDescriptorsChanged).toHaveBeenCalledOnce();
+
+    notifyToolsChanged?.();
+    await vi.waitFor(() => expect(client.listTools).toHaveBeenCalledTimes(3));
+    expect(onDescriptorsChanged).toHaveBeenCalledOnce();
+    await manager.close();
+  });
+
+  it("coalesces notification storms and never overlaps refreshes", async () => {
+    let notifyToolsChanged: (() => void) | undefined;
+    let activeLists = 0;
+    let maxActiveLists = 0;
+    let listCount = 0;
+    const pending: Array<(value: { tools: Tool[] }) => void> = [];
+    const client = createClient({
+      list: async () => {
+        listCount += 1;
+        if (listCount === 1) {
+          return { tools: [tool("initial")] };
+        }
+        activeLists += 1;
+        maxActiveLists = Math.max(maxActiveLists, activeLists);
+        try {
+          return await new Promise<{ tools: Tool[] }>((resolve) => {
+            pending.push(resolve);
+          });
+        } finally {
+          activeLists -= 1;
+        }
+      },
+    });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: (_serverName, options) => {
+          notifyToolsChanged = options.onToolsChanged;
+          return client;
+        },
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+
+    notifyToolsChanged?.();
+    await vi.waitFor(() => expect(activeLists).toBe(1));
+    for (let index = 0; index < 20; index += 1) {
+      notifyToolsChanged?.();
+    }
+    expect(client.listTools).toHaveBeenCalledTimes(2);
+    pending.shift()?.({ tools: [tool("middle")] });
+    await vi.waitFor(() => expect(client.listTools).toHaveBeenCalledTimes(3));
+    expect(maxActiveLists).toBe(1);
+    pending.shift()?.({ tools: [tool("final")] });
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual(["final"]),
+    );
+    expect(maxActiveLists).toBe(1);
+    await manager.close();
+  });
+
+  it("fences a stale refresh and reconnects after transport close", async () => {
+    let notifyToolsChanged: (() => void) | undefined;
+    let resolveStale: ((value: { tools: Tool[] }) => void) | undefined;
+    let firstList = true;
+    const stale = createClient({
+      list: async () => {
+        if (firstList) {
+          firstList = false;
+          return { tools: [tool("stale-initial")] };
+        }
+        return await new Promise<{ tools: Tool[] }>((resolve) => {
+          resolveStale = resolve;
+        });
+      },
+    });
+    const fresh = createClient({ tools: () => [tool("fresh")] });
+    let generation = 0;
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: (_serverName, options) => {
+          generation += 1;
+          if (generation === 1) {
+            notifyToolsChanged = options.onToolsChanged;
+            return stale;
+          }
+          return fresh;
+        },
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+
+    notifyToolsChanged?.();
+    await vi.waitFor(() => expect(stale.listTools).toHaveBeenCalledTimes(2));
+    stale.onclose?.();
+    expect(manager.descriptors).toEqual([]);
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual(["fresh"]),
+    );
+    resolveStale?.({ tools: [tool("stale-completion")] });
+    await Promise.resolve();
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual(["fresh"]);
+
+    stale.onclose?.();
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual(["fresh"]);
+    await manager.close();
+  });
+
+  it("withdraws a failed refresh while preserving a healthy sibling", async () => {
+    let notifyToolsChanged: (() => void) | undefined;
+    const failed = createClient({
+      list: vi
+        .fn<() => Promise<{ tools: Tool[] }>>()
+        .mockResolvedValueOnce({ tools: [tool("unsafe-stale")] })
+        .mockRejectedValueOnce(new Error("refresh failed https://mcp.invalid/?token=secret-value")),
+    });
+    const reconnectFailure = createClient({
+      connect: async () => {
+        throw new Error("still unavailable");
+      },
+    });
+    const healthy = createClient({ tools: () => [tool("healthy")] });
+    let failedGeneration = 0;
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { failed: { command: "failed" }, healthy: { command: "healthy" } },
+      {
+        createClient: (serverName, options) => {
+          if (serverName === "healthy") {
+            return healthy;
+          }
+          failedGeneration += 1;
+          if (failedGeneration === 1) {
+            notifyToolsChanged = options.onToolsChanged;
+            return failed;
+          }
+          return reconnectFailure;
+        },
+        resolveTransport: () => stdioTransport,
+        warn,
+      },
+    );
+
+    notifyToolsChanged?.();
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toEqual(["healthy"]),
+    );
+    await expect(manager.callMcpTool({ server: "healthy", tool: "healthy" })).resolves.toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+    expect(warn.mock.calls.flat().join("\n")).not.toContain("secret-value");
+    await manager.close();
+  });
+
+  it("recovers only an exact stateful Streamable HTTP 404 and never replays the call", async () => {
+    let releaseReplacement: (() => void) | undefined;
+    const replacementReady = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
+    });
+    const expiredStateful = createClient({
+      tools: () => [tool("run")],
+      call: async () => {
+        throw new StreamableHTTPError(404, "Session not found");
+      },
+    });
+    const clients = {
+      stateful: [
+        expiredStateful,
+        createClient({
+          tools: () => [tool("run")],
+          connect: async () => await replacementReady,
+        }),
+      ],
+      stateless: [
+        createClient({
+          tools: () => [tool("run")],
+          call: async () => {
+            throw new StreamableHTTPError(404, "Not found");
+          },
+        }),
+      ],
+      application: [
+        createClient({
+          tools: () => [tool("run")],
+          call: async () => ({ isError: true, content: [{ type: "text", text: "rejected" }] }),
+        }),
+      ],
+    } as const;
+    const generations = new Map<string, number>();
+    const manager = await startNodeHostMcpManager(
+      {
+        stateful: { url: "http://stateful.invalid/mcp" },
+        stateless: { url: "http://stateless.invalid/mcp" },
+        application: { url: "http://application.invalid/mcp" },
+      },
+      {
+        createClient: (serverName) => {
+          const generation = generations.get(serverName) ?? 0;
+          generations.set(serverName, generation + 1);
+          const client = clients[serverName as keyof typeof clients][generation];
+          if (!client) {
+            throw new Error(`unexpected ${serverName} MCP client generation ${generation}`);
+          }
+          return client;
+        },
+        resolveTransport: (serverName) =>
+          httpTransport(serverName === "stateful" ? "session-1" : undefined),
+        warn: vi.fn(),
+      },
+    );
+
+    await expect(manager.callMcpTool({ server: "stateful", tool: "run" })).rejects.toMatchObject({
+      code: "MCP_TOOL_ERROR",
+    });
+    expect(expiredStateful.callTool).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(generations.get("stateful")).toBe(2));
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).not.toContain(
+      "stateful",
+    );
+
+    releaseReplacement?.();
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toContain("stateful"),
+    );
+    await expect(manager.callMcpTool({ server: "stateful", tool: "run" })).resolves.toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+    expect(expiredStateful.callTool).toHaveBeenCalledOnce();
+
+    await expect(manager.callMcpTool({ server: "stateless", tool: "run" })).rejects.toMatchObject({
+      code: "MCP_TOOL_ERROR",
+    });
+    expect(generations.get("stateless")).toBe(1);
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toContain("stateless");
+
+    await expect(
+      manager.callMcpTool({ server: "application", tool: "run" }),
+    ).resolves.toMatchObject({ isError: true });
+    expect(generations.get("application")).toBe(1);
+    await manager.close();
+  });
+
+  it("does not retry unsupported restart-scoped transport config", async () => {
+    vi.useFakeTimers();
+    const mockCreateClient = vi.fn(() => createClient({}));
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { invalid: { transport: "stdio" } },
+      { createClient: mockCreateClient, resolveTransport: () => null, warn },
+    );
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    await manager.close();
+  });
+
+  it("caps reconnect backoff and cancels its timer on close", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const manager = await startNodeHostMcpManager(
+      { offline: { command: "offline" } },
+      {
+        createClient: () =>
+          createClient({
+            connect: async () => {
+              attempts += 1;
+              throw new Error("offline");
+            },
+          }),
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+    expect(attempts).toBe(1);
+
+    for (const [index, delayMs] of [
+      250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 60_000, 60_000,
+    ].entries()) {
+      await vi.advanceTimersByTimeAsync(delayMs - 1);
+      expect(attempts).toBe(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(attempts).toBe(index + 2);
+    }
+
+    await manager.close();
+    const attemptsAtClose = attempts;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(attempts).toBe(attemptsAtClose);
+  });
+
+  it("keeps global ordering and descriptor caps after refresh", async () => {
+    let listed = [tool("initial")];
+    let notifyToolsChanged: (() => void) | undefined;
+    const crowded = createClient({ tools: () => listed });
+    const sibling = createClient({ tools: () => [tool("sibling")] });
+    const manager = await startNodeHostMcpManager(
+      { crowded: { command: "crowded" }, sibling: { command: "sibling" } },
+      {
+        createClient: (serverName, options) => {
+          if (serverName === "crowded") {
+            notifyToolsChanged = options.onToolsChanged;
+            return crowded;
+          }
+          return sibling;
+        },
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+
+    listed = Array.from({ length: 130 }, (_, index) =>
+      tool(`tool-${String(index).padStart(3, "0")}`),
+    ).toReversed();
+    notifyToolsChanged?.();
+    await vi.waitFor(() => expect(manager.descriptors).toHaveLength(128));
+    expect(manager.descriptors[0]?.mcp).toEqual({ server: "crowded", tool: "tool-000" });
+    expect(manager.descriptors.at(-1)?.mcp).toEqual({ server: "crowded", tool: "tool-127" });
+    expect(manager.descriptors.some((descriptor) => descriptor.mcp?.server === "sibling")).toBe(
+      false,
+    );
+    await manager.close();
+  });
+
+  it("bounds initial server connection fan-out at six", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const releases: Array<() => void> = [];
+    const servers = Object.fromEntries(
+      Array.from({ length: 7 }, (_, index) => [`server-${index}`, { command: "server" }]),
+    );
+    const starting = startNodeHostMcpManager(servers, {
+      createClient: () =>
+        createClient({
+          connect: async () => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await new Promise<void>((resolve) => {
+              releases.push(resolve);
+            });
+            active -= 1;
+          },
+        }),
+      resolveTransport: () => stdioTransport,
+      warn: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(releases).toHaveLength(6));
+    expect(maxActive).toBe(6);
+    releases.shift()?.();
+    await vi.waitFor(() => expect(releases).toHaveLength(6));
+    for (const release of releases.splice(0)) {
+      release();
+    }
+    const manager = await starting;
+    expect(maxActive).toBe(6);
+    await manager.close();
+  });
+});

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -541,33 +541,41 @@ describe("node host MCP manager", () => {
   });
 
   it("closes a server when startup is aborted during paginated listing", async () => {
-    const controller = new AbortController();
-    const client = createClient({
-      list: async () =>
-        await new Promise<{ tools: Tool[] }>(() => {
-          // The startup abort owns closing the client behind this pending SDK request.
-        }),
-    });
-    const warn = vi.fn();
-    const starting = startNodeHostMcpManager(
-      { docs: { command: "docs" } },
-      {
-        createClient: () => client,
-        resolveTransport: () => transport,
-        signal: controller.signal,
-        warn,
-      },
-    );
-    await vi.waitFor(() => expect(client.listTools).toHaveBeenCalledOnce());
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const client = createClient({
+        list: async () =>
+          await new Promise<{ tools: Tool[] }>(() => {
+            // The startup abort owns closing the client behind this pending SDK request.
+          }),
+      });
+      const createClientMock = vi.fn(() => client);
+      const warn = vi.fn();
+      const starting = startNodeHostMcpManager(
+        { docs: { command: "docs" } },
+        {
+          createClient: createClientMock,
+          resolveTransport: () => transport,
+          signal: controller.signal,
+          warn,
+        },
+      );
+      await vi.waitFor(() => expect(client.listTools).toHaveBeenCalledOnce());
 
-    controller.abort();
-    const manager = await starting;
+      controller.abort();
+      const manager = await starting;
 
-    expect(client.close).toHaveBeenCalledOnce();
-    expect(manager.descriptors).toEqual([]);
-    expect(warn).not.toHaveBeenCalled();
-    await manager.close();
-    expect(client.close).toHaveBeenCalledOnce();
+      expect(client.close).toHaveBeenCalledOnce();
+      expect(manager.descriptors).toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      expect(createClientMock).toHaveBeenCalledOnce();
+      await manager.close();
+      expect(client.close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("cancels an in-flight MCP tool when its node invocation is aborted", async () => {

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -49,6 +49,7 @@ function createClient(params?: {
 
 const transport = {
   transport: {} as never,
+  transportType: "stdio" as const,
   connectionTimeoutMs: 100,
   requestTimeoutMs: 50,
 };
@@ -96,9 +97,76 @@ describe("node host MCP manager", () => {
     );
 
     await vi.waitFor(() => expect(second.connect).toHaveBeenCalledOnce());
+    expect(second.connect).toHaveBeenCalledWith(
+      transport.transport,
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        timeout: transport.connectionTimeoutMs,
+        maxTotalTimeout: transport.connectionTimeoutMs,
+      }),
+    );
     releaseFirst?.();
     const manager = await starting;
     await manager.close();
+  });
+
+  it("terminates streamable HTTP sessions on failed startup and manager close", async () => {
+    const events = new Map<string, string[]>();
+    const transports = new Map(
+      ["failed", "healthy"].map((serverName) => {
+        const serverEvents: string[] = [];
+        events.set(serverName, serverEvents);
+        return [
+          serverName,
+          {
+            close: vi.fn(async () => {
+              serverEvents.push("transport.close");
+            }),
+            terminateSession: vi.fn(async () => {
+              serverEvents.push("terminateSession");
+            }),
+          },
+        ] as const;
+      }),
+    );
+    const failed = createClient({
+      list: async () => {
+        throw new Error("listing failed");
+      },
+    });
+    const healthy = createClient({ tools: [tool("search")] });
+    for (const [serverName, client] of [
+      ["failed", failed],
+      ["healthy", healthy],
+    ] as const) {
+      client.close.mockImplementation(async () => {
+        events.get(serverName)?.push("client.close");
+      });
+    }
+
+    const manager = await startNodeHostMcpManager(
+      {
+        failed: { url: "https://failed.invalid/mcp" },
+        healthy: { url: "https://healthy.invalid/mcp" },
+      },
+      {
+        createClient: (serverName) => (serverName === "failed" ? failed : healthy),
+        resolveTransport: (serverName) => ({
+          transport: transports.get(serverName) as never,
+          transportType: "streamable-http",
+          connectionTimeoutMs: 100,
+          requestTimeoutMs: 50,
+        }),
+        warn: vi.fn(),
+      },
+    );
+
+    expect(events.get("failed")).toEqual(["terminateSession", "transport.close", "client.close"]);
+    expect(events.get("healthy")).toEqual([]);
+
+    await manager.close();
+
+    expect(events.get("healthy")).toEqual(["terminateSession", "transport.close", "client.close"]);
   });
 
   it("parses nodeHost.mcp config, isolates failures, filters tools, and shuts down", async () => {
@@ -188,14 +256,22 @@ describe("node host MCP manager", () => {
     await untrusted.close();
   });
 
-  it("withdraws only a closed server's descriptors and notifies the owner", async () => {
+  it("withdraws a closed server immediately, then republishes its replacement", async () => {
     const closed = createClient({ tools: [tool("closed-tool")] });
+    const replacement = createClient({ tools: [tool("closed-tool")] });
     const healthy = createClient({ tools: [tool("healthy-tool")] });
     const onDescriptorsChanged = vi.fn();
+    let closedGeneration = 0;
     const manager = await startNodeHostMcpManager(
       { closed: { command: "closed" }, healthy: { command: "healthy" } },
       {
-        createClient: (serverName) => (serverName === "closed" ? closed : healthy),
+        createClient: (serverName) => {
+          if (serverName === "healthy") {
+            return healthy;
+          }
+          closedGeneration += 1;
+          return closedGeneration === 1 ? closed : replacement;
+        },
         resolveTransport: () => transport,
         onDescriptorsChanged,
         warn: vi.fn(),
@@ -218,9 +294,22 @@ describe("node host MCP manager", () => {
       { content: [{ type: "text", text: "ok" }] },
     );
 
+    await vi.waitFor(() =>
+      expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toEqual([
+        "closed",
+        "healthy",
+      ]),
+    );
+    expect(onDescriptorsChanged).toHaveBeenCalledTimes(2);
+
+    // A callback retained by the retired client cannot withdraw its replacement.
     closed.onclose?.();
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toEqual([
+      "closed",
+      "healthy",
+    ]);
     await manager.close();
-    expect(onDescriptorsChanged).toHaveBeenCalledOnce();
+    expect(onDescriptorsChanged).toHaveBeenCalledTimes(2);
   });
 
   itWithFrozenClock("bounds untrusted descriptor count and schema bytes", async () => {

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -279,6 +279,9 @@ export async function startNodeHostMcpManager(
   const resolveTransport = deps.resolveTransport ?? resolveMcpTransport;
   const descriptors: NodePluginToolDescriptor[] = [];
   const lifecycleAbortController = new AbortController();
+  const lifecycleSignal = deps.signal
+    ? AbortSignal.any([deps.signal, lifecycleAbortController.signal])
+    : lifecycleAbortController.signal;
   const states = new Map<string, NodeHostMcpServerState>(
     listEnabledNodeHostMcpServers(servers).map(([serverName, config]) => [
       serverName,
@@ -336,7 +339,13 @@ export async function startNodeHostMcpManager(
   };
 
   const scheduleRetry = (state: NodeHostMcpServerState): void => {
-    if (closed || states.get(state.serverName) !== state || state.retryTimer || state.current) {
+    if (
+      closed ||
+      lifecycleSignal.aborted ||
+      states.get(state.serverName) !== state ||
+      state.retryTimer ||
+      state.current
+    ) {
       return;
     }
     const delayMs = state.retryDelayMs;
@@ -431,9 +440,9 @@ export async function startNodeHostMcpManager(
       return;
     }
     try {
-      await connectAndList(state, lifecycleAbortController.signal);
+      await connectAndList(state, lifecycleSignal);
     } catch (error) {
-      if (!closed) {
+      if (!closed && !lifecycleSignal.aborted) {
         warn(
           `node host MCP server "${state.serverName}" reconnect failed: ${formatMcpError(error)}`,
         );
@@ -451,7 +460,7 @@ export async function startNodeHostMcpManager(
         session.client,
         session.requestTimeoutMs,
         (toolName) => isMcpToolAllowed(state.config.toolFilter, toolName),
-        AbortSignal.any([lifecycleAbortController.signal, session.abortController.signal]),
+        AbortSignal.any([lifecycleSignal, session.abortController.signal]),
       );
       if (closed || state.current !== session) {
         return;
@@ -459,7 +468,7 @@ export async function startNodeHostMcpManager(
       state.listedTools = tools;
       rebuildDescriptors();
     } catch (error) {
-      if (closed || state.current !== session) {
+      if (closed || lifecycleSignal.aborted || state.current !== session) {
         return;
       }
       warn(
@@ -472,7 +481,13 @@ export async function startNodeHostMcpManager(
   };
 
   function requestRefresh(state: NodeHostMcpServerState, session: NodeHostMcpSession): void {
-    if (closed || state.current !== session || !session.connected || state.refreshQueued) {
+    if (
+      closed ||
+      lifecycleSignal.aborted ||
+      state.current !== session ||
+      !session.connected ||
+      state.refreshQueued
+    ) {
       return;
     }
     state.refreshQueued = true;
@@ -482,9 +497,6 @@ export async function startNodeHostMcpManager(
     });
   }
 
-  const startupSignal = deps.signal
-    ? AbortSignal.any([deps.signal, lifecycleAbortController.signal])
-    : lifecycleAbortController.signal;
   const tasks = Array.from(states.values(), (state) => async () => {
     if (state.config.auth === "oauth" || state.config.oauth) {
       states.delete(state.serverName);
@@ -492,9 +504,9 @@ export async function startNodeHostMcpManager(
       return;
     }
     try {
-      await connectAndList(state, startupSignal);
+      await connectAndList(state, lifecycleSignal);
     } catch (error) {
-      if (!startupSignal.aborted) {
+      if (!lifecycleSignal.aborted) {
         warn(`node host MCP server "${state.serverName}" failed: ${formatMcpError(error)}`);
       }
     }

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -1,4 +1,5 @@
 /** Process-lifetime MCP clients owned by the headless node host. */
+import { isDeepStrictEqual } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ErrorCode, type CallToolResult, type Tool } from "@modelcontextprotocol/sdk/types.js";
@@ -7,6 +8,11 @@ import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
+import {
+  connectMcpClient,
+  disposeMcpClient,
+  isStatefulMcpHttpSessionExpired,
+} from "../agents/mcp-client-lifecycle.js";
 import { createMcpJsonSchemaValidator } from "../agents/mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "../agents/mcp-metadata.js";
 import { collectMcpPaginatedItems } from "../agents/mcp-pagination.js";
@@ -20,6 +26,7 @@ import {
   NODE_MCP_TOOL_CALL_TIMEOUT_MS,
   NODE_MCP_TOOLS_CALL_COMMAND,
 } from "../infra/node-commands.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { VERSION } from "../version.js";
 
 const NODE_MCP_PLUGIN_ID = "node-mcp";
@@ -33,10 +40,16 @@ const NODE_MCP_MAX_CATALOG_BYTES = 10 * 1024 * 1024;
 const NODE_MCP_MAX_LIST_PAGES = NODE_MCP_MAX_DESCRIPTORS;
 // The byte cap charges every response; this separately bounds retained tiny-tool object overhead.
 const NODE_MCP_MAX_LISTED_TOOLS = NODE_MCP_MAX_DESCRIPTORS * NODE_MCP_MAX_LIST_PAGES;
+const NODE_MCP_CONNECT_CONCURRENCY = 6;
+const NODE_MCP_RETRY_INITIAL_MS = 250;
+const NODE_MCP_RETRY_MAX_MS = 60_000;
 
 type NodeHostMcpClient = {
   onclose?: () => void;
-  connect(transport: Transport): Promise<void>;
+  connect(
+    transport: Transport,
+    options: { signal: AbortSignal; timeout: number; maxTotalTimeout: number },
+  ): Promise<void>;
   listTools(
     params?: { cursor?: string },
     options?: { timeout?: number; maxTotalTimeout?: number; signal?: AbortSignal },
@@ -51,16 +64,28 @@ type NodeHostMcpClient = {
 
 type NodeHostMcpTransport = {
   transport: Transport;
+  transportType: "stdio" | "sse" | "streamable-http";
   connectionTimeoutMs: number;
   requestTimeoutMs: number;
   detachStderr?: () => void;
 };
 
-type NodeHostMcpSession = {
+type NodeHostMcpSession = NodeHostMcpTransport & {
   client: NodeHostMcpClient;
   connected: boolean;
   toolCallTimeoutMs: number;
-  detachStderr?: () => void;
+  abortController: AbortController;
+};
+
+type NodeHostMcpServerState = {
+  serverName: string;
+  config: McpServerConfig;
+  current?: NodeHostMcpSession;
+  listedTools: Tool[];
+  work: Promise<void>;
+  refreshQueued: boolean;
+  retryDelayMs: number;
+  retryTimer?: ReturnType<typeof setTimeout>;
 };
 
 type NodeHostMcpErrorCode =
@@ -92,16 +117,11 @@ export type NodeHostMcpManager = {
 };
 
 type NodeHostMcpManagerDeps = {
-  createClient?: (serverName: string) => NodeHostMcpClient;
+  createClient?: (serverName: string, options: { onToolsChanged: () => void }) => NodeHostMcpClient;
   resolveTransport?: (serverName: string, config: McpServerConfig) => NodeHostMcpTransport | null;
   onDescriptorsChanged?: () => void;
   warn?: (message: string) => void;
   signal?: AbortSignal;
-};
-
-type ListedNodeMcpTool = {
-  serverName: string;
-  tool: Tool;
 };
 
 function defaultWarn(message: string): void {
@@ -157,7 +177,7 @@ function normalizeInputSchema(value: unknown): Record<string, unknown> {
 
 /** Builds provider-safe MCP descriptors in stable server/tool order. */
 function buildNodeMcpToolDescriptors(
-  listedTools: readonly ListedNodeMcpTool[],
+  listedTools: ReadonlyArray<{ serverName: string; tool: Tool }>,
 ): NodePluginToolDescriptor[] {
   const usedNames = new Set<string>();
   const descriptors: NodePluginToolDescriptor[] = [];
@@ -197,53 +217,6 @@ function buildNodeMcpToolDescriptors(
   return descriptors;
 }
 
-async function connectWithTimeout(
-  client: NodeHostMcpClient,
-  transport: Transport,
-  timeoutMs: number,
-): Promise<void> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    await Promise.race([
-      client.connect(transport),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`MCP server connection timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
-async function withAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-  if (!signal) {
-    return await promise;
-  }
-  if (signal.aborted) {
-    throw new Error("MCP startup aborted");
-  }
-  return await new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(new Error("MCP startup aborted"));
-    signal.addEventListener("abort", onAbort, { once: true });
-    void promise.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      },
-    );
-  });
-}
-
 async function listAllTools(
   client: NodeHostMcpClient,
   timeoutMs: number,
@@ -276,7 +249,12 @@ async function listAllTools(
   });
 }
 
-/** Starts configured MCP servers once for the lifetime of the node host. */
+function disposeNodeHostMcpSession(session: NodeHostMcpSession): Promise<void> {
+  session.abortController.abort(new Error("node host MCP session retired"));
+  return disposeMcpClient(session);
+}
+
+/** Starts process-lifetime MCP server state for the node host. */
 export async function startNodeHostMcpManager(
   servers: Record<string, McpServerConfig> | undefined,
   deps: NodeHostMcpManagerDeps = {},
@@ -284,97 +262,261 @@ export async function startNodeHostMcpManager(
   const warn = deps.warn ?? defaultWarn;
   const createClient =
     deps.createClient ??
-    (() =>
+    ((_serverName, options) =>
       new Client(
         { name: "openclaw-node-host", version: VERSION },
-        { jsonSchemaValidator: createMcpJsonSchemaValidator() },
+        {
+          jsonSchemaValidator: createMcpJsonSchemaValidator(),
+          listChanged: {
+            tools: {
+              autoRefresh: false,
+              debounceMs: 0,
+              onChanged: () => options.onToolsChanged(),
+            },
+          },
+        },
       ) as NodeHostMcpClient);
   const resolveTransport = deps.resolveTransport ?? resolveMcpTransport;
-  const sessions = new Map<string, NodeHostMcpSession>();
-  const listedTools: ListedNodeMcpTool[] = [];
   const descriptors: NodePluginToolDescriptor[] = [];
+  const lifecycleAbortController = new AbortController();
+  const states = new Map<string, NodeHostMcpServerState>(
+    listEnabledNodeHostMcpServers(servers).map(([serverName, config]) => [
+      serverName,
+      {
+        serverName,
+        config,
+        listedTools: [],
+        work: Promise.resolve(),
+        refreshQueued: false,
+        retryDelayMs: NODE_MCP_RETRY_INITIAL_MS,
+      },
+    ]),
+  );
+  let closed = false;
+  let startupComplete = false;
 
-  await Promise.all(
-    listEnabledNodeHostMcpServers(servers).map(async ([serverName, config]) => {
-      if (config.auth === "oauth" || config.oauth) {
-        warn(`node host MCP server "${serverName}" skipped: OAuth is not supported`);
+  const rebuildDescriptors = () => {
+    if (closed) {
+      return;
+    }
+    const listedTools = Array.from(states.values()).flatMap((state) =>
+      state.listedTools.map((tool) => ({ serverName: state.serverName, tool })),
+    );
+    const next = buildNodeMcpToolDescriptors(listedTools);
+    if (next.length < listedTools.length) {
+      warn(
+        `node host MCP catalog bounded: published ${next.length} of ${listedTools.length} tools`,
+      );
+    }
+    if (isDeepStrictEqual(descriptors, next)) {
+      return;
+    }
+    descriptors.splice(0, descriptors.length, ...next);
+    if (startupComplete) {
+      deps.onDescriptorsChanged?.();
+    }
+  };
+
+  const invalidateCurrent = (
+    state: NodeHostMcpServerState,
+    session: NodeHostMcpSession,
+  ): boolean => {
+    if (state.current !== session) {
+      return false;
+    }
+    state.current = undefined;
+    session.abortController.abort(new Error("node host MCP session invalidated"));
+    state.listedTools = [];
+    rebuildDescriptors();
+    return true;
+  };
+
+  const enqueueWork = (state: NodeHostMcpServerState, task: () => Promise<void>): void => {
+    state.work = state.work.then(task, task).catch(() => {});
+  };
+
+  const scheduleRetry = (state: NodeHostMcpServerState): void => {
+    if (closed || states.get(state.serverName) !== state || state.retryTimer || state.current) {
+      return;
+    }
+    const delayMs = state.retryDelayMs;
+    state.retryDelayMs = Math.min(delayMs * 2, NODE_MCP_RETRY_MAX_MS);
+    state.retryTimer = setTimeout(() => {
+      state.retryTimer = undefined;
+      enqueueWork(state, () => reconnect(state));
+    }, delayMs);
+    state.retryTimer.unref?.();
+  };
+
+  const connectAndList = async (
+    state: NodeHostMcpServerState,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    let resolved: NodeHostMcpTransport | null | undefined;
+    let session: NodeHostMcpSession | undefined;
+    try {
+      resolved = resolveTransport(state.serverName, state.config);
+      if (!resolved) {
+        states.delete(state.serverName);
+        throw new Error("invalid or unsupported transport");
+      }
+      let onToolsChanged = () => {};
+      const client = createClient(state.serverName, {
+        onToolsChanged: () => onToolsChanged(),
+      });
+      const createdSession: NodeHostMcpSession = {
+        ...resolved,
+        client,
+        connected: false,
+        toolCallTimeoutMs: resolveMcpRequestTimeoutMs(state.config, NODE_MCP_TOOL_CALL_TIMEOUT_MS),
+        abortController: new AbortController(),
+      };
+      onToolsChanged = () => {
+        if (state.current === createdSession) {
+          requestRefresh(state, createdSession);
+        }
+      };
+      session = createdSession;
+      state.current = createdSession;
+      // MCP Client exposes callback properties rather than an EventTarget surface.
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener
+      client.onclose = () => {
+        if (createdSession.connected && invalidateCurrent(state, createdSession)) {
+          enqueueWork(state, async () => {
+            await disposeNodeHostMcpSession(createdSession);
+            scheduleRetry(state);
+          });
+        }
+      };
+      await connectMcpClient({
+        client,
+        transport: resolved.transport,
+        timeoutMs: resolved.connectionTimeoutMs,
+        signal,
+      });
+      if (closed || signal.aborted || state.current !== session) {
         return;
       }
-      let client: NodeHostMcpClient | undefined;
-      let resolved: NodeHostMcpTransport | null | undefined;
-      let session: NodeHostMcpSession | undefined;
-      try {
-        resolved = resolveTransport(serverName, config);
-        if (!resolved) {
-          warn(`node host MCP server "${serverName}" skipped: invalid or unsupported transport`);
-          return;
-        }
-        client = createClient(serverName);
-        session = {
-          client,
-          connected: false,
-          toolCallTimeoutMs: resolveMcpRequestTimeoutMs(config, NODE_MCP_TOOL_CALL_TIMEOUT_MS),
-          detachStderr: resolved.detachStderr,
-        };
-        // MCP Client exposes callback properties rather than an EventTarget surface.
-        // oxlint-disable-next-line unicorn/prefer-add-event-listener
-        client.onclose = () => {
-          if (!session?.connected) {
-            return;
-          }
-          session.connected = false;
-          descriptors.splice(
-            0,
-            descriptors.length,
-            ...descriptors.filter((descriptor) => descriptor.mcp?.server !== serverName),
-          );
-          deps.onDescriptorsChanged?.();
-        };
-        await withAbort(
-          connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs),
-          deps.signal,
-        );
-        session.connected = true;
-        const tools = await listAllTools(
-          client,
-          resolved.requestTimeoutMs,
-          (toolName) => isMcpToolAllowed(config.toolFilter, toolName),
-          deps.signal,
-        );
-        if (session.connected) {
-          sessions.set(serverName, session);
-          listedTools.push(...tools.map((tool) => ({ serverName, tool })));
-        }
-      } catch (error) {
-        if (session) {
-          session.connected = false;
-        }
-        resolved?.detachStderr?.();
-        if (client) {
-          await Promise.allSettled([client.close()]);
-        }
-        if (!deps.signal?.aborted) {
-          warn(`node host MCP server "${serverName}" failed: ${formatMcpError(error)}`);
-        }
+      session.connected = true;
+      const listSignal = AbortSignal.any([signal, session.abortController.signal]);
+      const tools = await listAllTools(
+        client,
+        resolved.requestTimeoutMs,
+        (toolName) => isMcpToolAllowed(state.config.toolFilter, toolName),
+        listSignal,
+      );
+      if (closed || state.current !== session) {
+        return;
       }
-    }),
-  );
+      state.listedTools = tools;
+      state.retryDelayMs = NODE_MCP_RETRY_INITIAL_MS;
+      rebuildDescriptors();
+    } catch (error) {
+      const lostOwnership = session !== undefined && state.current !== session;
+      if (session && state.current === session) {
+        invalidateCurrent(state, session);
+        await disposeNodeHostMcpSession(session);
+      } else if (!session) {
+        resolved?.detachStderr?.();
+      }
+      if (closed || signal.aborted || lostOwnership) {
+        return;
+      }
+      throw error;
+    }
+  };
 
-  const publishableTools = listedTools.filter(
-    ({ serverName }) => sessions.get(serverName)?.connected,
-  );
-  descriptors.push(...buildNodeMcpToolDescriptors(publishableTools));
-  if (descriptors.length < publishableTools.length) {
-    warn(
-      `node host MCP catalog bounded: published ${descriptors.length} of ${publishableTools.length} tools`,
-    );
+  async function reconnect(state: NodeHostMcpServerState): Promise<void> {
+    if (closed || state.current) {
+      return;
+    }
+    try {
+      await connectAndList(state, lifecycleAbortController.signal);
+    } catch (error) {
+      if (!closed) {
+        warn(
+          `node host MCP server "${state.serverName}" reconnect failed: ${formatMcpError(error)}`,
+        );
+        scheduleRetry(state);
+      }
+    }
   }
-  let closed = false;
+
+  const refresh = async (state: NodeHostMcpServerState, session: NodeHostMcpSession) => {
+    if (closed || state.current !== session || !session.connected) {
+      return;
+    }
+    try {
+      const tools = await listAllTools(
+        session.client,
+        session.requestTimeoutMs,
+        (toolName) => isMcpToolAllowed(state.config.toolFilter, toolName),
+        AbortSignal.any([lifecycleAbortController.signal, session.abortController.signal]),
+      );
+      if (closed || state.current !== session) {
+        return;
+      }
+      state.listedTools = tools;
+      rebuildDescriptors();
+    } catch (error) {
+      if (closed || state.current !== session) {
+        return;
+      }
+      warn(
+        `node host MCP server "${state.serverName}" tool refresh failed: ${formatMcpError(error)}`,
+      );
+      invalidateCurrent(state, session);
+      await disposeNodeHostMcpSession(session);
+      scheduleRetry(state);
+    }
+  };
+
+  function requestRefresh(state: NodeHostMcpServerState, session: NodeHostMcpSession): void {
+    if (closed || state.current !== session || !session.connected || state.refreshQueued) {
+      return;
+    }
+    state.refreshQueued = true;
+    enqueueWork(state, async () => {
+      state.refreshQueued = false;
+      await refresh(state, session);
+    });
+  }
+
+  const startupSignal = deps.signal
+    ? AbortSignal.any([deps.signal, lifecycleAbortController.signal])
+    : lifecycleAbortController.signal;
+  const tasks = Array.from(states.values(), (state) => async () => {
+    if (state.config.auth === "oauth" || state.config.oauth) {
+      states.delete(state.serverName);
+      warn(`node host MCP server "${state.serverName}" skipped: OAuth is not supported`);
+      return;
+    }
+    try {
+      await connectAndList(state, startupSignal);
+    } catch (error) {
+      if (!startupSignal.aborted) {
+        warn(`node host MCP server "${state.serverName}" failed: ${formatMcpError(error)}`);
+      }
+    }
+  });
+  await runTasksWithConcurrency({
+    tasks,
+    limit: NODE_MCP_CONNECT_CONCURRENCY,
+    errorMode: "continue",
+  });
+  startupComplete = true;
+  for (const state of states.values()) {
+    if (!state.current) {
+      scheduleRetry(state);
+    }
+  }
+
   return {
     descriptors,
     async callMcpTool(params) {
-      const session = sessions.get(params.server);
-      if (!session?.connected) {
+      const state = states.get(params.server);
+      const session = state?.current;
+      if (!state || !session?.connected) {
         throw new NodeHostMcpError(
           "MCP_SERVER_UNAVAILABLE",
           `MCP server "${params.server}" is unavailable`,
@@ -402,7 +544,14 @@ export async function startNodeHostMcpManager(
           },
         );
       } catch (error) {
-        if (!session.connected) {
+        const sessionExpired = isStatefulMcpHttpSessionExpired(session, error);
+        if (sessionExpired && invalidateCurrent(state, session)) {
+          enqueueWork(state, async () => {
+            await disposeNodeHostMcpSession(session);
+            scheduleRetry(state);
+          });
+        }
+        if (!sessionExpired && (!session.connected || state.current !== session)) {
           throw new NodeHostMcpError(
             "MCP_SERVER_UNAVAILABLE",
             `MCP server "${params.server}" disconnected`,
@@ -425,12 +574,21 @@ export async function startNodeHostMcpManager(
         return;
       }
       closed = true;
-      for (const session of sessions.values()) {
-        session.connected = false;
-        session.detachStderr?.();
-      }
-      await Promise.allSettled(Array.from(sessions.values(), (session) => session.client.close()));
-      sessions.clear();
+      lifecycleAbortController.abort(new Error("node host MCP manager closed"));
+      const closing = Array.from(states.values(), async (state) => {
+        if (state.retryTimer) {
+          clearTimeout(state.retryTimer);
+          state.retryTimer = undefined;
+        }
+        await state.work;
+        const session = state.current;
+        state.current = undefined;
+        state.listedTools = [];
+        if (session) {
+          await disposeNodeHostMcpSession(session);
+        }
+      });
+      await Promise.allSettled(closing);
     },
   };
 }

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
@@ -1,0 +1,507 @@
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import type { NodePluginToolDescriptor } from "../../../../packages/gateway-protocol/src/schema/nodes.js";
+import { createSessionMcpRuntime } from "../../../../src/agents/agent-bundle-mcp-runtime.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import {
+  MCP_SERVERS,
+  NODE_MCP_COMMAND,
+  TEST_TIMEOUT_MS,
+  WAIT_OPTIONS,
+  approvePairing,
+  createChildEnv,
+  createMcpServers,
+  expectedProbeResults,
+  flattenEffectiveTools,
+  invokeNodeMcp,
+  invokeNodeMcpPayload,
+  parseProbeResult,
+  processIsAlive,
+  readNode,
+  startHttpFixture,
+  startNodeProcess,
+  stopChild,
+  waitForNode,
+  waitForProcessExit,
+  type CapturedChild,
+  type GatewayHandle,
+  type HttpFixture,
+  type ProbeResult,
+  type ToolsEffectiveResult,
+} from "./gateway-node-mcp.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("Gateway and node-host MCP live process parity", () => {
+  it(
+    "connects, filters, inventories, invokes, withdraws, and cleans up all real transports",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const repoRoot = process.cwd();
+      const taskRoot = tempDirs.make("openclaw-gateway-node-mcp-");
+      const taskPath = (...parts: string[]) => path.join(taskRoot, ...parts);
+      const nodeHome = taskPath("node", "home");
+      const nodeStateDir = taskPath("node", "state");
+      const nodeConfigPath = taskPath("node", "openclaw.json");
+      const nodeTempDir = taskPath("node", "tmp");
+      const sessionWorkspace = taskPath("session", "workspace");
+      const sessionHome = taskPath("session", "home");
+      const sessionTempDir = taskPath("session", "tmp");
+      const fixturePath = path.join(
+        repoRoot,
+        "test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs",
+      );
+      await Promise.all(
+        [nodeHome, nodeStateDir, nodeTempDir, sessionWorkspace, sessionHome, sessionTempDir].map(
+          (dir) => fs.mkdir(dir, { recursive: true }),
+        ),
+      );
+
+      let sessionHttpFixture: HttpFixture | undefined;
+      let nodeHttpFixture: HttpFixture | undefined;
+      let gateway: GatewayHandle | undefined;
+      let node: CapturedChild | undefined;
+      let sessionRuntime: ReturnType<typeof createSessionMcpRuntime> | undefined;
+      let proofError: unknown;
+      const cleanupErrors: unknown[] = [];
+      let phase = "setup";
+      const diagnosticTimer = setTimeout(() => {
+        process.stderr.write(
+          `MCP parity E2E stalled during ${phase}\n${node?.logs() ?? "node not started"}\n${gateway?.logs() ?? "gateway not started"}\n`,
+        );
+      }, 150_000);
+      diagnosticTimer.unref();
+
+      try {
+        const sessionEnv = createChildEnv({ home: sessionHome, tempDir: sessionTempDir });
+        const nodeFixtureEnv = createChildEnv({ home: nodeHome, tempDir: nodeTempDir });
+        phase = "starting HTTP MCP fixtures";
+        [sessionHttpFixture, nodeHttpFixture] = await Promise.all([
+          startHttpFixture({ fixturePath, labelPrefix: "session", env: sessionEnv }),
+          startHttpFixture({ fixturePath, labelPrefix: "node", env: nodeFixtureEnv }),
+        ]);
+        const sessionMcpServers = createMcpServers({
+          placement: "session",
+          fixture: sessionHttpFixture,
+          stdioEnv: sessionEnv,
+          fixturePath,
+          repoRoot,
+        });
+        const nodeMcpServers = createMcpServers({
+          placement: "node",
+          fixture: nodeHttpFixture,
+          stdioEnv: nodeFixtureEnv,
+          fixturePath,
+          repoRoot,
+        });
+
+        const nodeConfig: OpenClawConfig = {
+          gateway: { mode: "local" },
+          plugins: { enabled: false },
+          nodeHost: { mcp: { servers: nodeMcpServers }, skills: { enabled: false } },
+        };
+        await fs.writeFile(nodeConfigPath, `${JSON.stringify(nodeConfig, null, 2)}\n`, "utf8");
+
+        phase = "starting Gateway";
+        gateway = await startQaGatewayChild({
+          repoRoot,
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: ["dist/index.js"],
+            cwd: repoRoot,
+            usePackagedPlugins: true,
+          },
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          runtimeEnvPatch: {
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+            OPENCLAW_SKIP_PROVIDERS: "1",
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          },
+          mutateConfig: (cfg) => {
+            const { plugins: _plugins, ...withoutPlugins } = cfg;
+            return {
+              ...withoutPlugins,
+              mcp: { servers: sessionMcpServers },
+              tools: { ...cfg.tools, profile: "full" },
+              gateway: {
+                ...cfg.gateway,
+                nodes: {
+                  ...cfg.gateway?.nodes,
+                  commands: { allow: [NODE_MCP_COMMAND] },
+                  pairing: { ...cfg.gateway?.nodes?.pairing, autoApproveLocal: false },
+                },
+              },
+            };
+          },
+        });
+
+        const gatewayPort = Number(new URL(gateway.baseUrl).port);
+        const nodeEnv = createChildEnv({
+          home: nodeHome,
+          tempDir: nodeTempDir,
+          extra: {
+            OPENCLAW_HOME: nodeHome,
+            OPENCLAW_STATE_DIR: nodeStateDir,
+            OPENCLAW_CONFIG_PATH: nodeConfigPath,
+            OPENCLAW_GATEWAY_TOKEN: gateway.token,
+            OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1",
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+            OPENCLAW_SKIP_PROVIDERS: "1",
+          },
+        });
+
+        // The first connection persists the approved device identity; the restart initiates node pairing.
+        phase = "approving node device identity";
+        node = startNodeProcess(gatewayPort, nodeEnv);
+        const nodeId = await approvePairing(gateway, "device");
+        phase = "restarting node after device approval";
+        await stopChild(node);
+        node = startNodeProcess(gatewayPort, nodeEnv);
+        phase = "approving node command surface";
+        await approvePairing(gateway, "node", nodeId);
+
+        phase = "waiting for node MCP publication";
+        const published = (await waitForNode(gateway, nodeId, 3)).nodePluginTools ?? [];
+        expect(
+          published.map((tool) => ({
+            pluginId: tool.pluginId,
+            command: tool.command,
+            server: tool.mcp?.server,
+            tool: tool.mcp?.tool,
+          })),
+        ).toEqual(
+          MCP_SERVERS.map((server) => ({
+            pluginId: "node-mcp",
+            command: NODE_MCP_COMMAND,
+            server,
+            tool: "parity_probe",
+          })),
+        );
+
+        phase = "loading session MCP catalog";
+        sessionRuntime = createSessionMcpRuntime({
+          sessionId: `qa-mcp-parity-${randomUUID()}`,
+          sessionKey: `agent:main:qa-mcp-parity-${randomUUID()}`,
+          workspaceDir: sessionWorkspace,
+          cfg: { plugins: { enabled: false }, mcp: { servers: sessionMcpServers } },
+        });
+        const catalog = await sessionRuntime.getCatalog();
+        expect(
+          catalog.tools
+            .map((tool) => [tool.serverName, tool.toolName] as const)
+            .toSorted(([left], [right]) => left.localeCompare(right)),
+        ).toEqual(MCP_SERVERS.map((server) => [server, "parity_probe"]));
+
+        phase = "calling node MCP tools";
+        const nodeResults = new Map<string, ProbeResult>();
+        for (const descriptor of published) {
+          const server = descriptor.mcp?.server;
+          if (!server) {
+            throw new Error(`node MCP descriptor ${descriptor.name} omitted its server`);
+          }
+          nodeResults.set(
+            server,
+            await invokeNodeMcp({
+              gateway,
+              nodeId,
+              descriptor,
+              marker: `node-${server}`,
+            }),
+          );
+        }
+
+        phase = "calling session MCP tools";
+        const sessionResults = new Map<string, ProbeResult>();
+        for (const server of MCP_SERVERS) {
+          sessionResults.set(
+            server,
+            parseProbeResult(
+              await sessionRuntime.callTool(server, "parity_probe", {
+                marker: `session-${server}`,
+              }),
+            ),
+          );
+        }
+
+        expect(Object.fromEntries(nodeResults)).toEqual(
+          expectedProbeResults("node", "node", nodeHttpFixture.pid),
+        );
+        expect(Object.fromEntries(sessionResults)).toEqual(
+          expectedProbeResults("session", "session", sessionHttpFixture.pid),
+        );
+        expect(nodeHttpFixture.pid).not.toBe(sessionHttpFixture.pid);
+        expect(nodeResults.get("stdio")?.pid).not.toBe(sessionResults.get("stdio")?.pid);
+
+        const nodeStreamable = published.find(
+          (descriptor) => descriptor.mcp?.server === "streamableHttp",
+        );
+        if (!nodeStreamable) {
+          throw new Error("node Streamable HTTP descriptor was not published");
+        }
+        phase = "preserving MCP application errors";
+        const nodeError = await invokeNodeMcpPayload({
+          gateway,
+          nodeId,
+          descriptor: nodeStreamable,
+          marker: "error-node-streamableHttp",
+        });
+        expect(nodeError).toMatchObject({
+          ok: true,
+          payload: {
+            isError: true,
+            structuredContent: {
+              marker: "error-node-streamableHttp",
+              retryable: true,
+            },
+          },
+        });
+        await expect(
+          sessionRuntime.callTool("streamableHttp", "parity_probe", {
+            marker: "error-session-streamableHttp",
+          }),
+        ).resolves.toMatchObject({
+          isError: true,
+          structuredContent: {
+            marker: "error-session-streamableHttp",
+            retryable: true,
+          },
+        });
+
+        phase = "rotating node MCP catalog";
+        await invokeNodeMcp({
+          gateway,
+          nodeId,
+          descriptor: nodeStreamable,
+          marker: "rotate-remove",
+        });
+        let rotatedPublished: NodePluginToolDescriptor[] = [];
+        const catalogGateway = gateway;
+        await vi.waitFor(async () => {
+          rotatedPublished = (await readNode(catalogGateway, nodeId))?.nodePluginTools ?? [];
+          expect(
+            rotatedPublished.map((descriptor) => [descriptor.mcp?.server, descriptor.mcp?.tool]),
+            catalogGateway.logs(),
+          ).toEqual([
+            ["sse", "parity_probe"],
+            ["stdio", "parity_probe"],
+            ["streamableHttp", "parity_rotated"],
+          ]);
+        }, WAIT_OPTIONS);
+        const rotatedNodeStreamable = rotatedPublished.find(
+          (descriptor) => descriptor.mcp?.server === "streamableHttp",
+        );
+        expect(rotatedNodeStreamable?.parameters).toMatchObject({
+          properties: { revision: { type: "string" } },
+        });
+        for (const server of ["sse", "stdio"] as const) {
+          const descriptor = rotatedPublished.find((candidate) => candidate.mcp?.server === server);
+          if (!descriptor) {
+            throw new Error(`healthy sibling ${server} disappeared during catalog rotation`);
+          }
+          await expect(
+            invokeNodeMcp({
+              gateway,
+              nodeId,
+              descriptor,
+              marker: `node-after-rotation-${server}`,
+            }),
+          ).resolves.toMatchObject({ marker: `node-after-rotation-${server}` });
+        }
+
+        phase = "rotating session MCP catalog";
+        await sessionRuntime.callTool("streamableHttp", "parity_probe", {
+          marker: "rotate-remove",
+        });
+        await vi.waitFor(async () => {
+          const refreshed = await sessionRuntime?.getCatalog();
+          expect(
+            refreshed?.tools
+              .filter((entry) => entry.serverName === "streamableHttp")
+              .map((entry) => entry.toolName),
+          ).toEqual(["parity_rotated"]);
+        }, WAIT_OPTIONS);
+        await expect(
+          sessionRuntime.callTool("streamableHttp", "parity_rotated", {
+            marker: "session-after-rotation",
+          }),
+        ).resolves.toBeDefined();
+
+        phase = "expiring node Streamable HTTP session";
+        if (!rotatedNodeStreamable) {
+          throw new Error("rotated node Streamable HTTP descriptor was not published");
+        }
+        await expect(
+          invokeNodeMcp({
+            gateway,
+            nodeId,
+            descriptor: rotatedNodeStreamable,
+            marker: "expire-session",
+          }),
+        ).rejects.toThrow();
+        await waitForNode(gateway, nodeId, 2);
+        const recoveredPublished = (await waitForNode(gateway, nodeId, 3)).nodePluginTools ?? [];
+        const recoveredStreamable = recoveredPublished.find(
+          (descriptor) => descriptor.mcp?.server === "streamableHttp",
+        );
+        if (!recoveredStreamable) {
+          throw new Error("node Streamable HTTP descriptor was not republished");
+        }
+        await expect(
+          invokeNodeMcp({
+            gateway,
+            nodeId,
+            descriptor: recoveredStreamable,
+            marker: "node-after-session-expiry",
+          }),
+        ).resolves.toMatchObject({ marker: "node-after-session-expiry" });
+        rotatedPublished = recoveredPublished;
+
+        phase = "reading effective MCP inventory";
+        const created = (await gateway.call("sessions.create", {
+          agentId: "main",
+          label: "QA MCP parity inventory",
+        })) as { key?: string };
+        if (!created.key) {
+          throw new Error("sessions.create did not return a session key");
+        }
+        const effective = (await gateway.call("tools.effective", {
+          sessionKey: created.key,
+        })) as ToolsEffectiveResult;
+        const effectiveNodeTools = flattenEffectiveTools(effective).filter(
+          (tool) => tool.pluginId === "node-mcp" && tool.source === "mcp",
+        );
+        expect(
+          effectiveNodeTools
+            .map((tool) => tool.id)
+            .toSorted((a, b) => (a ?? "").localeCompare(b ?? "")),
+        ).toEqual(rotatedPublished.map((tool) => tool.name).toSorted((a, b) => a.localeCompare(b)));
+
+        phase = "withdrawing node stdio MCP tool";
+        const nodeStdioPid = nodeResults.get("stdio")?.pid;
+        if (!nodeStdioPid) {
+          throw new Error("node stdio probe did not return its PID");
+        }
+        process.kill(nodeStdioPid, "SIGTERM");
+        await waitForProcessExit(nodeStdioPid);
+        const remaining = (await waitForNode(gateway, nodeId, 2)).nodePluginTools ?? [];
+        expect(
+          remaining
+            .map((tool) => tool.mcp?.server)
+            .toSorted((a, b) => (a ?? "").localeCompare(b ?? "")),
+        ).toEqual(["sse", "streamableHttp"]);
+        const remainingResults = new Map<string, ProbeResult>();
+        for (const descriptor of remaining) {
+          const server = descriptor.mcp?.server;
+          if (!server) {
+            throw new Error(`remaining descriptor ${descriptor.name} omitted its server`);
+          }
+          const result = await invokeNodeMcp({
+            gateway,
+            nodeId,
+            descriptor,
+            marker: `node-after-stdio-stop-${server}`,
+          });
+          remainingResults.set(server, result);
+        }
+        expect(Object.fromEntries(remainingResults)).toEqual(
+          expectedProbeResults("node", "node-after-stdio-stop", nodeHttpFixture.pid, [
+            "sse",
+            "streamableHttp",
+          ]),
+        );
+        phase = "waiting for node stdio MCP recovery";
+        const recoveredAfterStdio = (await waitForNode(gateway, nodeId, 3)).nodePluginTools ?? [];
+        const recoveredStdio = recoveredAfterStdio.find(
+          (descriptor) => descriptor.mcp?.server === "stdio",
+        );
+        if (!recoveredStdio) {
+          throw new Error("node stdio MCP descriptor was not republished");
+        }
+        const recoveredStdioResult = await invokeNodeMcp({
+          gateway,
+          nodeId,
+          descriptor: recoveredStdio,
+          marker: "node-after-stdio-recovery",
+        });
+        expect(recoveredStdioResult.marker).toBe("node-after-stdio-recovery");
+        expect(recoveredStdioResult.pid).not.toBe(nodeStdioPid);
+
+        phase = "disposing session MCP runtime";
+        const sessionStdioPid = sessionResults.get("stdio")?.pid;
+        await sessionRuntime.dispose();
+        sessionRuntime = undefined;
+        if (sessionStdioPid) {
+          await waitForProcessExit(sessionStdioPid);
+        }
+
+        phase = "stopping node host";
+        await stopChild(node);
+        node = undefined;
+        const activeGateway = gateway;
+        await vi.waitFor(async () => {
+          const disconnected = await readNode(activeGateway, nodeId);
+          expect(disconnected, activeGateway.logs()).toMatchObject({ connected: false });
+          expect(disconnected?.nodePluginTools ?? []).toEqual([]);
+        }, WAIT_OPTIONS);
+
+        const afterNodeStop = (await gateway.call("tools.effective", {
+          sessionKey: created.key,
+        })) as ToolsEffectiveResult;
+        expect(
+          flattenEffectiveTools(afterNodeStop).filter((tool) => tool.pluginId === "node-mcp"),
+        ).toEqual([]);
+        expect([sessionHttpFixture.pid, nodeHttpFixture.pid].every(processIsAlive)).toBe(true);
+
+        phase = "stopping HTTP MCP fixtures";
+        const httpPids = [sessionHttpFixture.pid, nodeHttpFixture.pid];
+        await Promise.all([stopChild(sessionHttpFixture), stopChild(nodeHttpFixture)]);
+        sessionHttpFixture = undefined;
+        nodeHttpFixture = undefined;
+        await Promise.all(httpPids.map(waitForProcessExit));
+      } catch (error) {
+        const message = error instanceof Error ? error.stack : String(error);
+        proofError = new Error(`${message}\nnode logs:\n${node?.logs() ?? "not started"}`, {
+          cause: error,
+        });
+      } finally {
+        phase = "cleanup";
+        const cleanup = [
+          ...(await Promise.allSettled([
+            ...(sessionRuntime ? [sessionRuntime.dispose()] : []),
+            ...(node ? [stopChild(node)] : []),
+          ])),
+          ...(await Promise.allSettled([
+            ...(gateway ? [Promise.resolve(gateway.stop())] : []),
+            ...(sessionHttpFixture ? [stopChild(sessionHttpFixture)] : []),
+            ...(nodeHttpFixture ? [stopChild(nodeHttpFixture)] : []),
+          ])),
+        ];
+        for (const result of cleanup) {
+          if (result.status === "rejected") {
+            cleanupErrors.push(result.reason);
+          }
+        }
+        if (gateway && existsSync(gateway.tempRoot)) {
+          cleanupErrors.push(new Error(`Gateway temp root was not removed: ${gateway.tempRoot}`));
+        }
+        clearTimeout(diagnosticTimer);
+      }
+
+      const failures = proofError === undefined ? cleanupErrors : [proofError, ...cleanupErrors];
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "Gateway/node MCP parity proof failed");
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import * as z from "zod/v4";
+
+const READY_TYPE = "openclaw-mcp-parity-ready";
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function createProbeServer(label, catalogState = { rotated: false }) {
+  const server = new McpServer({ name: `openclaw-mcp-parity-${label}`, version: "1.0.0" });
+  const initialToolConfig = {
+    description: `MCP parity probe for ${label}`,
+    inputSchema: { marker: z.string() },
+  };
+  const rotatedToolConfig = {
+    description: `Rotated MCP parity probe for ${label}`,
+    inputSchema: { marker: z.string(), revision: z.string().optional() },
+  };
+  const result = (resultLabel, marker) => ({
+    content: [
+      { type: "text", text: JSON.stringify({ label: resultLabel, marker, pid: process.pid }) },
+    ],
+  });
+  const runProbe = async ({ marker }) => {
+    if (marker === "rotate-remove" && !catalogState.rotated) {
+      catalogState.rotated = true;
+      registeredProbe.update({
+        name: "parity_rotated",
+        paramsSchema: rotatedToolConfig.inputSchema,
+      });
+    }
+    const response = result(label, marker);
+    return marker.startsWith("error-")
+      ? {
+          ...response,
+          structuredContent: { label, marker, retryable: true },
+          isError: true,
+        }
+      : response;
+  };
+  const registeredProbe = catalogState.rotated
+    ? server.registerTool("parity_rotated", rotatedToolConfig, runProbe)
+    : server.registerTool("parity_probe", initialToolConfig, runProbe);
+  server.registerTool("parity_hidden", initialToolConfig, async ({ marker }) =>
+    result(`${label}-hidden`, marker),
+  );
+  return server;
+}
+
+function installSignalShutdown(shutdown) {
+  let stopping;
+  const stop = () => {
+    stopping ??= shutdown().catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+      process.exitCode = 1;
+    });
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+}
+
+async function runStdio() {
+  const label = readOption("--label")?.trim() || "stdio";
+  const server = createProbeServer(label);
+  installSignalShutdown(async () => await server.close());
+  await server.connect(new StdioServerTransport());
+}
+
+async function runHttp() {
+  const labelPrefix = readOption("--label-prefix")?.trim();
+  if (!labelPrefix) {
+    throw new Error("HTTP mode requires --label-prefix");
+  }
+  const app = createMcpExpressApp();
+  const sessions = new Map();
+  const records = new Set();
+  const catalogState = { rotated: false };
+  const route = (handler) => (req, res, next) => void handler(req, res).catch(next);
+  const rpcError = (res, code, message) =>
+    res.status(code === -32603 ? 500 : 400).json({
+      jsonrpc: "2.0",
+      error: { code, message },
+      id: null,
+    });
+
+  function track(server, transport) {
+    const record = { server, transport };
+    records.add(record);
+    // The MCP SDK exposes callback properties rather than an EventTarget surface.
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener
+    transport.onclose = () => {
+      records.delete(record);
+      const sessionId = transport.sessionId;
+      if (sessionId) {
+        sessions.delete(sessionId);
+      }
+    };
+    return record;
+  }
+
+  async function handleStreamableRequest(req, res) {
+    try {
+      const sessionId = req.headers["mcp-session-id"];
+      let transport;
+      if (typeof sessionId === "string") {
+        const record = sessions.get(sessionId);
+        if (!(record?.transport instanceof StreamableHTTPServerTransport)) {
+          rpcError(res, -32000, "Unknown Streamable HTTP session");
+          return;
+        }
+        if (req.body?.params?.arguments?.marker === "expire-session") {
+          sessions.delete(sessionId);
+          res.status(404).json({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Session not found" },
+            id: req.body?.id ?? null,
+          });
+          return;
+        }
+        transport = record.transport;
+      } else if (req.method === "POST" && isInitializeRequest(req.body)) {
+        const createdTransport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: randomUUID,
+          onsessioninitialized: (createdSessionId) => {
+            sessions.set(createdSessionId, record);
+          },
+        });
+        const server = createProbeServer(`${labelPrefix}-streamable-http`, catalogState);
+        const record = track(server, createdTransport);
+        transport = createdTransport;
+        await server.connect(createdTransport);
+      } else {
+        rpcError(res, -32000, "Missing Streamable HTTP session");
+        return;
+      }
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      process.stderr.write(`Streamable HTTP request failed: ${String(error)}\n`);
+      if (!res.headersSent) {
+        rpcError(res, -32603, "Internal server error");
+      }
+    }
+  }
+
+  app.all("/mcp", route(handleStreamableRequest));
+
+  async function handleSseConnect(_req, res) {
+    const transport = new SSEServerTransport("/messages", res);
+    const server = createProbeServer(`${labelPrefix}-sse`, catalogState);
+    const record = track(server, transport);
+    sessions.set(transport.sessionId, record);
+    await server.connect(transport);
+  }
+
+  app.get("/sse", route(handleSseConnect));
+
+  async function handleSseMessage(req, res) {
+    const sessionId = typeof req.query.sessionId === "string" ? req.query.sessionId : "";
+    const record = sessions.get(sessionId);
+    if (!(record?.transport instanceof SSEServerTransport)) {
+      res.status(400).send("Unknown SSE session");
+      return;
+    }
+    await record.transport.handlePostMessage(req, res, req.body);
+  }
+
+  app.post("/messages", route(handleSseMessage));
+
+  const httpServer = app.listen(0, "127.0.0.1");
+  await new Promise((resolve, reject) => {
+    httpServer.once("listening", resolve);
+    httpServer.once("error", reject);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("HTTP MCP fixture did not bind a TCP port");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  process.stdout.write(
+    `${JSON.stringify({
+      type: READY_TYPE,
+      urls: {
+        streamableHttp: `${baseUrl}/mcp`,
+        sse: `${baseUrl}/sse`,
+      },
+    })}\n`,
+  );
+
+  installSignalShutdown(async () => {
+    await Promise.allSettled([...records].map((record) => record.server.close()));
+    httpServer.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      httpServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+}
+
+const mode = process.argv[2];
+if (mode === "stdio") {
+  await runStdio();
+} else if (mode === "http") {
+  await runHttp();
+} else {
+  throw new Error(
+    "usage: gateway-node-mcp.fixture.mjs stdio --label <label> | http --label-prefix <prefix>",
+  );
+}

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.live.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.live.test.ts
@@ -1,0 +1,300 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import type { McpServerConfig } from "../../../../src/config/types.mcp.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import {
+  NODE_MCP_COMMAND,
+  approvePairing,
+  createChildEnv,
+  startNodeProcess,
+  stopChild,
+  waitForNode,
+} from "./gateway-node-mcp.test-support.js";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY?.trim() ?? "";
+const LIVE_ENABLED = process.env.OPENCLAW_LIVE_TEST === "1" && Boolean(OPENAI_API_KEY);
+const MODEL_ID = process.env.OPENCLAW_MCP_LIVE_MODEL?.trim() || "gpt-5.6-luna";
+const MODEL_REF = `openai/${MODEL_ID}`;
+const REQUEST_TIMEOUT_MS = 120_000;
+const LIVE_TEST_TIMEOUT_MS = 5 * 60_000;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+type HistoryMessage = Record<string, unknown>;
+function stdioServer(
+  name: string,
+  label: string,
+  fixturePath: string,
+  repoRoot: string,
+  env: Record<string, string>,
+): Record<string, McpServerConfig> {
+  return {
+    [name]: {
+      transport: "stdio",
+      command: process.execPath,
+      args: [fixturePath, "stdio", "--label", label],
+      cwd: repoRoot,
+      env,
+      connectionTimeoutMs: 30_000,
+      requestTimeoutMs: 30_000,
+      toolFilter: { include: ["parity_probe"], exclude: ["parity_hidden"] },
+    },
+  };
+}
+function modelConfig(workspace: string): OpenClawConfig {
+  return {
+    secrets: { providers: { default: { source: "env" } } },
+    models: {
+      mode: "replace",
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-responses",
+          apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          models: [
+            {
+              id: MODEL_ID,
+              name: MODEL_ID,
+              api: "openai-responses",
+              reasoning: true,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 48_000,
+              contextTokens: 48_000,
+              maxTokens: 8_192,
+            },
+          ],
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        workspace,
+        model: { primary: MODEL_REF },
+        timeoutSeconds: Math.ceil(REQUEST_TIMEOUT_MS / 1_000),
+      },
+    },
+    tools: { profile: "full", toolSearch: false, codeMode: false },
+    memory: { search: { enabled: false } },
+    plugins: { enabled: false },
+    channels: {},
+  };
+}
+function expectCompletedTool(
+  messages: HistoryMessage[],
+  params: { name: string; marker: string; label: string },
+): void {
+  const called = messages.some((message) => {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      return false;
+    }
+    return message.content.some((block) => {
+      if (!isRecord(block) || block.type !== "toolCall" || block.name !== params.name) {
+        return false;
+      }
+      return JSON.stringify(block.arguments ?? block.input).includes(params.marker);
+    });
+  });
+  expect(called, `chat.history omitted tool call ${params.name}`).toBe(true);
+  const result = messages.find(
+    (candidate) =>
+      candidate.role === "toolResult" &&
+      candidate.toolName === params.name &&
+      JSON.stringify(candidate).includes(params.marker) &&
+      JSON.stringify(candidate).includes(params.label),
+  );
+  expect(result, `chat.history omitted completed result for ${params.name}`).toBeDefined();
+}
+function assistantText(message: HistoryMessage): string {
+  if (typeof message.content === "string") {
+    return message.content.trim();
+  }
+  const content = Array.isArray(message.content) ? message.content : [];
+  const text = content.find(
+    (block) => isRecord(block) && block.type === "text" && typeof block.text === "string",
+  );
+  return isRecord(text) && typeof text.text === "string" ? text.text.trim() : "";
+}
+describe.skipIf(!LIVE_ENABLED)("OpenAI cross-placement MCP model proof", () => {
+  it(
+    "calls one Gateway MCP tool and one node MCP tool in a real agent turn",
+    { timeout: LIVE_TEST_TIMEOUT_MS },
+    async () => {
+      const repoRoot = process.cwd();
+      const taskRoot = tempDirs.make("openclaw-gateway-node-mcp-live-");
+      const gatewayParent = path.join(taskRoot, "gateway");
+      const nodeRoot = path.join(taskRoot, "node");
+      const nodeHome = path.join(nodeRoot, "home");
+      const nodeStateDir = path.join(nodeRoot, "state");
+      const nodeConfigPath = path.join(nodeRoot, "openclaw.json");
+      const nodeWorkspace = path.join(nodeRoot, "workspace");
+      const nodeTempDir = path.join(nodeRoot, "tmp");
+      const fixturePath = path.join(
+        repoRoot,
+        "test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs",
+      );
+      let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
+      let node: ReturnType<typeof startNodeProcess> | undefined;
+      let proofError: unknown;
+      const cleanupErrors: unknown[] = [];
+      try {
+        await Promise.all(
+          [gatewayParent, nodeHome, nodeStateDir, nodeWorkspace, nodeTempDir].map((dir) =>
+            fs.mkdir(dir, { recursive: true }),
+          ),
+        );
+        const gatewayServers = stdioServer(
+          "gatewayLive",
+          "gateway-live",
+          fixturePath,
+          repoRoot,
+          createChildEnv({ home: gatewayParent, tempDir: gatewayParent }),
+        );
+        const nodeServers = stdioServer(
+          "nodeLive",
+          "node-live",
+          fixturePath,
+          repoRoot,
+          createChildEnv({ home: nodeHome, tempDir: nodeTempDir }),
+        );
+        const nodeConfig: OpenClawConfig = {
+          gateway: { mode: "local" },
+          agents: { defaults: { workspace: nodeWorkspace } },
+          plugins: { enabled: false },
+          nodeHost: { mcp: { servers: nodeServers }, skills: { enabled: false } },
+        };
+        await fs.writeFile(nodeConfigPath, `${JSON.stringify(nodeConfig, null, 2)}\n`, {
+          encoding: "utf8",
+          mode: 0o600,
+        });
+        gateway = await startQaGatewayChild({
+          repoRoot,
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: ["dist/index.js"],
+            cwd: repoRoot,
+            tempParentDir: gatewayParent,
+            usePackagedPlugins: true,
+          },
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          runtimeEnvPatch: {
+            OPENAI_API_KEY,
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+          },
+          mutateConfig: (cfg) => {
+            const live = modelConfig(cfg.agents?.defaults?.workspace ?? gatewayParent);
+            return {
+              ...live,
+              agents: {
+                ...cfg.agents,
+                ...live.agents,
+                defaults: { ...cfg.agents?.defaults, ...live.agents?.defaults },
+                entries: {
+                  ...cfg.agents?.entries,
+                  qa: { ...cfg.agents?.entries?.qa, model: { primary: MODEL_REF } },
+                },
+              },
+              mcp: { servers: gatewayServers },
+              gateway: {
+                ...cfg.gateway,
+                nodes: {
+                  ...cfg.gateway?.nodes,
+                  commands: { allow: [NODE_MCP_COMMAND] },
+                  pairing: { ...cfg.gateway?.nodes?.pairing, autoApproveLocal: false },
+                },
+              },
+            };
+          },
+        });
+        const gatewayPort = Number(new URL(gateway.baseUrl).port);
+        expect(gatewayPort).not.toBe(18_789);
+        const nodeEnv = createChildEnv({
+          home: nodeHome,
+          tempDir: nodeTempDir,
+          extra: {
+            OPENCLAW_HOME: nodeHome,
+            OPENCLAW_STATE_DIR: nodeStateDir,
+            OPENCLAW_CONFIG_PATH: nodeConfigPath,
+            OPENCLAW_GATEWAY_TOKEN: gateway.token,
+            OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1",
+          },
+        });
+        expect(nodeEnv).not.toHaveProperty("OPENAI_API_KEY");
+        node = startNodeProcess(gatewayPort, nodeEnv);
+        const nodeId = await approvePairing(gateway, "device");
+        await stopChild(node);
+        node = startNodeProcess(gatewayPort, nodeEnv);
+        await approvePairing(gateway, "node", nodeId);
+        const descriptors = (await waitForNode(gateway, nodeId, 1)).nodePluginTools ?? [];
+        expect(descriptors.map(({ name, mcp }) => ({ name, mcp }))).toEqual([
+          { name: "nodeLive_parity_probe", mcp: { server: "nodeLive", tool: "parity_probe" } },
+        ]);
+        const gatewayMarker = `gateway-${randomUUID()}`;
+        const nodeMarker = `node-${randomUUID()}`;
+        const expectedToken = `MCP_LIVE_OK_${randomUUID().replaceAll("-", "")}`;
+        const sessionKey = `agent:qa:mcp-live-${randomUUID()}`;
+        const idempotencyKey = randomUUID();
+        const prompt =
+          `Call gatewayLive__parity_probe with marker ${gatewayMarker}. ` +
+          `Call nodeLive_parity_probe with marker ${nodeMarker}. ` +
+          `Only after both calls return successfully, reply with exactly ${expectedToken} and nothing else.`;
+        const started = (await gateway.call(
+          "agent",
+          { sessionKey, message: prompt, deliver: false, idempotencyKey },
+          { timeoutMs: 30_000 },
+        )) as { runId?: unknown; status?: unknown };
+        if (started.status !== "accepted" || typeof started.runId !== "string") {
+          throw new Error(`live Gateway run did not start: ${JSON.stringify(started)}`);
+        }
+        const runId = started.runId;
+        const terminal = await gateway.call(
+          "agent.wait",
+          { runId, timeoutMs: REQUEST_TIMEOUT_MS },
+          { timeoutMs: REQUEST_TIMEOUT_MS + 5_000 },
+        );
+        expect(terminal, gateway.logs()).toMatchObject({ runId, status: "ok" });
+        const history = (await gateway.call("chat.history", {
+          sessionKey,
+          limit: 50,
+        })) as { messages?: HistoryMessage[] };
+        const messages = history.messages ?? [];
+        expectCompletedTool(messages, {
+          name: "gatewayLive__parity_probe",
+          marker: gatewayMarker,
+          label: "gateway-live",
+        });
+        expectCompletedTool(messages, {
+          name: "nodeLive_parity_probe",
+          marker: nodeMarker,
+          label: "node-live",
+        });
+        expect(
+          messages.some(
+            (message) => message.role === "assistant" && assistantText(message) === expectedToken,
+          ),
+          "chat.history omitted the exact final expected token",
+        ).toBe(true);
+      } catch (error) {
+        proofError = error;
+      } finally {
+        const stopped = await Promise.allSettled([
+          ...(node ? [stopChild(node)] : []),
+          ...(gateway ? [Promise.resolve(gateway.stop())] : []),
+        ]);
+        cleanupErrors.push(
+          ...stopped.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+        );
+      }
+      const failures = proofError === undefined ? cleanupErrors : [proofError, ...cleanupErrors];
+      if (failures.length > 0) {
+        throw failures.length === 1
+          ? failures[0]
+          : new AggregateError(failures, "OpenAI cross-placement MCP model proof failed");
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
@@ -1,0 +1,371 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { setTimeout as delay } from "node:timers/promises";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect, vi } from "vitest";
+import type { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import type { NodePluginToolDescriptor } from "../../../../packages/gateway-protocol/src/schema/nodes.js";
+import type { McpServerConfig } from "../../../../src/config/types.mcp.js";
+
+export const TEST_TIMEOUT_MS = 180_000;
+const WAIT_TIMEOUT_MS = 30_000;
+const FIXTURE_READY_TYPE = "openclaw-mcp-parity-ready";
+const NODE_DISPLAY_NAME = "QA MCP parity node";
+export const NODE_MCP_COMMAND = "mcp.tools.call.v1";
+export const WAIT_OPTIONS = { timeout: WAIT_TIMEOUT_MS, interval: 100 };
+export const MCP_SERVERS = ["sse", "stdio", "streamableHttp"] as const;
+const MCP_LABELS = { sse: "sse", stdio: "stdio", streamableHttp: "streamable-http" } as const;
+type McpServerName = keyof typeof MCP_LABELS;
+
+export type GatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
+export type CapturedChild = {
+  child: ChildProcess;
+  exited: Promise<void>;
+  logs: () => string;
+};
+export type HttpFixture = CapturedChild & {
+  pid: number;
+  urls: {
+    streamableHttp: string;
+    sse: string;
+  };
+};
+type NodeRead = {
+  nodeId: string;
+  displayName?: string;
+  approvalState?: string;
+  paired?: boolean;
+  connected?: boolean;
+  nodePluginTools?: NodePluginToolDescriptor[];
+};
+export type ProbeResult = {
+  label: string;
+  marker: string;
+  pid: number;
+};
+type EffectiveTool = {
+  id?: string;
+  source?: string;
+  pluginId?: string;
+};
+export type ToolsEffectiveResult = {
+  groups?: Array<{ tools?: EffectiveTool[] }>;
+};
+
+const CHILD_ENV_KEYS = ["PATH", "PATHEXT", "SystemRoot", "WINDIR", "ComSpec"] as const;
+
+function captureChild(child: ChildProcess): CapturedChild {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout = (stdout + chunk.toString()).slice(-200_000);
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr = (stderr + chunk.toString()).slice(-200_000);
+  });
+  return {
+    child,
+    exited: once(child, "exit").then(() => {}),
+    logs: () => `stdout:\n${stdout}\nstderr:\n${stderr}`,
+  };
+}
+
+export function createChildEnv(params: {
+  home: string;
+  tempDir: string;
+  extra?: Record<string, string>;
+}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of CHILD_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return {
+    ...env,
+    HOME: params.home,
+    USERPROFILE: params.home,
+    XDG_CACHE_HOME: path.join(params.home, ".cache"),
+    XDG_CONFIG_HOME: path.join(params.home, ".config"),
+    XDG_DATA_HOME: path.join(params.home, ".local", "share"),
+    TMPDIR: params.tempDir,
+    TMP: params.tempDir,
+    TEMP: params.tempDir,
+    ...params.extra,
+  };
+}
+
+export async function startHttpFixture(params: {
+  fixturePath: string;
+  labelPrefix: "session" | "node";
+  env: NodeJS.ProcessEnv;
+}): Promise<HttpFixture> {
+  const captured = captureChild(
+    spawn(process.execPath, [params.fixturePath, "http", "--label-prefix", params.labelPrefix], {
+      cwd: process.cwd(),
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+  const pid = captured.child.pid;
+  if (pid === undefined) {
+    throw new Error("HTTP MCP fixture did not start");
+  }
+  if (!captured.child.stdout) {
+    throw new Error("HTTP MCP fixture stdout was not piped");
+  }
+  const lines = createInterface({ input: captured.child.stdout });
+  const line = await Promise.race([
+    new Promise<string>((resolve) => {
+      lines.once("line", resolve);
+    }),
+    captured.exited.then(() => {
+      throw new Error(`HTTP MCP fixture exited before readiness:\n${captured.logs()}`);
+    }),
+    delay(WAIT_TIMEOUT_MS, undefined, { ref: false }).then(() => {
+      throw new Error(`HTTP MCP fixture readiness timed out:\n${captured.logs()}`);
+    }),
+  ]);
+  lines.close();
+  const value: unknown = JSON.parse(line);
+  if (
+    !isRecord(value) ||
+    value.type !== FIXTURE_READY_TYPE ||
+    !isRecord(value.urls) ||
+    typeof value.urls.streamableHttp !== "string" ||
+    typeof value.urls.sse !== "string"
+  ) {
+    throw new Error(`HTTP MCP fixture returned invalid readiness: ${line}`);
+  }
+  return {
+    ...captured,
+    pid,
+    urls: { streamableHttp: value.urls.streamableHttp, sse: value.urls.sse },
+  };
+}
+
+export function startNodeProcess(gatewayPort: number, nodeEnv: NodeJS.ProcessEnv): CapturedChild {
+  return captureChild(
+    spawn(
+      process.execPath,
+      [
+        "dist/index.js",
+        "node",
+        "run",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(gatewayPort),
+        "--display-name",
+        NODE_DISPLAY_NAME,
+      ],
+      {
+        cwd: process.cwd(),
+        env: nodeEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    ),
+  );
+}
+
+export async function stopChild(captured: CapturedChild | undefined): Promise<void> {
+  if (!captured || captured.child.exitCode !== null || captured.child.signalCode !== null) {
+    await captured?.exited.catch(() => {});
+    return;
+  }
+  captured.child.kill("SIGTERM");
+  const graceful = await Promise.race([
+    captured.exited.then(() => true),
+    delay(10_000, false, { ref: false }),
+  ]);
+  if (!graceful) {
+    captured.child.kill("SIGKILL");
+    await captured.exited;
+  }
+}
+
+export function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+export async function waitForProcessExit(pid: number): Promise<void> {
+  await vi.waitFor(() => expect(processIsAlive(pid)).toBe(false), WAIT_OPTIONS);
+}
+
+export async function approvePairing(
+  gateway: GatewayHandle,
+  kind: "device" | "node",
+  nodeId?: string,
+): Promise<string> {
+  let requestId = "";
+  let approvedId = "";
+  await vi.waitFor(async () => {
+    const result = (await gateway.call(`${kind}.pair.list`, {})) as {
+      pending?: Array<{
+        requestId?: string;
+        deviceId?: string;
+        nodeId?: string;
+        role?: string;
+      }>;
+    };
+    const pending = result.pending?.find((entry) =>
+      kind === "device" ? entry.role === "node" : entry.nodeId === nodeId,
+    );
+    expect(pending?.requestId, gateway.logs()).toBeTruthy();
+    requestId = pending?.requestId ?? "";
+    approvedId = kind === "device" ? (pending?.deviceId ?? "") : (pending?.nodeId ?? "");
+    expect(approvedId, gateway.logs()).toBeTruthy();
+  }, WAIT_OPTIONS);
+  await gateway.call(`${kind}.pair.approve`, { requestId });
+  return approvedId;
+}
+
+export async function readNode(
+  gateway: GatewayHandle,
+  nodeId: string,
+): Promise<NodeRead | undefined> {
+  const result = (await gateway.call("node.list", {})) as { nodes?: NodeRead[] };
+  return result.nodes?.find((entry) => entry.nodeId === nodeId);
+}
+
+export async function waitForNode(
+  gateway: GatewayHandle,
+  nodeId: string,
+  toolCount?: number,
+): Promise<NodeRead> {
+  let node: NodeRead | undefined;
+  await vi.waitFor(async () => {
+    node = await readNode(gateway, nodeId);
+    expect(node, gateway.logs()).toMatchObject({
+      nodeId,
+      displayName: NODE_DISPLAY_NAME,
+      approvalState: "approved",
+      paired: true,
+      connected: true,
+    });
+    if (toolCount !== undefined) {
+      expect(node?.nodePluginTools ?? [], gateway.logs()).toHaveLength(toolCount);
+    }
+  }, WAIT_OPTIONS);
+  if (!node) {
+    throw new Error(`node ${nodeId} did not connect:\n${gateway.logs()}`);
+  }
+  return node;
+}
+
+export function parseProbeResult(value: unknown): ProbeResult {
+  const payload = isRecord(value) && isRecord(value.payload) ? value.payload : value;
+  if (!isRecord(payload) || !Array.isArray(payload.content)) {
+    throw new Error(`MCP result omitted content: ${JSON.stringify(value)}`);
+  }
+  const text = payload.content.find(
+    (item) => isRecord(item) && item.type === "text" && typeof item.text === "string",
+  );
+  if (!isRecord(text) || typeof text.text !== "string") {
+    throw new Error(`MCP result omitted text: ${JSON.stringify(value)}`);
+  }
+  const parsed: unknown = JSON.parse(text.text);
+  if (
+    !isRecord(parsed) ||
+    typeof parsed.label !== "string" ||
+    typeof parsed.marker !== "string" ||
+    typeof parsed.pid !== "number"
+  ) {
+    throw new Error(`MCP result had invalid probe data: ${text.text}`);
+  }
+  return { label: parsed.label, marker: parsed.marker, pid: parsed.pid };
+}
+
+export async function invokeNodeMcpPayload(params: {
+  gateway: GatewayHandle;
+  nodeId: string;
+  descriptor: NodePluginToolDescriptor;
+  marker: string;
+}): Promise<unknown> {
+  const mcp = params.descriptor.mcp;
+  if (!mcp) {
+    throw new Error(`node descriptor ${params.descriptor.name} omitted MCP routing`);
+  }
+  return await params.gateway.call(
+    "node.invoke",
+    {
+      nodeId: params.nodeId,
+      command: NODE_MCP_COMMAND,
+      params: { server: mcp.server, tool: mcp.tool, arguments: { marker: params.marker } },
+      timeoutMs: WAIT_TIMEOUT_MS,
+      idempotencyKey: randomUUID(),
+    },
+    { timeoutMs: WAIT_TIMEOUT_MS },
+  );
+}
+
+export async function invokeNodeMcp(
+  params: Parameters<typeof invokeNodeMcpPayload>[0],
+): Promise<ProbeResult> {
+  return parseProbeResult(await invokeNodeMcpPayload(params));
+}
+
+export function flattenEffectiveTools(result: ToolsEffectiveResult): EffectiveTool[] {
+  return (result.groups ?? []).flatMap((group) => group.tools ?? []);
+}
+
+export function createMcpServers(params: {
+  placement: "session" | "node";
+  fixture: HttpFixture;
+  stdioEnv: Record<string, string>;
+  fixturePath: string;
+  repoRoot: string;
+}): Record<string, McpServerConfig> {
+  const common = {
+    connectionTimeoutMs: WAIT_TIMEOUT_MS,
+    requestTimeoutMs: WAIT_TIMEOUT_MS,
+    toolFilter: { include: ["parity_*"], exclude: ["*_hidden"] },
+  };
+  return {
+    stdio: {
+      ...common,
+      transport: "stdio",
+      command: process.execPath,
+      args: [params.fixturePath, "stdio", "--label", `${params.placement}-stdio`],
+      cwd: params.repoRoot,
+      env: params.stdioEnv,
+    },
+    streamableHttp: {
+      ...common,
+      transport: "streamable-http",
+      url: params.fixture.urls.streamableHttp,
+    },
+    sse: {
+      ...common,
+      transport: "sse",
+      url: params.fixture.urls.sse,
+    },
+  };
+}
+
+export function expectedProbeResults(
+  placement: "session" | "node",
+  markerPrefix: string,
+  httpPid: number,
+  servers: readonly McpServerName[] = MCP_SERVERS,
+) {
+  return Object.fromEntries(
+    servers.map((server) => [
+      server,
+      {
+        label: `${placement}-${MCP_LABELS[server]}`,
+        marker: `${markerPrefix}-${server}`,
+        pid: server === "stdio" ? expect.any(Number) : httpPid,
+      },
+    ]),
+  );
+}

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -119,6 +119,7 @@ describe("scripts/test-live-shard", () => {
       "src/infra/push-apns-http2.live.test.ts",
     ]);
     expect(selectLiveShardFiles("native-live-test", allFiles)).toEqual([
+      "test/e2e/qa-lab/runtime/gateway-node-mcp.live.test.ts",
       "test/image-generation.infer-cli.live.test.ts",
       "test/image-generation.runtime.live.test.ts",
       "test/openai-onboarding.live.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Node-hosted MCP reused the same configuration and low-level transport/filter primitives as Gateway/session MCP, but independently reimplemented client lifecycle and result projection. That drift left node tool catalogs stale after `tools/list_changed`, left expired stateful Streamable HTTP sessions broken until restart, abandoned server-side HTTP sessions during shutdown, and converted MCP application errors into failed node RPCs.

Closes #125044.

## Why This Change Was Made

Keeps the two correct architectural owners—session/requester lifetime in the Gateway and process lifetime on the node—while moving placement-neutral behavior into shared MCP primitives.

The shared client-lifecycle owner now handles initialize deadlines, parent aborts, bounded teardown, forced stdio cleanup, Streamable HTTP termination, and exact stateful-session expiry classification. The node owner now serializes per-server refresh/recovery, globally rebuilds the bounded descriptor catalog, republishes only effective changes, and reconnects with bounded backoff. The current published descriptor array remains the sole call authority.

The result projector now preserves the MCP contract: `CallToolResult.isError` is delivered as a model-visible failed tool result with structured and non-text content, while unavailable servers, unpublished tools, timeouts, and transport/protocol failures remain failed `node.invoke` RPCs.

AI-assisted: yes. The implementation received independent architecture, proof-coverage, dependency-contract, result-semantics, recovery, simplification, and structured autoreview passes. No agent transcript is attached.

## User Impact

Node-hosted MCP tools now update live when the server changes its catalog. Closed stdio/SSE/HTTP transports and expired stateful Streamable HTTP sessions withdraw stale tools and recover without restarting the node host. The call that discovers an expired session still fails once and is never replayed; later calls use the replacement connection after republishing.

Gateway/session MCP behavior is unchanged except for sharing the same lifecycle and result-projection owners. Node MCP application errors now retain useful structured content so the model can correct its request.

## Evidence

- Focused node MCP lifecycle/invoke suite: 33 passed.
- Session MCP materialization: 19 passed.
- Session timeout/retry regression: passed after removing a fire-and-forget log-order assertion that flaked under loaded process teardown.
- Real isolated Gateway + real `openclaw node run` E2E: passed.
  - real stdio, legacy SSE, and Streamable HTTP servers in both placements;
  - two-stage device/node pairing;
  - include/exclude filter parity;
  - real `node.pluginTools.update` publication and `node.invoke` calls;
  - MCP application-error payload preservation;
  - live tool rename/schema replacement through `tools/list_changed`;
  - stateful Streamable HTTP 404 withdrawal and later recovery without replay;
  - stdio process withdrawal and proactive reconnect;
  - `tools.effective` node inventory and disconnect cleanup.
- Complete private-QA build: passed locally.
- Blacksmith Testbox exact changed gate: passed on `tbx_01m072smmrmhprtjfzbanbw8jz` ([run](https://github.com/openclaw/openclaw/actions/runs/31997738700)); format, ratchets, dead exports, core/core-test/root typechecks, core/scripts lint, import cycles, and architecture guards all passed.
- Post-rebase CI inventory repair: 23 focused tests passed, Knip reported zero unused files, and formatting/diff checks passed.
- Exact-head GitHub CI: green for `2a4005519d52d396d926ff2d3970559a4d9f67b4` ([run](https://github.com/openclaw/openclaw/actions/runs/32001334793)).
- Pinned dependency contract: directly inspected installed `@modelcontextprotocol/sdk` 1.30.0 source for status-preserving `StreamableHTTPError`, session-ID handling, DELETE termination, abort propagation, and close-on-initialize-failure.
- Sibling Codex contract: directly inspected commit `92cbfb4d2431` for stateful-404-only expiry classification, single-flight session reinitialization, DELETE termination, and owned stdio shutdown.
- Fresh final Codex P1 autoreview after the startup-cancellation repair: clean, with no accepted/actionable findings.
- Authenticated OpenAI proof gap: both approved Molty OpenAI keys currently return HTTP 401. The lane reached the real OpenAI Responses endpoint and is kept as a gated live test, but this PR does not claim a successful external-model call.

Production LOC: +571/-349 (net +222) | Tests/support: +2005/-42 | Docs/ratchets/tooling: +10/-2. The production growth is the process-lifetime node recovery/catalog owner plus shared bounded lifecycle handling; duplicate per-placement projectors and teardown paths were removed.
