### PR TITLE
fix(agents): show waiting reply when sessions_yield pauses a turn

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -1171,10 +1171,7 @@
     },
     "sessions_yield": {
       "emoji": "⏸️",
-      "title": "Yield",
-      "detailKeys": [
-        "message"
-      ]
+      "title": "Yield"
     },
     "tts": {
       "emoji": "🔊",

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -287,6 +287,12 @@ answer until those completions arrive.
 loops over `subagents`, `sessions_list`, `sessions_history`, shell
 `sleep`, or process polling just to detect child completion.
 
+Use the optional `message` field for private context that the resumed turn
+should receive. Use `acknowledgment` for a waiting reply when an interactive
+parent turn would otherwise end silently. The acknowledgment is not sent from
+sub-agent, heartbeat, silent, or message-tool-only turns, and it does not
+replace a reply or message already delivered during the turn.
+
 On native Codex harness turns, `wait_agent` keeps the current turn active and
 is reserved for an intentional same-turn wait when the immediate next step is
 blocked on the child. Use `sessions_yield` instead when a native child's result

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -291,7 +291,9 @@ Use the optional `message` field for private context that the resumed turn
 should receive. Use `acknowledgment` for a waiting reply when an interactive
 parent turn would otherwise end silently. The acknowledgment is not sent from
 sub-agent, heartbeat, or silent turns, and it does not replace a reply or
-message already delivered during the turn.
+message already delivered during the turn. This host-owned waiting status
+bypasses message-tool-only source suppression; ordinary model replies remain
+private unless the model sends them through the message tool.
 
 On native Codex harness turns, `wait_agent` keeps the current turn active and
 is reserved for an intentional same-turn wait when the immediate next step is

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -290,8 +290,8 @@ loops over `subagents`, `sessions_list`, `sessions_history`, shell
 Use the optional `message` field for private context that the resumed turn
 should receive. Use `acknowledgment` for a waiting reply when an interactive
 parent turn would otherwise end silently. The acknowledgment is not sent from
-sub-agent, heartbeat, silent, or message-tool-only turns, and it does not
-replace a reply or message already delivered during the turn.
+sub-agent, heartbeat, or silent turns, and it does not replace a reply or
+message already delivered during the turn.
 
 On native Codex harness turns, `wait_agent` keeps the current turn active and
 is reserved for an intentional same-turn wait when the immediate next step is

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -171,6 +171,32 @@ async function buildDynamicToolsForTest(
 }
 
 describe("Codex app-server dynamic tool build", () => {
+  it("forwards the explicit yield acknowledgment without exposing private context", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    let capturedOnYield:
+      | ((message: string, acknowledgment?: string) => Promise<void> | void)
+      | undefined;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      capturedOnYield = (options as { onYield?: typeof capturedOnYield }).onYield;
+      return [];
+    });
+    const onYieldDetected = vi.fn();
+
+    await buildDynamicToolsForTest(params, workspaceDir, {
+      sandbox: null as never,
+      onYieldDetected,
+    });
+    await expectDefined(capturedOnYield, "captured onYield callback")(
+      "Resume after the fact-checker replies",
+      "Research started; results will follow.",
+    );
+
+    expect(onYieldDetected).toHaveBeenCalledWith("Research started; results will follow.");
+  });
+
   it("binds a resolver-backed constructed tool surface exactly once", async () => {
     const workspaceDir = path.join(tempDir, "resolver-bound-workspace");
     const params = createParams(path.join(tempDir, "resolver-bound-session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -110,7 +110,7 @@ type DynamicToolBuildParams = {
   ignoreRuntimePlan?: boolean;
   /** Host fact resolver; injectable only for focused plugin contract tests. */
   isHostScopedToolActive?: (toolName: string) => boolean;
-  onYieldDetected: () => void;
+  onYieldDetected: (acknowledgment?: string) => void;
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
   onPersistentWebSearchPolicyResolved?: (allowed: boolean) => void;
   onWebSearchPolicyResolved?: (allowed: boolean) => void;
@@ -340,8 +340,8 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         forceMessageTool: shouldForceMessageTool(messagePolicyParams),
         enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
         forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
-        onYield: (message) => {
-          input.onYieldDetected();
+        onYield: (message, acknowledgment) => {
+          input.onYieldDetected(acknowledgment);
           input.onCodexAppServerEvent?.({
             stream: "codex_app_server.tool",
             data: { name: "sessions_yield", message },

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -481,6 +481,9 @@ export async function finalizeCodexAttempt(
   );
   const finalizedResult: EmbeddedRunAttemptResult = {
     ...result,
+    ...(toolState.yieldAcknowledgment
+      ? { yieldAcknowledgment: toolState.yieldAcknowledgment }
+      : {}),
     terminal: attemptTerminal.normalize({
       timedOut: effectiveTimedOut,
       aborted: finalAborted,

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -84,8 +84,14 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       },
     );
   }
-  const toolState = {
+  const toolState: {
+    yieldDetected: boolean;
+    yieldAcknowledgment?: string;
+    persistentWebSearchAllowed?: boolean;
+    webSearchAllowed: boolean;
+  } = {
     yieldDetected: false,
+    yieldAcknowledgment: undefined,
     persistentWebSearchAllowed: undefined as boolean | undefined,
     webSearchAllowed: false,
   };
@@ -202,8 +208,9 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           cronCreatorAuthorityUnavailableReason: "queued-local-operator-configured-mcp" as const,
         }
       : {}),
-    onYieldDetected: () => {
+    onYieldDetected: (acknowledgment: string | undefined) => {
       toolState.yieldDetected = true;
+      toolState.yieldAcknowledgment = acknowledgment;
     },
     onCodexAppServerEvent: (event: Parameters<typeof emitCodexAppServerEvent>[1]) => {
       void emitCodexAppServerEvent(params, event);

--- a/extensions/copilot/src/attempt-config.ts
+++ b/extensions/copilot/src/attempt-config.ts
@@ -60,6 +60,7 @@ export function createResult(
     toolMetas?: AgentHarnessAttemptResult["toolMetas"];
     usage?: AssistantUsageSnapshot;
     yieldDetected?: boolean;
+    yieldAcknowledgment?: string;
   },
 ): AttemptResultWithSdkSessionId {
   const promptError = state.promptError;
@@ -137,6 +138,7 @@ export function createResult(
     sessionIdUsed: state.sessionIdUsed ?? readNonEmptyString(params.sessionId) ?? "copilot-session",
     toolMetas,
     yieldDetected: state.yieldDetected === true,
+    ...(state.yieldAcknowledgment ? { yieldAcknowledgment: state.yieldAcknowledgment } : {}),
   };
 }
 export function createPromptError(

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -122,6 +122,7 @@ export async function runCopilotExecution(context: {
   let downgradedFromResume = false;
   let resumeFailureRecovered = false;
   let yieldDetected = false;
+  let yieldAcknowledgment: string | undefined;
   let lastToolError: AgentHarnessAttemptResult["lastToolError"];
   const hostObserveToolTerminal = input.observeToolTerminal;
   const observeToolTerminal = hostObserveToolTerminal
@@ -277,8 +278,9 @@ export async function runCopilotExecution(context: {
           attemptParams: observeToolTerminal ? { ...input, observeToolTerminal } : input,
           computerContextEpoch,
           sessionRef,
-          onYieldDetected: () => {
+          onYieldDetected: (_message, acknowledgment) => {
             yieldDetected = true;
+            yieldAcknowledgment = acknowledgment;
           },
           onToolCompleted: ({ args, error, result, startedAt, toolCallId, toolName }) =>
             runAgentHarnessAfterToolCallHook({
@@ -662,5 +664,6 @@ export async function runCopilotExecution(context: {
     timedOut,
     timedOutDuringCompaction,
     yieldDetected,
+    yieldAcknowledgment,
   });
 }

--- a/extensions/copilot/src/attempt-finalize.ts
+++ b/extensions/copilot/src/attempt-finalize.ts
@@ -45,6 +45,7 @@ export async function completeCopilotAttempt(params: {
   timedOut: boolean;
   timedOutDuringCompaction: boolean;
   yieldDetected: boolean;
+  yieldAcknowledgment?: string;
 }): Promise<AgentHarnessAttemptResult> {
   const {
     aborted,
@@ -73,6 +74,7 @@ export async function completeCopilotAttempt(params: {
     timedOut,
     timedOutDuringCompaction,
     yieldDetected,
+    yieldAcknowledgment,
   } = params;
   const snap = bridge?.snapshot();
   const assistantTexts = bridge?.finalizeAssistantTexts() ?? [];
@@ -133,6 +135,7 @@ export async function completeCopilotAttempt(params: {
     toolMetas: snap ? [...snap.toolMetas] : [],
     usage: snap?.usage,
     yieldDetected,
+    yieldAcknowledgment,
   });
   if (sentTurnStarted && !settledToolFinalization && !transcriptJournal?.hasFailed()) {
     runAgentHarnessLlmOutputHook({

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1862,15 +1862,17 @@ describe("runCopilotAttempt", () => {
   it("F7: result.yieldDetected is true when the tool bridge fires onYieldDetected during the attempt", async () => {
     const sdk = makeFakeSdk();
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async (input: { onYieldDetected?: (msg?: string) => void }) => {
-      // Simulate a wrapped tool invoking sessions_yield before the
-      // attempt settles. The bridge is responsible for notifying the
-      // caller via onYieldDetected so the final result can carry the
-      // flag (parent runner uses it to mark liveness paused /
-      // stop_reason end_turn). Mirrors PI/codex parity.
-      input.onYieldDetected?.("paused by tool");
-      return { sdkTools: [], sourceTools: [] };
-    });
+    const createToolBridge = vi.fn(
+      async (input: { onYieldDetected?: (message?: string, acknowledgment?: string) => void }) => {
+        // Simulate a wrapped tool invoking sessions_yield before the
+        // attempt settles. The bridge is responsible for notifying the
+        // caller via onYieldDetected so the final result can carry the
+        // flag (parent runner uses it to mark liveness paused /
+        // stop_reason end_turn). Mirrors PI/codex parity.
+        input.onYieldDetected?.("private continuation", "Research started; results will follow.");
+        return { sdkTools: [], sourceTools: [] };
+      },
+    );
 
     const result = await runCopilotAttempt(makeParams(), {
       createToolBridge,
@@ -1878,6 +1880,7 @@ describe("runCopilotAttempt", () => {
     });
 
     expect(result.yieldDetected).toBe(true);
+    expect(result.yieldAcknowledgment).toBe("Research started; results will follow.");
   });
 
   it("F7: result.yieldDetected is false on a clean attempt (no sessions_yield fired)", async () => {

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1136,15 +1136,15 @@ describe("createCopilotToolBridge", () => {
         sessionRef,
       });
 
-      const onYield = getOpts().onYield as (msg?: string) => void;
+      const onYield = getOpts().onYield as (message?: string, acknowledgment?: string) => void;
       // No session bound yet: onYield must no-op the abort path
       // without throwing, but the onYieldDetected notification fires
       // regardless so a yield before session-bind is still surfaced
       // to the final attempt result.
-      expect(() => onYield("early yield")).not.toThrow();
+      expect(() => onYield("early yield", "Starting research.")).not.toThrow();
       expect(abort).toHaveBeenCalledTimes(0);
       expect(onYieldDetected).toHaveBeenCalledTimes(1);
-      expect(onYieldDetected).toHaveBeenCalledWith("early yield");
+      expect(onYieldDetected).toHaveBeenCalledWith("early yield", "Starting research.");
 
       // Bind the session after the fact (attempt.ts does this after
       // createSession/resumeSession resolves) and verify subsequent
@@ -1153,7 +1153,7 @@ describe("createCopilotToolBridge", () => {
       onYield("now yield");
       expect(abort).toHaveBeenCalledTimes(1);
       expect(onYieldDetected).toHaveBeenCalledTimes(2);
-      expect(onYieldDetected).toHaveBeenLastCalledWith("now yield");
+      expect(onYieldDetected).toHaveBeenLastCalledWith("now yield", undefined);
     });
 
     it("onYield still aborts the live session when onYieldDetected throws (defense in depth)", async () => {
@@ -1176,7 +1176,7 @@ describe("createCopilotToolBridge", () => {
         sessionRef,
       });
 
-      const onYield = getOpts().onYield as (msg?: string) => void;
+      const onYield = getOpts().onYield as (message?: string, acknowledgment?: string) => void;
       expect(() => onYield("handler-fails-but-abort-must-fire")).not.toThrow();
       expect(abort).toHaveBeenCalledTimes(1);
       warn.mockRestore();

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -137,7 +137,7 @@ interface CopilotToolBridgeInput {
    * `src/agents/pi-embedded-runner/run/attempt.ts:1107-1113` and
    * `extensions/codex/src/app-server/run-attempt.ts:539-541`.
    */
-  onYieldDetected?: (message?: string) => void;
+  onYieldDetected?: (message?: string, acknowledgment?: string) => void;
   onToolCompleted?: (completion: CopilotToolCompletion) => void | Promise<void>;
   createOpenClawCodingTools?: CreateOpenClawCodingToolsForBridge;
   beforeExecute?: (ctx: {
@@ -480,7 +480,7 @@ function buildOpenClawCodingToolsOptions(
     // surface attempt-stage telemetry yet. Codex omits this too.
     onToolOutcome: a.onToolOutcome,
     isTurnTainted: a.isTurnTainted,
-    onYield: (message) => {
+    onYield: (message, acknowledgment) => {
       // Notify the caller first so the final attempt result can carry
       // yieldDetected even if the abort below races a concurrent
       // settle path. Errors thrown by the caller's handler must not
@@ -489,7 +489,7 @@ function buildOpenClawCodingToolsOptions(
       // calling abort) and codex (`onYieldDetected()` runs before the
       // run-abort controller fires).
       try {
-        input.onYieldDetected?.(message);
+        input.onYieldDetected?.(message, acknowledgment);
       } catch (error) {
         console.warn("[copilot-tool-bridge] onYieldDetected handler threw; continuing", error);
       }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -346,7 +346,7 @@ type OpenClawCodingToolsOptions = {
   /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
   authProfileStore?: AuthProfileStore;
   /** Callback invoked when sessions_yield tool is called. */
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
   /** Live observer called after wrapped tool outcomes are recorded. */

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -59,6 +59,7 @@ export type CliOutput = {
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
   yielded?: true;
+  yieldAcknowledgment?: string;
 };
 
 export type CliStreamingDelta = {

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -554,6 +554,7 @@ export function buildCliRunResult(params: {
         : {}),
       systemPromptReport: context.systemPromptReport,
       ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
+      ...(output.yieldAcknowledgment ? { yieldAcknowledgment: output.yieldAcknowledgment } : {}),
       executionTrace: {
         winnerProvider: runParams.provider,
         winnerModel: context.modelId,

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -70,6 +70,7 @@ type ActiveCliTool = {
 export function createCliToolTracking(context: PreparedCliRunContext) {
   let gatewayCaptureKey: string | undefined;
   let yielded = false;
+  let yieldAcknowledgment: string | undefined;
   let didSendViaMessagingTool = false;
   let didDeliverSourceReplyViaMessageTool = false;
   let inFlightUnclassifiedMcpRequests = 0;
@@ -336,8 +337,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       isMessagingToolDeliveryAction(normalizeCliMessagingToolName(toolName), toolArgs);
     beginMcpLoopbackToolCallCapture({
       captureKey,
-      onYield: () => {
+      onYield: (_message, acknowledgment) => {
         yielded = true;
+        yieldAcknowledgment = acknowledgment;
       },
       onRequestStart: () => {
         inFlightUnclassifiedMcpRequests += 1;
@@ -625,6 +627,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       return {
         ...output,
         ...(yielded ? { yielded: true as const } : {}),
+        ...(yieldAcknowledgment ? { yieldAcknowledgment } : {}),
         ...(current.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
         ...(current.didDeliverSourceReplyViaMessageTool
           ? { didDeliverSourceReplyViaMessageTool: true }

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -2120,7 +2120,10 @@ describe("executePreparedCliRun supervisor output capture", () => {
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
       const input = args[0] as SupervisorSpawnInput;
       const captureHandle = markMcpLoopbackRequestStarted(input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY);
-      await resolveMcpLoopbackYieldContext(captureHandle)?.onYield("waiting on subagents");
+      await resolveMcpLoopbackYieldContext(captureHandle)?.onYield(
+        "private continuation",
+        "Research started; results will follow.",
+      );
       markMcpLoopbackRequestFinished(captureHandle);
       input.onStdout?.("yield acknowledged");
       return createManagedRun({
@@ -2138,6 +2141,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
     const result = await executePreparedCliRun(context);
 
     expect(result.yielded).toBe(true);
+    expect(result.yieldAcknowledgment).toBe("Research started; results will follow.");
   });
 
   it("keeps mutation delivery out of sent-reply dedupe evidence", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
@@ -75,6 +75,7 @@ export type EmbeddedAttemptExecutionPhaseInput = {
       yieldAbortSettled: Promise<void> | null;
       yieldDetected: boolean;
       yieldMessage: string | null;
+      yieldAcknowledgment?: string;
     };
     setToolSearchCatalogExecutor: (
       executor: ReturnType<typeof prepareEmbeddedAttemptStream>["toolSearchCatalogExecutor"],

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -13,6 +13,8 @@ function completeResult(params?: {
     completed: boolean;
   }>;
   pendingToolMediaReply?: { mediaUrls?: string[]; audioAsVoice?: boolean };
+  yieldDetected?: boolean;
+  yieldAcknowledgment?: string;
   toolMetas?: Array<{
     toolName: string;
     meta?: string;
@@ -64,7 +66,8 @@ function completeResult(params?: {
       sessionIdUsed: "session-1",
       messagesSnapshot: [],
       successfulNestedToolNames: params?.successfulNestedToolNames,
-      yieldDetected: false,
+      yieldDetected: params?.yieldDetected ?? false,
+      yieldAcknowledgment: params?.yieldAcknowledgment,
       didDeliverSourceReplyViaMessageTool: false,
       diagnosticTrace: { traceId: "trace-1", spanId: "span-1" },
     } as never,
@@ -86,6 +89,18 @@ describe("attempt result projection", () => {
   it("projects the last recovered tool", () => {
     expect(completeResult({ lastToolRecovery: { toolName: "write" } }).lastToolRecovery).toEqual({
       toolName: "write",
+    });
+  });
+
+  it("carries the explicit yield acknowledgment separately from continuation context", () => {
+    expect(
+      completeResult({
+        yieldDetected: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      }),
+    ).toMatchObject({
+      yieldDetected: true,
+      yieldAcknowledgment: "Research started; results will follow.",
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -78,6 +78,7 @@ type EmbeddedAttemptResultState = Pick<
   | "promptCache"
   | "contextBudgetStatus"
   | "yieldDetected"
+  | "yieldAcknowledgment"
   | "didDeliverSourceReplyViaMessageTool"
 > & {
   diagnosticTrace: DiagnosticTraceContext;
@@ -435,6 +436,7 @@ export function completeEmbeddedAttemptResult(
     compactionTokensAfter: getLastCompactionTokensAfter(),
     clientToolCalls,
     yieldDetected: state.yieldDetected || undefined,
+    yieldAcknowledgment: state.yieldAcknowledgment,
   };
   return finalizeEmbeddedAttempt({
     result,

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -546,6 +546,7 @@ export async function runEmbeddedAttemptSettledPhase(
       promptCache: sessionRuntimeState.promptCache,
       contextBudgetStatus,
       yieldDetected: input.lifecycle.readYieldState().yieldDetected,
+      yieldAcknowledgment: input.lifecycle.readYieldState().yieldAcknowledgment,
       didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
     },
     clientToolCallSlots,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -198,9 +198,10 @@ export async function runEmbeddedAttempt(
           effectiveCwd,
           effectiveWorkspace,
           markCoreToolStage: (name) => corePluginToolStages.mark(name),
-          onYield: (message) => {
+          onYield: (message, acknowledgment) => {
             yieldDetected = true;
             yieldMessage = message;
+            yieldAcknowledgment = acknowledgment;
             queueYieldInterruptForSession?.();
             runAbortController.abort(SESSIONS_YIELD_ABORT_REASON);
             abortSessionForYield?.();
@@ -256,6 +257,7 @@ export async function runEmbeddedAttempt(
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
+    let yieldAcknowledgment: string | undefined;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
@@ -483,7 +485,12 @@ export async function runEmbeddedAttempt(
         diagnostics: { diagnosticTrace, runTrace },
         state: executionState,
         lifecycle: {
-          readYieldState: () => ({ yieldAbortSettled, yieldDetected, yieldMessage }),
+          readYieldState: () => ({
+            yieldAbortSettled,
+            yieldDetected,
+            yieldMessage,
+            yieldAcknowledgment,
+          }),
           setToolSearchCatalogExecutor: (executor) => {
             toolSearchCatalogExecutor = executor;
           },

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -634,6 +634,9 @@ function completeEmbeddedRun(
         livenessState,
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
         ...(input.attempt.yieldDetected ? { yielded: true } : {}),
+        ...(input.attempt.yieldAcknowledgment
+          ? { yieldAcknowledgment: input.attempt.yieldAcknowledgment }
+          : {}),
         ...(input.emptyAssistantReplyIsSilent
           ? { terminalReplyKind: "silent-empty" as const }
           : {}),

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -341,6 +341,8 @@ export type EmbeddedRunAttemptResult = {
   clientToolCalls?: Array<{ name: string; params: Record<string, unknown> }>;
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
+  /** Explicit user-facing waiting status supplied to sessions_yield. */
+  yieldAcknowledgment?: string;
   /**
    * True when code mode owned this attempt's model tool surface. Absent means
    * the harness did not report engagement (treated as not engaged), which is

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
@@ -99,6 +99,7 @@ describe("sessions_yield orchestration", () => {
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(
         makeAttemptResult({
           yieldDetected: true,
+          yieldAcknowledgment: "Research started; results will follow.",
           assistantTexts: [],
           acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "child-key" }],
         }),
@@ -113,6 +114,7 @@ describe("sessions_yield orchestration", () => {
       expect(result.payloads).toBeUndefined();
       expect(result.meta.stopReason).toBe("end_turn");
       expect(result.meta.yielded).toBe(true);
+      expect(result.meta.yieldAcknowledgment).toBe("Research started; results will follow.");
     });
 
     it("yield with async started tool — diagnostic suppressed", async () => {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -185,6 +185,8 @@ export type EmbeddedAgentRunMeta = {
   terminalReplyKind?: "silent-empty";
   terminalReply?: AgentRunTerminalReplySnapshot;
   yielded?: boolean;
+  /** Explicit user-facing waiting status supplied to sessions_yield. */
+  yieldAcknowledgment?: string;
   error?: {
     kind:
       | "context_overflow"

--- a/src/agents/openclaw-tools.media-yield.ts
+++ b/src/agents/openclaw-tools.media-yield.ts
@@ -6,7 +6,7 @@ const log = createSubsystemLogger("agents/tools/media-generation-yield");
 
 export function createMediaGenerationAsyncStartCallback(params: {
   sessionKey?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
 }): ((message: string) => void) | undefined {
   if (!params.onYield || (params.sessionKey && isCronRunSessionKey(params.sessionKey))) {
     return undefined;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -225,7 +225,7 @@ export function createOpenClawTools(
     /** Current runtime directory used as the default project for follow-up suggestions. */
     cwd?: string;
     /** Callback invoked when sessions_yield tool is called. */
-    onYield?: (message: string) => Promise<void> | void;
+    onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
   } & SpawnedToolContext &

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -590,7 +590,7 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "PDF",
       detailKeys: ["path", "paths", "url", "urls", "prompt", "pageRange", "model"],
     },
-    sessions_yield: { emoji: "⏸️", title: "Yield", detailKeys: ["message"] },
+    sessions_yield: { emoji: "⏸️", title: "Yield" },
     tts: { emoji: "🔊", title: "TTS", detailKeys: ["text", "channel"] },
   },
 };

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -55,6 +55,19 @@ describe("tool display details", () => {
     expect(formatToolDetail(display)).toBe("path /tmp/screenshot.png, prompt Inspect the error");
   });
 
+  it("keeps sessions_yield private context out of tool status", () => {
+    const display = resolveToolDisplay({
+      name: "sessions_yield",
+      args: {
+        message: "private resume context",
+        acknowledgment: "Public waiting status",
+      },
+    });
+
+    expect(formatToolSummary(display)).toBe("⏸️ Yield");
+    expect(formatToolDetail(display)).toBeUndefined();
+  });
+
   it("puts the camera PTZ operation before its node and device", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -6,6 +6,7 @@ import { createSessionsYieldTool } from "./sessions-yield-tool.js";
 type SessionsYieldDetails = {
   status?: string;
   message?: string;
+  acknowledgment?: string;
   error?: string;
 };
 
@@ -28,7 +29,7 @@ describe("sessions_yield tool", () => {
     expect(details.status).toBe("yielded");
     expect(details.message).toBe("Turn yielded.");
     expect(onYield).toHaveBeenCalledOnce();
-    expect(onYield).toHaveBeenCalledWith("Turn yielded.");
+    expect(onYield).toHaveBeenCalledWith("Turn yielded.", undefined);
   });
 
   it("passes the custom message through the yield callback", async () => {
@@ -41,7 +42,27 @@ describe("sessions_yield tool", () => {
     expect(details.status).toBe("yielded");
     expect(details.message).toBe("Waiting for fact-checker");
     expect(onYield).toHaveBeenCalledOnce();
-    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
+    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker", undefined);
+  });
+
+  it("keeps private context separate from the user-facing acknowledgment", async () => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const result = await tool.execute("call-1", {
+      message: "Resume after the fact-checker replies",
+      acknowledgment: "Research started; results will follow.",
+    });
+    const details = result.details as SessionsYieldDetails;
+
+    expect(details).toMatchObject({
+      status: "yielded",
+      message: "Resume after the fact-checker replies",
+      acknowledgment: "Research started; results will follow.",
+    });
+    expect(onYield).toHaveBeenCalledWith(
+      "Resume after the fact-checker replies",
+      "Research started; results will follow.",
+    );
   });
 
   it("persists yield intent before aborting the requester run", async () => {

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -8,14 +8,21 @@ import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readToolStringParam } from "./common.js";
 
 const SessionsYieldToolSchema = Type.Object({
-  message: Type.Optional(Type.String()),
+  message: Type.Optional(
+    Type.String({ description: "Private context for the resumed turn; not sent to the user." }),
+  ),
+  acknowledgment: Type.Optional(
+    Type.String({
+      description: "Optional waiting reply for an otherwise-silent interactive parent turn.",
+    }),
+  ),
 });
 
 /** Creates the sessions_yield tool for runtimes that support yield callbacks. */
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
   onBeforeYield?: () => Promise<void> | void;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
 }): AnyAgentTool {
   return {
     label: "Yield",
@@ -23,11 +30,13 @@ export function createSessionsYieldTool(opts?: {
     // Turn-lifecycle contract: spawn flows instruct the model to yield, so the
     // tool must stay visible even when tool search compacts the catalog.
     catalogMode: "direct-only",
-    description: "End turn after subagent spawn; results arrive next message.",
+    description:
+      "End turn after subagent spawn; results arrive next message. For an otherwise-silent interactive parent turn, acknowledgment can send a waiting reply.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const message = readToolStringParam(params, "message") || "Turn yielded.";
+      const acknowledgment = readToolStringParam(params, "acknowledgment") || undefined;
       if (!opts?.sessionId) {
         return jsonResult({ status: "error", error: "No session context" });
       }
@@ -36,8 +45,12 @@ export function createSessionsYieldTool(opts?: {
       }
       await opts.onBeforeYield?.();
       // The runtime owns the actual pause/end-turn behavior; this tool records intent.
-      await opts.onYield(message);
-      return jsonResult({ status: "yielded", message });
+      await opts.onYield(message, acknowledgment);
+      return jsonResult({
+        status: "yielded",
+        message,
+        ...(acknowledgment ? { acknowledgment } : {}),
+      });
     },
   };
 }

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -13,6 +13,7 @@ import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { buildFallbackClearedNotice, buildFallbackNotice } from "../fallback-state.js";
 import {
@@ -43,6 +44,7 @@ import { attachMcpConnectChannelAction } from "./mcp-connect-channel-action.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { resolveOriginMessageTo } from "./origin-routing.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
+import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 import { resolveStrandedReplyRecovery } from "./stranded-reply-recovery.js";
 type ReplyAgentAccounting = Awaited<ReturnType<typeof accountAgentTurn>>;
 
@@ -135,13 +137,35 @@ export async function prepareReplyAgentPayloads(state: {
   const fallbackFailureKnown =
     fallbackAttempts.length > 0 || configuredFallbackModel.persistedAutoFallback;
   const hasSpecificFallbackFailure = fallbackTransition.fallbackActive && fallbackFailureKnown;
+  const isInteractive =
+    followupRun.currentInboundEventKind !== "room_event" &&
+    (followupRun.run.inputProvenance?.kind === undefined ||
+      followupRun.run.inputProvenance.kind === "external_user");
+  const isMessageToolOnly =
+    (opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode) ===
+    "message_tool_only";
+  const yieldAcknowledgmentPayload = terminalFailurePayload
+    ? undefined
+    : buildSessionsYieldAcknowledgmentPayload({
+        yielded: runResult.meta?.yielded === true,
+        yieldAcknowledgment: runResult.meta?.yieldAcknowledgment,
+        isInteractive,
+        isHeartbeat,
+        silentExpected: followupRun.run.silentExpected,
+        isMessageToolOnly,
+        isSubagentSession: isSubagentSessionKey(sessionKey ?? followupRun.run.sessionKey),
+        hasExplicitSilentReply: deliberateSilentTerminalReply,
+        // Child spawns are side effects, not user-visible messages. They must not
+        // suppress the explicit waiting reply for the parent turn.
+        hasVisibleMessageDelivery:
+          successfulSourceReplyDelivery ||
+          committedMessagingToolSourceReplyDelivery ||
+          runResult.didSendDeterministicApprovalPrompt === true,
+      });
   const emptyInteractiveReplyPayload = terminalFailurePayload
     ? undefined
     : buildEmptyInteractiveReplyPayload({
-        isInteractive:
-          followupRun.currentInboundEventKind !== "room_event" &&
-          (followupRun.run.inputProvenance?.kind === undefined ||
-            followupRun.run.inputProvenance.kind === "external_user"),
+        isInteractive,
         isHeartbeat,
         silentExpected: followupRun.run.silentExpected,
         allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
@@ -355,6 +379,7 @@ export async function prepareReplyAgentPayloads(state: {
     payloadArray.length === 0 &&
     fallbackNoticePayloads.length === 0 &&
     !shouldDeliverTerminalFailure &&
+    !yieldAcknowledgmentPayload &&
     (!emptyInteractiveReplyPayload || hasSpecificFallbackFailure)
   ) {
     const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
@@ -392,6 +417,10 @@ export async function prepareReplyAgentPayloads(state: {
     const terminalPayloadResult = await buildFinalPayloads([terminalFailurePayload]);
     replyPayloads = [...replyPayloads, ...terminalPayloadResult.replyPayloads];
     didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
+  } else if (yieldAcknowledgmentPayload && !hasTerminalReplyPayload) {
+    const acknowledgmentResult = await buildFinalPayloads([yieldAcknowledgmentPayload]);
+    replyPayloads = [...replyPayloads, ...acknowledgmentResult.replyPayloads];
+    didLogHeartbeatStrip = acknowledgmentResult.didLogHeartbeatStrip;
   } else if (hasSpecificFallbackFailure && !hasTerminalReplyPayload) {
     const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
     if (silentFallbackFailurePayload) {

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -141,9 +141,6 @@ export async function prepareReplyAgentPayloads(state: {
     followupRun.currentInboundEventKind !== "room_event" &&
     (followupRun.run.inputProvenance?.kind === undefined ||
       followupRun.run.inputProvenance.kind === "external_user");
-  const isMessageToolOnly =
-    (opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode) ===
-    "message_tool_only";
   const yieldAcknowledgmentPayload = terminalFailurePayload
     ? undefined
     : buildSessionsYieldAcknowledgmentPayload({
@@ -152,7 +149,6 @@ export async function prepareReplyAgentPayloads(state: {
         isInteractive,
         isHeartbeat,
         silentExpected: followupRun.run.silentExpected,
-        isMessageToolOnly,
         isSubagentSession: isSubagentSessionKey(sessionKey ?? followupRun.run.sessionKey),
         hasExplicitSilentReply: deliberateSilentTerminalReply,
         // Child spawns are side effects, not user-visible messages. They must not

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -3857,6 +3857,57 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(onPendingContinuation).toHaveBeenCalledTimes(pendingContinuation ? 1 : 0);
   });
 
+  it("delivers an explicit yield acknowledgment after accepting a child spawn", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+      acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+    });
+    const onPendingContinuation = vi.fn();
+    const { run } = createMinimalRun({ opts: { onPendingContinuation } });
+
+    await expect(run()).resolves.toMatchObject({
+      text: "Research started; results will follow.",
+      replyToId: "msg",
+    });
+    expect(onPendingContinuation).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a visible final reply instead of adding a yield acknowledgment", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Research already finished." }],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+    });
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toMatchObject({
+      text: "Research already finished.",
+      replyToId: "msg",
+    });
+  });
+
+  it("delivers a yield acknowledgment when the only payload is filtered", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "internal reasoning", isReasoning: true }],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+    });
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toMatchObject({
+      text: "Research started; results will follow.",
+      replyToId: "msg",
+    });
+  });
+
   it.each([
     {
       label: "room event",
@@ -4292,6 +4343,52 @@ describe("runReplyAgent typing (heartbeat)", () => {
       expect(payload?.text).toContain("configured model backend lmstudio/gemma-4-e4b-it");
       expect(payload?.text).toContain("Fallback used openai/gpt-5.5");
       expect(payload?.text).toContain("no visible reply");
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
+  it("delivers an explicit yield acknowledgment from a fallback model", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+    });
+    const fallbackSpy = vi
+      .spyOn(modelFallbackModule, "runWithModelFallback")
+      .mockImplementationOnce(makeCompletedFallbackRunner());
+
+    try {
+      const { run } = createMinimalRun({
+        runOverrides: {
+          provider: "lmstudio",
+          model: "gemma-4-e4b-it",
+        },
+        sessionCtx: {
+          Provider: "discord",
+          OriginatingChannel: "discord",
+          MessageSid: "1503645939964055592",
+        },
+      });
+      const result = await run();
+      const payloads = Array.isArray(result) ? result : result ? [result] : [];
+
+      expect(payloads).toContainEqual(
+        expect.objectContaining({
+          text: "Research started; results will follow.",
+          replyToId: "1503645939964055592",
+        }),
+      );
+      expect(payloads).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            isError: true,
+            text: expect.stringContaining("no visible reply"),
+          }),
+        ]),
+      );
     } finally {
       fallbackSpy.mockRestore();
     }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -3876,6 +3876,25 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(onPendingContinuation).toHaveBeenCalledOnce();
   });
 
+  it("delivers an explicit yield acknowledgment in message-tool-only mode", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+    });
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    const result = await run();
+    const payload = Array.isArray(result) ? result[0] : result;
+
+    expect(payload).toMatchObject({ text: "Research started; results will follow." });
+    expect(getReplyPayloadMetadata(payload ?? {})?.deliverDespiteSourceReplySuppression).toBe(true);
+  });
+
   it("preserves a visible final reply instead of adding a yield acknowledgment", async () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "Research already finished." }],

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -448,6 +448,31 @@ function createAccounting(
 }
 
 describe("resolveFollowupDeliveryDecision", () => {
+  it("delivers a yield acknowledgment after accepting a child spawn", () => {
+    const execution = createSettledExecution();
+    if (execution.outcome.kind === "settled") {
+      execution.outcome.result.meta = {
+        durationMs: 0,
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      };
+      execution.outcome.result.acceptedSessionSpawns = [
+        { runId: "child", childSessionKey: "agent:main:child" },
+      ];
+    }
+
+    expect(
+      resolveFollowupDeliveryDecision({
+        turn: createTurn(),
+        execution,
+        accounting: createAccounting(),
+      }),
+    ).toMatchObject({
+      kind: "deliver",
+      payloads: [{ text: "Research started; results will follow." }],
+    });
+  });
+
   it("keeps ambient room-event finals silent", () => {
     const turn = createTurn({
       queued: {

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -473,8 +473,9 @@ describe("resolveFollowupDeliveryDecision", () => {
     });
   });
 
-  it("delivers a yield acknowledgment in message-tool-only mode", () => {
+  it("delivers a yield acknowledgment in configured group message-tool-only mode", () => {
     const turn = createTurn();
+    turn.queued.originatingChatType = "group";
     turn.queued.run.sourceReplyDeliveryMode = "message_tool_only";
     const execution = createSettledExecution();
     if (execution.outcome.kind === "settled") {

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -473,6 +473,30 @@ describe("resolveFollowupDeliveryDecision", () => {
     });
   });
 
+  it("delivers a yield acknowledgment in message-tool-only mode", () => {
+    const turn = createTurn();
+    turn.queued.run.sourceReplyDeliveryMode = "message_tool_only";
+    const execution = createSettledExecution();
+    if (execution.outcome.kind === "settled") {
+      execution.outcome.result.meta = {
+        durationMs: 0,
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      };
+    }
+
+    expect(
+      resolveFollowupDeliveryDecision({
+        turn,
+        execution,
+        accounting: createAccounting(),
+      }),
+    ).toMatchObject({
+      kind: "deliver",
+      payloads: [{ text: "Research started; results will follow." }],
+    });
+  });
+
   it("keeps ambient room-event finals silent", () => {
     const turn = createTurn({
       queued: {

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -4,11 +4,13 @@ import {
   hasCommittedSourceReplyDeliveryEvidence,
   hasCompletedSourceReplyDeliveryEvidence,
   hasCompletedTerminalDeliveryEvidence,
+  hasVisibleCommittedMessagingToolDeliveryEvidence,
   hasVisibleOutboundDeliveryEvidence,
 } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import { hasDeliberateSilentTerminalReply } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { buildAgentRuntimeDeliveryPlan } from "../../agents/runtime-plan/build.js";
 import { logVerbose } from "../../globals.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
@@ -31,6 +33,7 @@ import { warnPrivateMessageToolFinal } from "./private-message-tool-final.js";
 import { enqueueFollowupRun, resolveQueueSettings, type FollowupRun } from "./queue.js";
 import type { ReplyDispatchKind } from "./reply-dispatcher.types.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
+import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import {
   buildStrandedReplyDeliveryFailurePayload,
@@ -207,7 +210,24 @@ export function resolveFollowupDeliveryDecision(params: {
         ? markReplyPayloadForSourceSuppressionDelivery(accounting.terminalFailurePayload)
         : accounting.terminalFailurePayload
       : undefined
-    : buildEmptyInteractiveReplyPayload({
+    : (buildSessionsYieldAcknowledgmentPayload({
+        yielded: result.meta?.yielded === true,
+        yieldAcknowledgment: result.meta?.yieldAcknowledgment,
+        isInteractive,
+        isHeartbeat: opts?.isHeartbeat,
+        silentExpected: turn.queued.run.silentExpected,
+        isMessageToolOnly: sourcePolicy.sourceReplyDeliveryMode === "message_tool_only",
+        isSubagentSession:
+          turn.session.kind === "session" && isSubagentSessionKey(turn.session.key),
+        hasExplicitSilentReply: hasDeliberateSilentTerminalReply(result),
+        // Child spawns are side effects, not user-visible messages. They must not
+        // suppress the explicit waiting reply for the parent turn.
+        hasVisibleMessageDelivery:
+          hasCommittedSourceReplyDeliveryEvidence(result) ||
+          hasVisibleCommittedMessagingToolDeliveryEvidence(result) ||
+          result.didSendDeterministicApprovalPrompt === true,
+      }) ??
+      buildEmptyInteractiveReplyPayload({
         isInteractive,
         isHeartbeat: opts?.isHeartbeat,
         silentExpected: turn.queued.run.silentExpected,
@@ -223,7 +243,7 @@ export function resolveFollowupDeliveryDecision(params: {
           Surface: turn.queued.originatingChannel,
         },
         cfg: turn.config,
-      });
+      }));
   const hasTerminalPayload = payloads.some(
     (payload) =>
       payload.isReasoning !== true &&

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -216,7 +216,6 @@ export function resolveFollowupDeliveryDecision(params: {
         isInteractive,
         isHeartbeat: opts?.isHeartbeat,
         silentExpected: turn.queued.run.silentExpected,
-        isMessageToolOnly: sourcePolicy.sourceReplyDeliveryMode === "message_tool_only",
         isSubagentSession:
           turn.session.kind === "session" && isSubagentSessionKey(turn.session.key),
         hasExplicitSilentReply: hasDeliberateSilentTerminalReply(result),

--- a/src/auto-reply/reply/sessions-yield-acknowledgment.test.ts
+++ b/src/auto-reply/reply/sessions-yield-acknowledgment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 
 describe("buildSessionsYieldAcknowledgmentPayload", () => {
@@ -6,16 +7,18 @@ describe("buildSessionsYieldAcknowledgmentPayload", () => {
     yielded: true,
     yieldAcknowledgment: " Research started; results will follow. ",
     isInteractive: true,
-    isMessageToolOnly: false,
     isSubagentSession: false,
     hasExplicitSilentReply: false,
     hasVisibleMessageDelivery: false,
   } as const;
 
   it("builds an explicit waiting status", () => {
-    expect(buildSessionsYieldAcknowledgmentPayload(baseParams)).toEqual({
+    const payload = buildSessionsYieldAcknowledgmentPayload(baseParams);
+
+    expect(payload).toEqual({
       text: "Research started; results will follow.",
     });
+    expect(getReplyPayloadMetadata(payload ?? {})?.deliverDespiteSourceReplySuppression).toBe(true);
   });
 
   it.each([
@@ -24,7 +27,6 @@ describe("buildSessionsYieldAcknowledgmentPayload", () => {
     { label: "internal turn", overrides: { isInteractive: false } },
     { label: "heartbeat", overrides: { isHeartbeat: true } },
     { label: "silent turn", overrides: { silentExpected: true } },
-    { label: "message-tool-only turn", overrides: { isMessageToolOnly: true } },
     { label: "subagent session", overrides: { isSubagentSession: true } },
     { label: "explicit silent reply", overrides: { hasExplicitSilentReply: true } },
     { label: "visible message delivery", overrides: { hasVisibleMessageDelivery: true } },

--- a/src/auto-reply/reply/sessions-yield-acknowledgment.test.ts
+++ b/src/auto-reply/reply/sessions-yield-acknowledgment.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
+
+describe("buildSessionsYieldAcknowledgmentPayload", () => {
+  const baseParams = {
+    yielded: true,
+    yieldAcknowledgment: " Research started; results will follow. ",
+    isInteractive: true,
+    isMessageToolOnly: false,
+    isSubagentSession: false,
+    hasExplicitSilentReply: false,
+    hasVisibleMessageDelivery: false,
+  } as const;
+
+  it("builds an explicit waiting status", () => {
+    expect(buildSessionsYieldAcknowledgmentPayload(baseParams)).toEqual({
+      text: "Research started; results will follow.",
+    });
+  });
+
+  it.each([
+    { label: "non-yielded turn", overrides: { yielded: false } },
+    { label: "missing acknowledgment", overrides: { yieldAcknowledgment: undefined } },
+    { label: "internal turn", overrides: { isInteractive: false } },
+    { label: "heartbeat", overrides: { isHeartbeat: true } },
+    { label: "silent turn", overrides: { silentExpected: true } },
+    { label: "message-tool-only turn", overrides: { isMessageToolOnly: true } },
+    { label: "subagent session", overrides: { isSubagentSession: true } },
+    { label: "explicit silent reply", overrides: { hasExplicitSilentReply: true } },
+    { label: "visible message delivery", overrides: { hasVisibleMessageDelivery: true } },
+  ])("suppresses the status for a $label", ({ overrides }) => {
+    expect(
+      buildSessionsYieldAcknowledgmentPayload({ ...baseParams, ...overrides }),
+    ).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/sessions-yield-acknowledgment.ts
+++ b/src/auto-reply/reply/sessions-yield-acknowledgment.ts
@@ -1,0 +1,29 @@
+import type { ReplyPayload } from "../types.js";
+
+export function buildSessionsYieldAcknowledgmentPayload(params: {
+  yielded: boolean;
+  yieldAcknowledgment?: string;
+  isInteractive: boolean;
+  isHeartbeat?: boolean;
+  silentExpected?: boolean;
+  isMessageToolOnly: boolean;
+  isSubagentSession: boolean;
+  hasExplicitSilentReply: boolean;
+  hasVisibleMessageDelivery: boolean;
+}): ReplyPayload | undefined {
+  const text = params.yieldAcknowledgment?.trim();
+  if (
+    !params.yielded ||
+    !text ||
+    !params.isInteractive ||
+    params.isHeartbeat === true ||
+    params.silentExpected === true ||
+    params.isMessageToolOnly ||
+    params.isSubagentSession ||
+    params.hasExplicitSilentReply ||
+    params.hasVisibleMessageDelivery
+  ) {
+    return undefined;
+  }
+  return { text };
+}

--- a/src/auto-reply/reply/sessions-yield-acknowledgment.ts
+++ b/src/auto-reply/reply/sessions-yield-acknowledgment.ts
@@ -1,3 +1,4 @@
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 export function buildSessionsYieldAcknowledgmentPayload(params: {
@@ -6,7 +7,6 @@ export function buildSessionsYieldAcknowledgmentPayload(params: {
   isInteractive: boolean;
   isHeartbeat?: boolean;
   silentExpected?: boolean;
-  isMessageToolOnly: boolean;
   isSubagentSession: boolean;
   hasExplicitSilentReply: boolean;
   hasVisibleMessageDelivery: boolean;
@@ -18,12 +18,11 @@ export function buildSessionsYieldAcknowledgmentPayload(params: {
     !params.isInteractive ||
     params.isHeartbeat === true ||
     params.silentExpected === true ||
-    params.isMessageToolOnly ||
     params.isSubagentSession ||
     params.hasExplicitSilentReply ||
     params.hasVisibleMessageDelivery
   ) {
     return undefined;
   }
-  return { text };
+  return markReplyPayloadForSourceSuppressionDelivery({ text });
 }

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -24,7 +24,7 @@ export type McpLoopbackToolCallStart = Pick<McpLoopbackToolCallResult, "toolName
 
 type McpLoopbackToolCallCapture = {
   generation: number;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   onRequestStart?: () => void;
   onRequestClassified?: () => void;
   onRequestFinish?: () => void;
@@ -88,7 +88,7 @@ function notifyMcpLoopbackToolCallCaptureActivity(capture: McpLoopbackToolCallCa
 /** Start loopback tool-call result capture for one serialized CLI invocation. */
 export function beginMcpLoopbackToolCallCapture(params: {
   captureKey: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   onRequestStart?: () => void;
   onRequestClassified?: () => void;
   onRequestFinish?: () => void;
@@ -124,15 +124,20 @@ export function beginMcpLoopbackToolCallCapture(params: {
 /** Resolve yield state bound to the request's admitted CLI capture generation. */
 export function resolveMcpLoopbackYieldContext(
   captureHandle: McpLoopbackRequestCaptureHandle | undefined,
-): { cacheKey: string; onYield: (message: string) => Promise<void> } | undefined {
+):
+  | {
+      cacheKey: string;
+      onYield: (message: string, acknowledgment?: string) => Promise<void>;
+    }
+  | undefined {
   const capture = captureHandle?.capture;
   if (!capture?.onYield) {
     return undefined;
   }
   return {
     cacheKey: String(capture.generation),
-    onYield: async (message: string) => {
-      await capture.onYield?.(message);
+    onYield: async (message: string, acknowledgment?: string) => {
+      await capture.onYield?.(message, acknowledgment);
     },
   };
 }

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -39,7 +39,7 @@ type McpLoopbackScopeParams = Omit<McpLoopbackRequestContext, "senderIsOwner"> &
   grantToken?: string;
   senderIsOwner: boolean | undefined;
   yieldContextCacheKey?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
 };
 
 type LoopbackToolsAllowMode = "exact" | "policy";

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1610,10 +1610,18 @@ describe("mcp loopback server", () => {
               if (!call.onYield) {
                 throw new Error("Yield not supported in this context");
               }
-              const message = (args as { message?: string }).message ?? "Turn yielded.";
-              await call.onYield(message);
+              const { message = "Turn yielded.", acknowledgment } = args as {
+                message?: string;
+                acknowledgment?: string;
+              };
+              await call.onYield(message, acknowledgment);
               return {
-                content: [{ type: "text", text: JSON.stringify({ status: "yielded", message }) }],
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ status: "yielded", message, acknowledgment }),
+                  },
+                ],
               };
             },
           }),
@@ -1626,7 +1634,8 @@ describe("mcp loopback server", () => {
     const sendYield = async (
       captureKey: string,
       message: string,
-      onYield: (message: string) => void,
+      acknowledgment: string,
+      onYield: (message: string, acknowledgment?: string) => void,
     ) => {
       beginMcpLoopbackToolCallCapture({
         captureKey,
@@ -1636,7 +1645,7 @@ describe("mcp loopback server", () => {
       return await sendLoopbackToolCall({
         token: runtime.ownerToken,
         name: "sessions_yield",
-        args: { message },
+        args: { message, acknowledgment },
         headers: {
           "x-session-key": "agent:main:main",
           "x-openclaw-session-id": "session-reused",
@@ -1646,11 +1655,13 @@ describe("mcp loopback server", () => {
     };
 
     const captureKey = "capture-reused";
-    expect((await sendYield(captureKey, "first yield", firstYield)).status).toBe(200);
-    expect((await sendYield(captureKey, "second yield", secondYield)).status).toBe(200);
+    expect((await sendYield(captureKey, "first yield", "First wait", firstYield)).status).toBe(200);
+    expect((await sendYield(captureKey, "second yield", "Second wait", secondYield)).status).toBe(
+      200,
+    );
 
-    expect(firstYield).toHaveBeenCalledWith("first yield");
-    expect(secondYield).toHaveBeenCalledWith("second yield");
+    expect(firstYield).toHaveBeenCalledWith("first yield", "First wait");
+    expect(secondYield).toHaveBeenCalledWith("second yield", "Second wait");
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -241,12 +241,14 @@ describe("resolveGatewayScopedTools", () => {
 
     const toolResult = await yieldTool.execute("tool-call-1", {
       message: "waiting on subagents",
+      acknowledgment: "I’m waiting on the subagents.",
     });
 
-    expect(onYield).toHaveBeenCalledWith("waiting on subagents");
+    expect(onYield).toHaveBeenCalledWith("waiting on subagents", "I’m waiting on the subagents.");
     expect(toolResult.details).toEqual({
       status: "yielded",
       message: "waiting on subagents",
+      acknowledgment: "I’m waiting on the subagents.",
     });
   });
 });

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -75,7 +75,7 @@ export function resolveGatewayScopedTools(params: {
   modelProvider?: string;
   modelId?: string;
   modelHasVision?: boolean;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   messageProvider?: string;
   currentChannelId?: string;
   currentThreadTs?: string;

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -45,10 +45,15 @@
           "type": "function"
         },
         {
-          "description": "End turn after subagent spawn; results arrive next message.",
+          "description": "End turn after subagent spawn; results arrive next message. For an otherwise-silent interactive parent turn, acknowledgment can send a waiting reply.",
           "inputSchema": {
             "properties": {
+              "acknowledgment": {
+                "description": "Optional waiting reply for an otherwise-silent interactive parent turn.",
+                "type": "string"
+              },
               "message": {
+                "description": "Private context for the resumed turn; not sent to the user.",
                 "type": "string"
               }
             },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1351,10 +1351,15 @@
     "name": "openclaw_direct",
     "tools": [
       {
-        "description": "End turn after subagent spawn; results arrive next message.",
+        "description": "End turn after subagent spawn; results arrive next message. For an otherwise-silent interactive parent turn, acknowledgment can send a waiting reply.",
         "inputSchema": {
           "properties": {
+            "acknowledgment": {
+              "description": "Optional waiting reply for an otherwise-silent interactive parent turn.",
+              "type": "string"
+            },
             "message": {
+              "description": "Private context for the resumed turn; not sent to the user.",
               "type": "string"
             }
           },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53001,
-    "roughTokens": 13251
+    "chars": 53365,
+    "roughTokens": 13342
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81865,
-    "roughTokens": 20467
+    "chars": 82229,
+    "roughTokens": 20558
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52693,
-    "roughTokens": 13174
+    "chars": 53057,
+    "roughTokens": 13265
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80077,
-    "roughTokens": 20020
+    "chars": 80441,
+    "roughTokens": 20111
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54250,
-    "roughTokens": 13563
+    "chars": 54614,
+    "roughTokens": 13654
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82050,
-    "roughTokens": 20513
+    "chars": 82414,
+    "roughTokens": 20604
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
Closes #107788

## What Problem This Solves

Fixes an issue where a parent agent could accept background work, call `sessions_yield`, and leave an interactive user with no visible waiting status until the child completed.

## Why This Change Was Made

`sessions_yield.message` remains private resume context. A separate optional `acknowledgment` now crosses the embedded, Codex, Copilot, and CLI result contracts and is delivered by the shared direct/queued reply owners only when the interactive parent turn would otherwise be silent. Existing visible replies, message-tool sends, terminal failures, silent turns, heartbeats, and sub-agent turns retain precedence.

Explicit product direction for this bug fix: the acknowledgment is a host-owned waiting status, so it bypasses `message_tool_only` source suppression in direct and group interactive turns. Ordinary model replies remain private and still require the message tool. Focused coverage locks both the forced direct and configured group policies.

Codex dynamic-tool results return to model state rather than channel delivery; OpenClaw therefore owns this projection. Verified against adjacent `openai/codex@94937de51ba28d4b308dbe1b8472d6fe1dddad28` in `dynamic.rs:135-161`, `bespoke_event_handling.rs:992-1016`, and `dynamic_tools.rs:18-56`.

## User Impact

Agents can explicitly acknowledge accepted background work immediately, while keeping private continuation context out of the chat. The eventual child result and parent continuation remain unchanged.

The `sessions_yield` tool-status renderer no longer includes the private `message` argument; live Telegram proof caught that transient progress-revision leak before final review.

## Evidence

- Pre-fix owner-boundary regression: expected `Research started; results will follow.`, received `undefined` after an accepted child spawn.
- Final focused E2E: 5 passed (`accepted spawn`, message-tool-only delivery, visible-final precedence, filtered-only fallback, fallback-model yield).
- Runtime bridge/owner suite: 434 passed across core, auto-reply, embedded, CLI, Codex, and Copilot shards.
- Tool-display privacy regression: 75 passed; private resume context produces only the generic `⏸️ Yield` status.
- ClawSweeper review on patch-identical pre-rebase head `a1542d51d656ac9cf54151b302aea6ba42761665`: patch correct; 0 findings; 0 security concerns; no maintainer decision; 0 Rank-up moves. Report: `/home/obviyus/Developer/clawsweeper/artifacts/local-review-125106-gpt-5-6-terra-a1542d51-20260817T075228.526Z/125106.md`.
- Final real-user Telegram trace on `a1542d51d656ac9cf54151b302aea6ba42761665`: provider lifecycle complete; acknowledgment visible before child completion; final visible; private context absent from every message/edit revision; `issueReproduced: false`. Local artifacts: `/tmp/telegram-yield-land.QGvUvg`.
- `CI=1 pnpm check:changed --staged --timed`: passed all selected format, ratchet, boundary, dead-export, typecheck, lint, schema, and import-cycle checks.
- `pnpm tsgo && pnpm check:test-types`: passed.
- Unrelated baseline defect: the full owner file's CLI cumulative-usage assertion receives `42000`; the exact `origin/main` base reproduces the same isolated failure.
- Distill: clean. Greybeard: clean.

Production delta: +170/-33. The positive delta is the new explicit acknowledgment contract propagated through four runtime harnesses plus the two canonical reply owners; no channel/provider special case or compatibility path was added.

## Final-head landing note

- Exact rebased head: `e88fdbb6586c9bd92b5fdeec6f874c55bdb97de3`.
- Rebased local proof: 901/901 focused tests; 6/6 changed-path E2E; format and core typecheck passed.
- Full owner E2E: 152/153 passed; only the documented main-reproduced CLI cumulative-usage assertion failed (`42000` vs `undefined`).
- Maintainer direction: waive only the unrelated Control UI gzip budget failure if every other exact-head CI check passes. The PR changes no Control UI source; the prior exact-head failure was 339,568 B versus a 339,297 B limit.
\n- Additional maintainer direction: Apple platform jobs are unrelated to this agent-only patch and are waived; do not wait on runner capacity. All completed exact-head checks pass.\n
- Final rebased head: `fd39045ca42dc0853bb438121a54fb3bb4006e60`; snapshot-only conflict resolution regenerated from source.
- Required sibling Codex source personally rechecked at `94937de51ba28d4b308dbe1b8472d6fe1dddad28`: `codex-rs/core/src/tools/handlers/dynamic.rs:135-220`, `codex-rs/core/src/session/mod.rs:2915-2937`, and `codex-rs/protocol/src/dynamic_tools.rs:47-78`. Dynamic-tool content returns through the pending call to model state; channel projection remains OpenClaw-owned.
- Final rebase proof: prompt snapshots current; format clean; changed-path E2E 6/6.

- Final exact-head status after the snapshot-only rebase: every substantive non-platform check completed green, including agent-runtime, all security shards, node/type/lint/boundary checks, and SQLite lifecycle. Maintainer waiver applies to remaining Apple/Android runner jobs; workflow metadata `dispatch`/`label` cancellations are non-test orchestration.
