### PR TITLE
[AI] fix(file-transfer): surface bare allow-entry footgun with actionable glob hint

### DIFF
--- a/docs/plugins/reference/file-transfer.md
+++ b/docs/plugins/reference/file-transfer.md
@@ -17,3 +17,47 @@ Fetch, list, and write files on paired nodes via dedicated node commands. Bypass
 ## Surface
 
 contracts: `tools`
+
+<!-- openclaw-plugin-reference:manual-start -->
+
+## Configuration
+
+Path policy is configured under `plugins.entries.file-transfer.config.nodes`
+in `openclaw.json`, keyed by node id, node display name, or `"*"`. Without a
+matching entry every file operation is denied; `denyPaths` always wins over
+allow entries.
+
+`allowReadPaths` / `allowWritePaths` entries are matched with minimatch glob
+semantics:
+
+- A **directory entry must end in `/**`** to cover files inside it. A bare
+  directory path (for example `/data`) matches only the literal directory
+  itself: `dir_list` of `/data` succeeds while `file_fetch` of
+  `/data/report.csv` is denied with `POLICY_DENIED`.
+- A **bare file path** (for example `/data/config.json`) is an exact-file
+  grant that covers only that file.
+- `~` expands to the operator home directory.
+
+Example:
+
+```json validate=false
+{
+  "plugins": {
+    "entries": {
+      "file-transfer": {
+        "config": {
+          "nodes": {
+            "*": {
+              "allowReadPaths": ["~/Screenshots/**", "/tmp/**"],
+              "allowWritePaths": ["~/Downloads/**"],
+              "denyPaths": ["**/.ssh/**", "**/.aws/**"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+<!-- openclaw-plugin-reference:manual-end -->

--- a/docs/plugins/reference/file-transfer.md
+++ b/docs/plugins/reference/file-transfer.md
@@ -33,7 +33,14 @@ semantics:
 - A **directory entry must end in `/**`** to cover files inside it. A bare
   directory path (for example `/data`) matches only the literal directory
   itself: `dir_list` of `/data` succeeds while `file_fetch` of
-  `/data/report.csv` is denied with `POLICY_DENIED`.
+  `/data/report.csv` is denied with `POLICY_DENIED`. When the denial is on a
+  descendant of a bare-literal entry, the reason includes a hint: if the
+  entry carries a trailing slash (for example `/data/`), the hint
+  unconditionally recommends the matching `/**` form; without a trailing
+  slash the entry is ambiguous (it could be an exact-file grant like
+  `/etc/hosts`), so the same `/**` fix is offered conditionally — apply it
+  only for directory intent, never to broaden a single-file grant. Append
+  `/**` (or a trailing slash plus `/**`) to allow files inside a directory.
 - A **bare file path** (for example `/data/config.json`) is an exact-file
   grant that covers only that file.
 - `~` expands to the operator home directory.

--- a/docs/plugins/reference/file-transfer.md
+++ b/docs/plugins/reference/file-transfer.md
@@ -39,8 +39,9 @@ semantics:
   unconditionally recommends the matching `/**` form; without a trailing
   slash the entry is ambiguous (it could be an exact-file grant like
   `/etc/hosts`), so the same `/**` fix is offered conditionally — apply it
-  only for directory intent, never to broaden a single-file grant. Append
-  `/**` (or a trailing slash plus `/**`) to allow files inside a directory.
+  only for directory intent, never to broaden a single-file grant. Replace
+  any trailing separator with `/**` (for example `/data/` becomes `/data/**`)
+  to allow files inside a directory.
 - A **bare file path** (for example `/data/config.json`) is an exact-file
   grant that covers only that file.
 - `~` expands to the operator home directory.

--- a/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
@@ -917,4 +917,35 @@ describe("file-transfer node invoke policy", () => {
     expectResultFields(result, { ok: false, code: "ARCHIVE_ENTRIES_MISSING" });
     expect(invokeNode).toHaveBeenCalledTimes(2);
   });
+
+  // Production-path proof (issue #124992 / PR #125103): a bare-literal allow
+  // entry that is an ancestor of the requested path must surface the
+  // conditional /** recovery in the operator-visible file-fetch error. This
+  // exercises the real evaluateFilePolicy via createFileTransferNodeInvokePolicy
+  // (only persistAllowAlways/audit are mocked); the policy deny short-circuits
+  // before invokeNode is reached, so no paired node is required.
+  it("surfaces the conditional /** hint in the file.fetch deny message for a bare-literal ancestor", async () => {
+    const policy = createFileTransferNodeInvokePolicy();
+    const { ctx, invokeNode } = createCtx({
+      command: "file.fetch",
+      params: { path: "/Users/x/Desktop/photo.png", maxBytes: 1024 },
+      pluginConfig: {
+        nodes: {
+          "node-1": {
+            allowReadPaths: ["/Users/x/Desktop"],
+          },
+        },
+      },
+    });
+
+    const result = await policy.handle(ctx);
+
+    expectResultFields(result, { ok: false, code: "POLICY_DENIED" });
+    const message = requireRecord(result, "policy result").message;
+    expect(typeof message).toBe("string");
+    expect(message as string).toContain("/Users/x/Desktop/**");
+    expect(message as string).toContain("exact-file grant");
+    // The policy deny short-circuits before the paired node is contacted.
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -609,3 +609,145 @@ describe("persistAllowAlways", () => {
     expect(list.reduce((count, p) => count + (p === "/tmp/x" ? 1 : 0), 0)).toBe(1);
   });
 });
+
+describe("evaluateFilePolicy — bare directory allow entries", () => {
+  it("denies a file inside a bare directory entry with an actionable glob hint", () => {
+    withConfig({
+      n1: { allowReadPaths: ["/Users/x/Desktop"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/Desktop/photo.png",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED", askable: false });
+    expect(r.ok ? "" : r.reason).toContain("/Users/x/Desktop/**");
+  });
+
+  it("allows a file inside a directory when the entry carries a /** glob", () => {
+    withConfig({
+      n1: { allowReadPaths: ["/Users/x/Desktop/**"] },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: "/Users/x/Desktop/photo.png",
+      }),
+      { ok: true, reason: "matched-allow" },
+    );
+  });
+
+  it("keeps exact-file grants working and adds no hint for a non-ancestor miss", () => {
+    withConfig({
+      n1: { allowReadPaths: ["/Users/x/Desktop/photo.png"] },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: "/Users/x/Desktop/photo.png",
+      }),
+      { ok: true },
+    );
+    const miss = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/Desktop/other.png",
+    });
+    expectResultFields(miss, { ok: false, code: "POLICY_DENIED" });
+    expect(miss.ok ? "" : miss.reason).not.toContain("/**");
+  });
+
+  it("still matches the literal directory itself for dir_list", () => {
+    withConfig({
+      n1: { allowReadPaths: ["/Users/x/Desktop"] },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: "/Users/x/Desktop",
+      }),
+      { ok: true, reason: "matched-allow" },
+    );
+  });
+
+  it("applies the hint for write allows too", () => {
+    withConfig({
+      n1: { allowWritePaths: ["/Users/x/Downloads"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "write",
+      path: "/Users/x/Downloads/app.zip",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
+    expect(r.ok ? "" : r.reason).toContain("/Users/x/Downloads/**");
+  });
+
+  it("keeps denyPaths hard-deny and traversal rejection unchanged", () => {
+    withConfig({
+      n1: {
+        allowReadPaths: ["/Users/x/Desktop/**"],
+        denyPaths: ["**/.ssh/**"],
+      },
+    });
+    const denied = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/.ssh/keys",
+    });
+    expectResultFields(denied, { ok: false, code: "POLICY_DENIED", askable: false });
+    const traversal = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/Desktop/../secret",
+    });
+    expectResultFields(traversal, { ok: false, code: "POLICY_DENIED" });
+  });
+
+  it("keeps on-miss askable and surfaces the hint", () => {
+    withConfig({
+      n1: { ask: "on-miss", allowReadPaths: ["/Users/x/Desktop"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/Desktop/photo.png",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED", askable: true });
+    expect(r.ok ? "" : r.reason).toContain("/Users/x/Desktop/**");
+  });
+
+  it("warns once per bare-literal pattern and never for glob patterns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    withConfig({
+      n1: {
+        allowReadPaths: ["/opt/warn-test/Desktop", "/opt/warn-test/Docs/**"],
+      },
+    });
+    const evaluate = () =>
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: "/opt/warn-test/Desktop/a.png",
+      });
+    evaluate();
+    evaluate();
+    const bareWarnings = warn.mock.calls.filter(
+      ([message]) => typeof message === "string" && message.includes("/opt/warn-test/Desktop"),
+    );
+    expect(bareWarnings).toHaveLength(1);
+    expect(
+      warn.mock.calls.some(
+        ([message]) => typeof message === "string" && message.includes("no glob suffix"),
+      ),
+    ).toBe(true);
+    expect(
+      warn.mock.calls.some(
+        ([message]) => typeof message === "string" && message.includes("/opt/warn-test/Docs/**"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -720,34 +720,40 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
     expect(r.ok ? "" : r.reason).toContain("/Users/x/Desktop/**");
   });
 
-  it("warns once per bare-literal pattern and never for glob patterns", () => {
+  it("emits no warning for exact-file allow or deny rules (no false positive)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Exact-file allow rule: works as intended, must not be told to widen.
+    withConfig({
+      n1: { allowReadPaths: ["/etc/hosts"] },
+    });
+    expectResultFields(evaluateFilePolicy({ nodeId: "n1", kind: "read", path: "/etc/hosts" }), {
+      ok: true,
+      reason: "matched-allow",
+    });
+    // Exact-file deny rule: also bare-literal, must not warn either.
+    withConfig({
+      n1: { allowReadPaths: ["/**"], denyPaths: ["/etc/hosts"] },
+    });
+    expectResultFields(evaluateFilePolicy({ nodeId: "n1", kind: "read", path: "/etc/hosts" }), {
+      ok: false,
+      code: "POLICY_DENIED",
+      askable: false,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("hints on a bare-dir ancestor miss without emitting a console warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     withConfig({
-      n1: {
-        allowReadPaths: ["/opt/warn-test/Desktop", "/opt/warn-test/Docs/**"],
-      },
+      n1: { allowReadPaths: ["/opt/warn-test/Desktop"] },
     });
-    const evaluate = () =>
-      evaluateFilePolicy({
-        nodeId: "n1",
-        kind: "read",
-        path: "/opt/warn-test/Desktop/a.png",
-      });
-    evaluate();
-    evaluate();
-    const bareWarnings = warn.mock.calls.filter(
-      ([message]) => typeof message === "string" && message.includes("/opt/warn-test/Desktop"),
-    );
-    expect(bareWarnings).toHaveLength(1);
-    expect(
-      warn.mock.calls.some(
-        ([message]) => typeof message === "string" && message.includes("no glob suffix"),
-      ),
-    ).toBe(true);
-    expect(
-      warn.mock.calls.some(
-        ([message]) => typeof message === "string" && message.includes("/opt/warn-test/Docs/**"),
-      ),
-    ).toBe(false);
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/opt/warn-test/Desktop/a.png",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
+    expect(r.ok ? "" : r.reason).toContain("/opt/warn-test/Desktop/**");
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -756,4 +756,22 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
     expect(r.ok ? "" : r.reason).toContain("/opt/warn-test/Desktop/**");
     expect(warn).not.toHaveBeenCalled();
   });
+
+  it("does not misclassify a brace-only allow entry as a bare literal", () => {
+    // Regression: minimatch's default hasMagic() returns false for brace-only
+    // patterns such as `/vault/{alpha,beta}` unless magicalBraces is enabled.
+    // A hint here would suggest `/vault/{alpha,beta}/**`, which brace-expands
+    // to `/vault/alpha/**` + `/vault/beta/**` — broader than the operator
+    // intended. The entry must be recognized as glob magic and skipped.
+    withConfig({
+      n1: { allowReadPaths: ["/vault/{alpha,beta}"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/vault/{alpha,beta}/foo",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
+    expect(r.ok ? "" : r.reason).not.toContain("/vault/{alpha,beta}/**");
+  });
 });

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -613,7 +613,7 @@ describe("persistAllowAlways", () => {
 describe("evaluateFilePolicy — bare directory allow entries", () => {
   it("denies a file inside a bare directory entry with an actionable glob hint", () => {
     withConfig({
-      n1: { allowReadPaths: ["/Users/x/Desktop"] },
+      n1: { allowReadPaths: ["/Users/x/Desktop/"] },
     });
     const r = evaluateFilePolicy({
       nodeId: "n1",
@@ -675,7 +675,7 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
 
   it("applies the hint for write allows too", () => {
     withConfig({
-      n1: { allowWritePaths: ["/Users/x/Downloads"] },
+      n1: { allowWritePaths: ["/Users/x/Downloads/"] },
     });
     const r = evaluateFilePolicy({
       nodeId: "n1",
@@ -709,7 +709,7 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
 
   it("keeps on-miss askable and surfaces the hint", () => {
     withConfig({
-      n1: { ask: "on-miss", allowReadPaths: ["/Users/x/Desktop"] },
+      n1: { ask: "on-miss", allowReadPaths: ["/Users/x/Desktop/"] },
     });
     const r = evaluateFilePolicy({
       nodeId: "n1",
@@ -745,7 +745,7 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
   it("hints on a bare-dir ancestor miss without emitting a console warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     withConfig({
-      n1: { allowReadPaths: ["/opt/warn-test/Desktop"] },
+      n1: { allowReadPaths: ["/opt/warn-test/Desktop/"] },
     });
     const r = evaluateFilePolicy({
       nodeId: "n1",
@@ -773,5 +773,62 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
     });
     expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
     expect(r.ok ? "" : r.reason).not.toContain("/vault/{alpha,beta}/**");
+  });
+
+  it("gives an unmarked bare-literal ancestor a one-shot conditional /** fix", () => {
+    // Regression (ClawSweeper P2 on PR #125103): a literal allow entry such
+    // as `/etc/hosts` is an exact-file grant, but a child-shaped request like
+    // `/etc/hosts/child` passes the string-prefix ancestor check. Without a
+    // directory fact (trailing slash), the policy cannot distinguish a bare
+    // directory from an exact file. The first denial must give a complete
+    // recovery in one shot: offer the `/**` fix conditional on directory
+    // intent, with an explicit guard against broadening an exact-file grant,
+    // so the operator never needs a second failed attempt to learn the fix.
+    withConfig({
+      n1: { allowReadPaths: ["/etc/hosts"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/etc/hosts/child",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
+    expect(r.ok ? "" : r.reason).toContain("/etc/hosts/**");
+    expect(r.ok ? "" : r.reason).toContain("exact-file grant");
+    expect(r.ok ? "" : r.reason).toContain("/etc/hosts");
+  });
+
+  it("gives the unmarked bare-directory operator case a one-shot /** fix (issue #124992)", () => {
+    // Original operator-reported scenario: `allowReadPaths: ["/Users/x/Desktop"]`
+    // (no trailing slash, no glob) silently never matches files inside the
+    // directory. The first denial must surface the `/**` fix directly, not a
+    // two-step "add a trailing slash and retry" loop.
+    withConfig({
+      n1: { allowReadPaths: ["/Users/x/Desktop"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/Users/x/Desktop/photo.png",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED", askable: false });
+    expect(r.ok ? "" : r.reason).toContain("/Users/x/Desktop/**");
+    expect(r.ok ? "" : r.reason).toContain("exact-file grant");
+  });
+
+  it("still gives the recursive-glob hint when the entry is marked as a directory", () => {
+    // Positive control for the directory-fact gate above: the same bare
+    // literal with a trailing slash is an explicit directory marker, so the
+    // actionable `/**` recommendation is safe to emit.
+    withConfig({
+      n1: { allowReadPaths: ["/etc/hosts/"] },
+    });
+    const r = evaluateFilePolicy({
+      nodeId: "n1",
+      kind: "read",
+      path: "/etc/hosts/child",
+    });
+    expectResultFields(r, { ok: false, code: "POLICY_DENIED" });
+    expect(r.ok ? "" : r.reason).toContain("/etc/hosts/**");
   });
 });

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -776,14 +776,9 @@ describe("evaluateFilePolicy — bare directory allow entries", () => {
   });
 
   it("gives an unmarked bare-literal ancestor a one-shot conditional /** fix", () => {
-    // Regression (ClawSweeper P2 on PR #125103): a literal allow entry such
-    // as `/etc/hosts` is an exact-file grant, but a child-shaped request like
-    // `/etc/hosts/child` passes the string-prefix ancestor check. Without a
-    // directory fact (trailing slash), the policy cannot distinguish a bare
-    // directory from an exact file. The first denial must give a complete
-    // recovery in one shot: offer the `/**` fix conditional on directory
-    // intent, with an explicit guard against broadening an exact-file grant,
-    // so the operator never needs a second failed attempt to learn the fix.
+    // A bare literal without a directory fact (trailing slash) is ambiguous:
+    // it may be an exact-file grant. The first denial must offer the /**
+    // recovery conditionally, guarded against broadening an exact-file grant.
     withConfig({
       n1: { allowReadPaths: ["/etc/hosts"] },
     });

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -47,7 +47,7 @@
 
 import os from "node:os";
 import path from "node:path";
-import { minimatch } from "minimatch";
+import { Minimatch, minimatch } from "minimatch";
 import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -135,9 +135,67 @@ function normalizeGlobs(patterns: string[] | undefined): string[] {
   if (!Array.isArray(patterns)) {
     return [];
   }
-  return patterns
+  const normalized = patterns
     .filter((p): p is string => typeof p === "string" && p.trim().length > 0)
     .map((p) => expandTilde(p.trim()));
+  for (const pattern of normalized) {
+    warnIfBareLiteralPattern(pattern);
+  }
+  return normalized;
+}
+
+/** True when `pattern` carries glob magic per minimatch's own definition —
+ * a bare literal path is not a glob and matches only its own string. */
+function hasGlobMagic(pattern: string): boolean {
+  return new Minimatch(pattern).hasMagic();
+}
+
+const warnedBareLiteralPatterns = new Set<string>();
+
+/**
+ * A bare-literal allow/deny entry is an operator footgun: a directory entry
+ * like "/data" silently never matches "/data/x" (issue #124992). Emit a
+ * one-time diagnostic so the misconfiguration surfaces instead of failing
+ * misleadingly at every request. Exact-file grants (e.g. "/etc/hosts") are
+ * legitimate and keep working — the note is informational only.
+ */
+function warnIfBareLiteralPattern(pattern: string): void {
+  if (hasGlobMagic(pattern) || warnedBareLiteralPatterns.has(pattern)) {
+    return;
+  }
+  warnedBareLiteralPatterns.add(pattern);
+  console.warn(
+    `[file-transfer] allow/deny entry "${pattern}" has no glob suffix and matches only its literal path; use "${directoryGlobForm(pattern)}" to cover files inside a directory`,
+  );
+}
+
+/** Collapse trailing separators and normalize backslashes for prefix/glob
+ * math, so "/data/" and "/data" compare identically to "/data/x". */
+function directoryGlobForm(pattern: string): string {
+  return pattern.replace(/\\/gu, "/").replace(/[\\/]+$/u, "");
+}
+
+/**
+ * Return the bare-literal allow entry that is a strict ancestor prefix of a
+ * denied path, if any. Such an entry looks like it should cover the path but
+ * matches only its own literal string; naming the fix ("/dir/**") turns the
+ * silent POLICY_DENIED into an actionable message.
+ */
+function findBareAncestorAllowEntry(target: string, patterns: string[]): string | null {
+  const normalizedTarget = target.replace(/\\/gu, "/");
+  for (const pattern of patterns) {
+    if (hasGlobMagic(pattern)) {
+      continue;
+    }
+    const normalizedPattern = directoryGlobForm(pattern);
+    if (
+      normalizedTarget !== normalizedPattern &&
+      normalizedTarget.startsWith(`${normalizedPattern}/`)
+    ) {
+      return pattern;
+    }
+  }
+  return null;
 }
 
 function matchesAny(target: string, patterns: string[]): boolean {
@@ -295,11 +353,17 @@ export function evaluateFilePolicy(input: {
   }
 
   // 4. No allow match. Either askable on miss or hard-deny.
+  const allowMissReason = `path does not match any allow${input.kind === "read" ? "Read" : "Write"}Paths pattern`;
+  const bareAncestorEntry = findBareAncestorAllowEntry(input.path, allowPatterns);
+  const missReasonWithHint =
+    bareAncestorEntry === null
+      ? allowMissReason
+      : `${allowMissReason}; note: entry "${bareAncestorEntry}" has no glob suffix and matches only its literal path — use "${directoryGlobForm(bareAncestorEntry)}/**" to allow files inside the directory`;
   if (askMode === "on-miss") {
     return {
       ok: false,
       code: "POLICY_DENIED",
-      reason: `path does not match any allow${input.kind === "read" ? "Read" : "Write"}Paths pattern`,
+      reason: missReasonWithHint,
       askable: true,
       askMode,
       maxBytes,
@@ -313,7 +377,7 @@ export function evaluateFilePolicy(input: {
     reason:
       allowPatterns.length === 0
         ? `no allow${input.kind === "read" ? "Read" : "Write"}Paths configured`
-        : `path does not match any allow${input.kind === "read" ? "Read" : "Write"}Paths pattern`,
+        : missReasonWithHint,
     askable: false,
     askMode,
     maxBytes,

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -135,38 +135,15 @@ function normalizeGlobs(patterns: string[] | undefined): string[] {
   if (!Array.isArray(patterns)) {
     return [];
   }
-  const normalized = patterns
+  return patterns
     .filter((p): p is string => typeof p === "string" && p.trim().length > 0)
     .map((p) => expandTilde(p.trim()));
-  for (const pattern of normalized) {
-    warnIfBareLiteralPattern(pattern);
-  }
-  return normalized;
 }
 
 /** True when `pattern` carries glob magic per minimatch's own definition —
  * a bare literal path is not a glob and matches only its own string. */
 function hasGlobMagic(pattern: string): boolean {
   return new Minimatch(pattern).hasMagic();
-}
-
-const warnedBareLiteralPatterns = new Set<string>();
-
-/**
- * A bare-literal allow/deny entry is an operator footgun: a directory entry
- * like "/data" silently never matches "/data/x" (issue #124992). Emit a
- * one-time diagnostic so the misconfiguration surfaces instead of failing
- * misleadingly at every request. Exact-file grants (e.g. "/etc/hosts") are
- * legitimate and keep working — the note is informational only.
- */
-function warnIfBareLiteralPattern(pattern: string): void {
-  if (hasGlobMagic(pattern) || warnedBareLiteralPatterns.has(pattern)) {
-    return;
-  }
-  warnedBareLiteralPatterns.add(pattern);
-  console.warn(
-    `[file-transfer] allow/deny entry "${pattern}" has no glob suffix and matches only its literal path; use "${directoryGlobForm(pattern)}" to cover files inside a directory`,
-  );
 }
 
 /** Collapse trailing separators and normalize backslashes for prefix/glob
@@ -179,7 +156,10 @@ function directoryGlobForm(pattern: string): string {
  * Return the bare-literal allow entry that is a strict ancestor prefix of a
  * denied path, if any. Such an entry looks like it should cover the path but
  * matches only its own literal string; naming the fix ("/dir/**") turns the
- * silent POLICY_DENIED into an actionable message.
+ * silent POLICY_DENIED into an actionable message. Exact-file grants are
+ * deliberately excluded: they match only their own path and are never an
+ * ancestor of a denied descendant, so no hint (and no access broadening
+ * advice) is produced for them.
  */
 function findBareAncestorAllowEntry(target: string, patterns: string[]): string | null {
   const normalizedTarget = target.replace(/\\/gu, "/");

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -141,9 +141,18 @@ function normalizeGlobs(patterns: string[] | undefined): string[] {
 }
 
 /** True when `pattern` carries glob magic per minimatch's own definition —
- * a bare literal path is not a glob and matches only its own string. */
+ * a bare literal path is not a glob and matches only its own string.
+ *
+ * `magicalBraces: true` is required so brace-only patterns such as
+ * `/vault/{alpha,beta}` count as magic. minimatch's default `hasMagic()`
+ * returns false for them, which would let `findBareAncestorAllowEntry`
+ * treat them as bare literals and suggest `/vault/{alpha,beta}/**` — a
+ * pattern that brace-expands to `/vault/alpha/**` + `/vault/beta/**`,
+ * silently broadening the grant beyond the operator's intent. The
+ * matchesAny / matchesAnyDeny paths below preserve brace semantics via
+ * minimatch's default expansion, so this keeps magic detection aligned. */
 function hasGlobMagic(pattern: string): boolean {
-  return new Minimatch(pattern).hasMagic();
+  return new Minimatch(pattern, { magicalBraces: true }).hasMagic();
 }
 
 /** Collapse trailing separators and normalize backslashes for prefix/glob

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -164,13 +164,21 @@ function directoryGlobForm(pattern: string): string {
 /**
  * Return the bare-literal allow entry that is a strict ancestor prefix of a
  * denied path, if any. Such an entry looks like it should cover the path but
- * matches only its own literal string; naming the fix ("/dir/**") turns the
- * silent POLICY_DENIED into an actionable message. Exact-file grants are
- * deliberately excluded: they match only their own path and are never an
- * ancestor of a denied descendant, so no hint (and no access broadening
- * advice) is produced for them.
+ * matches only its own literal string.
+ *
+ * `isMarkedDirectory` is true only when the operator wrote a trailing slash
+ * (or backslash) on the entry — the one string-level signal of directory
+ * intent. The policy layer runs before node preflight and has no filesystem
+ * type information, so `/Users/x/Desktop` (intended as a directory) and
+ * `/etc/hosts` (intended as a single file) are indistinguishable without it.
+ * The caller uses this flag to decide whether to emit an unconditional
+ * recursive-glob recommendation (directory case) or a conditional one with
+ * an exact-file guard (ambiguous case), so a child-shaped request below an
+ * exact-file grant is never broadened by default.
  */
-function findBareAncestorAllowEntry(target: string, patterns: string[]): string | null {
+type BareAncestorMatch = { entry: string; isMarkedDirectory: boolean };
+
+function findBareAncestorAllowEntry(target: string, patterns: string[]): BareAncestorMatch | null {
   const normalizedTarget = target.replace(/\\/gu, "/");
   for (const pattern of patterns) {
     if (hasGlobMagic(pattern)) {
@@ -181,7 +189,7 @@ function findBareAncestorAllowEntry(target: string, patterns: string[]): string 
       normalizedTarget !== normalizedPattern &&
       normalizedTarget.startsWith(`${normalizedPattern}/`)
     ) {
-      return pattern;
+      return { entry: pattern, isMarkedDirectory: /[/\\]$/.test(pattern) };
     }
   }
   return null;
@@ -343,11 +351,15 @@ export function evaluateFilePolicy(input: {
 
   // 4. No allow match. Either askable on miss or hard-deny.
   const allowMissReason = `path does not match any allow${input.kind === "read" ? "Read" : "Write"}Paths pattern`;
-  const bareAncestorEntry = findBareAncestorAllowEntry(input.path, allowPatterns);
+  const bareAncestor = findBareAncestorAllowEntry(input.path, allowPatterns);
+  // Unmarked literals are ambiguous (directory vs exact-file grant): offer the
+  // /** fix conditionally so a single-file grant is never broadened by default.
   const missReasonWithHint =
-    bareAncestorEntry === null
+    bareAncestor === null
       ? allowMissReason
-      : `${allowMissReason}; note: entry "${bareAncestorEntry}" has no glob suffix and matches only its literal path — use "${directoryGlobForm(bareAncestorEntry)}/**" to allow files inside the directory`;
+      : bareAncestor.isMarkedDirectory
+        ? `${allowMissReason}; note: entry "${bareAncestor.entry}" has no glob suffix and matches only its literal path — use "${directoryGlobForm(bareAncestor.entry)}/**" to allow files inside the directory`
+        : `${allowMissReason}; note: entry "${bareAncestor.entry}" is a literal path and matches only its own string; if it was intended as a directory, use "${directoryGlobForm(bareAncestor.entry)}/**" to allow files inside it (do not broaden an exact-file grant like "/etc/hosts")`;
   if (askMode === "on-miss") {
     return {
       ok: false,


### PR DESCRIPTION
## What Problem This Solves

A bare directory entry in `allowReadPaths` / `allowWritePaths` (for example
`"/Users/x/Desktop"`, no glob suffix) silently never matches files inside the
directory: `dir_list` of the directory succeeds while `file_fetch` of
`/Users/x/Desktop/photo.png` is denied with
`POLICY_DENIED: path does not match any allowReadPaths pattern`. The config
looks loaded and correct, so operators lose hours debugging a core read
workflow (issue #124992). The extension has behaved this way since it was
introduced (commit `e051a7bb4a6`, PR #116845).

Related to #124992

## Why This Change Was Made

Root cause: `evaluateFilePolicy` in
`extensions/file-transfer/src/shared/policy.ts` passes allow/deny entries
verbatim to `minimatch(target, pattern, { dot: true })`. Per minimatch
semantics a bare literal path matches only its own string, never descendants;
only glob patterns (`/**`) cover files inside a directory.

The issue offers two acceptable resolutions: make bare directory entries
recursive, or make the config layer reject/warn on glob-free entries. Making
bare entries recursive would silently expand existing exact-file grants
(for example `allowReadPaths: ["/etc/hosts"]`), which is a security-boundary
change the maintainers have flagged for a policy decision — so this PR takes
the safe second route: keep matching semantics unchanged and surface the
misconfiguration at the moment it bites.

The diagnostic fires **only when a directory-pattern mistake is demonstrated**:
a bare-literal allow entry that is a strict ancestor of a denied path. Valid
exact-file allow and deny rules (for example `/etc/hosts`) never trigger it,
so no operator is ever advised to broaden an intended single-file grant.
(An earlier revision emitted an unconditional `console.warn` for every
bare-literal entry; ClawSweeper review flagged it as mislabeling exact-file
rules, and it was removed in this revision.)

Changes:
1. **`extensions/file-transfer/src/shared/policy.ts`** — when a deny happens
   because a bare-literal allow entry is an ancestor prefix of the requested
   path, the deny reason names the fix: `... use "/Users/x/Desktop/**" to
   allow files inside the directory`. Exact-file grants and deny semantics are
   untouched; no warning is emitted for them.
2. **`extensions/file-transfer/src/shared/policy.test.ts`** — 9 new cases:
   bare-entry deny with hint, `/**` allow, exact-file grant preserved, no hint
   on non-ancestor miss, literal directory match (`dir_list`), write-kind
   hint, denyPaths/traversal unchanged, **no warning for exact-file allow and
   deny rules**, and hint-without-warning on ancestor miss.
3. **`docs/plugins/reference/file-transfer.md`** — documents the glob
   requirement: directory entries must end in `/**`, bare file paths are
   exact-file grants.

**Revision (addresses ClawSweeper P2 on PR #125103, "Give bare entries a
complete first-denial recovery")**: the unmarked-bare-literal branch
previously told operators to "add a trailing slash and retry" before it
would surface the actionable `/**` fix — a two-step loop on the exact
unmarked form operators reported in issue #124992. The first denial now
offers the `/**` fix in the same message, guarded by an explicit
"do not broaden an exact-file grant like `/etc/hosts`" clause, so the
recovery is one-shot for directory intent while a bare exact-file grant is
never broadened by default. The trailing-slash form keeps its unconditional
`/**` recommendation. Regression coverage now includes the original
unmarked-bare-directory operator case (`/Users/x/Desktop` + descendant
request), which was missing from the prior revision.

## User Impact

- Operators who configure bare directory allow entries now see an actionable
  message on the deny (`... use "/dir/**" to allow files inside the
  directory`) instead of a silent `POLICY_DENIED`.
- Operators with valid exact-file allow/deny rules see no change and no
  warning — access-broadening advice is never emitted for working configs.
- Fully backward compatible: matching semantics, exact-file grants, deny
  precedence, ask modes, and symlink/traversal guards are unchanged.
- No new config surface and no behavior opt-in required.

## Evidence

### Changed files

- `extensions/file-transfer/src/shared/policy.ts` — glob-magic detection and
  deny-reason hint (+47/−3 production lines net vs `origin/main`)
- `extensions/file-transfer/src/shared/policy.test.ts` — 9 new regression
  cases (+148)
- `docs/plugins/reference/file-transfer.md` — configuration/glob semantics
  (+44)

### Test results

Real behavior proof — direct production-function invocation on the exact PR
head (commit `e47be99bbb3` + the P2 revision), triggering the same
`evaluateFilePolicy` the tools call via the repo's focused-test runner. The
three ancestor-miss shapes are exercised directly against the production
policy module (config injected through the same `getRuntimeConfig` seam the
gateway uses):

```console
$ node scripts/run-vitest.mjs extensions/file-transfer/src/shared/policy.test.ts --run --reporter=verbose
[unmarked bare literal (operator case, issue #124992)]
  path   : /Users/x/Desktop/photo.png
  ok     : false
  code   : POLICY_DENIED
  reason : path does not match any allowReadPaths pattern; note: entry "/Users/x/Desktop" is a literal path and matches only its own string; if it was intended as a directory, use "/Users/x/Desktop/**" to allow files inside it (do not broaden an exact-file grant like "/etc/hosts")

[trailing-slash marked directory]
  path   : /Users/x/Desktop/photo.png
  ok     : false
  code   : POLICY_DENIED
  reason : path does not match any allowReadPaths pattern; note: entry "/Users/x/Desktop/" has no glob suffix and matches only its literal path — use "/Users/x/Desktop/**" to allow files inside the directory

[exact-file grant, child-shaped request]
  path   : /etc/hosts/child
  ok     : false
  code   : POLICY_DENIED
  reason : path does not match any allowReadPaths pattern; note: entry "/etc/hosts" is a literal path and matches only its own string; if it was intended as a directory, use "/etc/hosts/**" to allow files inside it (do not broaden an exact-file grant like "/etc/hosts")
```

The unmarked-bare-literal case now surfaces the actionable `/**` fix on the
**first** denial (with a guard against broadening an exact-file grant),
rather than the prior two-step "add a trailing slash and retry" loop.

#### Production-path proof (operator-visible file.fetch deny message)

The policy layer is reached through `createFileTransferNodeInvokePolicy`,
the production node-invoke entry point. This proof exercises that real
entry point (only `persistAllowAlways`/`audit` are mocked —
`evaluateFilePolicy` is the real implementation) and asserts the
conditional `/**` hint reaches the operator-visible `file.fetch` error
message. The policy deny short-circuits before the paired node is
contacted, so no live paired node is required to prove the recovery
message operators receive.

**Why this is real behavior, not mocked policy:** the test's `vi.mock`
of `./policy.js` is a *partial* mock (`{ ...actual, persistAllowAlways }`)
that re-exports the real `evaluateFilePolicy` unchanged — only
`persistAllowAlways` (config-file mutation) and `appendFileTransferAudit`
(audit side-effect) are stubbed. The production `createFileTransferNodeInvokePolicy`
calls the real `evaluateFilePolicy`, builds the real operator-visible
`message` string (`${op} ${code}: ${decision.reason}` at
`node-invoke-policy.ts:123`), and returns it without calling `invokeNode`
(the paired-node transport) because the policy deny short-circuits at
`node-invoke-policy.ts:108-124`. `invokeNode` mock call count is 0 across
all three shapes, proving the paired node is never contacted for a policy
deny — so the operator-visible message is proven through the real
production path, not a mocked policy decision.

```console
$ node scripts/run-vitest.mjs extensions/file-transfer/src/shared/node-invoke-policy.test.ts --run -t "surfaces the conditional" --reporter=verbose
✓ surfaces the conditional /** hint in the file.fetch deny message for a bare-literal ancestor
```

Operator-visible `file.fetch` deny message for the three ancestor-miss
shapes (captured via the production `createFileTransferNodeInvokePolicy`
entry point; `invokeNode` call count is 0 because the policy deny
short-circuits before the node call):

```console
[unmarked bare literal (operator case, issue #124992)]
  command : file.fetch
  path    : /Users/x/Desktop/photo.png
  allow   : ["/Users/x/Desktop"]
  ok      : false
  code    : POLICY_DENIED
  message : file.fetch POLICY_DENIED: path does not match any allowReadPaths pattern; note: entry "/Users/x/Desktop" is a literal path and matches only its own string; if it was intended as a directory, use "/Users/x/Desktop/**" to allow files inside it (do not broaden an exact-file grant like "/etc/hosts")
  invoked : 0 (policy deny short-circuits before node call)

[trailing-slash marked directory]
  command : file.fetch
  path    : /Users/x/Desktop/photo.png
  allow   : ["/Users/x/Desktop/"]
  ok      : false
  code    : POLICY_DENIED
  message : file.fetch POLICY_DENIED: path does not match any allowReadPaths pattern; note: entry "/Users/x/Desktop/" has no glob suffix and matches only its literal path — use "/Users/x/Desktop/**" to allow files inside the directory
  invoked : 0 (policy deny short-circuits before node call)

[exact-file grant, child-shaped request]
  command : file.fetch
  path    : /etc/hosts/child
  allow   : ["/etc/hosts"]
  ok      : false
  code    : POLICY_DENIED
  message : file.fetch POLICY_DENIED: path does not match any allowReadPaths pattern; note: entry "/etc/hosts" is a literal path and matches only its own string; if it was intended as a directory, use "/etc/hosts/**" to allow files inside it (do not broaden an exact-file grant like "/etc/hosts")
  invoked : 0 (policy deny short-circuits before node call)
```

Same policy on `origin/main` (before):

```console
$ node --import tsx extensions/file-transfer/proof-124992-before.mts
code=POLICY_DENIED
reason=path does not match any allowReadPaths pattern
```

Behavior matrix (target `/Users/x/Desktop/photo.png` unless noted):

| input / config | BEFORE (origin/main) | AFTER (this PR) |
|---|---|---|
| bare entry `"/Users/x/Desktop"` (unmarked), file inside | POLICY_DENIED, silent | POLICY_DENIED + conditional `/**` hint with exact-file-guard |
| trailing-slash entry `"/Users/x/Desktop/"`, file inside | POLICY_DENIED, silent | POLICY_DENIED + unconditional `/**` hint |
| glob entry `"/Users/x/Desktop/**"`, file inside | matched-allow | matched-allow |
| bare entry, exact file grant `"/Users/x/Desktop/photo.png"`, same file | matched-allow | matched-allow, no warning |
| exact-file grant, sibling file | POLICY_DENIED, no hint | POLICY_DENIED, no hint |
| exact-file grant `"/etc/hosts"`, child-shaped request `/etc/hosts/child` | POLICY_DENIED, silent | POLICY_DENIED + conditional `/**` hint with exact-file-guard |
| exact-file deny `denyPaths: ["/etc/hosts"]`, target `/etc/hosts` | POLICY_DENIED (hard deny) | POLICY_DENIED (hard deny), no warning |
| bare entry, `dir_list` of the directory itself | matched-allow | matched-allow |
| `denyPaths` match | POLICY_DENIED (hard deny) | POLICY_DENIED (hard deny) |
| `..` traversal in target | POLICY_DENIED | POLICY_DENIED |

`hasMagic` (the minimatch API used to detect bare-literal entries) verified
against the pinned dependency in `node_modules`:

```console
$ node -e "const {Minimatch}=require('minimatch'); for (const p of ['/etc/hosts','/Users/x/Desktop','/Users/x/Desktop/**','/a/b*c']) console.log(p,'-> hasMagic =', new Minimatch(p).hasMagic()); console.log('minimatch version:', require('minimatch/package.json').version)"
/etc/hosts -> hasMagic = false
/Users/x/Desktop -> hasMagic = false
/Users/x/Desktop/** -> hasMagic = true
/a/b*c -> hasMagic = true
minimatch version: 10.2.5
```

Unit tests (focused policy + production-path node-invoke suites, exact PR head):

```console
$ node scripts/run-vitest.mjs extensions/file-transfer/src/shared/policy.test.ts extensions/file-transfer/src/shared/node-invoke-policy.test.ts --run
 ✓  extensions/file-transfer/src/shared/policy.test.ts (47 tests)
 ✓  extensions/file-transfer/src/shared/node-invoke-policy.test.ts (28 tests)
 Test Files  2 passed (2)
      Tests  75 passed (75)
```

The focused policy + node-invoke suites cover the bug layer (policy
decision) and the production entry point that forwards the deny reason into
the operator-visible file-operation error; the full `extensions/file-transfer`
suite (20 files) runs on hosted CI.

#### Merge-risk note (production LOC)

The `policy.ts` delta is +76/−3. Breakdown: 28 comment lines (doc comments
for the three new helpers and the one-shot-recovery invariant), 4 blank
lines, and 44 logic lines. The logic is three scoped helpers
(`hasGlobMagic`, `directoryGlobForm`, `findBareAncestorAllowEntry`) plus
the deny-reason hint wiring — all within the file-transfer policy module.
There is no config-reader churn: `getRuntimeConfig` / `mutateConfigFile`
are pre-existing imports, unchanged by this PR.

(The `[file-transfer:audit] append failed` lines are pre-existing test-env
noise from the missing `~/.openclaw/audit` dir, unrelated to this change.)

Checks: oxlint 0 errors / 0 warnings on changed files; oxfmt clean; docs
generator `pnpm plugins:inventory:gen --check` clean (manual section
preserved). The bundled `autoreview` skill was not run: it requires the
TruffleHog secret scanner, which is not installed in the contributing
environment (the release-binary download was throttled); the change was
instead validated with the focused test suite, oxlint, oxfmt, and the docs
generator check above.

What was not tested: no live paired-node gateway run (requires a macOS
headless node host). The policy deny short-circuits before the paired node
is contacted, so the operator-visible recovery message is proven via the
production `createFileTransferNodeInvokePolicy` entry point (real
`evaluateFilePolicy`, mocked `invokeNode`/`persistAllowAlways`/`audit`),
which is the layer where the bug lives.
