### PR TITLE
fix(cli): honor channel resolve agent ownership

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -40,7 +40,7 @@ it does not guess one agent workspace.
 
 - `channels status`: `--channel <name>`, `--probe`, `--timeout <ms>` (default `10000`), `--json`
 - `channels capabilities`: `--channel <name>`, `--account <id>` (requires `--channel`), `--target <dest>` (requires `--channel`), `--timeout <ms>` (default `10000`, capped at `30000`), `--json`
-- `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--kind <auto|user|group>` (default `auto`), `--json`
+- `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--agent <id>`, `--kind <auto|user|group|channel>` (default `auto`), `--json`
 - `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--json`
 
 `channels status --probe` is the live path: on a reachable gateway it runs per-account
@@ -202,11 +202,14 @@ Resolve channel/user names to IDs using the provider directory:
 openclaw channels resolve --channel slack "#general" "@jane"
 openclaw channels resolve --channel discord "My Server/#support" "@someone"
 openclaw channels resolve --channel matrix "Project Room"
+openclaw channels --agent ops resolve --channel slack "#general"
+openclaw channels resolve --agent ops --channel slack "#general"
 ```
 
 Notes:
 
-- Use `--kind user|group|auto` to force the target type.
+- In multi-agent configurations, use `--agent <id>` in either parent or leaf position to select the agent-owned workspace and channel plugin context.
+- Use `--kind user|group|channel|auto` to force the target type.
 - Resolution prefers active matches when multiple entries share the same name.
 - `channels resolve` is read-only. If a selected account is configured via SecretRef but that credential is unavailable in the current command path, the command returns degraded unresolved results with notes instead of aborting the entire run.
 - `channels resolve` does not install channel plugins. Use `channels add --channel <name>` before resolving names for an installable catalog channel.

--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -107,6 +107,21 @@ describe("registerChannelsCli", () => {
     },
   );
 
+  it.each([
+    ["parent", ["channels", "--agent", "ops", "resolve", "room"]],
+    ["leaf", ["channels", "resolve", "--agent", "ops", "room"]],
+  ])("forwards the %s --agent option to channel resolution", async (_label, args) => {
+    const program = new Command().name("openclaw").enablePositionalOptions().exitOverride();
+
+    await registerChannelsCli(program, ["node", "openclaw", ...args]);
+    await program.parseAsync(args, { from: "user" });
+
+    expect(channelsResolveCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "ops", entries: ["room"] }),
+      runtimeMock,
+    );
+  });
+
   it("rejects unsupported resolve target kinds before dispatching", async () => {
     const writeErr = vi.fn();
     const program = new Command().name("openclaw").exitOverride().configureOutput({ writeErr });

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -236,7 +236,9 @@ export async function registerChannelsCli(
         const agentSource = command.getOptionValueSource("agent");
         const agent =
           agentSource && agentSource !== "default"
-            ? (opts.agent as string | undefined)
+            ? typeof opts.agent === "string"
+              ? opts.agent
+              : undefined
             : inheritOptionFromParent<string>(command, "agent");
         await channelsResolveCommand(
           {

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -17,7 +17,7 @@ import {
   type ChannelSetupCliOption,
 } from "./channels-cli-add-args.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
-import { hasExplicitOptions } from "./command-options.js";
+import { hasExplicitOptions, inheritOptionFromParent } from "./command-options.js";
 import { formatHelpExamples } from "./help-format.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
@@ -156,6 +156,7 @@ export async function registerChannelsCli(
   const channels = program
     .command("channels")
     .description("Manage connected chat channels and accounts")
+    .option("--agent <id>", "Agent owner for channel commands that require workspace context")
     .addHelpText(
       "after",
       () =>
@@ -222,17 +223,24 @@ export async function registerChannelsCli(
     .argument("<entries...>", "Entries to resolve (names or ids)")
     .option("--channel <name>", `Channel (${channelNames})`)
     .option("--account <id>", "Account id (accountId)")
+    .option("--agent <id>", "Agent owner for channel resolution")
     .addOption(
       new Option("--kind <kind>", "Target kind (auto|user|group|channel)")
         .choices(["auto", "user", "group", "channel"])
         .default("auto"),
     )
     .option("--json", "Output JSON", false)
-    .action(async (entries, opts) => {
+    .action(async (entries, opts, command) => {
       await runChannelsCommand(async () => {
         const { channelsResolveCommand } = await loadChannelsCommands();
+        const agentSource = command.getOptionValueSource("agent");
+        const agent =
+          agentSource && agentSource !== "default"
+            ? (opts.agent as string | undefined)
+            : inheritOptionFromParent<string>(command, "agent");
         await channelsResolveCommand(
           {
+            agent,
             channel: opts.channel as string | undefined,
             account: opts.account as string | undefined,
             kind: opts.kind as "auto" | "user" | "group" | "channel",

--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -35,6 +35,7 @@ describe("resolveCommandConfigWithSecrets", () => {
       config,
       commandName: "status",
       targetIds,
+      agentId: "ops",
       mode: "read_only_status",
       runtime,
     });
@@ -43,6 +44,7 @@ describe("resolveCommandConfigWithSecrets", () => {
       config,
       commandName: "status",
       targetIds,
+      agentId: "ops",
       mode: "read_only_status",
     });
     expect(runtime.error).toHaveBeenCalledWith("[secrets] resolved channels.telegram.token");

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -12,6 +12,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   config: TConfig;
   commandName: string;
   targetIds: Set<string>;
+  agentId?: string;
   mode?: CommandSecretResolutionMode;
   allowedPaths?: Set<string>;
   forcedActivePaths?: Set<string>;
@@ -30,6 +31,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     config: params.config,
     commandName: params.commandName,
     targetIds: params.targetIds,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
     ...(params.mode ? { mode: params.mode } : {}),
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
     ...(params.forcedActivePaths ? { forcedActivePaths: params.forcedActivePaths } : {}),

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { collectConfigAssignments as collectRuntimeConfigAssignments } from "../secrets/runtime-config-collectors.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -166,6 +167,9 @@ describe("resolveCommandSecretRefsViaGateway", () => {
   function setSingleSecretTargetDeps(params: {
     path: string;
     pathSegments: readonly string[];
+    collectConfigAssignments?: NonNullable<
+      Parameters<typeof commandSecretGatewayTesting.setDepsForTest>[0]["collectConfigAssignments"]
+    >;
     resolveManifestContractOwnerPluginId?: NonNullable<
       Parameters<
         typeof commandSecretGatewayTesting.setDepsForTest
@@ -207,9 +211,11 @@ describe("resolveCommandSecretRefsViaGateway", () => {
                 ],
         } as never;
       },
-      collectConfigAssignments: ({ context }) => {
-        context.assignments.push({ path: params.path } as never);
-      },
+      collectConfigAssignments:
+        params.collectConfigAssignments ??
+        (({ context }) => {
+          context.assignments.push({ path: params.path } as never);
+        }),
       discoverConfigSecretTargetsByIds: (config) =>
         [
           {
@@ -329,6 +335,66 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       targetIds: ["talk.providers.*.apiKey"],
     });
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("sk-live");
+  });
+
+  it("uses the explicit agent owner during channels resolve secret preflight", async () => {
+    const channelPath = "channels.telegram.botToken";
+    const channelPathSegments = ["channels", "telegram", "botToken"];
+    const config = {
+      agents: {
+        entries: {
+          ops: { sandbox: { backend: "docker" } },
+          research: { sandbox: { backend: "docker" } },
+        },
+        defaults: {
+          sandbox: {
+            backend: "ssh",
+            ssh: {
+              identityData: {
+                source: "env",
+                provider: "default",
+                id: "STALE_SANDBOX_IDENTITY",
+              },
+            },
+          },
+        },
+      },
+      channels: {
+        telegram: {
+          botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const restoreDeps = setSingleSecretTargetDeps({
+      path: channelPath,
+      pathSegments: channelPathSegments,
+      collectConfigAssignments: (params) => collectRuntimeConfigAssignments(params),
+    });
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: channelPath,
+          pathSegments: channelPathSegments,
+          value: "resolved-telegram-token",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    try {
+      const result = await resolveCommandSecretRefsViaGateway({
+        config,
+        commandName: "channels resolve",
+        targetIds: new Set([channelPath]),
+        agentId: "ops",
+        mode: "read_only_operational",
+      });
+
+      expect(result.resolvedConfig.channels?.telegram?.botToken).toBe("resolved-telegram-token");
+      expect(callGateway.mock.calls[0]?.[0].params).not.toHaveProperty("agentId");
+    } finally {
+      restoreDeps();
+    }
   });
 
   it("enforces unresolved checks only for allowed paths when provided", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -290,6 +290,7 @@ function collectConfiguredTargetRefPaths(params: {
 function classifyConfiguredTargetRefs(params: {
   config: OpenClawConfig;
   configuredTargetRefPaths: Set<string>;
+  agentId?: string;
   forcedActivePaths?: ReadonlySet<string>;
   optionalActivePaths?: ReadonlySet<string>;
 }): {
@@ -311,6 +312,7 @@ function classifyConfiguredTargetRefs(params: {
   commandSecretGatewayDeps.collectConfigAssignments({
     config: structuredClone(params.config),
     context,
+    agentId: params.agentId,
   });
 
   const activePaths = new Set(context.assignments.map((assignment) => assignment.path));
@@ -463,6 +465,7 @@ async function resolveCommandSecretRefsWithoutGateway(params: {
   config: OpenClawConfig;
   commandName: string;
   targetIds: Set<string>;
+  agentId?: string;
   preflightDiagnostics: string[];
   mode: CommandSecretResolutionMode;
   allowedPaths?: ReadonlySet<string>;
@@ -475,6 +478,7 @@ async function resolveCommandSecretRefsWithoutGateway(params: {
     config: params.config,
     commandName: params.commandName,
     targetIds: params.targetIds,
+    agentId: params.agentId,
     preflightDiagnostics: params.preflightDiagnostics,
     mode: params.mode,
     allowedPaths: params.allowedPaths,
@@ -541,6 +545,7 @@ async function resolveCommandSecretRefsLocally(params: {
   config: OpenClawConfig;
   commandName: string;
   targetIds: Set<string>;
+  agentId?: string;
   preflightDiagnostics: string[];
   mode: CommandSecretResolutionMode;
   allowedPaths?: ReadonlySet<string>;
@@ -564,6 +569,7 @@ async function resolveCommandSecretRefsLocally(params: {
   commandSecretGatewayDeps.collectConfigAssignments({
     config: structuredClone(params.config),
     context,
+    agentId: params.agentId,
   });
   if (
     targetsRuntimeWebResolution({
@@ -828,6 +834,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   config: OpenClawConfig;
   commandName: string;
   targetIds: Set<string>;
+  agentId?: string;
   mode?: CommandSecretResolutionModeInput;
   allowedPaths?: ReadonlySet<string>;
   forcedActivePaths?: ReadonlySet<string>;
@@ -856,6 +863,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   const preflight = classifyConfiguredTargetRefs({
     config: params.config,
     configuredTargetRefPaths,
+    agentId: params.agentId,
     forcedActivePaths: params.forcedActivePaths,
     optionalActivePaths: params.optionalActivePaths,
   });
@@ -875,6 +883,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       config: params.config,
       commandName: params.commandName,
       targetIds: params.targetIds,
+      agentId: params.agentId,
       preflightDiagnostics: preflight.diagnostics,
       mode,
       allowedPaths: params.allowedPaths,
@@ -902,6 +911,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         config: params.config,
         commandName: params.commandName,
         targetIds: params.targetIds,
+        agentId: params.agentId,
         preflightDiagnostics: preflight.diagnostics,
         mode,
         allowedPaths: params.allowedPaths,
@@ -1039,6 +1049,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         config: params.config,
         commandName: params.commandName,
         targetIds: params.targetIds,
+        agentId: params.agentId,
         preflightDiagnostics: [],
         mode,
         allowedPaths: new Set(analyzed.unresolved.map((entry) => entry.path)),

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -87,6 +87,10 @@ describe("resolveInstallableChannelPlugin", () => {
   });
 
   it("ignores untrusted workspace channel shadows during setup resolution", async () => {
+    const config = {
+      agents: { entries: { ops: {}, research: {} } },
+      plugins: { enabled: true },
+    };
     const workspaceEntry = createCatalogEntry({
       id: "telegram",
       pluginId: "evil-telegram-shadow",
@@ -114,9 +118,10 @@ describe("resolveInstallableChannelPlugin", () => {
     );
 
     const result = await resolveInstallableChannelPlugin({
-      cfg: { plugins: { enabled: true } },
+      cfg: config,
       runtime: {} as never,
       rawChannel: "telegram",
+      agentId: "ops",
       allowInstall: false,
     });
 
@@ -129,6 +134,8 @@ describe("resolveInstallableChannelPlugin", () => {
     expect(snapshotRequest?.channel).toBe("telegram");
     expect(snapshotRequest?.pluginId).toBe("telegram");
     expect(snapshotRequest?.workspaceDir).toBe("/tmp/workspace");
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(config, "ops");
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
   });
 
   it("keeps trusted workspace channel plugins eligible for setup resolution", async () => {

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -36,8 +36,8 @@ type ResolveInstallableChannelPluginResult = {
   supportsRequestedCapability?: boolean;
 };
 
-function resolveWorkspaceDir(cfg: OpenClawConfig) {
-  return resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+function resolveWorkspaceDir(cfg: OpenClawConfig, agentId?: string) {
+  return resolveAgentWorkspaceDir(cfg, agentId ?? resolveDefaultAgentId(cfg));
 }
 
 function resolveResolvedChannelId(params: {
@@ -54,7 +54,11 @@ function resolveResolvedChannelId(params: {
   return normalizeChannelId(params.catalogEntry.id) ?? (params.catalogEntry.id as ChannelId);
 }
 
-function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
+function resolveCatalogChannelEntry(
+  raw: string,
+  cfg: OpenClawConfig | null,
+  workspaceDir?: string,
+) {
   const trimmed = normalizeOptionalLowercaseString(raw);
   if (!trimmed) {
     return undefined;
@@ -62,7 +66,7 @@ function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
   const entries = cfg
     ? listTrustedChannelPluginCatalogEntries({
         cfg,
-        workspaceDir: resolveWorkspaceDir(cfg),
+        workspaceDir,
       })
     : listRawChannelPluginCatalogEntries({ excludeWorkspace: true });
   return entries.find((entry) => {
@@ -112,15 +116,18 @@ export async function resolveInstallableChannelPlugin(params: {
   runtime: RuntimeEnv;
   rawChannel?: string | null;
   channelId?: ChannelId;
+  agentId?: string;
   allowInstall?: boolean;
   prompter?: WizardPrompter;
   supports?: (plugin: ChannelPlugin) => boolean;
 }): Promise<ResolveInstallableChannelPluginResult> {
   const supports = params.supports ?? (() => true);
   let nextCfg = params.cfg;
-  const workspaceDir = resolveWorkspaceDir(nextCfg);
+  const workspaceDir = resolveWorkspaceDir(nextCfg, params.agentId);
   const catalogEntry =
-    (params.rawChannel ? resolveCatalogChannelEntry(params.rawChannel, nextCfg) : undefined) ??
+    (params.rawChannel
+      ? resolveCatalogChannelEntry(params.rawChannel, nextCfg, workspaceDir)
+      : undefined) ??
     (params.channelId
       ? getTrustedChannelPluginCatalogEntry(params.channelId, {
           cfg: nextCfg,
@@ -194,7 +201,7 @@ export async function resolveInstallableChannelPlugin(params: {
             channelId,
             supports,
             pluginId: installedPluginId,
-            workspaceDir: resolveWorkspaceDir(nextCfg),
+            workspaceDir: resolveWorkspaceDir(nextCfg, params.agentId),
           })
         : undefined;
       return {

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -111,6 +111,7 @@ describe("channelsResolveCommand", () => {
 
     await channelsResolveCommand(
       {
+        agent: "ops",
         channel: "whatsapp",
         entries: ["friends"],
       },
@@ -122,6 +123,12 @@ describe("channelsResolveCommand", () => {
       mocks.resolveInstallableChannelPlugin,
       "installable channel resolution",
     );
+    const commandSecretRequest = requireFirstMockArg(
+      mocks.resolveCommandSecretRefsViaGateway,
+      "command secret resolution",
+    );
+    expect(commandSecretRequest.agentId).toBe("ops");
+    expect(pluginResolutionRequest.agentId).toBe("ops");
     expect(pluginResolutionRequest.rawChannel).toBe("whatsapp");
     expect(pluginResolutionRequest.allowInstall).toBe(false);
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -20,6 +20,7 @@ import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin
 import { persistResolvedChannelPluginConfig } from "./plugin-config-persistence.js";
 
 export type ChannelsResolveOptions = {
+  agent?: string;
   channel?: string;
   account?: string;
   kind?: "auto" | "user" | "group" | "channel";
@@ -123,6 +124,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     config: loadedRaw,
     commandName: "channels resolve",
     targetIds: getChannelsCommandSecretTargetIds(),
+    agentId: opts.agent,
     mode: "read_only_operational",
     runtime,
     autoEnable: true,
@@ -139,6 +141,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     ? await resolveInstallableChannelPlugin({
         cfg,
         runtime,
+        agentId: opts.agent,
         rawChannel: explicitChannel,
         allowInstall: false,
         supports: (plugin) => Boolean(plugin.resolver?.resolveTargets),
@@ -165,6 +168,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     : await resolveMessageChannelSelection({
         cfg,
         channel: opts.channel ?? null,
+        agentId: opts.agent,
       });
   const plugin = selection.plugin;
   if (!plugin?.resolver?.resolveTargets) {

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -550,6 +550,7 @@ export function collectCoreConfigAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
+  agentId?: string;
 }): void {
   const providers = params.config.models?.providers as Record<string, ProviderLike> | undefined;
   if (providers) {

--- a/src/secrets/runtime-config-collectors-sandbox.ts
+++ b/src/secrets/runtime-config-collectors-sandbox.ts
@@ -57,6 +57,7 @@ export function collectAgentSandboxAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
+  agentId?: string;
 }): void {
   const rawAgents: unknown = params.config.agents;
   const agents = isRecord(rawAgents) ? rawAgents : undefined;
@@ -177,6 +178,10 @@ export function collectAgentSandboxAssignments(params: {
     // Unlisted agents and stale registry entries still resolve through defaults,
     // even when every current list entry overrides this credential.
     const active = defaultsBackend === "ssh";
+    const fallbackAgentId =
+      params.agentId === undefined
+        ? resolveDefaultAgentId(params.config)
+        : normalizeAgentId(params.agentId);
     collectAssignment({
       target: defaultsSsh,
       key,
@@ -185,7 +190,7 @@ export function collectAgentSandboxAssignments(params: {
       context: params.context,
       active,
       inactiveReason: "no enabled agent uses the sandbox SSH material.",
-      owner: sandboxSecretOwner(resolveDefaultAgentId(params.config), {
+      owner: sandboxSecretOwner(fallbackAgentId, {
         defaults: defaultsSandbox,
       }),
     });

--- a/src/secrets/runtime-config-collectors.ts
+++ b/src/secrets/runtime-config-collectors.ts
@@ -13,6 +13,8 @@ export function collectConfigAssignments(params: {
   config: OpenClawConfig;
   /** Resolver context carrying source config, env, cache, assignments, and warnings. */
   context: ResolverContext;
+  /** Explicit diagnostic owner for agent-scoped core assignments. */
+  agentId?: string;
   /** Optional installed plugin roots for channel/plugin contract lookup. */
   loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
 }): void {
@@ -22,6 +24,7 @@ export function collectConfigAssignments(params: {
     config: params.config,
     defaults,
     context: params.context,
+    agentId: params.agentId,
   });
 
   collectChannelConfigAssignments({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators resolving channel targets for an explicit agent could receive `AGENT_SELECTION_REQUIRED` in multi-agent configurations before any Gateway call. The `channels resolve` parser did not declare or forward `--agent`, and command-time secret preflight could therefore try to select a default owner for unclaimed sandbox SSH defaults before channel/plugin selection ran.

## Why This Change Was Made

The CLI now declares `--agent` on both the `channels` parent and the `resolve` leaf, inherits the parent value only when the leaf did not provide one, and carries that explicit owner through the existing command config/secret collection boundary. The same owner reaches plugin workspace resolution and message-channel selection, so ownership is recorded at the producers that need it; the Gateway protocol is intentionally unchanged.

This is the best-fix owner boundary because it preserves one canonical resolution flow and passes the already-known optional owner through it. A downstream catch for `AGENT_SELECTION_REQUIRED` would leave command-time secret classification and later workspace/channel selection disagreeing about ownership.

Production LOC: +53/-10 (net +43). Tests: +101/-4. Docs: +5/-2. The production growth is direct optional owner passthrough across the existing CLI, secret-collection, workspace, and channel-selection boundaries.

## User Impact

Operators can use either `channels --agent <id> resolve ...` or `channels resolve --agent <id> ...` in multi-agent setups. Explicit agent ownership now consistently controls command-time secret collection, plugin workspace lookup, and channel selection instead of failing early while trying to infer a default agent.

## Evidence

- Pre-fix regression: the new command-secret case failed 1/38 with `AgentSelectionRequiredError` through `collectAgentSandboxAssignments` / `classifyConfiguredTargetRefs` before any Gateway call. The same case passes after the fix.
- `node scripts/run-vitest.mjs src/cli/channels-cli.test.ts src/cli/command-config-resolution.test.ts src/cli/command-secret-gateway.test.ts src/commands/channel-setup/channel-plugin-resolution.test.ts src/commands/channels.resolve.test.ts` — 87/87 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `node scripts/run-tsgo-core-test-shards.mjs` — passed.
- Typed `node scripts/run-oxlint.mjs` over all 13 touched files — passed.
- `node_modules/.bin/oxfmt` over all 13 touched files — clean; `git diff --check` — passed.
- `node scripts/check-changed.mjs --dry-run -- <13 touched paths>` — classified the change as `core` / `coreTests`.
- Fresh autoreview — clean, with no accepted/actionable P0 findings.
- Black-box real CLI parser proof: `channels --agent ops resolve room --help` and `channels resolve --agent ops room --help` were both accepted; `--agentx` was rejected.
- Test-audit: the changed tests independently cover parent/leaf parsing, explicit-agent secret preflight, and agent-scoped plugin workspace/channel selection; no test-only production seam was added.
- Exact-head CI run 32001282879 exposed one attributable assertion-safety ratchet failure (`src/cli/channels-cli.ts: 8 > 7`). The fix replaced the new Commander cast with runtime string narrowing; focused tests remained 87/87, max-lines and assertion-safety ratchets passed, typed lint passed, and a fresh autoreview of the repair was clean.
- ClawSweeper's `--agent` documentation move was applied in the Channels reference, including both parent and leaf placements. `pnpm docs:list`, `pnpm docs:check-mdx` (774 files), `pnpm docs:check-links` (6,498 internal links, zero broken), targeted formatting, `git diff --check`, and fresh autoreview all passed.

Proof gap: no live channel API credentials were needed or used. The failure is deterministic parser/owner propagation before a channel API call, and the focused regression exercises the real command secret collector that previously raised the error.

AI-assisted: yes; understood and independently reviewed.
