### PR TITLE
fix(ui): prevent session status icons from clipping

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -305,6 +305,13 @@ export function renderRecentSession(params: {
                   title=${t("sessionsView.archived")}
                   >${icons.archive}</span
                 >`
+              : nothing}${session.forkSource
+              ? html`<span
+                  class="sidebar-session-fork-indicator"
+                  role="img"
+                  aria-label=${t("sessionsView.forkedSession")}
+                  >${icons.gitFork}</span
+                >`
               : nothing}${label}</span
           >
           <span class="sidebar-recent-session__details">

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -59,7 +59,7 @@ function renderPullRequestIndicator(
     role="img"
     aria-label=${label}
     title=${showTitle ? label : nothing}
-    >${icons.gitBranch}</span
+    >${pullRequestState === "open" ? icons.gitPullRequest : icons.gitMerge}</span
   >`;
 }
 
@@ -70,22 +70,14 @@ function renderSessionTrailingState(
   const sessionState = renderSessionState(session, false);
   const concurrentUnreadState = session.hasActiveRun ? renderSessionUnreadState(session) : nothing;
   if (
-    !session.forkSource &&
     pullRequestState === "none" &&
     sessionState === nothing &&
     concurrentUnreadState === nothing
   ) {
     return nothing;
   }
-  const forkLabel = t("sessionsView.forkedSession");
-  return html`
-    ${session.forkSource
-      ? html`<span class="session-row-fork-indicator" role="img" aria-label=${forkLabel}
-          >${icons.gitFork}</span
-        >`
-      : nothing}
-    ${renderPullRequestIndicator(pullRequestState, false)} ${sessionState} ${concurrentUnreadState}
-  `;
+  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}
+  ${concurrentUnreadState}`;
 }
 
 function renderPersistentSessionIcon(icon: string) {

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -242,10 +242,20 @@ suite.define(() => {
             kind: "direct",
             label: "Terminal tab bar redesign proposal",
             updatedAt: 2,
-            lastMessagePreview: "Implemented and committed as 094ab2",
+            activeRunIds: ["run-busy-session"],
+            hasActiveRun: true,
+            observerDigest: {
+              agentId: "main",
+              runId: "run-busy-session",
+              headline:
+                "The isolated clone is ready, but direct Git fetch and every remaining operation continue in the background",
+              health: "on-track",
+              updatedAt: 2,
+              revision: 1,
+            },
             incognito: true,
             hasAutomation: true,
-            status: "done",
+            status: "running",
             unread: true,
           },
           {
@@ -287,9 +297,20 @@ suite.define(() => {
           };
         };
         return {
+          atoms: Array.from(
+            row.querySelectorAll(
+              ".sidebar-recent-session__details-endcap :is(svg, .session-run-spinner, .session-unread-dot)",
+            ),
+            (element) => {
+              const box = element.getBoundingClientRect();
+              return { bottom: box.bottom, left: box.left, right: box.right, top: box.top };
+            },
+          ),
           badges: rect(".session-row-badges"),
           busyHeight: row.getBoundingClientRect().height,
+          endcap: rect(".sidebar-recent-session__details-endcap"),
           name: rect(".sidebar-recent-session__name"),
+          spinner: rect(".session-run-spinner"),
           state: rect(".session-row-state"),
           subtitle: rect(".sidebar-recent-session__subtitle"),
         };
@@ -307,6 +328,17 @@ suite.define(() => {
         (layout.subtitle.top + layout.subtitle.bottom) / 2,
         1,
       );
+      expect(layout.state.left).toBeGreaterThanOrEqual(layout.endcap.left);
+      expect(layout.state.right).toBeLessThanOrEqual(layout.endcap.right);
+      expect(layout.spinner.left).toBeGreaterThanOrEqual(layout.endcap.left);
+      expect(layout.spinner.right).toBeLessThanOrEqual(layout.endcap.right);
+      expect(layout.atoms.length).toBeGreaterThanOrEqual(4);
+      for (const atom of layout.atoms) {
+        expect(atom.left).toBeGreaterThanOrEqual(layout.endcap.left);
+        expect(atom.right).toBeLessThanOrEqual(layout.endcap.right);
+        expect(atom.top).toBeGreaterThanOrEqual(layout.endcap.top);
+        expect(atom.bottom).toBeLessThanOrEqual(layout.endcap.bottom);
+      }
 
       await busyRow.hover();
       await expect

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -118,7 +118,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps a long non-running state clear of always-visible touch actions", async () => {
+  it("keeps fork provenance in the title above always-visible touch actions", async () => {
     const context = await suite.browser.newContext({
       hasTouch: true,
       locale: "en-US",
@@ -149,25 +149,25 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       const row = page.locator('[data-session-key="agent:main:touch-forked"]');
       await row.waitFor({ state: "visible", timeout: 10_000 });
-      const state = row.locator(".session-row-state");
+      const fork = row.locator(".sidebar-recent-session__name .sidebar-session-fork-indicator");
       const pin = row.getByRole("button", { name: "Pin session" });
       const menu = row.getByRole("button", { name: "Open session menu" });
-      await expect.poll(() => state.locator(".session-row-fork-indicator").isVisible()).toBe(true);
-      await expect.poll(() => state.locator(".session-run-spinner").count()).toBe(0);
+      await expect.poll(() => fork.isVisible()).toBe(true);
+      await expect.poll(() => row.locator(".session-row-state").count()).toBe(0);
 
-      const [nameBounds, stateBounds, pinBounds, menuBounds] = await Promise.all([
+      const [nameBounds, forkBounds, pinBounds, menuBounds] = await Promise.all([
         row.locator(".sidebar-recent-session__name").boundingBox(),
-        state.boundingBox(),
+        fork.boundingBox(),
         pin.boundingBox(),
         menu.boundingBox(),
       ]);
-      if (!nameBounds || !stateBounds || !pinBounds || !menuBounds) {
-        throw new Error("Expected visible non-running touch state geometry");
+      if (!nameBounds || !forkBounds || !pinBounds || !menuBounds) {
+        throw new Error("Expected visible fork and touch action geometry");
       }
-      expect(nameBounds.y + nameBounds.height / 2).toBeLessThan(
-        stateBounds.y + stateBounds.height / 2,
-      );
-      expect(stateBounds.x + stateBounds.width).toBeLessThanOrEqual(pinBounds.x);
+      expect(
+        Math.abs(forkBounds.y + forkBounds.height / 2 - (nameBounds.y + nameBounds.height / 2)),
+      ).toBeLessThanOrEqual(2);
+      expect(nameBounds.y + nameBounds.height / 2).toBeLessThan(pinBounds.y + pinBounds.height / 2);
       expect(pinBounds.x + pinBounds.width).toBeLessThanOrEqual(menuBounds.x);
     } finally {
       await context.close();
@@ -295,12 +295,32 @@ suite.define(() => {
       const row = page.locator('[data-session-key="agent:main:combined-state"]');
       await row.waitFor({ state: "visible", timeout: 10_000 });
       const state = row.locator(".session-row-state");
-      await expect.poll(() => state.locator(".session-row-fork-indicator").isVisible()).toBe(true);
+      await expect
+        .poll(() =>
+          row.locator(".sidebar-recent-session__name .sidebar-session-fork-indicator").isVisible(),
+        )
+        .toBe(true);
+      await expect.poll(() => state.locator('[aria-label="Forked session"]').count()).toBe(0);
       await expect
         .poll(() => state.locator("[data-session-pr-state='open']").isVisible())
         .toBe(true);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-unread-dot").isVisible()).toBe(true);
+      const [endcapBounds, openPullRequestBounds, spinnerBounds, unreadBounds] = await Promise.all([
+        row.locator(".sidebar-recent-session__details-endcap").boundingBox(),
+        state.locator("[data-session-pr-state='open'] svg").boundingBox(),
+        state.locator(".session-run-spinner").boundingBox(),
+        state.locator(".session-unread-dot").boundingBox(),
+      ]);
+      if (!endcapBounds || !openPullRequestBounds || !spinnerBounds || !unreadBounds) {
+        throw new Error("Expected visible combined session state geometry");
+      }
+      for (const iconBounds of [openPullRequestBounds, spinnerBounds, unreadBounds]) {
+        expect(iconBounds.x).toBeGreaterThanOrEqual(endcapBounds.x);
+        expect(iconBounds.x + iconBounds.width).toBeLessThanOrEqual(
+          endcapBounds.x + endcapBounds.width,
+        );
+      }
       const link = row.locator(".sidebar-recent-session__link");
       const details = row.locator(".sidebar-recent-session__details");
       const pin = row.getByRole("button", { name: "Pin session" });

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5680,12 +5680,14 @@ td.data-table-key-col {
   pointer-events: none;
 }
 
-.session-row-fork-indicator {
+.sidebar-session-fork-indicator {
   display: inline-flex;
+  margin-right: 4px;
   color: var(--muted);
+  vertical-align: -2px;
 }
 
-.session-row-fork-indicator svg {
+.sidebar-session-fork-indicator svg {
   width: 14px;
   height: 14px;
   fill: none;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4184,7 +4184,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 }
 
 .sidebar-recent-session__subtitle {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -272,13 +272,13 @@ describe("AppSidebar session indicators", () => {
 
     const forked = sidebar.querySelector(`[data-session-key="${keys.forked}"]`);
     expectEmptyLead(forked);
-    expect(
-      forked?.querySelector(".session-row-aside > .session-row-state .session-row-fork-indicator"),
-    ).not.toBeNull();
-    expect(forked?.querySelector(".session-row-fork-indicator")?.getAttribute("aria-label")).toBe(
-      "Forked session",
+    const forkIndicator = forked?.querySelector(
+      ".sidebar-recent-session__name .sidebar-session-fork-indicator",
     );
-    expect(forked?.querySelector(".session-row-fork-indicator")?.hasAttribute("title")).toBe(false);
+    expect(forkIndicator).not.toBeNull();
+    expect(forkIndicator?.getAttribute("aria-label")).toBe("Forked session");
+    expect(forkIndicator?.hasAttribute("title")).toBe(false);
+    expect(forked?.querySelector(".session-row-state")).toBeNull();
 
     const unread = sidebar.querySelector(`[data-session-key="${keys.unread}"]`);
     expectEmptyLead(unread);
@@ -296,7 +296,7 @@ describe("AppSidebar session indicators", () => {
       runningUnread?.querySelector(".session-row-aside > .session-row-state .session-unread-dot"),
     ).not.toBeNull();
 
-    for (const key of [keys.forked, keys.unread, keys.runningUnread]) {
+    for (const key of [keys.unread, keys.runningUnread]) {
       const link = sidebar.querySelector(`[data-session-key="${key}"] a`);
       const descriptionId = link?.getAttribute("aria-describedby");
       expect(descriptionId).toBe(`sidebar-session-state-${encodeURIComponent(key)}`);
@@ -309,6 +309,16 @@ describe("AppSidebar session indicators", () => {
     expect(runningUnread?.querySelector(".session-row-state")?.getAttribute("aria-label")).toBe(
       "Active run · Unread",
     );
+
+    const openPullRequestIcon = sidebar.querySelector(
+      `[data-session-key="${keys.openPullRequest}"] [data-session-pr-state="open"] svg`,
+    );
+    const mergedPullRequestIcon = sidebar.querySelector(
+      `[data-session-key="${keys.mergedPullRequest}"] [data-session-pr-state="merged"] svg`,
+    );
+    expect(openPullRequestIcon).not.toBeNull();
+    expect(mergedPullRequestIcon).not.toBeNull();
+    expect(openPullRequestIcon?.isEqualNode(mergedPullRequestIcon ?? null)).toBe(false);
 
     for (const key of [keys.openPullRequest, keys.mergedPullRequest]) {
       const row = sidebar.querySelector(`[data-session-key="${key}"]`);


### PR DESCRIPTION
Related: #124960

## What Problem This Solves

Fixes an issue where long session subtitles could compress the second-row status endcap below the width of its contents, clipping run, pull-request, unread, or metadata icons rendered there. Fork provenance also competed with transient state in that endcap, and open and merged pull requests shared the same branch glyph.

## Why This Change Was Made

The truncating subtitle now consumes only the space left after the shared endcap, so every rendered endcap atom remains inside its clipping boundary. Fork provenance moves to the title line, while open and merged pull requests use distinct pull-request and merge glyphs.

## User Impact

Session status icons remain fully visible beside long subtitles. Forked sessions identify that provenance with their title, and pull-request state is visually distinguishable without relying on color alone.

## Evidence

The same mocked-Gateway Chromium fixture was run before and after the CSS repair at 1280×900.

**Before:** the 24px status state extended to x=273.8125 while its clipped endcap ended at x=231; only the first lock icon remained visible.

![Before: trailing status icons clipped after the lock](https://github.com/user-attachments/assets/7f744caa-7c33-49e3-99a1-2eadfa2e7f53)

**After:** the long subtitle truncates first and all lock, automation, run, and unread atoms remain visible inside the endcap.

![After: every trailing status icon remains visible](https://github.com/user-attachments/assets/fc3c88ba-e2fe-4e2f-aba3-3299c7b88d5c)

- Pre-fix focused browser control: failed at the geometric containment assertion (`273.8125 <= 231`).
- Fixed focused Control UI E2E: 1/1 passed (`3` unrelated cases skipped by the exact test filter).
- Related hover/touch Control UI E2E: 4/4 passed.
- `ui/src/components/app-sidebar.test.ts`: 263/263 passed.
- Source-blind behavior validation: all 5 contract clauses passed; no behavioral findings.
- Fresh Codex autoreview of exact head `2395356eabdb11eb47fd46e5dfff9040c755382d`: clean, no accepted/actionable findings (0.99 confidence).
- Exact-head hosted CI: 127 passed, 69 intentionally skipped, 0 pending or failed.

AI-assisted; the implementation, runtime behavior, and proof were independently reviewed before landing.
