### PR TITLE
refactor(ui): make the review panel default document part of its slot definition

### DIFF
--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -205,6 +205,43 @@ describeControlUiE2e("session diff panel", () => {
     await waitForSessionDiff(page);
   });
 
+  it("requests the default session diff once across subsequent pane renders", async () => {
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.files.list": {
+          sessionKey: "main",
+          root: "/tmp/checkout",
+          gitCheckout: true,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+        "sessions.diff": SESSION_DIFF_RESPONSE,
+      },
+    });
+    await page.goto(`${server.baseUrl}chat`);
+
+    await openChatSidePanelType(page, "Files");
+    await openChatSidePanelType(page, "Review");
+    await waitForSessionDiff(page);
+    await expect.poll(async () => (await gateway.getRequests("sessions.diff")).length).toBe(1);
+
+    await openChatSidePanelType(page, "Tasks");
+    await expect
+      .poll(() => page.locator(".tabstrip-tab__label").allTextContents())
+      .toContain("Tasks");
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+
+    expect(await gateway.getRequests("sessions.diff")).toHaveLength(1);
+  });
+
   it("loads the session diff into a persisted empty Review panel", async () => {
     const sessionKey = "agent:main:persisted-review";
     const context = await newBrowserContext();

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -6,10 +6,12 @@ import { t } from "../../i18n/index.ts";
 import { resolveAssistantAttachmentAuthToken } from "./chat-pane-state.ts";
 import type { ChatSessionCompanionThread } from "./chat-session-companion.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { resolveSessionDiffSidebarContent } from "./components/chat-session-workspace.ts";
 import type {
   SidebarPanelDefinition,
   SidebarPanelTemplates,
 } from "./components/chat-sidebar-region-types.ts";
+import type { SidebarContent } from "./components/chat-sidebar.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import type { SidebarSlotId } from "./sidebar-layout-types.ts";
 
@@ -21,7 +23,8 @@ type SidebarPanelDefinitionParams = {
   chat: TemplateResult;
   workspace: TemplateResult | typeof nothing;
   tasks: TemplateResult | typeof nothing;
-  detail: TemplateResult | null;
+  detailOpen: boolean;
+  renderDetail: (content: SidebarContent) => TemplateResult;
   digest: SessionObserverDigest | null;
   activeRunId: string | null;
   startedAt: number | undefined;
@@ -135,8 +138,16 @@ export function sidebarPanelDefinitions(
         .onStateChange=${params.discussion.onStateChange}
       ></openclaw-session-discussion>`
     : null;
+  const detailContent =
+    state?.sidebarContent ??
+    (state && params?.detailOpen ? resolveSessionDiffSidebarContent(state) : null);
   return [
-    definePanel("detail", "review", icons.diff, params?.detail ?? null),
+    definePanel(
+      "detail",
+      "review",
+      icons.diff,
+      detailContent && params ? params.renderDetail(detailContent) : null,
+    ),
     definePanel("terminal", "terminal", icons.terminal, terminal, {
       available: terminalAvailable,
       shortcut: "Ctrl+`",

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -56,10 +56,8 @@ import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import { createPageState } from "./chat-state-page.ts";
 import { refreshPageChat, retireChatMetadataRequests } from "./chat-state-refresh.ts";
 import { resetChatViewState } from "./chat-view-state.ts";
-import { detailSlotOpen } from "./components/chat-detail-slot.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
 import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
-import { resolveSessionDiffSidebarContent } from "./components/chat-session-workspace.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
@@ -647,24 +645,6 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     const board = this.resolveBoardView();
     this.syncRetainedBoardSession(board);
     this.sessionPanelToggles.flush();
-    this.seedSessionDiffSidebar();
-  }
-
-  private seedSessionDiffSidebar(): void {
-    const state = this.state;
-    const detailOpen =
-      state?.sidebarLayout.open === true && detailSlotOpen(state.sidebarLayout) && this.presented;
-    if (!state || !detailOpen || state.sidebarContent !== null) {
-      return;
-    }
-    const content = resolveSessionDiffSidebarContent(state);
-    if (!content) {
-      return;
-    }
-    // The null check is the per-pane/session transition latch. Assign content
-    // only: activating or opening the panel would override user intent.
-    state.sidebarContent = content;
-    state.requestUpdate?.();
   }
 
   override disconnectedCallback() {

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -637,17 +637,17 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       chat,
       workspace: renderSessionWorkspaceRail(sessionWorkspace, { embedded: true }),
       tasks: renderBackgroundTasksRail(backgroundTasks, { embedded: true }),
-      detail: state.sidebarContent
-        ? renderChatDetailSlot({
-            backgroundTasks,
-            chat: props,
-            content: state.sidebarContent,
-            fullMessageLoader,
-            host: state,
-            layout: sidebarLayout,
-            transcript: this.taskSidebarTranscript,
-          })
-        : null,
+      detailOpen: this.presented && sidebarLayout.open === true && detailSlotOpen(sidebarLayout),
+      renderDetail: (content) =>
+        renderChatDetailSlot({
+          backgroundTasks,
+          chat: props,
+          content,
+          fullMessageLoader,
+          host: state,
+          layout: sidebarLayout,
+          transcript: this.taskSidebarTranscript,
+        }),
       digest: observerDigest ?? null,
       activeRunId: observerRunId ?? null,
       startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -90,6 +90,13 @@ type OpenRequest = {
 
 type SessionWorkspaceOpenRequest = OpenRequest;
 
+// Re-renders must preserve the document identity or the mounted diff panel
+// treats its loader as new and requests sessions.diff again.
+const sessionDiffSidebarContentByHost = new WeakMap<
+  SessionWorkspaceHost,
+  { content: SidebarContent; sessionKey: string }
+>();
+
 export type SessionWorkspaceHost = {
   sessionKey: string;
   sessions: SessionCapability;
@@ -743,7 +750,16 @@ export function resolveSessionDiffSidebarContent(
     Boolean(state.client) &&
     workspace.list?.sessionKey === state.sessionKey &&
     workspace.list.gitCheckout !== false;
-  return canOpenDiff ? buildSessionDiffSidebarContent(state) : null;
+  if (!canOpenDiff) {
+    return null;
+  }
+  const cached = sessionDiffSidebarContentByHost.get(state);
+  if (cached?.sessionKey === state.sessionKey) {
+    return cached.content;
+  }
+  const content = buildSessionDiffSidebarContent(state);
+  sessionDiffSidebarContentByHost.set(state, { content, sessionKey: state.sessionKey });
+  return content;
 }
 
 /** Sidebar payload whose loader refetches sessions.diff for the pane's session. */


### PR DESCRIPTION
## What Problem This Solves

PR #124824 gave the Review panel a default document — the session diff — by seeding it from the pane's
render lifecycle: `seedSessionDiffSidebar()`, called from `updated()`, assigning `state.sidebarContent`
whenever the detail slot was open with nothing loaded. That fixed the reported bug and is proven by five
e2e cases, but it left the behavior as a special case outside the contract: a render-lifecycle side effect
mutating shared pane state, with a `sidebarContent !== null` latch quietly doing double duty as both
"already seeded" and "keep the object identity stable".

Meanwhile #124950 and #125019 made every other aspect of a slot — availability, content, empty state,
header actions — part of one declaration. Review's default document was the last thing that wasn't.

## Why This Change Was Made

The `detail` slot now declares its own default document in `sidebarPanelDefinitions()` like every other
slot declares its content: explicit `sidebarContent` wins if the operator opened something, otherwise the
session diff resolves when the slot is genuinely open. `seedSessionDiffSidebar()`, its `updated()` call,
and its imports are deleted — no shim.

The non-obvious part is object identity. `buildSessionDiffSidebarContent()` mints a new object per call and
the mounted diff panel takes it as a property, so a resolver that recomputed on every render would hand the
panel a fresh loader each time and refetch `sessions.diff` in a loop. The old latch prevented that as a side
effect of seeding once. This PR makes it explicit: a `WeakMap` keyed by pane host caches the resolved
document with its `sessionKey`, so re-renders reuse identity and a session change rebuilds it. That
invariant carries an inline comment at the cache, because it is invisible at the call site.

Gating is preserved exactly: `detailOpen` is `presented && sidebarLayout.open && detailSlotOpen(layout)` —
the same three conditions the lifecycle hook checked. The panel is never auto-opened.

## User Impact

None. Same panel, same document, same conditions — the behavior from #124824 is unchanged; only its owner
moved.

## Evidence

The five e2e cases encoding #124824's behavior pass **unchanged** — the e2e diff is `+37 / −0`, pure
addition, so nothing was adjusted to fit: menu open, persisted-open reload, session switch replacing the
seeded diff, branch-chip open, and a non-git session issuing no request.

New guard for the identity hazard, since no existing test could have caught a refetch loop (they all assert
*what* renders, never *how many times* it fetched):

```
it("requests the default session diff once across subsequent pane renders")
```

It opens Review, asserts exactly one `sessions.diff` request, then forces further renders by opening another
panel and awaiting two animation frames, and asserts the count is still one.

```
 Test Files  3 passed (3)      Tests  13 passed (13)
 Test Files  1 passed (1)      Tests  15 passed (15)
```

`pnpm check:changed` green; Codex autoreview clean ("patch is correct").

**reviewMetrics — production vs test LOC**: production `+41 / −34` (net **+7**), tests `+37 / −0`. The
lifecycle hook's deletion offsets most of the resolver and cache; the remainder buys an explicit invariant
where there was an implicit one. Series running total: −17 (#124950) +11 (#125019) +7 here = **net −1** in
production, with four scattered sources now collapsed into one declaration.

No `CHANGELOG.md` edit — release-only per repo policy, and this step is behavior-neutral.
