### PR TITLE
docs(gateway): record why Control UI admission exemptions exist

### DIFF
--- a/src/gateway/server/ws-connection/control-ui-build-admission.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.ts
@@ -9,6 +9,14 @@ type ControlUiBuildMismatch = {
 /**
  * The Gateway owns bundled same-origin UI admission. Browser code still owns
  * reload, but an older document must never become an RPC-capable session.
+ *
+ * The exemptions are deliberate, not gaps (ui/AGENTS.md "Gateway Coupling"):
+ * configured roots serve a non-dist build by definition, "dev" is the ui:dev
+ * sentinel, and cross-origin stays exempt because build ids embed the build
+ * timestamp — version-identical source-built installs carry different ids, so
+ * equality would reject matched pairings, and "reload" cannot remediate a
+ * client the Gateway did not serve. Exempted skew fails visibly at the first
+ * missing method instead.
  */
 export function resolveControlUiBuildMismatch(params: {
   clientId: string;

--- a/src/gateway/server/ws-connection/control-ui-build-admission.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.ts
@@ -11,12 +11,12 @@ type ControlUiBuildMismatch = {
  * reload, but an older document must never become an RPC-capable session.
  *
  * The exemptions are deliberate, not gaps (ui/AGENTS.md "Gateway Coupling"):
- * configured roots serve a non-dist build by definition, "dev" is the ui:dev
- * sentinel, and cross-origin stays exempt because build ids embed the build
- * timestamp — version-identical source-built installs carry different ids, so
- * equality would reject matched pairings, and "reload" cannot remediate a
- * client the Gateway did not serve. Exempted skew fails visibly at the first
- * missing method instead.
+ * configured roots serve an independently built artifact the Gateway owns no
+ * matching build identity for, "dev" is the ui:dev sentinel, and cross-origin
+ * stays exempt because build ids embed the build timestamp — version-identical
+ * source-built installs carry different ids, so equality would reject matched
+ * pairings, and "reload" cannot remediate a client the Gateway did not serve.
+ * Exempted skew fails visibly at the first missing method instead.
  */
 export function resolveControlUiBuildMismatch(params: {
   clientId: string;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #124971 closing its review loop. ClawSweeper twice proposed making the connect-time admission check reject the exempted pairings (dev builds, configured `gateway.controlUi.root`, cross-origin connections), because nothing in the code recorded why those exemptions are deliberate. This chip evaluated enforcement properly; the decisive facts were owner-confirmed skips, but they lived only in PR comments — reviewer context that evaporates.

## Why This Change Was Made

The evaluation result, now recorded as an invariant comment at the admission owner:

- **Configured roots** serve a non-dist build by definition; strict comparison would always reject and delete the feature.
- **`dev`** is the `ui:dev` sentinel — enforcement is impossible and the workflow is deliberate.
- **Cross-origin** is the load-bearing case: `buildId` embeds the build timestamp (`version-commit-builtAt`, see `dist/build-info.json`), so two *version-identical, commit-identical* source-built installs carry different ids. Cross-origin equality enforcement would hard-reject matched pairings — the common self-hosted source-built topology — and the rejection's "reload this page" guidance cannot remediate a client the Gateway did not serve.

Exempted skew fails visibly at the first missing method instead (the behavior #124971 established), per the `ui/AGENTS.md` "Gateway Coupling" rule.

## User Impact

None — comment-only. The change prevents recurring review churn proposing enforcement that the derivation facts rule out.

## Evidence

Every pairing is already contract-tested: the unit table in `control-ui-build-admission.test.ts` covers exact-match admitted, same-origin stale rejected (with normalized-host and explicit-port variants), differing-port/configured-root/separately-hosted/dev/absent-build admitted, non-Control-UI ignored; `message-handler.control-ui-build-admission.test.ts` covers admission over a real WebSocket connect. No test changes needed — the chip's "focused connect-session tests for each pairing" already ship. Production LOC +8/−0, all comment lines.
