### PR TITLE
fix(ui): prevent account suffixes from leaking into chat labels

### DIFF
--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -99,4 +99,32 @@ suite.define(() => {
       await context.close();
     }
   });
+
+  it("opens chat pane rename on the stored label, not the account-decorated title", async () => {
+    const cardsKey = "agent:main:telegram:cards:direct:42";
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([gatewayDirectRow(cardsKey, Date.now(), "cards")]),
+      },
+      sessionKey: cardsKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, cardsKey));
+      const title = page.locator(".chat-pane__session-title-button");
+      await expect.poll(() => title.textContent()).toContain("Alice · cards");
+      await title.click();
+      const field = page.locator(".chat-pane__session-title-input");
+      await field.waitFor({ state: "visible" });
+      expect(await field.inputValue()).toBe("");
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -320,7 +320,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     }
   >();
   protected headerRenameInitialLabel: string | null = null;
-  protected headerRenameInitialValue = "";
   protected headerRenameSessionKey = "";
   protected headerCopiedTimer: number | null = null;
   protected composerPrefillAttentionTimer: number | null = null;

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -244,11 +244,12 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       this.publishHeaderError(access.reason);
       return;
     }
-    const customLabel = row.label?.trim() || null;
+    const customLabel = normalizeOptionalString(row.label) ?? null;
     this.headerRenameSessionKey = row.key;
     this.headerRenameInitialLabel = customLabel;
-    this.headerRenameInitialValue = customLabel ?? this.paneTitle;
-    this.headerRenameValue = this.headerRenameInitialValue;
+    // Editable session names come only from persisted user data. Seeding from
+    // paneTitle would let display decoration become the next stored label.
+    this.headerRenameValue = customLabel ?? "";
     this.headerEditing = true;
     void this.updateComplete.then(() => {
       const input = this.querySelector<HTMLInputElement>(".chat-pane__session-title-input");
@@ -269,13 +270,11 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     const key = this.headerRenameSessionKey;
     const trimmed = this.headerRenameValue.trim();
     const label = trimmed || null;
-    const unchangedDerivedTitle =
-      this.headerRenameInitialLabel === null && trimmed === this.headerRenameInitialValue.trim();
     const unchangedLabel = label === this.headerRenameInitialLabel;
     this.headerEditing = false;
     this.headerRenameSessionKey = "";
     const state = this.state;
-    if (!key || !state || unchangedDerivedTitle || unchangedLabel) {
+    if (!key || !state || unchangedLabel) {
       return;
     }
     const access = readSessionMethodAccess(this.context.gateway.snapshot, {


### PR DESCRIPTION
Closes #124307

## What Problem This Solves

Fixes an issue where users renaming an unlabeled session from the chat pane could persist the rendered account suffix as part of the stored label. A later edit could then show a doubled or stale account discriminator.

## Why This Change Was Made

The chat pane now follows the established Sessions page and sidebar contract: inline rename starts from the persisted user label, or an empty value when no label exists. It no longer treats the rendered pane title as editable user data, and the obsolete derived-title unchanged guard is removed.

## User Impact

For account-qualified sessions such as `Alice · cards`, opening inline rename starts empty when the session has no custom label. Account decoration remains display-only and cannot leak into stored session labels through this flow.

## Evidence

Added focused Control UI browser regression coverage for an account-qualified session with `displayName: Alice`, `accountId: cards`, and no stored label. The test confirms the pane title renders as `Alice · cards` while the inline rename field opens empty.

Executable proof was not run locally per task constraint; CI/external review will execute the regression.

Static inspection: `git diff --check` passed. Production LOC: +5/-7 (net -2). Tests: +28/-0.
