### PR TITLE
feat(workboard): show full boards on session dashboards

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -363,13 +363,16 @@ the template id is stored as card metadata.
 
 ### Session-board widgets
 
-Workboard ships two native widgets for session dashboards (see
+Workboard ships three native widgets for session dashboards (see
 [Dashboards](/web/dashboards)). The agent pins them with its `dashboard` tool
 using `content: { kind: "plugin", pluginKind, props }`, and they render as
 first-party UI with live data — no sandbox frame or capability grant:
 
 - `workboard:card` with `props: { cardId }` shows one card with its status
   control, priority, and assigned agent.
+- `workboard:board` with optional `props: { boardId }` shows the full Kanban
+  board with draggable cards and status controls. Without `boardId` it shows
+  every board; with `boardId` it shows only that board.
 - `workboard:mini` with optional `props: { boardId, limit }` shows per-status
   counts plus the top ready/running cards, and links to the full board page.
   Without `boardId` it aggregates every board; with `boardId` it scopes to that

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -25,6 +25,12 @@ export default definePluginEntry({
     const store = WorkboardStore.openSqlite();
     api.session.controls.registerControlUiDescriptor({
       surface: "widget",
+      id: "board",
+      label: "Workboard board",
+      requiredScopes: ["operator.read"],
+    });
+    api.session.controls.registerControlUiDescriptor({
+      surface: "widget",
       id: "card",
       label: "Workboard card",
       requiredScopes: ["operator.write"],

--- a/package.json
+++ b/package.json
@@ -1990,6 +1990,7 @@
     "ui:i18n:report": "node --import tsx scripts/control-ui-i18n-report.ts",
     "ui:i18n:sync": "node --import tsx scripts/control-ui-i18n.ts sync --write",
     "ui:i18n:verify": "node --import tsx scripts/control-ui-i18n-verify.ts verify",
+    "ui:proof:workboard": "node --import tsx scripts/capture-workboard-ui-proof.mts",
     "native:i18n:baseline": "node --import tsx scripts/native-app-i18n.ts baseline --write",
     "native:i18n:check": "node --import tsx scripts/native-app-i18n.ts check",
     "native:i18n:sync": "node --import tsx scripts/native-app-i18n.ts sync --write",

--- a/scripts/capture-workboard-ui-proof.mts
+++ b/scripts/capture-workboard-ui-proof.mts
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+} from "../ui/src/test-helpers/control-ui-e2e.ts";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:5187";
+const DEFAULT_OUTPUT_DIR = path.resolve(".artifacts/control-ui-e2e/workboard-proof");
+const WORKBOARD_SESSION_KEY = "agent:main:workboard-proof";
+
+function readOption(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const baseUrl = new URL(readOption("base-url") ?? DEFAULT_BASE_URL);
+const outputDir = path.resolve(readOption("output-dir") ?? DEFAULT_OUTPUT_DIR);
+const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+if (!canRunPlaywrightChromium(executablePath)) {
+  throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
+}
+
+await mkdir(outputDir, { recursive: true });
+const browser = await chromium.launch({ executablePath });
+const context = await browser.newContext({
+  colorScheme: "light",
+  reducedMotion: "reduce",
+  viewport: { width: 1440, height: 900 },
+});
+const page = await context.newPage();
+page.setDefaultTimeout(30_000);
+
+const gatewayUrl = new URL(baseUrl);
+gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
+const settingsKey = `openclaw.control.settings.v1:${gatewayUrl.origin}`;
+await page.addInitScript(
+  ({ key, sessionKey }) => {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        boardSessionViews: { [sessionKey]: { activeTabId: "main" } },
+        theme: "light",
+      }),
+    );
+  },
+  { key: settingsKey, sessionKey: WORKBOARD_SESSION_KEY },
+);
+
+try {
+  await page.goto(new URL("/workboard/peter-tasks", baseUrl).toString());
+  const automationChip = page.locator(".workboard-automation-chip");
+  await automationChip.waitFor();
+  if ((await automationChip.textContent())?.trim() !== "Automation") {
+    throw new Error("Workboard automation chip did not render its expected label");
+  }
+  await page.getByText("Prepare launch readiness checklist", { exact: true }).waitFor();
+  await page.screenshot({
+    animations: "disabled",
+    path: path.join(outputDir, "workboard-chip.png"),
+  });
+
+  await page.goto(new URL("/dashboard", baseUrl).toString());
+  const widget = page.locator('[data-test-id="workboard-board-widget"]');
+  await widget.waitFor();
+  await page.getByText("Validate onboarding flow", { exact: true }).waitFor();
+  await page.getByText("Review accessibility audit", { exact: true }).waitFor();
+  await page.locator(".board-session-surface--dock-hidden").waitFor();
+  const columnCount = await widget.locator(".workboard-column").count();
+  if (columnCount !== 6) {
+    throw new Error(`Expected 6 Workboard columns, received ${columnCount}`);
+  }
+  await page.screenshot({
+    animations: "disabled",
+    path: path.join(outputDir, "workboard-widget.png"),
+  });
+} finally {
+  await context.close();
+  await browser.close();
+}
+
+console.log(`[workboard-ui-proof] ${outputDir}`);

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -39,7 +39,7 @@ import { buildSkillWorkshopMocks } from "./control-ui-mock-skill-workshop.js";
 
 type CliOptions = {
   allowedHosts: string[];
-  fixture?: "approval" | "board" | "swarm";
+  fixture?: "approval" | "board" | "swarm" | "workboard";
   host: string;
   port: number;
 };
@@ -161,7 +161,7 @@ function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (!value) {
     return undefined;
   }
-  if (value !== "approval" && value !== "board" && value !== "swarm") {
+  if (value !== "approval" && value !== "board" && value !== "swarm" && value !== "workboard") {
     throw new Error(`Unknown Control UI mock fixture: ${value}`);
   }
   return value;
@@ -645,7 +645,7 @@ function buildProfileUsageMocks(baseTime: number) {
  * across a few real section keys, and `config.get` returns a matching
  * snapshot with the hash `config.set`/`config.apply` are guarded by.
  */
-function buildConfigMocks(options: { swarmEnabled?: boolean } = {}) {
+function buildConfigMocks(options: { swarmEnabled?: boolean; workboardEnabled?: boolean } = {}) {
   const config = {
     logging: { level: "info", consoleTimestamps: true },
     messages: { queueLimit: 5, responsePrefix: "" },
@@ -654,6 +654,7 @@ function buildConfigMocks(options: { swarmEnabled?: boolean } = {}) {
     commands: { native: "auto", nativeSkills: "auto" },
     models: { mode: "merge" },
     ...(options.swarmEnabled ? { tools: { swarm: true } } : {}),
+    ...(options.workboardEnabled ? { plugins: { entries: { workboard: { enabled: true } } } } : {}),
     channels: {
       whatsapp: {
         enabled: true,
@@ -894,6 +895,86 @@ function buildConfigMocks(options: { swarmEnabled?: boolean } = {}) {
       ),
       version: "mock-config-schema",
       generatedAt: new Date(0).toISOString(),
+    },
+  };
+}
+
+function buildWorkboardMocks(baseTime: number) {
+  const boardId = "peter-tasks";
+  const card = (
+    id: string,
+    title: string,
+    status: string,
+    priority: string,
+    position: number,
+    labels: string[],
+  ) => ({
+    id,
+    title,
+    status,
+    priority,
+    labels,
+    position,
+    createdAt: baseTime - 86_400_000,
+    updatedAt: baseTime - position * 1_000,
+    metadata: { automation: { boardId } },
+  });
+  const cards = [
+    card("card-inbox", "Capture customer feedback themes", "todo", "normal", 1, ["research"]),
+    card("card-brief", "Draft weekly product brief", "todo", "low", 2, ["writing"]),
+    card("card-ready", "Prepare launch readiness checklist", "ready", "high", 1, ["launch"]),
+    card("card-running", "Validate onboarding flow", "running", "urgent", 1, ["quality"]),
+    card("card-review", "Review accessibility audit", "review", "high", 1, ["frontend"]),
+    card("card-blocked", "Confirm staging environment access", "blocked", "normal", 1, ["ops"]),
+    card("card-done", "Publish support handoff notes", "done", "low", 1, ["docs"]),
+  ];
+  const statuses = ["todo", "ready", "running", "review", "blocked", "done"];
+  const board = {
+    id: boardId,
+    name: "Product Operations",
+    description: "Shared product delivery queue",
+    icon: "✓",
+    color: "#2563eb",
+    automationJobId: "job-product-operations-daily",
+    total: cards.length,
+    active: cards.length - 1,
+    archived: 0,
+    byStatus: Object.fromEntries(
+      statuses.map((status) => [status, cards.filter((entry) => entry.status === status).length]),
+    ),
+    updatedAt: baseTime,
+  };
+  const sessionKey = "agent:main:workboard-proof";
+  return {
+    board,
+    cards,
+    sessionKey,
+    methodResponses: {
+      "board.get": {
+        sessionKey,
+        revision: 1,
+        tabs: [{ tabId: "main", title: "Workboard", position: 0, chatDock: "hidden" }],
+        widgets: [
+          {
+            name: "workboard-product-operations",
+            tabId: "main",
+            title: "Product Operations",
+            contentKind: "plugin",
+            pluginKind: "workboard:board",
+            props: { boardId },
+            heightMode: "fixed",
+            sizeW: 12,
+            sizeH: 16,
+            position: 0,
+            grantState: "none",
+            revision: 1,
+          },
+        ],
+      },
+      "workboard.boards.list": { boards: [board] },
+      "workboard.cards.list": { boards: [board], cards, statuses },
+      "workboard.cards.stats": { ...board, byAgent: {} },
+      "workboard.cards.move": { card: cards[0] },
     },
   };
 }
@@ -1294,7 +1375,16 @@ async function createChatPickerScenario(
           }),
         ]
       : [];
+  const workboardMocks = buildWorkboardMocks(baseTime);
   const sessions = [
+    ...(fixture === "workboard"
+      ? [
+          sessionRow(workboardMocks.sessionKey, "Product operations dashboard", baseTime, {
+            boardFace: "dashboard",
+            pinned: true,
+          }),
+        ]
+      : []),
     sessionRow("agent:main:main", "Molty", baseTime - 1_000, {
       activeRunIds: [PLAN_DEMO_RUN_ID],
       childSessions: ["agent:main:lisbon-trip", ...swarmChildRows.map((row) => row.key)],
@@ -1421,7 +1511,10 @@ async function createChatPickerScenario(
   const skillWorkshop = buildSkillWorkshopMocks(Date.now());
   const cronMocks = buildCronMocks(Date.now());
   const channelWizard = buildChannelWizardMocks();
-  const configMocks = buildConfigMocks({ swarmEnabled: fixture === "swarm" });
+  const configMocks = buildConfigMocks({
+    swarmEnabled: fixture === "swarm",
+    workboardEnabled: fixture === "workboard",
+  });
   const custodianHistory = {
     turns: [
       {
@@ -1502,7 +1595,25 @@ async function createChatPickerScenario(
       "sessions.create",
       "system.info",
       "terminal.open",
+      ...(fixture === "workboard"
+        ? [
+            "board.get",
+            "workboard.boards.list",
+            "workboard.cards.list",
+            "workboard.cards.move",
+            "workboard.cards.stats",
+          ]
+        : []),
     ],
+    ...(fixture === "workboard"
+      ? {
+          controlUiWidgetKinds: [
+            { pluginId: "workboard", kind: "workboard:board", label: "Workboard board" },
+            { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
+            { pluginId: "workboard", kind: "workboard:mini", label: "Workboard summary" },
+          ],
+        }
+      : {}),
     // Terminal has a second gate beyond the advertised method (see
     // ui/src/lib/terminal-availability.ts).
     terminalEnabled: true,
@@ -2268,6 +2379,7 @@ async function createChatPickerScenario(
           ...buildSessionListCases([...sessions, ...archivedSessions], {}, MOCK_SESSION_CREATORS),
         ],
       },
+      ...(fixture === "workboard" ? workboardMocks.methodResponses : {}),
     },
     models: modelProviders.models,
     repeatingSessionEvents: {
@@ -2339,7 +2451,7 @@ async function createChatPickerScenario(
       hasActiveRun: true,
       key: "agent:main:main",
     },
-    sessionKey: "agent:main:main",
+    sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
   };

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -72,7 +72,8 @@ const DashboardToolSchema = Type.Object(
     pluginKind: Type.Optional(
       Type.String({
         pattern: BOARD_PLUGIN_KIND_PATTERN,
-        description: "Plugin widget kind, for example workboard:card or workboard:mini",
+        description:
+          "Plugin widget kind, for example workboard:card, workboard:mini, or workboard:board",
       }),
     ),
     props: Type.Optional(
@@ -256,7 +257,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
     label: "Dashboard",
     name: "dashboard",
     description:
-      "Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). Widgets use stable names. Create trusted plugin widgets with widget_put; examples: workboard:card props {cardId}, workboard:mini props {boardId, limit}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
+      "Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). Widgets use stable names. Create trusted plugin widgets with widget_put; examples: workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
     parameters: DashboardToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3600,6 +3600,7 @@ export const en: TranslationMap = {
   },
   workboard: {
     widget: {
+      boardLabel: "Workboard board",
       cardLabel: "Workboard card",
       summaryLabel: "Workboard summary",
       loading: "Loading Workboard…",
@@ -3608,6 +3609,7 @@ export const en: TranslationMap = {
       unassigned: "Unassigned",
       openBoard: "Open board",
       statusCounts: "Cards by status",
+      cardCount: "{count} cards",
       noActiveCards: "No ready or running cards.",
     },
     disabledHelpStart: "Workboard is disabled. Enable",

--- a/ui/src/lib/board/widgets/index.test.ts
+++ b/ui/src/lib/board/widgets/index.test.ts
@@ -8,7 +8,15 @@ import {
 
 describe("plugin board widget registry", () => {
   it("resolves only advertised first-party kinds", () => {
-    const active = [{ pluginId: "workboard", kind: "workboard:card", label: "Workboard card" }];
+    const active = [
+      { pluginId: "workboard", kind: "workboard:board", label: "Workboard board" },
+      { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
+    ];
+    expect(getPluginWidgetKindContribution("workboard:board", active)).toMatchObject({
+      kind: "workboard:board",
+      label: "Workboard board",
+      loader: expect.any(Function),
+    });
     expect(getPluginWidgetKindContribution("workboard:card", active)).toMatchObject({
       kind: "workboard:card",
       label: "Workboard card",

--- a/ui/src/lib/board/widgets/index.ts
+++ b/ui/src/lib/board/widgets/index.ts
@@ -23,6 +23,11 @@ type PluginWidgetKindContribution = {
  * props, and use the standard gateway client for RPCs owned by their plugin.
  */
 const PLUGIN_WIDGET_KIND_CONTRIBUTIONS: Record<string, PluginWidgetKindContribution> = {
+  "workboard:board": {
+    kind: "workboard:board",
+    label: t("workboard.widget.boardLabel"),
+    loader: async () => (await import("./workboard-board.ts")).renderWorkboardBoardWidget,
+  },
   "workboard:card": {
     kind: "workboard:card",
     label: t("workboard.widget.cardLabel"),

--- a/ui/src/lib/board/widgets/workboard-board.ts
+++ b/ui/src/lib/board/widgets/workboard-board.ts
@@ -1,0 +1,104 @@
+import { html, type TemplateResult } from "lit";
+import { pathForRoute } from "../../../app-route-paths.ts";
+import { t } from "../../../i18n/index.ts";
+import "../../../styles/workboard.css";
+import { renderColumn } from "../../../pages/workboard/view-card.ts";
+import type { WorkboardProps } from "../../../pages/workboard/view-helpers.ts";
+import { matchesBoardFilter, WORKBOARD_ALL_BOARDS_FILTER } from "../../workboard/board-filter.ts";
+import type { WorkboardCard, WorkboardStatus } from "../../workboard/types.ts";
+import type { BoardWidget } from "../types.ts";
+import type { PluginBoardWidgetRenderer } from "./index.ts";
+import { WorkboardWidgetElement } from "./workboard-widget.ts";
+
+class OpenClawWorkboardBoardWidget extends WorkboardWidgetElement {
+  override render(): TemplateResult {
+    if (this.loading && !this.loaded) {
+      return html`<p class="workboard-widget__state">${t("workboard.widget.loading")}</p>`;
+    }
+    if (this.error) {
+      return html`<div class="workboard-widget__state" role="alert">
+        <span>${this.error}</span>
+        <button class="btn btn--sm" type="button" @click=${() => this.retryLoad()}>
+          ${t("common.retry")}
+        </button>
+      </div>`;
+    }
+
+    // No boardId prop means every board, matching the summary widget. Defaulting
+    // here would silently hide cards owned by explicitly named boards.
+    const boardId = this.readStringProp("boardId");
+    const filter = boardId ?? WORKBOARD_ALL_BOARDS_FILTER;
+    const cards = this.cards.filter((card) => matchesBoardFilter(card, filter));
+    const byStatus = new Map<WorkboardStatus, WorkboardCard[]>();
+    for (const status of this.statuses) {
+      byStatus.set(status, []);
+    }
+    for (const card of cards) {
+      byStatus.get(card.status)?.push(card);
+    }
+
+    const client = this.workboardClient;
+    const props: WorkboardProps = {
+      host: this.workboardStateHost,
+      client,
+      connected: client !== null,
+      canWrite: this.canMutate,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      onOpenSession: () => undefined,
+      onRequestUpdate: () => this.syncFromHost(),
+    };
+    const workboardBase = pathForRoute("workboard", this.context?.basePath ?? "");
+    const workboardPath = boardId
+      ? `${workboardBase}?board=${encodeURIComponent(boardId)}`
+      : workboardBase;
+
+    return html`
+      <section class="workboard-widget-board" data-test-id="workboard-board-widget">
+        <header class="workboard-widget-board__header">
+          <strong>${boardId ?? t("workboard.allBoards")}</strong>
+          <span>${t("workboard.widget.cardCount", { count: String(cards.length) })}</span>
+          <a href=${workboardPath}>${t("workboard.widget.openBoard")}</a>
+        </header>
+        <div class="workboard-board workboard-board--compact workboard-widget-board__columns">
+          ${this.statuses.map((status) =>
+            renderColumn(props, status, byStatus.get(status) ?? [], { surface: "widget" }),
+          )}
+        </div>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-workboard-board-widget")) {
+  customElements.define("openclaw-workboard-board-widget", OpenClawWorkboardBoardWidget);
+}
+
+export const renderWorkboardBoardWidget: PluginBoardWidgetRenderer = ({
+  widget,
+  sessionKey,
+  active,
+  canMutate,
+  requestUpdate,
+}: {
+  widget: BoardWidget;
+  sessionKey: string;
+  active: boolean;
+  canMutate: boolean;
+  requestUpdate: () => void;
+}) => html`
+  <openclaw-workboard-board-widget
+    .widget=${widget}
+    .sessionKey=${sessionKey}
+    .active=${active}
+    .canMutate=${canMutate}
+    .hostRequestUpdate=${requestUpdate}
+  ></openclaw-workboard-board-widget>
+`;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-workboard-board-widget": OpenClawWorkboardBoardWidget;
+  }
+}

--- a/ui/src/lib/board/widgets/workboard-mini.ts
+++ b/ui/src/lib/board/widgets/workboard-mini.ts
@@ -1,14 +1,11 @@
 import { html, type TemplateResult } from "lit";
 import { pathForRoute } from "../../../app-route-paths.ts";
 import { t } from "../../../i18n/index.ts";
-import { WORKBOARD_STATUSES, type WorkboardCard } from "../../workboard/types.ts";
+import { workboardCardBoardId } from "../../workboard/board-filter.ts";
+import { WORKBOARD_STATUSES } from "../../workboard/types.ts";
 import type { BoardWidget } from "../types.ts";
 import type { PluginBoardWidgetRenderer } from "./index.ts";
 import { WorkboardWidgetElement } from "./workboard-widget.ts";
-
-function cardBoardId(card: WorkboardCard): string {
-  return card.metadata?.automation?.boardId ?? "default";
-}
 
 class OpenClawWorkboardMiniWidget extends WorkboardWidgetElement {
   override render(): TemplateResult {
@@ -27,7 +24,9 @@ class OpenClawWorkboardMiniWidget extends WorkboardWidgetElement {
     // cards created with an explicit board id and renders an all-zero widget.
     const boardId = this.readStringProp("boardId");
     const limit = Math.min(10, this.readPositiveIntegerProp("limit", 5));
-    const cards = boardId ? this.cards.filter((card) => cardBoardId(card) === boardId) : this.cards;
+    const cards = boardId
+      ? this.cards.filter((card) => workboardCardBoardId(card) === boardId)
+      : this.cards;
     const topCards = cards
       .filter((card) => card.status === "ready" || card.status === "running")
       .toSorted(

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -175,6 +175,12 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     this.allCards = snapshot.cards;
     this.cards = snapshot.cards.filter(isActiveWorkboardCard);
     this.statuses = snapshot.statuses;
+    const state = getWorkboardState(this.workboardHost);
+    state.cards = [...snapshot.cards];
+    state.statuses = snapshot.statuses;
+    state.loaded = true;
+    state.loadAttempted = true;
+    state.mutationReadiness = "ready";
     this.loaded = true;
     this.error = "";
     this.requestRender();
@@ -253,6 +259,14 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   protected get loading(): boolean {
     return this.refreshTask.status === TaskStatus.PENDING;
+  }
+
+  protected get workboardClient(): GatewayBrowserClient | null {
+    return this.client;
+  }
+
+  protected get workboardStateHost(): WorkboardHost {
+    return this.workboardHost;
   }
 
   protected async moveCard(card: WorkboardCard, status: WorkboardStatus): Promise<void> {
@@ -336,7 +350,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     await this.refreshTask.run([client, sharedRuntime, force, refreshAfterInflight]);
   }
 
-  private syncFromHost(): void {
+  protected syncFromHost(): void {
     const state = getWorkboardState(this.workboardHost);
     this.allCards = [...state.cards];
     this.cards = this.allCards.filter(isActiveWorkboardCard);

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApplicationContext } from "../../../app/context.ts";
 import { createApplicationContextProvider } from "../../../test-helpers/application-context.ts";
 import type { BoardWidget } from "../types.ts";
+import "./workboard-board.ts";
 import "./workboard-card.ts";
 import "./workboard-mini.ts";
 
@@ -356,6 +357,67 @@ describe("Workboard plugin widgets", () => {
       select.value = "running";
       select.dispatchEvent(new Event("change"));
     }
+    expect(request).not.toHaveBeenCalledWith("workboard.cards.move", expect.anything());
+  });
+
+  it.each([
+    {
+      name: "scopes to boardId",
+      props: { boardId: "ops" },
+      expectedTitles: ["Ready card", "Running card", "Done card"],
+      omittedTitle: "Product card",
+    },
+    {
+      name: "shows all boards by default",
+      props: {},
+      expectedTitles: ["Ready card", "Running card", "Done card", "Product card"],
+      omittedTitle: null,
+    },
+  ])("renders real board columns and $name", async ({ props, expectedTitles, omittedTitle }) => {
+    const productCard = {
+      ...cards[0],
+      id: "card-product",
+      title: "Product card",
+      metadata: { automation: { boardId: "product" } },
+    };
+    const request = vi.fn(async () => ({
+      cards: [...cards, productCard],
+      statuses: ["ready", "running", "done"],
+    }));
+    const element = document.createElement("openclaw-workboard-board-widget");
+    element.widget = pluginWidget("workboard:board", props);
+    element.sessionKey = "agent:main:test";
+
+    await mount(element, createContext(request), request);
+
+    expect(element.querySelectorAll(".workboard-column")).toHaveLength(3);
+    for (const title of expectedTitles) {
+      expect(element.textContent).toContain(title);
+    }
+    if (omittedTitle) {
+      expect(element.textContent).not.toContain(omittedTitle);
+    }
+  });
+
+  it("keeps every board status control read-only without mutation access", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards, statuses: ["ready", "running", "done"] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const element = document.createElement("openclaw-workboard-board-widget");
+    element.widget = pluginWidget("workboard:board", { boardId: "ops" });
+    element.sessionKey = "agent:main:test";
+    element.canMutate = false;
+
+    await mount(element, createContext(request), request);
+
+    const selects = [...element.querySelectorAll("select")];
+    expect(selects).toHaveLength(cards.length);
+    expect(selects.every((select) => select.disabled)).toBe(true);
+    selects[0]!.value = "running";
+    selects[0]!.dispatchEvent(new Event("change"));
     expect(request).not.toHaveBeenCalledWith("workboard.cards.move", expect.anything());
   });
 

--- a/ui/src/lib/workboard/board-filter.ts
+++ b/ui/src/lib/workboard/board-filter.ts
@@ -1,0 +1,14 @@
+import type { WorkboardCard, WorkboardUiState } from "./types.ts";
+
+export const WORKBOARD_ALL_BOARDS_FILTER = "__all__";
+
+export function workboardCardBoardId(card: WorkboardCard): string {
+  return card.metadata?.automation?.boardId?.trim() || "default";
+}
+
+export function matchesBoardFilter(
+  card: WorkboardCard,
+  filter: WorkboardUiState["boardFilter"],
+): boolean {
+  return filter === WORKBOARD_ALL_BOARDS_FILTER || workboardCardBoardId(card) === filter;
+}

--- a/ui/src/pages/workboard/board-filter.ts
+++ b/ui/src/pages/workboard/board-filter.ts
@@ -1,24 +1,14 @@
 import { t } from "../../i18n/index.ts";
+import {
+  matchesBoardFilter,
+  workboardCardBoardId,
+  WORKBOARD_ALL_BOARDS_FILTER,
+} from "../../lib/workboard/board-filter.ts";
 import { workboardBoardLabel } from "../../lib/workboard/board-presentation.ts";
-import type {
-  WorkboardBoardSummary,
-  WorkboardCard,
-  WorkboardUiState,
-} from "../../lib/workboard/index.ts";
+import type { WorkboardBoardSummary, WorkboardCard } from "../../lib/workboard/index.ts";
 import type { WorkboardSelectOption } from "./workboard-select.ts";
 
-export const WORKBOARD_ALL_BOARDS_FILTER = "__all__";
-
-function cardBoardId(card: WorkboardCard): string {
-  return card.metadata?.automation?.boardId?.trim() || "default";
-}
-
-export function matchesBoardFilter(
-  card: WorkboardCard,
-  filter: WorkboardUiState["boardFilter"],
-): boolean {
-  return filter === WORKBOARD_ALL_BOARDS_FILTER || cardBoardId(card) === filter;
-}
+export { matchesBoardFilter, WORKBOARD_ALL_BOARDS_FILTER };
 
 function boardDescription(board: WorkboardBoardSummary): string {
   const params = { active: String(board.active), total: String(board.total) };
@@ -46,7 +36,7 @@ export function buildBoardFilterOptions(
     }
   }
   for (const card of cards) {
-    const id = cardBoardId(card);
+    const id = workboardCardBoardId(card);
     const board: WorkboardBoardSummary = uniqueBoards.get(id) ?? {
       id,
       total: 0,

--- a/ui/src/pages/workboard/view-card-actions.ts
+++ b/ui/src/pages/workboard/view-card-actions.ts
@@ -36,6 +36,7 @@ function moveCardToStatus(props: WorkboardProps, card: WorkboardCard, status: Wo
     status === card.status ||
     state.busyCardIds.has(card.id) ||
     state.dispatching ||
+    !canMutate(props) ||
     !props.connected ||
     !props.client
   ) {

--- a/ui/src/pages/workboard/view-card.ts
+++ b/ui/src/pages/workboard/view-card.ts
@@ -214,7 +214,9 @@ function renderLifecycle(
   `;
 }
 
-function renderCard(props: WorkboardProps, card: WorkboardCard) {
+type WorkboardCardSurface = "page" | "widget";
+
+function renderCard(props: WorkboardProps, card: WorkboardCard, surface: WorkboardCardSurface) {
   const {
     state,
     task,
@@ -226,44 +228,55 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     showStartControls,
     archived,
   } = getCardActionState(props, card);
+  const widget = surface === "widget";
   const healthHighlighted = state.activeHealthHighlight
     ? workboardCardMatchesHealthKey(card, state.activeHealthHighlight, props.sessions, task)
     : false;
   const dependencies = getWorkboardDependencyState(card, state.cards);
-  const topStartAction = showStartControls
-    ? renderStartExecutionButton(props, card, null, "autonomous", { iconOnly: true })
-    : nothing;
+  const topStartAction =
+    !widget && showStartControls
+      ? renderStartExecutionButton(props, card, null, "autonomous", { iconOnly: true })
+      : nothing;
   const topEditAction =
-    writable && !archived ? renderEditCardAction(props, card, { iconOnly: true }) : nothing;
-  const topArchiveAction = writable
-    ? renderArchiveCardAction(props, card, busy, archived, { iconOnly: true })
-    : nothing;
-  const detailAction = html`
-    <openclaw-tooltip .content=${t("workboard.viewDetails")}>
-      <button
-        class="btn btn--icon workboard-card__icon"
-        aria-label=${t("workboard.viewDetails")}
-        aria-haspopup="dialog"
-        aria-expanded=${state.detailCardId === card.id ? "true" : "false"}
-        aria-controls=${workboardCardDetailDrawerId}
-        @click=${() => {
-          openCardDetails(state, card);
-          props.onRequestUpdate?.();
-        }}
-      >
-        ${icons.panelRightOpen}
-      </button>
-    </openclaw-tooltip>
-  `;
-  const sessionAction = renderOpenSessionCardAction(props, linkedSessionKey, { iconOnly: true });
+    !widget && writable && !archived
+      ? renderEditCardAction(props, card, { iconOnly: true })
+      : nothing;
+  const topArchiveAction =
+    !widget && writable
+      ? renderArchiveCardAction(props, card, busy, archived, { iconOnly: true })
+      : nothing;
+  const detailAction = widget
+    ? nothing
+    : html`
+        <openclaw-tooltip .content=${t("workboard.viewDetails")}>
+          <button
+            class="btn btn--icon workboard-card__icon"
+            aria-label=${t("workboard.viewDetails")}
+            aria-haspopup="dialog"
+            aria-expanded=${state.detailCardId === card.id ? "true" : "false"}
+            aria-controls=${workboardCardDetailDrawerId}
+            @click=${() => {
+              openCardDetails(state, card);
+              props.onRequestUpdate?.();
+            }}
+          >
+            ${icons.panelRightOpen}
+          </button>
+        </openclaw-tooltip>
+      `;
+  const sessionAction = widget
+    ? nothing
+    : renderOpenSessionCardAction(props, linkedSessionKey, { iconOnly: true });
   const stopAction =
-    writable && (linkedSessionKey ? live : activeTask)
+    !widget && writable && (linkedSessionKey ? live : activeTask)
       ? renderStopCardAction(props, card, busy, { iconOnly: true })
       : nothing;
-  const moveAction = writable && !archived ? renderCardMoveControl(props, card, busy) : nothing;
-  const deleteAction = writable
-    ? renderDeleteCardAction(props, card, busy, { iconOnly: true })
-    : nothing;
+  const moveAction =
+    !archived && (writable || widget)
+      ? renderCardMoveControl(props, card, busy || !writable, { wide: widget })
+      : nothing;
+  const deleteAction =
+    !widget && writable ? renderDeleteCardAction(props, card, busy, { iconOnly: true }) : nothing;
   return html`
     <article
       class="workboard-card priority-${card.priority} ${busy
@@ -271,22 +284,22 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
         : ""} ${archived ? "workboard-card--archived" : ""}
       ${state.draggedCardId === card.id ? "workboard-card--dragging" : ""} ${healthHighlighted
         ? `workboard-card--health-highlight workboard-card--health-highlight-${state.activeHealthHighlight}`
-        : ""} workboard-card--openable"
-      role="button"
-      tabindex="0"
-      title=${t("workboard.viewDetails")}
-      aria-haspopup="dialog"
-      aria-expanded=${state.detailCardId === card.id ? "true" : "false"}
-      aria-controls=${workboardCardDetailDrawerId}
+        : ""} ${widget ? "workboard-card--widget" : "workboard-card--openable"}"
+      role=${widget ? nothing : "button"}
+      tabindex=${widget ? nothing : "0"}
+      title=${widget ? nothing : t("workboard.viewDetails")}
+      aria-haspopup=${widget ? nothing : "dialog"}
+      aria-expanded=${widget ? nothing : state.detailCardId === card.id ? "true" : "false"}
+      aria-controls=${widget ? nothing : workboardCardDetailDrawerId}
       draggable=${writable && !archived && !state.dispatching ? "true" : "false"}
       @click=${(event: MouseEvent) => {
-        if (!isCardActionTarget(event)) {
+        if (!widget && !isCardActionTarget(event)) {
           openCardDetails(state, card);
           props.onRequestUpdate?.();
         }
       }}
       @keydown=${(event: KeyboardEvent) => {
-        if (isCardActionTarget(event) || (event.key !== "Enter" && event.key !== " ")) {
+        if (widget || isCardActionTarget(event) || (event.key !== "Enter" && event.key !== " ")) {
           return;
         }
         openCardDetails(state, card);
@@ -345,14 +358,18 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
         <span>${linkedSessionKey ?? t("workboard.noLinkedSession")}</span>
       </div>
       ${renderEvents(card)}
-      <div class="workboard-card__actions">
-        ${renderCardActionSlot(detailAction)}
-        <div class="workboard-card__actions-primary">
-          ${renderCardActionSlot(sessionAction)} ${renderCardActionSlot(stopAction)}
-          ${renderCardActionSlot(moveAction)}
-        </div>
-        ${renderCardActionSlot(deleteAction)}
-      </div>
+      ${widget
+        ? html`<div class="workboard-card__actions workboard-card__actions--widget">
+            ${moveAction}
+          </div>`
+        : html`<div class="workboard-card__actions">
+            ${renderCardActionSlot(detailAction)}
+            <div class="workboard-card__actions-primary">
+              ${renderCardActionSlot(sessionAction)} ${renderCardActionSlot(stopAction)}
+              ${renderCardActionSlot(moveAction)}
+            </div>
+            ${renderCardActionSlot(deleteAction)}
+          </div>`}
     </article>
   `;
 }
@@ -361,6 +378,7 @@ export function renderColumn(
   props: WorkboardProps,
   status: WorkboardStatus,
   cards: WorkboardCard[],
+  options: { surface?: WorkboardCardSurface } = {},
 ) {
   const state = getWorkboardState(props.host);
   const writable = canMutate(props);
@@ -400,7 +418,7 @@ export function renderColumn(
       </div>
       <div class="workboard-column__cards">
         ${cards.length
-          ? cards.map((card) => renderCard(props, card))
+          ? cards.map((card) => renderCard(props, card, options.surface ?? "page"))
           : html`<div class="workboard-empty">${t("workboard.emptyColumn")}</div>`}
       </div>
     </section>

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -334,9 +334,12 @@ openclaw-board-widget-cell {
 }
 
 openclaw-workboard-card-widget,
-openclaw-workboard-mini-widget {
+openclaw-workboard-mini-widget,
+openclaw-workboard-board-widget {
   display: block;
+  max-width: 100%;
   min-height: 100%;
+  min-width: 0;
 }
 
 .workboard-widget-card,
@@ -457,6 +460,75 @@ openclaw-workboard-mini-widget {
 
 .workboard-widget-mini__card {
   justify-content: flex-start;
+}
+
+.workboard-widget-board {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 10px;
+}
+
+.workboard-widget-board__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.workboard-widget-board__header strong {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workboard-widget-board__header span {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.workboard-widget-board__header a {
+  color: var(--accent);
+  font-size: 10px;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.workboard-widget-board .workboard-board {
+  flex: 1;
+  grid-auto-columns: minmax(240px, 1fr);
+  grid-auto-flow: column;
+  grid-template-columns: none;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.workboard-widget-board .workboard-column,
+.workboard-widget-board .workboard-board--compact .workboard-column {
+  max-width: none;
+  min-height: 0;
+  min-width: 240px;
+  overflow: hidden;
+  width: auto;
+}
+
+.workboard-widget-board .workboard-column__cards {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.workboard-card__actions--widget {
+  justify-content: stretch;
 }
 
 .board-widget__mcp-app {


### PR DESCRIPTION
Related: #125023
Related: #125076

## What Problem This Solves

Dashboards could only show a single card or a mini summary. Operators wanting a full board as a session's main view—for example, “pin my tasks board to this thread”—had no widget for that workflow.

## Why This Change Was Made

This adds a third trusted plugin widget kind, `workboard:board`, with props `{ boardId }`; omitting `boardId` shows all boards. It renders through the Workboard page's own `renderColumn` with an explicit surface option so the page and widget cannot drift, gates mutations with `canMutate`, refreshes on live `plugin.workboard.changed` events, and updates the dashboard tool description. The change also includes reusable mocked-dev-server Workboard fixtures and a capture script used for the evidence below.

## User Impact

Operators can make a complete Workboard board—or all boards—the primary Dashboard view for a session while retaining live updates and the same board presentation and mutation controls as the Workboard page.

## Evidence

Focused proof after replaying the two widget-owned commits onto current `main`:

```text
$ pnpm test ui/src/lib/board ui/src/pages/workboard ui/src/lib/workboard extensions/workboard

Test Files  639 passed | 10 skipped (649)
Tests       9176 passed | 50 skipped (9226)

Test Files  1 passed (1)
Tests       97 passed (97)

Test Files  14 passed (14)
Tests       269 passed (269)

[test] passed 3 Vitest shards in 135.42s
```

The full board rendered on a session's Dashboard face:

![Full Workboard board on the session Dashboard](https://github.com/user-attachments/assets/283b6963-c233-4ce7-a304-1642c47e41a8)

The widget is visible live on the Dashboard face in this isolated dev-gateway recording:

https://github.com/user-attachments/assets/14fb3c89-5bc9-4aa7-8665-32bc7bc3ccad

AI-assisted; the maintainer reviewed the implementation and evidence.
